### PR TITLE
Fix dtype for params without tp_plan

### DIFF
--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -531,7 +531,7 @@ def shard_and_distribute_module(
             param, empty_param, param_type, param_casting_dtype, is_contiguous, rank, device_mesh
         )
     else:
-        param = param[...]
+        param = param[...].to(param_casting_dtype)
         if is_contiguous:
             param = param.contiguous()
 


### PR DESCRIPTION
# What does this PR do?

As per the title. Otherwise forward pass fail with errors such as `[rank2]: RuntimeError: expected mat1 and mat2 to have the same dtype, but got: c10::BFloat16 != c10::Half`
