### PR TITLE
One more fix for reviewer assignment

### DIFF
--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -22,12 +22,12 @@ from collections import Counter
 from pathlib import Path
 
 def pattern_to_regex(pattern):
-    start_anchor = pattern.startswith("/")
-    pattern = re.escape(pattern)
+    if pattern.startswith("/"):
+        pattern = "^" + re.escape(pattern[1:])
+    else:
+        pattern = re.escape(pattern)
     # Replace `*` with "any number of non-slash characters"
     pattern = pattern.replace(r"\*", "[^/]*")
-    if start_anchor:
-        pattern = "^" + pattern
     return pattern
 
 def get_file_owners(file_path, codeowners_lines):

--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -23,11 +23,15 @@ from pathlib import Path
 
 def pattern_to_regex(pattern):
     if pattern.startswith("/"):
-        pattern = "^" + re.escape(pattern[1:])
+        start_anchor = True
+        pattern = re.escape(pattern[1:])
     else:
+        start_anchor = False
         pattern = re.escape(pattern)
     # Replace `*` with "any number of non-slash characters"
     pattern = pattern.replace(r"\*", "[^/]*")
+    if start_anchor:
+        pattern = r"^\/?" + pattern  # Allow an optional leading slash after the start of the string
     return pattern
 
 def get_file_owners(file_path, codeowners_lines):


### PR DESCRIPTION
There was another bug I missed - the Github API doesn't always give start absolute paths from the root with `/`. This updated regex handles that!