### PR TITLE
Gemma 3 tests expect greedy decoding

### DIFF
--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -567,7 +567,7 @@ class Gemma3IntegrationTest(unittest.TestCase):
         input_size = inputs.input_ids.shape[-1]
         self.assertTrue(input_size > model.config.sliding_window)
 
-        out = model.generate(**inputs, max_new_tokens=20)[:, input_size:]
+        out = model.generate(**inputs, max_new_tokens=20, do_sample=False)[:, input_size:]
         output_text = tokenizer.batch_decode(out)
 
         EXPECTED_COMPLETIONS = [" and I'm going to take a walk.\n\nI really enjoy the scenery, and I'", ", green, yellow, orange, purple, brown, black, white, gray.\n\nI'"]  # fmt: skip
@@ -598,7 +598,7 @@ class Gemma3IntegrationTest(unittest.TestCase):
 
         generation_config = GenerationConfig(max_new_tokens=20)
 
-        out = model.generate(**inputs, generation_config=generation_config)[:, input_size:]
+        out = model.generate(**inputs, generation_config=generation_config, do_sample=False)[:, input_size:]
         output_text = tokenizer.batch_decode(out)
 
         EXPECTED_COMPLETIONS = [" and I'm going to take a walk.\n\nI really enjoy the scenery, and I'", ", green, yellow, orange, purple, brown, black, white, gray.\n\nI'"]  # fmt: skip


### PR DESCRIPTION
# What does this PR do?

Slow tests in gemma 3 expect greedy decoding. Recently hub config has changed https://huggingface.co/google/gemma-3-4b-pt/commit/2166bd1fba050eab3ed4fdd0b591ad1e11c96802 so it is preferred to enforce greedy decoding.