### PR TITLE
Support loading custom code objects (`trust_remote_code=True`) in offline mode from local

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -437,6 +437,9 @@ class PretrainedConfig(PushToHubMixin):
         self.to_json_file(output_config_file, use_diff=True)
         logger.info(f"Configuration saved in {output_config_file}")
 
+        # Save remote code to local
+        custom_object_save(self, save_directory)
+
         if push_to_hub:
             self._upload_modified_files(
                 save_directory,

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -129,10 +129,18 @@ def get_relative_import_files(module_file: Union[str, os.PathLike]) -> list[str]
         for f in files_to_check:
             new_imports.extend(get_relative_imports(f))
 
+        # get a full path for each new import file
         module_path = Path(module_file).parent
-        new_import_files = [str(module_path / m) for m in new_imports]
+        new_import_files = []
+        for m in new_imports:
+            raw_module_name = m.lstrip(".")
+            n_levels = len(m) - len(raw_module_name)
+            cur_level = module_path
+            for i in range(n_levels):
+                cur_level = cur_level.parent
+            new_import_files.append(str(cur_level / raw_module_name))
         new_import_files = [f for f in new_import_files if f not in all_relative_imports]
-        files_to_check = [f"{f}.py" for f in new_import_files]
+        files_to_check = [f"{f}.py" for f in new_import_files if os.path.isfile(f"{f}.py")]
 
         no_change = len(new_import_files) == 0
         all_relative_imports.extend(files_to_check)

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -422,6 +422,9 @@ class FeatureExtractionMixin(PushToHubMixin):
         self.to_json_file(output_feature_extractor_file)
         logger.info(f"Feature extractor saved in {output_feature_extractor_file}")
 
+        # Save remote code to local
+        custom_object_save(self, save_directory)
+
         if push_to_hub:
             self._upload_modified_files(
                 save_directory,

--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -257,6 +257,9 @@ class ImageProcessingMixin(PushToHubMixin):
         self.to_json_file(output_image_processor_file)
         logger.info(f"Image processor saved in {output_image_processor_file}")
 
+        # Save remote code to local
+        custom_object_save(self, save_directory)
+
         if push_to_hub:
             self._upload_modified_files(
                 save_directory,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3583,6 +3583,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             if self.can_generate():
                 model_to_save.generation_config.save_pretrained(save_directory)
 
+            # Save remote code to local
+            custom_object_save(self, save_directory)
+
             if _hf_peft_config_loaded:
                 logger.info(
                     "Detected adapters on the model, saving the model in the PEFT format, only adapter weights will be saved."

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2506,6 +2506,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             f.write(out_str)
         logger.info(f"tokenizer config file saved in {tokenizer_config_file}")
 
+        # Save remote code to local
+        custom_object_save(self, save_directory)
+
         # Sanitize AddedTokens in special_tokens_map
 
         # kept for forward compatibility, will be removed in transoformers 5. Typefields are not saved for FC, special should not be save either

--- a/tests/models/auto/test_configuration_auto.py
+++ b/tests/models/auto/test_configuration_auto.py
@@ -127,6 +127,17 @@ class AutoConfigTest(unittest.TestCase):
             self.assertEqual(reloaded_config.auto_map["AutoConfig"], "configuration.NewModelConfig")
         self.assertEqual(reloaded_config.__class__.__name__, "NewModelConfig")
 
+        # Test the dynamic module is reloaded and module objects are different.
+        # The module file is not changed after dumping,
+        # but since we're loading from local file - the module code should be reloaded for the new model.
+        self.assertIsNot(config.__class__, reloaded_config.__class__)
+
+        # Test the dynamic module is reloaded if we force it.
+        reloaded_config = AutoConfig.from_pretrained(
+            "hf-internal-testing/test_dynamic_model", trust_remote_code=True, force_download=True
+        )
+        self.assertIsNot(config.__class__, reloaded_config.__class__)
+
     def test_from_pretrained_dynamic_config_conflict(self):
         class NewModelConfigLocal(BertConfig):
             model_type = "new-model"

--- a/tests/models/auto/test_feature_extraction_auto.py
+++ b/tests/models/auto/test_feature_extraction_auto.py
@@ -132,6 +132,17 @@ class AutoFeatureExtractorTest(unittest.TestCase):
             )
         self.assertEqual(reloaded_feature_extractor.__class__.__name__, "NewFeatureExtractor")
 
+        # Test the dynamic module is reloaded and module objects are different.
+        # The module file is not changed after dumping,
+        # but since we're loading from local file - the module code should be reloaded for the new model.
+        self.assertIsNot(feature_extractor.__class__, reloaded_feature_extractor.__class__)
+
+        # Test the dynamic module is reloaded if we force it.
+        reloaded_feature_extractor = AutoFeatureExtractor.from_pretrained(
+            "hf-internal-testing/test_dynamic_feature_extractor", trust_remote_code=True, force_download=True
+        )
+        self.assertIsNot(feature_extractor.__class__, reloaded_feature_extractor.__class__)
+
     def test_new_feature_extractor_registration(self):
         try:
             AutoConfig.register("custom", CustomConfig)

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -197,6 +197,11 @@ class AutoImageProcessorTest(unittest.TestCase):
             )
         self.assertEqual(reloaded_image_processor.__class__.__name__, "NewImageProcessor")
 
+        # Test the dynamic module is reloaded and module objects are different.
+        # The module file is not changed after dumping,
+        # but since we're loading from local file - the module code should be reloaded for the new model.
+        self.assertIsNot(image_processor.__class__, reloaded_image_processor.__class__)
+
         # Test the dynamic module is reloaded if we force it.
         reloaded_image_processor = AutoImageProcessor.from_pretrained(
             "hf-internal-testing/test_dynamic_image_processor", trust_remote_code=True, force_download=True

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -332,6 +332,11 @@ class AutoModelTest(unittest.TestCase):
         for p1, p2 in zip(model.parameters(), reloaded_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
 
+        # Test the dynamic module is reloaded and module objects are different.
+        # The module file is not changed after dumping,
+        # but since we're loading from local file - the module code should be reloaded for the new model.
+        self.assertIsNot(model.__class__, reloaded_model.__class__)
+
         # Test the dynamic module is reloaded if we force it.
         reloaded_model = AutoModel.from_pretrained(
             "hf-internal-testing/test_dynamic_model", trust_remote_code=True, force_download=True
@@ -356,6 +361,11 @@ class AutoModelTest(unittest.TestCase):
         self.assertEqual(reloaded_model.__class__.__name__, "NewModel")
         for p1, p2 in zip(model.parameters(), reloaded_model.parameters()):
             self.assertTrue(torch.equal(p1, p2))
+
+        # Test the dynamic module is reloaded and module objects are different.
+        # The module file is not changed after dumping,
+        # but since we're loading from local file - the module code should be reloaded for the new model.
+        self.assertIsNot(model.__class__, reloaded_model.__class__)
 
         # Test the dynamic module is reloaded if we force it.
         reloaded_model = AutoModel.from_pretrained(

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -356,6 +356,11 @@ class AutoTokenizerTest(unittest.TestCase):
             self.assertEqual(tokenizer.__class__.__name__, "NewTokenizer")
             self.assertEqual(reloaded_tokenizer.__class__.__name__, "NewTokenizer")
 
+        # Test the dynamic module is reloaded and module objects are different.
+        # The module file is not changed after dumping,
+        # but since we're loading from local file - the module code should be reloaded for the new model.
+        self.assertIsNot(tokenizer.__class__, reloaded_tokenizer.__class__)
+
         # Test the dynamic module is reloaded if we force it.
         reloaded_tokenizer = AutoTokenizer.from_pretrained(
             "hf-internal-testing/test_dynamic_tokenizer", trust_remote_code=True, force_download=True


### PR DESCRIPTION
# What does this PR do?

Fixes #34855
And should fix https://github.com/UKPLab/sentence-transformers/issues/2613 (will close separately)

- Now [custom models](https://huggingface.co/docs/transformers/main/en/models#custom-models) (models that require `trust_remote_code=True`) or tokenizers/preprocessors/configs can be fully saved with `save_pretrained()` and able to be loaded with `from_pretrained()` in [offline mode](https://huggingface.co/docs/transformers/main/en/installation#offline-mode)
- All required code files are now saved in the local dir during `save_pretrained()`. And during loading with `from_pretrained()` in offline mode (even on a new fresh machine) it won't try to reach out to HF hub since all files will be self-contained in local dir
- Adds a couple of tests for corresponding offline behavior
- Changes expectations for a couple existing tests for dynamic models/tokenizers/preprocessors/configs to account for loading custom code from local instead of cache (previous behavior)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
   https://github.com/huggingface/transformers/issues/34855#issuecomment-2655944286
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
      No need to update the docs IMHO, since it adds expected behavior according to current docs
- [x] Did you write any new necessary tests?


## Who can review?

@Rocketknight1
@ArthurZucker