### PR TITLE
fix: loss computation after embeddings resize - mllama

### DIFF
--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -1902,14 +1902,12 @@ class MllamaForCausalLM(MllamaPreTrainedModel, GenerationMixin):
         full_text_row_masked_out_mask: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
         past_key_values: Optional[Union[Cache, List[torch.FloatTensor]]] = None,
         inputs_embeds: Optional[torch.FloatTensor] = None,
-        # labels: Optional[torch.LongTensor] = None,
         use_cache: Optional[bool] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
         logits_to_keep: Union[int, torch.Tensor] = 0,
-        # **loss_kwargs,
     ) -> Union[Tuple, CausalLMOutputWithPast]:
         r"""
             labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
@@ -1972,17 +1970,11 @@ class MllamaForCausalLM(MllamaPreTrainedModel, GenerationMixin):
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
         logits = self.lm_head(hidden_states[:, slice_indices, :]).float()
 
-        # loss = None
-        # if labels is not None:
-        #     loss = self.loss_function(logits, labels, self.vocab_size, **loss_kwargs)
-
         if not return_dict:
             output = (logits,) + outputs[1:]
-            #return (loss,) + output if loss is not None else output
             return output
 
         return CausalLMOutputWithPast(
-            #loss=loss,
             logits=logits,
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -325,7 +325,7 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
         # resizing embeddings should result in successful loss computation
         config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
         labels = torch.zeros(
-                    (self.batch_size, self.seq_length), dtype=torch.long, device=torch_device
+                    (self.model_tester.batch_size, self.model_tester.seq_length), dtype=torch.long, device=torch_device
                 )
 
         for model_class in self.all_model_classes:

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -324,6 +324,9 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
     def test_resize_embeddings_results_in_successful_loss(self):
         # resizing embeddings should result in successful loss computation
         config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
+        labels = torch.zeros(
+                    (self.batch_size, self.seq_length), dtype=torch.long, device=torch_device
+                )
 
         for model_class in self.all_model_classes:
             model = model_class(config)
@@ -334,6 +337,7 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
                 loss = model(
                     input_ids=inputs["input_ids"],
                     attention_mask=inputs["attention_mask"],
+                    labels=labels,
                     return_dict=True,
                 )["loss"]
             self.parent.assertFalse(torch.isnan(loss).any().item())

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -334,13 +334,13 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
             # Resize embeddings and call forward
             model.resize_token_embeddings(model_vocab_size + 10)
             with torch.autocast(device_type="cuda", dtype=torch.float16):
-                loss = model(
+                output = model(
                     input_ids=inputs["input_ids"],
                     attention_mask=inputs["attention_mask"],
                     labels=labels,
                     return_dict=True,
-                )["loss"]
-            self.parent.assertFalse(torch.isnan(loss).any().item())
+                )
+            assert hasattr(output, "loss")
 
     def _check_attentions_for_generate(
         self, batch_size, attentions, prompt_length, output_length, config, decoder_past_key_values


### PR DESCRIPTION
# What does this PR do?

background: https://github.com/huggingface/transformers/pull/36591

Fixes loss computation when vocab is resized by resize_embeddings. Only vocab size of parent conditionalgenerationclass is modified, hence loss has to be calculated there. Chosen approach until bigger refactor. Solution discussed with @zucchini-nlp in above PR 

Fixes # (issue)
https://github.com/huggingface/transformers/issues/36590

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@zucchini-nlp as discussed solution