### PR TITLE
Fix torch version guard at import

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -585,7 +585,7 @@ def _flatten_dynamic_cache_for_fx(cache, spec):
     return torch.utils._pytree.tree_flatten(dictionary)[0]
 
 
-if is_torch_greater_or_equal("2.2"):
+if is_torch_greater_or_equal("2.3"):
     torch.utils._pytree.register_pytree_node(
         DynamicCache,
         _flatten_dynamic_cache,


### PR DESCRIPTION
# What does this PR do?

Fixes #36888 and fixes #36906. As per title, the kwargs we are using (`flatten_with_keys_fn`) are available only from 2.3.0. We can also pin at 2.2.0 and pass it as positional argument, but then `flatten_with_keys_fn` will not be used in torch (from what I can see in torch repo)