### PR TITLE
Remove the redundant shift during the loss computation in the Moshi m…

### DIFF
--- a/src/transformers/models/moshi/modeling_moshi.py
+++ b/src/transformers/models/moshi/modeling_moshi.py
@@ -65,7 +65,7 @@ _CHECKPOINT_FOR_DOC = "kmhf/hf-moshiko"
 @dataclass
 class MoshiConditionalGenerationGenerateOutput(ModelOutput):
     """
-    Outputs of [`MoshiForConditionalConditionalGeneration.generate`].
+    Outputs of [`MoshiForConditionalGeneration.generate`].
 
     Args:
         audio_sequences (`torch.LongTensor` of shape `(batch_size*num_return_sequences, 1, sequence_length)`, *optional*):
@@ -1874,19 +1874,9 @@ class MoshiForCausalLM(MoshiPreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            # Upcast to float if we need to compute the loss to avoid potential precision issues
-            logits = logits.float()
-            # Shift so that tokens < n predict n
-            shift_logits = logits[..., :-1, :].contiguous()
-            shift_labels = labels[..., 1:].contiguous()
-            # Flatten the tokens
-            shift_logits = shift_logits.view(-1, self.config.vocab_size)
-            shift_labels = shift_labels.view(-1)
-            # Enable model parallelism
-            shift_labels = shift_labels.to(shift_logits.device)
             loss = self.loss_function(
-                shift_logits,
-                shift_labels,
+                logits,
+                labels,
                 vocab_size=self.config.vocab_size,
                 **kwargs,
             )


### PR DESCRIPTION
# What does this PR do?

Correct the loss computation process in the Moshi model to apply the shift only once, as it is currently being applied twice.

Because the class name **MoshiForCausalLM** contains '**ForCausalLM**', according to the mapping rules in **LOSS_MAPPING**, the **self.loss_function** used in the forward function of **MoshiForCausalLM** should be **ForCausalLMLoss**. As a result, logits and labels are shifted **twice**: once before calling self.loss_function and once inside self.loss_function. This leads to **tokens < n - 1 predicting n** instead of the expected behavior where **tokens < n predict n**.

This PR removes the shift before the self.loss_function call.

**References:**
**LOSS_MAPPING**:
https://github.com/huggingface/transformers/blob/9e125d9a2e696967b4d401dbfea24a4d40058017/src/transformers/loss/loss_utils.py#L130-L135

ForCausalLMLoss:
https://github.com/huggingface/transformers/blob/9e125d9a2e696967b4d401dbfea24a4d40058017/src/transformers/loss/loss_utils.py#L33-L57

