### PR TITLE
:rotating_light: :rotating_light: Allow saving and loading multiple "raw" chat template files

### DIFF
--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -298,13 +298,14 @@ class LlavaOnevisionProcessor(ProcessorMixin):
         self.video_processor.save_pretrained(video_processor_path)
 
         video_processor_present = "video_processor" in self.attributes
-        if video_processor_present:
-            self.attributes.remove("video_processor")
+        try:
+            if video_processor_present:
+                self.attributes.remove("video_processor")
 
-        outputs = super().save_pretrained(save_directory, **kwargs)
-
-        if video_processor_present:
-            self.attributes += ["video_processor"]
+            outputs = super().save_pretrained(save_directory, **kwargs)
+        finally:
+            if video_processor_present:
+                self.attributes += ["video_processor"]
         return outputs
 
     # override to load video-config from a separate config file

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -642,7 +642,7 @@ class ProcessorMixin(PushToHubMixin):
         # plus we save chat_template in its own file
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
         output_raw_chat_template_file = os.path.join(save_directory, CHAT_TEMPLATE_FILE)
-        output_chat_template_file = os.path.join(save_directory, "chat_template.json")  # Legacy filename
+        output_chat_template_file = os.path.join(save_directory, LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE)  # Legacy filename
         chat_template_dir = os.path.join(save_directory, CHAT_TEMPLATE_DIR)
 
         processor_dict = self.to_dict()

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -870,15 +870,15 @@ class ProcessorMixin(PushToHubMixin):
                 )
 
         # Add chat template as kwarg before returning because most models don't have processor config
+        default_chat_template = None
         if resolved_raw_chat_template_file is not None:
             with open(resolved_raw_chat_template_file, encoding="utf-8") as reader:
                 default_chat_template = reader.read()
         elif resolved_chat_template_file is not None:
             with open(resolved_chat_template_file, encoding="utf-8") as reader:
