### PR TITLE
Fix Compressed tensors to_dict_diff

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1360,7 +1360,7 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
 
         # only serialize values that differ from the default config
         for key, value in config_dict.items():
-            if value != default_config_dict[key]:
+            if key not in default_config_dict or value != default_config_dict[key]:
                 serializable_config_dict[key] = value
 
         return serializable_config_dict


### PR DESCRIPTION
# What does this PR do?
When creating the dict config, checks if the key exists in the defaut config before trying to access its value.
It was causing the error : 
```
File "./transformers/src/transformers/utils/quantization_config.py", line 1364, in to_diff_dict
    if value != default_config_dict[key]:
                ~~~~~~~~~~~~~~~~~~~^^^^^
KeyError: 'config_groups'
```

