### PR TITLE
Fix swanlab global step

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -2291,7 +2291,7 @@ class SwanLabCallback(TrainerCallback):
         if state.is_world_process_zero:
             for k, v in logs.items():
                 if k in single_value_scalars:
-                    self._swanlab.log({f"single_value/{k}": v})
+                    self._swanlab.log({f"single_value/{k}": v}, step=state.global_step)
             non_scalar_logs = {k: v for k, v in logs.items() if k not in single_value_scalars}
             non_scalar_logs = rewrite_logs(non_scalar_logs)
             self._swanlab.log({**non_scalar_logs, "train/global_step": state.global_step}, step=state.global_step)

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -2294,7 +2294,7 @@ class SwanLabCallback(TrainerCallback):
                     self._swanlab.log({f"single_value/{k}": v})
             non_scalar_logs = {k: v for k, v in logs.items() if k not in single_value_scalars}
             non_scalar_logs = rewrite_logs(non_scalar_logs)
-            self._swanlab.log({**non_scalar_logs, "train/global_step": state.global_step})
+            self._swanlab.log({**non_scalar_logs, "train/global_step": state.global_step}, step=state.global_step)
 
     def on_save(self, args, state, control, **kwargs):
         if self._log_model is not None and self._initialized and state.is_world_process_zero:


### PR DESCRIPTION
# What does this PR do?

A tiny fix to make the curves displayed by the `swanlab` logger align with the actual steps, provide a better experience for developers

Before this PR, if you set `logging_steps` to 5, the points in the line chart on SwanLab would still be spaced 1 step apart (without passing the `step` parameter in `swanlab.log`) 💦; after the modification, the points are spaced 5 steps apart, consistent with `logging_steps` 🎉

![image](https://github.com/user-attachments/assets/5c4c0e4a-b681-41c6-86c8-52628d57e59d)


---

This pull request includes a minor change to the logging functionality in the `on_log` method within the `integration_utils.py` file. The change ensures that the global step is included in the logging calls for better tracking and consistency.

Logging improvements:

* [`src/transformers/integrations/integration_utils.py`](diffhunk://#diff-70576373928eee203a92800d5ea1f6270d45462a9bde494cde65338710a0a331L2294-R2297): Modified the `on_log` method to include the `step` parameter in calls to `self._swanlab.log` for both single value scalars and non-scalar logs.