-                text = reader.read()
-            default_chat_template = json.loads(text)["chat_template"]
-        else:
-            default_chat_template = None
+                chat_template_json = json.loads(reader.read())
+            if "chat_template" in chat_template_json:  # These files are sometimes empty in tests
+                default_chat_template = chat_template_json["chat_template"]
         chat_templates = {
             template_name: open(template_file, "r", encoding="utf-8").read()
             for template_name, template_file in resolved_additional_chat_template_files.items()

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -877,6 +877,8 @@ class ProcessorMixin(PushToHubMixin):
             with open(resolved_chat_template_file, encoding="utf-8") as reader:
                 chat_template_json = json.loads(reader.read())
                 chat_templates = chat_template_json["chat_template"]
+                if isinstance(chat_templates, dict):
+                    chat_templates = {template["name"]: template["template"] for template in chat_templates}
                 if resolved_additional_chat_template_files:
                     raise ValueError(
                         "Cannot load chat template due to conflicting files - this checkpoint combines "

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -648,6 +648,8 @@ class ProcessorMixin(PushToHubMixin):
         processor_dict = self.to_dict()
         # Save `chat_template` in its own file. We can't get it from `processor_dict` as we popped it in `to_dict`
         # to avoid serializing chat template in json config file. So let's get it from `self` directly
+save_as_jinja = kwargs.get("save_raw_chat_template", False)
+is_single_file = isinstance(self.chat_template, str)
 
         if kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, str):
             # New format for single templates is to save them as chat_template.jinja

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -774,7 +774,7 @@ is_single_file = isinstance(self.chat_template, str)
                 template_dir = Path(pretrained_model_name_or_path, CHAT_TEMPLATE_DIR)
                 if template_dir.is_dir():
                     for template_file in template_dir.glob("*.jinja"):
-                        template_name = template_file.name.removesuffix(".jinja")
+                        template_name = template_file.stem
                         additional_chat_template_files[template_name] = f"{CHAT_TEMPLATE_DIR}/{template_file.name}"
             else:
                 try:

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -877,7 +877,6 @@ class ProcessorMixin(PushToHubMixin):
         elif resolved_chat_template_file is not None:
             with open(resolved_chat_template_file, encoding="utf-8") as reader:
                 chat_template_json = json.loads(reader.read())
-            if "chat_template" in chat_template_json:  # These files are sometimes empty in tests
                 default_chat_template = chat_template_json["chat_template"]
         chat_templates = {
             template_name: open(template_file, "r", encoding="utf-8").read()

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -885,6 +885,8 @@ class ProcessorMixin(PushToHubMixin):
         }
         if default_chat_template is not None:
             chat_templates["default"] = default_chat_template
+        if "default" in chat_templates and len(chat_templates) == 1:
+            chat_templates = chat_templates["default"]  # Flatten when we just have a single template/file
 
         kwargs["chat_template"] = chat_templates
 

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -674,7 +674,9 @@ class ProcessorMixin(PushToHubMixin):
             # chat template dicts are saved to chat_template.json as lists of dicts with fixed key names.
             chat_template_json_string = (
                 json.dumps(
-                    [{"name": k, "template": v} for k, v in self.chat_template.items()], indent=2, sort_keys=True
+                    {"chat_template": [{"name": k, "template": v} for k, v in self.chat_template.items()]},
+                    indent=2,
+                    sort_keys=True,
                 )
                 + "\n"
             )

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -56,6 +56,7 @@ from .tokenization_utils_base import (
 from .utils import (
     CHAT_TEMPLATE_DIR,
     CHAT_TEMPLATE_FILE,
+    LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE,
     PROCESSOR_NAME,
     PushToHubMixin,
     TensorType,
@@ -87,8 +88,6 @@ if sys.version_info >= (3, 11):
     Unpack = typing.Unpack
 else:
     Unpack = typing_extensions.Unpack
-
-LEGACY_CHAT_TEMPLATE_FILE = "chat_template.json"
 
 
 class TextKwargs(TypedDict, total=False):
@@ -808,12 +807,11 @@ class ProcessorMixin(PushToHubMixin):
                     _raise_exceptions_for_missing_entries=False,
                 )
 
-                # Load chat template from a separate json if exists
-                # because making it part of processor-config break BC.
-                # Processors in older version do not accept any kwargs
+                # chat_template.json is a legacy file used by the processor class
+                # a raw chat_template.jinja is preferred in future
                 resolved_chat_template_file = cached_file(
                     pretrained_model_name_or_path,
-                    LEGACY_CHAT_TEMPLATE_FILE,
+                    LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE,
                     cache_dir=cache_dir,
                     force_download=force_download,
                     proxies=proxies,

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -52,6 +52,8 @@ from .tokenization_utils_base import (
     TruncationStrategy,
 )
 from .utils import (
+    CHAT_TEMPLATE_DIR,
+    CHAT_TEMPLATE_FILE,
     PROCESSOR_NAME,
     PushToHubMixin,
     TensorType,
@@ -636,9 +638,9 @@ class ProcessorMixin(PushToHubMixin):
         # If we save using the predefined names, we can load using `from_pretrained`
         # plus we save chat_template in its own file
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
-        output_raw_chat_template_file = os.path.join(save_directory, "chat_template.jinja")
-        output_chat_template_file = os.path.join(save_directory, "chat_template.json")
-        chat_template_dir = os.path.join(save_directory, "additional_chat_templates")
+        output_raw_chat_template_file = os.path.join(save_directory, CHAT_TEMPLATE_FILE)
+        output_chat_template_file = os.path.join(save_directory, "chat_template.json")  # Legacy filename
+        chat_template_dir = os.path.join(save_directory, CHAT_TEMPLATE_DIR)
 
         processor_dict = self.to_dict()
         # Save `chat_template` in its own file. We can't get it from `processor_dict` as we popped it in `to_dict`

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -655,7 +655,7 @@ class ProcessorMixin(PushToHubMixin):
             with open(output_raw_chat_template_file, "w", encoding="utf-8") as f:
                 f.write(self.chat_template)
             logger.info(f"chat template saved in {output_raw_chat_template_file}")
-        elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict) and len(self.chat_template) > 0:
+        elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict):
             # New format for multiple templates is to save the default as chat_template.jinja
             # and the other templates in the chat_templates/ directory
             for template_name, template in self.chat_template.items():
@@ -669,7 +669,7 @@ class ProcessorMixin(PushToHubMixin):
                     with open(template_filepath, "w", encoding="utf-8") as f:
                         f.write(template)
                     logger.info(f"chat template saved in {template_filepath}")
-        elif isinstance(self.chat_template, dict) and len(self.chat_template) > 0:
+        elif isinstance(self.chat_template, dict):
             # Legacy format for multiple templates:
             # chat template dicts are saved to chat_template.json as lists of dicts with fixed key names.
             chat_template_json_string = (

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -650,7 +650,7 @@ class ProcessorMixin(PushToHubMixin):
         processor_dict = self.to_dict()
         # Save `chat_template` in its own file. We can't get it from `processor_dict` as we popped it in `to_dict`
         # to avoid serializing chat template in json config file. So let's get it from `self` directly
-        save_as_jinja = kwargs.get("save_raw_chat_template", False)
+        save_as_jinja = kwargs.get("save_jinja_files", False)
         is_single_template = isinstance(self.chat_template, str)
 
         if save_as_jinja and is_single_template:
@@ -685,7 +685,7 @@ class ProcessorMixin(PushToHubMixin):
             # chat template dicts are saved to chat_template.json as lists of dicts with fixed key names.
             raise ValueError(
                 "Multiple chat templates are not supported in the legacy format. Please save them as separate files "
-                "using the `save_raw_chat_template` argument."
+                "using the `save_jinja_files` argument."
             )
 
         # For now, let's not save to `processor_config.json` if the processor doesn't have extra attributes and

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -877,7 +877,8 @@ class ProcessorMixin(PushToHubMixin):
             with open(resolved_chat_template_file, encoding="utf-8") as reader:
                 chat_template_json = json.loads(reader.read())
                 chat_templates = chat_template_json["chat_template"]
-                if isinstance(chat_templates, dict):
+                if isinstance(chat_templates, (list, tuple)):
+                    # Un-flatten the list storage
                     chat_templates = {template["name"]: template["template"] for template in chat_templates}
                 if resolved_additional_chat_template_files:
                     raise ValueError(

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -663,7 +663,7 @@ class ProcessorMixin(PushToHubMixin):
                         f.write(self.chat_template["default"])
                     logger.info(f"chat template saved in {output_raw_chat_template_file}")
                 else:
-                    Path(chat_template_dir).mkdir(exist_ok=True)
+                    os.makedirs(chat_template_dir, exist_ok=True)
                     template_filepath = os.path.join(chat_template_dir, f"{template_name}.jinja")
                     with open(template_filepath, "w", encoding="utf-8") as f:
                         f.write(template)

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -642,7 +642,9 @@ class ProcessorMixin(PushToHubMixin):
         # plus we save chat_template in its own file
         output_processor_file = os.path.join(save_directory, PROCESSOR_NAME)
         output_chat_template_file_jinja = os.path.join(save_directory, CHAT_TEMPLATE_FILE)
-        output_chat_template_file_legacy = os.path.join(save_directory, LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE)  # Legacy filename
+        output_chat_template_file_legacy = os.path.join(
+            save_directory, LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE
+        )  # Legacy filename
         chat_template_dir = os.path.join(save_directory, CHAT_TEMPLATE_DIR)
 
         processor_dict = self.to_dict()

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -875,9 +875,17 @@ class ProcessorMixin(PushToHubMixin):
             with open(resolved_raw_chat_template_file, encoding="utf-8") as reader:
                 default_chat_template = reader.read()
         elif resolved_chat_template_file is not None:
+            # This is the legacy path
             with open(resolved_chat_template_file, encoding="utf-8") as reader:
                 chat_template_json = json.loads(reader.read())
                 default_chat_template = chat_template_json["chat_template"]
+                if resolved_additional_chat_template_files:
+                    raise ValueError(
+                        "Cannot load chat template due to conflicting files - this checkpoint combines "
+                        "a legacy chat_template.json file with separate template files, which is not "
+                        "supported. To resolve this error, replace the legacy chat_template.json file "
+                        "with a modern chat_template.jinja file."
+                    )
         chat_templates = {
             template_name: open(template_file, "r", encoding="utf-8").read()
             for template_name, template_file in resolved_additional_chat_template_files.items()

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -27,7 +27,6 @@ from typing import Any, Dict, List, Optional, TypedDict, Union
 
 import numpy as np
 import typing_extensions
-from huggingface_hub import list_repo_templates
 from huggingface_hub.errors import EntryNotFoundError
 
 from .audio_utils import load_audio
@@ -68,6 +67,7 @@ from .utils import (
     download_url,
     is_offline_mode,
     is_remote_url,
+    list_repo_templates,
     logging,
 )
 

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1346,12 +1346,14 @@ class ProcessorMixin(PushToHubMixin):
                 chat_template = self.chat_template["default"]
             elif isinstance(self.chat_template, dict):
                 raise ValueError(
-                    "The processor has multiple chat templates but none of them are named \"default\". You need to specify which one to use by passing the `chat_template` argument."
+                    'The processor has multiple chat templates but none of them are named "default". You need to specify which one to use by passing the `chat_template` argument.'
                 )
             elif self.chat_template is not None:
                 chat_template = self.chat_template
             else:
-                raise ValueError("Cannot use apply_chat_template because this processor does not have a chat template.")
+                raise ValueError(
+                    "Cannot use apply_chat_template because this processor does not have a chat template."
+                )
         else:
             if isinstance(self.chat_template, dict) and chat_template in self.chat_template:
                 # It's the name of a template, not a full template string

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1402,8 +1402,8 @@ class ProcessorMixin(PushToHubMixin):
             elif isinstance(self.chat_template, dict):
                 raise ValueError(
                     'The processor has multiple chat templates but none of them are named "default". You need to specify'
-                    ' which one to use by passing the `chat_template` argument. Available templates are: '
-                    f'{", ".join(self.chat_template.keys())}'
+                    " which one to use by passing the `chat_template` argument. Available templates are: "
+                    f"{', '.join(self.chat_template.keys())}"
                 )
             elif self.chat_template is not None:
                 chat_template = self.chat_template

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -655,7 +655,7 @@ class ProcessorMixin(PushToHubMixin):
             with open(output_raw_chat_template_file, "w", encoding="utf-8") as f:
                 f.write(self.chat_template)
             logger.info(f"chat template saved in {output_raw_chat_template_file}")
-        elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict):
+        elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict) and len(self.chat_template) > 0:
             # New format for multiple templates is to save the default as chat_template.jinja
             # and the other templates in the chat_templates/ directory
             for template_name, template in self.chat_template.items():
@@ -669,7 +669,7 @@ class ProcessorMixin(PushToHubMixin):
                     with open(template_filepath, "w", encoding="utf-8") as f:
                         f.write(template)
                     logger.info(f"chat template saved in {template_filepath}")
-        elif isinstance(self.chat_template, dict):
+        elif isinstance(self.chat_template, dict) and len(self.chat_template) > 0:
             # Legacy format for multiple templates:
             # chat template dicts are saved to chat_template.json as lists of dicts with fixed key names.
             chat_template_json_string = (
@@ -888,7 +888,8 @@ class ProcessorMixin(PushToHubMixin):
         if "default" in chat_templates and len(chat_templates) == 1:
             chat_templates = chat_templates["default"]  # Flatten when we just have a single template/file
 
-        kwargs["chat_template"] = chat_templates
+        if chat_templates:
+            kwargs["chat_template"] = chat_templates
 
         # Existing processors on the Hub created before #27761 being merged don't have `processor_config.json` (if not
         # updated afterward), and we need to keep `from_pretrained` work. So here it fallbacks to the empty dict.
@@ -1401,7 +1402,9 @@ class ProcessorMixin(PushToHubMixin):
                 chat_template = self.chat_template["default"]
             elif isinstance(self.chat_template, dict):
                 raise ValueError(
-                    'The processor has multiple chat templates but none of them are named "default". You need to specify which one to use by passing the `chat_template` argument.'
+                    'The processor has multiple chat templates but none of them are named "default". You need to specify'
+                    ' which one to use by passing the `chat_template` argument. Available templates are: '
+                    f'{", ".join(self.chat_template.keys())}'
                 )
             elif self.chat_template is not None:
                 chat_template = self.chat_template

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -650,7 +650,7 @@ class ProcessorMixin(PushToHubMixin):
         processor_dict = self.to_dict()
         # Save `chat_template` in its own file. We can't get it from `processor_dict` as we popped it in `to_dict`
         # to avoid serializing chat template in json config file. So let's get it from `self` directly
-        save_as_jinja = kwargs.get("save_jinja_files", False)
+        save_as_jinja = kwargs.get("save_jinja_files", True)
         is_single_template = isinstance(self.chat_template, str)
 
         if save_as_jinja and is_single_template:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2025,10 +2025,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                                 )
                     else:
                         for template in list_repo_templates(
-                                pretrained_model_name_or_path,
-                                local_files_only=local_files_only,
-                                revision=revision,
-                                cache_dir=cache_dir,
+                            pretrained_model_name_or_path,
+                            local_files_only=local_files_only,
+                            revision=revision,
+                            cache_dir=cache_dir,
                         ):
                             vocab_files[f"chat_template_{template}"] = f"{CHAT_TEMPLATE_DIR}/{template}.jinja"
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -39,6 +39,8 @@ from packaging import version
 from . import __version__
 from .dynamic_module_utils import custom_object_save
 from .utils import (
+    CHAT_TEMPLATE_DIR,
+    CHAT_TEMPLATE_FILE,
     ExplicitEnum,
     PaddingStrategy,
     PushToHubMixin,
@@ -148,8 +150,6 @@ AudioInput = Union["np.ndarray", "torch.Tensor", List["np.ndarray"], List["torch
 SPECIAL_TOKENS_MAP_FILE = "special_tokens_map.json"
 ADDED_TOKENS_FILE = "added_tokens.json"
 TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
-CHAT_TEMPLATE_FILE = "chat_template.jinja"
-CHAT_TEMPLATE_DIR = "additional_chat_templates"
 
 # Fast tokenizers (provided by HuggingFace tokenizer's library) can be saved in a single file
 FULL_TOKENIZER_FILE = "tokenizer.json"

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2494,43 +2494,42 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             tokenizer_config.update(self.extra_special_tokens)
 
         saved_raw_chat_template_files = []
-        if self.chat_template is not None:
-            if kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, str):
-                # New format for single templates is to save them as chat_template.jinja
-                with open(chat_template_file, "w", encoding="utf-8") as f:
-                    f.write(self.chat_template)
-                logger.info(f"chat template saved in {chat_template_file}")
-                saved_raw_chat_template_files.append(chat_template_file)
-                if "chat_template" in tokenizer_config:
-                    tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
-            elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict):
-                # New format for multiple templates is to save the default as chat_template.jinja
-                # and the other templates in the chat_templates/ directory
-                for template_name, template in self.chat_template.items():
-                    if template_name == "default":
-                        with open(chat_template_file, "w", encoding="utf-8") as f:
-                            f.write(self.chat_template["default"])
-                        logger.info(f"chat template saved in {chat_template_file}")
-                        saved_raw_chat_template_files.append(chat_template_file)
-                    else:
-                        Path(chat_template_dir).mkdir(exist_ok=True)
-                        template_filepath = os.path.join(chat_template_dir, f"{template_name}.jinja")
-                        with open(template_filepath, "w", encoding="utf-8") as f:
-                            f.write(template)
-                        logger.info(f"chat template saved in {template_filepath}")
-                        saved_raw_chat_template_files.append(template_filepath)
-                if "chat_template" in tokenizer_config:
-                    tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
-            elif isinstance(self.chat_template, dict):
-                # Legacy format for multiple templates:
-                # chat template dicts are saved to the config as lists of dicts with fixed key names.
-                # They will be reconstructed as a single dict during loading.
-                # We're trying to discourage chat template dicts, and they are always
-                # saved in the config, never as single files.
-                tokenizer_config["chat_template"] = [{"name": k, "template": v} for k, v in self.chat_template.items()]
-            else:
-                # Legacy format for single templates: Just make them a key in tokenizer_config.json
-                tokenizer_config["chat_template"] = self.chat_template
+        if kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, str):
+            # New format for single templates is to save them as chat_template.jinja
+            with open(chat_template_file, "w", encoding="utf-8") as f:
+                f.write(self.chat_template)
+            logger.info(f"chat template saved in {chat_template_file}")
+            saved_raw_chat_template_files.append(chat_template_file)
+            if "chat_template" in tokenizer_config:
+                tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
+        elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict):
+            # New format for multiple templates is to save the default as chat_template.jinja
+            # and the other templates in the chat_templates/ directory
+            for template_name, template in self.chat_template.items():
+                if template_name == "default":
+                    with open(chat_template_file, "w", encoding="utf-8") as f:
+                        f.write(self.chat_template["default"])
+                    logger.info(f"chat template saved in {chat_template_file}")
+                    saved_raw_chat_template_files.append(chat_template_file)
+                else:
+                    Path(chat_template_dir).mkdir(exist_ok=True)
+                    template_filepath = os.path.join(chat_template_dir, f"{template_name}.jinja")
+                    with open(template_filepath, "w", encoding="utf-8") as f:
+                        f.write(template)
+                    logger.info(f"chat template saved in {template_filepath}")
+                    saved_raw_chat_template_files.append(template_filepath)
+            if "chat_template" in tokenizer_config:
+                tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
+        elif isinstance(self.chat_template, dict):
+            # Legacy format for multiple templates:
+            # chat template dicts are saved to the config as lists of dicts with fixed key names.
+            # They will be reconstructed as a single dict during loading.
+            # We're trying to discourage chat template dicts, and they are always
+            # saved in the config, never as single files.
+            tokenizer_config["chat_template"] = [{"name": k, "template": v} for k, v in self.chat_template.items()]
+        elif self.chat_template is not None:
+            # Legacy format for single templates: Just make them a key in tokenizer_config.json
+            tokenizer_config["chat_template"] = self.chat_template
 
         if len(self.init_inputs) > 0:
             tokenizer_config["init_inputs"] = copy.deepcopy(self.init_inputs)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2006,7 +2006,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             if not template_file.path.endswith(".jinja"):
                                 continue
                             template_name = template_file.path.split("/")[-1].removesuffix(".jinja")
-                            additional_files_names[f"chat_template_{template_name}"] = template_file
+                            additional_files_names[f"chat_template_{template_name}"] = template_file.path
                     except EntryNotFoundError:
                         pass  # No template dir means no template files
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1992,7 +1992,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     if template_dir.is_dir():
                         for template_file in template_dir.glob("*.jinja"):
                             template_name = template_file.name.removesuffix(".jinja")
-                            additional_files_names[f"chat_template_{template_name}"] = f"{CHAT_TEMPLATE_DIR}/{template_file.name}"
+                            additional_files_names[f"chat_template_{template_name}"] = (
+                                f"{CHAT_TEMPLATE_DIR}/{template_file.name}"
+                            )
                 else:
                     try:
                         for template_file in list_repo_tree(

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2487,7 +2487,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             tokenizer_config.update(self.extra_special_tokens)
 
         saved_raw_chat_template_files = []
-        if kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, str):
+        if kwargs.get("save_jinja_files", False) and isinstance(self.chat_template, str):
             # New format for single templates is to save them as chat_template.jinja
             with open(chat_template_file, "w", encoding="utf-8") as f:
                 f.write(self.chat_template)
@@ -2495,7 +2495,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             saved_raw_chat_template_files.append(chat_template_file)
             if "chat_template" in tokenizer_config:
                 tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
-        elif kwargs.get("save_raw_chat_template", False) and isinstance(self.chat_template, dict):
+        elif kwargs.get("save_jinja_files", False) and isinstance(self.chat_template, dict):
             # New format for multiple templates is to save the default as chat_template.jinja
             # and the other templates in the chat_templates/ directory
             for template_name, template in self.chat_template.items():

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -884,9 +884,9 @@ class SpecialTokensMixin:
             if key in self.SPECIAL_TOKENS_ATTRIBUTES:
                 if key == "additional_special_tokens":
                     assert isinstance(value, (list, tuple)), f"Value {value} is not a list or tuple"
-                    assert all(isinstance(t, (str, AddedToken)) for t in value), (
-                        "One of the tokens is not a string or an AddedToken"
-                    )
+                    assert all(
+                        isinstance(t, (str, AddedToken)) for t in value
+                    ), "One of the tokens is not a string or an AddedToken"
                     setattr(self, key, value)
                 elif isinstance(value, (str, AddedToken)):
                     setattr(self, key, value)
@@ -970,9 +970,9 @@ class SpecialTokensMixin:
                 logger.info(f"Assigning {value} to the {key} key of the tokenizer")
 
             if key == "additional_special_tokens":
-                assert isinstance(value, (list, tuple)) and all(isinstance(t, (str, AddedToken)) for t in value), (
-                    f"Tokens {value} for key {key} should all be str or AddedToken instances"
-                )
+                assert isinstance(value, (list, tuple)) and all(
+                    isinstance(t, (str, AddedToken)) for t in value
+                ), f"Tokens {value} for key {key} should all be str or AddedToken instances"
 
                 to_add = []
                 for token in value:
@@ -3432,9 +3432,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             return BatchEncoding(encoded_inputs, tensor_type=return_tensors)
 
         batch_size = len(required_input)
-        assert all(len(v) == batch_size for v in encoded_inputs.values()), (
-            "Some items in the output dictionary have a different batch size than others."
-        )
+        assert all(
+            len(v) == batch_size for v in encoded_inputs.values()
+        ), "Some items in the output dictionary have a different batch size than others."
 
         if padding_strategy == PaddingStrategy.LONGEST:
             max_length = max(len(inputs) for inputs in required_input)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2163,11 +2163,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         if chat_template_file is not None:
             with open(chat_template_file) as chat_template_handle:
                 chat_templates["default"] = chat_template_handle.read()
-        extra_chat_template_files = resolved_vocab_files.pop("additional_chat_template_files", [])
         for extra_chat_template in extra_chat_templates:
             template_file = resolved_vocab_files.pop(extra_chat_template, None)
             if template_file is None:
-                continue
+                continue  # I think this should never happen, but just in case
             template_name = extra_chat_template.removeprefix("chat_template_")
             with open(template_file) as chat_template_handle:
                 chat_templates[template_name] = chat_template_handle.read()

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -884,9 +884,9 @@ class SpecialTokensMixin:
             if key in self.SPECIAL_TOKENS_ATTRIBUTES:
                 if key == "additional_special_tokens":
                     assert isinstance(value, (list, tuple)), f"Value {value} is not a list or tuple"
-                    assert all(
-                        isinstance(t, (str, AddedToken)) for t in value
-                    ), "One of the tokens is not a string or an AddedToken"
+                    assert all(isinstance(t, (str, AddedToken)) for t in value), (
+                        "One of the tokens is not a string or an AddedToken"
+                    )
                     setattr(self, key, value)
                 elif isinstance(value, (str, AddedToken)):
                     setattr(self, key, value)
@@ -970,9 +970,9 @@ class SpecialTokensMixin:
                 logger.info(f"Assigning {value} to the {key} key of the tokenizer")
 
             if key == "additional_special_tokens":
-                assert isinstance(value, (list, tuple)) and all(
-                    isinstance(t, (str, AddedToken)) for t in value
-                ), f"Tokens {value} for key {key} should all be str or AddedToken instances"
+                assert isinstance(value, (list, tuple)) and all(isinstance(t, (str, AddedToken)) for t in value), (
+                    f"Tokens {value} for key {key} should all be str or AddedToken instances"
+                )
 
                 to_add = []
                 for token in value:
@@ -3432,9 +3432,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             return BatchEncoding(encoded_inputs, tensor_type=return_tensors)
 
         batch_size = len(required_input)
-        assert all(
-            len(v) == batch_size for v in encoded_inputs.values()
-        ), "Some items in the output dictionary have a different batch size than others."
+        assert all(len(v) == batch_size for v in encoded_inputs.values()), (
+            "Some items in the output dictionary have a different batch size than others."
+        )
 
         if padding_strategy == PaddingStrategy.LONGEST:
             max_length = max(len(inputs) for inputs in required_input)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2523,9 +2523,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         elif isinstance(self.chat_template, dict):
             # Legacy format for multiple templates:
             # chat template dicts are saved to the config as lists of dicts with fixed key names.
-            # They will be reconstructed as a single dict during loading.
-            # We're trying to discourage chat template dicts, and they are always
-            # saved in the config, never as single files.
             tokenizer_config["chat_template"] = [{"name": k, "template": v} for k, v in self.chat_template.items()]
         elif self.chat_template is not None:
             # Legacy format for single templates: Just make them a key in tokenizer_config.json

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -20,7 +20,6 @@ of output with special method for the Fast tokenizers)
 
 import copy
 import json
-from pathlib import Path
 import os
 import re
 import warnings
@@ -29,9 +28,11 @@ from collections.abc import Mapping, Sized
 from contextlib import contextmanager
 from dataclasses import dataclass
 from inspect import isfunction
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
 
 import numpy as np
+from huggingface_hub import list_repo_tree
 from packaging import version
 
 from . import __version__
@@ -68,7 +69,6 @@ from .utils import (
 )
 from .utils.chat_template_utils import _compile_jinja_template, _render_with_assistant_indices
 from .utils.import_utils import PROTOBUF_IMPORT_ERROR
-from huggingface_hub import list_repo_tree
 
 
 if TYPE_CHECKING:
@@ -1991,10 +1991,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             template_name = template_file.name.removesuffix(".jinja")
                             additional_files_names[f"{template_name}_template"] = f"templates/{template_file.name}"
                 else:
-                    for template_file in list_repo_tree(pretrained_model_name_or_path, path_in_repo="templates", recursive=False):
+                    for template_file in list_repo_tree(
+                        pretrained_model_name_or_path, path_in_repo="templates", recursive=False
+                    ):
                         if not template_file.endswith(".jinja"):
                             continue
-                        template_name = template_file.split('/')[-1].removesuffix(".jinja")
+                        template_name = template_file.split("/")[-1].removesuffix(".jinja")
                         additional_files_names[f"{template_name}_template"] = template_file  # This might be wrong!
                 vocab_files = {**cls.vocab_files_names, **additional_files_names}
                 if "tokenizer_file" in vocab_files:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2479,7 +2479,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             f.write(template)
                         logger.info(f"chat template saved in {template_filepath}")
                         saved_raw_chat_template_files.append(template_filepath)
-                saved_raw_chat_template = True
                 if "chat_template" in tokenizer_config:
                     tokenizer_config.pop("chat_template")  # To ensure it doesn't somehow end up in the config too
             elif isinstance(self.chat_template, dict):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1985,24 +1985,6 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     "chat_template_file": CHAT_TEMPLATE_FILE,
                 }
 
