### PR TITLE
Skip flaky test counting calls to Hub

### DIFF
--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -529,6 +529,7 @@ class AutoModelTest(unittest.TestCase):
         with self.assertRaisesRegex(EnvironmentError, "Use `from_flax=True` to load this model"):
             _ = AutoModel.from_pretrained("hf-internal-testing/tiny-bert-flax-only")
 
+    @unittest.skip("Flaky/failing on main in the CI but passes locally, TODO Matt/ydshieh investigate at some point!")
     def test_cached_model_has_minimum_calls_to_head(self):
         # Make sure we have cached the model.
         _ = AutoModel.from_pretrained("hf-internal-testing/tiny-random-bert")

--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -23,7 +23,6 @@ from transformers import CONFIG_MAPPING, AutoConfig, BertConfig, GPT2Config, T5C
 from transformers.testing_utils import (
     DUMMY_UNKNOWN_IDENTIFIER,
     SMALL_MODEL_IDENTIFIER,
-    RequestCounter,
     require_tensorflow_probability,
     require_tf,
     slow,

--- a/tests/models/auto/test_modeling_tf_auto.py
+++ b/tests/models/auto/test_modeling_tf_auto.py
@@ -291,20 +291,3 @@ class TFAutoModelTest(unittest.TestCase):
     def test_model_from_pt_suggestion(self):
         with self.assertRaisesRegex(EnvironmentError, "Use `from_pt=True` to load this model"):
             _ = TFAutoModel.from_pretrained("hf-internal-testing/tiny-bert-pt-only")
-
-    def test_cached_model_has_minimum_calls_to_head(self):
-        # Make sure we have cached the model.
-        _ = TFAutoModel.from_pretrained("hf-internal-testing/tiny-random-bert")
-        with RequestCounter() as counter:
-            _ = TFAutoModel.from_pretrained("hf-internal-testing/tiny-random-bert")
-        self.assertEqual(counter["GET"], 0)
-        self.assertEqual(counter["HEAD"], 1)
-        self.assertEqual(counter.total_calls, 1)
-
-        # With a sharded checkpoint
-        _ = TFAutoModel.from_pretrained("ArthurZ/tiny-random-bert-sharded")
-        with RequestCounter() as counter:
-            _ = TFAutoModel.from_pretrained("ArthurZ/tiny-random-bert-sharded")
-        self.assertEqual(counter["GET"], 0)
-        self.assertEqual(counter["HEAD"], 1)
-        self.assertEqual(counter.total_calls, 1)

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -865,7 +865,8 @@ class CustomPipelineTest(unittest.TestCase):
             [{"label": "LABEL_0", "score": 0.505}],
         )
 
-    @require_torch_or_tf
+    @unittest.skip("Flaky/failing on main in the CI but passes locally, TODO Matt/ydshieh investigate at some point!")
+    @require_torch
     def test_cached_pipeline_has_minimum_calls_to_head(self):
         # Make sure we have cached the pipeline.
         _ = pipeline("text-classification", model="hf-internal-testing/tiny-random-bert")


### PR DESCRIPTION
This test works locally for me but seems very flaky on the CI. I'm going to disable it for now until we can properly investigate why! Also going to remove the TF version entirely.