### PR TITLE
Make the flaky list a little more general

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -41,8 +41,7 @@ FLAKY_TEST_FAILURE_PATTERNS = [
     "ConnectionError",  # Connection transient error
     "FileNotFoundError",  # Raised by `datasets` on Hub failures
     "PIL.UnidentifiedImageError",  # Raised by `PIL.Image.open` on connection issues
-    "HTTPError.*502",  # Hub-related
-    "HTTPError.*504",  # Hub-related
+    "HTTPError",  # Also catches HfHubHTTPError
     "AssertionError: Tensor-likes are not close!",  # `torch.testing.assert_close`, we might have unlucky random values
     # TODO: error downloading tokenizer's `merged.txt` from hub can cause all the exceptions below. Throw and handle
     # them under a single message.

--- a/tests/test_image_processing_common.py
+++ b/tests/test_image_processing_common.py
@@ -29,6 +29,7 @@ from transformers import AutoImageProcessor, BatchFeature
 from transformers.image_utils import AnnotationFormat, AnnotionFormat
 from transformers.testing_utils import (
     check_json_file_has_correct_format,
+    is_flaky,
     require_torch,
     require_torch_gpu,
     require_vision,
@@ -212,6 +213,7 @@ class ImageProcessingTestMixin:
 
     @require_vision
     @require_torch
+    @is_flaky()
     def test_fast_is_faster_than_slow(self):
         if not self.test_slow_image_processor or not self.test_fast_image_processor:
             self.skipTest(reason="Skipping speed test")


### PR DESCRIPTION
cc @gante, I also saw `HfHubHTTPError` in flaky tests, so I rewrote the list to include that too!