### PR TITLE
Allow quantizers to work with a state dict on meta device

### DIFF
--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -216,7 +216,9 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             quantized_stats = {}
             for k, v in state_dict.items():
                 if param_name + "." in k:
-                    quantized_stats[k] = v
+                    # the state dict may be loaded on meta -> move back to cpu in this case
+                    param = torch.empty_like(v, device="cpu") if v.device.type == "meta" else v
+                    quantized_stats[k] = param
                     if unexpected_keys is not None and k in unexpected_keys:
                         unexpected_keys.remove(k)
 

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -214,7 +214,8 @@ class HqqHfQuantizer(HfQuantizer):
         module_state_dict = {}
         for k, v in state_dict.items():
             if layer_name + "." in k:
-                module_state_dict[k.split(".")[-1]] = v
+                param = torch.empty_like(v, device="cpu") if v.device.type == "meta" else v
+                module_state_dict[k.split(".")[-1]] = param
                 if unexpected_keys is not None and k in unexpected_keys:
                     unexpected_keys.remove(k)
 

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -214,6 +214,7 @@ class HqqHfQuantizer(HfQuantizer):
         module_state_dict = {}
         for k, v in state_dict.items():
             if layer_name + "." in k:
+                # the state dict may be loaded on meta -> move back to cpu in this case
                 param = torch.empty_like(v, device="cpu") if v.device.type == "meta" else v
                 module_state_dict[k.split(".")[-1]] = param
                 if unexpected_keys is not None and k in unexpected_keys:


### PR DESCRIPTION
# What does this PR do?

Following https://github.com/huggingface/transformers/pull/35926 and https://github.com/huggingface/transformers/pull/37086, make the quantizers work with a state dict on meta device.
See https://github.com/huggingface/transformers/pull/37086 for the issue at hand

Currently, will lead to inconsistencies and params initialized with random weights

cc @SunMarc @MekkCyber is there any way to replace params with only `param_value` instead of doing it for a whole layer at once with the `state_dict` for hqq and bnb 4bits? I believe this should be possible, but would require to know a bit more about internals of each lib for me.
Otherwise if truly not possible we can add an exception for these 2 types of quantizers, but it would be so much simpler if we can simply standardize and just replace one param after the other, instead of doing a full layer at once