### PR TITLE
Disallow Offload to disk for gguf files

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4327,6 +4327,12 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, GenerationMixin, PushToHubMix
                 "You cannot combine Quantization and loading a model from a GGUF file, try again by making sure you did not passed a `quantization_config` or that you did not load a quantized model from the Hub."
             )
 
+        if gguf_file and device_map is not None and "disk" in device_map.values():
+            raise RuntimeError(
+                "One or more modules is configured to be mapped to disk. Disk offload is not supported for models "
+                "loaded from GGUF files."
+            )
+
         checkpoint_files, sharded_metadata = _get_resolved_checkpoint_files(
             pretrained_model_name_or_path=pretrained_model_name_or_path,
             subfolder=subfolder,


### PR DESCRIPTION
# What does this PR do?

Disallow offload to disk for gguf files. It was introduced in this pr https://github.com/huggingface/transformers/pull/35628. 
We can't have offload to disk in the case of gguf files because we need to modify the state_dict to be compatible with transformers.

