### PR TITLE
Add `use_hub_layer_forward` decorator for using layers from the hub

### DIFF
--- a/src/transformers/utils/kernel_hub.py
+++ b/src/transformers/utils/kernel_hub.py
@@ -1,0 +1,121 @@
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Dict
+
+
+if TYPE_CHECKING:
+    from torch import nn
+
+
+@dataclass(frozen=True)
+class _Architecture:
+    device_type: str
+
+    def __eq__(self, other):
+        return isinstance(other, _Architecture) and self.device_type == other.device_type
+
+    def __hash__(self):
+        return hash(self.device_type)
+
+
+@dataclass
+class LayerRepository:
+    """
+    Repository and name of a layer.
+    """
+
+    layer_name: str = field(metadata={"help": "The name of the layer in the kernel repository."})
+    repo_id: str = field(metadata={"help": "The kernel hub repository with the layer."})
+    revision: str = field(default="main", metadata={"help": "The revision of the layer."})
+
+
+_KERNEL_MAPPING: Dict[str, Dict[_Architecture, LayerRepository]] = {}
+
+
+def register_layer_mapping(kernel_name: str, *, device_type: str, layer_repository: LayerRepository):
+    """
+    Register a layer mapping.
+
+    This function regiters a mapping from a layer identifier and device type
+    to a layer in a kernel repository.
+    """
+    _KERNEL_MAPPING.setdefault(kernel_name, {})[_Architecture(device_type=device_type)] = layer_repository
+
+
+def use_hub_layer_forward(layer_name: str, *, use_fallback: bool = True):
+    """
+    Replace the forward function of a layer using a layer from the kernel hub.
+
+    This decorator can be applied to a layer and replaces the forward method
+    of the layer with that of a layer from the hub. The replacement is done
+    when a layer matching `layer_name` and device type is registered through
+    `register_layer_mapping`. The device type is inferred from the first
+    argument to `forward`.
+    """
+
+    def decorator(cls):
+        fallback_forward = cls.forward
+
+        cached_forward = {}
+
+        def forward(self, x, **args):
+            kernel = _KERNEL_MAPPING.get(layer_name)
+            if kernel is None:
+                if not use_fallback:
+                    raise ValueError(f"No layer mapping for `{layer_name}`")
+                return fallback_forward(self, x, **args)
+
+            device = getattr(x, "device", None)
+            if device is None:
+                return fallback_forward(self, x, **args)
+
+            # Short-circuit if we already loaded the layer.
+            arch = _Architecture(device_type=device.type)
+            layer_forward = cached_forward.get(arch, None)
+            if layer_forward is not None:
+                return layer_forward(self, x, **args)
+
+            repo = kernel.get(arch)
+            if repo is None:
+                if not use_fallback:
+                    raise ValueError(f"No layer mapping for `{layer_name}` with device type `{device.type}`")
+                return fallback_forward(self, x, **args)
+
+            try:
+                layer = _get_kernel_layer(
+                    repo_id=repo.repo_id,
+                    layer_name=repo.layer_name,
+                    revision=repo.revision,
+                )
+                layer_forward = layer.forward
+                cached_forward[arch] = layer_forward
+            except Exception as e:
+                if not use_fallback:
+                    raise e
+                layer_forward = fallback_forward
+
+            return layer_forward(self, x, **args)
+
+        cls.forward = forward
+
+        return cls
+
+    return decorator
+
+
+def _get_kernel_layer(*, repo_id: str, layer_name: str, revision: str) -> "nn.Module":
+    """Get a layer from a kernel."""
+
+    from kernels import get_kernel
+    from torch import nn
+
+    kernel = get_kernel(repo_id, revision=revision)
+
+    if getattr(kernel, "layers", None) is None:
+        raise ValueError(f"Kernel `{repo_id}` at revision `{revision}` does not define any layers.")
+
+    layer = getattr(kernel.layers, layer_name, None)
+    if layer is None:
+        raise ValueError(f"Layer `{layer_name}` not found in kernel `{repo_id}`.")
+    if not issubclass(layer, nn.Module):
+        raise TypeError(f"Layer `{layer_name}` is not a Torch layer.")
+    return layer

