### PR TITLE
Fix AriaForConditionalGeneration flex attn test

### DIFF
--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -1368,6 +1368,7 @@ ARIA_START_DOCSTRING = r"""
 class AriaForConditionalGeneration(AriaPreTrainedModel, GenerationMixin):
     config_class = AriaConfig
     _supports_flash_attn_2 = False
+    _supports_flex_attn = False
     _supports_sdpa = False
     _tied_weights_keys = ["language_model.lm_head.weight"]
 

--- a/src/transformers/models/aria/modular_aria.py
+++ b/src/transformers/models/aria/modular_aria.py
@@ -1348,6 +1348,7 @@ ARIA_START_DOCSTRING = r"""
 class AriaForConditionalGeneration(AriaPreTrainedModel, GenerationMixin):
     config_class = AriaConfig
     _supports_flash_attn_2 = False
+    _supports_flex_attn = False
     _supports_sdpa = False
     _tied_weights_keys = ["language_model.lm_head.weight"]
 


### PR DESCRIPTION
We had some tests failing related to flex_attention. I don't think there is a real bug present related to flex_attention, but rather that we simply haven't marked classes correctly as not supporting flex_attention.

Here are the observations/assumptions I've made:
Aria supports flex_attention.
Idefics3VisionTransformer does not.
AriaForConditionalGeneration depends on Idefics3VisionTransformer.
AriaForConditionalGeneration does not support flex_attention.

If that seems correct, as well as my solution of just slapping a `_supports_flex_attn = False` on AriaForConditionalGeneration, then we're good to go 👍 