### PR TITLE
fix hqq due to recent modeling changes

### DIFF
--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -169,7 +169,8 @@ class HqqHfQuantizer(HfQuantizer):
                 and tensor_name != "bias"
             )
         else:
-            return isinstance(module, torch.nn.Linear) and tensor_name == "weight"
+            # we need a special path for bias since hqq overwrote load_state_dict for this layer
+            return isinstance(module, torch.nn.Linear) and tensor_name == "weight" or (isinstance(module, HQQLinear) and tensor_name == "bias")
 
     def create_quantized_param(
         self,
@@ -193,6 +194,10 @@ class HqqHfQuantizer(HfQuantizer):
         layer_name = ".".join(param_name.split(".")[:-1])
         parent_module = find_parent(model, layer_name)
         node = layer_name.split(".")[-1]
+
+        if tensor_name == "bias":
+            # this should already be set
+            return
 
         # set module state_dict
         module_state_dict = {}

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -170,7 +170,11 @@ class HqqHfQuantizer(HfQuantizer):
             )
         else:
             # we need a special path for bias since hqq overwrote load_state_dict for this layer
-            return isinstance(module, torch.nn.Linear) and tensor_name == "weight" or (isinstance(module, HQQLinear) and tensor_name == "bias")
+            return (
+                isinstance(module, torch.nn.Linear)
+                and tensor_name == "weight"
+                or (isinstance(module, HQQLinear) and tensor_name == "bias")
+            )
 
     def create_quantized_param(
         self,

--- a/tests/quantization/hqq/test_hqq.py
+++ b/tests/quantization/hqq/test_hqq.py
@@ -149,6 +149,28 @@ class HQQTestMultiGPU(unittest.TestCase):
 @require_torch_gpu
 @require_accelerate
 @require_hqq
+class HQQTestBias(unittest.TestCase):
+    def tearDown(self):
+        cleanup()
+
+    def test_fp16_quantized_model(self):
+        """
+        Simple LLM model testing fp16 with bias
+        """
+        quant_config = HqqConfig(nbits=8, group_size=64)
+
+        hqq_runner = HQQLLMRunner(
+            model_id="facebook/opt-125m", quant_config=quant_config, compute_dtype=torch.float16, device=torch_device
+        )
+
+        check_hqqlayer(self, hqq_runner.model.model.decoder.layers[0].self_attn.v_proj)
+        check_forward(self, hqq_runner.model)
+
+
+@slow
+@require_torch_gpu
+@require_accelerate
+@require_hqq
 class HQQSerializationTest(unittest.TestCase):
     def tearDown(self):
         cleanup()


### PR DESCRIPTION
# What does this PR do?

This PR fixes Hqq quantizer due to recent modeling changes which make use of `load_state_dict` instead of `set_module_tensor_to_device`. The issue was that hqq had rewrote `load_state_dict` and it is causing issue with models with a bias. 