### PR TITLE
fix transformers_cli import relative path issue

### DIFF
--- a/src/transformers/commands/env.py
+++ b/src/transformers/commands/env.py
@@ -94,6 +94,7 @@ class EnvironmentCommand(BaseTransformersCLICommand):
 
             pt_version = torch.__version__
             pt_cuda_available = torch.cuda.is_available()
+            pt_xpu_available = torch.xpu.is_available()
             pt_npu_available = is_torch_npu_available()
             pt_hpu_available = is_torch_hpu_available()
 
@@ -151,6 +152,9 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             if pt_cuda_available:
                 info["Using GPU in script?"] = "<fill in>"
                 info["GPU type"] = torch.cuda.get_device_name()
+            elif pt_xpu_available:
+                info["Using XPU in script?"] = "<fill in>"
+                info["XPU type"] = torch.xpu.get_device_name()
             elif pt_hpu_available:
                 info["Using HPU in script?"] = "<fill in>"
                 info["HPU type"] = torch.hpu.get_device_name()

--- a/src/transformers/commands/transformers_cli.py
+++ b/src/transformers/commands/transformers_cli.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 from transformers import HfArgumentParser
-
 from transformers.commands.add_fast_image_processor import AddFastImageProcessorCommand
 from transformers.commands.add_new_model_like import AddNewModelLikeCommand
 from transformers.commands.chat import ChatCommand

--- a/src/transformers/commands/transformers_cli.py
+++ b/src/transformers/commands/transformers_cli.py
@@ -15,14 +15,14 @@
 
 from transformers import HfArgumentParser
 
-from .add_fast_image_processor import AddFastImageProcessorCommand
-from .add_new_model_like import AddNewModelLikeCommand
-from .chat import ChatCommand
-from .convert import ConvertCommand
-from .download import DownloadCommand
-from .env import EnvironmentCommand
-from .run import RunCommand
-from .serving import ServeCommand
+from transformers.commands.add_fast_image_processor import AddFastImageProcessorCommand
+from transformers.commands.add_new_model_like import AddNewModelLikeCommand
+from transformers.commands.chat import ChatCommand
+from transformers.commands.convert import ConvertCommand
+from transformers.commands.download import DownloadCommand
+from transformers.commands.env import EnvironmentCommand
+from transformers.commands.run import RunCommand
+from transformers.commands.serving import ServeCommand
 
 
 def main():


### PR DESCRIPTION
**Issue**
when use `python src/transformers/commands/transformers_cli.py env` to get env list by following this [doc](https://huggingface.co/docs/transformers/en/contributing), will report below error:

> Traceback (most recent call last): File "/workspace/transformers/src/transformers/commands/transformers_cli.py", line 18, in <module> from .add_fast_image_processor import AddFastImageProcessorCommand ImportError: attempted relative import with no known parent package

**Fix**
1. replace relative path import to module based import
2. add the missing XPU info

**Results**
Both  `python src/transformers/commands/transformers_cli.py env` and `transformers-cli env` works
