### PR TITLE
Don't accidentally mutate the base_model_tp_plan

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1895,8 +1895,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # If current model is a base model, attach `base_model_tp_plan` and `base_model_pp_plan` from config
         if self.base_model is self:
-            self._pp_plan = self.config.base_model_pp_plan.copy()
-            self._tp_plan = self.config.base_model_tp_plan.copy() or {}
+            self._pp_plan = (self.config.base_model_pp_plan or {}).copy()
+            self._tp_plan = (self.config.base_model_tp_plan or {}).copy()
         else:
             self._tp_plan = self._tp_plan or {}
             for name, module in self.named_children():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1897,7 +1897,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         if self.base_model is self:
             self._pp_plan = self.config.base_model_pp_plan
 
-        self._tp_plan = self._tp_plan or self.config.base_model_tp_plan or {}
+        if not self._tp_plan:
+            if isinstance(self.config.base_model_tp_plan, dict):
+                self._tp_plan = self.config.base_model_tp_plan.copy()
+            else:
+                self._tp_plan = {}
         for name, module in self.named_children():
             if plan := getattr(module, "_tp_plan", None):
                 self._tp_plan.update({f"{name}.{k}": v for k, v in plan.items()})

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1895,8 +1895,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # If current model is a base model, attach `base_model_tp_plan` and `base_model_pp_plan` from config
         if self.base_model is self:
-            self._pp_plan = (self.config.base_model_pp_plan or {}).copy()
-            self._tp_plan = (self.config.base_model_tp_plan or {}).copy()
+            self._pp_plan = self.config.base_model_pp_plan.copy() if self.config.base_model_pp_plan is not None else None
+            self._tp_plan = self.config.base_model_tp_plan.copy() if self.config.base_model_tp_plan is not None else {}
         else:
             self._tp_plan = self._tp_plan or {}
             for name, module in self.named_children():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1895,13 +1895,13 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # If current model is a base model, attach `base_model_tp_plan` and `base_model_pp_plan` from config
         if self.base_model is self:
-            self._pp_plan = self.config.base_model_pp_plan
-
-        if not self._tp_plan:
-            if isinstance(self.config.base_model_tp_plan, dict):
-                self._tp_plan = self.config.base_model_tp_plan.copy()
-            else:
-                self._tp_plan = {}
+            self._pp_plan = self.config.base_model_pp_plan.copy()
+            self._tp_plan = self.config.base_model_tp_plan.copy() or {}
+        else:
+            self._tp_plan = self._tp_plan or {}
+            for name, module in self.named_children():
+                if plan := getattr(module, "_tp_plan", None):
+                    self._tp_plan.update({f"{name}.{k}": v for k, v in plan.items()})
         for name, module in self.named_children():
             if plan := getattr(module, "_tp_plan", None):
                 self._tp_plan.update({f"{name}.{k}": v for k, v in plan.items()})

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1895,7 +1895,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         # If current model is a base model, attach `base_model_tp_plan` and `base_model_pp_plan` from config
         if self.base_model is self:
-            self._pp_plan = self.config.base_model_pp_plan.copy() if self.config.base_model_pp_plan is not None else None
+            self._pp_plan = (
+                self.config.base_model_pp_plan.copy() if self.config.base_model_pp_plan is not None else None
+            )
             self._tp_plan = self.config.base_model_tp_plan.copy() if self.config.base_model_tp_plan is not None else {}
         else:
             self._tp_plan = self._tp_plan or {}

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2305,6 +2305,7 @@ class GenerationTesterMixin:
             self.assertEqual(with_all_logits.tolist(), without_all_logits.tolist())
 
     @pytest.mark.generate
+    @is_flaky()
     def test_assisted_decoding_with_logits_to_keep(self):
         for model_class in self.all_generative_model_classes:
             if "logits_to_keep" not in set(inspect.signature(model_class.forward).parameters.keys()):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2305,7 +2305,7 @@ class GenerationTesterMixin:
             self.assertEqual(with_all_logits.tolist(), without_all_logits.tolist())
 
     @pytest.mark.generate
-    @is_flaky()
+    @is_flaky
     def test_assisted_decoding_with_logits_to_keep(self):
         for model_class in self.all_generative_model_classes:
             if "logits_to_keep" not in set(inspect.signature(model_class.forward).parameters.keys()):

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -803,6 +803,7 @@ class TrainerIntegrationPrerunTest(TestCasePlus, TrainerIntegrationCommon):
             trainer.train()
             self.check_trained_model(trainer.model, alternate_seed=True)
 
+    @slow
     def test_gradient_accumulation_loss_alignment_with_model_loss(self):
         set_seed(42)
         import datasets


### PR DESCRIPTION
All credit goes to @gante and @arthurzucker for figuring this one out and I'm just swooping in and stealing credit because I want this to be merged quickly!

If no `tp_plan` is provided, our code uses `self.config.base_model_tp_plan` as the default. The problem is that this is a mutable, instance-level dict, and we do in fact mutate it, which causes the instance dict to get very large and weird over time. We resolve the issue by correctly copying the base dict as an instance attribute instead of mutating it in-place.