### PR TITLE
Add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -458,7 +458,7 @@ setup(
     package_dir={"": "src"},
     packages=find_packages("src"),
     include_package_data=True,
-    package_data={"": ["**/*.cu", "**/*.cpp", "**/*.cuh", "**/*.h", "**/*.pyx"]},
+    package_data={"": ["**/*.cu", "**/*.cpp", "**/*.cuh", "**/*.h", "**/*.pyx", "py.typed"]},
     zip_safe=False,
     extras_require=extras,
     entry_points={"console_scripts": ["transformers-cli=transformers.commands.transformers_cli:main"]},


### PR DESCRIPTION
py.typed is a marker file to support typing. See [pep 561](https://peps.python.org/pep-0561/). It's used to indicate that transformer has typing support in the source code and tools such as mypy and pylint can take advantage of that. Therefore, we don't need an additional pyi file for typing.