### PR TITLE
Fixing typo in gemma3 image_processor_fast and adding a small test

### DIFF
--- a/src/transformers/models/gemma3/image_processing_gemma3_fast.py
+++ b/src/transformers/models/gemma3/image_processing_gemma3_fast.py
@@ -277,17 +277,17 @@ class Gemma3ImageProcessorFast(BaseImageProcessorFast):
         processed_images = []
         batch_num_crops = []
 
-        for image_list in images:
+        for images_list in images:
             if do_pan_and_scan:
                 images_list, num_crops = self._process_images_for_pan_and_scan(
-                    images=image_list,
+                    images=images_list,
                     do_pan_and_scan=do_pan_and_scan,
                     pan_and_scan_min_crop_size=pan_and_scan_min_crop_size,
                     pan_and_scan_max_num_crops=pan_and_scan_max_num_crops,
                     pan_and_scan_min_ratio_to_activate=pan_and_scan_min_ratio_to_activate,
                 )
             else:
-                num_crops = [[0] for images in images_list]
+                num_crops = [[0] for _ in images_list]
 
             # Group images by size for batched processing
             processed_image_patches_grouped = {}

--- a/tests/models/gemma3/test_image_processing_gemma3.py
+++ b/tests/models/gemma3/test_image_processing_gemma3.py
@@ -143,6 +143,29 @@ class Gemma3ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             image_processor = image_processing_class.from_dict(self.image_processor_dict, size=84)
             self.assertEqual(image_processor.size, {"height": 84, "width": 84})
 
+    def test_without_pan_and_scan(self):
+        """
+        Disable do_pan_and_scan parameter.
+        """
+        for image_processing_class in self.image_processor_list:
+            # Initialize image_processing
+            image_processor = image_processing_class.from_dict(self.image_processor_dict, do_pan_and_scan=False)
+
+            # create random PIL images
+            image_inputs = self.image_processor_tester.prepare_image_inputs(equal_resolution=True)
+            for image in image_inputs:
+                self.assertIsInstance(image, Image.Image)
+
+            # Test not batched input
+            encoded_images = image_processor(image_inputs[0], return_tensors="pt").pixel_values
+            expected_output_image_shape = (1, 3, 18, 18)
+            self.assertEqual(tuple(encoded_images.shape), expected_output_image_shape)
+
+            # Test batched
+            encoded_images = image_processor(image_inputs, return_tensors="pt").pixel_values
+            expected_output_image_shape = (7, 3, 18, 18)
+            self.assertEqual(tuple(encoded_images.shape), expected_output_image_shape)
+
     def test_pan_and_scan(self):
         """
         Enables Pan and Scan path by choosing the correct input image resolution. If you are changing


### PR DESCRIPTION
# What does this PR do?

Removes typo present in Gemma3 Model's ImageProcessorFast.
Added 1 small test for the verification of the same.
Fixes https://github.com/huggingface/transformers/issues/36739


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

PR Discussion - https://github.com/huggingface/transformers/issues/36739
Added small test for Gemma3 model with do_pan_and_scan disabled.

## Who can review?

@zucchini-nlp 
