### PR TITLE
[Validation] First implementation of `@strict` from `huggingface_hub`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ _deps = [
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
     "hf_xet",
-    "huggingface-hub>=0.30.0,<1.0",
+    "huggingface-hub>=0.31.4,<1.0",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "isort>=5.5.4",

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -215,6 +215,12 @@ class PretrainedConfig(PushToHubMixin):
         self._set_defaults(**kwargs)
 
     def _set_defaults(self, **kwargs):
+        def _get_default_if_unset(attribute_name, default_value):
+            set_attribute = getattr(self, attribute_name, None)
+            if set_attribute is not None:
+                return set_attribute
+            return kwargs.pop(attribute_name, default_value)
+
         # Attributes with defaults
         self.return_dict = kwargs.pop("return_dict", True)
         self.output_hidden_states = kwargs.pop("output_hidden_states", False)
@@ -273,12 +279,11 @@ class PretrainedConfig(PushToHubMixin):
         # Tokenizer arguments TODO: eventually tokenizer and models should share the same config
         self.tokenizer_class = kwargs.pop("tokenizer_class", None)
         self.prefix = kwargs.pop("prefix", None)
-        self.bos_token_id = kwargs.pop("bos_token_id", None)
-        self.pad_token_id = kwargs.pop("pad_token_id", None)
-        self.eos_token_id = kwargs.pop("eos_token_id", None)
-        self.sep_token_id = kwargs.pop("sep_token_id", None)
-
-        self.decoder_start_token_id = kwargs.pop("decoder_start_token_id", None)
+        self.bos_token_id = _get_default_if_unset("bos_token_id", None)
+        self.pad_token_id = _get_default_if_unset("pad_token_id", None)
+        self.eos_token_id = _get_default_if_unset("eos_token_id", None)
+        self.sep_token_id = _get_default_if_unset("sep_token_id", None)
+        self.decoder_start_token_id = _get_default_if_unset("decoder_start_token_id", None)
 
         # task specific arguments
         self.task_specific_params = kwargs.pop("task_specific_params", None)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -382,6 +382,22 @@ class PretrainedConfig(PushToHubMixin):
     def _attn_implementation(self, value):
         self._attn_implementation_internal = value
 
+    def validate(self):
+        """
+        Validates the contents of the config.
+        """
+        # Special token validation
+        text_config = self.get_text_config()
+        vocab_size = getattr(text_config, "vocab_size", None)
+        if vocab_size is not None:
+            for token_name in ["pad_token_id", "bos_token_id", "eos_token_id"]:
+                token_id = getattr(text_config, token_name, None)
+                if token_id is not None and not 0 <= token_id < vocab_size:
+                    raise ValueError(
+                        f"{token_name} must be `None` or an integer within the vocabulary, "
+                        f"i.e. between 0 and {vocab_size - 1}, got {token_id}."
+                    )
+
     def save_pretrained(self, save_directory: Union[str, os.PathLike], push_to_hub: bool = False, **kwargs):
         """
         Save a configuration object to the directory `save_directory`, so that it can be re-loaded using the

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -382,11 +382,8 @@ class PretrainedConfig(PushToHubMixin):
     def _attn_implementation(self, value):
         self._attn_implementation_internal = value
 
-    def validate(self):
-        """
-        Validates the contents of the config.
-        """
-        # Special token validation
+    def validate_token_ids(self):
+        """Part of `@strict`-powered validation. Validates the contents of the special tokens."""
         text_config = self.get_text_config()
         vocab_size = getattr(text_config, "vocab_size", None)
         if vocab_size is not None:

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -390,9 +390,9 @@ class PretrainedConfig(PushToHubMixin):
             for token_name in ["pad_token_id", "bos_token_id", "eos_token_id"]:
                 token_id = getattr(text_config, token_name, None)
                 if token_id is not None and not 0 <= token_id < vocab_size:
-                    raise ValueError(
-                        f"{token_name} must be `None` or an integer within the vocabulary, "
-                        f"i.e. between 0 and {vocab_size - 1}, got {token_id}."
+                    logger.warning_once(
+                        f"{token_name} must be `None` or an integer within the vocabulary (between 0 and "
+                        f"{vocab_size - 1}), got {token_id}. This may lead to unexpected behavior."
                     )
 
     def save_pretrained(self, save_directory: Union[str, os.PathLike], push_to_hub: bool = False, **kwargs):

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -393,6 +393,14 @@ class PretrainedConfig(PushToHubMixin):
     def _attn_implementation(self, value):
         self._attn_implementation_internal = value
 
+    @property
+    def attn_implementation(self):
+        return self._attn_implementation
+
+    @attn_implementation.setter
+    def attn_implementation(self, value):
+        self._attn_implementation = value
+
     def validate_token_ids(self):
         """Part of `@strict`-powered validation. Validates the contents of the special tokens."""
         text_config = self.get_text_config()

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -208,7 +208,13 @@ class PretrainedConfig(PushToHubMixin):
             key = super().__getattribute__("attribute_map")[key]
         return super().__getattribute__(key)
 
+    def __post_init__(self):
+        self._set_defaults()
+
     def __init__(self, **kwargs):
+        self._set_defaults(**kwargs)
+
+    def _set_defaults(self, **kwargs):
         # Attributes with defaults
         self.return_dict = kwargs.pop("return_dict", True)
         self.output_hidden_states = kwargs.pop("output_hidden_states", False)

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -24,7 +24,7 @@ deps = {
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
     "hf_xet": "hf_xet",
-    "huggingface-hub": "huggingface-hub>=0.30.0,<1.0",
+    "huggingface-hub": "huggingface-hub>=0.31.4,<1.0",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "isort": "isort>=5.5.4",

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2025,6 +2025,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
                 "`PretrainedConfig`. To create a model from a pretrained model use "
                 f"`model = {self.__class__.__name__}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
+        if hasattr(config, "validate"):  # e.g. in @strict_dataclass
+            config.validate()
         if not getattr(config, "_attn_implementation_autoset", False):
             # config usually has a `torch_dtype` but we need the next line for the `no_super_init` tests
             dtype = config.torch_dtype if hasattr(config, "torch_dtype") else torch.get_default_dtype()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2025,8 +2025,10 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
                 "`PretrainedConfig`. To create a model from a pretrained model use "
                 f"`model = {self.__class__.__name__}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
-        if hasattr(config, "validate"):  # e.g. in @strict_dataclass
+        # class-level validation of config (as opposed to the attribute-level validation provided by `@strict`)
+        if hasattr(config, "validate"):
             config.validate()
+
         if not getattr(config, "_attn_implementation_autoset", False):
             # config usually has a `torch_dtype` but we need the next line for the `no_super_init` tests
             dtype = config.torch_dtype if hasattr(config, "torch_dtype") else torch.get_default_dtype()

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -17,13 +17,13 @@
 
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Literal, Mapping, Optional
+from typing import Literal, Mapping, Optional, Union
 
 from huggingface_hub.dataclasses import strict
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
-from ...validators import activation_fn_key, interval, probability, token
+from ...validators import activation_fn_key, interval, probability
 
 
 @strict(accept_kwargs=True)
@@ -118,17 +118,17 @@ class AlbertConfig(PretrainedConfig):
     intermediate_size: int = interval(min=1)(default=16384)
     inner_group_num: int = interval(min=0)(default=1)
     hidden_act: str = activation_fn_key(default="gelu_new")
-    hidden_dropout_prob: float = probability(default=0.0)
-    attention_probs_dropout_prob: float = probability(default=0.0)
+    hidden_dropout_prob: Union[float, int] = probability(default=0.0)
+    attention_probs_dropout_prob: Union[float, int] = probability(default=0.0)
     max_position_embeddings: int = interval(min=0)(default=512)
     type_vocab_size: int = interval(min=1)(default=2)
     initializer_range: float = interval(min=0.0)(default=0.02)
     layer_norm_eps: float = interval(min=0.0)(default=1e-12)
     classifier_dropout_prob: float = probability(default=0.1)
     position_embedding_type: Literal["absolute", "relative_key", "relative_key_query"] = "absolute"
-    pad_token_id: Optional[int] = token(default=0)
-    bos_token_id: Optional[int] = token(default=2)
-    eos_token_id: Optional[int] = token(default=3)
+    pad_token_id: Optional[int] = 0
+    bos_token_id: Optional[int] = 2
+    eos_token_id: Optional[int] = 3
 
     # Not part of __init__
     model_type = "albert"
@@ -138,7 +138,7 @@ class AlbertConfig(PretrainedConfig):
         if self.hidden_size % self.num_attention_heads != 0:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads}"
+                f"heads ({self.num_attention_heads})."
             )
 
 

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -151,7 +151,7 @@ class AlbertConfig(PretrainedConfig):
 
     def validate(self):
         """Ensures the configuration is valid."""
-        if self.hidden_size % self.num_attention_heads != 0 and not hasattr(self, "embedding_size"):
+        if self.hidden_size % self.num_attention_heads != 0:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads}"

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -16,16 +16,18 @@
 """ALBERT model configuration"""
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Literal, Mapping, Optional
 
-from huggingface_hub.utils import strict_dataclass, validated_field
+from huggingface_hub.dataclasses import strict, validated_field
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
-from ...validators import activation_fn_key, interval, probability
+from ...validators import activation_fn_key, interval, probability, token
 
 
-@strict_dataclass
+@strict(accept_kwargs=True)
+@dataclass
 class AlbertConfig(PretrainedConfig):
     r"""
     This is the configuration class to store the configuration of a [`AlbertModel`] or a [`TFAlbertModel`]. It is used
@@ -124,21 +126,15 @@ class AlbertConfig(PretrainedConfig):
     layer_norm_eps: float = validated_field(interval(min=0.0), default=1e-12)
     classifier_dropout_prob: float = validated_field(probability, default=0.1)
     position_embedding_type: Literal["absolute", "relative_key", "relative_key_query"] = "absolute"
-    pad_token_id: Optional[int] = 0
-    bos_token_id: Optional[int] = 2
-    eos_token_id: Optional[int] = 3
+    pad_token_id: Optional[int] = validated_field(token, default=0)
+    bos_token_id: Optional[int] = validated_field(token, default=2)
+    eos_token_id: Optional[int] = validated_field(token, default=3)
 
     # Not part of __init__
     model_type = "albert"
 
     def __post_init__(self):
-        """Called after `__init__` from the dataclass: initializes parent classes and validates the instance."""
-        super().__init__(
-            pad_token_id=self.pad_token_id,
-            bos_token_id=self.bos_token_id,
-            eos_token_id=self.eos_token_id,
-            # **kwargs  -> this is missing
-        )
+        """Called after `__init__`: validates the instance."""
         self.validate()
 
     def validate(self):

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -133,16 +133,8 @@ class AlbertConfig(PretrainedConfig):
     # Not part of __init__
     model_type = "albert"
 
-    def __post_init__(self):
-        """Called after `__init__`: validates the instance."""
-        self.validate()
-
-    def validate(self):
-        """Ensures the configuration is valid by assessing combinations of arguments."""
-        # Generic config validation
-        super().validate()
-
-        # Architecture validation
+    def validate_architecture(self):
+        """Part of `@strict`-powered validation. Validates the architecture of the config."""
         if self.hidden_size % self.num_attention_heads != 0:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -19,7 +19,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Literal, Mapping, Optional
 
-from huggingface_hub.dataclasses import strict, validated_field
+from huggingface_hub.dataclasses import strict
 
 from ...configuration_utils import PretrainedConfig
 from ...onnx import OnnxConfig
@@ -109,26 +109,26 @@ class AlbertConfig(PretrainedConfig):
     >>> configuration = model.config
     ```"""
 
-    vocab_size: int = validated_field(interval(min=1), default=30000)
-    embedding_size: int = validated_field(interval(min=1), default=128)
-    hidden_size: int = validated_field(interval(min=1), default=4096)
-    num_hidden_layers: int = validated_field(interval(min=1), default=12)
-    num_hidden_groups: int = validated_field(interval(min=1), default=1)
-    num_attention_heads: int = validated_field(interval(min=0), default=64)
-    intermediate_size: int = validated_field(interval(min=1), default=16384)
-    inner_group_num: int = validated_field(interval(min=0), default=1)
-    hidden_act: str = validated_field(activation_fn_key, default="gelu_new")
-    hidden_dropout_prob: float = validated_field(probability, default=0.0)
-    attention_probs_dropout_prob: float = validated_field(probability, default=0.0)
-    max_position_embeddings: int = validated_field(interval(min=0), default=512)
-    type_vocab_size: int = validated_field(interval(min=1), default=2)
-    initializer_range: float = validated_field(interval(min=0.0), default=0.02)
-    layer_norm_eps: float = validated_field(interval(min=0.0), default=1e-12)
-    classifier_dropout_prob: float = validated_field(probability, default=0.1)
+    vocab_size: int = interval(min=1)(default=30000)
+    embedding_size: int = interval(min=1)(default=128)
+    hidden_size: int = interval(min=1)(default=4096)
+    num_hidden_layers: int = interval(min=1)(default=12)
+    num_hidden_groups: int = interval(min=1)(default=1)
+    num_attention_heads: int = interval(min=0)(default=64)
+    intermediate_size: int = interval(min=1)(default=16384)
+    inner_group_num: int = interval(min=0)(default=1)
+    hidden_act: str = activation_fn_key(default="gelu_new")
+    hidden_dropout_prob: float = probability(default=0.0)
+    attention_probs_dropout_prob: float = probability(default=0.0)
+    max_position_embeddings: int = interval(min=0)(default=512)
+    type_vocab_size: int = interval(min=1)(default=2)
+    initializer_range: float = interval(min=0.0)(default=0.02)
+    layer_norm_eps: float = interval(min=0.0)(default=1e-12)
+    classifier_dropout_prob: float = probability(default=0.1)
     position_embedding_type: Literal["absolute", "relative_key", "relative_key_query"] = "absolute"
-    pad_token_id: Optional[int] = validated_field(token, default=0)
-    bos_token_id: Optional[int] = validated_field(token, default=2)
-    eos_token_id: Optional[int] = validated_field(token, default=3)
+    pad_token_id: Optional[int] = token(default=0)
+    bos_token_id: Optional[int] = token(default=2)
+    eos_token_id: Optional[int] = token(default=3)
 
     # Not part of __init__
     model_type = "albert"
@@ -139,21 +139,15 @@ class AlbertConfig(PretrainedConfig):
 
     def validate(self):
         """Ensures the configuration is valid by assessing combinations of arguments."""
+        # Generic config validation
+        super().validate()
+
         # Architecture validation
         if self.hidden_size % self.num_attention_heads != 0:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads}"
             )
-
-        # Token validation
-        for token_name in ["pad_token_id", "bos_token_id", "eos_token_id"]:
-            token_id = getattr(self, token_name)
-            if token_id is not None and not 0 <= token_id < self.vocab_size:
-                raise ValueError(
-                    f"{token_name} must be in the vocabulary with size {self.vocab_size}, i.e. between 0 and "
-                    f"{self.vocab_size - 1}, got {token_id}."
-                )
 
 
 # Copied from transformers.models.bert.configuration_bert.BertOnnxConfig with Roberta->Albert

--- a/src/transformers/models/albert/configuration_albert.py
+++ b/src/transformers/models/albert/configuration_albert.py
@@ -131,28 +131,32 @@ class AlbertConfig(PretrainedConfig):
     # Not part of __init__
     model_type = "albert"
 
-    def __init__(self, **kwargs):
-        super().__init__(
-            pad_token_id=self.pad_token_id, bos_token_id=self.bos_token_id, eos_token_id=self.eos_token_id, **kwargs
-        )
-
     def __post_init__(self):
+        """Called after `__init__` from the dataclass: initializes parent classes and validates the instance."""
+        super().__init__(
+            pad_token_id=self.pad_token_id,
+            bos_token_id=self.bos_token_id,
+            eos_token_id=self.eos_token_id,
+            # **kwargs  -> this is missing
+        )
         self.validate()
 
     def validate(self):
-        """Ensures the configuration is valid."""
+        """Ensures the configuration is valid by assessing combinations of arguments."""
+        # Architecture validation
         if self.hidden_size % self.num_attention_heads != 0:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads}"
             )
 
-        # Special tokens must be in the vocabulary
+        # Token validation
         for token_name in ["pad_token_id", "bos_token_id", "eos_token_id"]:
             token_id = getattr(self, token_name)
             if token_id is not None and not 0 <= token_id < self.vocab_size:
                 raise ValueError(
-                    f"{token_name} must be in the vocabulary with size {self.vocab_size}, got {token_id}."
+                    f"{token_name} must be in the vocabulary with size {self.vocab_size}, i.e. between 0 and "
+                    f"{self.vocab_size - 1}, got {token_id}."
                 )
 
 

--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -245,12 +245,6 @@ class AlbertEmbeddings(nn.Module):
 class AlbertAttention(nn.Module):
     def __init__(self, config: AlbertConfig):
         super().__init__()
-        if config.hidden_size % config.num_attention_heads != 0 and not hasattr(config, "embedding_size"):
-            raise ValueError(
-                f"The hidden size ({config.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({config.num_attention_heads}"
-            )
-
         self.num_attention_heads = config.num_attention_heads
         self.hidden_size = config.hidden_size
         self.attention_head_size = config.hidden_size // config.num_attention_heads
@@ -898,6 +892,7 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "predictions.decoder.weight"]
 
     def __init__(self, config):
+        config.validate()
         super().__init__(config)
 
         self.albert = AlbertModel(config, add_pooling_layer=False)

--- a/src/transformers/models/albert/modeling_albert.py
+++ b/src/transformers/models/albert/modeling_albert.py
@@ -892,7 +892,6 @@ class AlbertForMaskedLM(AlbertPreTrainedModel):
     _tied_weights_keys = ["predictions.decoder.bias", "predictions.decoder.weight"]
 
     def __init__(self, config):
-        config.validate()
         super().__init__(config)
 
         self.albert = AlbertModel(config, add_pooling_layer=False)

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -19,6 +19,8 @@ describe the constraints of your dataclass fields, for the best user experience 
 
 from typing import Callable, Optional
 
+from huggingface_hub.dataclasses import as_validated_field
+
 from .activations import ACT2CLS
 
 
@@ -63,6 +65,7 @@ def interval(
     min = min or float("-inf")
     max = max or float("inf")
 
+    @as_validated_field
     def _inner(value: int | float):
         min_valid = min <= value if not exclude_min else min < value
         max_valid = value <= max if not exclude_max else value < max
@@ -72,12 +75,14 @@ def interval(
     return _inner
 
 
+@as_validated_field
 def probability(value: float):
     """Ensures that `value` is a valid probability number, i.e. [0,1]."""
     if not 0 <= value <= 1:
         raise ValueError(f"Value must be a probability between 0.0 and 1.0, got {value}.")
 
 
+@as_validated_field
 def token(value: Optional[int]):
     """Ensures that `value` is a potential token. A token, when set, must be a non-negative integer."""
     if value is not None and value < 0:
@@ -87,6 +92,7 @@ def token(value: Optional[int]):
 # String validators
 
 
+@as_validated_field
 def activation_fn_key(value: str):
     """Ensures that `value` is a string corresponding to an activation function."""
     # TODO (joao): in python 3.11+, we can build a Literal type from the keys of ACT2CLS

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+# Copyright 2025-present the HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Validators to be used with `huggingface_hub.utils.strict_dataclass`. We recommend using the validator(s) that best
+describe the constraints of your dataclass fields, for a best user experience (e.g. better error messages).
+"""
+
+from typing import Iterable
+from .activations import ACT2CLS
+
+
+# Integer validators
+
+
+def positive_int(value: int):
+    """Ensures that `value` is a positive integer (including 0)."""
+    if not value >= 0:
+        raise ValueError(f"Value must be a positive integer, got {value}.")
+
+
+def strictly_positive_int(value: int):
+    """Ensures that `value` is a positive integer (excluding 0)."""
+    if not value > 0:
+        raise ValueError(f"Value must be a strictly positive integer, got {value}.")
+
+
+def vocabulary_token(value: int, vocab_size: int):
+    """Ensures that `value` is a valid vocabulary token index."""
+    if not 0 <= value < vocab_size:
+        raise ValueError(f"Value must be a token in the vocabulary, got {value}. (vocabulary size = {vocab_size})")
+
+
+
+# Float validators
+
+
+def positive_float(value: float):
+    """Ensures that `value` is a positive float (including 0.0)."""
+    if not value >= 0:
+        raise ValueError(f"Value must be a positive float, got {value}.")
+
+
+def probability(value: float):
+    """Ensures that `value` is a valid probability number, i.e. [0,1]."""
+    if not 0 <= value <= 1:
+        raise ValueError(f"Value must be a probability between 0.0 and 1.0, got {value}.")
+
+
+# String validators
+
+
+def activation_function_key(value: str):
+    """Ensures that `value` is a string corresponding to an activation function."""
+    if value not in ACT2CLS:
+        raise ValueError(
+            f"Value must be one of {list(ACT2CLS.keys())}, got {value}. "
+            "Make sure to use a string that corresponds to an activation function."
+        )
+
+
+def choice_str(value: str, choices: Iterable[str]):
+    """Ensures that `value` is one of the choices in `choices`."""
+    if value not in choices:
+        raise ValueError(f"Value must be one of {choices}, got {value}")

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -17,7 +17,7 @@ Validators to be used with `huggingface_hub.dataclasses.validated_field`. We rec
 describe the constraints of your dataclass fields, for the best user experience (e.g. better error messages).
 """
 
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 from huggingface_hub.dataclasses import as_validated_field
 
@@ -34,8 +34,8 @@ else:
 
 
 def interval(
-    min: Optional[int | float] = None,
-    max: Optional[int | float] = None,
+    min: Optional[Union[int, float]] = None,
+    max: Optional[Union[int, float]] = None,
     exclude_min: bool = False,
     exclude_max: bool = False,
 ) -> Callable:

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -35,7 +35,7 @@ def interval(
 ) -> Callable:
     """
     Parameterized validator that ensures that `value` is within the defined interval. Optionally, the interval can be
-    open on either side. Expected usage: `validated_field(interval(min=0), default=8)`
+    open on either side. Expected usage: `interval(min=0)(default=8)`
 
     Args:
         min (`int` or `float`, *optional*):

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -72,7 +72,7 @@ def interval(
     max = max or float("inf")
 
     @as_validated_field
-    def _inner(value: int | float):
+    def _inner(value: Union[int, float]):
         min_valid = min <= value if not exclude_min else min < value
         max_valid = value <= max if not exclude_max else value < max
         if not (min_valid and max_valid):

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -21,7 +21,13 @@ from typing import Callable, Optional
 
 from huggingface_hub.dataclasses import as_validated_field
 
-from .activations import ACT2CLS
+from .utils import is_torch_available
+
+
+if is_torch_available():
+    from .activations import ACT2FN
+else:
+    ACT2FN = {}
 
 
 # Numerical validators
@@ -82,25 +88,19 @@ def probability(value: float):
         raise ValueError(f"Value must be a probability between 0.0 and 1.0, got {value}.")
 
 
-@as_validated_field
-def token(value: Optional[int]):
-    """Ensures that `value` is a potential token. A token, when set, must be a non-negative integer."""
-    if value is not None and value < 0:
-        raise ValueError(f"A token, when set, must be a non-negative integer, got {value}.")
-
-
 # String validators
 
 
 @as_validated_field
 def activation_fn_key(value: str):
     """Ensures that `value` is a string corresponding to an activation function."""
-    # TODO (joao): in python 3.11+, we can build a Literal type from the keys of ACT2CLS
-    if value not in ACT2CLS:
-        raise ValueError(
-            f"Value must be one of {list(ACT2CLS.keys())}, got {value}. "
-            "Make sure to use a string that corresponds to an activation function."
-        )
+    # TODO (joao): in python 3.11+, we can build a Literal type from the keys of ACT2FN
+    if len(ACT2FN) > 0:  # don't validate if we can't import ACT2FN
+        if value not in ACT2FN:
+            raise ValueError(
+                f"Value must be one of {list(ACT2FN.keys())}, got {value}. "
+                "Make sure to use a string that corresponds to an activation function."
+            )
 
 
-__all__ = ["interval", "probability", "token", "activation_fn_key"]
+__all__ = ["interval", "probability", "activation_fn_key"]

--- a/src/transformers/validators.py
+++ b/src/transformers/validators.py
@@ -18,6 +18,7 @@ describe the constraints of your dataclass fields, for a best user experience (e
 """
 
 from typing import Iterable
+
 from .activations import ACT2CLS
 
 
@@ -40,7 +41,6 @@ def vocabulary_token(value: int, vocab_size: int):
     """Ensures that `value` is a valid vocabulary token index."""
     if not 0 <= value < vocab_size:
         raise ValueError(f"Value must be a token in the vocabulary, got {value}. (vocabulary size = {vocab_size})")
-
 
 
 # Float validators

--- a/tests/models/albert/test_modeling_albert.py
+++ b/tests/models/albert/test_modeling_albert.py
@@ -275,7 +275,7 @@ class AlbertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
     def setUp(self):
         self.model_tester = AlbertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=AlbertConfig, hidden_size=37)
+        self.config_tester = ConfigTester(self, config_class=AlbertConfig, hidden_size=64)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -53,11 +53,12 @@ class ConfigTester:
             self.parent.assertTrue(hasattr(config, prop), msg=f"`{prop}` does not exist")
 
         # Test that config has the common properties as setter
-        for idx, name in enumerate(common_properties):
+        dummy_value = 64
+        for name in common_properties:
             try:
-                setattr(config, name, idx)
+                setattr(config, name, dummy_value)
                 self.parent.assertEqual(
-                    getattr(config, name), idx, msg=f"`{name} value {idx} expected, but was {getattr(config, name)}"
+                    getattr(config, name), dummy_value, msg=f"`{name} value {dummy_value} expected, but was {getattr(config, name)}"
                 )
             except NotImplementedError:
                 # Some models might not be able to implement setters for common_properties
