### PR TITLE
Add Sdpa Support: `[Electra]`

### DIFF
--- a/docs/source/en/model_doc/electra.md
+++ b/docs/source/en/model_doc/electra.md
@@ -21,6 +21,7 @@ rendered properly in your Markdown viewer.
 <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 <img alt="Flax" src="https://img.shields.io/badge/Flax-29a79b.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC0AAAAtCAMAAAANxBKoAAAC7lBMVEUAAADg5vYHPVgAoJH+/v76+v39/f9JbLP///9+AIgAnY3///+mcqzt8fXy9fgkXa3Ax9709fr+///9/f8qXq49qp5AaLGMwrv8/P0eW60VWawxYq8yqJzG2dytt9Wyu9elzci519Lf3O3S2efY3OrY0+Xp7PT///////+dqNCexMc6Z7AGpJeGvbenstPZ5ejQ1OfJzOLa7ejh4+/r8fT29vpccbklWK8PVa0AS6ghW63O498vYa+lsdKz1NDRt9Kw1c672tbD3tnAxt7R6OHp5vDe7OrDyuDn6vLl6/EAQKak0MgATakkppo3ZK/Bz9y8w9yzu9jey97axdvHzeG21NHH4trTwthKZrVGZLSUSpuPQJiGAI+GAI8SWKydycLL4d7f2OTi1+S9xNzL0ePT6OLGzeEAo5U0qJw/aLEAo5JFa7JBabEAp5Y4qZ2QxLyKmsm3kL2xoMOehrRNb7RIbbOZgrGre68AUqwAqZqNN5aKJ5N/lMq+qsd8kMa4pcWzh7muhLMEV69juq2kbKqgUaOTR5uMMZWLLZSGAI5VAIdEAH+ovNDHuNCnxcy3qcaYx8K8msGplrx+wLahjbYdXrV6vbMvYK9DrZ8QrZ8tqJuFms+Sos6sw8ecy8RffsNVeMCvmb43aLltv7Q4Y7EZWK4QWa1gt6meZKUdr6GOAZVeA4xPAISyveLUwtivxtKTpNJ2jcqfvcltiMiwwcfAoMVxhL+Kx7xjdrqTe60tsaNQs6KaRKACrJ6UTZwkqpqTL5pkHY4AloSgsd2ptNXPvNOOncuxxsqFl8lmg8apt8FJcr9EbryGxLqlkrkrY7dRa7ZGZLQ5t6iXUZ6PPpgVpZeJCJFKAIGareTa0+KJod3H0deY2M+esM25usmYu8d2zsJOdcBVvrCLbqcAOaaHaKQAMaScWqKBXqCXMJ2RHpiLF5NmJZAdAHN2kta11dKu1M+DkcZLdb+Mcql3TppyRJdzQ5ZtNZNlIY+DF4+voCOQAAAAZ3RSTlMABAT+MEEJ/RH+/TP+Zlv+pUo6Ifz8+fco/fz6+evr39S9nJmOilQaF/7+/f38+smmoYp6b1T+/v7++vj189zU0tDJxsGzsrKSfv34+Pf27dDOysG9t6+n/vv6+vr59uzr1tG+tZ6Qg9Ym3QAABR5JREFUSMeNlVVUG1EQhpcuxEspXqS0SKEtxQp1d3d332STTRpIQhIISQgJhODu7lAoDoUCpe7u7u7+1puGpqnCPOyZvffbOXPm/PsP9JfQgyCC+tmTABTOcbxDz/heENS7/1F+9nhvkHePG0wNDLbGWwdXL+rbLWvpmZHXD8+gMfBjTh+aSe6Gnn7lwQIOTR0c8wfX3PWgv7avbdKwf/ZoBp1Gp/PvuvXW3vw5ib7emnTW4OR+3D4jB9vjNJ/7gNvfWWeH/TO/JyYrsiKCRjVEZA3UB+96kON+DxOQ/NLE8PE5iUYgIXjFnCOlxEQMaSGVxjg4gxOnEycGz8bptuNjVx08LscIgrzH3umcn+KKtiBIyvzOO2O99aAdR8cF19oZalnCtvREUw79tCd5sow1g1UKM6kXqUx4T8wsi3sTjJ3yzDmmhenLXLpo8u45eG5y4Vvbk6kkC4LLtJMowkSQxmk4ggVJEG+7c6QpHT8vvW9X7/o7+3ELmiJi2mEzZJiz8cT6TBlanBk70cB5GGIGC1gRDdZ00yADLW1FL6gqhtvNXNG5S9gdSrk4M1qu7JAsmYshzDS4peoMrU/gT7qQdqYGZaYhxZmVbGJAm/CS/HloWyhRUlknQ9KYcExTwS80d3VNOxUZJpITYyspl0LbhArhpZCD9cRWEQuhYkNGMHToQ/2Cs6swJlb39CsllxdXX6IUKh/H5jbnSsPKjgmoaFQ1f8wRLR0UnGE/RcDEjj2jXG1WVTwUs8+zxfcrVO+vSsuOpVKxCfYZiQ0/aPKuxQbQ8lIz+DClxC8u+snlcJ7Yr1z1JPqUH0V+GDXbOwAib931Y4Imaq0NTIXPXY+N5L18GJ37SVWu+hwXff8l72Ds9XuwYIBaXPq6Shm4l+Vl/5QiOlV+uTk6YR9PxKsI9xNJny31ygK1e+nIRC1N97EGkFPI+jCpiHe5PCEy7oWqWSwRrpOvhFzcbTWMbm3ZJAOn1rUKpYIt/lDhW/5RHHteeWFN60qo98YJuoq1nK3uW5AabyspC1BcIEpOhft+SZAShYoLSvnmSfnYADUERP5jJn2h5XtsgCRuhYQqAvwTwn33+YWEKUI72HX5AtfSAZDe8F2DtPPm77afhl0EkthzuCQU0BWApgQIH9+KB0JhopMM7bJrdTRoleM2JAVNMyPF+wdoaz+XJpGoVAQ7WXUkcV7gT3oUZyi/ISIJAVKhgNp+4b4veCFhYVJw4locdSjZCp9cPUhLF9EZ3KKzURepMEtCDPP3VcWFx4UIiZIklIpFNfHpdEafIF2aRmOcrUmjohbT2WUllbmRvgfbythbQO3222fpDJoufaQPncYYuqoGtUEsCJZL6/3PR5b4syeSjZMQG/T2maGANlXT2v8S4AULWaUkCxfLyW8iW4kdka+nEMjxpL2NCwsYNBp+Q61PF43zyDg9Bm9+3NNySn78jMZUUkumqE4Gp7JmFOdP1vc8PpRrzj9+wPinCy8K1PiJ4aYbnTYpCCbDkBSbzhu2QJ1Gd82t8jI8TH51+OzvXoWbnXUOBkNW+0mWFwGcGOUVpU81/n3TOHb5oMt2FgYGjzau0Nif0Ss7Q3XB33hjjQHjHA5E5aOyIQc8CBrLdQSs3j92VG+3nNEjbkbdbBr9zm04ruvw37vh0QKOdeGIkckc80fX3KH/h7PT4BOjgCty8VZ5ux1MoO5Cf5naca2LAsEgehI+drX8o/0Nu+W0m6K/I9gGPd/dfx/EN/wN62AhsBWuAAAAAElFTkSuQmCC
 ">
