### PR TITLE
:rotating_light: :rotating_light: :rotating_light: No more pointing at remote repos

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -528,9 +528,8 @@ def get_class_from_dynamic_module(
 
     # Catch the name of the repo if it's specified in `class_reference`
     if "--" in class_reference:
-        repo_id, class_reference = class_reference.split("--")
-    else:
-        repo_id = pretrained_model_name_or_path
+        class_reference = class_reference.split("--")[1]
+    repo_id = pretrained_model_name_or_path
     module_file, class_name = class_reference.split(".")
 
     if code_revision is None and pretrained_model_name_or_path == repo_id:

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -427,9 +427,10 @@ class _BaseAutoModelClass:
         if has_remote_code and trust_remote_code:
             class_ref = config.auto_map[cls.__name__]
             if "--" in class_ref:
-                repo_id, class_ref = class_ref.split("--")
-            else:
-                repo_id = config.name_or_path
+                # The "--" syntax previously allowed remote code models to load from other repos, but this creates
+                # a supply chain attack vulnerability and is no longer supported.
+                class_ref = class_ref.split("--")[1]
+            repo_id = config.name_or_path
             model_class = get_class_from_dynamic_module(class_ref, repo_id, **kwargs)
             cls.register(config.__class__, model_class, exist_ok=True)
             _ = kwargs.pop("code_revision", None)


### PR DESCRIPTION
This is a very very draft PR, where we test disallowing one repo from loading another by using the `repo_id--classname` syntax, as this permits supply chain attacks. This is probably going to break all kinds of things until I chase down the code that was depending on it.