### PR TITLE
Stop DOSing the Hub in the CI

### DIFF
--- a/tests/models/fuyu/test_processor_fuyu.py
+++ b/tests/models/fuyu/test_processor_fuyu.py
@@ -1,6 +1,7 @@
 import io
 import tempfile
 import unittest
+from pathlib import Path
 
 import requests
 
@@ -32,18 +33,21 @@ if is_torch_available():
 class FuyuProcessingTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = FuyuProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.addClassCleanup(lambda tempdir=cls.tmpdirname: Path(tempdir).unlink(missing_ok=True))
 
         image_processor = FuyuImageProcessor()
         tokenizer = AutoTokenizer.from_pretrained("adept/fuyu-8b")
 
         processor = FuyuProcessor(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
-        self.text_prompt = "Generate a coco-style caption.\\n"
+        cls.text_prompt = "Generate a coco-style caption.\\n"
         bus_image_url = "https://huggingface.co/datasets/hf-internal-testing/fixtures-captioning/resolve/main/bus.png"
-        self.bus_image_pil = Image.open(io.BytesIO(requests.get(bus_image_url).content))
+        cls.bus_image_pil = Image.open(io.BytesIO(requests.get(bus_image_url).content))
+
 
     def get_processor(self):
         image_processor = FuyuImageProcessor()

--- a/tests/models/fuyu/test_processor_fuyu.py
+++ b/tests/models/fuyu/test_processor_fuyu.py
@@ -48,7 +48,6 @@ class FuyuProcessingTest(ProcessorTesterMixin, unittest.TestCase):
         bus_image_url = "https://huggingface.co/datasets/hf-internal-testing/fixtures-captioning/resolve/main/bus.png"
         cls.bus_image_pil = Image.open(io.BytesIO(requests.get(bus_image_url).content))
 
-
     def get_processor(self):
         image_processor = FuyuImageProcessor()
         tokenizer = AutoTokenizer.from_pretrained("adept/fuyu-8b")

--- a/tests/models/fuyu/test_processor_fuyu.py
+++ b/tests/models/fuyu/test_processor_fuyu.py
@@ -1,7 +1,7 @@
 import io
 import tempfile
 import unittest
-from pathlib import Path
+from shutil import rmtree
 
 import requests
 
@@ -36,7 +36,8 @@ class FuyuProcessingTest(ProcessorTesterMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.tmpdirname = tempfile.mkdtemp()
-        cls.addClassCleanup(lambda tempdir=cls.tmpdirname: Path(tempdir).unlink(missing_ok=True))
+        # Ensure tempdir is cleaned up even if there's a failure
+        cls.addClassCleanup(lambda tempdir=cls.tmpdirname: rmtree(tempdir))
 
         image_processor = FuyuImageProcessor()
         tokenizer = AutoTokenizer.from_pretrained("adept/fuyu-8b")


### PR DESCRIPTION
Several of our test suites use `setUp()` methods, but these are called **once per test**. This repeatedly loads the same files from the Hub when the test suite has lots of small tests, and this increases the risk of a single connection failure giving us a red CI, and also seems very likely to trigger DOS protection from the Hub. I'm experimenting with refactoring some tests so that Hub operations are only called once for the whole test class