### PR TITLE
[CI] remove redundant checks in `test_eager_matches_sdpa_inference`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -138,16 +138,16 @@ TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION = [
     (
         # test name for the test runner
         f"{dtype}_pad_{padding_side}{'' if use_attention_mask else '_no_attn_mask'}"
-        f"{'_output_attn' if output_attentions else ''}{'_sdpa_kernels' if enable_kernels else ''}",
+        f"{'_sdpa_kernels' if enable_kernels else ''}",
         # parameterization
-        *(dtype, padding_side, use_attention_mask, output_attentions, enable_kernels),
+        *(dtype, padding_side, use_attention_mask, False, enable_kernels),
     )
     for dtype in ("fp16", "fp32", "bf16")
     for padding_side in ("left", "right")
     for use_attention_mask in (True, False)
-    for output_attentions in (True, False)
     for enable_kernels in (True, False)
-]
+    # Extra test case: `output_attentions=True` has special attention mask handling and sdpa reverts to eager
+] + [("fp32_pad_left_output_attentions", "fp32", "left", True, True, False)]
 
 
 def _config_zero_init(config):
@@ -3618,7 +3618,7 @@ class ModelTesterMixin:
             ("cuda", False, torch.bfloat16): 1e-2,
             ("cuda", False, torch.float16): 5e-3,
             ("cuda", True, torch.float32): 1e-4,
-            ("cuda", True, torch.bfloat16): 3e-2,
+            ("cuda", True, torch.bfloat16): 3e-2,  # (different from others)
             ("cuda", True, torch.float16): 5e-3,
         }
 


### PR DESCRIPTION
# What does this PR do?

Follow-up to #36650 

Removes redundant test cases in `test_eager_matches_sdpa_inference`, related to `output_attentions`.

SDPA has special attention mask preparation (e.g. see [here](https://github.com/huggingface/transformers/blob/e3af4fec91bdac3381e07f6e60fb8b74c3957c11/src/transformers/models/llama/modeling_llama.py#L657)) but, when we pass `output_attentions`, SDPA reverts to eager attention. That means that mask preparation for SDPA + `output_attentions` must be the same as eager. In #30652 we added a `for` loop to test the cases with `output_attentions in (True, False)`, resulting in 24 new subtests. 

That's testing overkill, all we need to check is to confirm that we're preparing the attention mask correctly with `output_attentions=True`. This PR removes all but 1 of the redundant tests.

@ydshieh with this PR, both CPU and GPU CI is faster than in `v4.49.0` 🤗 