+<img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
 </div>
 
 ## Overview
@@ -65,6 +66,113 @@ This model was contributed by [lysandre](https://huggingface.co/lysandre). The o
   [`ElectraForMaskedLM`] model, and the generator may be loaded in the
   [`ElectraForPreTraining`] model (the classification head will be randomly initialized as it
   doesn't exist in the generator).
+
+### Using Scaled Dot Product Attention (SDPA)
+
+PyTorch includes a native scaled dot-product attention (SDPA) operator as part of `torch.nn.functional`. This function 
+encompasses several implementations that can be applied depending on the inputs and the hardware in use. See the 
+[official documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) 
+or the [GPU Inference](https://huggingface.co/docs/transformers/main/en/perf_infer_gpu_one#pytorch-scaled-dot-product-attention)
+page for more information.
+
+SDPA is used by default for `torch>=2.1.1` when an implementation is available, but you may also set 
+`attn_implementation="sdpa"` in `from_pretrained()` to explicitly request SDPA to be used.
+
+```py
+import torch
+from transformers import ElectraModel
+model = ElectraModel.from_pretrained("google/electra-base-generator", torch_dtype=torch.float16, attn_implementation="sdpa")
+```
+
+For the best speedups, we recommend loading the model in half-precision (e.g. `torch.float16` or `torch.bfloat16`).
+
+On a local benchmark (NVIDIA Tesla T4-15GB, PyTorch 2.5.1, OS Ubuntu 22.04.3 LTS) using float16 with `google/electra-base-generator` and `google/electra-base-discriminator` models with a MaskedLM head, we saw the following speedups during training and inference.
+
+#### Benchmarks For `google/electra-base-generator`
+#### Training Benchmark
+
+| num_training_steps | batch_sizes | sequence_lengths | is_cuda | is_half | Time per batch (eager - s) | Time per batch (sdpa - s) | Speedup (%) | Eager peak mem (MB) | sdpa peak mem (MB) | Mem saving (%) |
+|--------------------|-------------|------------------|---------|---------|----------------------------|---------------------------|-------------|---------------------|--------------------|----------------|
+| 100                | 2           | 32               | True    | True    | 0.0306                     | 0.024                     | 27.5264     | 249.684             | 249.684            | 0.0            |
+| 100                | 2           | 64               | True    | True    | 0.0306                     | 0.024                     | 29.1752     | 253.593             | 253.593            | 0.0            |
+| 100                | 2           | 128              | True    | True    | 0.0296                     | 0.023                     | 27.5778     | 261.409             | 261.409            | 0.0            |
+| 100                | 2           | 256              | True    | True    | 0.0298                     | 0.023                     | 28.2746     | 299.593             | 277.04             | 8.141          |
+| 100                | 4           | 32               | True    | True    | 0.0304                     | 0.024                     | 27.8372     | 253.593             | 253.593            | 0.0            |
+| 100                | 4           | 64               | True    | True    | 0.0298                     | 0.023                     | 28.8354     | 261.409             | 261.409            | 0.0            |
+| 100                | 4           | 128              | True    | True    | 0.0294                     | 0.0232                    | 28.4396     | 283.864             | 277.04             | 2.463          |
+| 100                | 4           | 256              | True    | True    | 0.0312                     | 0.0258                    | 21.7372     | 517.463             | 453.529            | 14.097         |
+| 100                | 8           | 32               | True    | True    | 0.0296                     | 0.0234                    | 26.9524     | 261.409             | 261.813            | -0.154         |
+| 100                | 8           | 64               | True    | True    | 0.0302                     | 0.023                     | 30.7350     | 277.243             | 277.446            | -0.073         |
+| 100                | 8           | 128              | True    | True    | 0.0312                     | 0.025                     | 24.5406     | 486.006             | 453.529            | 7.161          |
+| 100                | 8           | 256              | True    | True    | 0.0484                     | 0.042                     | 14.5422     | 947.451             | 821.915            | 15.274         |
+| 100                | 16          | 32               | True    | True    | 0.0298                     | 0.0232                    | 29.4218     | 277.446             | 277.446            | 0.0            |
+| 100                | 16          | 64               | True    | True    | 0.0308                     | 0.025                     | 24.5678     | 470.277             | 454.745            | 3.416          |
+| 100                | 16          | 128              | True    | True    | 0.0466                     | 0.041                     | 13.2722     | 884.536             | 821.915            | 7.619          |
+| 100                | 16          | 256              | True    | True    | 0.0970                     | 0.0832                    | 16.9086     | 1804.67             | 1553.798           | 16.146         |
+
+#### Inference Benchmark
+
+| num_batches | batch_sizes | sequence_lengths | is_cuda | is_half | use_mask | Per token latency (eager - ms) | Per token latency (sdpa - ms) | Speedup (%) | Mem eager (MB) | Mem sdpa (MB) | Mem saved (%) |
+|-------------|-------------|------------------|---------|---------|----------|-------------------------------|------------------------------|-------------|----------------|---------------|---------------|
+| 50          | 2           | 32               | True    | True    | True     | 0.1612                        | 0.1174                       | 37.65       | 85.004         | 85.004        | 0.0           |
+| 50          | 2           | 64               | True    | True    | True     | 0.078                         | 0.0588                       | 32.2768     | 92.949         | 92.949        | 0.0           |
+| 50          | 2           | 128              | True    | True    | True     | 0.0424                        | 0.029                        | 45.766      | 108.84         | 109.043       | -0.186        |
+| 50          | 2           | 256              | True    | True    | True     | 0.0206                        | 0.016                        | 28.5706     | 140.825        | 140.825       | 0.0           |
+| 50          | 4           | 32               | True    | True    | True     | 0.0766                        | 0.0588                       | 30.376      | 92.949         | 92.949        | 0.0           |
+| 50          | 4           | 64               | True    | True    | True     | 0.0384                        | 0.029                        | 32.6964     | 109.043        | 109.043       | 0.0           |
+| 50          | 4           | 128              | True    | True    | True     | 0.0202                        | 0.0158                       | 27.629      | 140.825        | 140.825       | 0.0           |
+| 50          | 4           | 256              | True    | True    | True     | 0.011                         | 0.009                        | 22.6098     | 204.997        | 204.997       | 0.0           |
+| 50          | 8           | 32               | True    | True    | True     | 0.0382                        | 0.029                        | 32.3578     | 109.043        | 109.043       | 0.0           |
+| 50          | 8           | 64               | True    | True    | True     | 0.0192                        | 0.0158                       | 24.546      | 140.825        | 140.825       | 0.0           |
+| 50          | 8           | 128              | True    | True    | True     | 0.011                         | 0.009                        | 22.6078     | 204.997        | 204.997       | 0.0           |
+| 50          | 8           | 256              | True    | True    | True     | 0.0072                        | 0.0062                       | 15.3892     | 332.935        | 332.935       | 0.0           |
+| 50          | 16          | 32               | True    | True    | True     | 0.0196                        | 0.0152                       | 28.3326     | 140.825        | 140.825       | 0.0           |
+| 50          | 16          | 64               | True    | True    | True     | 0.011                         | 0.009                        | 22.301      | 204.997        | 204.997       | 0.0           |
+| 50          | 16          | 128              | True    | True    | True     | 0.007                         | 0.006                        | 13.89       | 332.935        | 332.935       | 0.0           |
+| 50          | 16          | 256              | True    | True    | True     | 0.0072                        | 0.0062                       | 17.4658     | 585.568        | 585.568       | 0.0           |
+
+#### Benchmarks For `google/electra-base-discriminator`
+#### Training Benchmark
+
+| num_training_steps | batch_sizes | sequence_lengths | is_cuda | is_half | Time per batch (eager - s) | Time per batch (sdpa - s) | Speedup (%) | Eager peak mem (MB) | sdpa peak mem (MB) | Mem saving (%) |
+|--------------------|-------------|------------------|---------|---------|----------------------------|---------------------------|-------------|---------------------|--------------------|----------------|
+| 100                | 2           | 32               | True    | True    | 0.0312                     | 0.0242                    | 29.8518     | 568.647             | 566.126            | 0.445          |
+| 100                | 2           | 64               | True    | True    | 0.0308                     | 0.024                     | 29.3112     | 572.187             | 570.846            | 0.235          |
+| 100                | 2           | 128              | True    | True    | 0.0312                     | 0.0248                    | 25.9492     | 588.412             | 587.232            | 0.201          |
+| 100                | 2           | 256              | True    | True    | 0.031                      | 0.0298                    | 5.5548      | 631.001             | 602.644            | 4.705          |
+| 100                | 4           | 32               | True    | True    | 0.0312                     | 0.0238                    | 30.2574     | 572.187             | 570.846            | 0.235          |
+| 100                | 4           | 64               | True    | True    | 0.0312                     | 0.0242                    | 28.247      | 588.412             | 587.232            | 0.201          |
+| 100                | 4           | 128              | True    | True    | 0.0314                     | 0.0286                    | 10.2442     | 604.379             | 602.644            | 0.288          |
+| 100                | 4           | 256              | True    | True    | 0.053                      | 0.0498                    | 6.4654      | 1022.623            | 831.197            | 23.0304        |
+| 100                | 8           | 32               | True    | True    | 0.031                      | 0.0242                    | 28.8872     | 587.263             | 586.813            | 0.077          |
+| 100                | 8           | 64               | True    | True    | 0.0308                     | 0.0278                    | 10.7408     | 602.151             | 601.596            | 0.0924         |
+| 100                | 8           | 128              | True    | True    | 0.0492                     | 0.0474                    | 3.8086      | 927.308             | 831.197            | 11.5626        |
+| 100                | 8           | 256              | True    | True    | 0.105                      | 0.0976                    | 7.4594      | 1798.541            | 1418.122           | 26.8258        |
+| 100                | 16          | 32               | True    | True    | 0.0314                     | 0.0286                    | 10.8604     | 598.278             | 595.934            | 0.3934         |
+| 100                | 16          | 64               | True    | True    | 0.048                      | 0.0464                    | 3.7276      | 877.185             | 828.890            | 5.8264         |
+| 100                | 16          | 128              | True    | True    | 0.0986                     | 0.0944                    | 4.3308      | 1605.603            | 1415.605           | 13.4216        |
+| 100                | 16          | 256              | True    | True    | 0.2188                     | 0.2036                    | 7.4636      | 3318.753            | 2564.827           | 29.395         |
+
+#### Inference Benchmark
+
+| num_batches | batch_sizes | sequence_lengths | is_cuda | is_half | use_mask | Per token latency (eager - ms) | Per token latency (sdpa - ms) | Speedup (%) | Mem eager (MB) | Mem sdpa (MB) | Mem saved (%) |
+|-------------|-------------|------------------|---------|---------|----------|-------------------------------|------------------------------|-------------|----------------|---------------|---------------|
+| 50          | 2           | 32               | True    | True    | True     | 0.1528                        | 0.1178                       | 29.8324     | 244.13         | 243.868       | 0.107         |
+| 50          | 2           | 64               | True    | True    | True     | 0.0744                        | 0.056                        | 33.508      | 252.141        | 251.878       | 0.104         |
+| 50          | 2           | 128              | True    | True    | True     | 0.0416                        | 0.0298                       | 39.0368     | 268.163        | 268.103       | 0.022         |
+| 50          | 2           | 256              | True    | True    | True     | 0.021                         | 0.0182                       | 15.2404     | 300.409        | 300.147       | 0.087         |
+| 50          | 4           | 32               | True    | True    | True     | 0.0728                        | 0.0568                       | 27.5098     | 252.141        | 251.878       | 0.104         |
+| 50          | 4           | 64               | True    | True    | True     | 0.037                         | 0.03                         | 23.255      | 268.365        | 268.103       | 0.098         |
+| 50          | 4           | 128              | True    | True    | True     | 0.0208                        | 0.0176                       | 16.2526     | 300.409        | 300.147       | 0.087         |
+| 50          | 4           | 256              | True    | True    | True     | 0.0204                        | 0.0184                       | 7.9674      | 365.106        | 364.844       | 0.072         |
+| 50          | 8           | 32               | True    | True    | True     | 0.0382                        | 0.0294                       | 28.8184     | 268.365        | 268.103       | 0.098         |
+| 50          | 8           | 64               | True    | True    | True     | 0.0204                        | 0.0176                       | 16.746      | 300.409        | 300.147       | 0.087         |
+| 50          | 8           | 128              | True    | True    | True     | 0.0188                        | 0.0184                       | 2.9468      | 365.106        | 364.844       | 0.072         |
+| 50          | 8           | 256              | True    | True    | True     | 0.0214                        | 0.0198                       | 9.643       | 494.093        | 493.962       | 0.027         |
+| 50          | 16          | 32               | True    | True    | True     | 0.0202                        | 0.0186                       | 8.4296      | 300.409        | 300.147       | 0.087         |
+| 50          | 16          | 64               | True    | True    | True     | 0.0184                        | 0.0184                       | -1.118      | 365.106        | 364.844       | 0.072         |
+| 50          | 16          | 128              | True    | True    | True     | 0.0204                        | 0.0194                       | 2.7932      | 494.093        | 493.962       | 0.027         |
+| 50          | 16          | 256              | True    | True    | True     | 0.0234                        | 0.0212                       | 11.1332     | 748.823        | 748.561       | 0.035         |
 
 ## Resources
 

--- a/src/transformers/models/electra/modeling_electra.py
+++ b/src/transformers/models/electra/modeling_electra.py
@@ -21,11 +21,16 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 import torch.utils.checkpoint
+from packaging import version
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN, get_activation
 from ...generation import GenerationMixin
+from ...modeling_attn_mask_utils import (
+    _prepare_4d_attention_mask_for_sdpa,
+    _prepare_4d_causal_attention_mask_for_sdpa,
+)
 from ...modeling_outputs import (
     BaseModelOutputWithCrossAttentions,
     BaseModelOutputWithPastAndCrossAttentions,
@@ -43,6 +48,7 @@ from ...utils import (
     add_code_sample_docstrings,
     add_start_docstrings,
     add_start_docstrings_to_model_forward,
+    get_torch_version,
     logging,
     replace_return_docstrings,
 )
@@ -338,6 +344,108 @@ class ElectraSelfAttention(nn.Module):
         return outputs
 
 
+# Copied from transformers.models.bert.modeling_bert.BertSdpaSelfAttention with Bert->Electra
+class ElectraSdpaSelfAttention(ElectraSelfAttention):
+    def __init__(self, config, position_embedding_type=None):
+        super().__init__(config, position_embedding_type=position_embedding_type)
+        self.dropout_prob = config.attention_probs_dropout_prob
+        self.require_contiguous_qkv = version.parse(get_torch_version()) < version.parse("2.2.0")
+
+    # Adapted from ElectraSelfAttention
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        head_mask: Optional[torch.FloatTensor] = None,
+        encoder_hidden_states: Optional[torch.FloatTensor] = None,
+        encoder_attention_mask: Optional[torch.FloatTensor] = None,
+        past_key_value: Optional[Tuple[Tuple[torch.FloatTensor]]] = None,
+        output_attentions: Optional[bool] = False,
+    ) -> Tuple[torch.Tensor]:
+        if self.position_embedding_type != "absolute" or output_attentions or head_mask is not None:
+            # TODO: Improve this warning with e.g. `model.config._attn_implementation = "manual"` once implemented.
+            logger.warning_once(
+                "ElectraSdpaSelfAttention is used but `torch.nn.functional.scaled_dot_product_attention` does not support "
+                "non-absolute `position_embedding_type` or `output_attentions=True` or `head_mask`. Falling back to "
+                "the manual attention implementation, but specifying the manual implementation will be required from "
+                "Transformers version v5.0.0 onwards. This warning can be removed using the argument "
+                '`attn_implementation="eager"` when loading the model.'
+            )
+            return super().forward(
+                hidden_states,
+                attention_mask,
+                head_mask,
+                encoder_hidden_states,
+                encoder_attention_mask,
+                past_key_value,
+                output_attentions,
+            )
+
+        bsz, tgt_len, _ = hidden_states.size()
+
+        query_layer = self.transpose_for_scores(self.query(hidden_states))
+
+        # If this is instantiated as a cross-attention module, the keys and values come from an encoder; the attention
+        # mask needs to be such that the encoder's padding tokens are not attended to.
+        is_cross_attention = encoder_hidden_states is not None
+
+        current_states = encoder_hidden_states if is_cross_attention else hidden_states
+        attention_mask = encoder_attention_mask if is_cross_attention else attention_mask
+
+        # Check `seq_length` of `past_key_value` == `len(current_states)` to support prefix tuning
+        if is_cross_attention and past_key_value and past_key_value[0].shape[2] == current_states.shape[1]:
+            key_layer, value_layer = past_key_value
+        else:
+            key_layer = self.transpose_for_scores(self.key(current_states))
+            value_layer = self.transpose_for_scores(self.value(current_states))
+            if past_key_value is not None and not is_cross_attention:
+                key_layer = torch.cat([past_key_value[0], key_layer], dim=2)
+                value_layer = torch.cat([past_key_value[1], value_layer], dim=2)
+
+        if self.is_decoder:
+            # if cross_attention save Tuple(torch.Tensor, torch.Tensor) of all cross attention key/value_states.
+            # Further calls to cross_attention layer can then reuse all cross-attention
+            # key/value_states (first "if" case)
+            # if uni-directional self-attention (decoder) save Tuple(torch.Tensor, torch.Tensor) of
+            # all previous decoder key/value_states. Further calls to uni-directional self-attention
+            # can concat previous decoder key/value_states to current projected key/value_states (third "elif" case)
+            # if encoder bi-directional self-attention `past_key_value` is always `None`
+            past_key_value = (key_layer, value_layer)
+
+        # SDPA with memory-efficient backend is broken in torch==2.1.2 when using non-contiguous inputs and a custom
+        # attn_mask, so we need to call `.contiguous()` here. This was fixed in torch==2.2.0.
+        # Reference: https://github.com/pytorch/pytorch/issues/112577
+        if self.require_contiguous_qkv and query_layer.device.type == "cuda" and attention_mask is not None:
+            query_layer = query_layer.contiguous()
+            key_layer = key_layer.contiguous()
+            value_layer = value_layer.contiguous()
+
+        # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment
+        # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
+        # The tgt_len > 1 is necessary to match with AttentionMaskConverter.to_causal_4d that does not create
+        # a causal mask in case tgt_len == 1.
+        is_causal = (
+            True if self.is_decoder and not is_cross_attention and attention_mask is None and tgt_len > 1 else False
+        )
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            query_layer,
+            key_layer,
+            value_layer,
+            attn_mask=attention_mask,
+            dropout_p=self.dropout_prob if self.training else 0.0,
+            is_causal=is_causal,
+        )
+
+        attn_output = attn_output.transpose(1, 2)
+        attn_output = attn_output.reshape(bsz, tgt_len, self.all_head_size)
+
+        outputs = (attn_output,)
+        if self.is_decoder:
+            outputs = outputs + (past_key_value,)
+        return outputs
+
+
 # Copied from transformers.models.bert.modeling_bert.BertSelfOutput
 class ElectraSelfOutput(nn.Module):
     def __init__(self, config):
@@ -353,9 +461,7 @@ class ElectraSelfOutput(nn.Module):
         return hidden_states
 
 
-ELECTRA_SELF_ATTENTION_CLASSES = {
-    "eager": ElectraSelfAttention,
-}
+ELECTRA_SELF_ATTENTION_CLASSES = {"eager": ElectraSelfAttention, "sdpa": ElectraSdpaSelfAttention}
 
 
 # Copied from transformers.models.bert.modeling_bert.BertAttention with Bert->Electra,BERT->ELECTRA
@@ -669,6 +775,7 @@ class ElectraPreTrainedModel(PreTrainedModel):
     load_tf_weights = load_tf_weights_in_electra
     base_model_prefix = "electra"
     supports_gradient_checkpointing = True
+    _supports_sdpa = True
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights
     def _init_weights(self, module):
@@ -811,6 +918,10 @@ class ElectraModel(ElectraPreTrainedModel):
 
         self.encoder = ElectraEncoder(config)
         self.config = config
+
+        self.attn_implementation = config._attn_implementation
+        self.position_embedding_type = config.position_embedding_type
+
         # Initialize weights and apply final processing
         self.post_init()
 
@@ -872,8 +983,6 @@ class ElectraModel(ElectraPreTrainedModel):
         # past_key_values_length
         past_key_values_length = past_key_values[0][0].shape[2] if past_key_values is not None else 0
 
-        if attention_mask is None:
-            attention_mask = torch.ones(input_shape, device=device)
         if token_type_ids is None:
             if hasattr(self.embeddings, "token_type_ids"):
                 buffered_token_type_ids = self.embeddings.token_type_ids[:, :seq_length]
@@ -881,21 +990,6 @@ class ElectraModel(ElectraPreTrainedModel):
                 token_type_ids = buffered_token_type_ids_expanded
             else:
                 token_type_ids = torch.zeros(input_shape, dtype=torch.long, device=device)
-
-        extended_attention_mask = self.get_extended_attention_mask(attention_mask, input_shape)
-
-        # If a 2D or 3D attention mask is provided for the cross-attention
-        # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
-        if self.config.is_decoder and encoder_hidden_states is not None:
-            encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
-            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
-            if encoder_attention_mask is None:
-                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=device)
-            encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
-        else:
-            encoder_extended_attention_mask = None
-
-        head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
 
         hidden_states = self.embeddings(
             input_ids=input_ids,
@@ -905,8 +999,59 @@ class ElectraModel(ElectraPreTrainedModel):
             past_key_values_length=past_key_values_length,
         )
 
+        if attention_mask is None:
+            attention_mask = torch.ones(input_shape, device=device)
+
+        use_sdpa_attention_masks = (
+            self.attn_implementation == "sdpa"
+            and self.position_embedding_type == "absolute"
+            and head_mask is None
+            and not output_attentions
+        )
+
+        # Expand the attention mask
+        if use_sdpa_attention_masks and attention_mask.dim() == 2:
+            # Expand the attention mask for SDPA.
+            # [bsz, seq_len] -> [bsz, 1, seq_len, seq_len]
+            if self.config.is_decoder:
+                extended_attention_mask = _prepare_4d_causal_attention_mask_for_sdpa(
+                    attention_mask,
+                    input_shape,
+                    hidden_states,
+                    past_key_values_length,
+                )
+            else:
+                extended_attention_mask = _prepare_4d_attention_mask_for_sdpa(
+                    attention_mask, hidden_states.dtype, tgt_len=seq_length
+                )
+        else:
+            # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
+            # ourselves in which case we just need to make it broadcastable to all heads.
+            extended_attention_mask = self.get_extended_attention_mask(attention_mask, input_shape)
+
+        # If a 2D or 3D attention mask is provided for the cross-attention
+        # we need to make broadcastable to [batch_size, num_heads, seq_length, seq_length]
+        if self.config.is_decoder and encoder_hidden_states is not None:
+            encoder_batch_size, encoder_sequence_length, _ = encoder_hidden_states.size()
+            encoder_hidden_shape = (encoder_batch_size, encoder_sequence_length)
+            if encoder_attention_mask is None:
+                encoder_attention_mask = torch.ones(encoder_hidden_shape, device=device)
+
+            if use_sdpa_attention_masks and encoder_attention_mask.dim() == 2:
+                # Expand the attention mask for SDPA.
+                # [bsz, seq_len] -> [bsz, 1, seq_len, seq_len]
+                encoder_extended_attention_mask = _prepare_4d_attention_mask_for_sdpa(
+                    encoder_attention_mask, hidden_states.dtype, tgt_len=seq_length
+                )
+            else:
+                encoder_extended_attention_mask = self.invert_attention_mask(encoder_attention_mask)
+        else:
+            encoder_extended_attention_mask = None
+
         if hasattr(self, "embeddings_project"):
             hidden_states = self.embeddings_project(hidden_states)
+
+        head_mask = self.get_head_mask(head_mask, self.config.num_hidden_layers)
 
         hidden_states = self.encoder(
             hidden_states,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Towards #28005 and #37105

Adds SDPA (Scaled Dot-Product Attention) support for Google's Electra 🤗.  

Sample benchmarks comparing `sdpa` and `eager` attention for both the `google/electra-base-generator` and `google/electra-base-discriminator` models, under both training and inference, are provided below. 

Benchmarking scripts (adapted from @fxmarty's SDPA scripts) for the same, for training, inference, and execution of Electra Model on task of MaskedLM were made and are also linked below.

Electra Sdpa Benchmarking Scripts:
- [`Electra`: Benchmark Inference Script](https://gist.github.com/nnilayy/84e037104ad2e6697008fcd8a28ce316)  
- [`Electra`: Benchmark Training Script](https://gist.github.com/nnilayy/998b237a45cb3cca8acc27b47049b899)  
- [`Electra`: Execution Commands](https://gist.github.com/nnilayy/db493e3464c99f485990dd45e22f8a34)

Reference Sdpa Benchmarking Scripts by @fxmarty :
- [Benchmark Inference Script](https://gist.github.com/fxmarty/5113e4304fbdd38c9c3702ce44683f6a)  
- [Benchmark Training Script](https://gist.github.com/fxmarty/7e75cc3942d6974e4849093ebea0a331)  

**PS:** `Memory Savings %`'s remained consistent across the respective runs, but `Speed %`'s varied. To ensure reliability, each benchmark (for both training and inference on both models) was run **five times**, and the reported results are the **mean across all runs**. The full set of **individual run results** is linked in [this Benchmarking Runs gist](https://gist.github.com/nnilayy/1decc65a96f91d9ad9b6971801a25e81).  

### Benchmarks For `google/electra-base-generator`
#### _Training Benchmark_

| num_training_steps | batch_size | seq_len | is_cuda | is_half | Time per batch (eager - s) | Time per batch (sdpa - s) | Speedup (%) | Eager peak mem (MB) | sdpa peak mem (MB) | Mem saving (%) |
|--------------------|------------|---------|---------|---------|----------------------------|---------------------------|-------------|---------------------|--------------------|----------------|
| 100                | 2          | 32      | True    | True    | 0.0314                     | 0.024                     | 30.2028     | 249.684             | 249.684            | 0.0            |
| 100                | 2          | 64      | True    | True    | 0.031                      | 0.0244                    | 27.0706     | 253.593             | 253.593            | 0.0            |
| 100                | 2          | 128     | True    | True    | 0.0308                     | 0.0238                    | 30.0252     | 261.409             | 261.409            | 0.0            |
| 100                | 2          | 256     | True    | True    | 0.03                       | 0.024                     | 26.7504     | 299.593             | 277.243            | 8.061          |
| 100                | 4          | 32      | True    | True    | 0.0308                     | 0.024                     | 28.1694     | 253.593             | 253.593            | 0.0            |
| 100                | 4          | 64      | True    | True    | 0.0306                     | 0.0234                    | 30.8344     | 261.409             | 261.409            | 0.0            |
| 100                | 4          | 128     | True    | True    | 0.0302                     | 0.0236                    | 27.4524     | 283.864             | 277.243            | 2.388          |
| 100                | 4          | 256     | True    | True    | 0.031                      | 0.0252                    | 22.8936     | 517.463             | 454.745            | 13.792         |
| 100                | 8          | 32      | True    | True    | 0.0304                     | 0.0232                    | 31.0826     | 261.409             | 261.409            | 0.0            |
| 100                | 8          | 64      | True    | True    | 0.03                       | 0.0234                    | 27.6406     | 277.243             | 277.243            | 0.0            |
| 100                | 8          | 128     | True    | True    | 0.031                      | 0.0246                    | 25.3224     | 486.006             | 454.745            | 6.874          |
| 100                | 8          | 256     | True    | True    | 0.04                       | 0.0394                    | 2.3676      | 947.451             | 821.915            | 15.274         |
| 100                | 16         | 32      | True    | True    | 0.03                       | 0.0238                    | 26.6688     | 277.446             | 277.446            | 0.0            |
| 100                | 16         | 64      | True    | True    | 0.0312                     | 0.0242                    | 28.5026     | 470.277             | 454.745            | 3.416          |
| 100                | 16         | 128     | True    | True    | 0.0368                     | 0.0378                    | -2.7766     | 884.536             | 821.915            | 7.619          |
| 100                | 16         | 256     | True    | True    | 0.0774                     | 0.0712                    | 8.6964      | 1804.67             | 1553.798           | 16.146         |

#### _Inference Benchmark_

| num_batches | batch_size | seq_len | is_cuda | is_half | use_mask | Per token latency (eager - ms) | Per token latency (sdpa - ms) | Speedup (%) | Mem eager (MB) | Mem sdpa (MB) | Mem saved (%) |
|-------------|------------|---------|---------|---------|----------|-------------------------------|------------------------------|-------------|----------------|---------------|---------------|
| 50          | 2          | 32      | True    | True    | True     | 0.1566                        | 0.1176                       | 33.217      | 85.004         | 85.004        | 0.0           |
| 50          | 2          | 64      | True    | True    | True     | 0.0778                        | 0.0584                       | 33.349      | 92.949         | 92.949        | 0.0           |
| 50          | 2          | 128     | True    | True    | True     | 0.0424                        | 0.0288                       | 46.1208     | 108.84         | 109.043       | -0.186        |
| 50          | 2          | 256     | True    | True    | True     | 0.021                         | 0.0164                       | 27.676      | 140.825        | 140.825       | 0.0           |
| 50          | 4          | 32      | True    | True    | True     | 0.0764                        | 0.0604                       | 26.8224     | 92.949         | 92.949        | 0.0           |
| 50          | 4          | 64      | True    | True    | True     | 0.0386                        | 0.0294                       | 30.849      | 109.043        | 109.043       | 0.0           |
| 50          | 4          | 128     | True    | True    | True     | 0.0198                        | 0.0158                       | 25.8548     | 140.825        | 140.825       | 0.0           |
| 50          | 4          | 256     | True    | True    | True     | 0.0112                        | 0.009                        | 25.464      | 204.997        | 204.997       | 0.0           |
| 50          | 8          | 32      | True    | True    | True     | 0.0372                        | 0.0282                       | 31.764      | 109.043        | 109.043       | 0.0           |
| 50          | 8          | 64      | True    | True    | True     | 0.0194                        | 0.0156                       | 24.4376     | 140.825        | 140.825       | 0.0           |
| 50          | 8          | 128     | True    | True    | True     | 0.0108                        | 0.0092                       | 21.5298     | 204.997        | 204.997       | 0.0           |
| 50          | 8          | 256     | True    | True    | True     | 0.007                         | 0.006                        | 18.5566     | 332.935        | 332.935       | 0.0           |
| 50          | 16         | 32      | True    | True    | True     | 0.02                          | 0.0152                       | 32.5968     | 140.825        | 140.825       | 0.0           |
| 50          | 16         | 64      | True    | True    | True     | 0.0112                        | 0.0092                       | 23.3076     | 204.997        | 204.997       | 0.0           |
| 50          | 16         | 128     | True    | True    | True     | 0.007                         | 0.006                        | 17.745      | 332.935        | 332.935       | 0.0           |
| 50          | 16         | 256     | True    | True    | True     | 0.006                         | 0.005                        | 21.8322     | 585.568        | 585.568       | 0.0           |

### Benchmarks For `google/electra-base-discriminator`
#### _Training Benchmark_

| num_training_steps | batch_size | seq_len | is_cuda | is_half | Time per batch (eager - s) | Time per batch (sdpa - s) | Speedup (%) | Eager peak mem (MB) | sdpa peak mem (MB) | Mem saving (%) |
|--------------------|------------|---------|---------|---------|----------------------------|---------------------------|-------------|---------------------|--------------------|----------------|
| 100                | 2          | 32      | True    | True    | 0.0312                     | 0.0242                    | 29.8518     | 568.647             | 566.126            | 0.445          |
| 100                | 2          | 64      | True    | True    | 0.0308                     | 0.024                     | 29.3112     | 572.187             | 570.846            | 0.235          |
| 100                | 2          | 128     | True    | True    | 0.0312                     | 0.0248                    | 25.9492     | 588.412             | 587.232            | 0.201          |
| 100                | 2          | 256     | True    | True    | 0.031                      | 0.0298                    | 5.5548      | 631.001             | 602.644            | 4.705          |
| 100                | 4          | 32      | True    | True    | 0.0312                     | 0.0238                    | 30.2574     | 572.187             | 570.846            | 0.235          |
| 100                | 4          | 64      | True    | True    | 0.0312                     | 0.0242                    | 28.247      | 588.412             | 587.232            | 0.201          |
| 100                | 4          | 128     | True    | True    | 0.0314                     | 0.0286                    | 10.2442     | 604.379             | 602.644            | 0.288          |
| 100                | 4          | 256     | True    | True    | 0.053                      | 0.0498                    | 6.4654      | 1022.623            | 831.197            | 23.0304        |
| 100                | 8          | 32      | True    | True    | 0.031                      | 0.0242                    | 28.8872     | 587.263             | 586.813            | 0.077          |
| 100                | 8          | 64      | True    | True    | 0.0308                     | 0.0278                    | 10.7408     | 602.151             | 601.596            | 0.0924         |
| 100                | 8          | 128     | True    | True    | 0.0492                     | 0.0474                    | 3.8086      | 927.308             | 831.197            | 11.5626        |
| 100                | 8          | 256     | True    | True    | 0.105                      | 0.0976                    | 7.4594      | 1798.541            | 1418.122           | 26.8258        |
| 100                | 16         | 32      | True    | True    | 0.0314                     | 0.0286                    | 10.8604     | 598.278             | 595.934            | 0.3934         |
| 100                | 16         | 64      | True    | True    | 0.048                      | 0.0464                    | 3.7276      | 877.185             | 828.890            | 5.8264         |
| 100                | 16         | 128     | True    | True    | 0.0986                     | 0.0944                    | 4.3308      | 1605.603            | 1415.605           | 13.4216        |
| 100                | 16         | 256     | True    | True    | 0.2188                     | 0.2036                    | 7.4636      | 3318.753            | 2564.827           | 29.395         |

#### _Inference Benchmark_

| num_batches | batch_size | seq_len | is_cuda | is_half | use_mask | Per token latency (eager - ms) | Per token latency (sdpa - ms) | Speedup (%) | Mem eager (MB) | Mem sdpa (MB) | Mem saved (%) |
|-------------|------------|---------|---------|---------|----------|-------------------------------|------------------------------|-------------|----------------|---------------|---------------|
| 50          | 2          | 32      | True    | True    | True     | 0.1586                        | 0.115                        | 37.9428     | 244.13         | 243.868       | 0.107         |
| 50          | 2          | 64      | True    | True    | True     | 0.0782                        | 0.0568                       | 37.5862     | 252.141        | 251.878       | 0.104         |
| 50          | 2          | 128     | True    | True    | True     | 0.0424                        | 0.03                         | 40.611      | 268.163        | 268.103       | 0.022         |
| 50          | 2          | 256     | True    | True    | True     | 0.0204                        | 0.0166                       | 24.129      | 300.409        | 300.147       | 0.087         |
| 50          | 4          | 32      | True    | True    | True     | 0.0738                        | 0.061                        | 22.644      | 252.141        | 251.878       | 0.104         |
| 50          | 4          | 64      | True    | True    | True     | 0.0382                        | 0.0296                       | 28.352      | 268.365        | 268.103       | 0.098         |
| 50          | 4          | 128     | True    | True    | True     | 0.0206                        | 0.016                        | 27.1508     | 300.409        | 300.147       | 0.087         |
| 50          | 4          | 256     | True    | True    | True     | 0.017                         | 0.014                        | 22.3272     | 365.106        | 364.844       | 0.072         |
| 50          | 8          | 32      | True    | True    | True     | 0.0378                        | 0.0292                       | 29.0196     | 268.365        | 268.103       | 0.098         |
| 50          | 8          | 64      | True    | True    | True     | 0.0204                        | 0.016                        | 27.1664     | 300.409        | 300.147       | 0.087         |
| 50          | 8          | 128     | True    | True    | True     | 0.0158                        | 0.0138                       | 14.3932     | 365.106        | 364.844       | 0.072         |
| 50          | 8          | 256     | True    | True    | True     | 0.017                         | 0.014                        | 21.5304     | 494.093        | 493.962       | 0.027         |
| 50          | 16         | 32      | True    | True    | True     | 0.02                          | 0.0164                       | 20.9608     | 300.409        | 300.147       | 0.087         |
| 50          | 16         | 64      | True    | True    | True     | 0.015                         | 0.0138                       | 10.5592     | 365.106        | 364.844       | 0.072         |
| 50          | 16         | 128     | True    | True    | True     | 0.0156                        | 0.0138                       | 14.2278     | 494.093        | 493.962       | 0.027         |
| 50          | 16         | 256     | True    | True    | True     | 0.017                         | 0.0142                       | 18.969      | 748.823        | 748.561       | 0.035         |


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@fxmarty @ArthurZucker @amyeroberts @LysandreJik 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->