@@ -65,11 +66,11 @@ class ConfigTester:
                 pass
 
         # Test if config class can be called with Config(prop_name=..)
-        for idx, name in enumerate(common_properties):
+        for name in common_properties:
             try:
-                config = self.config_class(**{name: idx})
+                config = self.config_class(**{name: dummy_value})
                 self.parent.assertEqual(
-                    getattr(config, name), idx, msg=f"`{name} value {idx} expected, but was {getattr(config, name)}"
+                    getattr(config, name), dummy_value, msg=f"`{name} value {dummy_value} expected, but was {getattr(config, name)}"
                 )
             except NotImplementedError:
                 # Some models might not be able to implement setters for common_properties

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -58,7 +58,9 @@ class ConfigTester:
             try:
                 setattr(config, name, dummy_value)
                 self.parent.assertEqual(
-                    getattr(config, name), dummy_value, msg=f"`{name} value {dummy_value} expected, but was {getattr(config, name)}"
+                    getattr(config, name),
+                    dummy_value,
+                    msg=f"`{name} value {dummy_value} expected, but was {getattr(config, name)}",
                 )
             except NotImplementedError:
                 # Some models might not be able to implement setters for common_properties
@@ -70,7 +72,9 @@ class ConfigTester:
             try:
                 config = self.config_class(**{name: dummy_value})
                 self.parent.assertEqual(
-                    getattr(config, name), dummy_value, msg=f"`{name} value {dummy_value} expected, but was {getattr(config, name)}"
+                    getattr(config, name),
+                    dummy_value,
+                    msg=f"`{name} value {dummy_value} expected, but was {getattr(config, name)}",
                 )
             except NotImplementedError:
                 # Some models might not be able to implement setters for common_properties

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -12,77 +12,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import unittest
+from dataclasses import dataclass
+from typing import Optional, Union
+
+from huggingface_hub.dataclasses import StrictDataclassFieldValidationError, strict
 
 from transformers import AlbertConfig
