### PR TITLE
Enable tracing for Moshi

### DIFF
--- a/src/transformers/utils/fx.py
+++ b/src/transformers/utils/fx.py
@@ -194,6 +194,7 @@ _SPECIAL_SUPPORTED_MODELS = [
     "TrOCRDecoder",
     "PeftModelForCausalLM",
     "PeftModelForSeq2SeqLM",
+    "MoshiForConditionalGeneration",
     # TODO: add support for them as it should be quite easy to do so (small blocking issues).
     # XLNetForQuestionAnswering,
 ]

--- a/tests/models/moshi/test_modeling_moshi.py
+++ b/tests/models/moshi/test_modeling_moshi.py
@@ -538,6 +538,7 @@ class MoshiTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     test_headmasking = False
     test_resize_embeddings = False
     test_torchscript = False
+    fx_compatible = True
 
     def setUp(self):
         self.model_tester = MoshiTester(self)


### PR DESCRIPTION
# What does this PR do?

Enabled tracing of MoshiForConditionalGeneration

-  Replaced kwargs with args which was used inside forward
- Parsing forward signature to create kwargs for audio encoder, decoder, depth decoder
-  Enabled fx_compatible flag for testing


## Who can review?

@michaelbenayoun
@ylacombe 