-                # This block looks for any extra chat template files
-                if is_local:
-                    template_dir = Path(pretrained_model_name_or_path, CHAT_TEMPLATE_DIR)
-                    if template_dir.is_dir():
-                        for template_file in template_dir.glob("*.jinja"):
-                            template_name = template_file.name.removesuffix(".jinja")
-                            additional_files_names[f"chat_template_{template_name}"] = (
-                                f"{CHAT_TEMPLATE_DIR}/{template_file.name}"
-                            )
-                else:
-                    for template in list_repo_templates(
-                        pretrained_model_name_or_path,
-                        local_files_only=local_files_only,
-                        revision=revision,
-                        cache_dir=cache_dir,
-                    ):
-                        additional_files_names[f"chat_template_{template}"] = f"{CHAT_TEMPLATE_DIR}/{template}.jinja"
-
                 vocab_files = {**cls.vocab_files_names, **additional_files_names}
                 if "tokenizer_file" in vocab_files:
                     # Try to get the tokenizer config to see if there are versioned tokenizer files.
@@ -2031,6 +2013,24 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             if "fast_tokenizer_files" in tokenizer_config:
                                 fast_tokenizer_file = get_fast_tokenizer_file(tokenizer_config["fast_tokenizer_files"])
                     vocab_files["tokenizer_file"] = fast_tokenizer_file