-from transformers.validators import interval, probability, token, activation_fn_key
-from huggingface_hub.dataclasses import StrictDataclassFieldValidationError
+from transformers.validators import activation_fn_key, interval, probability, token
 
 
 class ValidatorsTests(unittest.TestCase):
     """
-    Sanity check tests for the validators. Note that the validators do not perform strict type checking
-    (`huggingface_hub.dataclasses.strict` is used for that).
+    Sanity check tests for the validators. Validators are `field` in a dataclass, and not meant to be used on
+    their own.
     """
 
     def test_interval(self):
+        # Setup test dataclasses
+        @strict
+        @dataclass
+        class TestInterval:
+            data: Union[int, float] = interval(min=1, max=10)()
+
+        @strict
+        @dataclass
+        class TestIntervalExcludeMinMax:
+            data: Union[int, float] = interval(min=1, max=10, exclude_min=True, exclude_max=True)()
+
         # valid
-        interval(1, 10)(5)
-        interval(1, 10)(5.0)
-        interval(1, 10)(10)
-        interval(1, 10)(1)
-        interval(1, 10, exclude_min=True)(1.0000001)
+        TestInterval(5)
+        TestInterval(5.0)
+        TestInterval(10)
+        TestInterval(1)
+        TestIntervalExcludeMinMax(1.0000001)
 
         # invalid
