### PR TITLE
Revert #37031

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -757,9 +757,6 @@ def _load_state_dict_into_meta_model(
     if is_meta_state_dict:
         file_pointer = safe_open(shard_file, framework="pt", device=tensor_device)
 
-    # Used to fix the issue mentioned in #37031: when loading a model with tied weights in state_dict + `tie_word_embeddings = False`,
-    # we need to make sure they are not loaded as tied weights!
-    data_ptrs = set()
     for param_name, empty_param in state_dict.items():
         if param_name not in expected_keys:
             continue
@@ -829,14 +826,8 @@ def _load_state_dict_into_meta_model(
                 if is_fsdp_enabled():
                     param_device = "cpu" if is_local_dist_rank_0() else "meta"
 
-                # avoid tied weights
-                if param.data_ptr() in data_ptrs:
-                    param = param.clone()
-
                 _load_parameter_into_model(model, param_name, param.to(param_device))
 
-                # Add `data_ptr` of `model.state_dict()[param_name]` to avoid tied weights
-                data_ptrs.add(model.state_dict()[param_name].data_ptr())
             else:
                 hf_quantizer.create_quantized_param(
                     model, param, param_name, param_device, state_dict, unexpected_keys


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/37031 caused much much longer loading times (see https://github.com/huggingface/transformers/issues/37160) basically causing going from ~3/4 min to 10+ hours for Deepseek R1.

I'm fully reverting for now.
I think (not completely sure) the issue is actually accessing the state dict over and over again, not so much the cloning (copying). I will investigate it later to see if I can re-add the fix without time overhead.