### PR TITLE
Fix auto-assign reviewers

### DIFF
--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -22,14 +22,8 @@ from collections import Counter
 from pathlib import Path
 
 def pattern_to_regex(pattern):
-    if pattern.startswith("/"):
-        start_anchor = True
-    else:
-        start_anchor = False
-    if pattern.endswith(".py") or pattern.endswith("*"):
-        end_anchor = True
-    else:
-        end_anchor = False
+    start_anchor = pattern.startswith("/")
+    end_anchor = pattern.endswith("*") or "." in pattern.split("/")[-1]
     pattern = re.escape(pattern)
     # Replace `*` with "any number of non-slash characters"
     pattern = pattern.replace(r"\*", "[^/]*")

--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -23,14 +23,11 @@ from pathlib import Path
 
 def pattern_to_regex(pattern):
     start_anchor = pattern.startswith("/")
-    end_anchor = pattern.endswith("*") or "." in pattern.split("/")[-1]
     pattern = re.escape(pattern)
     # Replace `*` with "any number of non-slash characters"
     pattern = pattern.replace(r"\*", "[^/]*")
     if start_anchor:
         pattern = "^" + pattern
-    if end_anchor:
-        pattern = pattern + "$"
     return pattern
 
 def get_file_owners(file_path, codeowners_lines):

--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -17,9 +17,27 @@ import os
 import github
 import json
 from github import Github
-from fnmatch import fnmatch
+import re
 from collections import Counter
 from pathlib import Path
+
+def pattern_to_regex(pattern):
+    if pattern.startswith("/"):
+        start_anchor = True
+    else:
+        start_anchor = False
+    if pattern.endswith(".py") or pattern.endswith("*"):
+        end_anchor = True
+    else:
+        end_anchor = False
+    pattern = re.escape(pattern)
+    # Replace `*` with "any number of non-slash characters"
+    pattern = pattern.replace(r"\*", "[^/]*")
+    if start_anchor:
+        pattern = "^" + pattern
+    if end_anchor:
+        pattern = pattern + "$"
+    return pattern
 
 def get_file_owners(file_path, codeowners_lines):
     # Process lines in reverse (last matching pattern takes precedence)
@@ -36,18 +54,20 @@ def get_file_owners(file_path, codeowners_lines):
         owners = [owner.removeprefix("@") for owner in parts[1:]]
 
         # Check if file matches pattern
-        if fnmatch(file_path, pattern):
+        file_regex = pattern_to_regex(pattern)
+        if re.search(file_regex, file_path) is not None:
             return owners  # Remember, can still be empty!
     return []  # Should never happen, but just in case
 
 def main():
+    script_dir = Path(__file__).parent.absolute()
+    with open(script_dir / "codeowners_for_review_action") as f:
+        codeowners_lines = f.readlines()
+
     g = Github(os.environ['GITHUB_TOKEN'])
     repo = g.get_repo("huggingface/transformers")
     with open(os.environ['GITHUB_EVENT_PATH']) as f:
         event = json.load(f)
-    script_dir = Path(__file__).parent.absolute()
-    with open(script_dir / "codeowners_for_review_action") as f:
-        codeowners_lines = f.readlines()
 
     # The PR number is available in the event payload
     pr_number = event['pull_request']['number']

--- a/.github/scripts/codeowners_for_review_action
+++ b/.github/scripts/codeowners_for_review_action
@@ -11,14 +11,14 @@ docs/ @stevhliu
 /src/transformers/models/*/image_processing* @qubvel
 /src/transformers/models/*/image_processing_*_fast* @yonigozlan
 
-
 # Owners of subsections of the library
 /src/transformers/generation/ @gante
 /src/transformers/pipeline/ @Rocketknight1 @yonigozlan
 /src/transformers/integrations/ @SunMarc @MekkCyber @muellerzr
 /src/transformers/quantizers/ @SunMarc @MekkCyber
-/src/transformers/tests/ @ydshieh
-/src/transformers/tests/generation/ @gante
+tests/ @ydshieh
+tests/generation/ @gante
+
 /src/transformers/models/auto/ @ArthurZucker
 /src/transformers/utils/ @ArthurZucker @Rocketknight1
 /src/transformers/loss/ @ArthurZucker


### PR DESCRIPTION
The `fnmatch` function didn't catch all of the cases I thought it did, so I had to write my own regex instead. I tested various cases that fail before and they work now!

A couple of lines in the codeowners file were also incorrect, so those have been rewritten.