-        with self.assertRaises(ValueError):
-            interval(1, 10)(11)  # greater than max
-        with self.assertRaises(ValueError):
-            interval(1, 10)(0.9999999)  # less than min
-        with self.assertRaises(ValueError):
-            interval(1, 10, exclude_max=True)(10)  # equal to max, but exclude_max is True
-        with self.assertRaises(ValueError):
-            interval(1, 10, exclude_min=True)(1.0)  # equal to min, but exclude_min is True
-        with self.assertRaises(ValueError):
-            interval(1, 10)(-5)  # less than min
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestInterval("one")  # different type
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestInterval(11)  # greater than max
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestInterval(0.9999999)  # less than min
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestIntervalExcludeMinMax(10)  # equal to max, but exclude_max is True
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestIntervalExcludeMinMax(1.0)  # equal to min, but exclude_min is True
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestInterval(-5)  # less than min
 
     def test_probability(self):
+        # Setup test dataclasses
+        @strict
+        @dataclass
+        class TestProbability:
+            data: float = probability()
+
         # valid
-        probability(0.5)
-        probability(0)
-        probability(1)
+        TestProbability(0.5)
+        TestProbability(0.0)
+        TestProbability(1.0)
 
         # invalid
-        with self.assertRaises(ValueError):
-            probability(99)  # 0-1 probabilities only
-        with self.assertRaises(ValueError):
-            probability(1.1)  # greater than 1
-        with self.assertRaises(ValueError):
-            probability(-0.1)  # less than 0
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestProbability(1)  # different type
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestProbability(99.0)  # 0-1 probabilities only
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestProbability(1.1)  # greater than 1
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestProbability(-0.1)  # less than 0
 
     def test_token(self):
