### PR TITLE
handle training summary when creating modelcard but offline mode is set

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -386,7 +386,12 @@ class TrainingSummary:
                 for tag in info.tags:
                     if tag.startswith("license:"):
                         self.license = tag[8:]
-            except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError, HFValidationError, OfflineModeIsEnabled):
+            except (
+                requests.exceptions.HTTPError,
+                requests.exceptions.ConnectionError,
+                HFValidationError,
+                OfflineModeIsEnabled,
+            ):
                 pass
 
     def create_model_index(self, metric_mapping):

--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -24,6 +24,7 @@ from typing import Any, Optional, Union
 import requests
 import yaml
 from huggingface_hub import model_info
+from huggingface_hub.errors import OfflineModeIsEnabled
 from huggingface_hub.utils import HFValidationError
 
 from . import __version__
@@ -385,7 +386,7 @@ class TrainingSummary:
                 for tag in info.tags:
                     if tag.startswith("license:"):
                         self.license = tag[8:]
-            except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError, HFValidationError):
+            except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError, HFValidationError, OfflineModeIsEnabled):
                 pass
 
     def create_model_index(self, metric_mapping):


### PR DESCRIPTION
# What does this PR do?
When using the trainer with HF_HUB_OFFLINE=1, I get this stack trace due to an unhandled edge case

```
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/trainer.py:4665: in create_model_card
    training_summary = TrainingSummary.from_trainer(
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/modelcard.py:611: in from_trainer
    return cls(
<string>:17: in __init__
    ???
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/modelcard.py:383: in __post_init__
    info = model_info(self.finetuned_from)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py:114: in _inner_fn
    return fn(*args, **kwargs)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/huggingface_hub/hf_api.py:2518: in model_info
    r = get_session().get(path, headers=headers, timeout=timeout, params=params)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/requests/sessions.py:602: in get
    return self.request("GET", url, **kwargs)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/requests/sessions.py:589: in request
    resp = self.send(prep, **send_kwargs)
/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/requests/sessions.py:703: in send
    r = adapter.send(request, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <huggingface_hub.utils._http.OfflineAdapter object at 0x2a7cc82cf3d0>
request = <PreparedRequest [GET]>, args = ()
kwargs = {'cert': None, 'proxies': OrderedDict(), 'stream': False, 'timeout': None, ...}

    def send(self, request: PreparedRequest, *args, **kwargs) -> Response:
>       raise OfflineModeIsEnabled(
            f"Cannot reach {request.url}: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable."
        )
E       huggingface_hub.errors.OfflineModeIsEnabled: Cannot reach https://huggingface.co/api/models/axolotl-ai-co/DeepSeek-V3-11M: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable.

/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/huggingface_hub/utils/_http.py:107: OfflineModeIsEnabled
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@zach-huggingface @SunMarc

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
