### PR TITLE
Added support for seed in `DataCollatorForWholeWordMask`

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -1309,7 +1309,7 @@ class DataCollatorForWholeWordMask(DataCollatorForLanguageModeling):
         elif self.return_tensors == "tf":
             import tensorflow as tf
 
-            seed = self.generator.uniform(shape=(2,), minval=0, maxval=2**31 - 1, dtype=tf.int32)
+            seed = self.generator.make_seeds(2)[0]
             indices = tf.random.experimental.stateless_shuffle(tf.range(len(cand_indexes)), seed=seed).numpy().tolist()
             return [cand_indexes[i] for i in indices]
 

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -447,18 +447,18 @@ class DataCollatorIntegrationTest(unittest.TestCase):
 
     def test_data_collator_for_whole_word_mask_with_seed(self):
         tokenizer = BertTokenizer(self.vocab_file)
-        features = [{"input_ids": list(range(30))}, {"input_ids": list(range(30))}]
+        features = [{"input_ids": list(range(1000))}, {"input_ids": list(range(1000))}]
 
         # check if seed is respected between two different DataCollatorForWholeWordMask instances
         data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42)
         batch_1 = data_collator(features)
-        self.assertEqual(batch_1["input_ids"].shape, torch.Size((2, 30)))
-        self.assertEqual(batch_1["labels"].shape, torch.Size((2, 30)))
+        self.assertEqual(batch_1["input_ids"].shape, torch.Size((2, 1000)))
+        self.assertEqual(batch_1["labels"].shape, torch.Size((2, 1000)))
 
         data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42)
         batch_2 = data_collator(features)
-        self.assertEqual(batch_2["input_ids"].shape, torch.Size((2, 30)))
-        self.assertEqual(batch_2["labels"].shape, torch.Size((2, 30)))
+        self.assertEqual(batch_2["input_ids"].shape, torch.Size((2, 1000)))
+        self.assertEqual(batch_2["labels"].shape, torch.Size((2, 1000)))
 
         self.assertTrue(torch.all(batch_1["input_ids"] == batch_2["input_ids"]))
         self.assertTrue(torch.all(batch_1["labels"] == batch_2["labels"]))
@@ -1281,18 +1281,18 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
 
     def test_data_collator_for_whole_word_mask_with_seed(self):
         tokenizer = BertTokenizer(self.vocab_file)
-        features = [{"input_ids": list(range(50))}, {"input_ids": list(range(50))}]
+        features = [{"input_ids": list(range(1000))}, {"input_ids": list(range(1000))}]
 
         # check if seed is respected between two different DataCollatorForWholeWordMask instances
         data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="tf")
         batch_1 = data_collator(features)
-        self.assertEqual(batch_1["input_ids"].shape.as_list(), [2, 50])
-        self.assertEqual(batch_1["labels"].shape.as_list(), [2, 50])
+        self.assertEqual(batch_1["input_ids"].shape.as_list(), [2, 1000])
+        self.assertEqual(batch_1["labels"].shape.as_list(), [2, 1000])
 
         data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="tf")
         batch_2 = data_collator(features)
-        self.assertEqual(batch_2["input_ids"].shape.as_list(), [2, 50])
-        self.assertEqual(batch_2["labels"].shape.as_list(), [2, 50])
+        self.assertEqual(batch_2["input_ids"].shape.as_list(), [2, 1000])
+        self.assertEqual(batch_2["labels"].shape.as_list(), [2, 1000])
 
         self.assertTrue(np.all(batch_1["input_ids"] == batch_2["input_ids"]))
         self.assertTrue(np.all(batch_1["labels"] == batch_2["labels"]))
@@ -1300,8 +1300,8 @@ class TFDataCollatorIntegrationTest(unittest.TestCase):
         # try with different seed
         data_collator = DataCollatorForWholeWordMask(tokenizer, seed=43, return_tensors="tf")
         batch_3 = data_collator(features)
-        self.assertEqual(batch_3["input_ids"].shape.as_list(), [2, 50])
-        self.assertEqual(batch_3["labels"].shape.as_list(), [2, 50])
+        self.assertEqual(batch_3["input_ids"].shape.as_list(), [2, 1000])
+        self.assertEqual(batch_3["labels"].shape.as_list(), [2, 1000])
 
         self.assertFalse(np.all(batch_1["input_ids"] == batch_3["input_ids"]))
         self.assertFalse(np.all(batch_1["labels"] == batch_3["labels"]))


### PR DESCRIPTION
# What does this PR do?
- Added support for seed in `DataCollatorForWholeWordMask`, following the same logic as in https://github.com/huggingface/transformers/pull/36497.
- Fixed bugs: Parameters `mask_replace_prob` and `random_replace_prob` were not being used. Instead, the values were hardcoded.
- Added tests
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #36655 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@Rocketknight1 should review this!

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