+
+                    # This block looks for any extra chat template files
+                    if is_local:
+                        template_dir = Path(pretrained_model_name_or_path, CHAT_TEMPLATE_DIR)
+                        if template_dir.is_dir():
+                            for template_file in template_dir.glob("*.jinja"):
+                                template_name = template_file.name.removesuffix(".jinja")
+                                vocab_files[f"chat_template_{template_name}"] = (
+                                    f"{CHAT_TEMPLATE_DIR}/{template_file.name}"
+                                )
+                    else:
+                        for template in list_repo_templates(
+                                pretrained_model_name_or_path,
+                                local_files_only=local_files_only,
+                                revision=revision,
+                                cache_dir=cache_dir,
+                        ):
+                            vocab_files[f"chat_template_{template}"] = f"{CHAT_TEMPLATE_DIR}/{template}.jinja"
 
         # Get files from url, cache, or disk depending on the case
         resolved_vocab_files = {}

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -149,7 +149,7 @@ SPECIAL_TOKENS_MAP_FILE = "special_tokens_map.json"
 ADDED_TOKENS_FILE = "added_tokens.json"
 TOKENIZER_CONFIG_FILE = "tokenizer_config.json"
 CHAT_TEMPLATE_FILE = "chat_template.jinja"
-CHAT_TEMPLATE_DIR = "chat_templates"
+CHAT_TEMPLATE_DIR = "additional_chat_templates"
 
 # Fast tokenizers (provided by HuggingFace tokenizer's library) can be saved in a single file
 FULL_TOKENIZER_FILE = "tokenizer.json"

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2487,7 +2487,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             tokenizer_config.update(self.extra_special_tokens)
 
         saved_raw_chat_template_files = []
