### PR TITLE
More ReDOS fixes!

### DIFF
--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -46,7 +46,7 @@ if is_torch_available():
 
 ALLOWED_KEY_CHARS = set(string.ascii_letters + string.whitespace)
 ALLOWED_VALUE_CHARS = set(
-    string.ascii_letters + string.digits + string.whitespace + ".!\"#$%&'()*+,\\-/:<=>?@\\[\\]^_`{|}~"
+    string.ascii_letters + string.digits + string.whitespace + r".!\"#$%&'()*+,\-/:<=>?@[]^_`{|}~"
 )
 
 HELP_STRING = """\

--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -71,7 +71,7 @@ SUPPORTED_GENERATION_KWARGS = [
     "repetition_penalty",
 ]
 
-SETTING_RE = r"^set\s+[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,\-/:<=>?@\[\]^_`{|}~\s]+(?:;\s*[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,\-/:<=>?@\[\]^_`{|}~\s]+)*$"
+SETTING_RE = r"^set\s+[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,-/:<=>?@\[\]^_`{|}~\s]+(?:;\s*[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,-/:<=>?@\[\]^_`{|}~\s]+)*$"
 
 DEFAULT_EXAMPLES = {
     "llama": {"text": "There is a Llama in my lawn, how can I get rid of it?"},

--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -71,7 +71,7 @@ SUPPORTED_GENERATION_KWARGS = [
     "repetition_penalty",
 ]
 
-SETTING_RE = r"^set\s+[A-Za-z\s_]+=[A-Za-z\d\s.!\"#$%&'()*+,-/:<=>?@\[\]^_`{|}~]+(?:;\s*[A-Za-z\s_]+=[A-Za-z\d\s.!\"#$%&'()*+,-/:<=>?@\[\]^_`{|}~]+)*$"
+SETTING_RE = r"^set\s+[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,\-/:<=>?@\[\]^_`{|}~\s]+(?:;\s*[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,\-/:<=>?@\[\]^_`{|}~\s]+)*$"
 
 DEFAULT_EXAMPLES = {
     "llama": {"text": "There is a Llama in my lawn, how can I get rid of it?"},

--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -17,7 +17,7 @@ import copy
 import json
 import os
 import platform
-import re
+import string
 import time
 from argparse import ArgumentParser, Namespace
 from dataclasses import dataclass, field
@@ -44,6 +44,10 @@ if is_torch_available():
 
     from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig, TextIteratorStreamer
 
+ALLOWED_KEY_CHARS = set(string.ascii_letters + string.whitespace)
+ALLOWED_VALUE_CHARS = set(
+    string.ascii_letters + string.digits + string.whitespace + ".!\"#$%&'()*+,\\-/:<=>?@\\[\\]^_`{|}~"
+)
 
 HELP_STRING = """\
 
@@ -70,8 +74,6 @@ SUPPORTED_GENERATION_KWARGS = [
     "top_k",
     "repetition_penalty",
 ]
