### PR TITLE
Fixing _pre_quantization_dtype when torch_dtype is None

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4448,7 +4448,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
             # once the weights have been quantized
             # Note that once you have loaded a quantized model, you can't change its dtype so this will
             # remain a single source of truth
-            config._pre_quantization_dtype = torch_dtype
+            config._pre_quantization_dtype = torch_dtype if torch_dtype is not None else torch.get_default_dtype()
 
         # Prepare the full device map
         if device_map is not None:


### PR DESCRIPTION
# What does this PR do?

Sets `_pre_quantization_dtype` to the default dtype (`float32`) when `torch_dtype` is set to None. It was causing the `casting_dtype` to be None for `bitnet` for example
