### PR TITLE
Refactor object-detection models

### DIFF
--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -363,7 +363,7 @@ class ConditionalDetrConvEncoder(nn.Module):
 
         # replace batch norm by frozen batch norm
         replace_batch_norm(backbone)
-        
+
         self.model = backbone
         self.intermediate_channel_sizes = (
             self.model.feature_info.channels() if config.use_timm_backbone else self.model.channels

--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -362,8 +362,8 @@ class ConditionalDetrConvEncoder(nn.Module):
             backbone = load_backbone(config)
 
         # replace batch norm by frozen batch norm
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+        replace_batch_norm(backbone)
+        
         self.model = backbone
         self.intermediate_channel_sizes = (
             self.model.feature_info.channels() if config.use_timm_backbone else self.model.channels

--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -270,12 +270,13 @@ class ConditionalDetrFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -288,17 +289,15 @@ class ConditionalDetrFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 # Copied from transformers.models.detr.modeling_detr.replace_batch_norm with Detr->ConditionalDetr

--- a/src/transformers/models/dab_detr/modeling_dab_detr.py
+++ b/src/transformers/models/dab_detr/modeling_dab_detr.py
@@ -264,10 +264,10 @@ class DabDetrConvEncoder(nn.Module):
 
         self.config = config
         backbone = load_backbone(config)
-
+        
         # replace batch norm by frozen batch norm
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+        replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = self.model.channels
 

--- a/src/transformers/models/dab_detr/modeling_dab_detr.py
+++ b/src/transformers/models/dab_detr/modeling_dab_detr.py
@@ -264,7 +264,7 @@ class DabDetrConvEncoder(nn.Module):
 
         self.config = config
         backbone = load_backbone(config)
-        
+
         # replace batch norm by frozen batch norm
         replace_batch_norm(backbone)
 

--- a/src/transformers/models/dab_detr/modeling_dab_detr.py
+++ b/src/transformers/models/dab_detr/modeling_dab_detr.py
@@ -195,12 +195,13 @@ class DabDetrFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -213,17 +214,15 @@ class DabDetrFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 # Copied from transformers.models.detr.modeling_detr.replace_batch_norm with Detr->DabDetr

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -428,8 +428,8 @@ class DeformableDetrConvEncoder(nn.Module):
             backbone = load_backbone(config)
 
         # replace batch norm by frozen batch norm
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+        replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = (
             self.model.feature_info.channels() if config.use_timm_backbone else self.model.channels

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -337,12 +337,13 @@ class DeformableDetrFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -355,17 +356,15 @@ class DeformableDetrFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 # Copied from transformers.models.detr.modeling_detr.replace_batch_norm with Detr->DeformableDetr

--- a/src/transformers/models/deprecated/deta/modeling_deta.py
+++ b/src/transformers/models/deprecated/deta/modeling_deta.py
@@ -415,8 +415,10 @@ class DetaBackboneWithPositionalEncodings(nn.Module):
         super().__init__()
 
         backbone = load_backbone(config)
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+
+        # replace batch norm by frozen batch norm
+        replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = self.model.channels
 

--- a/src/transformers/models/detr/modeling_detr.py
+++ b/src/transformers/models/detr/modeling_detr.py
@@ -261,12 +261,13 @@ class DetrFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -279,17 +280,15 @@ class DetrFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 def replace_batch_norm(model):

--- a/src/transformers/models/detr/modeling_detr.py
+++ b/src/transformers/models/detr/modeling_detr.py
@@ -351,8 +351,8 @@ class DetrConvEncoder(nn.Module):
             backbone = load_backbone(config)
 
         # replace batch norm by frozen batch norm
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+        replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = (
             self.model.feature_info.channels() if config.use_timm_backbone else self.model.channels

--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -445,8 +445,8 @@ class GroundingDinoConvEncoder(nn.Module):
             backbone = load_backbone(config)
 
         # replace batch norm by frozen batch norm
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+        replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = (
             self.model.feature_info.channels() if config.use_timm_backbone else self.model.channels

--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -365,12 +365,13 @@ class GroundingDinoFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -383,17 +384,15 @@ class GroundingDinoFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 # Copied from transformers.models.detr.modeling_detr.replace_batch_norm with Detr->GroundingDino

--- a/src/transformers/models/omdet_turbo/modeling_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/modeling_omdet_turbo.py
@@ -575,10 +575,9 @@ class OmDetTurboCSPRepLayer(nn.Module):
             self.conv3 = nn.Identity()
 
     def forward(self, hidden_state):
-        device = hidden_state.device
         hidden_state_1 = self.conv1(hidden_state)
-        hidden_state_1 = self.bottlenecks(hidden_state_1).to(device)
-        hidden_state_2 = self.conv2(hidden_state).to(device)
+        hidden_state_1 = self.bottlenecks(hidden_state_1)
+        hidden_state_2 = self.conv2(hidden_state)
         return self.conv3(hidden_state_1 + hidden_state_2)
 
 

--- a/src/transformers/models/omdet_turbo/modeling_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/modeling_omdet_turbo.py
@@ -29,7 +29,7 @@ from torch import Tensor, nn
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 
-from ...activations import ACT2CLS, ACT2FN
+from ...activations import ACT2FN
 from ...file_utils import (
     ModelOutput,
     add_start_docstrings,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -560,8 +560,8 @@ class RTDetrConvEncoder(nn.Module):
 
         if config.freeze_backbone_batch_norms:
             # replace batch norm by frozen batch norm
-            with torch.no_grad():
-                replace_batch_norm(backbone)
+            replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = self.model.channels
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -610,6 +610,8 @@ class RTDetrConvNormLayer(nn.Module):
 class RTDetrEncoderLayer(nn.Module):
     def __init__(self, config: RTDetrConfig):
         super().__init__()
+        self.activation_dropout = config.activation_dropout
+        self.dropout = config.dropout
         self.normalize_before = config.normalize_before
 
         # self-attention
@@ -618,14 +620,16 @@ class RTDetrEncoderLayer(nn.Module):
             num_heads=config.num_attention_heads,
             dropout=config.dropout,
         )
-        self.self_attn_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
-        self.dropout = config.dropout
+
+        # feed-forward
         self.activation_fn = ACT2FN[config.encoder_activation_function]
-        self.activation_dropout = config.activation_dropout
         self.fc1 = nn.Linear(config.encoder_hidden_dim, config.encoder_ffn_dim)
         self.fc2 = nn.Linear(config.encoder_ffn_dim, config.encoder_hidden_dim)
-        self.final_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
+
+        # norms
         self.identity = nn.Identity()
+        self.self_attn_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
+        self.final_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
 
     def forward(
         self,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -814,9 +814,6 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
 
         self.disable_custom_kernels = config.disable_custom_kernels
 
-    def with_pos_embed(self, tensor: torch.Tensor, position_embeddings: Optional[Tensor]):
-        return tensor if position_embeddings is None else tensor + position_embeddings
-
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -832,7 +829,7 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
     ):
         # add position embeddings to the hidden states before projecting to queries and keys
         if position_embeddings is not None:
-            hidden_states = self.with_pos_embed(hidden_states, position_embeddings)
+            hidden_states = hidden_states +position_embeddings
 
         batch_size, num_queries, _ = hidden_states.shape
         batch_size, sequence_length, _ = encoder_hidden_states.shape
@@ -1745,8 +1742,9 @@ class RTDetrModel(RTDetrPreTrainedModel):
                 indexing="ij",
             )
             grid_xy = torch.stack([grid_x, grid_y], -1)
-            valid_wh = torch.tensor([width, height], device=device).to(dtype)
-            grid_xy = (grid_xy.unsqueeze(0) + 0.5) / valid_wh
+            grid_xy = grid_xy.unsqueeze(0) + 0.5
+            grid_xy[..., 0] /= width
+            grid_xy[..., 1] /= height
             wh = torch.ones_like(grid_xy) * grid_size * (2.0**level)
             anchors.append(torch.concat([grid_xy, wh], -1).reshape(-1, height * width, 4))
         # define the valid range for anchor coordinates
@@ -1847,14 +1845,15 @@ class RTDetrModel(RTDetrPreTrainedModel):
         # Prepare encoder inputs (by flattening)
         source_flatten = []
         spatial_shapes_list = []
+        spatial_shapes = torch.empty((len(sources), 2), device=device, dtype=torch.long)
         for level, source in enumerate(sources):
-            batch_size, num_channels, height, width = source.shape
-            spatial_shape = (height, width)
-            spatial_shapes_list.append(spatial_shape)
+            height, width = source.shape[-2:]
+            spatial_shapes[level, 0] = height
+            spatial_shapes[level, 1] = width
+            spatial_shapes_list.append((height, width))
             source = source.flatten(2).transpose(1, 2)
             source_flatten.append(source)
         source_flatten = torch.cat(source_flatten, 1)
-        spatial_shapes = torch.as_tensor(spatial_shapes_list, dtype=torch.long, device=source_flatten.device)
         level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
 
         # prepare denoising training

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -698,9 +698,10 @@ class RTDetrRepVggBlock(nn.Module):
         self.conv2 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, kernel_size=1, stride=1, padding=0)
         self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
 
-    def forward(self, x):
-        y = self.conv1(x) + self.conv2(x)
-        return self.activation(y)
+    def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Feature map of shape (batch_size, embed_dim, height, width)"""
+        feature_map = self.conv1(feature_map) + self.conv2(feature_map)
+        return self.activation(feature_map)
 
 
 class RTDetrCSPRepLayer(nn.Module):

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1036,7 +1036,7 @@ class RTDetrDecoderLayer(nn.Module):
         self.dropout = config.dropout
         self.activation_dropout = config.activation_dropout
 
-        # self-attention
+        # Self-Attention
         self.self_attn = RTDetrMultiheadAttention(
             embed_dim=config.hidden_size,
             num_heads=config.decoder_attention_heads,
@@ -1045,7 +1045,7 @@ class RTDetrDecoderLayer(nn.Module):
         self.activation_fn = ACT2FN[config.decoder_activation_function]
         self.self_attn_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
-        # cross-attention
+        # Cross-Attention
         self.encoder_attn = RTDetrMultiscaleDeformableAttention(
             config,
             num_heads=config.decoder_attention_heads,
@@ -1053,7 +1053,7 @@ class RTDetrDecoderLayer(nn.Module):
         )
         self.encoder_attn_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
-        # feedforward neural networks
+        # Feedforward
         self.fc1 = nn.Linear(config.hidden_size, config.decoder_ffn_dim)
         self.fc2 = nn.Linear(config.decoder_ffn_dim, config.hidden_size)
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
@@ -1092,7 +1092,7 @@ class RTDetrDecoderLayer(nn.Module):
                 returned tensors for more detail.
         """
 
-        # Self Attention
+        # Self-Attention
         self_attn_residual = hidden_states
         hidden_states, self_attn_weights = self.self_attn(
             hidden_states=hidden_states,
@@ -1120,7 +1120,7 @@ class RTDetrDecoderLayer(nn.Module):
         hidden_states = cross_attn_residual + hidden_states
         hidden_states = self.encoder_attn_layer_norm(hidden_states)
 
-        # Fully Connected
+        # Feedforward
         fc_residual = hidden_states
         hidden_states = self.activation_fn(self.fc1(hidden_states))
         hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
@@ -1146,7 +1146,7 @@ class RTDetrPreTrainedModel(PreTrainedModel):
     def _init_weights(self, module):
         """Initalize the weights"""
 
-        """initialize linear layer bias value according to a given probability value."""
+        # initialize linear layer bias value according to a given probability value
         if isinstance(module, (RTDetrForObjectDetection, RTDetrDecoder)):
             if module.class_embed is not None:
                 for layer in module.class_embed:

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -343,10 +343,6 @@ class RTDetrObjectDetectionOutput(ModelOutput):
     denoising_meta_values: Optional[Dict] = None
 
 
-def _get_clones(partial_module, N):
-    return nn.ModuleList([partial_module() for i in range(N)])
-
-
 # Copied from transformers.models.conditional_detr.modeling_conditional_detr.inverse_sigmoid
 def inverse_sigmoid(x, eps=1e-5):
     x = x.clamp(min=0, max=1)

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1593,15 +1593,10 @@ class RTDetrDecoder(RTDetrPreTrainedModel):
         )
 
 
-# taken from https://github.com/facebookresearch/detr/blob/master/models/detr.py
 class RTDetrMLPPredictionHead(nn.Module):
     """
     Very simple multi-layer perceptron (MLP, also called FFN), used to predict the normalized center coordinates,
     height and width of a bounding box w.r.t. an image.
-
-    Copied from https://github.com/facebookresearch/detr/blob/master/models/detr.py
-    Origin from https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/rtdetr_paddle/ppdet/modeling/transformers/utils.py#L453
-
     """
 
     def __init__(self, input_dim: int, hidden_dim: int, output_dim: int, num_layers: int):
@@ -1953,14 +1948,14 @@ class RTDetrForObjectDetection(RTDetrPreTrainedModel):
 
         # Detection heads on top
         # if two-stage, the last class_embed and bbox_embed is for region proposal generation
-        num_pred = config.decoder_layers
-        self.class_embed = nn.ModuleList([nn.Linear(config.hidden_size, config.num_labels) for _ in range(num_pred)])
+        num_layers = config.decoder_layers
+        self.class_embed = nn.ModuleList([nn.Linear(config.hidden_size, config.num_labels) for _ in range(num_layers)])
         self.bbox_embed = nn.ModuleList(
             [
                 RTDetrMLPPredictionHead(
                     input_dim=config.hidden_size, hidden_dim=config.hidden_size, output_dim=4, num_layers=3
                 )
-                for _ in range(num_pred)
+                for _ in range(num_layers)
             ]
         )
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1537,8 +1537,6 @@ class RTDetrDecoder(RTDetrPreTrainedModel):
         intermediate_reference_points = ()
         intermediate_logits = ()
 
-        reference_points = F.sigmoid(reference_points)
-
         # https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/rtdetr_pytorch/src/zoo/rtdetr/rtdetr_decoder.py#L252
         for idx, decoder_layer in enumerate(self.layers):
             reference_points_input = reference_points.unsqueeze(2)
@@ -1910,7 +1908,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
             inputs_embeds=target,
             encoder_hidden_states=hidden_states,
             encoder_attention_mask=attention_mask,
-            reference_points=init_reference_points,
+            reference_points=topk_bbox,
             spatial_shapes=spatial_shapes,
             spatial_shapes_list=spatial_shapes_list,
             level_start_index=level_start_index,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -317,7 +317,7 @@ class MultiScaleDeformableAttentionFunction(Function):
         return grad_value, None, None, grad_sampling_loc, grad_attn_weight, None
 
 
-# Copied from transformers.models.deformable_detr.modeling_deformable_detr.multi_scale_deformable_attention
+# Modified from transformers.models.deformable_detr.modeling_deformable_detr.multi_scale_deformable_attention
 def multi_scale_deformable_attention(
     value: Tensor,
     value_spatial_shapes: Union[Tensor, List[Tuple]],
@@ -366,7 +366,7 @@ def multi_scale_deformable_attention(
     return output
 
 
-# Copied from transformers.models.deformable_detr.modeling_deformable_detr.DeformableDetrMultiscaleDeformableAttention with DeformableDetr->RTDetr
+# Modified from transformers.models.deformable_detr.modeling_deformable_detr.DeformableDetrMultiscaleDeformableAttention with DeformableDetr->RTDetr
 class RTDetrMultiscaleDeformableAttention(nn.Module):
     """
     Multiscale deformable attention as proposed in Deformable DETR.
@@ -1224,7 +1224,6 @@ class RTDetrDecoderLayer(nn.Module):
         self.fc2_dropout = nn.Dropout(config.dropout)
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
-    # TODO: rename hidden_states -> hidden_state
     def forward(
         self,
         hidden_state: torch.Tensor,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1318,12 +1318,12 @@ class RTDetrMLPPredictionHead(nn.Module):
         output_dims = [hidden_dim] * (num_layers - 1) + [output_dim]
         self.layers = nn.ModuleList(nn.Linear(in_dim, out_dim) for in_dim, out_dim in zip(input_dims, output_dims))
 
-    def forward(self, x):
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
         for i, layer in enumerate(self.layers):
-            x = layer(x)
+            hidden_state = layer(hidden_state)
             if i < self.num_layers - 1:
-                x = nn.functional.relu(x)
-        return x
+                hidden_state = nn.functional.relu(hidden_state)
+        return hidden_state
 
 
 class RTDetrDecoder(nn.Module):

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1064,31 +1064,37 @@ class RTDetrDecoderLayer(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        reference_points: torch.Tensor,
+        spatial_shapes: torch.Tensor,
+        spatial_shapes_list: List[Tuple[int, int]],
         position_embeddings: Optional[torch.Tensor] = None,
-        reference_points=None,
-        spatial_shapes=None,
-        spatial_shapes_list=None,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
         encoder_attention_mask: Optional[torch.Tensor] = None,
-        output_attentions: Optional[bool] = False,
+        output_attentions: bool = False,
     ):
         """
         Args:
-            hidden_states (`torch.FloatTensor`):
+            hidden_states (`torch.Tensor`):
                 Input to the layer of shape `(batch_size, num_queries, hidden_size)`.
-            position_embeddings (`torch.FloatTensor`, *optional*):
-                Position embeddings that are added to the queries and keys in the self-attention layer of
-                shape `(batch_size, num_queries, hidden_size)`.
-            reference_points (`torch.FloatTensor`, *optional*):
+            encoder_hidden_states (`torch.Tensor`):
+                Flattened and concatenated encoder feature maps of shape `(batch_size, sequence_length, hidden_size)`.
+                Where `sequence_length` is the sum of the product of all spatial shapes of the encoder feature maps.
+                For example, spatial_shapes = [(80, 80), (40, 40), (20, 20)] ->
+                sequence_length = 80 * 80 + 40 * 40 + 20 * 20 = 6400 + 1600 + 400 = 8400.
+            reference_points (`torch.Tensor`, *optional*):
                 Reference points of shape `(batch_size, num_queries, 1, 2)`.
             spatial_shapes (`torch.LongTensor`, *optional*):
-                Spatial shapes of shape `(num_feature_levels, 2)`.
-            encoder_hidden_states (`torch.FloatTensor`):
-                cross attention input to the layer of shape `(seq_len, batch, embed_dim)`
-            encoder_attention_mask (`torch.FloatTensor`): encoder attention mask of size
-                `(batch, 1, target_len, source_len)` where padding elements are indicated by very large negative
-                values.
-            output_attentions (`bool`, *optional*):
+                Spatial shapes of encoder feature maps of shape `(num_feature_levels, 2)`.
+            spatial_shapes_list (`List[Tuple[int, int]]`, *optional*):
+                Spatial shapes of encoder feature maps of shape `(num_feature_levels, 2)`.
+                Same as `spatial_shapes` but as a list of tuples for `torch.compile` compatibility.
+            position_embeddings (`torch.Tensor`, *optional*):
+                Position embeddings that are added to the queries and keys in the self-attention layer of
+                shape `(batch_size, num_queries, hidden_size)`.
+            encoder_attention_mask (`torch.Tensor`):
+                4d encoder attention mask of size `(batch, 1, target_len, source_len)` where padding elements
+                are indicated by very large negative values.
+            output_attentions (`bool`, defaults to `False`):
                 Whether or not to return the attentions tensors of all attention layers. See `attentions` under
                 returned tensors for more detail.
         """

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -947,13 +947,13 @@ class RTDetrEncoderLayer(nn.Module):
     ):
         """
         Args:
-            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
-            attention_mask (`torch.FloatTensor`): attention mask of size
+            hidden_states (`torch.Tensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.Tensor`): attention mask of size
                 `(batch, 1, target_len, source_len)` where padding elements are indicated by very large negative
                 values.
-            position_embeddings (`torch.FloatTensor`, *optional*):
+            position_embeddings (`torch.Tensor`, *optional*):
                 Object queries (also called content embeddings), to be added to the hidden states.
-            output_attentions (`bool`, *optional*):
+            output_attentions (`bool`, defaults to `False`):
                 Whether or not to return the attentions tensors of all attention layers. See `attentions` under
                 returned tensors for more detail.
         """
@@ -995,12 +995,7 @@ class RTDetrEncoderLayer(nn.Module):
                 clamp_value = torch.finfo(hidden_states.dtype).max - 1000
                 hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
 
-        outputs = (hidden_states,)
-
-        if output_attentions:
-            outputs += (attn_weights,)
-
-        return outputs
+        return hidden_states, attn_weights
 
 
 class RTDetrEncoder(nn.Module):

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -814,6 +814,9 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
 
         self.disable_custom_kernels = config.disable_custom_kernels
 
+    def with_pos_embed(self, tensor: torch.Tensor, position_embeddings: Optional[Tensor]):
+        return tensor if position_embeddings is None else tensor + position_embeddings
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -829,7 +832,7 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
     ):
         # add position embeddings to the hidden states before projecting to queries and keys
         if position_embeddings is not None:
-            hidden_states = hidden_states + position_embeddings
+            hidden_states = self.with_pos_embed(hidden_states, position_embeddings)
 
         batch_size, num_queries, _ = hidden_states.shape
         batch_size, sequence_length, _ = encoder_hidden_states.shape

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1588,16 +1588,6 @@ RTDETR_INPUTS_DOCSTRING = r"""
             - 0 for pixels that are padding (i.e. **masked**).
 
             [What are attention masks?](../glossary#attention-mask)
-        encoder_outputs (`tuple(tuple(torch.FloatTensor)`, *optional*):
-            Tuple consists of (`last_hidden_state`, *optional*: `hidden_states`, *optional*: `attentions`)
-            `last_hidden_state` of shape `(batch_size, sequence_length, hidden_size)`, *optional*) is a sequence of
-            hidden-states at the output of the last layer of the encoder. Used in the cross-attention of the decoder.
-        inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-            Optionally, instead of passing the flattened feature map (output of the backbone + projection layer), you
-            can choose to directly pass a flattened representation of an image.
-        decoder_inputs_embeds (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`, *optional*):
-            Optionally, instead of initializing the queries with a tensor of zeros, you can choose to directly pass an
-            embedded representation.
         labels (`List[Dict]` of len `(batch_size,)`, *optional*):
             Labels for computing the bipartite matching loss. List of dicts, each dictionary containing at least the
             following 2 keys: 'class_labels' and 'boxes' (the class labels and bounding boxes of an image in the batch
@@ -1744,9 +1734,6 @@ class RTDetrModel(RTDetrPreTrainedModel):
         self,
         pixel_values: torch.FloatTensor,
         pixel_mask: Optional[torch.LongTensor] = None,
-        encoder_outputs: Optional[torch.FloatTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        decoder_inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[List[dict]] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -1782,7 +1769,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
         )
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        batch_size, num_channels, height, width = pixel_values.shape
+        batch_size, _, height, width = pixel_values.shape
         device = pixel_values.device
 
         # Stage 1: Convolutional backbone
@@ -1974,9 +1961,6 @@ class RTDetrForObjectDetection(RTDetrPreTrainedModel):
         self,
         pixel_values: torch.FloatTensor,
         pixel_mask: Optional[torch.LongTensor] = None,
-        encoder_outputs: Optional[torch.FloatTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        decoder_inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[List[dict]] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -2000,9 +1984,6 @@ class RTDetrForObjectDetection(RTDetrPreTrainedModel):
         outputs = self.model(
             pixel_values,
             pixel_mask=pixel_mask,
-            encoder_outputs=encoder_outputs,
-            inputs_embeds=inputs_embeds,
-            decoder_inputs_embeds=decoder_inputs_embeds,
             labels=labels,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -829,7 +829,7 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
     ):
         # add position embeddings to the hidden states before projecting to queries and keys
         if position_embeddings is not None:
-            hidden_states = hidden_states +position_embeddings
+            hidden_states = hidden_states + position_embeddings
 
         batch_size, num_queries, _ = hidden_states.shape
         batch_size, sequence_length, _ = encoder_hidden_states.shape

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -921,8 +921,8 @@ class RTDetrEncoderLayer(nn.Module):
         # self-attention
         self.self_attn = RTDetrMultiheadAttention(
             embed_dim=config.encoder_hidden_dim,
-            num_heads=config.decoder_attention_heads,
-            dropout=config.attention_dropout,
+            num_heads=config.num_attention_heads,
+            dropout=config.dropout,
         )
         self.self_attn_dropout = nn.Dropout(config.dropout)
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -367,12 +367,13 @@ class RTDetrFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -385,17 +386,15 @@ class RTDetrFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 # Copied from transformers.models.detr.modeling_detr.replace_batch_norm with Detr->RTDetr

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -780,15 +780,13 @@ def multi_scale_deformable_attention(
         sampled_values.append(sampled_value_i)
     sampled_values = torch.stack(sampled_values, dim=-2)
 
-    # (batch_size, num_queries, num_heads, num_levels, num_points)
-    # -> (batch_size, num_heads, num_queries, num_levels, num_points)
-    # -> (batch_size, num_heads, 1, num_queries, num_levels*num_points)
+    # (batch_size, num_queries, num_heads, ...) -> (batch_size, num_heads, num_queries, ...)
     attention_weights = attention_weights.transpose(1, 2)
     attention_weights = attention_weights.reshape(batch_size * num_heads, 1, num_queries, num_levels * num_points)
 
-    attention_weights = attention_weights * sampled_values.flatten(-2)
+    output = attention_weights * sampled_values.flatten(-2)
+    output = output.sum(-1)
 
-    output = attention_weights.sum(-1)
     output = output.view(batch_size, num_heads * hidden_dim, num_queries)
     output = output.transpose(1, 2).contiguous()
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -42,6 +42,7 @@ from ...utils import (
     is_torchdynamo_compiling,
     logging,
     replace_return_docstrings,
+    torch_int,
 )
 from ...utils.backbone_utils import load_backbone
 from .configuration_rt_detr import RTDetrConfig
@@ -500,7 +501,7 @@ def get_contrastive_denoising_training_group(
         denoise_positive_idx, [n * num_groups_denoising_queries for n in num_ground_truths]
     )
     # total denoising queries
-    num_denoising_queries = int(max_gt_num * 2 * num_groups_denoising_queries)
+    num_denoising_queries = torch_int(max_gt_num * 2 * num_groups_denoising_queries)
 
     if label_noise_ratio > 0:
         mask = torch.rand_like(input_query_class, dtype=torch.float) < (label_noise_ratio * 0.5)
@@ -1322,8 +1323,8 @@ class RTDetrHybridEncoder(nn.Module):
     def build_2d_sincos_position_embedding(
         width, height, embed_dim=256, temperature=10000.0, device="cpu", dtype=torch.float32
     ):
-        grid_w = torch.arange(int(width), device=device).to(dtype)
-        grid_h = torch.arange(int(height), device=device).to(dtype)
+        grid_w = torch.arange(torch_int(width), device=device).to(dtype)
+        grid_h = torch.arange(torch_int(height), device=device).to(dtype)
         grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
         if embed_dim % 4 != 0:
             raise ValueError("Embed dimension must be divisible by 4 for 2D sin-cos position embedding")

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -848,14 +848,13 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
     def forward(
         self,
         hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        reference_points: torch.Tensor,
+        spatial_shapes: torch.Tensor,
+        spatial_shapes_list: List[Tuple[int, int]],
+        level_start_index: torch.Tensor,
         attention_mask: Optional[torch.Tensor] = None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
         position_embeddings: Optional[torch.Tensor] = None,
-        reference_points=None,
-        spatial_shapes=None,
-        spatial_shapes_list=None,
-        level_start_index=None,
         output_attentions: bool = False,
     ):
         # add position embeddings to the hidden states before projecting to queries and keys
@@ -939,6 +938,9 @@ class RTDetrMultiscaleDeformableAttention(nn.Module):
                     value, spatial_shapes_list, sampling_locations, attention_weights
                 )
         output = self.output_proj(output)
+
+        if not output_attentions:
+            attention_weights = None
 
         return output, attention_weights
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1336,11 +1336,6 @@ class RTDetrHybridEncoder(nn.Module):
     def forward(
         self,
         inputs_embeds=None,
-        attention_mask=None,
-        position_embeddings=None,
-        spatial_shapes=None,
-        level_start_index=None,
-        valid_ratios=None,
         output_attentions=None,
         output_hidden_states=None,
         return_dict=None,
@@ -1349,19 +1344,6 @@ class RTDetrHybridEncoder(nn.Module):
         Args:
             inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
                 Flattened feature map (output of the backbone + projection layer) that is passed to the encoder.
-            attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
-                Mask to avoid performing attention on padding pixel features. Mask values selected in `[0, 1]`:
-                - 1 for pixel features that are real (i.e. **not masked**),
-                - 0 for pixel features that are padding (i.e. **masked**).
-                [What are attention masks?](../glossary#attention-mask)
-            position_embeddings (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
-                Position embeddings that are added to the queries and keys in each self-attention layer.
-            spatial_shapes (`torch.LongTensor` of shape `(num_feature_levels, 2)`):
-                Spatial shapes of each feature map.
-            level_start_index (`torch.LongTensor` of shape `(num_feature_levels)`):
-                Starting index of each feature map.
-            valid_ratios (`torch.FloatTensor` of shape `(batch_size, num_feature_levels, 2)`):
-                Ratio of valid area in each feature level.
             output_attentions (`bool`, *optional*):
                 Whether or not to return the attentions tensors of all attention layers. See `attentions` under
                 returned tensors for more detail.

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -921,8 +921,8 @@ class RTDetrEncoderLayer(nn.Module):
         # self-attention
         self.self_attn = RTDetrMultiheadAttention(
             embed_dim=config.encoder_hidden_dim,
-            num_heads=config.num_attention_heads,
-            dropout=config.dropout,
+            num_heads=config.decoder_attention_heads,
+            dropout=config.attention_dropout,
         )
         self.self_attn_dropout = nn.Dropout(config.dropout)
 

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -730,18 +730,20 @@ class RTDetrCSPRepLayer(nn.Module):
         else:
             self.conv3 = nn.Identity()
 
-    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
+    def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Feature map of shape (batch_size, embed_dim, height, width)"""
+
         # branch 1
-        hidden_state_1 = self.conv1(hidden_state)
-        hidden_state_1 = self.bottlenecks(hidden_state_1)
+        feature_map_1 = self.conv1(feature_map)
+        feature_map_1 = self.bottlenecks(feature_map_1)
 
         # branch 2
-        hidden_state_2 = self.conv2(hidden_state)
+        feature_map_2 = self.conv2(feature_map)
 
         # fuse step
-        hidden_state = self.conv3(hidden_state_1 + hidden_state_2)
+        feature_map = self.conv3(feature_map_1 + feature_map_2)
 
-        return hidden_state
+        return feature_map
 
 
 # Copied from transformers.models.deformable_detr.modeling_deformable_detr.multi_scale_deformable_attention

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1709,12 +1709,18 @@ class RTDetrModel(RTDetrPreTrainedModel):
             param.requires_grad_(True)
 
     @compile_compatible_method_lru_cache(maxsize=32)
-    def generate_anchors(self, spatial_shapes=None, grid_size=0.05, device="cpu", dtype=torch.float32):
+    def generate_anchors(
+        self,
+        spatial_shapes: Optional[Tuple[Tuple[int, int], ...]] = None,
+        grid_size: float = 0.05,
+        device: str = "cpu",
+        dtype: torch.dtype = torch.float32,
+    ):
         if spatial_shapes is None:
-            spatial_shapes = [
-                [int(self.config.anchor_image_size[0] / s), int(self.config.anchor_image_size[1] / s)]
-                for s in self.config.feat_strides
-            ]
+            height, width = self.config.anchor_image_size
+            spatial_shapes = tuple(
+                [(int(height / stride), int(width / stride)) for stride in self.config.feat_strides]
+            )
         anchors = []
         for level, (height, width) in enumerate(spatial_shapes):
             grid_y, grid_x = torch.meshgrid(

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -707,8 +707,8 @@ class RTDetrRepVggBlock(nn.Module):
 
         activation = config.activation_function
         hidden_channels = int(config.encoder_hidden_dim * config.hidden_expansion)
-        self.conv1 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, 3, 1, padding=1)
-        self.conv2 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, 1, 1, padding=0)
+        self.conv1 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, kernel_size=3, stride=1, padding=1)
+        self.conv2 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, kernel_size=1, stride=1, padding=0)
         self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
 
     def forward(self, x):

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -146,7 +146,6 @@ class RTDetrModelOutput(ModelOutput):
     """
 
     last_hidden_state: torch.FloatTensor = None
-    intermediate_hidden_states: torch.FloatTensor = None
     class_outputs: torch.FloatTensor = None
     bbox_outputs: torch.FloatTensor = None
     decoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
@@ -225,7 +224,6 @@ class RTDetrObjectDetectionOutput(ModelOutput):
     pred_boxes: torch.FloatTensor = None
     auxiliary_outputs: Optional[List[Dict]] = None
     last_hidden_state: torch.FloatTensor = None
-    intermediate_hidden_states: torch.FloatTensor = None
     class_outputs: torch.FloatTensor = None
     bbox_outputs: torch.FloatTensor = None
     decoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1902,7 +1902,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
 
         if not return_dict:
             enc_outputs = tuple(
-                value for value in [topk_logits, topk_bbox, class_logits, bboxes_logits] if value is not None
+                value for value in [topk_logits, topk_bboxes, class_logits, bboxes_logits] if value is not None
             )
             dn_outputs = tuple(value if value is not None else None for value in [denoising_meta_values])
             tuple_outputs = decoder_outputs + encoder_outputs + (init_reference_points,) + enc_outputs + dn_outputs
@@ -1922,7 +1922,7 @@ class RTDetrModel(RTDetrPreTrainedModel):
             encoder_attentions=encoder_outputs.attentions,
             init_reference_points=init_reference_points,
             enc_topk_logits=topk_logits,
-            enc_topk_bboxes=topk_bbox,
+            enc_topk_bboxes=topk_bboxes,
             enc_outputs_class=class_logits,
             enc_outputs_coord_logits=bboxes_logits,
             denoising_meta_values=denoising_meta_values,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -27,7 +27,7 @@ from torch import Tensor, nn
 from torch.autograd import Function
 from torch.autograd.function import once_differentiable
 
-from ...activations import ACT2CLS, ACT2FN
+from ...activations import ACT2FN
 from ...image_transforms import center_to_corners_format, corners_to_center_format
 from ...modeling_utils import PreTrainedModel
 from ...pytorch_utils import compile_compatible_method_lru_cache
@@ -786,7 +786,7 @@ class RTDetrConvNormLayer(nn.Module):
             bias=False,
         )
         self.norm = nn.BatchNorm2d(out_channels, config.batch_norm_eps)
-        self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
+        self.activation = ACT2FN[activation] if activation is not None else nn.Identity()
 
     def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
         """Feature map of shape (batch_size, embed_dim, height, width)"""
@@ -808,7 +808,7 @@ class RTDetrRepVggBlock(nn.Module):
         hidden_channels = int(config.encoder_hidden_dim * config.hidden_expansion)
         self.conv1 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, kernel_size=3, stride=1, padding=1)
         self.conv2 = RTDetrConvNormLayer(config, hidden_channels, hidden_channels, kernel_size=1, stride=1, padding=0)
-        self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
+        self.activation = ACT2FN[activation] if activation is not None else nn.Identity()
 
     def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
         """Feature map of shape (batch_size, embed_dim, height, width)"""

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -628,7 +628,6 @@ class RTDetrEncoderLayer(nn.Module):
         attention_mask: torch.Tensor,
         position_embeddings: Optional[torch.Tensor] = None,
         output_attentions: bool = False,
-        **kwargs,
     ):
         """
         Args:

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -560,8 +560,8 @@ class RTDetrConvEncoder(nn.Module):
             replace_batch_norm(self.model)
 
     def forward(self, pixel_values: torch.Tensor) -> List[torch.Tensor]:
-        features = self.model(pixel_values).feature_maps
-        return features
+        feature_maps = self.model(pixel_values).feature_maps
+        return feature_maps
 
 
 class RTDetrConvNormLayer(nn.Module):
@@ -587,11 +587,12 @@ class RTDetrConvNormLayer(nn.Module):
         self.norm = nn.BatchNorm2d(out_channels, config.batch_norm_eps)
         self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
 
-    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
-        hidden_state = self.conv(hidden_state)
-        hidden_state = self.norm(hidden_state)
-        hidden_state = self.activation(hidden_state)
-        return hidden_state
+    def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Feature map of shape (batch_size, embed_dim, height, width)"""
+        feature_map = self.conv(feature_map)
+        feature_map = self.norm(feature_map)
+        feature_map = self.activation(feature_map)
+        return feature_map
 
 
 class RTDetrEncoderLayer(nn.Module):

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -578,7 +578,16 @@ class RTDetrConvEncoder(nn.Module):
 
 
 class RTDetrConvNormLayer(nn.Module):
-    def __init__(self, config, in_channels, out_channels, kernel_size, stride, padding=None, activation=None):
+    def __init__(
+        self,
+        config: RTDetrConfig,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int,
+        padding: Optional[int] = None,
+        activation: Optional[str] = None,
+    ):
         super().__init__()
         self.conv = nn.Conv2d(
             in_channels,
@@ -591,7 +600,7 @@ class RTDetrConvNormLayer(nn.Module):
         self.norm = nn.BatchNorm2d(out_channels, config.batch_norm_eps)
         self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
 
-    def forward(self, hidden_state):
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
         hidden_state = self.conv(hidden_state)
         hidden_state = self.norm(hidden_state)
         hidden_state = self.activation(hidden_state)

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1128,7 +1128,7 @@ class RTDetrPreTrainedModel(PreTrainedModel):
     config_class = RTDetrConfig
     base_model_prefix = "rt_detr"
     main_input_name = "pixel_values"
-    _no_split_modules = [r"RTDetrConvEncoder", r"RTDetrEncoderLayer", r"RTDetrDecoderLayer", r"RTDetrCSPRepLayer"]
+    _no_split_modules = [r"RTDetrHybridEncoder", r"RTDetrDecoderLayer"]
 
     def _init_weights(self, module):
         """Initalize the weights"""

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -1128,7 +1128,7 @@ class RTDetrPreTrainedModel(PreTrainedModel):
     config_class = RTDetrConfig
     base_model_prefix = "rt_detr"
     main_input_name = "pixel_values"
-    _no_split_modules = [r"RTDetrConvEncoder", r"RTDetrEncoderLayer", r"RTDetrDecoderLayer", r"RTDetrV2CSPRepLayer"]
+    _no_split_modules = [r"RTDetrConvEncoder", r"RTDetrEncoderLayer", r"RTDetrDecoderLayer", r"RTDetrCSPRepLayer"]
 
     def _init_weights(self, module):
         """Initalize the weights"""

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -19,24 +19,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
+import os
 import warnings
 from dataclasses import dataclass
-from functools import partial
+from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
+from torch.autograd import Function
+from torch.autograd.function import once_differentiable
 
-from ...activations import ACT2CLS, ACT2FN
+from ...activations import ACT2FN
 from ...image_transforms import center_to_corners_format, corners_to_center_format
-from ...modeling_outputs import BaseModelOutput
 from ...modeling_utils import PreTrainedModel
 from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import (
     ModelOutput,
+    add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
+    is_ninja_available,
+    is_torch_cuda_available,
+    is_torchdynamo_compiling,
+    logging,
     replace_return_docstrings,
     torch_int,
 )
@@ -44,7 +51,92 @@ from ...utils.backbone_utils import load_backbone
 from .configuration_rt_detr_v2 import RTDetrV2Config
 
 
+logger = logging.get_logger(__name__)
+_CHECKPOINT_FOR_DOC = "PekingU/RTDetrV2_r50vd"
+
 _CONFIG_FOR_DOC = "RTDetrV2Config"
+
+# Global module placeholder for custom cuda kernel, will be loaded lazily in DeformableAttention
+# in case of first usage (if no disabled in config).
+MultiScaleDeformableAttention = None
+
+
+class MultiScaleDeformableAttentionFunction(Function):
+    @staticmethod
+    def forward(
+        context,
+        value,
+        value_spatial_shapes,
+        value_level_start_index,
+        sampling_locations,
+        attention_weights,
+        im2col_step,
+    ):
+        context.im2col_step = im2col_step
+        output = MultiScaleDeformableAttention.ms_deform_attn_forward(
+            value,
+            value_spatial_shapes,
+            value_level_start_index,
+            sampling_locations,
+            attention_weights,
+            context.im2col_step,
+        )
+        context.save_for_backward(
+            value, value_spatial_shapes, value_level_start_index, sampling_locations, attention_weights
+        )
+        return output
+
+    @staticmethod
+    @once_differentiable
+    def backward(context, grad_output):
+        (
+            value,
+            value_spatial_shapes,
+            value_level_start_index,
+            sampling_locations,
+            attention_weights,
+        ) = context.saved_tensors
+        grad_value, grad_sampling_loc, grad_attn_weight = MultiScaleDeformableAttention.ms_deform_attn_backward(
+            value,
+            value_spatial_shapes,
+            value_level_start_index,
+            sampling_locations,
+            attention_weights,
+            grad_output,
+            context.im2col_step,
+        )
+
+        return grad_value, None, None, grad_sampling_loc, grad_attn_weight, None
+
+
+def load_cuda_kernels():
+    from torch.utils.cpp_extension import load
+
+    global MultiScaleDeformableAttention
+
+    root = Path(__file__).resolve().parent.parent.parent / "kernels" / "deformable_detr"
+    src_files = [
+        root / filename
+        for filename in [
+            "vision.cpp",
+            os.path.join("cpu", "ms_deform_attn_cpu.cpp"),
+            os.path.join("cuda", "ms_deform_attn_cuda.cu"),
+        ]
+    ]
+
+    MultiScaleDeformableAttention = load(
+        "MultiScaleDeformableAttention",
+        src_files,
+        with_cuda=True,
+        extra_include_paths=[str(root)],
+        extra_cflags=["-DWITH_CUDA=1"],
+        extra_cuda_cflags=[
+            "-DCUDA_HAS_FP16=1",
+            "-D__CUDA_NO_HALF_OPERATORS__",
+            "-D__CUDA_NO_HALF_CONVERSIONS__",
+            "-D__CUDA_NO_HALF2_OPERATORS__",
+        ],
+    )
 
 
 def multi_scale_deformable_attention_v2(
@@ -126,6 +218,8 @@ def multi_scale_deformable_attention_v2(
 
 class RTDetrV2MultiscaleDeformableAttention(nn.Module):
     """
+    Multiscale deformable attention as proposed in Deformable DETR.
+
     RTDetrV2 version of multiscale deformable attention, extending the base implementation
     with improved offset handling and initialization.
     """
@@ -143,7 +237,7 @@ class RTDetrV2MultiscaleDeformableAttention(nn.Module):
         head_dim = config.hidden_size // num_heads
         if not ((head_dim & (head_dim - 1) == 0) and head_dim != 0):
             warnings.warn(
-                "You'd better set embed_dim (d_model) in RTDetrMultiscaleDeformableAttention to make the"
+                "You'd better set embed_dim (d_model) in RTDetrV2MultiscaleDeformableAttention to make the"
                 " dimension of each attention head a power of 2 which is more efficient in the authors' CUDA"
                 " implementation."
             )
@@ -156,12 +250,23 @@ class RTDetrV2MultiscaleDeformableAttention(nn.Module):
         self.num_points = num_points
         self.disable_custom_kernels = config.disable_custom_kernels
 
+        # Load custom deformable attention kernel if needed,
+        # otherwise use the pytorch implementation would be used
+        if (
+            not config.disable_custom_kernels  # manually disabled in config
+            and is_torch_cuda_available()  # only CUDA is supported for now
+            and is_ninja_available()  # we need Ninja to compile the kernel
+            and MultiScaleDeformableAttention is not None  # only if the kernel is previously loaded
+        ):
+            try:
+                load_cuda_kernels()
+            except Exception as e:
+                logger.warning(f"Could not load the custom kernel for multi-scale deformable attention: {e}")
+
         self.sampling_offsets = nn.Linear(self.hidden_size, self.num_heads * self.num_levels * self.num_points * 2)
         self.attention_weights = nn.Linear(self.hidden_size, self.num_heads * self.num_levels * self.num_points)
         self.value_proj = nn.Linear(self.hidden_size, self.hidden_size)
         self.output_proj = nn.Linear(self.hidden_size, self.hidden_size)
-
-        # V2-specific attributes
         self.offset_scale = config.decoder_offset_scale
         self.method = config.decoder_method
 
@@ -228,9 +333,37 @@ class RTDetrV2MultiscaleDeformableAttention(nn.Module):
         else:
             raise ValueError(f"Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
 
-        output = multi_scale_deformable_attention_v2(
-            value, spatial_shapes_list, sampling_locations, attention_weights, method=self.method
-        )
+        if (
+            self.disable_custom_kernels  # manually disabled in config
+            or MultiScaleDeformableAttention is None  # error while loading the kernel
+            or is_torchdynamo_compiling()  # torch.compile / torch.export mode
+        ):
+            # PyTorch implementation
+            output = multi_scale_deformable_attention_v2(
+                value, spatial_shapes_list, sampling_locations, attention_weights, method=self.method
+            )
+        else:
+            try:
+                # Calling custom kernel
+                # Note: for custom kernel we pass sampling locations as 6D tensor,
+                #       but for torch implementation we keep it as 5D tensor (for CoreML compat)
+                kernel_sampling_locations = sampling_locations.view(
+                    batch_size, num_queries, self.num_heads, self.num_levels, self.num_points, 2
+                )
+                level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
+                output = MultiScaleDeformableAttentionFunction.apply(
+                    value,
+                    spatial_shapes,
+                    level_start_index,
+                    kernel_sampling_locations,
+                    attention_weights,
+                    self.im2col_step,
+                )
+            except Exception:
+                # PyTorch implementation
+                output = multi_scale_deformable_attention_v2(
+                    value, spatial_shapes_list, sampling_locations, attention_weights, method=self.method
+                )
 
         output = self.output_proj(output)
 
@@ -238,230 +371,6 @@ class RTDetrV2MultiscaleDeformableAttention(nn.Module):
             attention_weights = None
 
         return output, attention_weights
-
-
-class RTDetrV2MultiheadAttention(nn.Module):
-    """
-    Multi-headed attention from 'Attention Is All You Need' paper.
-
-    Here, we add position embeddings to the queries and keys (as explained in the Deformable DETR paper).
-    """
-
-    def __init__(
-        self,
-        embed_dim: int,
-        num_heads: int,
-        dropout: float = 0.0,
-        bias: bool = True,
-    ):
-        super().__init__()
-        self.embed_dim = embed_dim
-        self.num_heads = num_heads
-        self.dropout = dropout
-        self.head_dim = embed_dim // num_heads
-        if self.head_dim * num_heads != self.embed_dim:
-            raise ValueError(
-                f"embed_dim must be divisible by num_heads (got `embed_dim`: {self.embed_dim} and `num_heads`:"
-                f" {num_heads})."
-            )
-        self.scaling = self.head_dim**-0.5
-
-        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
-
-    def _reshape(self, tensor: torch.Tensor, seq_len: int, batch_size: int):
-        return tensor.view(batch_size, seq_len, self.num_heads, self.head_dim).transpose(1, 2).contiguous()
-
-    def with_pos_embed(self, tensor: torch.Tensor, position_embeddings: Optional[Tensor]):
-        return tensor if position_embeddings is None else tensor + position_embeddings
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attention_mask: Optional[torch.Tensor] = None,
-        position_embeddings: Optional[torch.Tensor] = None,
-        output_attentions: bool = False,
-    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-        """Input shape: Batch x Time x Channel"""
-
-        batch_size, target_len, embed_dim = hidden_states.size()
-        # add position embeddings to the hidden states before projecting to queries and keys
-        if position_embeddings is not None:
-            hidden_states_original = hidden_states
-            hidden_states = self.with_pos_embed(hidden_states, position_embeddings)
-
-        # get queries, keys and values
-        query_states = self.q_proj(hidden_states) * self.scaling
-        key_states = self._reshape(self.k_proj(hidden_states), -1, batch_size)
-        value_states = self._reshape(self.v_proj(hidden_states_original), -1, batch_size)
-
-        proj_shape = (batch_size * self.num_heads, -1, self.head_dim)
-        query_states = self._reshape(query_states, target_len, batch_size).view(*proj_shape)
-        key_states = key_states.view(*proj_shape)
-        value_states = value_states.view(*proj_shape)
-
-        source_len = key_states.size(1)
-
-        attn_weights = torch.bmm(query_states, key_states.transpose(1, 2))
-
-        if attn_weights.size() != (batch_size * self.num_heads, target_len, source_len):
-            raise ValueError(
-                f"Attention weights should be of size {(batch_size * self.num_heads, target_len, source_len)}, but is"
-                f" {attn_weights.size()}"
-            )
-
-        # expand attention_mask
-        if attention_mask is not None:
-            # [seq_len, seq_len] -> [batch_size, 1, target_seq_len, source_seq_len]
-            attention_mask = attention_mask.expand(batch_size, 1, *attention_mask.size())
-
-        if attention_mask is not None:
-            if attention_mask.size() != (batch_size, 1, target_len, source_len):
-                raise ValueError(
-                    f"Attention mask should be of size {(batch_size, 1, target_len, source_len)}, but is"
-                    f" {attention_mask.size()}"
-                )
-            attn_weights = attn_weights.view(batch_size, self.num_heads, target_len, source_len) + attention_mask
-            attn_weights = attn_weights.view(batch_size * self.num_heads, target_len, source_len)
-
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
-
-        if output_attentions:
-            # this operation is a bit awkward, but it's required to
-            # make sure that attn_weights keeps its gradient.
-            # In order to do so, attn_weights have to reshaped
-            # twice and have to be reused in the following
-            attn_weights_reshaped = attn_weights.view(batch_size, self.num_heads, target_len, source_len)
-            attn_weights = attn_weights_reshaped.view(batch_size * self.num_heads, target_len, source_len)
-        else:
-            attn_weights_reshaped = None
-
-        attn_probs = nn.functional.dropout(attn_weights, p=self.dropout, training=self.training)
-
-        attn_output = torch.bmm(attn_probs, value_states)
-
-        if attn_output.size() != (batch_size * self.num_heads, target_len, self.head_dim):
-            raise ValueError(
-                f"`attn_output` should be of size {(batch_size, self.num_heads, target_len, self.head_dim)}, but is"
-                f" {attn_output.size()}"
-            )
-
-        attn_output = attn_output.view(batch_size, self.num_heads, target_len, self.head_dim)
-        attn_output = attn_output.transpose(1, 2)
-        attn_output = attn_output.reshape(batch_size, target_len, embed_dim)
-
-        attn_output = self.out_proj(attn_output)
-
-        return attn_output, attn_weights_reshaped
-
-
-class RTDetrV2DecoderLayer(nn.Module):
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__()
-        # self-attention
-        self.self_attn = RTDetrV2MultiheadAttention(
-            embed_dim=config.d_model,
-            num_heads=config.decoder_attention_heads,
-            dropout=config.attention_dropout,
-        )
-        self.dropout = config.dropout
-        self.activation_fn = ACT2FN[config.decoder_activation_function]
-        self.activation_dropout = config.activation_dropout
-
-        self.self_attn_layer_norm = nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
-        # override only the encoder attention module with v2 version
-        self.encoder_attn = RTDetrV2MultiscaleDeformableAttention(
-            config, num_heads=config.decoder_attention_heads, num_points=config.decoder_n_points
-        )
-        self.encoder_attn_layer_norm = nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
-        # feedforward neural networks
-        self.fc1 = nn.Linear(config.d_model, config.decoder_ffn_dim)
-        self.fc2 = nn.Linear(config.decoder_ffn_dim, config.d_model)
-        self.final_layer_norm = nn.LayerNorm(config.d_model, eps=config.layer_norm_eps)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        position_embeddings: Optional[torch.Tensor] = None,
-        reference_points=None,
-        spatial_shapes=None,
-        spatial_shapes_list=None,
-        level_start_index=None,
-        encoder_hidden_states: Optional[torch.Tensor] = None,
-        encoder_attention_mask: Optional[torch.Tensor] = None,
-        output_attentions: Optional[bool] = False,
-    ):
-        """
-        Args:
-            hidden_states (`torch.FloatTensor`):
-                Input to the layer of shape `(seq_len, batch, embed_dim)`.
-            position_embeddings (`torch.FloatTensor`, *optional*):
-                Position embeddings that are added to the queries and keys in the self-attention layer.
-            reference_points (`torch.FloatTensor`, *optional*):
-                Reference points.
-            spatial_shapes (`torch.LongTensor`, *optional*):
-                Spatial shapes.
-            level_start_index (`torch.LongTensor`, *optional*):
-                Level start index.
-            encoder_hidden_states (`torch.FloatTensor`):
-                cross attention input to the layer of shape `(seq_len, batch, embed_dim)`
-            encoder_attention_mask (`torch.FloatTensor`): encoder attention mask of size
-                `(batch, 1, target_len, source_len)` where padding elements are indicated by very large negative
-                values.
-            output_attentions (`bool`, *optional*):
-                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
-                returned tensors for more detail.
-        """
-        residual = hidden_states
-
-        # Self Attention
-        hidden_states, self_attn_weights = self.self_attn(
-            hidden_states=hidden_states,
-            attention_mask=encoder_attention_mask,
-            position_embeddings=position_embeddings,
-            output_attentions=output_attentions,
-        )
-
-        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = residual + hidden_states
-        hidden_states = self.self_attn_layer_norm(hidden_states)
-
-        second_residual = hidden_states
-
-        # Cross-Attention
-        cross_attn_weights = None
-        hidden_states, cross_attn_weights = self.encoder_attn(
-            hidden_states=hidden_states,
-            encoder_hidden_states=encoder_hidden_states,
-            position_embeddings=position_embeddings,
-            reference_points=reference_points,
-            spatial_shapes=spatial_shapes,
-            spatial_shapes_list=spatial_shapes_list,
-            output_attentions=output_attentions,
-        )
-
-        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = second_residual + hidden_states
-
-        hidden_states = self.encoder_attn_layer_norm(hidden_states)
-
-        # Fully Connected
-        residual = hidden_states
-        hidden_states = self.activation_fn(self.fc1(hidden_states))
-        hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
-        hidden_states = self.fc2(hidden_states)
-        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-        hidden_states = residual + hidden_states
-        hidden_states = self.final_layer_norm(hidden_states)
-
-        outputs = (hidden_states,)
-
-        if output_attentions:
-            outputs += (self_attn_weights, cross_attn_weights)
-
-        return outputs
 
 
 @dataclass
@@ -473,35 +382,32 @@ class RTDetrV2DecoderOutput(ModelOutput):
     - a stacked tensor of intermediate reference points.
 
     Args:
-        last_hidden_state (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
-            Sequence of hidden-states at the output of the last layer of the model.
-        intermediate_hidden_states (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, hidden_size)`):
-            Stacked intermediate hidden states (output of each layer of the decoder).
-        intermediate_logits (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, sequence_length, config.num_labels)`):
-            Stacked intermediate logits (logits of each layer of the decoder).
-        intermediate_reference_points (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, sequence_length, hidden_size)`):
-            Stacked intermediate reference points (reference points of each layer of the decoder).
-        hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
-            Tuple of `torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer) of
+        class_outputs (`torch.Tensor` of shape `(batch_size, config.decoder_layers, sequence_length, config.num_labels)`):
+            Stacked class head outputs of each layer of the decoder.
+        bbox_outputs (`torch.Tensor` of shape `(batch_size, config.decoder_layers, sequence_length, 4)`):
+            Stacked bbox head outputs of each layer of the decoder.
+        last_hidden_state (`torch.Tensor` of shape `(batch_size, sequence_length, hidden_size)`):
+            The last hidden state of the decoder.
+        hidden_states (`tuple(torch.Tensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple of `torch.Tensor` (one for the output of the embeddings + one for the output of each layer) of
             shape `(batch_size, sequence_length, hidden_size)`. Hidden-states of the model at the output of each layer
             plus the initial embedding outputs.
-        attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
-            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
+        attentions (`tuple(torch.Tensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
+            Tuple of `torch.Tensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
             sequence_length)`. Attentions weights after the attention softmax, used to compute the weighted average in
             the self-attention heads.
-        cross_attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` and `config.add_cross_attention=True` is passed or when `config.output_attentions=True`):
-            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
+        cross_attentions (`tuple(torch.Tensor)`, *optional*, returned when `output_attentions=True` and `config.add_cross_attention=True` is passed or when `config.output_attentions=True`):
+            Tuple of `torch.Tensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
             sequence_length)`. Attentions weights of the decoder's cross-attention layer, after the attention softmax,
             used to compute the weighted average in the cross-attention heads.
     """
 
-    last_hidden_state: torch.FloatTensor = None
-    intermediate_hidden_states: torch.FloatTensor = None
-    intermediate_logits: torch.FloatTensor = None
-    intermediate_reference_points: torch.FloatTensor = None
-    hidden_states: Optional[Tuple[torch.FloatTensor]] = None
-    attentions: Optional[Tuple[torch.FloatTensor]] = None
-    cross_attentions: Optional[Tuple[torch.FloatTensor]] = None
+    last_hidden_state: torch.Tensor = None
+    class_outputs: Optional[torch.Tensor] = None
+    bbox_outputs: Optional[torch.Tensor] = None
+    hidden_states: Optional[Tuple[torch.Tensor]] = None
+    self_attentions: Optional[Tuple[torch.Tensor]] = None
+    cross_attentions: Optional[Tuple[torch.Tensor]] = None
 
 
 @dataclass
@@ -512,12 +418,10 @@ class RTDetrV2ModelOutput(ModelOutput):
     Args:
         last_hidden_state (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the decoder of the model.
-        intermediate_hidden_states (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, hidden_size)`):
-            Stacked intermediate hidden states (output of each layer of the decoder).
-        intermediate_logits (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, sequence_length, config.num_labels)`):
-            Stacked intermediate logits (logits of each layer of the decoder).
-        intermediate_reference_points (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, 4)`):
-            Stacked intermediate reference points (reference points of each layer of the decoder).
+        class_outputs (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, sequence_length, config.num_labels)`):
+            Stacked class head outputs of each layer of the decoder.
+        bbox_outputs (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, 4)`):
+            Stacked bbox head outputs of each layer of the decoder.
         decoder_hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple of `torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer) of
             shape `(batch_size, num_queries, hidden_size)`. Hidden-states of the decoder at the output of each layer
@@ -540,39 +444,27 @@ class RTDetrV2ModelOutput(ModelOutput):
             Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_queries, num_heads, 4, 4)`.
             Attentions weights of the encoder, after the attention softmax, used to compute the weighted average in the
             self-attention heads.
-        init_reference_points (`torch.FloatTensor` of shape  `(batch_size, num_queries, 4)`):
-            Initial reference points sent through the Transformer decoder.
         enc_topk_logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.num_labels)`):
             Predicted bounding boxes scores where the top `config.two_stage_num_proposals` scoring bounding boxes are
             picked as region proposals in the encoder stage. Output of bounding box binary classification (i.e.
             foreground and background).
         enc_topk_bboxes (`torch.FloatTensor` of shape `(batch_size, sequence_length, 4)`):
             Logits of predicted bounding boxes coordinates in the encoder stage.
-        enc_outputs_class (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.num_labels)`, *optional*, returned when `config.with_box_refine=True` and `config.two_stage=True`):
-            Predicted bounding boxes scores where the top `config.two_stage_num_proposals` scoring bounding boxes are
-            picked as region proposals in the first stage. Output of bounding box binary classification (i.e.
-            foreground and background).
-        enc_outputs_coord_logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, 4)`, *optional*, returned when `config.with_box_refine=True` and `config.two_stage=True`):
-            Logits of predicted bounding boxes coordinates in the first stage.
         denoising_meta_values (`dict`):
             Extra dictionary for the denoising related values
     """
 
     last_hidden_state: torch.FloatTensor = None
-    intermediate_hidden_states: torch.FloatTensor = None
-    intermediate_logits: torch.FloatTensor = None
-    intermediate_reference_points: torch.FloatTensor = None
+    class_outputs: torch.FloatTensor = None
+    bbox_outputs: torch.FloatTensor = None
     decoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
     decoder_attentions: Optional[Tuple[torch.FloatTensor]] = None
     cross_attentions: Optional[Tuple[torch.FloatTensor]] = None
     encoder_last_hidden_state: Optional[torch.FloatTensor] = None
     encoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
     encoder_attentions: Optional[Tuple[torch.FloatTensor]] = None
-    init_reference_points: torch.FloatTensor = None
     enc_topk_logits: Optional[torch.FloatTensor] = None
     enc_topk_bboxes: Optional[torch.FloatTensor] = None
-    enc_outputs_class: Optional[torch.FloatTensor] = None
-    enc_outputs_coord_logits: Optional[torch.FloatTensor] = None
     denoising_meta_values: Optional[Dict] = None
 
 
@@ -601,12 +493,10 @@ class RTDetrV2ObjectDetectionOutput(ModelOutput):
             `pred_boxes`) for each decoder layer.
         last_hidden_state (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`):
             Sequence of hidden-states at the output of the last layer of the decoder of the model.
-        intermediate_hidden_states (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, hidden_size)`):
-            Stacked intermediate hidden states (output of each layer of the decoder).
-        intermediate_logits (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, config.num_labels)`):
-            Stacked intermediate logits (logits of each layer of the decoder).
-        intermediate_reference_points (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, 4)`):
-            Stacked intermediate reference points (reference points of each layer of the decoder).
+        class_outputs (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, sequence_length, config.num_labels)`):
+            Stacked class head outputs of each layer of the decoder.
+        bbox_outputs (`torch.FloatTensor` of shape `(batch_size, config.decoder_layers, num_queries, 4)`):
+            Stacked bbox head outputs of each layer of the decoder.
         decoder_hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
             Tuple of `torch.FloatTensor` (one for the output of the embeddings + one for the output of each layer) of
             shape `(batch_size, num_queries, hidden_size)`. Hidden-states of the decoder at the output of each layer
@@ -629,18 +519,10 @@ class RTDetrV2ObjectDetectionOutput(ModelOutput):
             Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_queries, num_heads, 4, 4)`.
             Attentions weights of the encoder, after the attention softmax, used to compute the weighted average in the
             self-attention heads.
-        init_reference_points (`torch.FloatTensor` of shape  `(batch_size, num_queries, 4)`):
-            Initial reference points sent through the Transformer decoder.
         enc_topk_logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.num_labels)`, *optional*, returned when `config.with_box_refine=True` and `config.two_stage=True`):
             Logits of predicted bounding boxes coordinates in the encoder.
         enc_topk_bboxes (`torch.FloatTensor` of shape `(batch_size, sequence_length, 4)`, *optional*, returned when `config.with_box_refine=True` and `config.two_stage=True`):
             Logits of predicted bounding boxes coordinates in the encoder.
-        enc_outputs_class (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.num_labels)`, *optional*, returned when `config.with_box_refine=True` and `config.two_stage=True`):
-            Predicted bounding boxes scores where the top `config.two_stage_num_proposals` scoring bounding boxes are
-            picked as region proposals in the first stage. Output of bounding box binary classification (i.e.
-            foreground and background).
-        enc_outputs_coord_logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, 4)`, *optional*, returned when `config.with_box_refine=True` and `config.two_stage=True`):
-            Logits of predicted bounding boxes coordinates in the first stage.
         denoising_meta_values (`dict`):
             Extra dictionary for the denoising related values
     """
@@ -651,20 +533,16 @@ class RTDetrV2ObjectDetectionOutput(ModelOutput):
     pred_boxes: torch.FloatTensor = None
     auxiliary_outputs: Optional[List[Dict]] = None
     last_hidden_state: torch.FloatTensor = None
-    intermediate_hidden_states: torch.FloatTensor = None
-    intermediate_logits: torch.FloatTensor = None
-    intermediate_reference_points: torch.FloatTensor = None
+    class_outputs: torch.FloatTensor = None
+    bbox_outputs: torch.FloatTensor = None
     decoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
     decoder_attentions: Optional[Tuple[torch.FloatTensor]] = None
     cross_attentions: Optional[Tuple[torch.FloatTensor]] = None
     encoder_last_hidden_state: Optional[torch.FloatTensor] = None
     encoder_hidden_states: Optional[Tuple[torch.FloatTensor]] = None
     encoder_attentions: Optional[Tuple[torch.FloatTensor]] = None
-    init_reference_points: Optional[Tuple[torch.FloatTensor]] = None
     enc_topk_logits: Optional[torch.FloatTensor] = None
     enc_topk_bboxes: Optional[torch.FloatTensor] = None
-    enc_outputs_class: Optional[torch.FloatTensor] = None
-    enc_outputs_coord_logits: Optional[torch.FloatTensor] = None
     denoising_meta_values: Optional[Dict] = None
 
 
@@ -676,12 +554,13 @@ class RTDetrV2FrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -694,17 +573,15 @@ class RTDetrV2FrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 def replace_batch_norm(model):
@@ -739,32 +616,32 @@ class RTDetrV2ConvEncoder(nn.Module):
     https://github.com/lyuwenyu/RT-DETR/blob/main/RTDetrV2_pytorch/src/nn/backbone/presnet.py#L142
     """
 
-    def __init__(self, config):
+    def __init__(self, config: RTDetrV2Config):
         super().__init__()
 
-        backbone = load_backbone(config)
-
-        if config.freeze_backbone_batch_norms:
-            # replace batch norm by frozen batch norm
-            with torch.no_grad():
-                replace_batch_norm(backbone)
-        self.model = backbone
+        self.model = load_backbone(config)
         self.intermediate_channel_sizes = self.model.channels
 
-    def forward(self, pixel_values: torch.Tensor, pixel_mask: torch.Tensor):
-        # send pixel_values through the model to get list of feature maps
-        features = self.model(pixel_values).feature_maps
+        # replace batch norm by frozen batch norm
+        if config.freeze_backbone_batch_norms:
+            replace_batch_norm(self.model)
 
-        out = []
-        for feature_map in features:
-            # downsample pixel_mask to match shape of corresponding feature_map
-            mask = nn.functional.interpolate(pixel_mask[None].float(), size=feature_map.shape[-2:]).to(torch.bool)[0]
-            out.append((feature_map, mask))
-        return out
+    def forward(self, pixel_values: torch.Tensor) -> List[torch.Tensor]:
+        feature_maps = self.model(pixel_values).feature_maps
+        return feature_maps
 
 
 class RTDetrV2ConvNormLayer(nn.Module):
-    def __init__(self, config, in_channels, out_channels, kernel_size, stride, padding=None, activation=None):
+    def __init__(
+        self,
+        config: RTDetrV2Config,
+        in_channels: int,
+        out_channels: int,
+        kernel_size: int,
+        stride: int,
+        padding: Optional[int] = None,
+        activation: Optional[str] = None,
+    ):
         super().__init__()
         self.conv = nn.Conv2d(
             in_channels,
@@ -775,13 +652,166 @@ class RTDetrV2ConvNormLayer(nn.Module):
             bias=False,
         )
         self.norm = nn.BatchNorm2d(out_channels, config.batch_norm_eps)
-        self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
+        self.activation = ACT2FN[activation] if activation is not None else nn.Identity()
 
-    def forward(self, hidden_state):
-        hidden_state = self.conv(hidden_state)
-        hidden_state = self.norm(hidden_state)
-        hidden_state = self.activation(hidden_state)
-        return hidden_state
+    def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Feature map of shape (batch_size, embed_dim, height, width)"""
+        feature_map = self.conv(feature_map)
+        feature_map = self.norm(feature_map)
+        feature_map = self.activation(feature_map)
+        return feature_map
+
+
+class RTDetrV2RepVggBlock(nn.Module):
+    """
+    RepVGG architecture block introduced by the work "RepVGG: Making VGG-style ConvNets Great Again".
+    """
+
+    def __init__(self, config: RTDetrV2Config):
+        super().__init__()
+
+        activation = config.activation_function
+        hidden_channels = int(config.encoder_hidden_dim * config.hidden_expansion)
+        self.conv1 = RTDetrV2ConvNormLayer(
+            config, hidden_channels, hidden_channels, kernel_size=3, stride=1, padding=1
+        )
+        self.conv2 = RTDetrV2ConvNormLayer(
+            config, hidden_channels, hidden_channels, kernel_size=1, stride=1, padding=0
+        )
+        self.activation = ACT2FN[activation] if activation is not None else nn.Identity()
+
+    def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Feature map of shape (batch_size, embed_dim, height, width)"""
+        feature_map = self.conv1(feature_map) + self.conv2(feature_map)
+        return self.activation(feature_map)
+
+
+class RTDetrV2CSPRepLayer(nn.Module):
+    """
+    Cross Stage Partial (CSP) network layer with RepVGG blocks.
+    """
+
+    def __init__(self, config: RTDetrV2Config):
+        super().__init__()
+
+        in_channels = config.encoder_hidden_dim * 2
+        out_channels = config.encoder_hidden_dim
+        hidden_channels = int(out_channels * config.hidden_expansion)
+        params = {"kernel_size": 1, "stride": 1, "activation": config.activation_function}
+
+        # branch 1
+        self.conv1 = RTDetrV2ConvNormLayer(config, in_channels, hidden_channels, **params)
+        self.bottlenecks = nn.Sequential(*[RTDetrV2RepVggBlock(config) for _ in range(3)])
+
+        # branch 2
+        self.conv2 = RTDetrV2ConvNormLayer(config, in_channels, hidden_channels, **params)
+
+        # fuse step
+        if hidden_channels != out_channels:
+            self.conv3 = RTDetrV2ConvNormLayer(config, hidden_channels, out_channels, **params)
+        else:
+            self.conv3 = nn.Identity()
+
+    def forward(self, feature_map: torch.Tensor) -> torch.Tensor:
+        """Feature map of shape (batch_size, embed_dim, height, width)"""
+
+        # branch 1
+        feature_map_1 = self.conv1(feature_map)
+        feature_map_1 = self.bottlenecks(feature_map_1)
+
+        # branch 2
+        feature_map_2 = self.conv2(feature_map)
+
+        # fuse step
+        feature_map = self.conv3(feature_map_1 + feature_map_2)
+
+        return feature_map
+
+
+class RTDetrV2MultiheadAttention(nn.Module):
+    """
+    Multi-headed attention from 'Attention Is All You Need' paper.
+
+    Here, we add position embeddings to the queries and keys (as explained in the Deformable DETR paper).
+    """
+
+    def __init__(
+        self,
+        embed_dim: int,
+        num_heads: int,
+        dropout: float = 0.0,
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.embed_dim = embed_dim
+        self.num_heads = num_heads
+        self.dropout = dropout
+        self.head_dim = embed_dim // num_heads
+        self.scaling = self.head_dim**-0.5
+
+        if self.head_dim * num_heads != self.embed_dim:
+            raise ValueError(
+                f"embed_dim must be divisible by num_heads (got `embed_dim`: {self.embed_dim} and `num_heads`:"
+                f" {num_heads})."
+            )
+
+        self.k_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.v_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.q_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+        self.out_proj = nn.Linear(embed_dim, embed_dim, bias=bias)
+
+    def _reshape_for_multihead_attention(self, tensor: torch.Tensor):
+        """Reshape tensor (batch_size, seq_length, embed_dim) to (batch_size, num_heads, seq_length, head_dim)"""
+        batch_size, seq_length, _ = tensor.shape
+        tensor = tensor.view(batch_size, seq_length, self.num_heads, self.head_dim)
+        tensor = tensor.transpose(1, 2).contiguous()
+        return tensor
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[torch.Tensor] = None,
+        output_attentions: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+        batch_size, seq_length, embed_dim = hidden_states.shape
+        query_states, key_states, value_states = hidden_states, hidden_states, hidden_states
+
+        if position_embeddings is not None:
+            query_states = query_states + position_embeddings
+            key_states = query_states  # avoid recomputing, they are the same
+
+        # Apply projection and scaling
+        query_states = self.q_proj(query_states) * self.scaling
+        key_states = self.k_proj(key_states)
+        value_states = self.v_proj(value_states)
+
+        # (batch_size, seq_length, embed_dim) -> (batch_size, num_heads, seq_length, head_dim)
+        query_states = self._reshape_for_multihead_attention(query_states)
+        key_states = self._reshape_for_multihead_attention(key_states)
+        value_states = self._reshape_for_multihead_attention(value_states)
+
+        # Compute attention weights
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3))
+
+        if attention_mask is not None:
+            attention_mask = attention_mask.expand(batch_size, self.num_heads, seq_length, seq_length)
+            attn_weights = attn_weights + attention_mask
+
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+        attn_weights = nn.functional.dropout(attn_weights, p=self.dropout, training=self.training)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        # Reshape back to original shape
+        attn_output = attn_output.transpose(1, 2)
+        attn_output = attn_output.reshape(batch_size, seq_length, embed_dim)
+
+        attn_output = self.out_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights
 
 
 class RTDetrV2EncoderLayer(nn.Module):
@@ -795,139 +825,97 @@ class RTDetrV2EncoderLayer(nn.Module):
             num_heads=config.num_attention_heads,
             dropout=config.dropout,
         )
-        self.self_attn_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
-        self.dropout = config.dropout
-        self.activation_fn = ACT2FN[config.encoder_activation_function]
-        self.activation_dropout = config.activation_dropout
+        self.self_attn_dropout = nn.Dropout(config.dropout)
+
+        # feed-forward
         self.fc1 = nn.Linear(config.encoder_hidden_dim, config.encoder_ffn_dim)
+        self.fc1_activation = ACT2FN[config.encoder_activation_function]
+        self.fc1_dropout = nn.Dropout(config.activation_dropout)
         self.fc2 = nn.Linear(config.encoder_ffn_dim, config.encoder_hidden_dim)
+        self.fc2_dropout = nn.Dropout(config.dropout)
+
+        # norms
+        self.identity = nn.Identity()
+        self.self_attn_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
         self.final_layer_norm = nn.LayerNorm(config.encoder_hidden_dim, eps=config.layer_norm_eps)
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         attention_mask: torch.Tensor,
-        position_embeddings: torch.Tensor = None,
+        position_embeddings: Optional[torch.Tensor] = None,
         output_attentions: bool = False,
-        **kwargs,
     ):
         """
         Args:
-            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
-            attention_mask (`torch.FloatTensor`): attention mask of size
+            hidden_states (`torch.Tensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.Tensor`): attention mask of size
                 `(batch, 1, target_len, source_len)` where padding elements are indicated by very large negative
                 values.
-            position_embeddings (`torch.FloatTensor`, *optional*):
+            position_embeddings (`torch.Tensor`, *optional*):
                 Object queries (also called content embeddings), to be added to the hidden states.
-            output_attentions (`bool`, *optional*):
+            output_attentions (`bool`, defaults to `False`):
                 Whether or not to return the attentions tensors of all attention layers. See `attentions` under
                 returned tensors for more detail.
         """
-        residual = hidden_states
         if self.normalize_before:
-            hidden_states = self.self_attn_layer_norm(hidden_states)
+            norm1 = self.self_attn_layer_norm
+            norm2 = self.final_layer_norm
+            norm3 = self.identity
+        else:
+            norm1 = self.identity
+            norm2 = self.self_attn_layer_norm
+            norm3 = self.final_layer_norm
 
+        # self-attention step
+        residual = hidden_states
+        hidden_states = norm1(hidden_states)
         hidden_states, attn_weights = self.self_attn(
             hidden_states=hidden_states,
             attention_mask=attention_mask,
             position_embeddings=position_embeddings,
             output_attentions=output_attentions,
         )
-
-        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
+        hidden_states = self.self_attn_dropout(hidden_states)
         hidden_states = residual + hidden_states
-        if not self.normalize_before:
-            hidden_states = self.self_attn_layer_norm(hidden_states)
+        hidden_states = norm2(hidden_states)
 
-        if self.normalize_before:
-            hidden_states = self.final_layer_norm(hidden_states)
+        # feed-forward step
         residual = hidden_states
-
-        hidden_states = self.activation_fn(self.fc1(hidden_states))
-        hidden_states = nn.functional.dropout(hidden_states, p=self.activation_dropout, training=self.training)
-
+        hidden_states = self.fc1(hidden_states)
+        hidden_states = self.fc1_activation(hidden_states)
+        hidden_states = self.fc1_dropout(hidden_states)
         hidden_states = self.fc2(hidden_states)
-
-        hidden_states = nn.functional.dropout(hidden_states, p=self.dropout, training=self.training)
-
+        hidden_states = self.fc2_dropout(hidden_states)
         hidden_states = residual + hidden_states
-        if not self.normalize_before:
-            hidden_states = self.final_layer_norm(hidden_states)
+        hidden_states = norm3(hidden_states)
 
+        # clamp values if training
         if self.training:
             if torch.isinf(hidden_states).any() or torch.isnan(hidden_states).any():
                 clamp_value = torch.finfo(hidden_states.dtype).max - 1000
                 hidden_states = torch.clamp(hidden_states, min=-clamp_value, max=clamp_value)
 
-        outputs = (hidden_states,)
-
-        if output_attentions:
-            outputs += (attn_weights,)
-
-        return outputs
-
-
-class RTDetrV2RepVggBlock(nn.Module):
-    """
-    RepVGG architecture block introduced by the work "RepVGG: Making VGG-style ConvNets Great Again".
-    """
-
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__()
-
-        activation = config.activation_function
-        hidden_channels = int(config.encoder_hidden_dim * config.hidden_expansion)
-        self.conv1 = RTDetrV2ConvNormLayer(config, hidden_channels, hidden_channels, 3, 1, padding=1)
-        self.conv2 = RTDetrV2ConvNormLayer(config, hidden_channels, hidden_channels, 1, 1, padding=0)
-        self.activation = nn.Identity() if activation is None else ACT2CLS[activation]()
-
-    def forward(self, x):
-        y = self.conv1(x) + self.conv2(x)
-        return self.activation(y)
-
-
-class RTDetrV2CSPRepLayer(nn.Module):
-    """
-    Cross Stage Partial (CSP) network layer with RepVGG blocks.
-    """
-
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__()
-
-        in_channels = config.encoder_hidden_dim * 2
-        out_channels = config.encoder_hidden_dim
-        num_blocks = 3
-        activation = config.activation_function
-
-        hidden_channels = int(out_channels * config.hidden_expansion)
-        self.conv1 = RTDetrV2ConvNormLayer(config, in_channels, hidden_channels, 1, 1, activation=activation)
-        self.conv2 = RTDetrV2ConvNormLayer(config, in_channels, hidden_channels, 1, 1, activation=activation)
-        self.bottlenecks = nn.Sequential(*[RTDetrV2RepVggBlock(config) for _ in range(num_blocks)])
-        if hidden_channels != out_channels:
-            self.conv3 = RTDetrV2ConvNormLayer(config, hidden_channels, out_channels, 1, 1, activation=activation)
-        else:
-            self.conv3 = nn.Identity()
-
-    def forward(self, hidden_state):
-        hidden_state_1 = self.conv1(hidden_state)
-        hidden_state_1 = self.bottlenecks(hidden_state_1)
-        hidden_state_2 = self.conv2(hidden_state)
-        return self.conv3(hidden_state_1 + hidden_state_2)
+        return hidden_states, attn_weights
 
 
 class RTDetrV2Encoder(nn.Module):
     def __init__(self, config: RTDetrV2Config):
         super().__init__()
-
         self.layers = nn.ModuleList([RTDetrV2EncoderLayer(config) for _ in range(config.encoder_layers)])
 
-    def forward(self, src, src_mask=None, pos_embed=None, output_attentions: bool = False) -> torch.Tensor:
-        hidden_states = src
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_embeddings: Optional[torch.Tensor] = None,
+        output_attentions: bool = False,
+    ) -> torch.Tensor:
         for layer in self.layers:
             hidden_states = layer(
-                hidden_states,
-                attention_mask=src_mask,
-                position_embeddings=pos_embed,
+                hidden_states=hidden_states,
+                attention_mask=attention_mask,
+                position_embeddings=position_embeddings,
                 output_attentions=output_attentions,
             )
         return hidden_states
@@ -958,7 +946,7 @@ class RTDetrV2HybridEncoder(nn.Module):
         activation = config.activation_function
 
         # encoder transformer
-        self.encoder = nn.ModuleList([RTDetrV2Encoder(config) for _ in range(len(self.encode_proj_layers))])
+        self.encoder = nn.ModuleList([RTDetrV2Encoder(config) for _ in self.encode_proj_layers])
 
         # top-down FPN
         self.lateral_convs = nn.ModuleList()
@@ -992,15 +980,16 @@ class RTDetrV2HybridEncoder(nn.Module):
             self.downsample_convs.append(downsample_conv)
             self.pan_blocks.append(pan_block)
 
-    @staticmethod
+    @compile_compatible_method_lru_cache(maxsize=32)
     def build_2d_sincos_position_embedding(
-        width, height, embed_dim=256, temperature=10000.0, device="cpu", dtype=torch.float32
+        self, width, height, embed_dim=256, temperature=10000.0, device="cpu", dtype=torch.float32
     ):
         grid_w = torch.arange(torch_int(width), device=device).to(dtype)
         grid_h = torch.arange(torch_int(height), device=device).to(dtype)
         grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
         if embed_dim % 4 != 0:
             raise ValueError("Embed dimension must be divisible by 4 for 2D sin-cos position embedding")
+
         pos_dim = embed_dim // 4
         omega = torch.arange(pos_dim, device=device).to(dtype) / pos_dim
         omega = 1.0 / (temperature**omega)
@@ -1012,92 +1001,72 @@ class RTDetrV2HybridEncoder(nn.Module):
 
     def forward(
         self,
-        inputs_embeds=None,
-        attention_mask=None,
-        position_embeddings=None,
-        spatial_shapes=None,
-        level_start_index=None,
-        valid_ratios=None,
-        output_attentions=None,
-        output_hidden_states=None,
-        return_dict=None,
+        feature_maps: List[torch.Tensor],
+        output_hidden_states: bool = False,
+        output_attentions: bool = False,
     ):
         r"""
+        Apply the transformer encoder to the feature maps. Then apply the FPN and PAN to the feature maps.
+
         Args:
-            inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
-                Flattened feature map (output of the backbone + projection layer) that is passed to the encoder.
-            attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
-                Mask to avoid performing attention on padding pixel features. Mask values selected in `[0, 1]`:
-                - 1 for pixel features that are real (i.e. **not masked**),
-                - 0 for pixel features that are padding (i.e. **masked**).
-                [What are attention masks?](../glossary#attention-mask)
-            position_embeddings (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`):
-                Position embeddings that are added to the queries and keys in each self-attention layer.
-            spatial_shapes (`torch.LongTensor` of shape `(num_feature_levels, 2)`):
-                Spatial shapes of each feature map.
-            level_start_index (`torch.LongTensor` of shape `(num_feature_levels)`):
-                Starting index of each feature map.
-            valid_ratios (`torch.FloatTensor` of shape `(batch_size, num_feature_levels, 2)`):
-                Ratio of valid area in each feature level.
-            output_attentions (`bool`, *optional*):
-                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
-                returned tensors for more detail.
-            output_hidden_states (`bool`, *optional*):
+            feature_maps (`List[torch.FloatTensor]` of shape `(batch_size, embed_dim, height, width)`):
+                List of feature maps from different stages of the backbone. For example, for RT-DETR-R50
+                `[torch.Size([1, 256, 80, 80]), torch.Size([1, 256, 40, 40]), torch.Size([1, 256, 20, 20])]`.
+            output_hidden_states (`bool`, default `False`):
                 Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
                 for more detail.
