### PR TITLE
Proposed fix for V4.49.0 gemma 3 release to solve issue #36758

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4679,7 +4679,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         state_dict_folder = None
         state_dict_index = None
 
-        import pdb;pdb.set_trace()
         if device_map is not None and "disk" in device_map.values():
             archive_file = (
                 resolved_archive_file[0] if isinstance(resolved_archive_file, (list, tuple)) else resolved_archive_file
@@ -4890,7 +4889,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         model_to_load.expected_keys = expected_keys
         if device_map is not None:
-            # import pdb; pdb.set_trace()
             expanded_device_map = expand_device_map(device_map, original_loaded_keys, start_prefix)
             if hf_quantizer is None:
                 caching_allocator_warmup(model_to_load, expanded_device_map, dtype)
@@ -5876,7 +5874,6 @@ def expand_device_map(device_map, param_names, start_prefix):
     """
     Expand a device map to return the correspondence parameter name to device.
     """
-    import pdb; pdb.set_trace()
     new_device_map = {}
     param_names = [p[len(start_prefix) :] for p in param_names if p.startswith(start_prefix)]
     for module, device in device_map.items():
@@ -5896,7 +5893,6 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: Dict, 
     accelerator_device_map = {
         param: torch.device(device) for param, device in expanded_device_map.items() if device not in ["cpu", "disk"]
     }
-    # import pdb; pdb.set_trace()
     if not len(accelerator_device_map):
         return
 
@@ -5908,11 +5904,12 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: Dict, 
     # import pdb; pdb.set_trace()
     for param_name, device in accelerator_device_map.items():
         try:
-            param = getattr(model, param_name)
+            param = model.get_parameter(param_name)
         except AttributeError:
             if "." in param_name:
+                import pdb; pdb.set_trace()
                 param_name, param_type = param_name.rsplit(".", 1)
-                param = getattr(model.get_submodule(param_name), param_type)
+                param = model.get_submodule(param_name).get_parameter(param_type)
             else:
                 param = model.get_buffer(param_name)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4679,6 +4679,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         state_dict_folder = None
         state_dict_index = None
 
+        import pdb;pdb.set_trace()
         if device_map is not None and "disk" in device_map.values():
             archive_file = (
                 resolved_archive_file[0] if isinstance(resolved_archive_file, (list, tuple)) else resolved_archive_file
@@ -4889,6 +4890,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         model_to_load.expected_keys = expected_keys
         if device_map is not None:
+            # import pdb; pdb.set_trace()
             expanded_device_map = expand_device_map(device_map, original_loaded_keys, start_prefix)
             if hf_quantizer is None:
                 caching_allocator_warmup(model_to_load, expanded_device_map, dtype)
@@ -5874,6 +5876,7 @@ def expand_device_map(device_map, param_names, start_prefix):
     """
     Expand a device map to return the correspondence parameter name to device.
     """
+    import pdb; pdb.set_trace()
     new_device_map = {}
     param_names = [p[len(start_prefix) :] for p in param_names if p.startswith(start_prefix)]
     for module, device in device_map.items():
@@ -5893,6 +5896,7 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: Dict, 
     accelerator_device_map = {
         param: torch.device(device) for param, device in expanded_device_map.items() if device not in ["cpu", "disk"]
     }
+    # import pdb; pdb.set_trace()
     if not len(accelerator_device_map):
         return
 
@@ -5901,6 +5905,7 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: Dict, 
     if torch.distributed.is_initialized() or len(set(accelerator_device_map.values())) >= 2:
         allocation_factor = 2
 
+    # import pdb; pdb.set_trace()
     for param_name, device in accelerator_device_map.items():
         try:
             param = getattr(model, param_name)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4163,7 +4163,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # We'll need to download and cache each checkpoint shard if the checkpoint is sharded.
         if is_sharded:
             # resolved_archive_file becomes a list of files that point to the different checkpoint shards in this case.
-            import pdb; pdb.set_trace()
             resolved_archive_file, sharded_metadata = get_checkpoint_shard_files(
                 pretrained_model_name_or_path,
                 resolved_archive_file,
@@ -4284,7 +4283,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 (torch_dtype == torch.float16) or hasattr(hf_quantizer, "use_keep_in_fp32_modules")
             )
 
-            import pdb; pdb.set_trace()
             if is_sharded:
                 loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
             else:
@@ -4443,7 +4441,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if dtype_orig is not None:
                 torch.set_default_dtype(dtype_orig)
 
-            import pdb; pdb.set_trace()
             (
                 model,
                 missing_keys,
@@ -4706,7 +4703,6 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Retrieve missing & unexpected_keys
         model_state_dict = model.state_dict()
         expected_keys = list(model_state_dict.keys())
-        import pdb; pdb.set_trace()
         prefix = model.base_model_prefix
 
         if hf_quantizer is not None:
@@ -4893,7 +4889,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
 
         model_to_load.expected_keys = expected_keys
         if device_map is not None:
-            expanded_device_map = expand_device_map(device_map, original_loaded_keys, start_prefix)
+            expanded_device_map = expand_device_map(device_map, expected_keys, start_prefix)
             if hf_quantizer is None:
                 caching_allocator_warmup(model_to_load, expanded_device_map, dtype)
 
@@ -5905,13 +5901,11 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: Dict, 
     if torch.distributed.is_initialized() or len(set(accelerator_device_map.values())) >= 2:
         allocation_factor = 2
 
-    # import pdb; pdb.set_trace()
     for param_name, device in accelerator_device_map.items():
         try:
             param = model.get_parameter(param_name)
         except AttributeError:
             if "." in param_name:
-                import pdb; pdb.set_trace()
                 param_name, param_type = param_name.rsplit(".", 1)
                 param = model.get_submodule(param_name).get_parameter(param_type)
             else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4163,6 +4163,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # We'll need to download and cache each checkpoint shard if the checkpoint is sharded.
         if is_sharded:
             # resolved_archive_file becomes a list of files that point to the different checkpoint shards in this case.
+            import pdb; pdb.set_trace()
             resolved_archive_file, sharded_metadata = get_checkpoint_shard_files(
                 pretrained_model_name_or_path,
                 resolved_archive_file,
@@ -4283,6 +4284,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 (torch_dtype == torch.float16) or hasattr(hf_quantizer, "use_keep_in_fp32_modules")
             )
 
+            import pdb; pdb.set_trace()
             if is_sharded:
                 loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
             else:
@@ -4441,6 +4443,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             if dtype_orig is not None:
                 torch.set_default_dtype(dtype_orig)
 
+            import pdb; pdb.set_trace()
             (
                 model,
                 missing_keys,
@@ -4703,6 +4706,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
         # Retrieve missing & unexpected_keys
         model_state_dict = model.state_dict()
         expected_keys = list(model_state_dict.keys())
+        import pdb; pdb.set_trace()
         prefix = model.base_model_prefix
 
         if hf_quantizer is not None:

--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -1523,6 +1523,8 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMi
 
         # Initialize weights and apply final processing
         self.post_init()
+        del self.lm_head
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
     def get_input_embeddings(self):
         return self.model.embed_tokens

--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -1523,8 +1523,6 @@ class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMi
 
         # Initialize weights and apply final processing
         self.post_init()
-        del self.lm_head
-        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
 
     def get_input_embeddings(self):
         return self.model.embed_tokens


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR is a proposed solution for [issue #36758](https://github.com/huggingface/transformers/issues/36758). In a word, this issue points out two bugs in the [v4.49.0-Gemma-3-release](https://github.com/huggingface/transformers/tree/v4.49.0-Gemma-3-release) branch of transformers, and this PR uses two fixes to fix these two bugs respectively.

Reproduction:
```python
from transformers import AutoModelForCausalLM
model = AutoModelForCausalLM.from_pretrained(
    "./models/Llama-2-7b-hf",
    device_map="cpu"
)
```

Bug 1:
```bash
AttributeError: 'LlamaForCausalLM' object has no attribute 'model.layers.0.self_attn.rotary_emb.inv_freq'
```

Fix 1:
After checking the differences between the main branch and this branch, I noticed the bug lies in `caching_allocator_warmup()` [main](https://github.com/huggingface/transformers/blob/7f5077e53682ca855afc826162b204ebf809f1f9/src/transformers/modeling_utils.py#L5816) | [branch](https://github.com/huggingface/transformers/blob/46350f5eae87ac1d168ddfdc57a0b39b64b9a029/src/transformers/modeling_utils.py#L5904). The new version removes the function `model.get_parameter_or_buffer()` and implements the function directly in the loop. However, the main branch is using `model.get_parameter(name)` whereas the new version `getattr(model, name)`, which is likely the cause of the issue. Therefore, I changed `getattr()` to `model.get_parameter()`.

Bug 2:
```bash
AttributeError: LlamaAttention has no attribute `rotary_emb`
```

Fix 2:
Again, after reviewing the difference between the branch and the new branch, I noticed the new version is likely passing a wrong `expanded_device_map` to [`caching_allocator_warmup()`](https://github.com/huggingface/transformers/blob/46350f5eae87ac1d168ddfdc57a0b39b64b9a029/src/transformers/modeling_utils.py#L5886). The `expanded_device_map` is created with `expanded_device_map = expand_device_map(device_map, expected_keys)` whereas `expanded_device_map = expand_device_map(device_map, original_loaded_keys, start_prefix)` in the new version. After checking the context, I decided to modify the new version to `expanded_device_map = expand_device_map(device_map, expected_keys, start_prefix)`. See [main](https://github.com/huggingface/transformers/blob/7f5077e53682ca855afc826162b204ebf809f1f9/src/transformers/modeling_utils.py#L4826) | [branch](https://github.com/huggingface/transformers/blob/46350f5eae87ac1d168ddfdc57a0b39b64b9a029/src/transformers/modeling_utils.py#L4892C13-L4892C100) for comparison.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
