### PR TITLE
RWKV: fix mask warning typo

### DIFF
--- a/src/transformers/models/rwkv/modeling_rwkv.py
+++ b/src/transformers/models/rwkv/modeling_rwkv.py
@@ -625,7 +625,7 @@ class RwkvModel(RwkvPreTrainedModel):
         use_cache = use_cache if use_cache is not None else (self.config.use_cache if not self.training else False)
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
-        if attention_mask is None:
+        if attention_mask is not None:
             logger.warning_once("`attention_mask` was passed, but it is unused in this model.")
 
         if self.training == self.layers_are_rescaled:


### PR DESCRIPTION
`RwKvModel.forward` is supposed to warn if `attention_mask` is passed. Right now the check is `attention_mask is None` which I assume was supposed to be `attention_mask is not None`, which this PR fixes. @gante