### PR TITLE
fix best_model_checkpoint is None issue when distiributed training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3217,9 +3217,8 @@ class Trainer:
         if self.args.save_strategy in [SaveStrategy.STEPS, SaveStrategy.EPOCH] and self.state.best_global_step:
             best_checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.best_global_step}"
             best_checkpoint_dir = os.path.join(run_dir, best_checkpoint_folder)
-
-            if os.path.exists(best_checkpoint_dir):
-                self.state.best_model_checkpoint = best_checkpoint_dir
+            os.makedirs(best_checkpoint_dir, exist_ok=True)
+            self.state.best_model_checkpoint = best_checkpoint_dir
 
         if not self.args.save_only_model:
             # Save optimizer and scheduler


### PR DESCRIPTION
Fixes # (issue)
- After learning is complete, the problem of saving the model occurs at the end of the train() function. (Multi-GPU)

When load_best_model_at_end is enabled, The cause was that self.state.best_model_checkpoint did not exist in a specific rank.