### PR TITLE
Add FastImageProcessor for EfficientNet

### DIFF
--- a/docs/source/en/model_doc/efficientnet.md
+++ b/docs/source/en/model_doc/efficientnet.md
@@ -43,6 +43,11 @@ The original code can be found [here](https://github.com/tensorflow/tpu/tree/mas
 [[autodoc]] EfficientNetImageProcessor
     - preprocess
 
+## EfficientNetImageProcessorFast
+
+[[autodoc]] EfficientNetImageProcessorFast
+    - preprocess
+
 ## EfficientNetModel
 
 [[autodoc]] EfficientNetModel

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -1351,6 +1351,7 @@ else:
     _import_structure["models.deit"].append("DeiTImageProcessorFast")
     _import_structure["models.depth_pro"].append("DepthProImageProcessorFast")
     _import_structure["models.detr"].append("DetrImageProcessorFast")
+    _import_structure["models.efficientnet"].append("EfficientNetImageProcessorFast")
     _import_structure["models.gemma3"].append("Gemma3ImageProcessorFast")
     _import_structure["models.got_ocr2"].append("GotOcr2ImageProcessorFast")
     _import_structure["models.llava"].append("LlavaImageProcessorFast")
@@ -1360,6 +1361,7 @@ else:
     _import_structure["models.pixtral"].append("PixtralImageProcessorFast")
     _import_structure["models.qwen2_vl"].append("Qwen2VLImageProcessorFast")
     _import_structure["models.rt_detr"].append("RTDetrImageProcessorFast")
+    _import_structure["models.sam"].append("SamImageProcessorFast")
     _import_structure["models.siglip"].append("SiglipImageProcessorFast")
     _import_structure["models.siglip2"].append("Siglip2ImageProcessorFast")
     _import_structure["models.vit"].append("ViTImageProcessorFast")
@@ -6620,6 +6622,7 @@ if TYPE_CHECKING:
         from .models.deit import DeiTImageProcessorFast
         from .models.depth_pro import DepthProImageProcessorFast
         from .models.detr import DetrImageProcessorFast
+        from .models.efficientnet import EfficientNetImageProcessorFast
         from .models.gemma3 import Gemma3ImageProcessorFast
         from .models.got_ocr2 import GotOcr2ImageProcessorFast
         from .models.llava import LlavaImageProcessorFast
@@ -6629,6 +6632,7 @@ if TYPE_CHECKING:
         from .models.pixtral import PixtralImageProcessorFast
         from .models.qwen2_vl import Qwen2VLImageProcessorFast
         from .models.rt_detr import RTDetrImageProcessorFast
+        from .models.sam import SamImageProcessorFast
         from .models.siglip import SiglipImageProcessorFast
         from .models.siglip2 import Siglip2ImageProcessorFast
         from .models.vit import ViTImageProcessorFast

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 else:
     IMAGE_PROCESSOR_MAPPING_NAMES = OrderedDict(
         [
-            ("align", ("EfficientNetImageProcessor",)),
+            ("align", ("EfficientNetImageProcessor", "EfficientNetImageProcessorFast")),
             ("aria", ("AriaImageProcessor")),
             ("beit", ("BeitImageProcessor",)),
             ("bit", ("BitImageProcessor",)),
@@ -82,7 +82,7 @@ else:
             ("donut-swin", ("DonutImageProcessor",)),
             ("dpt", ("DPTImageProcessor",)),
             ("efficientformer", ("EfficientFormerImageProcessor",)),
-            ("efficientnet", ("EfficientNetImageProcessor",)),
+            ("efficientnet", ("EfficientNetImageProcessor", "EfficientNetImageProcessorFast")),
             ("flava", ("FlavaImageProcessor",)),
             ("focalnet", ("BitImageProcessor",)),
             ("fuyu", ("FuyuImageProcessor",)),
@@ -136,7 +136,7 @@ else:
             ("regnet", ("ConvNextImageProcessor", "ConvNextImageProcessorFast")),
             ("resnet", ("ConvNextImageProcessor", "ConvNextImageProcessorFast")),
             ("rt_detr", ("RTDetrImageProcessor", "RTDetrImageProcessorFast")),
-            ("sam", ("SamImageProcessor",)),
+            ("sam", ("SamImageProcessor", "SamImageProcessorFast")),
             ("segformer", ("SegformerImageProcessor",)),
             ("seggpt", ("SegGptImageProcessor",)),
             ("shieldgemma2", ("Gemma3ImageProcessor", "Gemma3ImageProcessorFast")),

--- a/src/transformers/models/efficientnet/__init__.py
+++ b/src/transformers/models/efficientnet/__init__.py
@@ -20,6 +20,7 @@ from ...utils.import_utils import define_import_structure
 if TYPE_CHECKING:
     from .configuration_efficientnet import *
     from .image_processing_efficientnet import *
+    from .image_processing_efficientnet_fast import *
     from .modeling_efficientnet import *
 else:
     import sys

--- a/src/transformers/models/efficientnet/image_processing_efficientnet_fast.py
+++ b/src/transformers/models/efficientnet/image_processing_efficientnet_fast.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 """Fast Image processor class for EfficientNet."""
 
+import PIL
+
 from ...image_processing_utils_fast import BASE_IMAGE_PROCESSOR_FAST_DOCSTRING, BaseImageProcessorFast
 from ...image_utils import IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD
 from ...utils import add_start_docstrings

--- a/src/transformers/models/efficientnet/image_processing_efficientnet_fast.py
+++ b/src/transformers/models/efficientnet/image_processing_efficientnet_fast.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fast Image processor class for EfficientNet."""
+
+from ...image_processing_utils_fast import BASE_IMAGE_PROCESSOR_FAST_DOCSTRING, BaseImageProcessorFast
+from ...image_utils import IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD
+from ...utils import add_start_docstrings
+
+
+@add_start_docstrings(
+    "Constructs a fast EfficientNet image processor.",
+    BASE_IMAGE_PROCESSOR_FAST_DOCSTRING,
+)
+class EfficientNetImageProcessorFast(BaseImageProcessorFast):
+    # This generated class can be used as a starting point for the fast image processor.
+    # if the image processor is only used for simple augmentations, such as resizing, center cropping, rescaling, or normalizing,
+    # only the default values should be set in the class.
+    # If the image processor requires more complex augmentations, methods from BaseImageProcessorFast can be overridden.
+    # In most cases, only the `_preprocess` method should be overridden.
+
+    # For an example of a fast image processor requiring more complex augmentations, see `LlavaNextImageProcessorFast`.
+
+    # Default values should be checked against the slow image processor
+    # None values left after checking can be removed
+    resample = PIL.Image.NEAREST
+    image_mean = IMAGENET_STANDARD_MEAN
+    image_std = IMAGENET_STANDARD_STD
+    size = {"height": 346, "width": 346}
+    crop_size = {"height": 289, "width": 289}
+    do_resize = True
+    do_center_crop = False
+    do_rescale = True
+    do_normalize = True
+
+
+__all__ = ["EfficientNetImageProcessorFast"]

--- a/src/transformers/models/sam/__init__.py
+++ b/src/transformers/models/sam/__init__.py
@@ -20,6 +20,7 @@ from ...utils.import_utils import define_import_structure
 if TYPE_CHECKING:
     from .configuration_sam import *
     from .image_processing_sam import *
+    from .image_processing_sam_fast import *
     from .modeling_sam import *
     from .modeling_tf_sam import *
     from .processing_sam import *

--- a/src/transformers/models/sam/image_processing_sam_fast.py
+++ b/src/transformers/models/sam/image_processing_sam_fast.py
@@ -1,0 +1,50 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fast Image processor class for SAM."""
+
+from ...image_processing_utils_fast import BASE_IMAGE_PROCESSOR_FAST_DOCSTRING, BaseImageProcessorFast
+from ...image_utils import IMAGENET_DEFAULT_MEAN, IMAGENET_DEFAULT_STD, PILImageResampling
+from ...utils import add_start_docstrings
+
+
+@add_start_docstrings(
+    "Constructs a fast Sam image processor.",
+    BASE_IMAGE_PROCESSOR_FAST_DOCSTRING,
+)
+class SamImageProcessorFast(BaseImageProcessorFast):
+    # This generated class can be used as a starting point for the fast image processor.
+    # if the image processor is only used for simple augmentations, such as resizing, center cropping, rescaling, or normalizing,
+    # only the default values should be set in the class.
+    # If the image processor requires more complex augmentations, methods from BaseImageProcessorFast can be overridden.
+    # In most cases, only the `_preprocess` method should be overridden.
+
+    # For an example of a fast image processor requiring more complex augmentations, see `LlavaNextImageProcessorFast`.
+
+    # Default values should be checked against the slow image processor
+    # None values left after checking can be removed
+    resample = PILImageResampling.BILINEAR
+    image_mean = IMAGENET_DEFAULT_MEAN
+    image_std = IMAGENET_DEFAULT_STD
+    size = {"longest_edge": 1024}
+    default_to_square = None
+    crop_size = None
+    do_resize = True
+    do_center_crop = None
+    do_rescale = True
+    do_normalize = True
+    do_convert_rgb = True
+
+
+__all__ = ["SamImageProcessorFast"]

--- a/src/transformers/utils/dummy_torchvision_objects.py
+++ b/src/transformers/utils/dummy_torchvision_objects.py
@@ -58,6 +58,13 @@ class DetrImageProcessorFast(metaclass=DummyObject):
         requires_backends(self, ["torchvision"])
 
 
+class EfficientNetImageProcessorFast(metaclass=DummyObject):
+    _backends = ["torchvision"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torchvision"])
+
+
 class Gemma3ImageProcessorFast(metaclass=DummyObject):
     _backends = ["torchvision"]
 
@@ -122,6 +129,13 @@ class RTDetrImageProcessorFast(metaclass=DummyObject):
 
 
 class SiglipImageProcessorFast(metaclass=DummyObject):
+    _backends = ["torchvision"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["torchvision"])
+
+
+class SamImageProcessorFast(metaclass=DummyObject):
     _backends = ["torchvision"]
 
     def __init__(self, *args, **kwargs):

--- a/tests/models/efficientnet/test_image_processing_efficientnet.py
+++ b/tests/models/efficientnet/test_image_processing_efficientnet.py
@@ -19,13 +19,16 @@ import unittest
 import numpy as np
 
 from transformers.testing_utils import require_torch, require_vision
-from transformers.utils import is_vision_available
+from transformers.utils import is_torchvision_available, is_vision_available
 
 from ...test_image_processing_common import ImageProcessingTestMixin, prepare_image_inputs
 
 
 if is_vision_available():
     from transformers import EfficientNetImageProcessor
+
+    if is_torchvision_available():
+        from transformers import EfficientNetImageProcessorFast
 
 
 class EfficientNetImageProcessorTester:
@@ -83,7 +86,15 @@ class EfficientNetImageProcessorTester:
 @require_torch
 @require_vision
 class EfficientNetImageProcessorTest(ImageProcessingTestMixin, unittest.TestCase):
-    image_processing_class = EfficientNetImageProcessor if is_vision_available() else None
+
+    image_processor_list = []
+    if is_vision_available():
+        from transformers import EfficientNetImageProcessor
+        image_processor_list.append(EfficientNetImageProcessor)
+
+        if is_torchvision_available():
+            from transformers import EfficientNetImageProcessorFast
+            image_processor_list.append(EfficientNetImageProcessorFast)
 
     def setUp(self):
         super().setUp()
@@ -94,30 +105,31 @@ class EfficientNetImageProcessorTest(ImageProcessingTestMixin, unittest.TestCase
         return self.image_processor_tester.prepare_image_processor_dict()
 
     def test_image_processor_properties(self):
-        image_processing = self.image_processing_class(**self.image_processor_dict)
-        self.assertTrue(hasattr(image_processing, "image_mean"))
-        self.assertTrue(hasattr(image_processing, "image_std"))
-        self.assertTrue(hasattr(image_processing, "do_normalize"))
-        self.assertTrue(hasattr(image_processing, "do_resize"))
-        self.assertTrue(hasattr(image_processing, "size"))
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+            self.assertTrue(hasattr(image_processing, "image_mean"))
+            self.assertTrue(hasattr(image_processing, "image_std"))
+            self.assertTrue(hasattr(image_processing, "do_normalize"))
+            self.assertTrue(hasattr(image_processing, "do_resize"))
+            self.assertTrue(hasattr(image_processing, "size"))
 
     def test_image_processor_from_dict_with_kwargs(self):
-        image_processor = self.image_processing_class.from_dict(self.image_processor_dict)
-        self.assertEqual(image_processor.size, {"height": 18, "width": 18})
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            self.assertEqual(image_processor.size, {"height": 18, "width": 18})
 
-        image_processor = self.image_processing_class.from_dict(self.image_processor_dict, size=42)
-        self.assertEqual(image_processor.size, {"height": 42, "width": 42})
+            image_processor = image_processing_class.from_dict(self.image_processor_dict, size=42)
+            self.assertEqual(image_processor.size, {"height": 42, "width": 42})
 
     def test_rescale(self):
-        # EfficientNet optionally rescales between -1 and 1 instead of the usual 0 and 1
         image = np.arange(0, 256, 1, dtype=np.uint8).reshape(1, 8, 32)
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class(**self.image_processor_dict)
 
-        image_processor = self.image_processing_class(**self.image_processor_dict)
+            rescaled_image = image_processor.rescale(image, scale=1 / 127.5)
+            expected_image = (image * (1 / 127.5)).astype(np.float32) - 1
+            self.assertTrue(np.allclose(rescaled_image, expected_image))
 
-        rescaled_image = image_processor.rescale(image, scale=1 / 127.5)
-        expected_image = (image * (1 / 127.5)).astype(np.float32) - 1
-        self.assertTrue(np.allclose(rescaled_image, expected_image))
-
-        rescaled_image = image_processor.rescale(image, scale=1 / 255, offset=False)
-        expected_image = (image / 255.0).astype(np.float32)
-        self.assertTrue(np.allclose(rescaled_image, expected_image))
+            rescaled_image = image_processor.rescale(image, scale=1 / 255, offset=False)
+            expected_image = (image / 255.0).astype(np.float32)
+            self.assertTrue(np.allclose(rescaled_image, expected_image))

--- a/tests/models/efficientnet/test_image_processing_efficientnet.py
+++ b/tests/models/efficientnet/test_image_processing_efficientnet.py
@@ -25,10 +25,8 @@ from ...test_image_processing_common import ImageProcessingTestMixin, prepare_im
 
 
 if is_vision_available():
-    from transformers import EfficientNetImageProcessor
-
     if is_torchvision_available():
-        from transformers import EfficientNetImageProcessorFast
+        pass
 
 
 class EfficientNetImageProcessorTester:
@@ -86,14 +84,15 @@ class EfficientNetImageProcessorTester:
 @require_torch
 @require_vision
 class EfficientNetImageProcessorTest(ImageProcessingTestMixin, unittest.TestCase):
-
     image_processor_list = []
     if is_vision_available():
         from transformers import EfficientNetImageProcessor
+
         image_processor_list.append(EfficientNetImageProcessor)
 
         if is_torchvision_available():
             from transformers import EfficientNetImageProcessorFast
+
             image_processor_list.append(EfficientNetImageProcessorFast)
 
     def setUp(self):


### PR DESCRIPTION
# Add FastImageProcessor for EfficientNet

## What does this PR do?

This PR implements a `FastImageProcessor` for the `EfficientNet` model using `BaseImageProcessorFast`.

- Added `EfficientNetImageProcessorFast` to support fast GPU-based preprocessing using PyTorch/Torchvision ops
- Verified default values (e.g., size, crop_size, normalization) match the existing slow processor
- Cleaned out unused attributes (`default_to_square`, `do_convert_rgb`) after comparing both implementations
- Updated the test file `test_image_processing_efficientnet.py` to support both fast and slow processors using `image_processor_list` pattern
- Verified that all relevant tests pass with `RUN_SLOW=1`

This PR contributes to [[#36978](https://github.com/huggingface/transformers/issues/36978)](https://github.com/huggingface/transformers/issues/36978)

## Before submitting

- [x] I have read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)
- [x] This PR was initiated via a GitHub issue: #36978
- [x] I have matched default attributes between the slow and fast image processors
- [x] I have updated test coverage to loop over both slow and fast processors
- [x] I have verified all tests pass with `RUN_SLOW=1`
- [x] I ran `black` and `make fixup` to format the code
- [ ] Documentation did not need updating (no new public methods introduced)
- [x] All new methods follow the docstring conventions

## Who can review?

This contribution affects **vision models**.  
Tagging: @qubvel @amyeroberts for review.

Thanks in advance! 🤗