### PR TITLE
Limit numpy version to <2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -133,7 +133,7 @@ _deps = [
     "natten>=0.14.6,<0.15.0",
     "nltk<=3.8.1",
     "num2words",
-    "numpy>=1.17",
+    "numpy>=1.17,<2.0.0",
     "onnxconverter-common",
     "onnxruntime-tools>=1.4.2",
     "onnxruntime>=1.4.0",


### PR DESCRIPTION
# What does this PR do?

Limits numpy version to <2.0.0 to prevent it being installed on numpy>=2.0.0 projects since it is clearly incompatible in some regards.

Fixes https://discuss.huggingface.co/t/unable-to-create-tensor-you-should-probably-activate-padding-with-padding-true-to-have-batched-tensors-with-the-same-length/98181