### PR TITLE
Fix warning message for PEFT models in text-generation pipeline #36783

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1214,25 +1214,26 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                     else:
                         supported_models_names.append(model.__name__)
             supported_models = supported_models_names
-        
+
         # Check if the model is a PEFT model
         model_class_name = self.model.__class__.__name__
         is_peft_model = False
         try:
             import peft
+
             peft_model_classes = [
-                "PeftModel", 
-                "PeftModelForSequenceClassification", 
-                "PeftModelForCausalLM", 
-                "PeftModelForSeq2SeqLM", 
-                "PeftModelForTokenClassification", 
-                "PeftModelForQuestionAnswering", 
-                "PeftModelForFeatureExtraction"
+                "PeftModel",
+                "PeftModelForSequenceClassification",
+                "PeftModelForCausalLM",
+                "PeftModelForSeq2SeqLM",
+                "PeftModelForTokenClassification",
+                "PeftModelForQuestionAnswering",
+                "PeftModelForFeatureExtraction",
             ]
             is_peft_model = model_class_name in peft_model_classes or isinstance(self.model, peft.PeftModel)
         except ImportError:
             pass
-        
+
         if model_class_name not in supported_models and not is_peft_model:
             logger.error(
                 f"The model '{model_class_name}' is not supported for {self.task}. Supported models are"

--- a/tests/test_peft_pipeline.py
+++ b/tests/test_peft_pipeline.py
@@ -1,6 +1,7 @@
-import torch
-from transformers import pipeline, AutoModelForCausalLM, AutoTokenizer
-from peft import PeftModel, LoraConfig, get_peft_model
+from peft import LoraConfig, get_peft_model
+
+from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+
 
 # Test with a small model
 model_name = "gpt2"
@@ -11,31 +12,17 @@ model = AutoModelForCausalLM.from_pretrained(model_name)
 tokenizer = AutoTokenizer.from_pretrained(model_name)
 
 # Create a dummy PEFT model
-peft_config = LoraConfig(
-    task_type="CAUSAL_LM",
-    r=8,
-    lora_alpha=32,
-    lora_dropout=0.1,
-    target_modules=["c_attn"]
-)
+peft_config = LoraConfig(task_type="CAUSAL_LM", r=8, lora_alpha=32, lora_dropout=0.1, target_modules=["c_attn"])
 peft_model = get_peft_model(model, peft_config)
 
 # Test base model pipeline
 print("Testing base model pipeline:")
-base_generator = pipeline(
-    task="text-generation",
-    model=model,
-    tokenizer=tokenizer
-)
+base_generator = pipeline(task="text-generation", model=model, tokenizer=tokenizer)
 print(base_generator(text, max_length=30))
 
 # Test PEFT model pipeline
 print("\nTesting PEFT model pipeline:")
-peft_generator = pipeline(
-    task="text-generation",
-    model=peft_model,
-    tokenizer=tokenizer
-)
+peft_generator = pipeline(task="text-generation", model=peft_model, tokenizer=tokenizer)
 print(peft_generator(text, max_length=30))
 
 print("\nIf no error message appears between the two outputs, the fix is working correctly!")

--- a/tests/test_peft_pipeline.py
+++ b/tests/test_peft_pipeline.py
@@ -1,0 +1,41 @@
+import torch
+from transformers import pipeline, AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel, LoraConfig, get_peft_model
+
+# Test with a small model
+model_name = "gpt2"
+text = "Hello, I'm a language model"
+
+# Load base model
+model = AutoModelForCausalLM.from_pretrained(model_name)
+tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+# Create a dummy PEFT model
+peft_config = LoraConfig(
+    task_type="CAUSAL_LM",
+    r=8,
+    lora_alpha=32,
+    lora_dropout=0.1,
+    target_modules=["c_attn"]
+)
+peft_model = get_peft_model(model, peft_config)
+
+# Test base model pipeline
+print("Testing base model pipeline:")
+base_generator = pipeline(
+    task="text-generation",
+    model=model,
+    tokenizer=tokenizer
+)
+print(base_generator(text, max_length=30))
+
+# Test PEFT model pipeline
+print("\nTesting PEFT model pipeline:")
+peft_generator = pipeline(
+    task="text-generation",
+    model=peft_model,
+    tokenizer=tokenizer
+)
+print(peft_generator(text, max_length=30))
+
+print("\nIf no error message appears between the two outputs, the fix is working correctly!")


### PR DESCRIPTION
## Issue Description

When using a `PeftModel` from the PEFT library with the text-generation pipeline, an error message is displayed even though the pipeline works correctly:

```
The model 'PeftModel' is not supported for text-generation. Supported models are [...]
```

This issue was reported in #36783  , where @falconlee236 was using a PEFT-adapted DeepSeek model with the text-generation pipeline. The pipeline functioned correctly, but the warning message was unnecessary.

## Root Cause Analysis

The issue occurs in the `check_model_type` method in `src/transformers/pipelines/base.py`. This method verifies if the model's class name is in a list of supported models for the specific pipeline task.

The problem is that PEFT models (like `PeftModel`, `PeftModelForCausalLM`, etc.) aren't included in this list of supported models, causing the warning message to appear even though these models work perfectly fine with the pipeline.

The check is based on the exact class name rather than using `isinstance()` checks, which means it doesn't recognize that PEFT models are compatible with the pipeline tasks.

## Implementation Details

The solution adds a special check for PEFT models before displaying the error message. The implementation:

1. Attempts to import the PEFT library
2. If successful, checks if the model is a PEFT model either by:
   - Checking if the class name is in a list of known PEFT model classes
   - Using `isinstance()` to check if it's a subclass of `peft.PeftModel`
3. Only displays the error message if the model is not in the supported list AND is not a PEFT model

This approach:
- Maintains backward compatibility
- Doesn't require adding PEFT models to the supported models list
- Gracefully handles cases where PEFT is not installed
- Works with all current and future PEFT model classes

## Testing

A test script was created to verify the fix. The test:
1. Creates a base GPT-2 model
2. Creates a PEFT-adapted version of the model using LoRA
3. Uses both models with the text-generation pipeline
4. Verifies that no error message appears when using the PEFT model

The test confirms that both pipelines generate text successfully without the error message about unsupported models.

## Screenshot of Successful Test

<img width="1406" alt="Screenshot 2025-03-20 at 11 49 10 PM" src="https://github.com/user-attachments/assets/c54f90c6-8194-4ce6-9499-bd4b001d2028" />

this shows that the change was successful , since we don't get any of the error message we got earlier here . 

## Validation Against Original Reproduction Case

The fix directly addresses the issue in the original reproduction script from #36783 . In that script:
1. A base model is loaded
2. A PEFT adapter is applied to create a `PeftModel`
3. The model is used with the text-generation pipeline

With the fix, the pipeline no longer shows the error message when using a `PeftModel`, while maintaining all the original functionality.

**fixes** : #36783 

**cc**: @Rocketknight1 