### PR TITLE
Cleanup the regex used for doc preprocessing

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -2732,8 +2732,8 @@ def preprocess_string(string, skip_cuda_tests):
     cuda stuff is detective (with a heuristic), this method will return an empty string so no doctest will be run for
     `string`.
     """
-    codeblock_pattern = r"(```(?:python|py)\s*\n\s*>>> )((?:.*?\n)*?.*?```)"
-    codeblocks = re.split(re.compile(codeblock_pattern, flags=re.MULTILINE | re.DOTALL), string)
+    codeblock_pattern = r"(```(?:python|py)\s*\n\s*>>> )(.*?```)"
+    codeblocks = re.split(codeblock_pattern, string, flags=re.DOTALL)
     is_cuda_found = False
     for i, codeblock in enumerate(codeblocks):
         if "load_dataset(" in codeblock and "# doctest: +IGNORE_RESULT" not in codeblock:


### PR DESCRIPTION
We had an overly-complex regex designed to capture docstrings, and as a result it has potentially exponential runtime for malicious inputs. This PR makes the following simplifying changes:

- Explicit calls to `re.compile` without saving the compiled object are removed - these only hurt performance (see [note](https://docs.python.org/3/library/re.html#re.compile))
- `re.MULTILINE` was removed because this only [affects the behaviour](https://docs.python.org/3/library/re.html#re.MULTILINE) of `^` and `$` characters, which are not used in this regex
- Over-complex non-capturing group replaced with much simpler regex, because `re.DOTALL` allows `.*?` to go through newlines

cc @Michellehbn!