--- a/tests/utils/test_kernel_hub.py
+++ b/tests/utils/test_kernel_hub.py
@@ -1,0 +1,144 @@
+import unittest
+
+import pytest
+import torch
+from torch import nn
+
+from transformers.testing_utils import require_torch_gpu
+from transformers.utils.kernel_hub import (
+    LayerRepository,
+    register_layer_mapping,
+    use_hub_layer_forward,
+)
+
+
+register_layer_mapping(
+    "LlamaRMSNormForTesting",
+    device_type="cuda",
+    layer_repository=LayerRepository(
+        layer_name="RMSNorm",
+        repo_id="kernels-community/triton-layer-norm",
+        revision="9fc83e639335d0c9a8ac2ecd7f64f7ebebc727f5",
+    ),
+)
+
+register_layer_mapping(
+    "LlamaRMSNormNonExistingDevice",
+    device_type="bogus",
+    layer_repository=LayerRepository(
+        layer_name="RMSNorm",
+        repo_id="kernels-community/triton-layer-norm",
+        revision="9fc83e639335d0c9a8ac2ecd7f64f7ebebc727f5",
+    ),
+)
+
+register_layer_mapping(
+    "LlamaRMSNormNonExistingRepo",
+    device_type="cuda",
+    layer_repository=LayerRepository(
+        layer_name="RMSNorm",
+        repo_id="kernels-community/does-not-exist",
+        revision="9fc83e639335d0c9a8ac2ecd7f64f7ebebc727f5",
+    ),
+)
+
+
+class LlamaRMSNormReference(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        LlamaRMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+        # Align parameters with hub kernel.
+        self.bias = None
+        self.drop = None
+        self.eps = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+@use_hub_layer_forward("LlamaRMSNormForTesting", use_fallback=False)
+class LlamaRMSNormHub(LlamaRMSNormReference):
+    pass
+
+
+@require_torch_gpu
+class KernelHubTest(unittest.TestCase):
+    def test_use_hub_layer_forward(self):
+        torch.manual_seed(0)
+        layer_ref = LlamaRMSNormReference(64).cuda()
+        layer_hub = LlamaRMSNormHub(64).cuda()
+        X = torch.randn((8, 64), device="cuda", dtype=torch.float32)
+        self.assertTrue(torch.allclose(layer_ref(X), layer_hub(X)))
+
+
+@use_hub_layer_forward("LlamaRMSNormNonExistingName", use_fallback=False)
+class LlamaRMSNormHubNonExistingName(LlamaRMSNormReference):
+    pass
+
+
+@use_hub_layer_forward("LlamaRMSNormNonExistingDevice", use_fallback=False)
+class LlamaRMSNormHubNonExistingDevice(LlamaRMSNormReference):
+    pass
+
+
+@use_hub_layer_forward("LlamaRMSNormNonExistingRepo", use_fallback=False)
+class LlamaRMSNormHubNonExistingRepo(LlamaRMSNormReference):
+    pass
+
+
+@pytest.mark.parametrize(
+    "layer_cls",
+    [
+        LlamaRMSNormHubNonExistingName,
+        LlamaRMSNormHubNonExistingDevice,
+        LlamaRMSNormHubNonExistingRepo,
+    ],
+)
+@require_torch_gpu
+def test_nonexisting_hub_layers_fails_without_fallback(layer_cls):
+    layer = layer_cls(64).cuda()
+    X = torch.randn((8, 64), device="cuda", dtype=torch.float32)
+    with pytest.raises(Exception):
+        layer(X)
+
+
+@use_hub_layer_forward("LlamaRMSNormNonExistingName")
+class LlamaRMSNormHubNonExistingNameFallback(LlamaRMSNormReference):
+    pass
+
+
+@use_hub_layer_forward("LlamaRMSNormNonExistingDevice")
+class LlamaRMSNormHubNonExistingDeviceFallback(LlamaRMSNormReference):
+    pass
+
+
+@use_hub_layer_forward("LlamaRMSNormNonExistingRepo")
+class LlamaRMSNormHubNonExistingRepoFallback(LlamaRMSNormReference):
+    pass
+
+
+@pytest.mark.parametrize(
+    "layer_cls",
+    [
+        LlamaRMSNormHubNonExistingNameFallback,
+        LlamaRMSNormHubNonExistingDeviceFallback,
+        LlamaRMSNormHubNonExistingRepoFallback,
+    ],
+)
+@require_torch_gpu
+def test_nonexisting_hub_layers_succeeds_with_fallback(layer_cls):
+    layer = layer_cls(64).cuda()
+    X = torch.randn((8, 64), device="cuda", dtype=torch.float32)
+    # Must not raise.
+    layer(X)


### PR DESCRIPTION
# What does this PR do?

This change add a decorator `use_hub_layer_forward` that can replace the `forward` method of a layer from that of a layer from the kernel hub. The decorator accepts an identifier. Users can then register kernels for that identifier using the `register_layer_mapping` method.

By default, if no compatible mapping is found, the layer will fall back to the original `forward` method.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @LysandreJik 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
