### PR TITLE
fix tied weigths isuue 

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -780,6 +780,8 @@ def _load_state_dict_into_meta_model(
     if is_meta_state_dict:
         file_pointer = safe_open(shard_file, framework="pt", device=tensor_device)
 
+    # Used to fix the issue mentioned in #37031: when loading a model with tied weights in state_dict + `tie_word_embeddings = False`,
+    # we need to make sure they are not loaded as tied weights!
     data_ptrs = set()
     for param_name, empty_param in state_dict.items():
         if param_name not in expected_keys:


### PR DESCRIPTION
# What does this PR do?

An update of #33913 before merge. That PR is approved by @ArthurZucker , but since then a huge refactorization is done by @Cyrilvallez, and I prefer to make sure the updated changes still looks fine for @Cyrilvallez .

In order to see the effect, run the following code snippet. On `main` it fails and on this PR it passes.

Fix #33689 and #33688


```python
import torch
from transformers import AutoModelForCausalLM

configs = [
    (torch.float32, False, "cpu"   ),  # fails
    #(torch.float16, True,  "cpu"   ),  # passes
    #(torch.float16, False, "cpu"   ),  # passes
    #(torch.float32, True,  "cpu"   ),  # passes
    #(torch.float32, False, "cpu"   ),  # fails
    #(torch.float32, False, "cuda:0"),  # passes
]

def test_model_save(torch_dtype, tie_word_embeddings, device_map, tmp_path="./"):
    model = AutoModelForCausalLM.from_pretrained(
        "Xenova/llama2.c-stories15M",
        torch_dtype=torch_dtype,
        tie_word_embeddings=tie_word_embeddings,
        device_map=device_map,
        revision="ccdd47c2dc554aeecd2bb4e713e1c988f206a296",
    )
    model.save_pretrained(tmp_path, safe_serialization=True)


for config in configs:
    test_model_save(*config)

```