-
-SETTING_RE = r"^set\s+[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,-/:<=>?@\[\]^_`{|}~\s]+(?:;\s*[A-Za-z_][A-Za-z_\s]*=[A-Za-z\d.!\"#$%&'()*+,-/:<=>?@\[\]^_`{|}~\s]+)*$"
 
 DEFAULT_EXAMPLES = {
     "llama": {"text": "There is a Llama in my lawn, how can I get rid of it?"},
@@ -438,6 +440,36 @@ class ChatCommand(BaseTransformersCLICommand):
     def __init__(self, args):
         self.args = args
 
+    @staticmethod
+    def is_valid_setting_command(s: str) -> bool:
+        # First check the basic structure
+        if not s.startswith("set ") or "=" not in s:
+            return False
+
+        # Split into individual assignments
+        assignments = [a.strip() for a in s[4:].split(";") if a.strip()]
+
+        for assignment in assignments:
+            # Each assignment should have exactly one '='
+            if assignment.count("=") != 1:
+                return False
+
+            key, value = assignment.split("=", 1)
+            key = key.strip()
+            value = value.strip()
+            if not key or not value:
+                return False
+
+            # Keys can only have alphabetic characters, spaces and underscores
+            if not set(key).issubset(ALLOWED_KEY_CHARS):
+                return False
+
+            # Values can have just about anything that isn't a semicolon
+            if not set(value).issubset(ALLOWED_VALUE_CHARS):
+                return False
+
+        return True
+
     def run(self):
         if not is_rich_available():
             raise ImportError("You need to install rich to use the chat interface. (`pip install rich`)")
@@ -499,7 +531,7 @@ class ChatCommand(BaseTransformersCLICommand):
                     interface.print_green(f"Chat saved in {filename}!")
                     continue
 
-                if re.match(SETTING_RE, user_input):
+                if self.is_valid_setting_command(user_input):
                     current_args, success = parse_settings(user_input, current_args, interface)
                     if success:
                         chat = []

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1157,7 +1157,7 @@ def get_configuration_file(configuration_files: list[str]) -> str:
     """
     configuration_files_map = {}
     for file_name in configuration_files:
-        if file_name.startswith("config.") and file_name.endswith(".json"):
+        if file_name.startswith("config.") and file_name.endswith(".json") and file_name != "config.json":
             v = file_name.removeprefix("config.").removesuffix(".json")
             configuration_files_map[v] = file_name
     available_versions = sorted(configuration_files_map.keys())

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1157,8 +1157,8 @@ def get_configuration_file(configuration_files: list[str]) -> str:
     """
     configuration_files_map = {}
     for file_name in configuration_files:
-        if file_name.startswith("config_") and file_name.endswith(".json"):
-            v = file_name.removeprefix("config_").removesuffix(".json")
+        if file_name.startswith("config.") and file_name.endswith(".json"):
+            v = file_name.removeprefix("config.").removesuffix(".json")
             configuration_files_map[v] = file_name
     available_versions = sorted(configuration_files_map.keys())
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -17,7 +17,6 @@
 import copy
 import json
 import os
-import re
 import warnings
 from typing import Any, Optional, Union
 
@@ -43,8 +42,6 @@ from .utils.generic import is_timm_config_dict
 
 
 logger = logging.get_logger(__name__)
-
-_re_configuration_file = re.compile(r"config\.(.*)\.json")
 
 
 class PretrainedConfig(PushToHubMixin):
@@ -1160,9 +1157,8 @@ def get_configuration_file(configuration_files: list[str]) -> str:
     """
     configuration_files_map = {}
     for file_name in configuration_files:
-        search = _re_configuration_file.search(file_name)
-        if search is not None:
-            v = search.groups()[0]
+        if file_name.startswith("config_") and file_name.endswith(".json"):
+            v = file_name.removeprefix("config_").removesuffix(".json")
             configuration_files_map[v] = file_name
     available_versions = sorted(configuration_files_map.keys())
 

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -156,8 +156,10 @@ def get_imports(filename: Union[str, os.PathLike]) -> list[str]:
             return  #  Don't recurse into Try blocks and ignore imports in them
         elif isinstance(node, ast.If):
             test = node.test
-            if isinstance(test, ast.Call) and test.func.id.startswith("is_flash_attn"):
-                return  # Don't recurse into in "if flash_attn_available()" blocks and ignore imports in them
+            for condition_node in ast.walk(test):
+                if isinstance(condition_node, ast.Call) and condition_node.func.id.startswith("is_flash_attn"):
+                    # Don't recurse into "if flash_attn_available()" blocks and ignore imports in them
+                    return
         elif isinstance(node, ast.Import):
             # Handle 'import x' statements
             for alias in node.names:


### PR DESCRIPTION
This PR replaces three more problematic regexes. In all cases I eliminate the regex entirely. 

When parsing Python files for `import` statements we now rely on `ast.parse()` instead. This is the most complex code but it seems to pass tests.

In `chat.py` I think I figured out what the regex was doing and wrote a Python method to duplicate its functionality - cc @gante to confirm I got it right! 

Finally, the change in `configuration_utils.py` was very straightforward; we could just use `str.startswith()` and `str.endswith()` instead.