+        # Setup test dataclasses
+        @strict
+        @dataclass
+        class TestToken:
+            data: Optional[int] = token()
+
         # valid
-        token(None)
-        token(0)
-        token(1)
-        token(999999999)
+        TestToken(None)
+        TestToken(0)
+        TestToken(1)
+        TestToken(999999999)
 
         # invalid
-        with self.assertRaises(ValueError):
-            token(-1)  # less than 0
-        with self.assertRaises(TypeError):
-            token("<eos>")  # must be the token id, not its string counterpart
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestToken(-1)  # less than 0
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestToken("<eos>")  # different type: must be the token id, not its string counterpart
 
     def test_activation_fn_key(self):
+        # Setup test dataclasses
+        @strict
+        @dataclass
+        class TestActivationFnKey:
+            data: str = activation_fn_key()
+
         # valid
-        activation_fn_key("relu")
-        activation_fn_key("gelu")
+        TestActivationFnKey("relu")
+        TestActivationFnKey("gelu")
 
         # invalid
-        with self.assertRaises(ValueError):
-            activation_fn_key("foo")  # obvious one
-        with self.assertRaises(ValueError):
-            activation_fn_key(None)  # can't be None
-        with self.assertRaises(ValueError):
-            activation_fn_key("Relu")  # typo: should be "relu", not "Relu"
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestActivationFnKey("foo")  # obvious one
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestActivationFnKey(None)  # different type: can't be None
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            TestActivationFnKey("Relu")  # typo: should be "relu", not "Relu"
 
 
 class ValidatorsIntegrationTests(unittest.TestCase):
