### PR TITLE
Fix check for XPU. PyTorch >= 2.6 no longer needs ipex.

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -896,17 +896,19 @@ def is_ipex_available(min_version: str = ""):
 @lru_cache
 def is_torch_xpu_available(check_device=False):
     """
-    Checks if XPU acceleration is available either via `intel_extension_for_pytorch` or
-    via stock PyTorch (>=2.4) and potentially if a XPU is in the environment
+    Checks if XPU acceleration is available either via native PyTorch (>=2.6),
+    `intel_extension_for_pytorch` or via stock PyTorch (>=2.4) and potentially
+    if a XPU is in the environment.
     """
     if not is_torch_available():
         return False
 
     torch_version = version.parse(_torch_version)
-    if is_ipex_available():
-        import intel_extension_for_pytorch  # noqa: F401
-    elif torch_version.major < 2 or (torch_version.major == 2 and torch_version.minor < 4):
-        return False
+    if torch_version.major < 2 or (torch_version.major == 2 and torch_version.minor < 6):
+        if is_ipex_available():
+            import intel_extension_for_pytorch  # noqa: F401
+        elif torch_version.major < 2 or (torch_version.major == 2 and torch_version.minor < 4):
+            return False
 
     import torch
 


### PR DESCRIPTION
Update is_torch_xpu_available. Only check for ipex module if torch version is less than 2.6. Ipex is no longer necessary as of torch 2.6.

@Rocketknight1
