### PR TITLE
fix: argument

### DIFF
--- a/docs/source/en/modular_transformers.md
+++ b/docs/source/en/modular_transformers.md
@@ -24,7 +24,7 @@ A linter "unravels" the modular file into a `modeling.py` file to preserve the s
 Run the command below to automatically generate a `modeling.py` file from a modular file.
 
 ```bash
-python utils/modular_model_converter.py --files-to-parse src/transformers/models/<your_model>/modular_<your_model>.py
+python utils/modular_model_converter.py --files_to_parse src/transformers/models/<your_model>/modular_<your_model>.py
 ```
 
 For example:


### PR DESCRIPTION
Arguments is different in the docs.

https://github.com/huggingface/transformers/blob/752ef3fd4e70869626ec70657a770a85c0ad9219/utils/modular_model_converter.py#L1729