@@ -121,7 +157,7 @@ class ValidatorsIntegrationTests(unittest.TestCase):
         with self.assertRaises(StrictDataclassFieldValidationError):
             config = AlbertConfig(position_embedding_type="foo")
 
-       # eos_token_id is a token, and must be non-negative
+        # eos_token_id is a token, and must be non-negative
         with self.assertRaises(StrictDataclassFieldValidationError):
             config = AlbertConfig(eos_token_id=-1)
 

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -1,0 +1,135 @@
+# Copyright 2025 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from transformers import AlbertConfig
+from transformers.validators import interval, probability, token, activation_fn_key
+from huggingface_hub.dataclasses import StrictDataclassFieldValidationError
+
+
+class ValidatorsTests(unittest.TestCase):
+    """
+    Sanity check tests for the validators. Note that the validators do not perform strict type checking
+    (`huggingface_hub.dataclasses.strict` is used for that).
+    """
+
+    def test_interval(self):
+        # valid
+        interval(1, 10)(5)
+        interval(1, 10)(5.0)
+        interval(1, 10)(10)
+        interval(1, 10)(1)
+        interval(1, 10, exclude_min=True)(1.0000001)
+
+        # invalid
+        with self.assertRaises(ValueError):
+            interval(1, 10)(11)  # greater than max
+        with self.assertRaises(ValueError):
+            interval(1, 10)(0.9999999)  # less than min
+        with self.assertRaises(ValueError):
+            interval(1, 10, exclude_max=True)(10)  # equal to max, but exclude_max is True
+        with self.assertRaises(ValueError):
+            interval(1, 10, exclude_min=True)(1.0)  # equal to min, but exclude_min is True
+        with self.assertRaises(ValueError):
+            interval(1, 10)(-5)  # less than min
+
+    def test_probability(self):
+        # valid
+        probability(0.5)
+        probability(0)
+        probability(1)
+
+        # invalid
+        with self.assertRaises(ValueError):
+            probability(99)  # 0-1 probabilities only
+        with self.assertRaises(ValueError):
+            probability(1.1)  # greater than 1
+        with self.assertRaises(ValueError):
+            probability(-0.1)  # less than 0
+
+    def test_token(self):
+        # valid
+        token(None)
+        token(0)
+        token(1)
+        token(999999999)
+
+        # invalid
+        with self.assertRaises(ValueError):
+            token(-1)  # less than 0
+        with self.assertRaises(TypeError):
+            token("<eos>")  # must be the token id, not its string counterpart
+
+    def test_activation_fn_key(self):
+        # valid
+        activation_fn_key("relu")
+        activation_fn_key("gelu")
+
+        # invalid
+        with self.assertRaises(ValueError):
+            activation_fn_key("foo")  # obvious one
+        with self.assertRaises(ValueError):
+            activation_fn_key(None)  # can't be None
+        with self.assertRaises(ValueError):
+            activation_fn_key("Relu")  # typo: should be "relu", not "Relu"
+
+
+class ValidatorsIntegrationTests(unittest.TestCase):
+    """Tests in which the validators are used as part of another class/function"""
+
+    def test_model_config_validation(self):
+        """Sanity check tests for the integration of model config with `huggingface_hub.dataclasses.strict`"""
+        # 1 - We can initialize the config, including with arbitrary kwargs
+        config = AlbertConfig()
+        config = AlbertConfig(eos_token_id=5)
+        self.assertEqual(config.eos_token_id, 5)
+        config = AlbertConfig(eos_token_id=None)
+        self.assertIsNone(config.eos_token_id)
+        config = AlbertConfig(foo="bar")  # Ensures backwards compatibility
+        self.assertEqual(config.foo, "bar")
+
+        # 2 - Manual specification, traveling through an invalid config, should be allowed
+        config.eos_token_id = 99  # vocab_size = 30000, eos_token_id = 99 -> valid
+        config.vocab_size = 10  # vocab_size = 10, eos_token_id = 99 -> invalid (but only throws error in `validate()`)
+        with self.assertRaises(ValueError):
+            config.validate()
+        config.eos_token_id = 9  # vocab_size = 10, eos_token_id = 9 -> valid
+        config.validate()
+
+        # 3 - These cases should raise an error
+
+        # vocab_size is an int
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            config = AlbertConfig(vocab_size=10.0)
+
+        # num_hidden_layers is an int
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            config = AlbertConfig(num_hidden_layers=None)
+
+        # position_embedding_type is a Literal, foo is not one of the options
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            config = AlbertConfig(position_embedding_type="foo")
+
+       # eos_token_id is a token, and must be non-negative
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            config = AlbertConfig(eos_token_id=-1)
+
+        # `validate()` is called in `__post_init__`, i.e. after `__init__`. A special token must be in the vocabulary.
+        with self.assertRaises(ValueError):
+            config = AlbertConfig(vocab_size=10, eos_token_id=99)
+
+        # vocab size is assigned after init, individual attributes are checked on assignment
+        with self.assertRaises(StrictDataclassFieldValidationError):
+            config = AlbertConfig()
+            config.vocab_size = "foo"

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -161,9 +161,16 @@ class ValidatorsIntegrationTests(unittest.TestCase):
         with self.assertRaises(StrictDataclassFieldValidationError):
             config = AlbertConfig(eos_token_id=-1)
 