-            return_dict (`bool`, *optional*):
-                Whether or not to return a [`~file_utils.ModelOutput`] instead of a plain tuple.
+            output_attentions (`bool`, default `False`):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
         """
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        hidden_states = inputs_embeds
+        encoder_intermediates = () if output_hidden_states else None
+        encoder_attentions = () if output_attentions else None
 
-        encoder_states = () if output_hidden_states else None
-        all_attentions = () if output_attentions else None
-
-        # encoder
-        if self.config.encoder_layers > 0:
-            for i, enc_ind in enumerate(self.encode_proj_layers):
-                if output_hidden_states:
-                    encoder_states = encoder_states + (hidden_states[enc_ind],)
-                height, width = hidden_states[enc_ind].shape[2:]
-                # flatten [batch, channel, height, width] to [batch, height*width, channel]
-                src_flatten = hidden_states[enc_ind].flatten(2).permute(0, 2, 1)
-                if self.training or self.eval_size is None:
-                    pos_embed = self.build_2d_sincos_position_embedding(
-                        width,
-                        height,
-                        self.encoder_hidden_dim,
-                        self.positional_encoding_temperature,
-                        device=src_flatten.device,
-                        dtype=src_flatten.dtype,
-                    )
-                else:
-                    pos_embed = None
-
-                layer_outputs = self.encoder[i](
-                    src_flatten,
-                    pos_embed=pos_embed,
-                    output_attentions=output_attentions,
-                )
-                hidden_states[enc_ind] = (
-                    layer_outputs[0].permute(0, 2, 1).reshape(-1, self.encoder_hidden_dim, height, width).contiguous()
-                )
-
-                if output_attentions:
-                    all_attentions = all_attentions + (layer_outputs[1],)
+        # Step 1: Apply transformer encoder
+        for i, feature_map_idx in enumerate(self.encode_proj_layers):
+            feature_map = feature_maps[feature_map_idx]
 
             if output_hidden_states:
-                encoder_states = encoder_states + (hidden_states[enc_ind],)
+                encoder_intermediates = encoder_intermediates + (feature_map,)
 
-        # top-down FPN
-        fpn_feature_maps = [hidden_states[-1]]
+            # 1. flatten [batch, channel, height, width] to [batch, height * width, channel]
+            height, width = feature_map.shape[2:]
+            hidden_state = feature_map.flatten(2).permute(0, 2, 1)
+
+            # build position embeddings
+            position_embeddings = self.build_2d_sincos_position_embedding(
+                width,
+                height,
+                self.encoder_hidden_dim,
+                self.positional_encoding_temperature,
+                device=hidden_state.device,
+                dtype=hidden_state.dtype,
+            )
+
+            # 2. Apply transformer encoder layer
+            layer_outputs = self.encoder[i](
+                hidden_state,
+                position_embeddings=position_embeddings,
+                output_attentions=output_attentions,
+            )
+            hidden_state = layer_outputs[0]
+
+            # 3. Reshape back to [batch, height, width, channel]
+            hidden_state = hidden_state.permute(0, 2, 1)
+            feature_map = hidden_state.reshape(-1, self.encoder_hidden_dim, height, width)
+            feature_maps[feature_map_idx] = feature_map.contiguous()
+
+            if output_attentions:
+                encoder_attentions += (layer_outputs[1],)
+
+        if output_hidden_states:
+            encoder_intermediates += (feature_maps[feature_map_idx],)
+
+        # Step 2: Apply FPN (conv part)
+        fpn_feature_maps = [feature_maps[-1]]
         for idx, (lateral_conv, fpn_block) in enumerate(zip(self.lateral_convs, self.fpn_blocks)):
-            backbone_feature_map = hidden_states[self.num_fpn_stages - idx - 1]
+            backbone_feature_map = feature_maps[self.num_fpn_stages - idx - 1]
             top_fpn_feature_map = fpn_feature_maps[-1]
             # apply lateral block
             top_fpn_feature_map = lateral_conv(top_fpn_feature_map)
@@ -1110,7 +1079,7 @@ class RTDetrV2HybridEncoder(nn.Module):
 
         fpn_feature_maps = fpn_feature_maps[::-1]
 
-        # bottom-up PAN
+        # Step 3: Apply PAN (conv part)
         pan_feature_maps = [fpn_feature_maps[0]]
         for idx, (downsample_conv, pan_block) in enumerate(zip(self.downsample_convs, self.pan_blocks)):
             top_pan_feature_map = pan_feature_maps[-1]
@@ -1120,11 +1089,143 @@ class RTDetrV2HybridEncoder(nn.Module):
             new_pan_feature_map = pan_block(fused_feature_map)
             pan_feature_maps.append(new_pan_feature_map)
 
-        if not return_dict:
-            return tuple(v for v in [pan_feature_maps, encoder_states, all_attentions] if v is not None)
-        return BaseModelOutput(
-            last_hidden_state=pan_feature_maps, hidden_states=encoder_states, attentions=all_attentions
+        return pan_feature_maps, encoder_intermediates, encoder_attentions
+
+
+class RTDetrV2DecoderLayer(nn.Module):
+    def __init__(self, config: RTDetrV2Config):
+        super().__init__()
+
+        self.dropout = config.dropout
+        self.activation_dropout = config.activation_dropout
+
+        # Self-Attention
+        self.self_attn = RTDetrV2MultiheadAttention(
+            embed_dim=config.hidden_size,
+            num_heads=config.decoder_attention_heads,
+            dropout=config.attention_dropout,
         )
+        self.self_attn_dropout = nn.Dropout(config.dropout)
+        self.self_attn_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+        # Cross-Attention
+        self.encoder_attn = RTDetrV2MultiscaleDeformableAttention(
+            config,
+            num_heads=config.decoder_attention_heads,
+            num_points=config.decoder_n_points,
+        )
+        self.encoder_attn_dropout = nn.Dropout(config.dropout)
+        self.encoder_attn_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+        # Feedforward
+        self.fc1 = nn.Linear(config.hidden_size, config.decoder_ffn_dim)
+        self.fc1_activation = ACT2FN[config.decoder_activation_function]
+        self.fc1_dropout = nn.Dropout(config.activation_dropout)
+        self.fc2 = nn.Linear(config.decoder_ffn_dim, config.hidden_size)
+        self.fc2_dropout = nn.Dropout(config.dropout)
+        self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+    # TODO: rename hidden_states -> hidden_state
+    def forward(
+        self,
+        hidden_state: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        reference_points: torch.Tensor,
+        spatial_shapes: torch.Tensor,
+        spatial_shapes_list: List[Tuple[int, int]],
+        position_embeddings: Optional[torch.Tensor] = None,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        output_attentions: bool = False,
+    ):
+        """
+        Args:
+            hidden_state (`torch.Tensor`):
+                Input to the layer of shape `(batch_size, num_queries, hidden_size)`.
+            encoder_hidden_states (`torch.Tensor`):
+                Flattened and concatenated encoder feature maps of shape `(batch_size, sequence_length, hidden_size)`.
+                Where `sequence_length` is the sum of the product of all spatial shapes of the encoder feature maps.
+                For example, spatial_shapes = [(80, 80), (40, 40), (20, 20)] ->
+                sequence_length = 80 * 80 + 40 * 40 + 20 * 20 = 6400 + 1600 + 400 = 8400.
+            reference_points (`torch.Tensor`, *optional*):
+                Reference points of shape `(batch_size, num_queries, 1, 2)`.
+            spatial_shapes (`torch.LongTensor`, *optional*):
+                Spatial shapes of encoder feature maps of shape `(num_feature_levels, 2)`.
+            spatial_shapes_list (`List[Tuple[int, int]]`, *optional*):
+                Spatial shapes of encoder feature maps of shape `(num_feature_levels, 2)`.
+                Same as `spatial_shapes` but as a list of tuples for `torch.compile` compatibility.
+            position_embeddings (`torch.Tensor`, *optional*):
+                Position embeddings that are added to the queries and keys in the self-attention layer of
+                shape `(batch_size, num_queries, hidden_size)`.
+            encoder_attention_mask (`torch.Tensor`):
+                4d encoder attention mask of size `(batch, 1, target_len, source_len)` where padding elements
+                are indicated by very large negative values.
+            output_attentions (`bool`, defaults to `False`):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+        """
+
+        # Self-Attention
+        self_attn_residual = hidden_state
+        hidden_state, self_attn_weights = self.self_attn(
+            hidden_states=hidden_state,
+            attention_mask=encoder_attention_mask,
+            position_embeddings=position_embeddings,
+            output_attentions=output_attentions,
+        )
+        hidden_state = self.self_attn_dropout(hidden_state)
+        hidden_state = self_attn_residual + hidden_state
+        hidden_state = self.self_attn_layer_norm(hidden_state)
+
+        # Cross-Attention
+        cross_attn_residual = hidden_state
+        hidden_state, cross_attn_weights = self.encoder_attn(
+            hidden_states=hidden_state,
+            encoder_hidden_states=encoder_hidden_states,
+            position_embeddings=position_embeddings,
+            reference_points=reference_points,
+            spatial_shapes=spatial_shapes,
+            spatial_shapes_list=spatial_shapes_list,
+            output_attentions=output_attentions,
+        )
+        hidden_state = self.encoder_attn_dropout(hidden_state)
+        hidden_state = cross_attn_residual + hidden_state
+        hidden_state = self.encoder_attn_layer_norm(hidden_state)
+
+        # Feedforward
+        ffn_residual = hidden_state
+        hidden_state = self.fc1(hidden_state)
+        hidden_state = self.fc1_activation(hidden_state)
+        hidden_state = self.fc1_dropout(hidden_state)
+        hidden_state = self.fc2(hidden_state)
+        hidden_state = self.fc2_dropout(hidden_state)
+        hidden_state = ffn_residual + hidden_state
+        hidden_state = self.final_layer_norm(hidden_state)
+
+        if not output_attentions:
+            self_attn_weights, cross_attn_weights = None, None
+
+        return hidden_state, self_attn_weights, cross_attn_weights
+
+
+class RTDetrV2MLPPredictionHead(nn.Module):
+    """
+    Very simple multi-layer perceptron (MLP, also called FFN), used to predict the normalized center coordinates,
+    height and width of a bounding box w.r.t. an image.
+    """
+
+    def __init__(self, input_dim: int, hidden_dim: int, output_dim: int, num_layers: int):
+        super().__init__()
+        self.num_layers = num_layers
+        input_dims = [input_dim] + [hidden_dim] * (num_layers - 1)
+        output_dims = [hidden_dim] * (num_layers - 1) + [output_dim]
+        self.layers = nn.ModuleList(nn.Linear(in_dim, out_dim) for in_dim, out_dim in zip(input_dims, output_dims))
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers):
+            x = layer(x)
+            if i < self.num_layers - 1:
+                x = nn.functional.relu(x)
+        return x
 
 
 def inverse_sigmoid(x, eps=1e-5):
@@ -1132,6 +1233,123 @@ def inverse_sigmoid(x, eps=1e-5):
     x1 = x.clamp(min=eps)
     x2 = (1 - x).clamp(min=eps)
     return torch.log(x1 / x2)
+
+
+class RTDetrV2Decoder(nn.Module):
+    def __init__(self, config: RTDetrV2Config):
+        super().__init__()
+
+        self.dropout = config.dropout
+        self.layers = nn.ModuleList([RTDetrV2DecoderLayer(config) for _ in range(config.decoder_layers)])
+        self.query_pos_head = RTDetrV2MLPPredictionHead(
+            input_dim=4, hidden_dim=2 * config.hidden_size, output_dim=config.hidden_size, num_layers=2
+        )
+
+        # hack implementation for iterative bounding box refinement and two-stage RT-DETR
+        self.bbox_embed = None
+        self.class_embed = None
+
+    def forward(
+        self,
+        hidden_state: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        reference_points: torch.Tensor,
+        spatial_shapes: torch.Tensor,
+        spatial_shapes_list: List[Tuple[int, int]],
+        encoder_attention_mask: torch.Tensor,
+        output_attentions: bool = False,
+        output_hidden_states: bool = False,
+        return_dict: bool = True,
+    ):
+        r"""
+        Args:
+            hidden_state (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`):
+                The query embeddings that are passed into the decoder.
+            encoder_hidden_states (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+                Sequence of hidden-states at the output of the last layer of the encoder. Used in the cross-attention
+                of the decoder.
+            encoder_attention_mask (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Mask to avoid performing cross-attention on padding pixel_values of the encoder. Mask values selected
+                in `[0, 1]`:
+                - 1 for pixels that are real (i.e. **not masked**),
+                - 0 for pixels that are padding (i.e. **masked**).
+            reference_points (`torch.FloatTensor` of shape `(batch_size, num_queries, 4)` is `as_two_stage` else `(batch_size, num_queries, 2)` or , *optional*):
+                Reference point in range `[0, 1]`, top-left (0,0), bottom-right (1, 1), including padding area.
+            spatial_shapes (`torch.FloatTensor` of shape `(num_feature_levels, 2)`):
+                Spatial shapes of the feature maps.
+            output_attentions (`bool`, defaults to `False`):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            output_hidden_states (`bool`, defaults to `False`):
+                Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
+                for more detail.
+            return_dict (`bool`, defaults to `True`):
+                Whether or not to return a [`~file_utils.ModelOutput`] instead of a plain tuple.
+        """
+
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attentions = () if output_attentions else None
+        all_cross_attentions = () if output_attentions else None
+        all_bbox_outputs = () if self.bbox_embed is not None else None
+        all_class_outputs = () if self.class_embed is not None else None
+
+        for idx, decoder_layer in enumerate(self.layers):
+            reference_points_input = reference_points.unsqueeze(2)
+            position_embeddings = self.query_pos_head(reference_points)
+
+            if output_hidden_states:
+                all_hidden_states += (hidden_state,)
+
+            hidden_state, self_attn_weights, cross_attn_weights = decoder_layer(
+                hidden_state,
+                position_embeddings=position_embeddings,
+                encoder_hidden_states=encoder_hidden_states,
+                reference_points=reference_points_input,
+                spatial_shapes=spatial_shapes,
+                spatial_shapes_list=spatial_shapes_list,
+                encoder_attention_mask=encoder_attention_mask,
+                output_attentions=output_attentions,
+            )
+
+            if output_attentions and self_attn_weights is not None:
+                all_self_attentions += (self_attn_weights,)
+
+            if output_attentions and cross_attn_weights is not None:
+                all_cross_attentions += (cross_attn_weights,)
+
+            # Iterative bounding box and class refinement
+            if self.bbox_embed is not None:
+                box_refinement = self.bbox_embed[idx](hidden_state)
+                reference_points = F.sigmoid(inverse_sigmoid(reference_points) + box_refinement)
+                all_bbox_outputs += (reference_points,)
+                reference_points = reference_points.detach()
+
+            if self.class_embed is not None:
+                class_output = self.class_embed[idx](hidden_state)
+                all_class_outputs += (class_output,)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_state,)
+
+        if self.bbox_embed is not None:
+            all_bbox_outputs = torch.stack(all_bbox_outputs, dim=1)
+
+        if self.class_embed is not None:
+            all_class_outputs = torch.stack(all_class_outputs, dim=1)
+
+        outputs = RTDetrV2DecoderOutput(
+            last_hidden_state=hidden_state,
+            class_outputs=all_class_outputs,
+            bbox_outputs=all_bbox_outputs,
+            hidden_states=all_hidden_states,
+            self_attentions=all_self_attentions,
+            cross_attentions=all_cross_attentions,
+        )
+
+        if not return_dict:
+            outputs = outputs.to_tuple()
+        return outputs
 
 
 def get_contrastive_denoising_training_group(
@@ -1273,6 +1491,7 @@ RTDetrV2_START_DOCSTRING = r"""
             [`~PreTrainedModel.from_pretrained`] method to load the model weights.
 """
 
+
 RTDetrV2_INPUTS_DOCSTRING = r"""
     Args:
         pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, height, width)`):