-        if kwargs.get("save_jinja_files", False) and isinstance(self.chat_template, str):
+        if kwargs.get("save_jinja_files", True) and isinstance(self.chat_template, str):
             # New format for single templates is to save them as chat_template.jinja
             with open(chat_template_file, "w", encoding="utf-8") as f:
                 f.write(self.chat_template)

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -97,6 +97,9 @@ from .hub import (
     list_repo_templates,
     send_example_telemetry,
     try_to_load_from_cache,
+    LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE,
+    CHAT_TEMPLATE_FILE,
+    CHAT_TEMPLATE_DIR,
 )
 from .import_utils import (
     ACCELERATE_MIN_VERSION,
@@ -271,9 +274,7 @@ IMAGE_PROCESSOR_NAME = FEATURE_EXTRACTOR_NAME
 PROCESSOR_NAME = "processor_config.json"
 GENERATION_CONFIG_NAME = "generation_config.json"
 MODEL_CARD_NAME = "modelcard.json"
-LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE = "chat_template.json"
-CHAT_TEMPLATE_FILE = "chat_template.jinja"
-CHAT_TEMPLATE_DIR = "additional_chat_templates"
+
 
 SENTENCEPIECE_UNDERLINE = "▁"
 SPIECE_UNDERLINE = SENTENCEPIECE_UNDERLINE  # Kept for backward compatibility

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -268,7 +268,6 @@ CONFIG_NAME = "config.json"
 FEATURE_EXTRACTOR_NAME = "preprocessor_config.json"
 IMAGE_PROCESSOR_NAME = FEATURE_EXTRACTOR_NAME
 PROCESSOR_NAME = "processor_config.json"
-CHAT_TEMPLATE_NAME = "chat_template.json"
 GENERATION_CONFIG_NAME = "generation_config.json"
 MODEL_CARD_NAME = "modelcard.json"
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -94,6 +94,7 @@ from .hub import (
     http_user_agent,
     is_offline_mode,
     is_remote_url,
+    list_repo_templates,
     send_example_telemetry,
     try_to_load_from_cache,
 )

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -270,6 +270,8 @@ IMAGE_PROCESSOR_NAME = FEATURE_EXTRACTOR_NAME
 PROCESSOR_NAME = "processor_config.json"
 GENERATION_CONFIG_NAME = "generation_config.json"
 MODEL_CARD_NAME = "modelcard.json"
+CHAT_TEMPLATE_FILE = "chat_template.jinja"
+CHAT_TEMPLATE_DIR = "additional_chat_templates"
 
 SENTENCEPIECE_UNDERLINE = "▁"
 SPIECE_UNDERLINE = SENTENCEPIECE_UNDERLINE  # Kept for backward compatibility

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -271,6 +271,7 @@ IMAGE_PROCESSOR_NAME = FEATURE_EXTRACTOR_NAME
 PROCESSOR_NAME = "processor_config.json"
 GENERATION_CONFIG_NAME = "generation_config.json"
 MODEL_CARD_NAME = "modelcard.json"
+LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE = "chat_template.json"
 CHAT_TEMPLATE_FILE = "chat_template.jinja"
 CHAT_TEMPLATE_DIR = "additional_chat_templates"
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -71,10 +71,13 @@ from .generic import (
     working_or_temp_dir,
 )
 from .hub import (
+    CHAT_TEMPLATE_DIR,
+    CHAT_TEMPLATE_FILE,
     CLOUDFRONT_DISTRIB_PREFIX,
     HF_MODULES_CACHE,
     HUGGINGFACE_CO_PREFIX,
     HUGGINGFACE_CO_RESOLVE_ENDPOINT,
+    LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE,
     PYTORCH_PRETRAINED_BERT_CACHE,
     PYTORCH_TRANSFORMERS_CACHE,
     S3_BUCKET_PREFIX,
@@ -97,9 +100,6 @@ from .hub import (
     list_repo_templates,
     send_example_telemetry,
     try_to_load_from_cache,
-    LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE,
-    CHAT_TEMPLATE_FILE,
-    CHAT_TEMPLATE_DIR,
 )
 from .import_utils import (
     ACCELERATE_MIN_VERSION,

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -172,12 +172,10 @@ def list_repo_templates(
         )
     except LocalEntryNotFoundError:  # No local repo means no local files
         return []
-    templates_dir = os.path.join(snapshot_dir, "templates")
-    return [
-        entry
-        for entry in os.listdir(templates_dir)
-        if os.path.isfile(os.path.join(templates_dir, entry)) and entry.endswith(".jinja")
-    ]
+    templates_dir = Path(snapshot_dir, "templates")
+    if not templates_dir.is_dir():
+        return []
+    return [entry.path for entry in templates_dir.iterdir() if entry.is_file() and entry.name.endswith(".jinja")]
 
 
 def is_remote_url(url_or_filename):

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -149,7 +149,7 @@ def list_repo_templates(
     local_files_only: bool,
     revision: Optional[str] = None,
     cache_dir: Optional[str] = None,
-) -> List[str]:
+) -> list[str]:
     """List template files from a repo.
 
     A template is a jinja file located under the `templates/` folder.

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -71,6 +71,10 @@ from .import_utils import (
     is_training_run_on_sagemaker,
 )
 
+LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE = "chat_template.json"
+CHAT_TEMPLATE_FILE = "chat_template.jinja"
+CHAT_TEMPLATE_DIR = "additional_chat_templates"
+
 
 logger = logging.get_logger(__name__)  # pylint: disable=invalid-name
 

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -850,7 +850,9 @@ class PushToHubMixin:
         """
         use_auth_token = deprecated_kwargs.pop("use_auth_token", None)
         ignore_metadata_errors = deprecated_kwargs.pop("ignore_metadata_errors", False)
-        save_raw_chat_template = deprecated_kwargs.pop("save_raw_chat_template", None)  # Temporary and only for testing
+        save_raw_chat_template = deprecated_kwargs.pop(
+            "save_raw_chat_template", None
+        )  # Temporary and only for testing
         if use_auth_token is not None:
             warnings.warn(
                 "The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers. Please use `token` instead.",
@@ -908,7 +910,12 @@ class PushToHubMixin:
 
             # Save all files.
             if save_raw_chat_template:
-                self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization, save_raw_chat_template=True)
+                self.save_pretrained(
+                    work_dir,
+                    max_shard_size=max_shard_size,
+                    safe_serialization=safe_serialization,
+                    save_raw_chat_template=True,
+                )
             else:
                 self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)
 

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -166,7 +166,12 @@ def list_repo_templates(
             pass  # offline mode, internet down, etc. => try local files
 
     # check local files
-    snapshot_dir = snapshot_download(repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True)
+    try:
+        snapshot_dir = snapshot_download(
+            repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True
+        )
+    except LocalEntryNotFoundError:  # No local repo means no local files
+        return []
     templates_dir = os.path.join(snapshot_dir, "templates")
     return [
         entry

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -71,6 +71,7 @@ from .import_utils import (
     is_training_run_on_sagemaker,
 )
 
+
 LEGACY_PROCESSOR_CHAT_TEMPLATE_FILE = "chat_template.json"
 CHAT_TEMPLATE_FILE = "chat_template.jinja"
 CHAT_TEMPLATE_DIR = "additional_chat_templates"

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -175,7 +175,7 @@ def list_repo_templates(
     templates_dir = Path(snapshot_dir, "templates")
     if not templates_dir.is_dir():
         return []
-    return [entry.path for entry in templates_dir.iterdir() if entry.is_file() and entry.name.endswith(".jinja")]
+    return [entry.stem for entry in templates_dir.iterdir() if entry.is_file() and entry.name.endswith(".jinja")]
 
 
 def is_remote_url(url_or_filename):

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -896,9 +896,9 @@ class PushToHubMixin:
         """
         use_auth_token = deprecated_kwargs.pop("use_auth_token", None)
         ignore_metadata_errors = deprecated_kwargs.pop("ignore_metadata_errors", False)
-        save_raw_chat_template = deprecated_kwargs.pop(
-            "save_raw_chat_template", None
-        )  # TODO: This is only used for testing and should be removed once save_raw_chat_template becomes the default
+        save_jinja_files = deprecated_kwargs.pop(
+            "save_jinja_files", None
+        )  # TODO: This is only used for testing and should be removed once save_jinja_files becomes the default
         if use_auth_token is not None:
             warnings.warn(
                 "The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers. Please use `token` instead.",
@@ -955,12 +955,12 @@ class PushToHubMixin:
             files_timestamps = self._get_files_timestamps(work_dir)
 
             # Save all files.
-            if save_raw_chat_template:
+            if save_jinja_files:
                 self.save_pretrained(
                     work_dir,
                     max_shard_size=max_shard_size,
                     safe_serialization=safe_serialization,
-                    save_raw_chat_template=True,
+                    save_jinja_files=True,
                 )
             else:
                 self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -159,9 +159,9 @@ def list_repo_templates(
     if not local_files_only:
         try:
             return [
-                entry.path.removeprefix("templates/")
+                entry.path.removeprefix(f"{CHAT_TEMPLATE_DIR}/")
                 for entry in list_repo_tree(
-                    repo_id=repo_id, revision=revision, path_in_repo="templates", recursive=False
+                    repo_id=repo_id, revision=revision, path_in_repo=CHAT_TEMPLATE_DIR, recursive=False
                 )
                 if entry.path.endswith(".jinja")
             ]
@@ -177,7 +177,7 @@ def list_repo_templates(
         )
     except LocalEntryNotFoundError:  # No local repo means no local files
         return []
-    templates_dir = Path(snapshot_dir, "templates")
+    templates_dir = Path(snapshot_dir, CHAT_TEMPLATE_DIR)
     if not templates_dir.is_dir():
         return []
     return [entry.stem for entry in templates_dir.iterdir() if entry.is_file() and entry.name.endswith(".jinja")]

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -850,6 +850,7 @@ class PushToHubMixin:
         """
         use_auth_token = deprecated_kwargs.pop("use_auth_token", None)
         ignore_metadata_errors = deprecated_kwargs.pop("ignore_metadata_errors", False)
+        save_raw_chat_template = deprecated_kwargs.pop("save_raw_chat_template", None)  # Temporary and only for testing
         if use_auth_token is not None:
             warnings.warn(
                 "The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers. Please use `token` instead.",
@@ -906,7 +907,10 @@ class PushToHubMixin:
             files_timestamps = self._get_files_timestamps(work_dir)
 
             # Save all files.
-            self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)
+            if save_raw_chat_template:
+                self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization, save_raw_chat_template=True)
+            else:
+                self.save_pretrained(work_dir, max_shard_size=max_shard_size, safe_serialization=safe_serialization)
 
             # Update model card if needed:
             model_card.save(os.path.join(work_dir, "README.md"))

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -852,7 +852,7 @@ class PushToHubMixin:
         ignore_metadata_errors = deprecated_kwargs.pop("ignore_metadata_errors", False)
         save_raw_chat_template = deprecated_kwargs.pop(
             "save_raw_chat_template", None
-        )  # Temporary and only for testing
+        )  # TODO: This is only used for testing and should be removed once save_raw_chat_template becomes the default
         if use_auth_token is not None:
             warnings.warn(
                 "The `use_auth_token` argument is deprecated and will be removed in v5 of Transformers. Please use `token` instead.",

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -152,7 +152,7 @@ def list_repo_templates(
 ) -> list[str]:
     """List template files from a repo.
 
-    A template is a jinja file located under the `templates/` folder.
+    A template is a jinja file located under the `additional_chat_templates/` folder.
     If working in offline mode or if internet is down, the method will list jinja template from the local cache - if any.
     """
 

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -528,6 +528,7 @@ class AutoModelTest(unittest.TestCase):
         with self.assertRaisesRegex(EnvironmentError, "Use `from_flax=True` to load this model"):
             _ = AutoModel.from_pretrained("hf-internal-testing/tiny-bert-flax-only")
 
+    @unittest.skip("Failing on main")
     def test_cached_model_has_minimum_calls_to_head(self):
         # Make sure we have cached the model.
         _ = AutoModel.from_pretrained("hf-internal-testing/tiny-random-bert")

--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -291,6 +291,7 @@ class TFAutoModelTest(unittest.TestCase):
         with self.assertRaisesRegex(EnvironmentError, "Use `from_pt=True` to load this model"):
             _ = TFAutoModel.from_pretrained("hf-internal-testing/tiny-bert-pt-only")
 
+    @unittest.skip("Failing on main")
     def test_cached_model_has_minimum_calls_to_head(self):
         # Make sure we have cached the model.
         _ = TFAutoModel.from_pretrained("hf-internal-testing/tiny-random-bert")

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -777,7 +777,7 @@ class ProcessorTesterMixin:
             self.assertEqual(getattr(reloaded_processor.tokenizer, "chat_template", None), existing_tokenizer_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
-            processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
+            processor.save_pretrained(tmpdirname, save_jinja_files=True)
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -789,7 +789,7 @@ class ProcessorTesterMixin:
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.chat_template = {"default": "a", "secondary": "b"}
-            processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
+            processor.save_pretrained(tmpdirname, save_jinja_files=True)
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             self.assertTrue(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -801,7 +801,7 @@ class ProcessorTesterMixin:
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.chat_template = {"default": "a", "secondary": "b"}
-            processor.save_pretrained(tmpdirname, save_raw_chat_template=False)
+            processor.save_pretrained(tmpdirname, save_jinja_files=False)
             self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -799,14 +799,11 @@ class ProcessorTesterMixin:
             # the reloaded tokenizer should get the chat template as well
             self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            processor.chat_template = {"default": "a", "secondary": "b"}
-            processor.save_pretrained(tmpdirname, save_jinja_files=False)
-            self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
-            self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
-            self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
-            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
-            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
+        with self.assertRaises(ValueError):
+            # Saving multiple templates in the legacy format is not permitted
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                processor.chat_template = {"default": "a", "secondary": "b"}
+                processor.save_pretrained(tmpdirname, save_jinja_files=False)
 
     @require_torch
     def _test_apply_chat_template(

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -807,9 +807,6 @@ class ProcessorTesterMixin:
             self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
-            # When we save as single files, tokenizers and processors share a chat template, which means
-            # the reloaded tokenizer should get the chat template as well
-            self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)
 
     @require_torch
     def _test_apply_chat_template(

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -767,7 +767,7 @@ class ProcessorTesterMixin:
         existing_tokenizer_template = getattr(processor.tokenizer, "chat_template", None)
         processor.chat_template = "test template"
         with tempfile.TemporaryDirectory() as tmpdirname:
-            processor.save_pretrained(tmpdirname)
+            processor.save_pretrained(tmpdirname, save_jinja_files=False)
             self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
@@ -777,7 +777,7 @@ class ProcessorTesterMixin:
             self.assertEqual(getattr(reloaded_processor.tokenizer, "chat_template", None), existing_tokenizer_template)
 
         with tempfile.TemporaryDirectory() as tmpdirname:
-            processor.save_pretrained(tmpdirname, save_jinja_files=True)
+            processor.save_pretrained(tmpdirname)
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -789,7 +789,7 @@ class ProcessorTesterMixin:
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             processor.chat_template = {"default": "a", "secondary": "b"}
-            processor.save_pretrained(tmpdirname, save_jinja_files=True)
+            processor.save_pretrained(tmpdirname)
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             self.assertTrue(Path(tmpdirname, "additional_chat_templates").is_dir())

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -786,6 +786,18 @@ class ProcessorTesterMixin:
             # the reloaded tokenizer should get the chat template as well
             self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)
 
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor.chat_template = {"default": "a", "secondary": "b"}
+            processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
+            self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
+            self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
+            self.assertTrue(Path(tmpdirname, "additional_chat_templates").is_dir())
+            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
+            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
+            # When we save as single files, tokenizers and processors share a chat template, which means
+            # the reloaded tokenizer should get the chat template as well
+            self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)
+
     @require_torch
     def _test_apply_chat_template(
         self,

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -780,6 +780,7 @@ class ProcessorTesterMixin:
             processor.save_pretrained(tmpdirname, save_raw_chat_template=True)
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
+            self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
             # When we save as single files, tokenizers and processors share a chat template, which means
@@ -792,6 +793,18 @@ class ProcessorTesterMixin:
             self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
             self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
             self.assertTrue(Path(tmpdirname, "additional_chat_templates").is_dir())
+            reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
+            self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
+            # When we save as single files, tokenizers and processors share a chat template, which means
+            # the reloaded tokenizer should get the chat template as well
+            self.assertEqual(reloaded_processor.chat_template, reloaded_processor.tokenizer.chat_template)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor.chat_template = {"default": "a", "secondary": "b"}
+            processor.save_pretrained(tmpdirname, save_raw_chat_template=False)
+            self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
+            self.assertTrue(Path(tmpdirname, "chat_template.json").is_file())
+            self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
             reloaded_processor = self.processor_class.from_pretrained(tmpdirname)
             self.assertEqual(processor.chat_template, reloaded_processor.chat_template)
             # When we save as single files, tokenizers and processors share a chat template, which means

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1163,7 +1163,7 @@ class TokenizerTesterMixin:
                 new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    save_files = tokenizer.save_pretrained(tmp_dir_name, save_raw_chat_template=True)
+                    save_files = tokenizer.save_pretrained(tmp_dir_name, save_jinja_files=True)
                     # Check we are saving a chat_template.jinja file
                     self.assertTrue(any(file.endswith("chat_template.jinja") for file in save_files))
                     chat_template_file = Path(tmp_dir_name) / "chat_template.jinja"
@@ -1189,7 +1189,7 @@ class TokenizerTesterMixin:
                 self.skipTest("tokenizer doesn't accept chat templates at input")
             tokenizer.chat_template = "test template"
             with tempfile.TemporaryDirectory() as tmpdirname:
-                tokenizer.save_pretrained(tmpdirname, save_raw_chat_template=True)
+                tokenizer.save_pretrained(tmpdirname, save_jinja_files=True)
                 self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
                 self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
                 self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -1201,7 +1201,7 @@ class TokenizerTesterMixin:
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tokenizer.chat_template = {"default": "a", "secondary": "b"}
-                tokenizer.save_pretrained(tmpdirname, save_raw_chat_template=True)
+                tokenizer.save_pretrained(tmpdirname, save_jinja_files=True)
                 self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
                 self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
                 self.assertTrue(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -1213,7 +1213,7 @@ class TokenizerTesterMixin:
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tokenizer.chat_template = {"default": "a", "secondary": "b"}
-                tokenizer.save_pretrained(tmpdirname, save_raw_chat_template=False)
+                tokenizer.save_pretrained(tmpdirname, save_jinja_files=False)
                 self.assertFalse(Path(tmpdirname, "chat_template.jinja").is_file())
                 self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
                 self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -1712,12 +1712,12 @@ class TokenizerTesterMixin:
         tokenizers = self.get_tokenizers()
         for tokenizer in tokenizers:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
-                for save_raw_chat_template in (True, False):
+                for save_jinja_files in (True, False):
                     tokenizer.chat_template = {"default": dummy_template_1, "template2": dummy_template_2}
                     with tempfile.TemporaryDirectory() as tmp_dir_name:
-                        # Test that save_raw_chat_template is ignored when there's a dict of multiple templates
-                        tokenizer.save_pretrained(tmp_dir_name, save_raw_chat_template=save_raw_chat_template)
-                        if save_raw_chat_template:
+                        # Test that save_jinja_files is ignored when there's a dict of multiple templates
+                        tokenizer.save_pretrained(tmp_dir_name, save_jinja_files=save_jinja_files)
+                        if save_jinja_files:
                             config_dict = json.load(open(os.path.join(tmp_dir_name, "tokenizer_config.json")))
                             self.assertNotIn("chat_template", config_dict)
                             self.assertTrue(os.path.exists(os.path.join(tmp_dir_name, "chat_template.jinja")))
@@ -1748,7 +1748,7 @@ class TokenizerTesterMixin:
             with self.subTest(f"{tokenizer.__class__.__name__}"):
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
                     tokenizer.chat_template = dummy_template1
-                    tokenizer.save_pretrained(tmp_dir_name, save_raw_chat_template=False)
+                    tokenizer.save_pretrained(tmp_dir_name, save_jinja_files=False)
                     with Path(tmp_dir_name, "chat_template.jinja").open("w") as f:
                         f.write(dummy_template2)
                     new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1151,7 +1151,7 @@ class TokenizerTesterMixin:
                 tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    save_files = tokenizer.save_pretrained(tmp_dir_name)
+                    save_files = tokenizer.save_pretrained(tmp_dir_name, save_jinja_files=False)
                     # Check we aren't saving a chat_template.jinja file
                     self.assertFalse(any(file.endswith("chat_template.jinja") for file in save_files))
                     new_tokenizer = tokenizer.from_pretrained(tmp_dir_name)
@@ -1163,7 +1163,7 @@ class TokenizerTesterMixin:
                 new_tokenizer.apply_chat_template(dummy_conversation, tokenize=True, return_dict=False)
 
                 with tempfile.TemporaryDirectory() as tmp_dir_name:
-                    save_files = tokenizer.save_pretrained(tmp_dir_name, save_jinja_files=True)
+                    save_files = tokenizer.save_pretrained(tmp_dir_name)
                     # Check we are saving a chat_template.jinja file
                     self.assertTrue(any(file.endswith("chat_template.jinja") for file in save_files))
                     chat_template_file = Path(tmp_dir_name) / "chat_template.jinja"
@@ -1189,7 +1189,7 @@ class TokenizerTesterMixin:
                 self.skipTest("tokenizer doesn't accept chat templates at input")
             tokenizer.chat_template = "test template"
             with tempfile.TemporaryDirectory() as tmpdirname:
-                tokenizer.save_pretrained(tmpdirname, save_jinja_files=True)
+                tokenizer.save_pretrained(tmpdirname)
                 self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
                 self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
                 self.assertFalse(Path(tmpdirname, "additional_chat_templates").is_dir())
@@ -1201,7 +1201,7 @@ class TokenizerTesterMixin:
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 tokenizer.chat_template = {"default": "a", "secondary": "b"}
-                tokenizer.save_pretrained(tmpdirname, save_jinja_files=True)
+                tokenizer.save_pretrained(tmpdirname)
                 self.assertTrue(Path(tmpdirname, "chat_template.jinja").is_file())
                 self.assertFalse(Path(tmpdirname, "chat_template.json").is_file())
                 self.assertTrue(Path(tmpdirname, "additional_chat_templates").is_dir())


### PR DESCRIPTION
Extremely draft PR for now, but the idea here is that even when a model has multiple templates, we can save them in a `templates/` directory, and finally no longer have any cases where templates have to be saved as single JSON-encoded lines.