-        # `validate()` is called in `__post_init__`, i.e. after `__init__`. A special token must be in the vocabulary.
+        # `@strict` calls `validate()` in `__post_init__`, i.e. after `__init__`. All functions defined as
+        # `validate_XXX(self)` will be called as part of the validation process. In this case, a special token must
+        # be in the vocabulary, and the validation function is defined in the base config class.
         with self.assertRaises(ValueError):
             config = AlbertConfig(vocab_size=10, eos_token_id=99)
+
+        # Similar to the previous case, but the validation function is defined in the model config class. The hidden
+        # size must be divisible by the number of attention heads.
+        with self.assertRaises(ValueError):
+            config = AlbertConfig(hidden_size=10, num_attention_heads=3)
 
         # vocab size is assigned after init, individual attributes are checked on assignment
         with self.assertRaises(StrictDataclassFieldValidationError):

--- a/tests/utils/test_validators.py
+++ b/tests/utils/test_validators.py
@@ -15,7 +15,11 @@ import unittest
 from dataclasses import dataclass
 from typing import Optional, Union
 
-from huggingface_hub.dataclasses import StrictDataclassFieldValidationError, strict
+from huggingface_hub.dataclasses import (
+    StrictDataclassClassValidationError,
+    StrictDataclassFieldValidationError,
+    strict,
+)
 
 from transformers import AlbertConfig
 from transformers.validators import activation_fn_key, interval, probability, token
