### PR TITLE
Update min version of safetensors to allow integer indexing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -164,7 +164,7 @@ _deps = [
     "ruff==0.5.1",
     "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses",
-    "safetensors>=0.4.1",
+    "safetensors>=0.4.3",
     "sagemaker>=2.31.0",
     "schedulefree>=1.2.6",
     "scikit-learn",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -70,7 +70,7 @@ deps = {
     "ruff": "ruff==0.5.1",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",
-    "safetensors": "safetensors>=0.4.1",
+    "safetensors": "safetensors>=0.4.3",
     "sagemaker": "sagemaker>=2.31.0",
     "schedulefree": "schedulefree>=1.2.6",
     "scikit-learn": "scikit-learn",


### PR DESCRIPTION
# What does this PR do?
This PR update the minimum version of safetensors to 0.4.3 in order to have support for integer indexing which is required in our TP integration. 
PR : https://github.com/huggingface/safetensors/pull/440 
release : https://github.com/huggingface/safetensors/releases/tag/v0.4.3