@@ -1285,16 +1504,6 @@ RTDetrV2_INPUTS_DOCSTRING = r"""
             - 0 for pixels that are padding (i.e. **masked**).
 
             [What are attention masks?](../glossary#attention-mask)
-        encoder_outputs (`tuple(tuple(torch.FloatTensor)`, *optional*):
-            Tuple consists of (`last_hidden_state`, *optional*: `hidden_states`, *optional*: `attentions`)
-            `last_hidden_state` of shape `(batch_size, sequence_length, hidden_size)`, *optional*) is a sequence of
-            hidden-states at the output of the last layer of the encoder. Used in the cross-attention of the decoder.
-        inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-            Optionally, instead of passing the flattened feature map (output of the backbone + projection layer), you
-            can choose to directly pass a flattened representation of an image.
-        decoder_inputs_embeds (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`, *optional*):
-            Optionally, instead of initializing the queries with a tensor of zeros, you can choose to directly pass an
-            embedded representation.
         labels (`List[Dict]` of len `(batch_size,)`, *optional*):
             Labels for computing the bipartite matching loss. List of dicts, each dictionary containing at least the
             following 2 keys: 'class_labels' and 'boxes' (the class labels and bounding boxes of an image in the batch
@@ -1309,22 +1518,25 @@ RTDetrV2_INPUTS_DOCSTRING = r"""
         return_dict (`bool`, *optional*):
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
 """
-
-
-def _get_clones(partial_module, N):
-    return nn.ModuleList([partial_module() for i in range(N)])
+_DETECTION_OUTPUT_FOR_DOC = """
+    Detected 'sofa' (0.97) at [0.14, 0.38, 640.13, 476.21]
+    Detected 'cat' (0.96) at [343.38, 24.28, 640.14, 371.5]
+    Detected 'cat' (0.96) at [13.23, 54.18, 318.98, 472.22]
+    Detected 'remote' (0.95) at [40.11, 73.44, 175.96, 118.48]
+    Detected 'remote' (0.92) at [333.73, 76.58, 369.97, 186.99]
+"""
 
 
 class RTDetrV2PreTrainedModel(PreTrainedModel):
     config_class = RTDetrV2Config
-    base_model_prefix = "rt_detr_v2"
+    base_model_prefix = "model"
     main_input_name = "pixel_values"
     _no_split_modules = [r"RTDetrV2HybridEncoder", r"RTDetrV2DecoderLayer"]
 
     def _init_weights(self, module):
         """Initalize the weights"""
 
-        """initialize linear layer bias value according to a given probability value."""
+        # initialize linear layer bias value according to a given probability value
         if isinstance(module, (RTDetrV2ForObjectDetection, RTDetrV2Decoder)):
             if module.class_embed is not None:
                 for layer in module.class_embed:
@@ -1378,165 +1590,6 @@ class RTDetrV2PreTrainedModel(PreTrainedModel):
             nn.init.xavier_uniform_(module.denoising_class_embed.weight)
 
 
-class RTDetrV2Decoder(RTDetrV2PreTrainedModel):
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__(config)
-
-        self.dropout = config.dropout
-        self.layers = nn.ModuleList([RTDetrV2DecoderLayer(config) for _ in range(config.decoder_layers)])
-        self.query_pos_head = RTDetrV2MLPPredictionHead(config, 4, 2 * config.d_model, config.d_model, num_layers=2)
-
-        # hack implementation for iterative bounding box refinement and two-stage Deformable DETR
-        self.bbox_embed = None
-        self.class_embed = None
-
-        # Initialize weights and apply final processing
-        self.post_init()
-
-    def forward(
-        self,
-        inputs_embeds=None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
-        position_embeddings=None,
-        reference_points=None,
-        spatial_shapes=None,
-        spatial_shapes_list=None,
-        level_start_index=None,
-        valid_ratios=None,
-        output_attentions=None,
-        output_hidden_states=None,
-        return_dict=None,
-    ):
-        r"""
-        Args:
-            inputs_embeds (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`):
-                The query embeddings that are passed into the decoder.
-            encoder_hidden_states (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
-                Sequence of hidden-states at the output of the last layer of the encoder. Used in the cross-attention
-                of the decoder.
-            encoder_attention_mask (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
-                Mask to avoid performing cross-attention on padding pixel_values of the encoder. Mask values selected
-                in `[0, 1]`:
-                - 1 for pixels that are real (i.e. **not masked**),
-                - 0 for pixels that are padding (i.e. **masked**).
-            position_embeddings (`torch.FloatTensor` of shape `(batch_size, num_queries, hidden_size)`, *optional*):
-                Position embeddings that are added to the queries and keys in each self-attention layer.
-            reference_points (`torch.FloatTensor` of shape `(batch_size, num_queries, 4)` is `as_two_stage` else `(batch_size, num_queries, 2)` or , *optional*):
-                Reference point in range `[0, 1]`, top-left (0,0), bottom-right (1, 1), including padding area.
-            spatial_shapes (`torch.FloatTensor` of shape `(num_feature_levels, 2)`):
-                Spatial shapes of the feature maps.
-            level_start_index (`torch.LongTensor` of shape `(num_feature_levels)`, *optional*):
-                Indexes for the start of each feature level. In range `[0, sequence_length]`.
-            valid_ratios (`torch.FloatTensor` of shape `(batch_size, num_feature_levels, 2)`, *optional*):
-                Ratio of valid area in each feature level.
-
-            output_attentions (`bool`, *optional*):
-                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
-                returned tensors for more detail.
-            output_hidden_states (`bool`, *optional*):
-                Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors
-                for more detail.
-            return_dict (`bool`, *optional*):
-                Whether or not to return a [`~file_utils.ModelOutput`] instead of a plain tuple.
-        """
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        if inputs_embeds is not None:
-            hidden_states = inputs_embeds
-
-        # decoder layers
-        all_hidden_states = () if output_hidden_states else None
-        all_self_attns = () if output_attentions else None
-        all_cross_attentions = () if (output_attentions and encoder_hidden_states is not None) else None
-        intermediate = ()
-        intermediate_reference_points = ()
-        intermediate_logits = ()
-
-        reference_points = F.sigmoid(reference_points)
-
-        # https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/RTDetrV2_pytorch/src/zoo/RTDetrV2/RTDetrV2_decoder.py#L252
-        for idx, decoder_layer in enumerate(self.layers):
-            reference_points_input = reference_points.unsqueeze(2)
-            position_embeddings = self.query_pos_head(reference_points)
-
-            if output_hidden_states:
-                all_hidden_states += (hidden_states,)
-
-            layer_outputs = decoder_layer(
-                hidden_states,
-                position_embeddings=position_embeddings,
-                encoder_hidden_states=encoder_hidden_states,
-                reference_points=reference_points_input,
-                spatial_shapes=spatial_shapes,
-                spatial_shapes_list=spatial_shapes_list,
-                level_start_index=level_start_index,
-                encoder_attention_mask=encoder_attention_mask,
-                output_attentions=output_attentions,
-            )
-
-            hidden_states = layer_outputs[0]
-
-            # hack implementation for iterative bounding box refinement
-            if self.bbox_embed is not None:
-                tmp = self.bbox_embed[idx](hidden_states)
-                new_reference_points = F.sigmoid(tmp + inverse_sigmoid(reference_points))
-                reference_points = new_reference_points.detach()
-
-            intermediate += (hidden_states,)
-            intermediate_reference_points += (
-                (new_reference_points,) if self.bbox_embed is not None else (reference_points,)
-            )
-
-            if self.class_embed is not None:
-                logits = self.class_embed[idx](hidden_states)
-                intermediate_logits += (logits,)
-
-            if output_attentions:
-                all_self_attns += (layer_outputs[1],)
-
-                if encoder_hidden_states is not None:
-                    all_cross_attentions += (layer_outputs[2],)
-
-        # Keep batch_size as first dimension
-        intermediate = torch.stack(intermediate, dim=1)
-        intermediate_reference_points = torch.stack(intermediate_reference_points, dim=1)
-        if self.class_embed is not None:
-            intermediate_logits = torch.stack(intermediate_logits, dim=1)
-
-        # add hidden states from the last decoder layer
-        if output_hidden_states:
-            all_hidden_states += (hidden_states,)
-
-        if not return_dict:
-            return tuple(
-                v
-                for v in [
-                    hidden_states,
-                    intermediate,
-                    intermediate_logits,
-                    intermediate_reference_points,
-                    all_hidden_states,
-                    all_self_attns,
-                    all_cross_attentions,
-                ]
-                if v is not None
-            )
-        return RTDetrV2DecoderOutput(
-            last_hidden_state=hidden_states,
-            intermediate_hidden_states=intermediate,
-            intermediate_logits=intermediate_logits,
-            intermediate_reference_points=intermediate_reference_points,
-            hidden_states=all_hidden_states,
-            attentions=all_self_attns,
-            cross_attentions=all_cross_attentions,
-        )
-
-
 @add_start_docstrings(
     """
     RT-DETR Model (consisting of a backbone and encoder-decoder) outputting raw hidden states without any head on top.
@@ -1546,72 +1599,66 @@ class RTDetrV2Decoder(RTDetrV2PreTrainedModel):
 class RTDetrV2Model(RTDetrV2PreTrainedModel):
     def __init__(self, config: RTDetrV2Config):
         super().__init__(config)
+        self.learn_initial_query = config.learn_initial_query
 
         # Create backbone
         self.backbone = RTDetrV2ConvEncoder(config)
-        intermediate_channel_sizes = self.backbone.intermediate_channel_sizes
 
         # Create encoder input projection layers
-        # https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/RTDetrV2_pytorch/src/zoo/RTDetrV2/hybrid_encoder.py#L212
+        intermediate_channel_sizes = self.backbone.intermediate_channel_sizes
         num_backbone_outs = len(intermediate_channel_sizes)
-        encoder_input_proj_list = []
-        for _ in range(num_backbone_outs):
-            in_channels = intermediate_channel_sizes[_]
-            encoder_input_proj_list.append(
-                nn.Sequential(
-                    nn.Conv2d(in_channels, config.encoder_hidden_dim, kernel_size=1, bias=False),
-                    nn.BatchNorm2d(config.encoder_hidden_dim),
-                )
-            )
-        self.encoder_input_proj = nn.ModuleList(encoder_input_proj_list)
+        self.encoder_input_proj = nn.ModuleList()
+        for idx in range(num_backbone_outs):
+            in_channels = intermediate_channel_sizes[idx]
+            conv = nn.Conv2d(in_channels, config.encoder_hidden_dim, kernel_size=1, bias=False)
+            batchnorm = nn.BatchNorm2d(config.encoder_hidden_dim)
+            self.encoder_input_proj.append(nn.Sequential(conv, batchnorm))
 
         # Create encoder
         self.encoder = RTDetrV2HybridEncoder(config)
 
-        # denoising part
+        # De-noising part
         if config.num_denoising > 0:
             self.denoising_class_embed = nn.Embedding(
-                config.num_labels + 1, config.d_model, padding_idx=config.num_labels
+                config.num_labels + 1, config.hidden_size, padding_idx=config.num_labels
             )
 
-        # decoder embedding
-        if config.learn_initial_query:
-            self.weight_embedding = nn.Embedding(config.num_queries, config.d_model)
+        # Decoder embedding
+        if self.learn_initial_query:
+            self.weight_embedding = nn.Embedding(config.num_queries, config.hidden_size)
 
-        # encoder head
+        # Encoder head
         self.enc_output = nn.Sequential(
-            nn.Linear(config.d_model, config.d_model),
-            nn.LayerNorm(config.d_model, eps=config.layer_norm_eps),
+            nn.Linear(config.hidden_size, config.hidden_size),
+            nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps),
         )
-        self.enc_score_head = nn.Linear(config.d_model, config.num_labels)
-        self.enc_bbox_head = RTDetrV2MLPPredictionHead(config, config.d_model, config.d_model, 4, num_layers=3)
+        self.enc_score_head = nn.Linear(config.hidden_size, config.num_labels)
+        self.enc_bbox_head = RTDetrV2MLPPredictionHead(
+            input_dim=config.hidden_size, hidden_dim=config.hidden_size, output_dim=4, num_layers=3
+        )
 
-        # init encoder output anchors and valid_mask
+        # Init encoder output anchors and valid_mask
         if config.anchor_image_size:
             self.anchors, self.valid_mask = self.generate_anchors(dtype=self.dtype)
 
         # Create decoder input projection layers
         # https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/RTDetrV2_pytorch/src/zoo/RTDetrV2/RTDetrV2_decoder.py#L412
         num_backbone_outs = len(config.decoder_in_channels)
-        decoder_input_proj_list = []
-        for _ in range(num_backbone_outs):
-            in_channels = config.decoder_in_channels[_]
-            decoder_input_proj_list.append(
-                nn.Sequential(
-                    nn.Conv2d(in_channels, config.d_model, kernel_size=1, bias=False),
-                    nn.BatchNorm2d(config.d_model, config.batch_norm_eps),
-                )
-            )
+        self.decoder_input_proj = nn.ModuleList()
+
+        for idx in range(num_backbone_outs):
+            in_channels = config.decoder_in_channels[idx]
+            conv = nn.Conv2d(in_channels, config.hidden_size, kernel_size=1, bias=False)
+            batchnorm = nn.BatchNorm2d(config.hidden_size, eps=config.batch_norm_eps)
+            self.decoder_input_proj.append(nn.Sequential(conv, batchnorm))
+
         for _ in range(config.num_feature_levels - num_backbone_outs):
-            decoder_input_proj_list.append(
-                nn.Sequential(
-                    nn.Conv2d(in_channels, config.d_model, kernel_size=3, stride=2, padding=1, bias=False),
-                    nn.BatchNorm2d(config.d_model, config.batch_norm_eps),
-                )
-            )
-            in_channels = config.d_model
-        self.decoder_input_proj = nn.ModuleList(decoder_input_proj_list)
-        # decoder
+            conv = nn.Conv2d(in_channels, config.hidden_size, kernel_size=3, stride=2, padding=1, bias=False)
+            batchnorm = nn.BatchNorm2d(config.hidden_size, eps=config.batch_norm_eps)
+            self.decoder_input_proj.append(nn.Sequential(conv, batchnorm))
+            in_channels = config.hidden_size
+
+        # Decoder
         self.decoder = RTDetrV2Decoder(config)
 
         self.post_init()
@@ -1631,28 +1678,35 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
             param.requires_grad_(True)
 
     @compile_compatible_method_lru_cache(maxsize=32)
-    def generate_anchors(self, spatial_shapes=None, grid_size=0.05, device="cpu", dtype=torch.float32):
+    def generate_anchors(
+        self,
+        spatial_shapes: Optional[Tuple[Tuple[int, int], ...]] = None,
+        grid_size: float = 0.05,
+        device: str = "cpu",
+        dtype: torch.dtype = torch.float32,
+    ):
         if spatial_shapes is None:
-            spatial_shapes = [
-                [int(self.config.anchor_image_size[0] / s), int(self.config.anchor_image_size[1] / s)]
-                for s in self.config.feat_strides
-            ]
+            height, width = self.config.anchor_image_size
+            spatial_shapes = tuple(
+                [(int(height / stride), int(width / stride)) for stride in self.config.feat_strides]
+            )
+
         anchors = []
         for level, (height, width) in enumerate(spatial_shapes):
-            grid_y, grid_x = torch.meshgrid(
-                torch.arange(end=height, device=device).to(dtype),
-                torch.arange(end=width, device=device).to(dtype),
-                indexing="ij",
-            )
-            grid_xy = torch.stack([grid_x, grid_y], -1)
-            grid_xy = grid_xy.unsqueeze(0) + 0.5
-            grid_xy[..., 0] /= width
-            grid_xy[..., 1] /= height
-            wh = torch.ones_like(grid_xy) * grid_size * (2.0**level)
-            anchors.append(torch.concat([grid_xy, wh], -1).reshape(-1, height * width, 4))
+            # Generate normalized grid coordinates from the center of the first pixel
+            # to the center of the last pixel (e.g. 0.5 / width, 1 - 0.5 / width)
+            grid_x = torch.linspace(0.5 / width, 1 - 0.5 / width, width, device=device, dtype=dtype)
+            grid_y = torch.linspace(0.5 / height, 1 - 0.5 / height, height, device=device, dtype=dtype)
+            grid_y, grid_x = torch.meshgrid(grid_y, grid_x, indexing="ij")
+            grid_xy = torch.stack([grid_x, grid_y], dim=-1)
+
+            grid_wh = torch.ones_like(grid_xy) * grid_size * (2.0**level)
+            level_anchors = torch.concat([grid_xy, grid_wh], dim=-1).reshape(height * width, 4)
+            anchors.append(level_anchors)
+        anchors = torch.concat(anchors).unsqueeze(0)
+
         # define the valid range for anchor coordinates
         eps = 1e-2
-        anchors = torch.concat(anchors, 1)
         valid_mask = ((anchors > eps) * (anchors < 1 - eps)).all(-1, keepdim=True)
         anchors = torch.log(anchors / (1 - anchors))
         anchors = torch.where(valid_mask, anchors, torch.tensor(torch.finfo(dtype).max, dtype=dtype, device=device))
@@ -1665,9 +1719,6 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
         self,
         pixel_values: torch.FloatTensor,
         pixel_mask: Optional[torch.LongTensor] = None,
-        encoder_outputs: Optional[torch.FloatTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        decoder_inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[List[dict]] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -1703,61 +1754,42 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
         )
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        batch_size, num_channels, height, width = pixel_values.shape
+        batch_size, _, height, width = pixel_values.shape
         device = pixel_values.device
 
-        if pixel_mask is None:
-            pixel_mask = torch.ones(((batch_size, height, width)), device=device)
+        # Stage 1: Convolutional backbone
+        backbone_outputs = self.backbone(pixel_values)
 
-        features = self.backbone(pixel_values, pixel_mask)
+        # Stage 2: Hybrid encoder (transformer -> FPN -> PAN)
+        projected_feature_maps = [
+            layer(feature_map) for layer, feature_map in zip(self.encoder_input_proj, backbone_outputs)
+        ]
+        encoder_outputs = self.encoder(
+            projected_feature_maps,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+        )
 
-        proj_feats = [self.encoder_input_proj[level](source) for level, (source, mask) in enumerate(features)]
+        feature_maps = encoder_outputs[0]
+        last_encoder_feature_map = feature_maps[-1]
 
-        if encoder_outputs is None:
-            encoder_outputs = self.encoder(
-                proj_feats,
-                output_attentions=output_attentions,
-                output_hidden_states=output_hidden_states,
-                return_dict=return_dict,
-            )
-        # If the user passed a tuple for encoder_outputs, we wrap it in a BaseModelOutput when return_dict=True
-        elif return_dict and not isinstance(encoder_outputs, BaseModelOutput):
-            encoder_outputs = BaseModelOutput(
-                last_hidden_state=encoder_outputs[0],
-                hidden_states=encoder_outputs[1] if output_hidden_states else None,
-                attentions=encoder_outputs[2]
-                if len(encoder_outputs) > 2
-                else encoder_outputs[1]
-                if output_attentions
-                else None,
-            )
+        # Apply projection to each feature map
+        feature_maps = [proj(feature_map) for proj, feature_map in zip(self.decoder_input_proj, feature_maps)]
+        for i in range(len(feature_maps), self.config.num_feature_levels):
+            feature_maps.append(self.decoder_input_proj[i](last_encoder_feature_map))
 
-        # Equivalent to def _get_encoder_input
-        # https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/RTDetrV2_pytorch/src/zoo/RTDetrV2/RTDetrV2_decoder.py#L412
-        sources = []
-        for level, source in enumerate(encoder_outputs[0]):
-            sources.append(self.decoder_input_proj[level](source))
+        # Flatten decoder inputs
+        hidden_states = [feature_map.flatten(2).transpose(1, 2) for feature_map in feature_maps]
+        hidden_states = torch.cat(hidden_states, dim=1)
 
-        # Lowest resolution feature maps are obtained via 3x3 stride 2 convolutions on the final stage
-        if self.config.num_feature_levels > len(sources):
-            _len_sources = len(sources)
-            sources.append(self.decoder_input_proj[_len_sources](encoder_outputs[0])[-1])
-            for i in range(_len_sources + 1, self.config.num_feature_levels):
-                sources.append(self.decoder_input_proj[i](encoder_outputs[0][-1]))
-
-        # Prepare encoder inputs (by flattening)
-        source_flatten = []
-        spatial_shapes_list = []
-        spatial_shapes = torch.empty((len(sources), 2), device=device, dtype=torch.long)
-        for level, source in enumerate(sources):
+        # Prepare spatial shapes, we have to keep both: the list and the tensor
+        # for torch.compile fullgraph=True and ONNX dynamic export
+        spatial_shapes_list = [(feat.shape[-2], feat.shape[-1]) for feat in feature_maps]
+        spatial_shapes = torch.empty((len(feature_maps), 2), device=device, dtype=torch.long)
+        for level, source in enumerate(feature_maps):
             height, width = source.shape[-2:]
             spatial_shapes[level, 0] = height
             spatial_shapes[level, 1] = width
-            spatial_shapes_list.append((height, width))
-            source = source.flatten(2).transpose(1, 2)
-            source_flatten.append(source)
-        source_flatten = torch.cat(source_flatten, 1)
-        level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
 
         # prepare denoising training
         if self.training and self.config.num_denoising > 0 and labels is not None:
@@ -1778,9 +1810,9 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
         else:
             denoising_class, denoising_bbox_unact, attention_mask, denoising_meta_values = None, None, None, None
 
-        batch_size = len(source_flatten)
-        device = source_flatten.device
-        dtype = source_flatten.dtype
+        batch_size = len(hidden_states)
+        device = hidden_states.device
+        dtype = hidden_states.dtype
 
         # prepare input for decoder
         if self.training or self.config.anchor_image_size is None:
@@ -1793,105 +1825,64 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
             anchors, valid_mask = anchors.to(device, dtype), valid_mask.to(device, dtype)
 
         # use the valid_mask to selectively retain values in the feature map where the mask is `True`
-        memory = valid_mask.to(source_flatten.dtype) * source_flatten
+        masked_hidden_states = hidden_states * valid_mask.to(hidden_states.dtype)
+        proj_hidden_states = self.enc_output(masked_hidden_states)
 
-        output_memory = self.enc_output(memory)
+        class_logits = self.enc_score_head(proj_hidden_states)
+        bboxes_logits = self.enc_bbox_head(proj_hidden_states) + anchors
 
-        enc_outputs_class = self.enc_score_head(output_memory)
-        enc_outputs_coord_logits = self.enc_bbox_head(output_memory) + anchors
+        # gather encoder logits and boxes based on top K confident logits
+        _, topk_ind = torch.topk(class_logits.max(-1).values, self.config.num_queries, dim=1)
+        topk_ind = topk_ind.unsqueeze(-1)
 
-        _, topk_ind = torch.topk(enc_outputs_class.max(-1).values, self.config.num_queries, dim=1)
-
-        reference_points_unact = enc_outputs_coord_logits.gather(
-            dim=1, index=topk_ind.unsqueeze(-1).repeat(1, 1, enc_outputs_coord_logits.shape[-1])
-        )
-
-        enc_topk_bboxes = F.sigmoid(reference_points_unact)
+        topk_logits = class_logits.gather(dim=1, index=topk_ind.repeat(1, 1, class_logits.shape[-1]))
+        topk_bboxes_logits = bboxes_logits.gather(dim=1, index=topk_ind.repeat(1, 1, bboxes_logits.shape[-1]))
         if denoising_bbox_unact is not None:
-            reference_points_unact = torch.concat([denoising_bbox_unact, reference_points_unact], 1)
-
-        enc_topk_logits = enc_outputs_class.gather(
-            dim=1, index=topk_ind.unsqueeze(-1).repeat(1, 1, enc_outputs_class.shape[-1])
-        )
+            topk_bboxes_logits = torch.concat([denoising_bbox_unact, topk_bboxes_logits], 1)
 
         # extract region features
-        if self.config.learn_initial_query:
+        if self.learn_initial_query:
             target = self.weight_embedding.tile([batch_size, 1, 1])
         else:
-            target = output_memory.gather(dim=1, index=topk_ind.unsqueeze(-1).repeat(1, 1, output_memory.shape[-1]))
+            target = proj_hidden_states.gather(dim=1, index=topk_ind.repeat(1, 1, proj_hidden_states.shape[-1]))
             target = target.detach()
 
         if denoising_class is not None:
             target = torch.concat([denoising_class, target], 1)
 
-        init_reference_points = reference_points_unact.detach()
+        topk_bboxes = F.sigmoid(topk_bboxes_logits)
 
         # decoder
-        decoder_outputs = self.decoder(
-            inputs_embeds=target,
-            encoder_hidden_states=source_flatten,
+        decoder_outputs: RTDetrV2DecoderOutput = self.decoder(
+            hidden_state=target,
+            encoder_hidden_states=hidden_states,
             encoder_attention_mask=attention_mask,
-            reference_points=init_reference_points,
+            reference_points=topk_bboxes,
             spatial_shapes=spatial_shapes,
             spatial_shapes_list=spatial_shapes_list,
-            level_start_index=level_start_index,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            return_dict=True,
+        )
+
+        outputs = RTDetrV2ModelOutput(
+            last_hidden_state=decoder_outputs.last_hidden_state,
+            class_outputs=decoder_outputs.class_outputs,  # + for loss and output logits
+            bbox_outputs=decoder_outputs.bbox_outputs,  # + for loss and output boxes
+            decoder_hidden_states=decoder_outputs.hidden_states,
+            decoder_attentions=decoder_outputs.self_attentions,
+            cross_attentions=decoder_outputs.cross_attentions,
+            encoder_last_hidden_state=encoder_outputs[0],
+            encoder_hidden_states=encoder_outputs[1],
+            encoder_attentions=encoder_outputs[2],
+            enc_topk_logits=topk_logits,  # + for loss
+            enc_topk_bboxes=topk_bboxes,  # + for loss
+            denoising_meta_values=denoising_meta_values,  # + for loss
         )
 
         if not return_dict:
-            enc_outputs = tuple(
-                value
-                for value in [enc_topk_logits, enc_topk_bboxes, enc_outputs_class, enc_outputs_coord_logits]
-                if value is not None
-            )
-            dn_outputs = tuple(value if value is not None else None for value in [denoising_meta_values])
-            tuple_outputs = decoder_outputs + encoder_outputs + (init_reference_points,) + enc_outputs + dn_outputs
-
-            return tuple_outputs
-
-        return RTDetrV2ModelOutput(
-            last_hidden_state=decoder_outputs.last_hidden_state,
-            intermediate_hidden_states=decoder_outputs.intermediate_hidden_states,
-            intermediate_logits=decoder_outputs.intermediate_logits,
-            intermediate_reference_points=decoder_outputs.intermediate_reference_points,
-            decoder_hidden_states=decoder_outputs.hidden_states,
-            decoder_attentions=decoder_outputs.attentions,
-            cross_attentions=decoder_outputs.cross_attentions,
-            encoder_last_hidden_state=encoder_outputs.last_hidden_state,
-            encoder_hidden_states=encoder_outputs.hidden_states,
-            encoder_attentions=encoder_outputs.attentions,
-            init_reference_points=init_reference_points,
-            enc_topk_logits=enc_topk_logits,
-            enc_topk_bboxes=enc_topk_bboxes,
-            enc_outputs_class=enc_outputs_class,
-            enc_outputs_coord_logits=enc_outputs_coord_logits,
-            denoising_meta_values=denoising_meta_values,
-        )
-
-
-# taken from https://github.com/facebookresearch/detr/blob/master/models/detr.py
-class RTDetrV2MLPPredictionHead(nn.Module):
-    """
-    Very simple multi-layer perceptron (MLP, also called FFN), used to predict the normalized center coordinates,
-    height and width of a bounding box w.r.t. an image.
-
-    Copied from https://github.com/facebookresearch/detr/blob/master/models/detr.py
-    Origin from https://github.com/lyuwenyu/RT-DETR/blob/94f5e16708329d2f2716426868ec89aa774af016/RTDetrV2_paddle/ppdet/modeling/transformers/utils.py#L453
-
-    """
-
-    def __init__(self, config, input_dim, d_model, output_dim, num_layers):
-        super().__init__()
-        self.num_layers = num_layers
-        h = [d_model] * (num_layers - 1)
-        self.layers = nn.ModuleList(nn.Linear(n, k) for n, k in zip([input_dim] + h, h + [output_dim]))
-
-    def forward(self, x):
-        for i, layer in enumerate(self.layers):
-            x = nn.functional.relu(layer(x)) if i < self.num_layers - 1 else layer(x)
-        return x
+            outputs = outputs.to_tuple()
+        return outputs
 
 
 @add_start_docstrings(
@@ -1909,38 +1900,41 @@ class RTDetrV2ForObjectDetection(RTDetrV2PreTrainedModel):
 
     def __init__(self, config: RTDetrV2Config):
         super().__init__(config)
-        # RTDETR encoder-decoder model
+
+        # RTDetrV2 encoder-decoder model
         self.model = RTDetrV2Model(config)
 
         # Detection heads on top
-        class_embed = partial(nn.Linear, config.d_model, config.num_labels)
-        bbox_embed = partial(RTDetrV2MLPPredictionHead, config, config.d_model, config.d_model, 4, num_layers=3)
+        # if two-stage, the last class_embed and bbox_embed is for region proposal generation
+        num_layers = config.decoder_layers
+        self.class_embed = nn.ModuleList([nn.Linear(config.hidden_size, config.num_labels) for _ in range(num_layers)])
+        self.bbox_embed = nn.ModuleList(
+            [
+                RTDetrV2MLPPredictionHead(
+                    input_dim=config.hidden_size, hidden_dim=config.hidden_size, output_dim=4, num_layers=3
+                )
+                for _ in range(num_layers)
+            ]
+        )
 
-        self.class_embed = nn.ModuleList([class_embed() for _ in range(config.decoder_layers)])
-        self.bbox_embed = nn.ModuleList([bbox_embed() for _ in range(config.decoder_layers)])
-
+        # hack implementation for iterative bounding box refinement
         self.model.decoder.class_embed = self.class_embed
         self.model.decoder.bbox_embed = self.bbox_embed
 
         # Initialize weights and apply final processing
         self.post_init()
 
-    @torch.jit.unused
-    def _set_aux_loss(self, outputs_class, outputs_coord):
-        # this is a workaround to make torchscript happy, as torchscript
-        # doesn't support dictionary with non-homogeneous values, such
-        # as a dict having both a Tensor and a list.
-        return [{"logits": a, "pred_boxes": b} for a, b in zip(outputs_class, outputs_coord)]
-
     @add_start_docstrings_to_model_forward(RTDetrV2_INPUTS_DOCSTRING)
-    @replace_return_docstrings(output_type=RTDetrV2ObjectDetectionOutput, config_class=_CONFIG_FOR_DOC)
+    @add_code_sample_docstrings(
+        checkpoint=_CHECKPOINT_FOR_DOC,
+        output_type=RTDetrV2ObjectDetectionOutput,
+        config_class=_CONFIG_FOR_DOC,
+        expected_output=_DETECTION_OUTPUT_FOR_DOC,
+    )
     def forward(
         self,
         pixel_values: torch.FloatTensor,
         pixel_mask: Optional[torch.LongTensor] = None,
-        encoder_outputs: Optional[torch.FloatTensor] = None,
-        inputs_embeds: Optional[torch.FloatTensor] = None,
-        decoder_inputs_embeds: Optional[torch.FloatTensor] = None,
         labels: Optional[List[dict]] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -1954,131 +1948,60 @@ class RTDetrV2ForObjectDetection(RTDetrV2PreTrainedModel):
             respectively). The class labels themselves should be a `torch.LongTensor` of len `(number of bounding boxes
             in the image,)` and the boxes a `torch.FloatTensor` of shape `(number of bounding boxes in the image, 4)`.
 
-        Returns:
-
-        Examples:
-
-        ```python
-        >>> from transformers import RTDetrV2ImageProcessor, RTDetrV2ForObjectDetection
-        >>> from PIL import Image
-        >>> import requests
-        >>> import torch
-
-        >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
-        >>> image = Image.open(requests.get(url, stream=True).raw)
-
-        >>> image_processor = RTDetrV2ImageProcessor.from_pretrained("PekingU/RTDetrV2_r50vd")
-        >>> model = RTDetrV2ForObjectDetection.from_pretrained("PekingU/RTDetrV2_r50vd")
-
-        >>> # prepare image for the model
-        >>> inputs = image_processor(images=image, return_tensors="pt")
-
-        >>> # forward pass
-        >>> outputs = model(**inputs)
-
-        >>> logits = outputs.logits
-        >>> list(logits.shape)
-        [1, 300, 80]
-
-        >>> boxes = outputs.pred_boxes
-        >>> list(boxes.shape)
-        [1, 300, 4]
-
-        >>> # convert outputs (bounding boxes and class logits) to Pascal VOC format (xmin, ymin, xmax, ymax)
-        >>> target_sizes = torch.tensor([image.size[::-1]])
-        >>> results = image_processor.post_process_object_detection(outputs, threshold=0.9, target_sizes=target_sizes)[
-        ...     0
-        ... ]
-
-        >>> for score, label, box in zip(results["scores"], results["labels"], results["boxes"]):
-        ...     box = [round(i, 2) for i in box.tolist()]
-        ...     print(
-        ...         f"Detected {model.config.id2label[label.item()]} with confidence "
-        ...         f"{round(score.item(), 3)} at location {box}"
-        ...     )
-        Detected sofa with confidence 0.97 at location [0.14, 0.38, 640.13, 476.21]
-        Detected cat with confidence 0.96 at location [343.38, 24.28, 640.14, 371.5]
-        Detected cat with confidence 0.958 at location [13.23, 54.18, 318.98, 472.22]
-        Detected remote with confidence 0.951 at location [40.11, 73.44, 175.96, 118.48]
-        Detected remote with confidence 0.924 at location [333.73, 76.58, 369.97, 186.99]
-        ```"""
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
-
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        outputs = self.model(
+        outputs: RTDetrV2ModelOutput = self.model(
             pixel_values,
             pixel_mask=pixel_mask,
-            encoder_outputs=encoder_outputs,
-            inputs_embeds=inputs_embeds,
-            decoder_inputs_embeds=decoder_inputs_embeds,
             labels=labels,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            return_dict=True,
         )
 
-        denoising_meta_values = (
-            outputs.denoising_meta_values if return_dict else outputs[-1] if self.training else None
-        )
+        denoising_meta_values = outputs.denoising_meta_values if self.training else None
+        class_outputs = outputs.class_outputs
+        bbox_outputs = outputs.bbox_outputs
 
-        outputs_class = outputs.intermediate_logits if return_dict else outputs[2]
-        outputs_coord = outputs.intermediate_reference_points if return_dict else outputs[3]
+        logits = class_outputs[:, -1]
+        pred_boxes = bbox_outputs[:, -1]
 
-        logits = outputs_class[:, -1]
-        pred_boxes = outputs_coord[:, -1]
-
-        loss, loss_dict, auxiliary_outputs, enc_topk_logits, enc_topk_bboxes = None, None, None, None, None
+        # Conpute loss if labels are provided
+        loss, loss_dict, auxiliary_outputs = None, None, None
         if labels is not None:
-            enc_topk_logits = outputs.enc_topk_logits if return_dict else outputs[-5]
-            enc_topk_bboxes = outputs.enc_topk_bboxes if return_dict else outputs[-4]
+            enc_topk_logits = outputs.enc_topk_logits
+            enc_topk_bboxes = outputs.enc_topk_bboxes
             loss, loss_dict, auxiliary_outputs = self.loss_function(
-                logits,
-                labels,
-                self.device,
-                pred_boxes,
-                self.config,
-                outputs_class,
-                outputs_coord,
+                logits=logits,
+                labels=labels,
+                pred_boxes=pred_boxes,
+                config=self.config,
+                outputs_class=class_outputs,
+                outputs_coord=bbox_outputs,
                 enc_topk_logits=enc_topk_logits,
                 enc_topk_bboxes=enc_topk_bboxes,
                 denoising_meta_values=denoising_meta_values,
+                device=self.device,
                 **loss_kwargs,
             )
 
-        if not return_dict:
-            if auxiliary_outputs is not None:
-                output = (logits, pred_boxes) + (auxiliary_outputs,) + outputs
-            else:
-                output = (logits, pred_boxes) + outputs
-            return ((loss, loss_dict) + output) if loss is not None else output
-
-        return RTDetrV2ObjectDetectionOutput(
+        detection_outputs = RTDetrV2ObjectDetectionOutput(
             loss=loss,
             loss_dict=loss_dict,
             logits=logits,
             pred_boxes=pred_boxes,
             auxiliary_outputs=auxiliary_outputs,
-            last_hidden_state=outputs.last_hidden_state,
-            intermediate_hidden_states=outputs.intermediate_hidden_states,
-            intermediate_logits=outputs.intermediate_logits,
-            intermediate_reference_points=outputs.intermediate_reference_points,
-            decoder_hidden_states=outputs.decoder_hidden_states,
-            decoder_attentions=outputs.decoder_attentions,
-            cross_attentions=outputs.cross_attentions,
-            encoder_last_hidden_state=outputs.encoder_last_hidden_state,
-            encoder_hidden_states=outputs.encoder_hidden_states,
-            encoder_attentions=outputs.encoder_attentions,
-            init_reference_points=outputs.init_reference_points,
-            enc_topk_logits=outputs.enc_topk_logits,
-            enc_topk_bboxes=outputs.enc_topk_bboxes,
-            enc_outputs_class=outputs.enc_outputs_class,
-            enc_outputs_coord_logits=outputs.enc_outputs_coord_logits,
-            denoising_meta_values=outputs.denoising_meta_values,
+            **outputs,
         )
+
+        if not return_dict:
+            detection_outputs = detection_outputs.to_tuple()
+        return detection_outputs
 
 
 __all__ = ["RTDetrV2Model", "RTDetrV2PreTrainedModel", "RTDetrV2ForObjectDetection"]

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -39,6 +39,7 @@ from ...utils import (
     add_start_docstrings_to_model_forward,
     is_torchdynamo_compiling,
     replace_return_docstrings,
+    torch_int,
 )
 from ...utils.backbone_utils import load_backbone
 from .configuration_rt_detr_v2 import RTDetrV2Config
@@ -986,8 +987,8 @@ class RTDetrV2HybridEncoder(nn.Module):
     def build_2d_sincos_position_embedding(
         width, height, embed_dim=256, temperature=10000.0, device="cpu", dtype=torch.float32
     ):
-        grid_w = torch.arange(int(width), device=device).to(dtype)
-        grid_h = torch.arange(int(height), device=device).to(dtype)
+        grid_w = torch.arange(torch_int(width), device=device).to(dtype)
+        grid_h = torch.arange(torch_int(height), device=device).to(dtype)
         grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
         if embed_dim % 4 != 0:
             raise ValueError("Embed dimension must be divisible by 4 for 2D sin-cos position embedding")
@@ -1204,7 +1205,7 @@ def get_contrastive_denoising_training_group(
         denoise_positive_idx, [n * num_groups_denoising_queries for n in num_ground_truths]
     )
     # total denoising queries
-    num_denoising_queries = int(max_gt_num * 2 * num_groups_denoising_queries)
+    num_denoising_queries = torch_int(max_gt_num * 2 * num_groups_denoising_queries)
 
     if label_noise_ratio > 0:
         mask = torch.rand_like(input_query_class, dtype=torch.float) < (label_noise_ratio * 0.5)

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -216,6 +216,7 @@ def multi_scale_deformable_attention_v2(
     return output
 
 
+# Modified from transformers.models.deformable_detr.modeling_deformable_detr.DeformableDetrMultiscaleDeformableAttention with DeformableDetr->RTDetrV2
 class RTDetrV2MultiscaleDeformableAttention(nn.Module):
     """
     Multiscale deformable attention as proposed in Deformable DETR.
@@ -1125,7 +1126,6 @@ class RTDetrV2DecoderLayer(nn.Module):
         self.fc2_dropout = nn.Dropout(config.dropout)
         self.final_layer_norm = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
 
-    # TODO: rename hidden_states -> hidden_state
     def forward(
         self,
         hidden_state: torch.Tensor,

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -899,10 +899,9 @@ class RTDetrV2CSPRepLayer(nn.Module):
             self.conv3 = nn.Identity()
 
     def forward(self, hidden_state):
-        device = hidden_state.device
         hidden_state_1 = self.conv1(hidden_state)
-        hidden_state_1 = self.bottlenecks(hidden_state_1).to(device)
-        hidden_state_2 = self.conv2(hidden_state).to(device)
+        hidden_state_1 = self.bottlenecks(hidden_state_1)
+        hidden_state_2 = self.conv2(hidden_state)
         return self.conv3(hidden_state_1 + hidden_state_2)
 
 
@@ -974,13 +973,13 @@ class RTDetrV2HybridEncoder(nn.Module):
     def build_2d_sincos_position_embedding(
         width, height, embed_dim=256, temperature=10000.0, device="cpu", dtype=torch.float32
     ):
-        grid_w = torch.arange(int(width), dtype=dtype, device=device)
-        grid_h = torch.arange(int(height), dtype=dtype, device=device)
+        grid_w = torch.arange(int(width), device=device).to(dtype)
+        grid_h = torch.arange(int(height), device=device).to(dtype)
         grid_w, grid_h = torch.meshgrid(grid_w, grid_h, indexing="ij")
         if embed_dim % 4 != 0:
             raise ValueError("Embed dimension must be divisible by 4 for 2D sin-cos position embedding")
         pos_dim = embed_dim // 4
-        omega = torch.arange(pos_dim, dtype=dtype, device=device) / pos_dim
+        omega = torch.arange(pos_dim, device=device).to(dtype) / pos_dim
         omega = 1.0 / (temperature**omega)
 
         out_w = grid_w.flatten()[..., None] @ omega[None]
@@ -1074,13 +1073,20 @@ class RTDetrV2HybridEncoder(nn.Module):
         # broadcasting and fusion
         fpn_feature_maps = [hidden_states[-1]]
         for idx in range(len(self.in_channels) - 1, 0, -1):
-            feat_high = fpn_feature_maps[0]
-            feat_low = hidden_states[idx - 1]
-            feat_high = self.lateral_convs[len(self.in_channels) - 1 - idx](feat_high)
-            fpn_feature_maps[0] = feat_high
-            upsample_feat = F.interpolate(feat_high, scale_factor=2.0, mode="nearest")
-            fps_map = self.fpn_blocks[len(self.in_channels) - 1 - idx](torch.concat([upsample_feat, feat_low], dim=1))
-            fpn_feature_maps.insert(0, fps_map)
+            # blocks
+            lateral_block = self.lateral_convs[len(self.in_channels) - 1 - idx]
+            fpn_block = self.fpn_blocks[len(self.in_channels) - 1 - idx]
+            # feature maps
+            backbone_feature_map = hidden_states[idx - 1]
+            top_fpn_feature_map = fpn_feature_maps[0]
+            # apply lateral block
+            top_fpn_feature_map = lateral_block(top_fpn_feature_map)
+            fpn_feature_maps[0] = top_fpn_feature_map
+            # apply fpn block
+            top_fpn_feature_map = F.interpolate(top_fpn_feature_map, scale_factor=2.0, mode="nearest")
+            fused_feature_map = torch.concat([top_fpn_feature_map, backbone_feature_map], dim=1)
+            new_fpn_feature_map = fpn_block(fused_feature_map)
+            fpn_feature_maps.insert(0, new_fpn_feature_map)
 
         fpn_states = [fpn_feature_maps[0]]
         for idx in range(len(self.in_channels) - 1):
@@ -1289,7 +1295,12 @@ class RTDetrV2PreTrainedModel(PreTrainedModel):
     config_class = RTDetrV2Config
     base_model_prefix = "rt_detr_v2"
     main_input_name = "pixel_values"
-    _no_split_modules = [r"RTDetrV2ConvEncoder", r"RTDetrV2EncoderLayer", r"RTDetrV2DecoderLayer"]
+    _no_split_modules = [
+        r"RTDetrV2ConvEncoder",
+        r"RTDetrV2EncoderLayer",
+        r"RTDetrV2DecoderLayer",
+        r"RTDetrV2CSPRepLayer",
+    ]
 
     def _init_weights(self, module):
         """Initalize the weights"""
@@ -1610,8 +1621,8 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
         anchors = []
         for level, (height, width) in enumerate(spatial_shapes):
             grid_y, grid_x = torch.meshgrid(
-                torch.arange(end=height, dtype=dtype, device=device),
-                torch.arange(end=width, dtype=dtype, device=device),
+                torch.arange(end=height, device=device).to(dtype),
+                torch.arange(end=width, device=device).to(dtype),
                 indexing="ij",
             )
             grid_xy = torch.stack([grid_x, grid_y], -1)
@@ -1758,8 +1769,7 @@ class RTDetrV2Model(RTDetrV2PreTrainedModel):
             anchors, valid_mask = self.generate_anchors(spatial_shapes_tuple, device=device, dtype=dtype)
         else:
             anchors, valid_mask = self.anchors, self.valid_mask
-
-        anchors, valid_mask = anchors.to(device, dtype), valid_mask.to(device, dtype)
+            anchors, valid_mask = anchors.to(device, dtype), valid_mask.to(device, dtype)
 
         # use the valid_mask to selectively retain values in the feature map where the mask is `True`
         memory = valid_mask.to(source_flatten.dtype) * source_flatten

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -943,31 +943,44 @@ class RTDetrV2HybridEncoder(nn.Module):
         self.eval_size = config.eval_size
         self.out_channels = [self.encoder_hidden_dim for _ in self.in_channels]
         self.out_strides = self.feat_strides
-        activation_function = config.activation_function
+        self.num_fpn_stages = len(self.in_channels) - 1
+        self.num_pan_stages = len(self.in_channels) - 1
+        activation = config.activation_function
 
         # encoder transformer
         self.encoder = nn.ModuleList([RTDetrV2Encoder(config) for _ in range(len(self.encode_proj_layers))])
-        # top-down fpn
+
+        # top-down FPN
         self.lateral_convs = nn.ModuleList()
         self.fpn_blocks = nn.ModuleList()
-        for _ in range(len(self.in_channels) - 1, 0, -1):
-            self.lateral_convs.append(
-                RTDetrV2ConvNormLayer(
-                    config, self.encoder_hidden_dim, self.encoder_hidden_dim, 1, 1, activation=activation_function
-                )
+        for _ in range(self.num_fpn_stages):
+            lateral_conv = RTDetrV2ConvNormLayer(
+                config,
+                in_channels=self.encoder_hidden_dim,
+                out_channels=self.encoder_hidden_dim,
+                kernel_size=1,
+                stride=1,
+                activation=activation,
             )
-            self.fpn_blocks.append(RTDetrV2CSPRepLayer(config))
+            fpn_block = RTDetrV2CSPRepLayer(config)
+            self.lateral_convs.append(lateral_conv)
+            self.fpn_blocks.append(fpn_block)
 
-        # bottom-up pan
+        # bottom-up PAN
         self.downsample_convs = nn.ModuleList()
         self.pan_blocks = nn.ModuleList()
-        for _ in range(len(self.in_channels) - 1):
-            self.downsample_convs.append(
-                RTDetrV2ConvNormLayer(
-                    config, self.encoder_hidden_dim, self.encoder_hidden_dim, 3, 2, activation=activation_function
-                )
+        for _ in range(self.num_pan_stages):
+            downsample_conv = RTDetrV2ConvNormLayer(
+                config,
+                in_channels=self.encoder_hidden_dim,
+                out_channels=self.encoder_hidden_dim,
+                kernel_size=3,
+                stride=2,
+                activation=activation,
             )
-            self.pan_blocks.append(RTDetrV2CSPRepLayer(config))
+            pan_block = RTDetrV2CSPRepLayer(config)
+            self.downsample_convs.append(downsample_conv)
+            self.pan_blocks.append(pan_block)
 
     @staticmethod
     def build_2d_sincos_position_embedding(
@@ -1035,6 +1048,7 @@ class RTDetrV2HybridEncoder(nn.Module):
 
         encoder_states = () if output_hidden_states else None
         all_attentions = () if output_attentions else None
+
         # encoder
         if self.config.encoder_layers > 0:
             for i, enc_ind in enumerate(self.encode_proj_layers):
@@ -1070,37 +1084,37 @@ class RTDetrV2HybridEncoder(nn.Module):
             if output_hidden_states:
                 encoder_states = encoder_states + (hidden_states[enc_ind],)
 
-        # broadcasting and fusion
+        # top-down FPN
         fpn_feature_maps = [hidden_states[-1]]
-        for idx in range(len(self.in_channels) - 1, 0, -1):
-            # blocks
-            lateral_block = self.lateral_convs[len(self.in_channels) - 1 - idx]
-            fpn_block = self.fpn_blocks[len(self.in_channels) - 1 - idx]
-            # feature maps
-            backbone_feature_map = hidden_states[idx - 1]
-            top_fpn_feature_map = fpn_feature_maps[0]
+        for idx, (lateral_conv, fpn_block) in enumerate(zip(self.lateral_convs, self.fpn_blocks)):
+            backbone_feature_map = hidden_states[self.num_fpn_stages - idx - 1]
+            top_fpn_feature_map = fpn_feature_maps[-1]
             # apply lateral block
-            top_fpn_feature_map = lateral_block(top_fpn_feature_map)
-            fpn_feature_maps[0] = top_fpn_feature_map
+            top_fpn_feature_map = lateral_conv(top_fpn_feature_map)
+            fpn_feature_maps[-1] = top_fpn_feature_map
             # apply fpn block
             top_fpn_feature_map = F.interpolate(top_fpn_feature_map, scale_factor=2.0, mode="nearest")
             fused_feature_map = torch.concat([top_fpn_feature_map, backbone_feature_map], dim=1)
             new_fpn_feature_map = fpn_block(fused_feature_map)
-            fpn_feature_maps.insert(0, new_fpn_feature_map)
+            fpn_feature_maps.append(new_fpn_feature_map)
 
-        fpn_states = [fpn_feature_maps[0]]
-        for idx in range(len(self.in_channels) - 1):
-            feat_low = fpn_states[-1]
-            feat_high = fpn_feature_maps[idx + 1]
-            downsample_feat = self.downsample_convs[idx](feat_low)
-            hidden_states = self.pan_blocks[idx](
-                torch.concat([downsample_feat, feat_high.to(downsample_feat.device)], dim=1)
-            )
-            fpn_states.append(hidden_states)
+        fpn_feature_maps = fpn_feature_maps[::-1]
+
+        # bottom-up PAN
+        pan_feature_maps = [fpn_feature_maps[0]]
+        for idx, (downsample_conv, pan_block) in enumerate(zip(self.downsample_convs, self.pan_blocks)):
+            top_pan_feature_map = pan_feature_maps[-1]
+            fpn_feature_map = fpn_feature_maps[idx + 1]
+            downsampled_feature_map = downsample_conv(top_pan_feature_map)
+            fused_feature_map = torch.concat([downsampled_feature_map, fpn_feature_map], dim=1)
+            new_pan_feature_map = pan_block(fused_feature_map)
+            pan_feature_maps.append(new_pan_feature_map)
 
         if not return_dict:
-            return tuple(v for v in [fpn_states, encoder_states, all_attentions] if v is not None)
-        return BaseModelOutput(last_hidden_state=fpn_states, hidden_states=encoder_states, attentions=all_attentions)
+            return tuple(v for v in [pan_feature_maps, encoder_states, all_attentions] if v is not None)
+        return BaseModelOutput(
+            last_hidden_state=pan_feature_maps, hidden_states=encoder_states, attentions=all_attentions
+        )
 
 
 def inverse_sigmoid(x, eps=1e-5):

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -52,7 +52,8 @@ from .configuration_rt_detr_v2 import RTDetrV2Config
 
 
 logger = logging.get_logger(__name__)
-_CHECKPOINT_FOR_DOC = "PekingU/RTDetrV2_r50vd"
+
+_CHECKPOINT_FOR_DOC = "PekingU/rtdetr_v2_r50vd"
 
 _CONFIG_FOR_DOC = "RTDetrV2Config"
 
@@ -1220,12 +1221,12 @@ class RTDetrV2MLPPredictionHead(nn.Module):
         output_dims = [hidden_dim] * (num_layers - 1) + [output_dim]
         self.layers = nn.ModuleList(nn.Linear(in_dim, out_dim) for in_dim, out_dim in zip(input_dims, output_dims))
 
-    def forward(self, x):
+    def forward(self, hidden_state: torch.Tensor) -> torch.Tensor:
         for i, layer in enumerate(self.layers):
-            x = layer(x)
+            hidden_state = layer(hidden_state)
             if i < self.num_layers - 1:
-                x = nn.functional.relu(x)
-        return x
+                hidden_state = nn.functional.relu(hidden_state)
+        return hidden_state
 
 
 def inverse_sigmoid(x, eps=1e-5):
@@ -1519,11 +1520,11 @@ RTDetrV2_INPUTS_DOCSTRING = r"""
             Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
 """
 _DETECTION_OUTPUT_FOR_DOC = """
-    Detected 'sofa' (0.97) at [0.14, 0.38, 640.13, 476.21]
-    Detected 'cat' (0.96) at [343.38, 24.28, 640.14, 371.5]
-    Detected 'cat' (0.96) at [13.23, 54.18, 318.98, 472.22]
-    Detected 'remote' (0.95) at [40.11, 73.44, 175.96, 118.48]
-    Detected 'remote' (0.92) at [333.73, 76.58, 369.97, 186.99]
+    Detected 'cat' (0.96) at [13.71, 54.12, 317.53, 472.65]
+    Detected 'cat' (0.95) at [343.73, 23.68, 640.28, 373.05]
+    Detected 'sofa' (0.94) at [0.2, 1.32, 640.17, 474.38]
+    Detected 'remote' (0.93) at [40.6, 73.21, 175.74, 118.33]
+    Detected 'remote' (0.89) at [333.51, 76.79, 370.17, 188.13]
 """
 
 

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -1309,12 +1309,7 @@ class RTDetrV2PreTrainedModel(PreTrainedModel):
     config_class = RTDetrV2Config
     base_model_prefix = "rt_detr_v2"
     main_input_name = "pixel_values"
-    _no_split_modules = [
-        r"RTDetrV2ConvEncoder",
-        r"RTDetrV2EncoderLayer",
-        r"RTDetrV2DecoderLayer",
-        r"RTDetrV2CSPRepLayer",
-    ]
+    _no_split_modules = [r"RTDetrV2HybridEncoder", r"RTDetrV2DecoderLayer"]
 
     def _init_weights(self, module):
         """Initalize the weights"""

--- a/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
@@ -12,9 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import warnings
-from functools import partial
-from typing import List, Optional
+from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
@@ -27,11 +25,11 @@ from ...utils.backbone_utils import (
 )
 from ..auto import CONFIG_MAPPING
 from ..rt_detr.modeling_rt_detr import (
-    RTDetrDecoder,
-    RTDetrDecoderLayer,
+    MultiScaleDeformableAttention,
+    MultiScaleDeformableAttentionFunction,
     RTDetrForObjectDetection,
-    RTDetrMLPPredictionHead,
     RTDetrModel,
+    RTDetrMultiscaleDeformableAttention,
     RTDetrPreTrainedModel,
 )
 
@@ -389,137 +387,101 @@ class RTDetrV2Config(PretrainedConfig):
 
 def multi_scale_deformable_attention_v2(
     value: Tensor,
-    value_spatial_shapes: Tensor,
+    value_spatial_shapes: Union[Tensor, List[Tuple]],
     sampling_locations: Tensor,
     attention_weights: Tensor,
-    num_points_list: List[int],
     method="default",
 ) -> Tensor:
+    """
+    In addition to the `multi_scale_deformable_attention` (v1) function,
+    this function supports the `discrete` method of sampling, for `default` sampling method
+    the behavior is the same as the `multi_scale_deformable_attention` (v1) function.
+    """
     batch_size, _, num_heads, hidden_dim = value.shape
-    _, num_queries, num_heads, num_levels, num_points = sampling_locations.shape
-    value_list = (
-        value.permute(0, 2, 3, 1)
-        .flatten(0, 1)
-        .split([height * width for height, width in value_spatial_shapes], dim=-1)
-    )
-    # sampling_offsets [8, 480, 8, 12, 2]
+    batched_num_queries, num_heads, num_levels, num_points, _ = sampling_locations.shape
+    num_queries = batched_num_queries // batch_size
+
     if method == "default":
         sampling_grids = 2 * sampling_locations - 1
     elif method == "discrete":
         sampling_grids = sampling_locations
-    sampling_grids = sampling_grids.permute(0, 2, 1, 3, 4).flatten(0, 1)
-    sampling_grids = sampling_grids.split(num_points_list, dim=-2)
-    sampling_value_list = []
-    for level_id, (height, width) in enumerate(value_spatial_shapes):
-        # batch_size, height*width, num_heads, hidden_dim
-        # -> batch_size, height*width, num_heads*hidden_dim
-        # -> batch_size, num_heads*hidden_dim, height*width
-        # -> batch_size*num_heads, hidden_dim, height, width
-        value_l_ = value_list[level_id].reshape(batch_size * num_heads, hidden_dim, height, width)
-        # batch_size, num_queries, num_heads, num_points, 2
-        # -> batch_size, num_heads, num_queries, num_points, 2
-        # -> batch_size*num_heads, num_queries, num_points, 2
-        sampling_grid_l_ = sampling_grids[level_id]
-        # batch_size*num_heads, hidden_dim, num_queries, num_points
+
+    value_levels = value.split([height * width for height, width in value_spatial_shapes], dim=1)
+
+    sampled_values = []
+    for idx, (height, width) in enumerate(value_spatial_shapes):
+        # batch_size, height * width, num_heads, hidden_dim
+        # -> batch_size, num_heads * hidden_dim, height * width
+        # -> batch_size * num_heads, hidden_dim, height, width
+        value_i = value_levels[idx]
+        value_i = value_i.flatten(2).transpose(1, 2)
+        value_i = value_i.reshape(batch_size * num_heads, hidden_dim, height, width)
+
+        # batch_size * num_queries, num_heads, num_points, 2
+        # -> batch_size * num_heads, num_queries, num_points, 2
+        sampling_grid_i = sampling_grids[:, :, idx]
+        sampling_grid_i = sampling_grid_i.view(batch_size, num_queries, num_heads, num_points, 2)
+        sampling_grid_i = sampling_grid_i.transpose(1, 2).flatten(0, 1)
+
+        # batch_size * num_heads, hidden_dim, num_queries, num_points
         if method == "default":
-            sampling_value_l_ = nn.functional.grid_sample(
-                value_l_, sampling_grid_l_, mode="bilinear", padding_mode="zeros", align_corners=False
+            sampled_value_i = nn.functional.grid_sample(
+                value_i, sampling_grid_i, mode="bilinear", padding_mode="zeros", align_corners=False
             )
         elif method == "discrete":
-            sampling_coord = (sampling_grid_l_ * torch.tensor([[width, height]], device=value.device) + 0.5).to(
-                torch.int64
-            )
+            sampling_coord = sampling_grid_i * torch.tensor([[width, height]], device=value_i.device) + 0.5
+            sampling_coord = sampling_coord.to(torch.int64)
 
             # Separate clamping for x and y coordinates
             sampling_coord_x = sampling_coord[..., 0].clamp(0, width - 1)
             sampling_coord_y = sampling_coord[..., 1].clamp(0, height - 1)
 
-            # Combine the clamped coordinates
-            sampling_coord = torch.stack([sampling_coord_x, sampling_coord_y], dim=-1)
-            sampling_coord = sampling_coord.reshape(batch_size * num_heads, num_queries * num_points_list[level_id], 2)
-            sampling_idx = (
-                torch.arange(sampling_coord.shape[0], device=value.device)
-                .unsqueeze(-1)
-                .repeat(1, sampling_coord.shape[1])
-            )
-            sampling_value_l_ = value_l_[sampling_idx, :, sampling_coord[..., 1], sampling_coord[..., 0]]
-            sampling_value_l_ = sampling_value_l_.permute(0, 2, 1).reshape(
-                batch_size * num_heads, hidden_dim, num_queries, num_points_list[level_id]
-            )
-        sampling_value_list.append(sampling_value_l_)
-    # (batch_size, num_queries, num_heads, num_levels, num_points)
-    # -> (batch_size, num_heads, num_queries, num_levels, num_points)
-    # -> (batch_size, num_heads, 1, num_queries, num_levels*num_points)
-    attention_weights = attention_weights.permute(0, 2, 1, 3).reshape(
-        batch_size * num_heads, 1, num_queries, sum(num_points_list)
-    )
-    output = (
-        (torch.concat(sampling_value_list, dim=-1) * attention_weights)
-        .sum(-1)
-        .view(batch_size, num_heads * hidden_dim, num_queries)
-    )
-    return output.transpose(1, 2).contiguous()
+            sampling_coord_x = sampling_coord_x.reshape(batch_size * num_heads, num_queries * num_points)
+            sampling_coord_y = sampling_coord_y.reshape(batch_size * num_heads, num_queries * num_points)
+
+            sampling_idx = torch.arange(batch_size * num_heads, device=value_i.device)
+            sampling_idx = sampling_idx.unsqueeze(-1).repeat(1, num_queries * num_points)
+
+            sampled_value_i = value_i[sampling_idx, :, sampling_coord_y, sampling_coord_x]
+            sampled_value_i = sampled_value_i.transpose(1, 2)
+            sampled_value_i = sampled_value_i.reshape(batch_size * num_heads, hidden_dim, num_queries, num_points)
+
+        sampled_values.append(sampled_value_i)
+    sampled_values = torch.stack(sampled_values, dim=-2)
+
+    # (batch_size, num_queries, num_heads, ...) -> (batch_size, num_heads, num_queries, ...)
+    attention_weights = attention_weights.transpose(1, 2)
+    attention_weights = attention_weights.reshape(batch_size * num_heads, 1, num_queries, num_levels * num_points)
+
+    output = attention_weights * sampled_values.flatten(-2)
+    output = output.sum(-1)
+
+    output = output.view(batch_size, num_heads * hidden_dim, num_queries)
+    output = output.transpose(1, 2).contiguous()
+
+    return output
 
 
-# the main change
-class RTDetrV2MultiscaleDeformableAttention(nn.Module):
+class RTDetrV2MultiscaleDeformableAttention(RTDetrMultiscaleDeformableAttention):
     """
     RTDetrV2 version of multiscale deformable attention, extending the base implementation
     with improved offset handling and initialization.
     """
 
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__()
-        num_heads = config.decoder_attention_heads
-        n_points = config.decoder_n_points
-
-        if config.d_model % num_heads != 0:
-            raise ValueError(
-                f"embed_dim (d_model) must be divisible by num_heads, but got {config.d_model} and {num_heads}"
-            )
-        dim_per_head = config.d_model // num_heads
-        # check if dim_per_head is power of 2
-        if not ((dim_per_head & (dim_per_head - 1) == 0) and dim_per_head != 0):
-            warnings.warn(
-                "You'd better set embed_dim (d_model) in RTDetrV2MultiscaleDeformableAttention to make the"
-                " dimension of each attention head a power of 2 which is more efficient in the authors' CUDA"
-                " implementation."
-            )
-
-        self.im2col_step = 64
-
-        self.d_model = config.d_model
-
-        # V2-specific attributes
-        self.n_levels = config.decoder_n_levels
-        self.n_heads = num_heads
-        self.n_points = n_points
-
-        self.sampling_offsets = nn.Linear(config.d_model, num_heads * self.n_levels * n_points * 2)
-        self.attention_weights = nn.Linear(config.d_model, num_heads * self.n_levels * n_points)
-        self.value_proj = nn.Linear(config.d_model, config.d_model)
-        self.output_proj = nn.Linear(config.d_model, config.d_model)
-
+    def __init__(self, config: RTDetrV2Config, num_heads: int, num_points: int):
+        super().__init__(config, num_heads, num_points)
         self.offset_scale = config.decoder_offset_scale
         self.method = config.decoder_method
-
-        # Initialize n_points list and scale
-        n_points_list = [self.n_points for _ in range(self.n_levels)]
-        self.n_points_list = n_points_list
-        n_points_scale = [1 / n for n in n_points_list for _ in range(n)]
-        self.register_buffer("n_points_scale", torch.tensor(n_points_scale, dtype=torch.float32))
 
     def forward(
         self,
         hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        reference_points: torch.Tensor,
+        spatial_shapes: torch.Tensor,
+        spatial_shapes_list: List[Tuple[int, int]],
         attention_mask: Optional[torch.Tensor] = None,
-        encoder_hidden_states=None,
-        encoder_attention_mask=None,
         position_embeddings: Optional[torch.Tensor] = None,
-        reference_points=None,
-        spatial_shapes=None,
-        spatial_shapes_list=None,
-        level_start_index=None,
         output_attentions: bool = False,
     ):
         # Process inputs up to sampling locations calculation using parent class logic
@@ -528,96 +490,102 @@ class RTDetrV2MultiscaleDeformableAttention(nn.Module):
 
         batch_size, num_queries, _ = hidden_states.shape
         batch_size, sequence_length, _ = encoder_hidden_states.shape
-        if not is_torchdynamo_compiling() and (spatial_shapes[:, 0] * spatial_shapes[:, 1]).sum() != sequence_length:
+
+        total_elements = sum(height * width for height, width in spatial_shapes_list)
+        if total_elements != sequence_length:
             raise ValueError(
                 "Make sure to align the spatial shapes with the sequence length of the encoder hidden states"
             )
 
         value = self.value_proj(encoder_hidden_states)
         if attention_mask is not None:
-            value = value.masked_fill(~attention_mask[..., None], float(0))
-        value = value.view(batch_size, sequence_length, self.n_heads, self.d_model // self.n_heads)
+            # we invert the attention_mask
+            value = value.masked_fill(~attention_mask[..., None], 0.0)
 
-        # V2-specific sampling offsets shape
-        sampling_offsets = self.sampling_offsets(hidden_states).view(
-            batch_size, num_queries, self.n_heads, self.n_levels * self.n_points, 2
-        )
+        value = value.view(batch_size, sequence_length, self.num_heads, self.head_dim)
 
         attention_weights = self.attention_weights(hidden_states).view(
-            batch_size, num_queries, self.n_heads, self.n_levels * self.n_points
+            batch_size, num_queries, self.num_heads, self.num_levels * self.num_points
         )
         attention_weights = F.softmax(attention_weights, -1)
+        attention_weights = attention_weights.view(
+            batch_size, num_queries, self.num_heads, self.num_levels, self.num_points
+        )
 
-        # V2-specific sampling locations calculation
-        if reference_points.shape[-1] == 2:
-            offset_normalizer = torch.stack([spatial_shapes[..., 1], spatial_shapes[..., 0]], -1)
-            sampling_locations = (
-                reference_points[:, :, None, :, None, :]
-                + sampling_offsets / offset_normalizer[None, None, None, :, None, :]
-            )
-        elif reference_points.shape[-1] == 4:
-            n_points_scale = self.n_points_scale.to(dtype=hidden_states.dtype).unsqueeze(-1)
-            offset = sampling_offsets * n_points_scale * reference_points[:, :, None, :, 2:] * self.offset_scale
-            sampling_locations = reference_points[:, :, None, :, :2] + offset
+        # Sampling offsets shape
+        sampling_offsets = self.sampling_offsets(hidden_states)
+        sampling_offsets = sampling_offsets.view(
+            batch_size * num_queries, self.num_heads, self.num_levels, self.num_points, 2
+        )
+
+        # Sampling locations calculation
+        batch_size, num_reference_points, _, num_coordinates = reference_points.shape
+        reference_points = reference_points.view(batch_size * num_reference_points, 1, -1, 1, num_coordinates)
+
+        if num_coordinates == 2:
+            height, width = spatial_shapes[..., 0], spatial_shapes[..., 1]
+            offset_normalizer = torch.stack([width, height], -1)
+            normalized_sampling_offsets = sampling_offsets / offset_normalizer[None, None, :, None, :]
+            sampling_locations = reference_points + normalized_sampling_offsets
+
+        elif num_coordinates == 4:
+            reference_points_xy = reference_points[..., :2]
+            offset = sampling_offsets / self.num_points * reference_points[..., 2:] * self.offset_scale
+            sampling_locations = reference_points_xy + offset
+
         else:
             raise ValueError(f"Last dim of reference_points must be 2 or 4, but got {reference_points.shape[-1]}")
 
-        # V2-specific attention implementation choice
-        output = multi_scale_deformable_attention_v2(
-            value, spatial_shapes_list, sampling_locations, attention_weights, self.n_points_list, self.method
-        )
+        if (
+            self.disable_custom_kernels  # manually disabled in config
+            or MultiScaleDeformableAttention is None  # error while loading the kernel
+            or is_torchdynamo_compiling()  # torch.compile / torch.export mode
+        ):
+            # PyTorch implementation
+            output = multi_scale_deformable_attention_v2(
+                value, spatial_shapes_list, sampling_locations, attention_weights, method=self.method
+            )
+        else:
+            try:
+                # Calling custom kernel
+                # Note: for custom kernel we pass sampling locations as 6D tensor,
+                #       but for torch implementation we keep it as 5D tensor (for CoreML compat)
+                kernel_sampling_locations = sampling_locations.view(
+                    batch_size, num_queries, self.num_heads, self.num_levels, self.num_points, 2
+                )
+                level_start_index = torch.cat((spatial_shapes.new_zeros((1,)), spatial_shapes.prod(1).cumsum(0)[:-1]))
+                output = MultiScaleDeformableAttentionFunction.apply(
+                    value,
+                    spatial_shapes,
+                    level_start_index,
+                    kernel_sampling_locations,
+                    attention_weights,
+                    self.im2col_step,
+                )
+            except Exception:
+                # PyTorch implementation
+                output = multi_scale_deformable_attention_v2(
+                    value, spatial_shapes_list, sampling_locations, attention_weights, method=self.method
+                )
 
         output = self.output_proj(output)
+
+        if not output_attentions:
+            attention_weights = None
+
         return output, attention_weights
-
-
-class RTDetrV2DecoderLayer(RTDetrDecoderLayer):
-    def __init__(self, config: RTDetrV2Config):
-        # initialize parent class
-        super().__init__(config)
-        # override only the encoder attention module with v2 version
-        self.encoder_attn = RTDetrV2MultiscaleDeformableAttention(config)
 
 
 class RTDetrV2PreTrainedModel(RTDetrPreTrainedModel):
     pass
 
 
-class RTDetrV2Decoder(RTDetrDecoder):
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__(config)
-        self.layers = nn.ModuleList([RTDetrV2DecoderLayer(config) for _ in range(config.decoder_layers)])
-
-
 class RTDetrV2Model(RTDetrModel):
-    def __init__(self, config: RTDetrV2Config):
-        super().__init__(config)
-        # decoder
-        self.decoder = RTDetrV2Decoder(config)
-
-
-class RTDetrV2MLPPredictionHead(RTDetrMLPPredictionHead):
     pass
 
 
 class RTDetrV2ForObjectDetection(RTDetrForObjectDetection, RTDetrV2PreTrainedModel):
-    def __init__(self, config: RTDetrV2Config):
-        RTDetrV2PreTrainedModel.__init__(config)
-        # RTDETR encoder-decoder model
-        self.model = RTDetrV2Model(config)
-
-        # Detection heads on top
-        class_embed = partial(nn.Linear, config.d_model, config.num_labels)
-        bbox_embed = partial(RTDetrV2MLPPredictionHead, config, config.d_model, config.d_model, 4, num_layers=3)
-
-        self.class_embed = nn.ModuleList([class_embed() for _ in range(config.decoder_layers)])
-        self.bbox_embed = nn.ModuleList([bbox_embed() for _ in range(config.decoder_layers)])
-
-        self.model.decoder.class_embed = self.class_embed
-        self.model.decoder.bbox_embed = self.bbox_embed
-
-        # Initialize weights and apply final processing
-        self.post_init()
+    pass
 
 
 __all__ = [

--- a/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
@@ -36,6 +36,15 @@ from ..rt_detr.modeling_rt_detr import (
 
 logger = logging.get_logger(__name__)
 
+_CHECKPOINT_FOR_DOC = "PekingU/rtdetr_v2_r50vd"
+_DETECTION_OUTPUT_FOR_DOC = """
+    Detected 'cat' (0.96) at [13.71, 54.12, 317.53, 472.65]
+    Detected 'cat' (0.95) at [343.73, 23.68, 640.28, 373.05]
+    Detected 'sofa' (0.94) at [0.2, 1.32, 640.17, 474.38]
+    Detected 'remote' (0.93) at [40.6, 73.21, 175.74, 118.33]
+    Detected 'remote' (0.89) at [333.51, 76.79, 370.17, 188.13]
+"""
+
 
 class RTDetrV2Config(PretrainedConfig):
     r"""

--- a/src/transformers/models/table_transformer/modeling_table_transformer.py
+++ b/src/transformers/models/table_transformer/modeling_table_transformer.py
@@ -285,8 +285,8 @@ class TableTransformerConvEncoder(nn.Module):
             backbone = load_backbone(config)
 
         # replace batch norm by frozen batch norm
-        with torch.no_grad():
-            replace_batch_norm(backbone)
+        replace_batch_norm(backbone)
+
         self.model = backbone
         self.intermediate_channel_sizes = (
             self.model.feature_info.channels() if config.use_timm_backbone else self.model.channels

--- a/src/transformers/models/table_transformer/modeling_table_transformer.py
+++ b/src/transformers/models/table_transformer/modeling_table_transformer.py
@@ -193,12 +193,13 @@ class TableTransformerFrozenBatchNorm2d(nn.Module):
     torchvision.models.resnet[18,34,50,101] produce nans.
     """
 
-    def __init__(self, n):
+    def __init__(self, num_features: int, eps: float = 1e-5):
         super().__init__()
-        self.register_buffer("weight", torch.ones(n))
-        self.register_buffer("bias", torch.zeros(n))
-        self.register_buffer("running_mean", torch.zeros(n))
-        self.register_buffer("running_var", torch.ones(n))
+        self.eps = eps
+        self.register_buffer("weight", torch.ones(num_features))
+        self.register_buffer("bias", torch.zeros(num_features))
+        self.register_buffer("running_mean", torch.zeros(num_features))
+        self.register_buffer("running_var", torch.ones(num_features))
 
     def _load_from_state_dict(
         self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
@@ -211,17 +212,15 @@ class TableTransformerFrozenBatchNorm2d(nn.Module):
             state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
         )
 
-    def forward(self, x):
-        # move reshapes to the beginning
-        # to make it user-friendly
-        weight = self.weight.reshape(1, -1, 1, 1)
-        bias = self.bias.reshape(1, -1, 1, 1)
-        running_var = self.running_var.reshape(1, -1, 1, 1)
-        running_mean = self.running_mean.reshape(1, -1, 1, 1)
-        epsilon = 1e-5
-        scale = weight * (running_var + epsilon).rsqrt()
-        bias = bias - running_mean * scale
-        return x * scale + bias
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # reshape for broadcasting
+        weight = self.weight.view(1, -1, 1, 1)
+        bias = self.bias.view(1, -1, 1, 1)
+        running_var = self.running_var.view(1, -1, 1, 1)
+        running_mean = self.running_mean.view(1, -1, 1, 1)
+        # compute batchnorm
+        scale = weight * (running_var + self.eps).rsqrt()
+        return (x - running_mean) * scale + bias
 
 
 # Copied from transformers.models.detr.modeling_detr.replace_batch_norm with Detr->TableTransformer

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -616,6 +616,34 @@ PT_VISION_SEQ_CLASS_SAMPLE = r"""
     ```
 """
 
+PT_OBJECT_DETECTION_SAMPLE = """
+    Example:
+
+    ```python
+    >>> import torch
+    >>> from transformers.image_utils import load_image
+    >>> from transformers import AutoImageProcessor, {model_class}
+
+    >>> image = load_image("http://images.cocodataset.org/val2017/000000039769.jpg")
+
+    >>> processor = AutoImageProcessor.from_pretrained("{checkpoint}")
+    >>> model = {model_class}.from_pretrained("{checkpoint}")
+
+    >>> inputs = processor(images=image, return_tensors="pt")
+    >>> with torch.no_grad():
+    ...     outputs = model(**inputs)
+
+    >>> target_sizes = [(image.height, image.width)]
+    >>> results = processor.post_process_object_detection(outputs, target_sizes=target_sizes)
+
+    >>> for result in results:
+    ...     for score, label_id, box in zip(result["scores"], result["labels"], result["boxes"]):
+    ...         score, label = score.item(), label_id.item()
+    ...         box = [round(i, 2) for i in box.tolist()]
+    ...         print(f"Detected '{{model.config.id2label[label]}}' ({{score:.2f}}) at {{box}}")
+    {expected_output}
+    ```
+"""
 
 PT_SAMPLE_DOCSTRINGS = {
     "SequenceClassification": PT_SEQUENCE_CLASSIFICATION_SAMPLE,
@@ -632,6 +660,7 @@ PT_SAMPLE_DOCSTRINGS = {
     "AudioXVector": PT_SPEECH_XVECTOR_SAMPLE,
     "VisionBaseModel": PT_VISION_BASE_MODEL_SAMPLE,
     "ImageClassification": PT_VISION_SEQ_CLASS_SAMPLE,
+    "ObjectDetection": PT_OBJECT_DETECTION_SAMPLE,
 }
 
 
@@ -1154,6 +1183,8 @@ def add_code_sample_docstrings(
             code_sample = sample_docstrings["AudioXVector"]
         elif "Model" in model_class and modality == "audio":
             code_sample = sample_docstrings["SpeechBaseModel"]
+        elif "ObjectDetection" in model_class:
+            code_sample = sample_docstrings["ObjectDetection"]
         elif "Model" in model_class and modality == "vision":
             code_sample = sample_docstrings["VisionBaseModel"]
         elif "Model" in model_class or "Encoder" in model_class:

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -772,4 +772,4 @@ class RTDetrModelIntegrationTest(unittest.TestCase):
 
         torch.testing.assert_close(results["scores"][:4], expected_scores, rtol=1e-4, atol=1e-4)
         self.assertSequenceEqual(results["labels"][:4].tolist(), expected_labels)
-        torch.testing.assert_close(results["boxes"][:4], expected_slice_boxes, rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(results["boxes"][:4], expected_slice_boxes, rtol=1e-4, atol=2e-3)

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -364,14 +364,15 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             )
             out_len = len(outputs)
 
-            correct_outlen = 13
+            correct_outlen = 7
 
-            # loss is at first position
             if "labels" in inputs_dict:
-                correct_outlen += 1  # loss is added to beginning
-            # Object Detection model returns pred_logits and pred_boxes
+                correct_outlen += 3  # loss, loss_dict, auxiliary_outputs are added
+
+            # Object Detection model returns 'pred_logits', 'pred_boxes'
+            # 'class_outputs', 'bbox_outputs' as well
             if model_class.__name__ == "RTDetrForObjectDetection":
-                correct_outlen += 2
+                correct_outlen += 4
 
             self.assertEqual(out_len, correct_outlen)
 

--- a/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
+++ b/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
@@ -733,9 +733,9 @@ class RTDetrV2ModelIntegrationTest(unittest.TestCase):
 
         expected_logits = torch.tensor(
             [
-                [-3.7025, -5.1861, -6.1760],
-                [-4.0303, -9.3277, -5.1979],
-                [-4.1273, -4.7408, -5.8560],
+                [-3.7047, -5.1914, -6.1787],
+                [-4.0108, -9.3449, -5.2047],
+                [-4.1287, -4.7461, -5.8633],
             ]
         ).to(torch_device)
         expected_boxes = torch.tensor(
@@ -760,10 +760,10 @@ class RTDetrV2ModelIntegrationTest(unittest.TestCase):
         expected_labels = [15, 15, 65, 57]
         expected_slice_boxes = torch.tensor(
             [
-                [3.4114e02, 2.5115e01, 6.3997e02, 3.7289e02],
-                [1.2781e01, 5.6344e01, 3.1766e02, 4.7135e02],
-                [3.9958e01, 7.3110e01, 1.7564e02, 1.1744e02],
-                [-1.0269e-01, 2.9497e00, 6.3989e02, 4.7362e02],
+                [3.4114e02, 2.5111e01, 6.3998e02, 3.7289e02],
+                [1.2780e01, 5.6346e01, 3.1767e02, 4.7134e02],
+                [3.9959e01, 7.3117e01, 1.7565e02, 1.1744e02],
+                [-1.0521e-01, 2.9717e00, 6.3989e02, 4.7362e02],
             ],
             device=torch_device,
         )

--- a/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
+++ b/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
@@ -391,11 +391,12 @@ class RTDetrV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
             self.assertIsInstance(cross_attentions, (list, tuple))
             self.assertEqual(len(cross_attentions), self.model_tester.decoder_layers)
             self.assertListEqual(
-                list(cross_attentions[0].shape[-3:]),
+                list(cross_attentions[0].shape[-4:]),
                 [
                     self.model_tester.num_queries,
                     self.model_tester.decoder_attention_heads,
-                    self.model_tester.decoder_n_levels * self.model_tester.decoder_n_points,
+                    self.model_tester.decoder_n_levels,
+                    self.model_tester.decoder_n_points,
                 ],
             )
 

--- a/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
+++ b/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
@@ -362,14 +362,15 @@ class RTDetrV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
             )
             out_len = len(outputs)
 
-            correct_outlen = 13
+            correct_outlen = 7
 
-            # loss is at first position
             if "labels" in inputs_dict:
-                correct_outlen += 1  # loss is added to beginning
-            # Object Detection model returns pred_logits and pred_boxes
+                correct_outlen += 3  # loss, loss_dict, auxiliary_outputs are added
+
+            # Object Detection model returns 'pred_logits', 'pred_boxes'
+            # 'class_outputs', 'bbox_outputs' as well
             if model_class.__name__ == "RTDetrV2ForObjectDetection":
-                correct_outlen += 2
+                correct_outlen += 4
 
             self.assertEqual(out_len, correct_outlen)
 
@@ -732,9 +733,9 @@ class RTDetrV2ModelIntegrationTest(unittest.TestCase):
 
         expected_logits = torch.tensor(
             [
-                [-3.7047, -5.1914, -6.1787],
-                [-4.0108, -9.3449, -5.2047],
-                [-4.1287, -4.7461, -5.8633],
+                [-3.7025, -5.1861, -6.1760],
+                [-4.0303, -9.3277, -5.1979],
+                [-4.1273, -4.7408, -5.8560],
             ]
         ).to(torch_device)
         expected_boxes = torch.tensor(
@@ -759,10 +760,10 @@ class RTDetrV2ModelIntegrationTest(unittest.TestCase):
         expected_labels = [15, 15, 65, 57]
         expected_slice_boxes = torch.tensor(
             [
-                [3.4114e02, 2.5111e01, 6.3998e02, 3.7289e02],
-                [1.2780e01, 5.6346e01, 3.1767e02, 4.7134e02],
-                [3.9959e01, 7.3117e01, 1.7565e02, 1.1744e02],
-                [-1.0521e-01, 2.9717e00, 6.3989e02, 4.7362e02],
+                [3.4114e02, 2.5115e01, 6.3997e02, 3.7289e02],
+                [1.2781e01, 5.6344e01, 3.1766e02, 4.7135e02],
+                [3.9958e01, 7.3110e01, 1.7564e02, 1.1744e02],
+                [-1.0269e-01, 2.9497e00, 6.3989e02, 4.7362e02],
             ],
             device=torch_device,
         )

--- a/utils/check_config_attributes.py
+++ b/utils/check_config_attributes.py
@@ -204,6 +204,7 @@ SPECIAL_CASES_TO_ALLOW = {
         "weight_loss_vfl",
     ],
     "RTDetrV2Config": [
+        "decoder_n_levels",
         "eos_coefficient",
         "focal_loss_alpha",
         "focal_loss_gamma",


### PR DESCRIPTION
# What does this PR do?`

Improves code readability for object-detection models, should be merged after 
 - #36460 
 
**Note:**

> RT-DETR and RT-DETR-v2 are refactored, for other models just Freezed BatchNorm2d module updated.

**RT-DETR refactoring:** 

  - Make code closer to `transformers` standards (no one-letter vars, common var names, ...)
  - Remove some unused outputs (seems not necessary, but add overhead on implementation and docs)
  - Clean up signatures from unused arguments (where it's possible)
  - Better comments and shape comments
  - Add default docstring for object-detection
  - Unify RT-DETR and RT-DETRv2 implementations (simpler modular file for v2)

**In addition:**
 
 - Fix CoreML export for RT-DETR (avoid 6D tensors in deformable_attention)
 
Mostly, the changes are backward compatible, but some **internal** modules' signatures have changed. I suspect RT-DETR **internal** modules are used on their own somewhere outside the `transformers` repository. A quick search on GitHub shows only transformers forks, and I have never seen custom code samples on HF Hub for object detection. Therefore, I think we can change them to establish better standards for upcoming models such as D-Fine (a state-of-the-art real-time object detector) and RT-DETRv3, both of which are based on RT-DETR.

### Test changes

I tried to keep tests untouched, but there are a few modifications:
 - the number of outputs in ModelOuput is reduced

## Who can review?

cc @SangbumChoi @jadechoghari as model contributors, in case you want to have a look. Please let me know if anything is missing / incorrectly re-implemented