@@ -138,7 +142,7 @@ class ValidatorsIntegrationTests(unittest.TestCase):
         # 2 - Manual specification, traveling through an invalid config, should be allowed
         config.eos_token_id = 99  # vocab_size = 30000, eos_token_id = 99 -> valid
         config.vocab_size = 10  # vocab_size = 10, eos_token_id = 99 -> invalid (but only throws error in `validate()`)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(StrictDataclassClassValidationError):
             config.validate()
         config.eos_token_id = 9  # vocab_size = 10, eos_token_id = 9 -> valid
         config.validate()
@@ -164,12 +168,12 @@ class ValidatorsIntegrationTests(unittest.TestCase):
         # `@strict` calls `validate()` in `__post_init__`, i.e. after `__init__`. All functions defined as
         # `validate_XXX(self)` will be called as part of the validation process. In this case, a special token must
         # be in the vocabulary, and the validation function is defined in the base config class.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(StrictDataclassClassValidationError):
             config = AlbertConfig(vocab_size=10, eos_token_id=99)
 
         # Similar to the previous case, but the validation function is defined in the model config class. The hidden
         # size must be divisible by the number of attention heads.
-        with self.assertRaises(ValueError):
+        with self.assertRaises(StrictDataclassClassValidationError):
             config = AlbertConfig(hidden_size=10, num_attention_heads=3)
 
         # vocab size is assigned after init, individual attributes are checked on assignment


### PR DESCRIPTION
# What does this PR do?

Testbed for https://github.com/huggingface/huggingface_hub/pull/2895, released recently.

Core ideas:
- All config arguments are individually validated at `__init__` and assignment time, using strict type checks and custom value validators;
- Class-level validation happens after `__init__` through `dataclass`'s `__post_init__`, or manually through `.validate()` (⚠️ when mutating the config after initializing, `.validate()` must be called to validate at a class-level). With this, we can check e.g. if a special token is within the vocabulary range;
- Arbitrary validators can be added as `validate_xxx` methods: `@strict` adds them to its validation functions.

____________________________________
Minimal test script:
```py
from transformers import AlbertConfig

# These should work
config = AlbertConfig()
config = AlbertConfig(eos_token_id=5)
config = AlbertConfig(foo="bar")  # Ensures backward compatibility

# Manual specification, traveling through an invalid config, should be allowed
config.hidden_size = 65 # the config is impossible here
config.num_attention_heads = 5
config.validate()

# These will raise an exception
config = AlbertConfig(vocab_size=10.0)  # vocab_size is an int
config = AlbertConfig(num_hidden_layers=None)  # num_hidden_layers is an int
config = AlbertConfig(position_embedding_type="foo")  # position_embedding_type is a Literal, foo is not one of the options
config = AlbertConfig(hidden_size=65)  # hidden_size % num_attention_heads must be 0
```