### PR TITLE
Remove `dist": "loadfile"` for `pytest` for CircleCI jobs

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -30,7 +30,7 @@ COMMON_ENV_VARIABLES = {
     "RUN_PIPELINE_TESTS": False,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
-COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "dist": "loadfile", "vvv": None, "rsfE":None}
+COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "vvv": None, "rsfE":None}
 DEFAULT_DOCKER_IMAGE = [{"image": "cimg/python:3.8.12"}]
 
 # Strings that commonly appear in the output of flaky tests when they fail. These are used with `pytest-rerunfailures`

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -269,6 +269,7 @@ examples_torch_job = CircleCIJob(
     docker_image=[{"image":"huggingface/transformers-examples-torch"}],
     # TODO @ArthurZucker remove this once docker is easier to build
     install_steps=["uv venv && uv pip install . && uv pip install -r examples/pytorch/_tests_requirements.txt"],
+    pytest_num_workers=4,
 )
 
 
@@ -276,6 +277,7 @@ examples_tensorflow_job = CircleCIJob(
     "examples_tensorflow",
     additional_env={"OMP_NUM_THREADS": 8},
     docker_image=[{"image":"huggingface/transformers-examples-tf"}],
+    pytest_num_workers=4,
 )
 
 

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -277,7 +277,7 @@ examples_tensorflow_job = CircleCIJob(
     "examples_tensorflow",
     additional_env={"OMP_NUM_THREADS": 8},
     docker_image=[{"image":"huggingface/transformers-examples-tf"}],
-    pytest_num_workers=4,
+    pytest_num_workers=2,
 )
 
 


### PR DESCRIPTION
# What does this PR do?

This pytest option forces all tests  from a test file to be run in the same CPU process when using `-n X` (from `pytest-xdist` pluging) to distribute tests across multiple CPU processes.

However, this leads some worker(s) to run much longer if a test file have tests that are slower. Removing `dist": "loadfile"` allows those tests are also being distributed to multiple processes.

Results: 

tests_tokenization: `main` | 1 run on PR

- the longest runtime among 8 paralle CircleCI runners: 8m30s | 5m
- total runtime from all 8 paralle CircleCI runners: 43m | 27m
- total idle time from 8 parallel CircleCI runners: 25m40s | 12m

tests_torch: `main` | 2 runs on PR

- the longest runtime among 8 paralle CircleCI runners: 6m40s | (6m | 5m10s)
- total runtime from all 8 paralle CircleCI runners: 31m15s | (30m | 28m)
- total idle time from 8 parallel CircleCI runners: 22m 10s | (18m | 13m15s)

tests_non_model: `main` | 1 run on PR

- the longest runtime among 8 paralle CircleCI runners: 6m | 2m50
- total runtime from all 8 paralle CircleCI runners: 21m20 | 14m50
- total idle time from 8 parallel CircleCI runners: 26m 50s | 7m 55s