### PR TITLE
Handling an exception related to HQQ quantization in modeling

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -709,9 +709,15 @@ def _find_identical(tensors: List[Set[str]], state_dict: Dict[str, torch.Tensor]
 
 
 def _infer_parameter_dtype(
-    model: "PreTrainedModel", param_name: str, empty_param, keep_in_fp32_modules=None
+    model: "PreTrainedModel", param_name: str, empty_param, keep_in_fp32_modules=None, hf_quantizer: Optional[HfQuantizer] = None
 ) -> Union[bool, Optional[torch.dtype]]:
-    old_param = model.get_parameter_or_buffer(param_name)
+    try :
+        old_param = model.get_parameter_or_buffer(param_name)
+    except Exception as e:
+        if hf_quantizer is not None and hf_quantizer.quantization_config.quant_method == QuantizationMethod.HQQ : 
+            return True, None
+        else:
+            raise e
     is_torch_e4m3fn_available = hasattr(torch, "float8_e4m3fn")
     # We convert floating dtypes to the `dtype` passed except for float8_e4m3fn type. We also want to keep the buffers/params
     # in int/uint/bool and not cast them.
@@ -781,6 +787,7 @@ def _load_state_dict_into_meta_model(
             param_name,
             empty_param,
             keep_in_fp32_modules,
+            hf_quantizer,
         )
 
         if device_mesh is not None:  # In this case, the param is already on the correct device!

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -709,12 +709,16 @@ def _find_identical(tensors: List[Set[str]], state_dict: Dict[str, torch.Tensor]
 
 
 def _infer_parameter_dtype(
-    model: "PreTrainedModel", param_name: str, empty_param, keep_in_fp32_modules=None, hf_quantizer: Optional[HfQuantizer] = None
+    model: "PreTrainedModel",
+    param_name: str,
+    empty_param,
+    keep_in_fp32_modules=None,
+    hf_quantizer: Optional[HfQuantizer] = None,
 ) -> Union[bool, Optional[torch.dtype]]:
-    try :
+    try:
         old_param = model.get_parameter_or_buffer(param_name)
     except Exception as e:
-        if hf_quantizer is not None and hf_quantizer.quantization_config.quant_method == QuantizationMethod.HQQ : 
+        if hf_quantizer is not None and hf_quantizer.quantization_config.quant_method == QuantizationMethod.HQQ:
             return True, None
         else:
             raise e

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -711,8 +711,8 @@ def _find_identical(tensors: List[Set[str]], state_dict: Dict[str, torch.Tensor]
 def _infer_parameter_dtype(
     model: "PreTrainedModel",
     param_name: str,
-    empty_param,
-    keep_in_fp32_modules=None,
+    empty_param: torch.Tensor,
+    keep_in_fp32_modules: Optional[List[str]] = None,
     hf_quantizer: Optional[HfQuantizer] = None,
 ) -> Union[bool, Optional[torch.dtype]]:
     try:


### PR DESCRIPTION
# What does this PR do?

Adds exception handling to allow HQQ quantization to proceed when parameter names don't match between the model and state dict. It's due to the fact that in HQQ we only replace the linears on the fly by the hqqlinears, and this is because of some internal hqq considerations (to quantize each layer with a different precision...)

## Who can review ?
@SunMarc 