### PR TITLE
[generate] clarify docstrings: when to inherit `GenerationMixin`

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -344,12 +344,13 @@ GenerateOutput = Union[GenerateNonBeamOutput, GenerateBeamOutput]
 
 class GenerationMixin:
     """
-    A class containing all functions for auto-regressive text generation, to be used as a mixin in models.
+    A class containing all functions for auto-regressive text generation, to be used as a mixin in model classes.
 
-    A model class should inherit from `GenerationMixin` to include shared methods like `generate`, or when it has a
-    custom `generate` method that relies on some part of `GenerationMixin`, directly or indirectly (e.g. an inner model
-    calling `GenerationMixin.generate`). Inheriting from this class causes the model to load a `GenerationConfig` at
-    initialization time, and ensures `generate`-related class tests are run.
+    A model class should inherit from `GenerationMixin` to enable calling methods like `generate`, or when it
+    has a custom `generate` method that relies on some part of `GenerationMixin`, directly or indirectly (e.g. the
+    model with a custom `generate` has an inner model calling `GenerationMixin.generate`). Inheriting from this class
+    causes the model to load a `GenerationConfig` at initialization time, and ensures `generate`-related class tests
+    are run in `transformers` CI.
 
     The class exposes [`~generation.GenerationMixin.generate`], which can be used for:
         - *greedy decoding* if `num_beams=1` and `do_sample=False`

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -344,7 +344,12 @@ GenerateOutput = Union[GenerateNonBeamOutput, GenerateBeamOutput]
 
 class GenerationMixin:
     """
-    A class containing all functions for auto-regressive text generation, to be used as a mixin in [`PreTrainedModel`].
+    A class containing all functions for auto-regressive text generation, to be used as a mixin in models.
+
+    A model class should inherit from `GenerationMixin` to include shared methods like `generate`, or when it has a
+    custom `generate` method that relies on some part of `GenerationMixin`, directly or indirectly (e.g. an inner model
+    calling `GenerationMixin.generate`). Inheriting from this class causes the model to load a `GenerationConfig` at
+    initialization time, and ensures `generate`-related class tests are run.
 
     The class exposes [`~generation.GenerationMixin.generate`], which can be used for:
         - *greedy decoding* if `num_beams=1` and `do_sample=False`

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1739,6 +1739,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         """
         Returns whether this model can generate sequences with `.generate()` from the `GenerationMixin`.
 
+        Under the hood, on classes where this function returns True, some generation-specific changes are triggered:
+        for instance, the model instance will have a populated `generation_config` attribute.
+
         Returns:
             `bool`: Whether this model can generate sequences with `.generate()`.
         """


### PR DESCRIPTION
# What does this PR do?

From the discussion in #36570: clarify docstrings regarding when should a model inherit `GenerationMixin`. This information was not present anywhere.