### PR TITLE
:rotating_light::rotating_light::rotating_light: Replace SetUp with SetUpClass

### DIFF
--- a/tests/models/albert/test_modeling_albert.py
+++ b/tests/models/albert/test_modeling_albert.py
@@ -284,9 +284,10 @@ class AlbertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = AlbertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=AlbertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = AlbertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=AlbertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/align/test_modeling_align.py
+++ b/tests/models/align/test_modeling_align.py
@@ -139,10 +139,11 @@ class AlignVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_head_masking = False
     has_attentions = False
 
-    def setUp(self):
-        self.model_tester = AlignVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = AlignVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=AlignVisionConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/align/test_processor_align.py
+++ b/tests/models/align/test_processor_align.py
@@ -36,8 +36,9 @@ if is_vision_available():
 class AlignProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AlignProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab_tokens = [
             "[UNK]",
@@ -56,8 +57,8 @@ class AlignProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "low",
             "lowest",
         ]
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         image_processor_map = {
@@ -67,8 +68,8 @@ class AlignProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "image_mean": [0.48145466, 0.4578275, 0.40821073],
             "image_std": [0.26862954, 0.26130258, 0.27577711],
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/altclip/test_modeling_altclip.py
+++ b/tests/models/altclip/test_modeling_altclip.py
@@ -140,10 +140,11 @@ class AltCLIPVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = AltCLIPVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=AltCLIPVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = AltCLIPVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=AltCLIPVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/altclip/test_processor_altclip.py
+++ b/tests/models/altclip/test_processor_altclip.py
@@ -27,15 +27,16 @@ from ...test_processing_common import ProcessorTesterMixin
 class AltClipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AltCLIPProcessor
 
-    def setUp(self):
-        self.model_id = "BAAI/AltCLIP"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.model_id = "BAAI/AltCLIP"
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = CLIPImageProcessor()
-        tokenizer = XLMRobertaTokenizer.from_pretrained(self.model_id)
+        tokenizer = XLMRobertaTokenizer.from_pretrained(cls.model_id)
 
-        processor = self.processor_class(image_processor, tokenizer)
+        processor = cls.processor_class(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return XLMRobertaTokenizer.from_pretrained(self.model_id, **kwargs)

--- a/tests/models/aria/test_modeling_aria.py
+++ b/tests/models/aria/test_modeling_aria.py
@@ -193,9 +193,10 @@ class AriaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTesterMi
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = AriaVisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=AriaConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = AriaVisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=AriaConfig, has_text_modality=False)
 
     # overwrite inputs_embeds tests because we need to delete "pixel values" for LVLMs
     def test_inputs_embeds(self):

--- a/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_feature_extraction_audio_spectrogram_transformer.py
@@ -107,8 +107,9 @@ class ASTFeatureExtractionTester:
 class ASTFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = ASTFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = ASTFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = ASTFeatureExtractionTester(cls)
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus

--- a/tests/models/audio_spectrogram_transformer/test_modeling_audio_spectrogram_transformer.py
+++ b/tests/models/audio_spectrogram_transformer/test_modeling_audio_spectrogram_transformer.py
@@ -181,9 +181,10 @@ class ASTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         return False
 
-    def setUp(self):
-        self.model_tester = ASTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ASTConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ASTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ASTConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/auto/test_configuration_auto.py
+++ b/tests/models/auto/test_configuration_auto.py
@@ -38,7 +38,8 @@ SAMPLE_ROBERTA_CONFIG = get_tests_dir("fixtures/dummy-config.json")
 
 
 class AutoConfigTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     def test_module_spec(self):

--- a/tests/models/auto/test_feature_extraction_auto.py
+++ b/tests/models/auto/test_feature_extraction_auto.py
@@ -43,7 +43,8 @@ SAMPLE_CONFIG = get_tests_dir("fixtures/dummy-config.json")
 
 
 class AutoFeatureExtractorTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     def test_feature_extractor_from_model_shortcut(self):

--- a/tests/models/auto/test_image_processing_auto.py
+++ b/tests/models/auto/test_image_processing_auto.py
@@ -40,7 +40,8 @@ from test_module.custom_image_processing import CustomImageProcessor  # noqa E40
 
 
 class AutoImageProcessorTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     def test_image_processor_from_model_shortcut(self):

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -91,7 +91,8 @@ if is_torch_available():
 
 @require_torch
 class AutoModelTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     @slow

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -60,7 +60,8 @@ SAMPLE_PROCESSOR_CONFIG_DIR = get_tests_dir("fixtures")
 class AutoFeatureExtractorTest(unittest.TestCase):
     vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]", "bla", "blou"]
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     def test_processor_from_model_shortcut(self):

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -66,7 +66,8 @@ if is_tokenizers_available():
 
 
 class AutoTokenizerTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         transformers.dynamic_module_utils.TIME_OUT_REMOTE_CODE = 0
 
     @slow

--- a/tests/models/autoformer/test_modeling_autoformer.py
+++ b/tests/models/autoformer/test_modeling_autoformer.py
@@ -212,9 +212,10 @@ class AutoformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     test_torchscript = False
     test_inputs_embeds = False
 
-    def setUp(self):
-        self.model_tester = AutoformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=AutoformerConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = AutoformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=AutoformerConfig, has_text_modality=False)
 
     # TODO: (ydshieh) Fix the wrong logic for `tmp_delay` is possible
     @unittest.skip(

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -199,9 +199,10 @@ class AyaVisionModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = AyaVisionVisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=AyaVisionConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = AyaVisionVisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=AyaVisionConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/aya_vision/test_processor_aya_vision.py
+++ b/tests/models/aya_vision/test_processor_aya_vision.py
@@ -38,8 +38,9 @@ if is_vision_available():
 class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AyaVisionProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = GotOcr2ImageProcessor(
             do_resize=True,
@@ -53,14 +54,14 @@ class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             do_convert_rgb=True,
         )
         tokenizer = AutoTokenizer.from_pretrained("CohereForAI/aya-vision-8b", padding_side="left")
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
         processor = AyaVisionProcessor.from_pretrained(
             "CohereForAI/aya-vision-8b",
             image_processor=image_processor,
             tokenizer=tokenizer,
             **processor_kwargs,
         )
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def prepare_processor_dict(self):
         return {"patch_size": 10, "img_size": 20}

--- a/tests/models/bamba/test_modeling_bamba.py
+++ b/tests/models/bamba/test_modeling_bamba.py
@@ -269,9 +269,10 @@ class BambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = BambaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BambaConfig, hidden_size=64)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BambaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BambaConfig, hidden_size=64)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bark/test_modeling_bark.py
+++ b/tests/models/bark/test_modeling_bark.py
@@ -540,9 +540,10 @@ class BarkSemanticModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Te
 
     test_resize_embeddings = True
 
-    def setUp(self):
-        self.model_tester = BarkSemanticModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BarkSemanticConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BarkSemanticModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BarkSemanticConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bark/test_processor_bark.py
+++ b/tests/models/bark/test_processor_bark.py
@@ -25,13 +25,14 @@ from transformers.testing_utils import require_torch, slow
 
 @require_torch
 class BarkProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.checkpoint = "suno/bark-small"
-        self.tmpdirname = tempfile.mkdtemp()
-        self.voice_preset = "en_speaker_1"
-        self.input_string = "This is a test string"
-        self.speaker_embeddings_dict_path = "speaker_embeddings_path.json"
-        self.speaker_embeddings_directory = "speaker_embeddings"
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "suno/bark-small"
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.voice_preset = "en_speaker_1"
+        cls.input_string = "This is a test string"
+        cls.speaker_embeddings_dict_path = "speaker_embeddings_path.json"
+        cls.speaker_embeddings_directory = "speaker_embeddings"
 
     def get_tokenizer(self, **kwargs):
         return AutoTokenizer.from_pretrained(self.checkpoint, **kwargs)

--- a/tests/models/bart/test_modeling_bart.py
+++ b/tests/models/bart/test_modeling_bart.py
@@ -438,9 +438,10 @@ class BartModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     fx_compatible = False  # Fix me Michael
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = BartModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BartConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BartModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BartConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/beit/test_modeling_beit.py
+++ b/tests/models/beit/test_modeling_beit.py
@@ -267,9 +267,10 @@ class BeitModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = BeitModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BeitConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BeitModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BeitConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bert/test_modeling_bert.py
+++ b/tests/models/bert/test_modeling_bert.py
@@ -481,9 +481,10 @@ class BertModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = BertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bert_generation/test_modeling_bert_generation.py
+++ b/tests/models/bert_generation/test_modeling_bert_generation.py
@@ -249,9 +249,10 @@ class BertGenerationEncoderTest(ModelTesterMixin, GenerationTesterMixin, Pipelin
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = BertGenerationEncoderTester(self)
-        self.config_tester = ConfigTester(self, config_class=BertGenerationConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BertGenerationEncoderTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BertGenerationConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/big_bird/test_modeling_big_bird.py
+++ b/tests/models/big_bird/test_modeling_big_bird.py
@@ -481,9 +481,10 @@ class BigBirdModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = BigBirdModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BigBirdConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BigBirdModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BigBirdConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bigbird_pegasus/test_modeling_bigbird_pegasus.py
+++ b/tests/models/bigbird_pegasus/test_modeling_bigbird_pegasus.py
@@ -289,9 +289,10 @@ class BigBirdPegasusModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineT
 
         return False
 
-    def setUp(self):
-        self.model_tester = BigBirdPegasusModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BigBirdPegasusConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BigBirdPegasusModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BigBirdPegasusConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/biogpt/test_modeling_biogpt.py
+++ b/tests/models/biogpt/test_modeling_biogpt.py
@@ -297,9 +297,10 @@ class BioGptModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     )
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = BioGptModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BioGptConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BioGptModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BioGptConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bit/test_modeling_bit.py
+++ b/tests/models/bit/test_modeling_bit.py
@@ -172,10 +172,11 @@ class BitModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = BitModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=BitConfig, has_text_modality=False, common_properties=["num_channels"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BitModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=BitConfig, has_text_modality=False, common_properties=["num_channels"]
         )
 
     def test_config(self):

--- a/tests/models/blenderbot/test_modeling_blenderbot.py
+++ b/tests/models/blenderbot/test_modeling_blenderbot.py
@@ -242,9 +242,10 @@ class BlenderbotModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
     test_pruning = False
     test_missing_keys = False
 
-    def setUp(self):
-        self.model_tester = BlenderbotModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BlenderbotConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BlenderbotModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BlenderbotConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
+++ b/tests/models/blenderbot_small/test_modeling_blenderbot_small.py
@@ -246,9 +246,10 @@ class BlenderbotSmallModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
     ):
         return pipeline_test_case_name == "TextGenerationPipelineTests"
 
-    def setUp(self):
-        self.model_tester = BlenderbotSmallModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BlenderbotSmallConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BlenderbotSmallModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BlenderbotSmallConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/blip/test_modeling_blip.py
+++ b/tests/models/blip/test_modeling_blip.py
@@ -157,9 +157,10 @@ class BlipVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = BlipVisionModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BlipVisionConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BlipVisionModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BlipVisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/blip/test_modeling_blip_text.py
+++ b/tests/models/blip/test_modeling_blip_text.py
@@ -130,9 +130,10 @@ class BlipTextModelTest(ModelTesterMixin, unittest.TestCase):
     test_pruning = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = BlipTextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BlipTextConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BlipTextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BlipTextConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/blip/test_modeling_tf_blip_text.py
+++ b/tests/models/blip/test_modeling_tf_blip_text.py
@@ -130,9 +130,10 @@ class BlipTextModelTest(TFModelTesterMixin, unittest.TestCase):
     test_pruning = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = BlipTextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BlipTextConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BlipTextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BlipTextConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/blip/test_processor_blip.py
+++ b/tests/models/blip/test_processor_blip.py
@@ -31,15 +31,16 @@ if is_vision_available():
 class BlipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = BlipProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = BlipImageProcessor()
         tokenizer = BertTokenizer.from_pretrained("hf-internal-testing/tiny-random-BertModel")
 
         processor = BlipProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -165,9 +165,7 @@ class Blip2VisionModelTest(ModelTesterMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model_tester = Blip2VisionModelTester(cls)
-        cls.config_tester = ConfigTester(
-            cls, config_class=Blip2VisionConfig, has_text_modality=False, hidden_size=37
-        )
+        cls.config_tester = ConfigTester(cls, config_class=Blip2VisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/blip_2/test_modeling_blip_2.py
+++ b/tests/models/blip_2/test_modeling_blip_2.py
@@ -162,10 +162,11 @@ class Blip2VisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Blip2VisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Blip2VisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Blip2VisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Blip2VisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/blip_2/test_processor_blip_2.py
+++ b/tests/models/blip_2/test_processor_blip_2.py
@@ -31,15 +31,16 @@ if is_vision_available():
 class Blip2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Blip2Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = BlipImageProcessor()
         tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-GPT2Model")
 
         processor = Blip2Processor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -345,9 +345,10 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     test_pruning = False
     test_torchscript = True  # torch.autograd functions seems not to be supported
 
-    def setUp(self):
-        self.model_tester = BloomModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BloomConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BloomModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BloomConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bridgetower/test_modeling_bridgetower.py
+++ b/tests/models/bridgetower/test_modeling_bridgetower.py
@@ -331,9 +331,10 @@ class BridgeTowerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     def extract_output(self, outputs, model_class):
         return outputs["pooler_output"] if model_class == "BridgeTowerModel" else outputs["logits"]
 
-    def setUp(self):
-        self.model_tester = BridgeTowerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BridgeTowerConfig, hidden_size=37, vocab_size=99)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BridgeTowerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BridgeTowerConfig, hidden_size=37, vocab_size=99)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/bridgetower/test_processor_bridgetower.py
+++ b/tests/models/bridgetower/test_processor_bridgetower.py
@@ -34,15 +34,16 @@ if is_vision_available():
 class BridgeTowerProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = BridgeTowerProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = BridgeTowerImageProcessor()
         tokenizer = RobertaTokenizerFast.from_pretrained("BridgeTower/bridgetower-large-itm-mlm-itc")
 
         processor = BridgeTowerProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/bros/test_modeling_bros.py
+++ b/tests/models/bros/test_modeling_bros.py
@@ -305,9 +305,10 @@ class BrosModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = BrosModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BrosConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = BrosModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=BrosConfig, hidden_size=37)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/canine/test_modeling_canine.py
+++ b/tests/models/canine/test_modeling_canine.py
@@ -238,10 +238,11 @@ class CanineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = CanineModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CanineModelTester(cls)
         # we set has_text_modality to False as the config has no vocab_size attribute
-        self.config_tester = ConfigTester(self, config_class=CanineConfig, has_text_modality=False, hidden_size=37)
+        cls.config_tester = ConfigTester(cls, config_class=CanineConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/chameleon/test_modeling_chameleon.py
+++ b/tests/models/chameleon/test_modeling_chameleon.py
@@ -286,9 +286,10 @@ class ChameleonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     test_pruning = False
     fx_compatible = False
 
-    def setUp(self):
-        self.model_tester = ChameleonModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ChameleonConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ChameleonModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ChameleonConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/chameleon/test_processor_chameleon.py
+++ b/tests/models/chameleon/test_processor_chameleon.py
@@ -34,11 +34,12 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 class ChameleonProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ChameleonProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = ChameleonImageProcessor()
         tokenizer = LlamaTokenizer(vocab_file=SAMPLE_VOCAB)
         tokenizer.pad_token_id = 0
         tokenizer.sep_token_id = 1
-        processor = self.processor_class(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor = cls.processor_class(image_processor=image_processor, tokenizer=tokenizer)
+        processor.save_pretrained(cls.tmpdirname)

--- a/tests/models/chinese_clip/test_modeling_chinese_clip.py
+++ b/tests/models/chinese_clip/test_modeling_chinese_clip.py
@@ -333,9 +333,10 @@ class ChineseCLIPTextModelTest(ModelTesterMixin, unittest.TestCase):
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = ChineseCLIPTextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ChineseCLIPTextConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ChineseCLIPTextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ChineseCLIPTextConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/chinese_clip/test_processor_chinese_clip.py
+++ b/tests/models/chinese_clip/test_processor_chinese_clip.py
@@ -36,8 +36,9 @@ if is_vision_available():
 class ChineseCLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ChineseCLIPProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab_tokens = [
             "[UNK]",
@@ -59,8 +60,8 @@ class ChineseCLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "t",
             "shirt",
         ]
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         image_processor_map = {
@@ -73,14 +74,14 @@ class ChineseCLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "image_std": [0.26862954, 0.26130258, 0.27577711],
             "do_convert_rgb": True,
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
-        tokenizer = self.get_tokenizer()
-        image_processor = self.get_image_processor()
+        tokenizer = cls.get_tokenizer()
+        image_processor = cls.get_image_processor()
         processor = ChineseCLIPProcessor(tokenizer=tokenizer, image_processor=image_processor)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return BertTokenizer.from_pretrained(self.tmpdirname, **kwargs)

--- a/tests/models/clap/test_feature_extraction_clap.py
+++ b/tests/models/clap/test_feature_extraction_clap.py
@@ -114,7 +114,6 @@ class ClapFeatureExtractionTester:
 class ClapFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = ClapFeatureExtractor
 
-    # Copied from tests.models.whisper.test_feature_extraction_whisper.WhisperFeatureExtractionTest.setUp with Whisper->Clap
     @classmethod
     def setUpClass(cls):
         cls.feat_extract_tester = ClapFeatureExtractionTester(cls)

--- a/tests/models/clap/test_feature_extraction_clap.py
+++ b/tests/models/clap/test_feature_extraction_clap.py
@@ -115,8 +115,9 @@ class ClapFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.Tes
     feature_extraction_class = ClapFeatureExtractor
 
     # Copied from tests.models.whisper.test_feature_extraction_whisper.WhisperFeatureExtractionTest.setUp with Whisper->Clap
-    def setUp(self):
-        self.feat_extract_tester = ClapFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = ClapFeatureExtractionTester(cls)
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus

--- a/tests/models/clap/test_modeling_clap.py
+++ b/tests/models/clap/test_modeling_clap.py
@@ -166,9 +166,10 @@ class ClapAudioModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = ClapAudioModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ClapAudioConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ClapAudioModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ClapAudioConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/clap/test_processor_clap.py
+++ b/tests/models/clap/test_processor_clap.py
@@ -25,9 +25,10 @@ from .test_feature_extraction_clap import floats_list
 @require_torchaudio
 @require_sentencepiece
 class ClapProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.checkpoint = "laion/clap-htsat-unfused"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "laion/clap-htsat-unfused"
+        cls.tmpdirname = tempfile.mkdtemp()
 
     def get_tokenizer(self, **kwargs):
         return RobertaTokenizer.from_pretrained(self.checkpoint, **kwargs)

--- a/tests/models/clip/test_modeling_clip.py
+++ b/tests/models/clip/test_modeling_clip.py
@@ -386,9 +386,10 @@ class CLIPVisionModelTest(CLIPModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = CLIPVisionModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=CLIPVisionConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CLIPVisionModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=CLIPVisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/clip/test_processor_clip.py
+++ b/tests/models/clip/test_processor_clip.py
@@ -36,19 +36,20 @@ if is_vision_available():
 class CLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = CLIPProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab = ["l", "o", "w", "e", "r", "s", "t", "i", "d", "n", "lo", "l</w>", "w</w>", "r</w>", "t</w>", "low</w>", "er</w>", "lowest</w>", "newer</w>", "wider", "<unk>", "<|startoftext|>", "<|endoftext|>"]  # fmt: skip
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "l o", "lo w</w>", "e r</w>", ""]
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
         image_processor_map = {
@@ -60,8 +61,8 @@ class CLIPProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "image_mean": [0.48145466, 0.4578275, 0.40821073],
             "image_std": [0.26862954, 0.26130258, 0.27577711],
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/clipseg/test_modeling_clipseg.py
+++ b/tests/models/clipseg/test_modeling_clipseg.py
@@ -144,10 +144,11 @@ class CLIPSegVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = CLIPSegVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=CLIPSegVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CLIPSegVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=CLIPSegVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/clipseg/test_processor_clipseg.py
+++ b/tests/models/clipseg/test_processor_clipseg.py
@@ -36,19 +36,20 @@ if is_vision_available():
 class CLIPSegProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = CLIPSegProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab = ["l", "o", "w", "e", "r", "s", "t", "i", "d", "n", "lo", "l</w>", "w</w>", "r</w>", "t</w>", "low</w>", "er</w>", "lowest</w>", "newer</w>", "wider", "<unk>", "<|startoftext|>", "<|endoftext|>"]  # fmt: skip
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "l o", "lo w</w>", "e r</w>", ""]
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
         image_processor_map = {
@@ -60,8 +61,8 @@ class CLIPSegProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "image_mean": [0.48145466, 0.4578275, 0.40821073],
             "image_std": [0.26862954, 0.26130258, 0.27577711],
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/clvp/test_feature_extraction_clvp.py
+++ b/tests/models/clvp/test_feature_extraction_clvp.py
@@ -115,8 +115,9 @@ class ClvpFeatureExtractionTester:
 class ClvpFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = ClvpFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = ClvpFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = ClvpFeatureExtractionTester(cls)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/models/clvp/test_modeling_clvp.py
+++ b/tests/models/clvp/test_modeling_clvp.py
@@ -167,9 +167,10 @@ class ClvpEncoderTest(ModelTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = ClvpEncoderTester(self)
-        self.encoder_config_tester = ConfigTester(self, config_class=ClvpEncoderConfig, hidden_size=32)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ClvpEncoderTester(cls)
+        cls.encoder_config_tester = ConfigTester(cls, config_class=ClvpEncoderConfig, hidden_size=32)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/models/clvp/test_processor_clvp.py
+++ b/tests/models/clvp/test_processor_clvp.py
@@ -26,9 +26,10 @@ from .test_feature_extraction_clvp import floats_list
 
 @require_torch
 class ClvpProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.checkpoint = "susnato/clvp_dev"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "susnato/clvp_dev"
+        cls.tmpdirname = tempfile.mkdtemp()
 
     def tearDown(self):
         super().tearDown()

--- a/tests/models/codegen/test_modeling_codegen.py
+++ b/tests/models/codegen/test_modeling_codegen.py
@@ -336,9 +336,10 @@ class CodeGenModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         inputs_dict = super()._prepare_for_class(inputs_dict, model_class, return_labels=return_labels)
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = CodeGenModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=CodeGenConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CodeGenModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=CodeGenConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/cohere/test_modeling_cohere.py
+++ b/tests/models/cohere/test_modeling_cohere.py
@@ -290,9 +290,10 @@ class CohereModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = CohereModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=CohereConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CohereModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=CohereConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -65,9 +65,10 @@ class Cohere2ModelTest(CohereModelTest, unittest.TestCase):
     )
     _is_stateful = True
 
-    def setUp(self):
-        self.model_tester = Cohere2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Cohere2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Cohere2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Cohere2Config, hidden_size=37)
 
     @unittest.skip("Failing because of unique cache (HybridCache)")
     def test_model_outputs_equivalence(self, **kwargs):

--- a/tests/models/colpali/test_modeling_colpali.py
+++ b/tests/models/colpali/test_modeling_colpali.py
@@ -186,9 +186,10 @@ class ColPaliForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = True
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = ColPaliForRetrievalModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ColPaliConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ColPaliForRetrievalModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ColPaliConfig, has_text_modality=False)
 
         # overwrite inputs_embeds tests because we need to delete "pixel values" for LVLMs
 

--- a/tests/models/colpali/test_processing_colpali.py
+++ b/tests/models/colpali/test_processing_colpali.py
@@ -27,13 +27,14 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 class ColPaliProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ColPaliProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = SiglipImageProcessor.from_pretrained("google/siglip-so400m-patch14-384")
         image_processor.image_seq_length = 0
         tokenizer = GemmaTokenizer(SAMPLE_VOCAB, keep_accents=True)
         processor = PaliGemmaProcessor(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/conditional_detr/test_modeling_conditional_detr.py
+++ b/tests/models/conditional_detr/test_modeling_conditional_detr.py
@@ -222,9 +222,10 @@ class ConditionalDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.T
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = ConditionalDetrModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ConditionalDetrConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ConditionalDetrModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ConditionalDetrConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/convbert/test_modeling_convbert.py
+++ b/tests/models/convbert/test_modeling_convbert.py
@@ -274,9 +274,10 @@ class ConvBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_pruning = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = ConvBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ConvBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ConvBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ConvBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/convnext/test_modeling_convnext.py
+++ b/tests/models/convnext/test_modeling_convnext.py
@@ -182,10 +182,11 @@ class ConvNextModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ConvNextModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ConvNextModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=ConvNextConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/convnextv2/test_modeling_convnextv2.py
+++ b/tests/models/convnextv2/test_modeling_convnextv2.py
@@ -190,10 +190,11 @@ class ConvNextV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ConvNextV2ModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ConvNextV2ModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=ConvNextV2Config,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/cpmant/test_modeling_cpmant.py
+++ b/tests/models/cpmant/test_modeling_cpmant.py
@@ -148,9 +148,10 @@ class CpmAntModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_resize_embeddings = False
 
-    def setUp(self):
-        self.model_tester = CpmAntModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=CpmAntConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CpmAntModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=CpmAntConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/ctrl/test_modeling_ctrl.py
+++ b/tests/models/ctrl/test_modeling_ctrl.py
@@ -226,9 +226,10 @@ class CTRLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
 
         return False
 
-    def setUp(self):
-        self.model_tester = CTRLModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=CTRLConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CTRLModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=CTRLConfig, n_embd=37)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/models/cvt/test_modeling_cvt.py
+++ b/tests/models/cvt/test_modeling_cvt.py
@@ -161,10 +161,11 @@ class CvtModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = CvtModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = CvtModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=CvtConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/dab_detr/test_modeling_dab_detr.py
+++ b/tests/models/dab_detr/test_modeling_dab_detr.py
@@ -218,9 +218,10 @@ class DabDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = DabDetrModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DabDetrConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DabDetrModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DabDetrConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/dac/test_feature_extraction_dac.py
+++ b/tests/models/dac/test_feature_extraction_dac.py
@@ -107,8 +107,9 @@ class DacFeatureExtractionTester:
 class DacFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = DacFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = DacFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = DacFeatureExtractionTester(cls)
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus

--- a/tests/models/dac/test_modeling_dac.py
+++ b/tests/models/dac/test_modeling_dac.py
@@ -133,10 +133,11 @@ class DacModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             inputs_dict.pop("output_hidden_states")
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = DacModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=DacConfig, hidden_size=37, common_properties=[], has_text_modality=False
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DacModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=DacConfig, hidden_size=37, common_properties=[], has_text_modality=False
         )
 
     def test_config(self):

--- a/tests/models/data2vec/test_modeling_data2vec_audio.py
+++ b/tests/models/data2vec/test_modeling_data2vec_audio.py
@@ -383,9 +383,10 @@ class Data2VecAudioModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Tes
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = Data2VecAudioModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Data2VecAudioConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Data2VecAudioModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Data2VecAudioConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/data2vec/test_modeling_data2vec_text.py
+++ b/tests/models/data2vec/test_modeling_data2vec_text.py
@@ -388,9 +388,10 @@ class Data2VecTextModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTes
     )
     model_split_percents = [0.5, 0.9]
 
-    def setUp(self):
-        self.model_tester = Data2VecTextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Data2VecTextConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Data2VecTextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Data2VecTextConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/data2vec/test_modeling_data2vec_vision.py
+++ b/tests/models/data2vec/test_modeling_data2vec_vision.py
@@ -203,10 +203,11 @@ class Data2VecVisionModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Data2VecVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Data2VecVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Data2VecVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Data2VecVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/dbrx/test_modeling_dbrx.py
+++ b/tests/models/dbrx/test_modeling_dbrx.py
@@ -326,9 +326,10 @@ class DbrxModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = DbrxModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DbrxConfig, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DbrxModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DbrxConfig, d_model=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/deberta/test_modeling_deberta.py
+++ b/tests/models/deberta/test_modeling_deberta.py
@@ -244,9 +244,10 @@ class DebertaModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     test_head_masking = False
     is_encoder_decoder = False
 
-    def setUp(self):
-        self.model_tester = DebertaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DebertaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DebertaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DebertaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/deberta_v2/test_modeling_deberta_v2.py
+++ b/tests/models/deberta_v2/test_modeling_deberta_v2.py
@@ -258,9 +258,10 @@ class DebertaV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_head_masking = False
     is_encoder_decoder = False
 
-    def setUp(self):
-        self.model_tester = DebertaV2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DebertaV2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DebertaV2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DebertaV2Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/decision_transformer/test_modeling_decision_transformer.py
+++ b/tests/models/decision_transformer/test_modeling_decision_transformer.py
@@ -141,9 +141,10 @@ class DecisionTransformerModelTest(ModelTesterMixin, PipelineTesterMixin, unitte
     test_gradient_checkpointing = False
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = DecisionTransformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DecisionTransformerConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DecisionTransformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DecisionTransformerConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -347,9 +347,10 @@ class DeepseekV3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
     # used in `test_torch_compile_for_training`
     _torch_compile_train_cls = DeepseekV3ForCausalLM if is_torch_available() else None
 
-    def setUp(self):
-        self.model_tester = DeepseekV3ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DeepseekV3Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DeepseekV3ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DeepseekV3Config, hidden_size=37)
 
     @unittest.skip("Failing because of unique cache (HybridCache)")
     def test_model_outputs_equivalence(self, **kwargs):

--- a/tests/models/deformable_detr/test_modeling_deformable_detr.py
+++ b/tests/models/deformable_detr/test_modeling_deformable_detr.py
@@ -228,10 +228,11 @@ class DeformableDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = DeformableDetrModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DeformableDetrModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=DeformableDetrConfig,
             has_text_modality=False,
             common_properties=["num_channels", "d_model", "encoder_attention_heads", "decoder_attention_heads"],

--- a/tests/models/deit/test_modeling_deit.py
+++ b/tests/models/deit/test_modeling_deit.py
@@ -224,9 +224,10 @@ class DeiTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DeiTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DeiTConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DeiTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DeiTConfig, has_text_modality=False, hidden_size=37)
 
     @unittest.skip(
         "Since `torch==2.3+cu121`, although this test passes, many subsequent tests have `CUDA error: misaligned address`."

--- a/tests/models/depth_anything/test_modeling_depth_anything.py
+++ b/tests/models/depth_anything/test_modeling_depth_anything.py
@@ -148,10 +148,11 @@ class DepthAnythingModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Tes
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DepthAnythingModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DepthAnythingModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=DepthAnythingConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/depth_pro/test_modeling_depth_pro.py
+++ b/tests/models/depth_pro/test_modeling_depth_pro.py
@@ -214,9 +214,10 @@ class DepthProModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DepthProModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DepthProConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DepthProModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DepthProConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/detr/test_modeling_detr.py
+++ b/tests/models/detr/test_modeling_detr.py
@@ -222,9 +222,10 @@ class DetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = DetrModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DetrConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DetrModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DetrConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/diffllama/test_modeling_diffllama.py
+++ b/tests/models/diffllama/test_modeling_diffllama.py
@@ -319,9 +319,10 @@ class DiffLlamaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     # used in `test_torch_compile_for_training`
     _torch_compile_train_cls = DiffLlamaForCausalLM if is_torch_available() else None
 
-    def setUp(self):
-        self.model_tester = DiffLlamaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DiffLlamaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DiffLlamaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DiffLlamaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/dinat/test_modeling_dinat.py
+++ b/tests/models/dinat/test_modeling_dinat.py
@@ -218,10 +218,11 @@ class DinatModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DinatModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=DinatConfig, embed_dim=37, common_properties=["patch_size", "num_channels"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DinatModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=DinatConfig, embed_dim=37, common_properties=["patch_size", "num_channels"]
         )
 
     def test_config(self):

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -234,9 +234,10 @@ class Dinov2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Dinov2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Dinov2Config, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Dinov2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Dinov2Config, has_text_modality=False, hidden_size=37)
 
     @is_flaky(max_attempts=3, description="`torch.nn.init.trunc_normal_` is flaky.")
     def test_initialization(self):

--- a/tests/models/dinov2_with_registers/test_modeling_dinov2_with_registers.py
+++ b/tests/models/dinov2_with_registers/test_modeling_dinov2_with_registers.py
@@ -239,10 +239,11 @@ class Dinov2WithRegistersModelTest(ModelTesterMixin, PipelineTesterMixin, unitte
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = Dinov2WithRegistersModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Dinov2WithRegistersConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Dinov2WithRegistersModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Dinov2WithRegistersConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_initialization(self):

--- a/tests/models/distilbert/test_modeling_distilbert.py
+++ b/tests/models/distilbert/test_modeling_distilbert.py
@@ -230,9 +230,10 @@ class DistilBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     test_resize_embeddings = True
     test_resize_position_embeddings = True
 
-    def setUp(self):
-        self.model_tester = DistilBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DistilBertConfig, dim=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DistilBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DistilBertConfig, dim=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/donut/test_modeling_donut_swin.py
+++ b/tests/models/donut/test_modeling_donut_swin.py
@@ -151,10 +151,11 @@ class DonutSwinModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = DonutSwinModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DonutSwinModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=DonutSwinConfig,
             has_text_modality=False,
             embed_dim=37,

--- a/tests/models/donut/test_processor_donut.py
+++ b/tests/models/donut/test_processor_donut.py
@@ -26,16 +26,17 @@ class DonutProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     from_pretrained_id = "naver-clova-ix/donut-base"
     processor_class = DonutProcessor
 
-    def setUp(self):
-        self.processor = DonutProcessor.from_pretrained(self.from_pretrained_id)
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.processor = DonutProcessor.from_pretrained(cls.from_pretrained_id)
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = DonutImageProcessor()
-        tokenizer = XLMRobertaTokenizerFast.from_pretrained(self.from_pretrained_id)
+        tokenizer = XLMRobertaTokenizerFast.from_pretrained(cls.from_pretrained_id)
 
         processor = DonutProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def test_token2json(self):
         expected_json = {

--- a/tests/models/dpr/test_modeling_dpr.py
+++ b/tests/models/dpr/test_modeling_dpr.py
@@ -191,9 +191,10 @@ class DPRModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = DPRModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DPRConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DPRModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DPRConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/dpt/test_modeling_dpt.py
+++ b/tests/models/dpt/test_modeling_dpt.py
@@ -174,9 +174,10 @@ class DPTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DPTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DPTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/dpt/test_modeling_dpt_auto_backbone.py
+++ b/tests/models/dpt/test_modeling_dpt_auto_backbone.py
@@ -142,9 +142,10 @@ class DPTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DPTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DPTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/dpt/test_modeling_dpt_hybrid.py
+++ b/tests/models/dpt/test_modeling_dpt_hybrid.py
@@ -188,9 +188,10 @@ class DPTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = DPTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = DPTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=DPTConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/efficientnet/test_modeling_efficientnet.py
+++ b/tests/models/efficientnet/test_modeling_efficientnet.py
@@ -141,10 +141,11 @@ class EfficientNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = EfficientNetModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = EfficientNetModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=EfficientNetConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/electra/test_modeling_electra.py
+++ b/tests/models/electra/test_modeling_electra.py
@@ -417,9 +417,10 @@ class ElectraModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = ElectraModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ElectraConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ElectraModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ElectraConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/emu3/test_modeling_emu3.py
+++ b/tests/models/emu3/test_modeling_emu3.py
@@ -135,9 +135,10 @@ class Emu3Text2TextModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTe
     test_pruning = False
     fx_compatible = False
 
-    def setUp(self):
-        self.model_tester = Emu3Text2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Emu3TextConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Emu3Text2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Emu3TextConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/emu3/test_processor_emu3.py
+++ b/tests/models/emu3/test_processor_emu3.py
@@ -32,8 +32,9 @@ if is_vision_available():
 class Emu3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Emu3Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = Emu3ImageProcessor()
         extra_special_tokens = extra_special_tokens = {
             "image_token": "<image>",
@@ -47,10 +48,10 @@ class Emu3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         tokenizer.pad_token_id = 0
         tokenizer.sep_token_id = 1
-        processor = self.processor_class(
+        processor = cls.processor_class(
             image_processor=image_processor, tokenizer=tokenizer, chat_template="dummy_template"
         )
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def prepare_processor_dict(self):
         return {

--- a/tests/models/encodec/test_feature_extraction_encodec.py
+++ b/tests/models/encodec/test_feature_extraction_encodec.py
@@ -103,8 +103,9 @@ class EnCodecFeatureExtractionTester:
 class EnCodecFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = EncodecFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = EnCodecFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = EnCodecFeatureExtractionTester(cls)
 
     def test_call(self):
         # Tests that all call wrap to encode_plus and batch_encode_plus

--- a/tests/models/encodec/test_modeling_encodec.py
+++ b/tests/models/encodec/test_modeling_encodec.py
@@ -162,10 +162,11 @@ class EncodecModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
             inputs_dict.pop("output_hidden_states")
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = EncodecModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=EncodecConfig, hidden_size=37, common_properties=[], has_text_modality=False
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = EncodecModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=EncodecConfig, hidden_size=37, common_properties=[], has_text_modality=False
         )
 
     def test_config(self):

--- a/tests/models/ernie/test_modeling_ernie.py
+++ b/tests/models/ernie/test_modeling_ernie.py
@@ -471,9 +471,10 @@ class ErnieModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = ErnieModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ErnieConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ErnieModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ErnieConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -209,9 +209,10 @@ class EsmModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_sequence_classification_problem_types = True
     model_split_percents = [0.5, 0.8, 0.9]
 
-    def setUp(self):
-        self.model_tester = EsmModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=EsmConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = EsmModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=EsmConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/esm/test_modeling_esmfold.py
+++ b/tests/models/esm/test_modeling_esmfold.py
@@ -172,9 +172,10 @@ class EsmFoldModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     pipeline_model_mapping = {} if is_torch_available() else {}
     test_sequence_classification_problem_types = False
 
-    def setUp(self):
-        self.model_tester = EsmFoldModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=EsmConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = EsmFoldModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=EsmConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/models/falcon/test_modeling_falcon.py
@@ -318,9 +318,10 @@ class FalconModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = FalconModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=FalconConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FalconModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=FalconConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
+++ b/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
@@ -279,10 +279,11 @@ class FalconMambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTest
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = FalconMambaModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=FalconMambaConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FalconMambaModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=FalconMambaConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
 
     def assertInterval(self, member, container, msg=None):

--- a/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
+++ b/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
@@ -127,9 +127,10 @@ class FastSpeech2ConformerModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     is_encoder_decoder = True
 
-    def setUp(self):
-        self.model_tester = FastSpeech2ConformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=FastSpeech2ConformerConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FastSpeech2ConformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=FastSpeech2ConformerConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/flaubert/test_modeling_flaubert.py
+++ b/tests/models/flaubert/test_modeling_flaubert.py
@@ -430,9 +430,10 @@ class FlaubertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = FlaubertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=FlaubertConfig, emb_dim=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FlaubertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=FlaubertConfig, emb_dim=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/flava/test_modeling_flava.py
+++ b/tests/models/flava/test_modeling_flava.py
@@ -169,9 +169,10 @@ class FlavaImageModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = FlavaImageModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=FlavaImageConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FlavaImageModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=FlavaImageConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/flava/test_processor_flava.py
+++ b/tests/models/flava/test_processor_flava.py
@@ -43,13 +43,14 @@ if is_vision_available():
 class FlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = FlavaProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]", "want", "##want", "##ed", "wa", "un", "runn", "##ing", ",", "low", "lowest"]  # fmt: skip
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
 
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write("".join([x + "\n" for x in vocab_tokens]))
 
         image_processor_map = {
@@ -76,8 +77,8 @@ class FlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "codebook_image_std": FLAVA_CODEBOOK_STD,
         }
 
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/fnet/test_modeling_fnet.py
+++ b/tests/models/fnet/test_modeling_fnet.py
@@ -432,9 +432,10 @@ class FNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         self.assertIsNotNone(hidden_states.grad)
 
-    def setUp(self):
-        self.model_tester = FNetModelTester(self)
-        self.config_tester = FNetConfigTester(self, config_class=FNetConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FNetModelTester(cls)
+        cls.config_tester = FNetConfigTester(cls, config_class=FNetConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/focalnet/test_modeling_focalnet.py
+++ b/tests/models/focalnet/test_modeling_focalnet.py
@@ -249,10 +249,11 @@ class FocalNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = FocalNetModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FocalNetModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=FocalNetConfig,
             embed_dim=37,
             has_text_modality=False,

--- a/tests/models/fsmt/test_modeling_fsmt.py
+++ b/tests/models/fsmt/test_modeling_fsmt.py
@@ -177,17 +177,18 @@ class FSMTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_pruning = False
     test_missing_keys = False
 
-    def setUp(self):
-        self.model_tester = FSMTModelTester(self)
-        self.langs = ["en", "ru"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FSMTModelTester(cls)
+        cls.langs = ["en", "ru"]
         config = {
-            "langs": self.langs,
+            "langs": cls.langs,
             "src_vocab_size": 10,
             "tgt_vocab_size": 20,
         }
         # XXX: hack to appease to all other models requiring `vocab_size`
         config["vocab_size"] = 99  # no such thing in FSMT
-        self.config_tester = ConfigTester(self, config_class=FSMTConfig, **config)
+        cls.config_tester = ConfigTester(cls, config_class=FSMTConfig, **config)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/funnel/test_modeling_funnel.py
+++ b/tests/models/funnel/test_modeling_funnel.py
@@ -390,9 +390,10 @@ class FunnelModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = FunnelModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=FunnelConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FunnelModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=FunnelConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/fuyu/test_image_processing_fuyu.py
+++ b/tests/models/fuyu/test_image_processing_fuyu.py
@@ -23,20 +23,21 @@ if is_vision_available():
 @require_vision
 @require_torchvision
 class TestFuyuImageProcessor(unittest.TestCase):
-    def setUp(self):
-        self.size = {"height": 160, "width": 320}
-        self.processor = FuyuImageProcessor(size=self.size, padding_value=1.0)
-        self.batch_size = 3
-        self.channels = 3
-        self.height = 300
-        self.width = 300
+    @classmethod
+    def setUpClass(cls):
+        cls.size = {"height": 160, "width": 320}
+        cls.processor = FuyuImageProcessor(size=cls.size, padding_value=1.0)
+        cls.batch_size = 3
+        cls.channels = 3
+        cls.height = 300
+        cls.width = 300
 
-        self.image_input = torch.rand(self.batch_size, self.channels, self.height, self.width)
+        cls.image_input = torch.rand(cls.batch_size, cls.channels, cls.height, cls.width)
 
-        self.image_patch_dim_h = 30
-        self.image_patch_dim_w = 30
-        self.sample_image = np.zeros((450, 210, 3), dtype=np.uint8)
-        self.sample_image_pil = Image.fromarray(self.sample_image)
+        cls.image_patch_dim_h = 30
+        cls.image_patch_dim_w = 30
+        cls.sample_image = np.zeros((450, 210, 3), dtype=np.uint8)
+        cls.sample_image_pil = Image.fromarray(cls.sample_image)
 
     def test_patches(self):
         expected_num_patches = self.processor.get_num_patches(image_height=self.height, image_width=self.width)

--- a/tests/models/fuyu/test_modeling_fuyu.py
+++ b/tests/models/fuyu/test_modeling_fuyu.py
@@ -278,8 +278,9 @@ class FuyuModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_disk_offload = False
     test_model_parallel = False
 
-    def setUp(self):
-        self.model_tester = FuyuModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FuyuModelTester(cls)
 
     @unittest.skip(
         reason="This architecture seem to not compute gradients properly when using GC, check: https://github.com/huggingface/transformers/pull/27124"

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -334,9 +334,10 @@ class GemmaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = GemmaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GemmaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GemmaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GemmaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -80,9 +80,10 @@ class Gemma2ModelTest(GemmaModelTest, unittest.TestCase):
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 
-    def setUp(self):
-        self.model_tester = Gemma2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Gemma2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Gemma2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Gemma2Config, hidden_size=37)
 
     @unittest.skip("Failing because of unique cache (HybridCache)")
     def test_model_outputs_equivalence(self, **kwargs):

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -71,9 +71,10 @@ class Gemma3ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 
-    def setUp(self):
-        self.model_tester = Gemma3ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Gemma3Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Gemma3ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Gemma3Config, hidden_size=37)
 
     @unittest.skip("Failing because of unique cache (HybridCache)")
     def test_model_outputs_equivalence(self, **kwargs):

--- a/tests/models/gemma3/test_processing_gemma3.py
+++ b/tests/models/gemma3/test_processing_gemma3.py
@@ -34,8 +34,9 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 class Gemma3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Gemma3Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         gemma3_image_processor_kwargs = {
             "do_pan_and_scan": True,
             "pan_and_scan_min_crop_size": 256,
@@ -52,9 +53,9 @@ class Gemma3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "eoi_token": "<end_of_image>",
         }
         tokenizer = GemmaTokenizer(SAMPLE_VOCAB, keep_accents=True, extra_special_tokens=extra_special_tokens)
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
         processor = Gemma3Processor(image_processor=image_processor, tokenizer=tokenizer, **processor_kwargs)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/git/test_modeling_git.py
+++ b/tests/models/git/test_modeling_git.py
@@ -131,9 +131,10 @@ class GitVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = GitVisionModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GitVisionConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GitVisionModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GitVisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/git/test_processor_git.py
+++ b/tests/models/git/test_processor_git.py
@@ -31,8 +31,9 @@ if is_vision_available():
 class GitProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = GitProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = CLIPImageProcessor()
         tokenizer = BertTokenizer.from_pretrained(
@@ -41,7 +42,7 @@ class GitProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         processor = GitProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -299,9 +299,10 @@ class GlmModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = GlmModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GlmConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GlmModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GlmConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/glpn/test_modeling_glpn.py
+++ b/tests/models/glpn/test_modeling_glpn.py
@@ -154,9 +154,10 @@ class GLPNModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = GLPNModelTester(self)
-        self.config_tester = GLPNConfigTester(self, config_class=GLPNConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GLPNModelTester(cls)
+        cls.config_tester = GLPNConfigTester(cls, config_class=GLPNConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/got_ocr2/test_modeling_got_ocr2.py
+++ b/tests/models/got_ocr2/test_modeling_got_ocr2.py
@@ -180,9 +180,10 @@ class GotOcr2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = GotOcr2VisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GotOcr2Config, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GotOcr2VisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GotOcr2Config, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/got_ocr2/test_processor_got_ocr2.py
+++ b/tests/models/got_ocr2/test_processor_got_ocr2.py
@@ -31,14 +31,15 @@ if is_vision_available():
 class GotOcr2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = GotOcr2Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = GotOcr2ImageProcessor()
         tokenizer = PreTrainedTokenizerFast.from_pretrained("stepfun-ai/GOT-OCR-2.0-hf")
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
         processor = GotOcr2Processor(image_processor, tokenizer, **processor_kwargs)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -532,9 +532,10 @@ class GPT2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = GPT2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GPT2Config, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GPT2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GPT2Config, n_embd=37)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py
+++ b/tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py
@@ -413,9 +413,10 @@ class GPTBigCodeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = GPTBigCodeModelTester(self, multi_query=self.multi_query)
-        self.config_tester = ConfigTester(self, config_class=GPTBigCodeConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GPTBigCodeModelTester(cls, multi_query=cls.multi_query)
+        cls.config_tester = ConfigTester(cls, config_class=GPTBigCodeConfig, n_embd=37)
 
     def tearDown(self):
         super().tearDown()

--- a/tests/models/gpt_neo/test_modeling_gpt_neo.py
+++ b/tests/models/gpt_neo/test_modeling_gpt_neo.py
@@ -398,9 +398,10 @@ class GPTNeoModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         inputs_dict = super()._prepare_for_class(inputs_dict, model_class, return_labels=return_labels)
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = GPTNeoModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GPTNeoConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GPTNeoModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GPTNeoConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/gpt_neox/test_modeling_gpt_neox.py
+++ b/tests/models/gpt_neox/test_modeling_gpt_neox.py
@@ -291,9 +291,10 @@ class GPTNeoXModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     test_model_parallel = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = GPTNeoXModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GPTNeoXConfig, hidden_size=64, num_attention_heads=8)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GPTNeoXModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GPTNeoXConfig, hidden_size=64, num_attention_heads=8)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/gpt_neox_japanese/test_modeling_gpt_neox_japanese.py
+++ b/tests/models/gpt_neox_japanese/test_modeling_gpt_neox_japanese.py
@@ -208,9 +208,10 @@ class GPTNeoXModelJapaneseTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
     test_model_parallel = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = GPTNeoXJapaneseModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GPTNeoXJapaneseConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GPTNeoXJapaneseModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GPTNeoXJapaneseConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/gptj/test_modeling_gptj.py
+++ b/tests/models/gptj/test_modeling_gptj.py
@@ -392,9 +392,10 @@ class GPTJModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         inputs_dict = super()._prepare_for_class(inputs_dict, model_class, return_labels=return_labels)
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = GPTJModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GPTJConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GPTJModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GPTJConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/granite/test_modeling_granite.py
+++ b/tests/models/granite/test_modeling_granite.py
@@ -297,9 +297,10 @@ class GraniteModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = GraniteModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GraniteConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GraniteModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GraniteConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/granitemoe/test_modeling_granitemoe.py
+++ b/tests/models/granitemoe/test_modeling_granitemoe.py
@@ -296,9 +296,10 @@ class GraniteMoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = GraniteMoeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GraniteMoeConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GraniteMoeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GraniteMoeConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/granitemoeshared/test_modeling_granitemoeshared.py
+++ b/tests/models/granitemoeshared/test_modeling_granitemoeshared.py
@@ -299,9 +299,10 @@ class GraniteMoeSharedModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = GraniteMoeSharedModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=GraniteMoeSharedConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GraniteMoeSharedModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=GraniteMoeSharedConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/grounding_dino/test_modeling_grounding_dino.py
+++ b/tests/models/grounding_dino/test_modeling_grounding_dino.py
@@ -284,10 +284,11 @@ class GroundingDinoModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Tes
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = GroundingDinoModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GroundingDinoModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=GroundingDinoConfig,
             has_text_modality=False,
             common_properties=["d_model", "encoder_attention_heads", "decoder_attention_heads"],

--- a/tests/models/grounding_dino/test_processor_grounding_dino.py
+++ b/tests/models/grounding_dino/test_processor_grounding_dino.py
@@ -44,12 +44,13 @@ class GroundingDinoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     from_pretrained_id = "IDEA-Research/grounding-dino-base"
     processor_class = GroundingDinoProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab_tokens = ["[UNK]","[CLS]","[SEP]","[PAD]","[MASK]","want","##want","##ed","wa","un","runn","##ing",",","low","lowest"]  # fmt: skip
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         image_processor_map = {
@@ -62,21 +63,21 @@ class GroundingDinoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "rescale_factor": 1 / 255,
             "do_pad": True,
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
         image_processor = GroundingDinoImageProcessor()
-        tokenizer = BertTokenizer.from_pretrained(self.from_pretrained_id)
+        tokenizer = BertTokenizer.from_pretrained(cls.from_pretrained_id)
 
         processor = GroundingDinoProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
-        self.batch_size = 7
-        self.num_queries = 5
-        self.embed_dim = 5
-        self.seq_length = 5
+        cls.batch_size = 7
+        cls.num_queries = 5
+        cls.embed_dim = 5
+        cls.seq_length = 5
 
     def prepare_text_inputs(self, batch_size: Optional[int] = None):
         labels = ["a cat", "remote control"]

--- a/tests/models/groupvit/test_modeling_groupvit.py
+++ b/tests/models/groupvit/test_modeling_groupvit.py
@@ -149,10 +149,11 @@ class GroupViTVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = GroupViTVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=GroupViTVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = GroupViTVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=GroupViTVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/helium/test_modeling_helium.py
+++ b/tests/models/helium/test_modeling_helium.py
@@ -71,9 +71,10 @@ class HeliumModelTest(GemmaModelTest, unittest.TestCase):
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 
-    def setUp(self):
-        self.model_tester = HeliumModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=HeliumConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = HeliumModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=HeliumConfig, hidden_size=37)
 
 
 @slow

--- a/tests/models/hiera/test_modeling_hiera.py
+++ b/tests/models/hiera/test_modeling_hiera.py
@@ -252,9 +252,10 @@ class HieraModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = HieraModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=HieraConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = HieraModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=HieraConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.create_and_test_config_to_json_string()

--- a/tests/models/hubert/test_modeling_hubert.py
+++ b/tests/models/hubert/test_modeling_hubert.py
@@ -319,9 +319,10 @@ class HubertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = HubertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=HubertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = HubertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=HubertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/ibert/test_modeling_ibert.py
+++ b/tests/models/ibert/test_modeling_ibert.py
@@ -255,9 +255,10 @@ class IBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = IBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=IBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = IBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=IBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -366,9 +366,10 @@ class IdeficsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         finally:
             self.all_model_classes = orig
 
-    def setUp(self):
-        self.model_tester = IdeficsModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=IdeficsConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = IdeficsModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=IdeficsConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/idefics/test_processor_idefics.py
+++ b/tests/models/idefics/test_processor_idefics.py
@@ -43,17 +43,18 @@ if is_vision_available():
 class IdeficsProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = IdeficsProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = IdeficsImageProcessor(return_tensors="pt")
         tokenizer = LlamaTokenizerFast.from_pretrained("HuggingFaceM4/tiny-random-idefics")
 
         processor = IdeficsProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
-        self.input_keys = ["pixel_values", "input_ids", "attention_mask", "image_attention_mask"]
+        cls.input_keys = ["pixel_values", "input_ids", "attention_mask", "image_attention_mask"]
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/idefics2/test_modeling_idefics2.py
+++ b/tests/models/idefics2/test_modeling_idefics2.py
@@ -182,10 +182,11 @@ class Idefics2ModelTest(ModelTesterMixin, unittest.TestCase):
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = Idefics2VisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Idefics2Config, has_text_modality=False, common_properties=["image_token_id"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Idefics2VisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Idefics2Config, has_text_modality=False, common_properties=["image_token_id"]
         )
 
     def test_config(self):

--- a/tests/models/idefics2/test_processor_idefics2.py
+++ b/tests/models/idefics2/test_processor_idefics2.py
@@ -42,38 +42,39 @@ if is_vision_available():
 class Idefics2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Idefics2Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         processor = Idefics2Processor.from_pretrained("HuggingFaceM4/idefics2-8b", image_seq_len=2)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
-        self.image1 = Image.open(
+        cls.image1 = Image.open(
             BytesIO(
                 requests.get(
                     "https://cdn.britannica.com/61/93061-050-99147DCE/Statue-of-Liberty-Island-New-York-Bay.jpg"
                 ).content
             )
         )
-        self.image2 = Image.open(
+        cls.image2 = Image.open(
             BytesIO(requests.get("https://cdn.britannica.com/59/94459-050-DBA42467/Skyline-Chicago.jpg").content)
         )
-        self.image3 = Image.open(
+        cls.image3 = Image.open(
             BytesIO(
                 requests.get(
                     "https://thumbs.dreamstime.com/b/golden-gate-bridge-san-francisco-purple-flowers-california-echium-candicans-36805947.jpg"
                 ).content
             )
         )
-        self.bos_token = processor.tokenizer.bos_token
-        self.image_token = processor.image_token.content
-        self.fake_image_token = processor.fake_image_token.content
+        cls.bos_token = processor.tokenizer.bos_token
+        cls.image_token = processor.image_token.content
+        cls.fake_image_token = processor.fake_image_token.content
 
-        self.bos_token_id = processor.tokenizer.convert_tokens_to_ids(self.bos_token)
-        self.image_token_id = processor.tokenizer.convert_tokens_to_ids(self.image_token)
-        self.fake_image_token_id = processor.tokenizer.convert_tokens_to_ids(self.fake_image_token)
-        self.image_seq_len = processor.image_seq_len
+        cls.bos_token_id = processor.tokenizer.convert_tokens_to_ids(cls.bos_token)
+        cls.image_token_id = processor.tokenizer.convert_tokens_to_ids(cls.image_token)
+        cls.fake_image_token_id = processor.tokenizer.convert_tokens_to_ids(cls.fake_image_token)
+        cls.image_seq_len = processor.image_seq_len
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/idefics3/test_modeling_idefics3.py
+++ b/tests/models/idefics3/test_modeling_idefics3.py
@@ -172,10 +172,11 @@ class Idefics3ModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = True
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Idefics3VisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Idefics3Config, has_text_modality=False, common_properties=["image_token_id"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Idefics3VisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Idefics3Config, has_text_modality=False, common_properties=["image_token_id"]
         )
 
     def test_config(self):

--- a/tests/models/ijepa/test_modeling_ijepa.py
+++ b/tests/models/ijepa/test_modeling_ijepa.py
@@ -209,10 +209,11 @@ class IJepaModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = IJepaModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = IJepaModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=IJepaConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/imagegpt/test_modeling_imagegpt.py
+++ b/tests/models/imagegpt/test_modeling_imagegpt.py
@@ -261,9 +261,10 @@ class ImageGPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     def test_beam_search_generate_dict_outputs_use_cache(self):
         super().test_beam_search_generate_dict_outputs_use_cache()
 
-    def setUp(self):
-        self.model_tester = ImageGPTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ImageGPTConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ImageGPTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ImageGPTConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/informer/test_modeling_informer.py
+++ b/tests/models/informer/test_modeling_informer.py
@@ -199,13 +199,14 @@ class InformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_torchscript = False
     test_inputs_embeds = False
 
-    def setUp(self):
-        self.model_tester = InformerModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = InformerModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=InformerConfig,
             has_text_modality=False,
-            prediction_length=self.model_tester.prediction_length,
+            prediction_length=cls.model_tester.prediction_length,
         )
 
     def test_config(self):

--- a/tests/models/instructblip/test_modeling_instructblip.py
+++ b/tests/models/instructblip/test_modeling_instructblip.py
@@ -155,10 +155,11 @@ class InstructBlipVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = InstructBlipVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = InstructBlipVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=InstructBlipConfig,
             has_text_modality=False,
             common_properties=["num_query_tokens", "image_token_index"],

--- a/tests/models/instructblip/test_processor_instructblip.py
+++ b/tests/models/instructblip/test_processor_instructblip.py
@@ -38,8 +38,9 @@ if is_vision_available():
 class InstructBlipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = InstructBlipProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = BlipImageProcessor()
         tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-GPT2Model")
@@ -47,7 +48,7 @@ class InstructBlipProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         processor = InstructBlipProcessor(image_processor, tokenizer, qformer_tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/instructblipvideo/test_modeling_instructblipvideo.py
+++ b/tests/models/instructblipvideo/test_modeling_instructblipvideo.py
@@ -157,11 +157,12 @@ class InstructBlipVideoVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = InstructBlipVideoVisionModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = InstructBlipVideoVisionModelTester(cls)
         common_properties = ["num_query_tokens", "video_token_index"]
-        self.config_tester = ConfigTester(
-            self, config_class=InstructBlipVideoConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=InstructBlipVideoConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/instructblipvideo/test_processor_instructblipvideo.py
+++ b/tests/models/instructblipvideo/test_processor_instructblipvideo.py
@@ -39,8 +39,9 @@ if is_vision_available():
 class InstructBlipVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = InstructBlipVideoProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = InstructBlipVideoImageProcessor()
         tokenizer = GPT2Tokenizer.from_pretrained("hf-internal-testing/tiny-random-GPT2Model")
@@ -48,7 +49,7 @@ class InstructBlipVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
         processor = InstructBlipVideoProcessor(image_processor, tokenizer, qformer_tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/jamba/test_modeling_jamba.py
+++ b/tests/models/jamba/test_modeling_jamba.py
@@ -340,9 +340,10 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = JambaModelTester(self)
-        self.config_tester = JambaConfigTester(self, config_class=JambaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = JambaModelTester(cls)
+        cls.config_tester = JambaConfigTester(cls, config_class=JambaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/jetmoe/test_modeling_jetmoe.py
+++ b/tests/models/jetmoe/test_modeling_jetmoe.py
@@ -297,10 +297,11 @@ class JetMoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     test_disk_offload_bin = False
     test_disk_offload_safetensors = False
 
-    def setUp(self):
-        self.model_tester = JetMoeModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=JetMoeConfig, common_properties=["hidden_size", "num_hidden_layers"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = JetMoeModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=JetMoeConfig, common_properties=["hidden_size", "num_hidden_layers"]
         )
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_config

--- a/tests/models/kosmos2/test_modeling_kosmos2.py
+++ b/tests/models/kosmos2/test_modeling_kosmos2.py
@@ -305,10 +305,11 @@ class Kosmos2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = Kosmos2ModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Kosmos2Config, has_text_modality=False, common_properties=["latent_query_num"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Kosmos2ModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Kosmos2Config, has_text_modality=False, common_properties=["latent_query_num"]
         )
 
     def test_config(self):

--- a/tests/models/kosmos2/test_processor_kosmos2.py
+++ b/tests/models/kosmos2/test_processor_kosmos2.py
@@ -58,8 +58,9 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 class Kosmos2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Kosmos2Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = CLIPImageProcessor(do_center_crop=False)
 
@@ -68,7 +69,7 @@ class Kosmos2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         fast_tokenizer = XLMRobertaTokenizerFast(__slow_tokenizer=slow_tokenizer)
 
         processor = Kosmos2Processor(image_processor, fast_tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     # We override this method to take the fast tokenizer by default
     def get_component(self, attribute, **kwargs):

--- a/tests/models/layoutlm/test_modeling_layoutlm.py
+++ b/tests/models/layoutlm/test_modeling_layoutlm.py
@@ -246,9 +246,10 @@ class LayoutLMModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     )
     fx_compatible = True
 
-    def setUp(self):
-        self.model_tester = LayoutLMModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LayoutLMConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LayoutLMModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LayoutLMConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
@@ -282,9 +282,10 @@ class LayoutLMv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = LayoutLMv2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LayoutLMv2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LayoutLMv2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LayoutLMv2Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/layoutlmv2/test_processor_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_processor_layoutlmv2.py
@@ -41,7 +41,8 @@ class LayoutLMv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     rust_tokenizer_class = LayoutLMv2TokenizerFast
     processor_class = LayoutLMv2Processor
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         vocab_tokens = [
             "[UNK]",
             "[CLS]",
@@ -66,12 +67,12 @@ class LayoutLMv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "apply_ocr": True,
         }
 
-        self.tmpdirname = tempfile.mkdtemp()
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
-        self.image_processing_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.image_processing_file, "w", encoding="utf-8") as fp:
+        cls.image_processing_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.image_processing_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(image_processor_map) + "\n")
 
     def get_tokenizer(self, **kwargs) -> PreTrainedTokenizer:

--- a/tests/models/layoutlmv3/test_modeling_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_modeling_layoutlmv3.py
@@ -307,9 +307,10 @@ class LayoutLMv3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         # (see the line `embedding_output = torch.cat([embedding_output, visual_embeddings], dim=1)`)
         return True
 
-    def setUp(self):
-        self.model_tester = LayoutLMv3ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LayoutLMv3Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LayoutLMv3ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LayoutLMv3Config, hidden_size=37)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/layoutlmv3/test_processor_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_processor_layoutlmv3.py
@@ -41,7 +41,8 @@ class LayoutLMv3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     rust_tokenizer_class = LayoutLMv3TokenizerFast
     processor_class = LayoutLMv3Processor
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # Adapted from Sennrich et al. 2015 and https://github.com/rsennrich/subword-nmt
         vocab = [
             "l",
@@ -65,16 +66,16 @@ class LayoutLMv3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "\u0120wider",
             "<unk>",
         ]
-        self.tmpdirname = tempfile.mkdtemp()
+        cls.tmpdirname = tempfile.mkdtemp()
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "\u0120 l", "\u0120l o", "\u0120lo w", "e r", ""]
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
         image_processor_map = {
@@ -83,8 +84,8 @@ class LayoutLMv3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "apply_ocr": True,
         }
 
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(image_processor_map) + "\n")
 
     def get_tokenizer(self, **kwargs) -> PreTrainedTokenizer:

--- a/tests/models/layoutxlm/test_processor_layoutxlm.py
+++ b/tests/models/layoutxlm/test_processor_layoutxlm.py
@@ -47,25 +47,26 @@ class LayoutXLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     rust_tokenizer_class = LayoutXLMTokenizerFast
     processor_class = LayoutXLMProcessor
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         image_processor_map = {
             "do_resize": True,
             "size": 224,
             "apply_ocr": True,
         }
 
-        self.tmpdirname = tempfile.mkdtemp()
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(image_processor_map) + "\n")
 
         # taken from `test_tokenization_layoutxlm.LayoutXLMTokenizationTest.test_save_pretrained`
-        self.tokenizer_pretrained_name = "hf-internal-testing/tiny-random-layoutxlm"
+        cls.tokenizer_pretrained_name = "hf-internal-testing/tiny-random-layoutxlm"
 
-        tokenizer = self.get_tokenizer()
-        image_processor = self.get_image_processor()
+        tokenizer = cls.get_tokenizer()
+        image_processor = cls.get_image_processor()
         processor = LayoutXLMProcessor(tokenizer=tokenizer, image_processor=image_processor)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs) -> PreTrainedTokenizer:
         return self.tokenizer_class.from_pretrained(self.tokenizer_pretrained_name, **kwargs)

--- a/tests/models/led/test_modeling_led.py
+++ b/tests/models/led/test_modeling_led.py
@@ -315,9 +315,10 @@ class LEDModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
 
         return False
 
-    def setUp(self):
-        self.model_tester = LEDModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LEDConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LEDModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LEDConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/levit/test_modeling_levit.py
+++ b/tests/models/levit/test_modeling_levit.py
@@ -188,10 +188,11 @@ class LevitModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     has_attentions = False
 
-    def setUp(self):
-        self.model_tester = LevitModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=LevitConfig, has_text_modality=False, common_properties=["image_size", "num_channels"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LevitModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=LevitConfig, has_text_modality=False, common_properties=["image_size", "num_channels"]
         )
 
     def test_config(self):

--- a/tests/models/lilt/test_modeling_lilt.py
+++ b/tests/models/lilt/test_modeling_lilt.py
@@ -255,9 +255,10 @@ class LiltModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = LiltModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LiltConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LiltModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LiltConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -312,9 +312,10 @@ class LlamaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     # used in `test_torch_compile_for_training`
     _torch_compile_train_cls = LlamaForCausalLM if is_torch_available() else None
 
-    def setUp(self):
-        self.model_tester = LlamaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LlamaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LlamaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LlamaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/llava/test_modeling_llava.py
+++ b/tests/models/llava/test_modeling_llava.py
@@ -190,11 +190,12 @@ class LlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTesterM
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = LlavaVisionText2TextModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LlavaVisionText2TextModelTester(cls)
         common_properties = ["image_token_index", "vision_feature_layer", "image_seq_length"]
-        self.config_tester = ConfigTester(
-            self, config_class=LlavaConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=LlavaConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/llava/test_processor_llava.py
+++ b/tests/models/llava/test_processor_llava.py
@@ -34,14 +34,15 @@ if is_torch_available:
 class LlavaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = CLIPImageProcessor(do_center_crop=False)
         tokenizer = LlamaTokenizerFast.from_pretrained("huggyllama/llama-7b")
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
         processor = LlavaProcessor(image_processor, tokenizer, **processor_kwargs)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/llava_next/test_modeling_llava_next.py
+++ b/tests/models/llava_next/test_modeling_llava_next.py
@@ -220,11 +220,12 @@ class LlavaNextForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = LlavaNextVisionText2TextModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LlavaNextVisionText2TextModelTester(cls)
         common_properties = ["image_token_index", "vision_feature_layer", "image_seq_length"]
-        self.config_tester = ConfigTester(
-            self, config_class=LlavaNextConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=LlavaNextConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/llava_next/test_processor_llava_next.py
+++ b/tests/models/llava_next/test_processor_llava_next.py
@@ -34,14 +34,15 @@ if is_vision_available():
 class LlavaNextProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaNextProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = LlavaNextImageProcessor()
         tokenizer = LlamaTokenizerFast.from_pretrained("huggyllama/llama-7b")
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
         processor = LlavaNextProcessor(image_processor, tokenizer, **processor_kwargs)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return LlavaNextProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/llava_next_video/test_modeling_llava_next_video.py
+++ b/tests/models/llava_next_video/test_modeling_llava_next_video.py
@@ -235,11 +235,12 @@ class LlavaNextVideoForConditionalGenerationModelTest(ModelTesterMixin, Generati
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = LlavaNextVideoVisionText2TextModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LlavaNextVideoVisionText2TextModelTester(cls)
         common_properties = ["image_token_index", "video_token_index", "vision_feature_layer", "image_seq_length"]
-        self.config_tester = ConfigTester(
-            self, config_class=LlavaNextVideoConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=LlavaNextVideoConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/llava_next_video/test_processor_llava_next_video.py
+++ b/tests/models/llava_next_video/test_processor_llava_next_video.py
@@ -36,17 +36,18 @@ if is_torch_available:
 class LlavaNextVideoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaNextVideoProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = LlavaNextImageProcessor()
         video_processor = LlavaNextVideoImageProcessor()
         tokenizer = LlamaTokenizerFast.from_pretrained("llava-hf/LLaVA-NeXT-Video-7B-hf")
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
 
         processor = LlavaNextVideoProcessor(
             video_processor=video_processor, image_processor=image_processor, tokenizer=tokenizer, **processor_kwargs
         )
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/llava_onevision/test_modeling_llava_onevision.py
+++ b/tests/models/llava_onevision/test_modeling_llava_onevision.py
@@ -222,11 +222,12 @@ class LlavaOnevisionForConditionalGenerationModelTest(ModelTesterMixin, Generati
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = LlavaOnevisionVisionText2TextModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LlavaOnevisionVisionText2TextModelTester(cls)
         common_properties = ["image_token_index", "video_token_index", "vision_feature_layer"]
-        self.config_tester = ConfigTester(
-            self, config_class=LlavaOnevisionConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=LlavaOnevisionConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/llava_onevision/test_processor_llava_onevision.py
+++ b/tests/models/llava_onevision/test_processor_llava_onevision.py
@@ -39,17 +39,18 @@ if is_torch_available:
 class LlavaOnevisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = LlavaOnevisionProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = LlavaOnevisionImageProcessor()
         video_processor = LlavaOnevisionVideoProcessor()
         tokenizer = Qwen2TokenizerFast.from_pretrained("Qwen/Qwen2-0.5B-Instruct")
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
 
         processor = LlavaOnevisionProcessor(
             video_processor=video_processor, image_processor=image_processor, tokenizer=tokenizer, **processor_kwargs
         )
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/longformer/test_modeling_longformer.py
+++ b/tests/models/longformer/test_modeling_longformer.py
@@ -352,9 +352,10 @@ class LongformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
 
         return False
 
-    def setUp(self):
-        self.model_tester = LongformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LongformerConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LongformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LongformerConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -519,9 +519,10 @@ class LongT5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     test_model_parallel = False
     is_encoder_decoder = True
 
-    def setUp(self):
-        self.model_tester = LongT5ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LongT5Config, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LongT5ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LongT5Config, d_model=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/luke/test_modeling_luke.py
+++ b/tests/models/luke/test_modeling_luke.py
@@ -693,9 +693,10 @@ class LukeModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = LukeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LukeConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LukeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LukeConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/lxmert/test_modeling_lxmert.py
+++ b/tests/models/lxmert/test_modeling_lxmert.py
@@ -558,9 +558,10 @@ class LxmertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = LxmertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=LxmertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = LxmertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=LxmertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/m2m_100/test_modeling_m2m_100.py
+++ b/tests/models/m2m_100/test_modeling_m2m_100.py
@@ -273,9 +273,10 @@ class M2M100ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
 
         return False
 
-    def setUp(self):
-        self.model_tester = M2M100ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=M2M100Config)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = M2M100ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=M2M100Config)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mamba/test_modeling_mamba.py
+++ b/tests/models/mamba/test_modeling_mamba.py
@@ -250,10 +250,11 @@ class MambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
         {"feature-extraction": MambaModel, "text-generation": MambaForCausalLM} if is_torch_available() else {}
     )
 
-    def setUp(self):
-        self.model_tester = MambaModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=MambaConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MambaModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=MambaConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
 
     def assertInterval(self, member, container, msg=None):

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -226,10 +226,11 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         {"feature-extraction": Mamba2Model, "text-generation": Mamba2ForCausalLM} if is_torch_available() else {}
     )
 
-    def setUp(self):
-        self.model_tester = Mamba2ModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Mamba2Config, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Mamba2ModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Mamba2Config, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
 
     def test_mamba2_caching(self):

--- a/tests/models/marian/test_modeling_marian.py
+++ b/tests/models/marian/test_modeling_marian.py
@@ -246,9 +246,10 @@ class MarianModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     test_pruning = False
     test_missing_keys = False
 
-    def setUp(self):
-        self.model_tester = MarianModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MarianConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MarianModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MarianConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/markuplm/test_feature_extraction_markuplm.py
+++ b/tests/models/markuplm/test_feature_extraction_markuplm.py
@@ -76,8 +76,9 @@ def get_html_strings():
 class MarkupLMFeatureExtractionTest(FeatureExtractionSavingTestMixin, unittest.TestCase):
     feature_extraction_class = MarkupLMFeatureExtractor if is_bs4_available() else None
 
-    def setUp(self):
-        self.feature_extract_tester = MarkupLMFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feature_extract_tester = MarkupLMFeatureExtractionTester(cls)
 
     @property
     def feat_extract_dict(self):

--- a/tests/models/markuplm/test_modeling_markuplm.py
+++ b/tests/models/markuplm/test_modeling_markuplm.py
@@ -314,9 +314,10 @@ class MarkupLMModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
         # (batch of pretokenized examples).
         return True
 
-    def setUp(self):
-        self.model_tester = MarkupLMModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MarkupLMConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MarkupLMModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MarkupLMConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/markuplm/test_processor_markuplm.py
+++ b/tests/models/markuplm/test_processor_markuplm.py
@@ -44,29 +44,30 @@ class MarkupLMProcessorTest(unittest.TestCase):
     tokenizer_class = MarkupLMTokenizer
     rust_tokenizer_class = MarkupLMTokenizerFast
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # Adapted from Sennrich et al. 2015 and https://github.com/rsennrich/subword-nmt
         vocab = ["l", "o", "w", "e", "r", "s", "t", "i", "d", "n", "\u0120", "\u0120l", "\u0120n", "\u0120lo", "\u0120low", "er", "\u0120lowest", "\u0120newer", "\u0120wider", "\u0120hello", "\u0120world", "<unk>",]  # fmt: skip
-        self.tmpdirname = tempfile.mkdtemp()
+        cls.tmpdirname = tempfile.mkdtemp()
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "\u0120 l", "\u0120l o", "\u0120lo w", "e r", ""]
-        self.tags_dict = {"a": 0, "abbr": 1, "acronym": 2, "address": 3}
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.tags_dict = {"a": 0, "abbr": 1, "acronym": 2, "address": 3}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
-        self.tokenizer_config_file = os.path.join(self.tmpdirname, "tokenizer_config.json")
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
+        cls.tokenizer_config_file = os.path.join(cls.tmpdirname, "tokenizer_config.json")
 
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
-        with open(self.tokenizer_config_file, "w", encoding="utf-8") as fp:
-            fp.write(json.dumps({"tags_dict": self.tags_dict}))
+        with open(cls.tokenizer_config_file, "w", encoding="utf-8") as fp:
+            fp.write(json.dumps({"tags_dict": cls.tags_dict}))
 
         feature_extractor_map = {"feature_extractor_type": "MarkupLMFeatureExtractor"}
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(feature_extractor_map) + "\n")
 
     def get_tokenizer(self, **kwargs) -> PreTrainedTokenizer:

--- a/tests/models/mask2former/test_modeling_mask2former.py
+++ b/tests/models/mask2former/test_modeling_mask2former.py
@@ -207,9 +207,10 @@ class Mask2FormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     test_missing_keys = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = Mask2FormerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Mask2FormerConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Mask2FormerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Mask2FormerConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/maskformer/test_modeling_maskformer.py
+++ b/tests/models/maskformer/test_modeling_maskformer.py
@@ -211,9 +211,10 @@ class MaskFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     zero_init_hidden_state = True
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = MaskFormerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MaskFormerConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MaskFormerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MaskFormerConfig, has_text_modality=False)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/maskformer/test_modeling_maskformer_swin.py
+++ b/tests/models/maskformer/test_modeling_maskformer_swin.py
@@ -183,10 +183,11 @@ class MaskFormerSwinModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = MaskFormerSwinModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MaskFormerSwinModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=MaskFormerSwinConfig,
             has_text_modality=False,
             embed_dim=37,

--- a/tests/models/mbart/test_modeling_mbart.py
+++ b/tests/models/mbart/test_modeling_mbart.py
@@ -265,9 +265,10 @@ class MBartModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
 
         return False
 
-    def setUp(self):
-        self.model_tester = MBartModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MBartConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MBartModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MBartConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/megatron_bert/test_modeling_megatron_bert.py
+++ b/tests/models/megatron_bert/test_modeling_megatron_bert.py
@@ -315,9 +315,10 @@ class MegatronBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = MegatronBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MegatronBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MegatronBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MegatronBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mgp_str/test_modeling_mgp_str.py
+++ b/tests/models/mgp_str/test_modeling_mgp_str.py
@@ -130,9 +130,10 @@ class MgpstrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_attention_outputs = False
 
-    def setUp(self):
-        self.model_tester = MgpstrModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MgpstrConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MgpstrModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MgpstrConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mgp_str/test_processor_mgp_str.py
+++ b/tests/models/mgp_str/test_processor_mgp_str.py
@@ -48,15 +48,16 @@ class MgpstrProcessorTest(unittest.TestCase):
     def image_processor_dict(self):
         return self.prepare_image_processor_dict()
 
-    def setUp(self):
-        self.image_size = (3, 32, 128)
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.image_size = (3, 32, 128)
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab = ['[GO]', '[s]', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z']  # fmt: skip
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
 
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
 
         image_processor_map = {
@@ -66,8 +67,8 @@ class MgpstrProcessorTest(unittest.TestCase):
             "resample": 3,
             "size": {"height": 32, "width": 128},
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
     # We copy here rather than use the ProcessorTesterMixin as this processor has a `char_tokenizer` instead of a

--- a/tests/models/mimi/test_modeling_mimi.py
+++ b/tests/models/mimi/test_modeling_mimi.py
@@ -173,10 +173,11 @@ class MimiModelTest(ModelTesterMixin, unittest.TestCase):
             inputs_dict.pop("output_hidden_states")
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = MimiModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=MimiConfig, hidden_size=37, common_properties=[], has_text_modality=False
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MimiModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=MimiConfig, hidden_size=37, common_properties=[], has_text_modality=False
         )
 
     def test_config(self):

--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -330,9 +330,10 @@ class MistralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = MistralModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MistralConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MistralModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MistralConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mistral3/test_modeling_mistral3.py
+++ b/tests/models/mistral3/test_modeling_mistral3.py
@@ -203,9 +203,10 @@ class Mistral3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = Mistral3VisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Mistral3Config, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Mistral3VisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Mistral3Config, has_text_modality=False)
 
     def test_config(self):
         # overwritten from `tests/test_configuration_common.py::ConfigTester` after #36077

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -329,9 +329,10 @@ class MixtralModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = MixtralModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MixtralConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MixtralModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MixtralConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -127,9 +127,10 @@ class MllamaForCausalLMModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
     test_pruning = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = MllamaText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MllamaTextConfig, has_text_modality=True)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MllamaText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MllamaTextConfig, has_text_modality=True)
 
 
 class MllamaVisionText2TextModelTester:

--- a/tests/models/mllama/test_processor_mllama.py
+++ b/tests/models/mllama/test_processor_mllama.py
@@ -37,18 +37,19 @@ if is_vision_available():
 class MllamaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = MllamaProcessor
 
-    def setUp(self):
-        self.checkpoint = "hf-internal-testing/mllama-11b"
-        processor = MllamaProcessor.from_pretrained(self.checkpoint)
-        self.image1 = Image.new("RGB", (224, 220))
-        self.image2 = Image.new("RGB", (512, 128))
-        self.image_token = processor.image_token
-        self.image_token_id = processor.image_token_id
-        self.pad_token_id = processor.tokenizer.pad_token_id
-        self.bos_token = processor.bos_token
-        self.bos_token_id = processor.tokenizer.bos_token_id
-        self.tmpdirname = tempfile.mkdtemp()
-        processor.save_pretrained(self.tmpdirname)
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "hf-internal-testing/mllama-11b"
+        processor = MllamaProcessor.from_pretrained(cls.checkpoint)
+        cls.image1 = Image.new("RGB", (224, 220))
+        cls.image2 = Image.new("RGB", (512, 128))
+        cls.image_token = processor.image_token
+        cls.image_token_id = processor.image_token_id
+        cls.pad_token_id = processor.tokenizer.pad_token_id
+        cls.bos_token = processor.bos_token
+        cls.bos_token_id = processor.tokenizer.bos_token_id
+        cls.tmpdirname = tempfile.mkdtemp()
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/mobilebert/test_modeling_mobilebert.py
+++ b/tests/models/mobilebert/test_modeling_mobilebert.py
@@ -304,9 +304,10 @@ class MobileBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def test_resize_tokens_embeddings(self):
         super().test_resize_tokens_embeddings()
 
-    def setUp(self):
-        self.model_tester = MobileBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MobileBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MobileBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MobileBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mobilenet_v1/test_modeling_mobilenet_v1.py
+++ b/tests/models/mobilenet_v1/test_modeling_mobilenet_v1.py
@@ -156,9 +156,10 @@ class MobileNetV1ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = MobileNetV1ModelTester(self)
-        self.config_tester = MobileNetV1ConfigTester(self, config_class=MobileNetV1Config, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MobileNetV1ModelTester(cls)
+        cls.config_tester = MobileNetV1ConfigTester(cls, config_class=MobileNetV1Config, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mobilenet_v2/test_modeling_mobilenet_v2.py
+++ b/tests/models/mobilenet_v2/test_modeling_mobilenet_v2.py
@@ -207,9 +207,10 @@ class MobileNetV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = MobileNetV2ModelTester(self)
-        self.config_tester = MobileNetV2ConfigTester(self, config_class=MobileNetV2Config, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MobileNetV2ModelTester(cls)
+        cls.config_tester = MobileNetV2ConfigTester(cls, config_class=MobileNetV2Config, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mobilevit/test_modeling_mobilevit.py
+++ b/tests/models/mobilevit/test_modeling_mobilevit.py
@@ -200,9 +200,10 @@ class MobileViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = MobileViTModelTester(self)
-        self.config_tester = MobileViTConfigTester(self, config_class=MobileViTConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MobileViTModelTester(cls)
+        cls.config_tester = MobileViTConfigTester(cls, config_class=MobileViTConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
+++ b/tests/models/mobilevitv2/test_modeling_mobilevitv2.py
@@ -202,9 +202,10 @@ class MobileViTV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = MobileViTV2ModelTester(self)
-        self.config_tester = MobileViTV2ConfigTester(self, config_class=MobileViTV2Config, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MobileViTV2ModelTester(cls)
+        cls.config_tester = MobileViTV2ConfigTester(cls, config_class=MobileViTV2Config, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/modernbert/test_modeling_modernbert.py
+++ b/tests/models/modernbert/test_modeling_modernbert.py
@@ -266,9 +266,10 @@ class ModernBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = ModernBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ModernBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ModernBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ModernBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/moonshine/test_modeling_moonshine.py
+++ b/tests/models/moonshine/test_modeling_moonshine.py
@@ -182,9 +182,10 @@ class MoonshineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = MoonshineModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MoonshineConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MoonshineModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MoonshineConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/moshi/test_modeling_moshi.py
+++ b/tests/models/moshi/test_modeling_moshi.py
@@ -169,13 +169,14 @@ class MoshiDecoderTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = MoshiDecoderTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MoshiDecoderTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=MoshiConfig,
             hidden_size=16,
-            audio_encoder_config={"model_type": self.model_tester.audio_encoder_type},
+            audio_encoder_config={"model_type": cls.model_tester.audio_encoder_type},
         )
 
     @unittest.skip(reason="The MoshiModel does not have support dynamic compile yet")

--- a/tests/models/mpnet/test_modeling_mpnet.py
+++ b/tests/models/mpnet/test_modeling_mpnet.py
@@ -219,9 +219,10 @@ class MPNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = True
 
-    def setUp(self):
-        self.model_tester = MPNetModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MPNetConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MPNetModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MPNetConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mpt/test_modeling_mpt.py
+++ b/tests/models/mpt/test_modeling_mpt.py
@@ -372,9 +372,10 @@ class MptModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = MptModelTester(self)
-        self.config_tester = MptConfigTester(self, config_class=MptConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MptModelTester(cls)
+        cls.config_tester = MptConfigTester(cls, config_class=MptConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mra/test_modeling_mra.py
+++ b/tests/models/mra/test_modeling_mra.py
@@ -311,9 +311,10 @@ class MraModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = MraModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MraConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MraModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MraConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/mt5/test_modeling_mt5.py
+++ b/tests/models/mt5/test_modeling_mt5.py
@@ -574,9 +574,10 @@ class MT5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     # The small MT5 model needs higher percentages for CPU/MP tests
     model_split_percents = [0.5, 0.8, 0.9]
 
-    def setUp(self):
-        self.model_tester = MT5ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MT5Config, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MT5ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MT5Config, d_model=37)
 
     # `QAPipelineTests` is not working well with slow tokenizers (for some models) and we don't want to touch the file
     # `src/transformers/data/processors/squad.py` (where this test fails for this model)

--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -184,9 +184,10 @@ class MusicgenDecoderTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
     test_pruning = False
     test_resize_embeddings = False
 
-    def setUp(self):
-        self.model_tester = MusicgenDecoderTester(self)
-        self.config_tester = ConfigTester(self, config_class=MusicgenDecoderConfig, hidden_size=16)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MusicgenDecoderTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MusicgenDecoderConfig, hidden_size=16)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/musicgen/test_processor_musicgen.py
+++ b/tests/models/musicgen/test_processor_musicgen.py
@@ -50,9 +50,10 @@ def floats_list(shape, scale=1.0, rng=None, name=None):
 @require_torch
 @require_sentencepiece
 class MusicgenProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.checkpoint = "facebook/musicgen-small"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "facebook/musicgen-small"
+        cls.tmpdirname = tempfile.mkdtemp()
 
     def get_tokenizer(self, **kwargs):
         return T5Tokenizer.from_pretrained(self.checkpoint, **kwargs)

--- a/tests/models/musicgen_melody/test_feature_extraction_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_feature_extraction_musicgen_melody.py
@@ -123,8 +123,9 @@ class MusicgenMelodyFeatureExtractionTester:
 class MusicgenMelodyFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = MusicgenMelodyFeatureExtractor if is_torchaudio_available() else None
 
-    def setUp(self):
-        self.feat_extract_tester = MusicgenMelodyFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = MusicgenMelodyFeatureExtractionTester(cls)
 
     # Copied from tests.models.seamless_m4t.test_feature_extraction_seamless_m4t.SeamlessM4TFeatureExtractionTest.test_feat_extract_from_and_save_pretrained
     def test_feat_extract_from_and_save_pretrained(self):

--- a/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
@@ -186,9 +186,10 @@ class MusicgenMelodyDecoderTest(ModelTesterMixin, GenerationTesterMixin, unittes
     test_pruning = False
     test_resize_embeddings = False
 
-    def setUp(self):
-        self.model_tester = MusicgenMelodyDecoderTester(self)
-        self.config_tester = ConfigTester(self, config_class=MusicgenMelodyDecoderConfig, hidden_size=16)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MusicgenMelodyDecoderTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MusicgenMelodyDecoderConfig, hidden_size=16)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/musicgen_melody/test_processor_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_processor_musicgen_melody.py
@@ -52,10 +52,11 @@ def floats_list(shape, scale=1.0, rng=None, name=None):
 @require_torchaudio
 # Copied from tests.models.musicgen.test_processor_musicgen.MusicgenProcessorTest with Musicgen->MusicgenMelody, Encodec->MusicgenMelody, padding_mask->attention_mask, input_values->input_features
 class MusicgenMelodyProcessorTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # Ignore copy
-        self.checkpoint = "facebook/musicgen-melody"
-        self.tmpdirname = tempfile.mkdtemp()
+        cls.checkpoint = "facebook/musicgen-melody"
+        cls.tmpdirname = tempfile.mkdtemp()
 
     def get_tokenizer(self, **kwargs):
         return T5Tokenizer.from_pretrained(self.checkpoint, **kwargs)

--- a/tests/models/mvp/test_modeling_mvp.py
+++ b/tests/models/mvp/test_modeling_mvp.py
@@ -461,9 +461,10 @@ class MvpModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
 
         return False
 
-    def setUp(self):
-        self.model_tester = MvpModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=MvpConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = MvpModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=MvpConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/myt5/test_tokenization_myt5.py
+++ b/tests/models/myt5/test_tokenization_myt5.py
@@ -39,8 +39,9 @@ def str_to_hex(line: str, sep: str = " ") -> str:
 
 
 class TestByteRewriter(unittest.TestCase):
-    def setUp(self) -> None:
-        self.tokenizer = MyT5Tokenizer.from_pretrained("Tomlim/myt5-base")
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.tokenizer = MyT5Tokenizer.from_pretrained("Tomlim/myt5-base")
 
     def test_simple_decompose(self):
         decompose_rewriter = self.tokenizer.decompose_rewriter

--- a/tests/models/nllb_moe/test_modeling_nllb_moe.py
+++ b/tests/models/nllb_moe/test_modeling_nllb_moe.py
@@ -277,9 +277,10 @@ class NllbMoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         # Saving the slow tokenizer after saving the fast tokenizer causes the loading of the later hanging forever.
         return True
 
-    def setUp(self):
-        self.model_tester = NllbMoeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=NllbMoeConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = NllbMoeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=NllbMoeConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/nystromformer/test_modeling_nystromformer.py
+++ b/tests/models/nystromformer/test_modeling_nystromformer.py
@@ -243,9 +243,10 @@ class NystromformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Tes
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = NystromformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=NystromformerConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = NystromformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=NystromformerConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/olmo/test_modeling_olmo.py
+++ b/tests/models/olmo/test_modeling_olmo.py
@@ -289,9 +289,10 @@ class OlmoModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = OlmoModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=OlmoConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OlmoModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=OlmoConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/olmo2/test_modeling_olmo2.py
+++ b/tests/models/olmo2/test_modeling_olmo2.py
@@ -288,9 +288,10 @@ class Olmo2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = Olmo2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Olmo2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Olmo2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Olmo2Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/olmoe/test_modeling_olmoe.py
+++ b/tests/models/olmoe/test_modeling_olmoe.py
@@ -302,9 +302,10 @@ class OlmoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def setUp(self):
-        self.model_tester = OlmoeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=OlmoeConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OlmoeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=OlmoeConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/omdet_turbo/test_modeling_omdet_turbo.py
+++ b/tests/models/omdet_turbo/test_modeling_omdet_turbo.py
@@ -208,10 +208,11 @@ class OmDetTurboModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = OmDetTurboModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OmDetTurboModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=OmDetTurboConfig,
             has_text_modality=False,
             common_properties=["d_model", "encoder_attention_heads", "decoder_num_heads"],

--- a/tests/models/omdet_turbo/test_processor_omdet_turbo.py
+++ b/tests/models/omdet_turbo/test_processor_omdet_turbo.py
@@ -44,15 +44,16 @@ class OmDetTurboProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = OmDetTurboProcessor
     text_input_name = "classes_input_ids"
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = DetrImageProcessor()
         tokenizer = CLIPTokenizerFast.from_pretrained("openai/clip-vit-base-patch32")
 
         processor = OmDetTurboProcessor(image_processor, tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
-        self.input_keys = [
+        cls.input_keys = [
             "tasks_input_ids",
             "tasks_attention_mask",
             "classes_input_ids",
@@ -62,9 +63,9 @@ class OmDetTurboProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "pixel_mask",
         ]
 
-        self.batch_size = 5
-        self.num_queries = 5
-        self.embed_dim = 3
+        cls.batch_size = 5
+        cls.num_queries = 5
+        cls.embed_dim = 3
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/oneformer/test_modeling_oneformer.py
+++ b/tests/models/oneformer/test_modeling_oneformer.py
@@ -262,9 +262,10 @@ class OneFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
 
         return False
 
-    def setUp(self):
-        self.model_tester = OneFormerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=OneFormerConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OneFormerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=OneFormerConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/oneformer/test_processor_oneformer.py
+++ b/tests/models/oneformer/test_processor_oneformer.py
@@ -195,8 +195,9 @@ class OneFormerProcessingTest(unittest.TestCase):
     # only for test_feat_extracttion_common.test_feat_extract_to_json_string
     feature_extraction_class = processing_class
 
-    def setUp(self):
-        self.processing_tester = OneFormerProcessorTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.processing_tester = OneFormerProcessorTester(cls)
 
     @property
     def processor_dict(self):

--- a/tests/models/openai/test_modeling_openai.py
+++ b/tests/models/openai/test_modeling_openai.py
@@ -248,9 +248,10 @@ class OpenAIGPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = OpenAIGPTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=OpenAIGPTConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OpenAIGPTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=OpenAIGPTConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/opt/test_modeling_opt.py
+++ b/tests/models/opt/test_modeling_opt.py
@@ -247,9 +247,10 @@ class OPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
 
         return False
 
-    def setUp(self):
-        self.model_tester = OPTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=OPTConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OPTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=OPTConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -149,10 +149,11 @@ class Owlv2VisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Owlv2VisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Owlv2VisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Owlv2VisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Owlv2VisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -152,9 +152,7 @@ class Owlv2VisionModelTest(ModelTesterMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model_tester = Owlv2VisionModelTester(cls)
-        cls.config_tester = ConfigTester(
-            cls, config_class=Owlv2VisionConfig, has_text_modality=False, hidden_size=37
-        )
+        cls.config_tester = ConfigTester(cls, config_class=Owlv2VisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/owlv2/test_processor_owlv2.py
+++ b/tests/models/owlv2/test_processor_owlv2.py
@@ -14,10 +14,11 @@ from ...test_processing_common import ProcessorTesterMixin
 class Owlv2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Owlv2Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
-        processor = self.processor_class.from_pretrained("google/owlv2-base-patch16-ensemble")
-        processor.save_pretrained(self.tmpdirname)
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
+        processor = cls.processor_class.from_pretrained("google/owlv2-base-patch16-ensemble")
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -147,10 +147,11 @@ class OwlViTVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = OwlViTVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=OwlViTVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = OwlViTVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=OwlViTVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -150,9 +150,7 @@ class OwlViTVisionModelTest(ModelTesterMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model_tester = OwlViTVisionModelTester(cls)
-        cls.config_tester = ConfigTester(
-            cls, config_class=OwlViTVisionConfig, has_text_modality=False, hidden_size=37
-        )
+        cls.config_tester = ConfigTester(cls, config_class=OwlViTVisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/owlvit/test_processor_owlvit.py
+++ b/tests/models/owlvit/test_processor_owlvit.py
@@ -36,19 +36,20 @@ if is_vision_available():
 class OwlViTProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = OwlViTProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab = ["", "l", "o", "w", "e", "r", "s", "t", "i", "d", "n", "lo", "l</w>", "w</w>", "r</w>", "t</w>", "low</w>", "er</w>", "lowest</w>", "newer</w>", "wider", "<unk>", "<|startoftext|>", "<|endoftext|>"]  # fmt: skip
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "l o", "lo w</w>", "e r</w>", ""]
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["merges_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
         image_processor_map = {
@@ -60,8 +61,8 @@ class OwlViTProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "image_mean": [0.48145466, 0.4578275, 0.40821073],
             "image_std": [0.26862954, 0.26130258, 0.27577711],
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/paligemma/test_modeling_paligemma.py
+++ b/tests/models/paligemma/test_modeling_paligemma.py
@@ -186,9 +186,10 @@ class PaliGemmaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = PaliGemmaVisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PaliGemmaConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PaliGemmaVisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PaliGemmaConfig, has_text_modality=False)
 
     # overwrite inputs_embeds tests because we need to delete "pixel values" for LVLMs
     def test_inputs_embeds(self):

--- a/tests/models/paligemma/test_processor_paligemma.py
+++ b/tests/models/paligemma/test_processor_paligemma.py
@@ -33,13 +33,14 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 class PaliGemmaProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = PaliGemmaProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = SiglipImageProcessor.from_pretrained("google/siglip-so400m-patch14-384")
         image_processor.image_seq_length = 0
         tokenizer = GemmaTokenizer(SAMPLE_VOCAB, keep_accents=True)
         processor = PaliGemmaProcessor(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/paligemma2/test_modeling_paligemma2.py
+++ b/tests/models/paligemma2/test_modeling_paligemma2.py
@@ -183,9 +183,10 @@ class PaliGemma2ForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = PaliGemma2VisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PaliGemmaConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PaliGemma2VisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PaliGemmaConfig, has_text_modality=False)
 
     # overwrite inputs_embeds tests because we need to delete "pixel values" for LVLMs
     def test_inputs_embeds(self):

--- a/tests/models/patchtsmixer/test_modeling_patchtsmixer.py
+++ b/tests/models/patchtsmixer/test_modeling_patchtsmixer.py
@@ -233,13 +233,14 @@ class PatchTSMixerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     test_model_parallel = False
     has_attentions = False
 
-    def setUp(self):
-        self.model_tester = PatchTSMixerModelTester()
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PatchTSMixerModelTester()
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=PatchTSMixerConfig,
             has_text_modality=False,
-            prediction_length=self.model_tester.prediction_length,
+            prediction_length=cls.model_tester.prediction_length,
             common_properties=["hidden_size", "expansion_factor", "num_hidden_layers"],
         )
 

--- a/tests/models/patchtst/test_modeling_patchtst.py
+++ b/tests/models/patchtst/test_modeling_patchtst.py
@@ -172,13 +172,14 @@ class PatchTSTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_model_parallel = False
     has_attentions = True
 
-    def setUp(self):
-        self.model_tester = PatchTSTModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PatchTSTModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=PatchTSTConfig,
             has_text_modality=False,
-            prediction_length=self.model_tester.prediction_length,
+            prediction_length=cls.model_tester.prediction_length,
         )
 
     def test_config(self):

--- a/tests/models/pegasus/test_modeling_pegasus.py
+++ b/tests/models/pegasus/test_modeling_pegasus.py
@@ -252,9 +252,10 @@ class PegasusModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     test_pruning = False
     test_missing_keys = False
 
-    def setUp(self):
-        self.model_tester = PegasusModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PegasusConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PegasusModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PegasusConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/pegasus_x/test_modeling_pegasus_x.py
+++ b/tests/models/pegasus_x/test_modeling_pegasus_x.py
@@ -218,9 +218,10 @@ class PegasusXModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     test_head_masking = False
     test_missing_keys = False
 
-    def setUp(self):
-        self.model_tester = PegasusXModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PegasusXConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PegasusXModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PegasusXConfig)
 
     @unittest.skip(
         "`PegasusXGlobalLocalAttention` returns attentions as dictionary - not compatible with torchscript "

--- a/tests/models/perceiver/test_modeling_perceiver.py
+++ b/tests/models/perceiver/test_modeling_perceiver.py
@@ -313,13 +313,14 @@ class PerceiverModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
 
     maxDiff = None
 
-    def setUp(self):
-        self.model_tester = PerceiverModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PerceiverModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=PerceiverConfig,
             hidden_size=37,
-            common_properties=["d_model", "num_self_attention_heads", "num_cross_attention_heads"],
+            common_properties=["d_model", "num_cls_attention_heads", "num_cross_attention_heads"],
         )
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):

--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -300,9 +300,10 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     test_pruning = False
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Persimmon
-    def setUp(self):
-        self.model_tester = PersimmonModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PersimmonConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PersimmonModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PersimmonConfig, hidden_size=37)
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_config
     def test_config(self):

--- a/tests/models/persimmon/test_modeling_persimmon.py
+++ b/tests/models/persimmon/test_modeling_persimmon.py
@@ -299,7 +299,6 @@ class PersimmonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     test_headmasking = False
     test_pruning = False
 
-    # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Persimmon
     @classmethod
     def setUpClass(cls):
         cls.model_tester = PersimmonModelTester(cls)

--- a/tests/models/phi/test_modeling_phi.py
+++ b/tests/models/phi/test_modeling_phi.py
@@ -307,9 +307,10 @@ class PhiModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
         return True
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Phi
-    def setUp(self):
-        self.model_tester = PhiModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PhiConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PhiModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PhiConfig, hidden_size=37)
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_config
     def test_config(self):

--- a/tests/models/phi/test_modeling_phi.py
+++ b/tests/models/phi/test_modeling_phi.py
@@ -306,7 +306,6 @@ class PhiModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     ):
         return True
 
-    # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Phi
     @classmethod
     def setUpClass(cls):
         cls.model_tester = PhiModelTester(cls)

--- a/tests/models/phi3/test_modeling_phi3.py
+++ b/tests/models/phi3/test_modeling_phi3.py
@@ -362,7 +362,6 @@ class Phi3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     ):
         return True
 
-    # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Phi3
     @classmethod
     def setUpClass(cls):
         cls.model_tester = Phi3ModelTester(cls)

--- a/tests/models/phi3/test_modeling_phi3.py
+++ b/tests/models/phi3/test_modeling_phi3.py
@@ -363,9 +363,10 @@ class Phi3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
         return True
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Phi3
-    def setUp(self):
-        self.model_tester = Phi3ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Phi3Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Phi3ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Phi3Config, hidden_size=37)
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_config
     def test_config(self):

--- a/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
+++ b/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
@@ -215,9 +215,10 @@ class Phi4MultimodalModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = Phi4MultimodalModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Phi4MultimodalConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Phi4MultimodalModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Phi4MultimodalConfig)
 
     @unittest.skip(reason="Unstable test")
     def test_initialization(self):

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -360,9 +360,10 @@ class PhimoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         return True
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Phimoe
-    def setUp(self):
-        self.model_tester = PhimoeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PhimoeConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PhimoeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PhimoeConfig, hidden_size=37)
 
     # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.test_config
     def test_config(self):

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -359,7 +359,6 @@ class PhimoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     ):
         return True
 
-    # Copied from tests.models.llama.test_modeling_llama.LlamaModelTest.setUp with Llama->Phimoe
     @classmethod
     def setUpClass(cls):
         cls.model_tester = PhimoeModelTester(cls)

--- a/tests/models/pix2struct/test_modeling_pix2struct.py
+++ b/tests/models/pix2struct/test_modeling_pix2struct.py
@@ -150,10 +150,11 @@ class Pix2StructVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Pix2StructVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Pix2StructVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Pix2StructVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Pix2StructVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/pix2struct/test_processor_pix2struct.py
+++ b/tests/models/pix2struct/test_processor_pix2struct.py
@@ -40,15 +40,16 @@ class Pix2StructProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     text_input_name = "decoder_input_ids"
     images_input_name = "flattened_patches"
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         image_processor = Pix2StructImageProcessor()
         tokenizer = T5Tokenizer.from_pretrained("google-t5/t5-small")
 
         processor = Pix2StructProcessor(image_processor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/pixtral/test_modeling_pixtral.py
+++ b/tests/models/pixtral/test_modeling_pixtral.py
@@ -141,9 +141,10 @@ class PixtralVisionModelModelTest(ModelTesterMixin, unittest.TestCase):
     test_torchscript = False
     test_resize_embeddings = False
 
-    def setUp(self):
-        self.model_tester = PixtralVisionModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PixtralVisionConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PixtralVisionModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PixtralVisionConfig, has_text_modality=False)
 
     def test_model_get_set_embeddings(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/plbart/test_modeling_plbart.py
+++ b/tests/models/plbart/test_modeling_plbart.py
@@ -260,9 +260,10 @@ class PLBartModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
 
         return False
 
-    def setUp(self):
-        self.model_tester = PLBartModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=PLBartConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PLBartModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=PLBartConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/poolformer/test_modeling_poolformer.py
+++ b/tests/models/poolformer/test_modeling_poolformer.py
@@ -134,9 +134,10 @@ class PoolFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = PoolFormerModelTester(self)
-        self.config_tester = PoolFormerConfigTester(self, config_class=PoolFormerConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PoolFormerModelTester(cls)
+        cls.config_tester = PoolFormerConfigTester(cls, config_class=PoolFormerConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/pop2piano/test_feature_extraction_pop2piano.py
+++ b/tests/models/pop2piano/test_feature_extraction_pop2piano.py
@@ -91,8 +91,9 @@ class Pop2PianoFeatureExtractionTester:
 class Pop2PianoFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = Pop2PianoFeatureExtractor if requirements_available else None
 
-    def setUp(self):
-        self.feat_extract_tester = Pop2PianoFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = Pop2PianoFeatureExtractionTester(cls)
 
     def test_feat_extract_from_and_save_pretrained(self):
         feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)

--- a/tests/models/pop2piano/test_modeling_pop2piano.py
+++ b/tests/models/pop2piano/test_modeling_pop2piano.py
@@ -517,9 +517,10 @@ class Pop2PianoModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_model_parallel = False
     is_encoder_decoder = True
 
-    def setUp(self):
-        self.model_tester = Pop2PianoModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Pop2PianoConfig, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Pop2PianoModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Pop2PianoConfig, d_model=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/pop2piano/test_processor_pop2piano.py
+++ b/tests/models/pop2piano/test_processor_pop2piano.py
@@ -62,14 +62,15 @@ if requirements_available:
 @require_essentia
 @require_pretty_midi
 class Pop2PianoProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         feature_extractor = Pop2PianoFeatureExtractor.from_pretrained("sweetcocoa/pop2piano")
         tokenizer = Pop2PianoTokenizer.from_pretrained("sweetcocoa/pop2piano")
         processor = Pop2PianoProcessor(feature_extractor, tokenizer)
 
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return Pop2PianoTokenizer.from_pretrained(self.tmpdirname, **kwargs)

--- a/tests/models/prompt_depth_anything/test_modeling_prompt_depth_anything.py
+++ b/tests/models/prompt_depth_anything/test_modeling_prompt_depth_anything.py
@@ -147,10 +147,11 @@ class PromptDepthAnythingModelTest(ModelTesterMixin, PipelineTesterMixin, unitte
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = PromptDepthAnythingModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PromptDepthAnythingModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=PromptDepthAnythingConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/prophetnet/test_modeling_prophetnet.py
+++ b/tests/models/prophetnet/test_modeling_prophetnet.py
@@ -922,9 +922,10 @@ class ProphetNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
 
         return False
 
-    def setUp(self):
-        self.model_tester = ProphetNetModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ProphetNetConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ProphetNetModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ProphetNetConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/pvt/test_modeling_pvt.py
+++ b/tests/models/pvt/test_modeling_pvt.py
@@ -168,9 +168,10 @@ class PvtModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = PvtModelTester(self)
-        self.config_tester = PvtConfigTester(self, config_class=PvtConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PvtModelTester(cls)
+        cls.config_tester = PvtConfigTester(cls, config_class=PvtConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/pvt_v2/test_modeling_pvt_v2.py
+++ b/tests/models/pvt_v2/test_modeling_pvt_v2.py
@@ -204,9 +204,10 @@ class PvtV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = PvtV2ModelTester(self)
-        self.config_tester = PvtV2ConfigTester(self, config_class=PvtV2Config)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = PvtV2ModelTester(cls)
+        cls.config_tester = PvtV2ConfigTester(cls, config_class=PvtV2Config)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/qwen2/test_modeling_qwen2.py
+++ b/tests/models/qwen2/test_modeling_qwen2.py
@@ -341,9 +341,10 @@ class Qwen2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = Qwen2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen2Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -233,9 +233,10 @@ class Qwen2_5_VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
     test_pruning = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = Qwen2_5_VLVisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen2_5_VLConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen2_5_VLVisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen2_5_VLConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/qwen2_5_vl/test_processor_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processor_qwen2_5_vl.py
@@ -36,10 +36,11 @@ if is_vision_available():
 class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2_5_VLProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         processor = Qwen2_5_VLProcessor.from_pretrained("Qwen/Qwen2-VL-7B-Instruct", patch_size=4)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/qwen2_audio/test_modeling_qwen2_audio.py
+++ b/tests/models/qwen2_audio/test_modeling_qwen2_audio.py
@@ -158,9 +158,10 @@ class Qwen2AudioForConditionalGenerationModelTest(ModelTesterMixin, unittest.Tes
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = Qwen2AudioModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen2AudioConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen2AudioModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen2AudioConfig, has_text_modality=False)
 
     @unittest.skip(reason="Compile not yet supported because in Qwen2Audio models")
     def test_sdpa_can_compile_dynamic(self):

--- a/tests/models/qwen2_audio/test_processor_qwen2_audio.py
+++ b/tests/models/qwen2_audio/test_processor_qwen2_audio.py
@@ -32,13 +32,14 @@ if is_torch_available:
 class Qwen2AudioProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2AudioProcessor
 
-    def setUp(self):
-        self.checkpoint = "Qwen/Qwen2-Audio-7B-Instruct"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "Qwen/Qwen2-Audio-7B-Instruct"
+        cls.tmpdirname = tempfile.mkdtemp()
 
-        processor_kwargs = self.prepare_processor_dict()
-        processor = Qwen2AudioProcessor.from_pretrained(self.checkpoint, **processor_kwargs)
-        processor.save_pretrained(self.tmpdirname)
+        processor_kwargs = cls.prepare_processor_dict()
+        processor = Qwen2AudioProcessor.from_pretrained(cls.checkpoint, **processor_kwargs)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
+++ b/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
@@ -369,9 +369,10 @@ class Qwen2MoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = Qwen2MoeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen2MoeConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen2MoeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen2MoeConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
@@ -230,9 +230,10 @@ class Qwen2VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = Qwen2VLVisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen2VLConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen2VLVisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen2VLConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/qwen2_vl/test_processor_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processor_qwen2_vl.py
@@ -36,10 +36,11 @@ if is_vision_available():
 class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Qwen2VLProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         processor = Qwen2VLProcessor.from_pretrained("Qwen/Qwen2-VL-7B-Instruct", patch_size=4)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer

--- a/tests/models/qwen3/test_modeling_qwen3.py
+++ b/tests/models/qwen3/test_modeling_qwen3.py
@@ -344,9 +344,10 @@ class Qwen3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = Qwen3ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen3Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen3ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen3Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/qwen3_moe/test_modeling_qwen3_moe.py
+++ b/tests/models/qwen3_moe/test_modeling_qwen3_moe.py
@@ -363,9 +363,10 @@ class Qwen3MoeModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = Qwen3MoeModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen3MoeConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Qwen3MoeModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Qwen3MoeConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/rag/test_retrieval_rag.py
+++ b/tests/models/rag/test_retrieval_rag.py
@@ -40,9 +40,10 @@ if is_faiss_available():
 
 @require_faiss
 class RagRetrieverTest(TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
-        self.retrieval_vector_size = 8
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.retrieval_vector_size = 8
 
         # DPR tok
         vocab_tokens = [
@@ -62,10 +63,10 @@ class RagRetrieverTest(TestCase):
             "low",
             "lowest",
         ]
-        dpr_tokenizer_path = os.path.join(self.tmpdirname, "dpr_tokenizer")
+        dpr_tokenizer_path = os.path.join(cls.tmpdirname, "dpr_tokenizer")
         os.makedirs(dpr_tokenizer_path, exist_ok=True)
-        self.vocab_file = os.path.join(dpr_tokenizer_path, DPR_VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(dpr_tokenizer_path, DPR_VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         # BART tok
@@ -93,15 +94,15 @@ class RagRetrieverTest(TestCase):
         ]
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "\u0120 l", "\u0120l o", "\u0120lo w", "e r", ""]
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        bart_tokenizer_path = os.path.join(self.tmpdirname, "bart_tokenizer")
+        bart_tokenizer_path = os.path.join(cls.tmpdirname, "bart_tokenizer")
         os.makedirs(bart_tokenizer_path, exist_ok=True)
-        self.vocab_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["merges_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
     def get_dpr_tokenizer(self) -> DPRQuestionEncoderTokenizer:

--- a/tests/models/rag/test_tokenization_rag.py
+++ b/tests/models/rag/test_tokenization_rag.py
@@ -35,9 +35,10 @@ if is_torch_available() and is_datasets_available() and is_faiss_available():
 @require_faiss
 @require_torch
 class RagTokenizerTest(TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
-        self.retrieval_vector_size = 8
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.retrieval_vector_size = 8
 
         # DPR tok
         vocab_tokens = [
@@ -57,10 +58,10 @@ class RagTokenizerTest(TestCase):
             "low",
             "lowest",
         ]
-        dpr_tokenizer_path = os.path.join(self.tmpdirname, "dpr_tokenizer")
+        dpr_tokenizer_path = os.path.join(cls.tmpdirname, "dpr_tokenizer")
         os.makedirs(dpr_tokenizer_path, exist_ok=True)
-        self.vocab_file = os.path.join(dpr_tokenizer_path, DPR_VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(dpr_tokenizer_path, DPR_VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         # BART tok
@@ -88,15 +89,15 @@ class RagTokenizerTest(TestCase):
         ]
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
         merges = ["#version: 0.2", "\u0120 l", "\u0120l o", "\u0120lo w", "e r", ""]
-        self.special_tokens_map = {"unk_token": "<unk>"}
+        cls.special_tokens_map = {"unk_token": "<unk>"}
 
-        bart_tokenizer_path = os.path.join(self.tmpdirname, "bart_tokenizer")
+        bart_tokenizer_path = os.path.join(cls.tmpdirname, "bart_tokenizer")
         os.makedirs(bart_tokenizer_path, exist_ok=True)
-        self.vocab_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["vocab_file"])
-        self.merges_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["merges_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.vocab_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["vocab_file"])
+        cls.merges_file = os.path.join(bart_tokenizer_path, BART_VOCAB_FILES_NAMES["merges_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
-        with open(self.merges_file, "w", encoding="utf-8") as fp:
+        with open(cls.merges_file, "w", encoding="utf-8") as fp:
             fp.write("\n".join(merges))
 
     def get_dpr_tokenizer(self) -> DPRQuestionEncoderTokenizer:

--- a/tests/models/recurrent_gemma/test_modeling_recurrent_gemma.py
+++ b/tests/models/recurrent_gemma/test_modeling_recurrent_gemma.py
@@ -318,11 +318,12 @@ class RecurrentGemmaModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Te
     ):
         return True
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         # We don't output attentions
-        self.has_attentions = False
-        self.model_tester = RecurrentGemmaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=RecurrentGemmaConfig, hidden_size=37)
+        cls.has_attentions = False
+        cls.model_tester = RecurrentGemmaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=RecurrentGemmaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/reformer/test_modeling_reformer.py
+++ b/tests/models/reformer/test_modeling_reformer.py
@@ -608,9 +608,10 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, GenerationTesterMixin, Mod
     test_torchscript = False
     test_sequence_classification_problem_types = True
 
-    def setUp(self):
-        self.model_tester = ReformerModelTester(self, text_seq_length=16)
-        self.config_tester = ConfigTester(self, config_class=ReformerConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ReformerModelTester(cls, text_seq_length=16)
+        cls.config_tester = ConfigTester(cls, config_class=ReformerConfig, hidden_size=37)
 
     @slow
     def test_model_from_pretrained(self):

--- a/tests/models/regnet/test_modeling_regnet.py
+++ b/tests/models/regnet/test_modeling_regnet.py
@@ -135,10 +135,11 @@ class RegNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = RegNetModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RegNetModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=RegNetConfig,
             has_text_modality=False,
             common_properties=["num_channels", "hidden_sizes"],

--- a/tests/models/rembert/test_modeling_rembert.py
+++ b/tests/models/rembert/test_modeling_rembert.py
@@ -389,9 +389,10 @@ class RemBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = RemBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=RemBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RemBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=RemBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/resnet/test_modeling_resnet.py
+++ b/tests/models/resnet/test_modeling_resnet.py
@@ -180,10 +180,11 @@ class ResNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ResNetModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ResNetModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=ResNetConfig,
             has_text_modality=False,
             common_properties=["num_channels", "hidden_sizes"],

--- a/tests/models/roberta/test_modeling_roberta.py
+++ b/tests/models/roberta/test_modeling_roberta.py
@@ -396,9 +396,10 @@ class RobertaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     fx_compatible = True
     model_split_percents = [0.5, 0.8, 0.9]
 
-    def setUp(self):
-        self.model_tester = RobertaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=RobertaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RobertaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=RobertaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/roberta_prelayernorm/test_modeling_roberta_prelayernorm.py
+++ b/tests/models/roberta_prelayernorm/test_modeling_roberta_prelayernorm.py
@@ -395,9 +395,10 @@ class RobertaPreLayerNormModelTest(ModelTesterMixin, GenerationTesterMixin, Pipe
     model_split_percents = [0.5, 0.8, 0.9]
 
     # Copied from tests.models.roberta.test_modeling_roberta.RobertaModelTest.setUp with Roberta->RobertaPreLayerNorm
-    def setUp(self):
-        self.model_tester = RobertaPreLayerNormModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=RobertaPreLayerNormConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RobertaPreLayerNormModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=RobertaPreLayerNormConfig, hidden_size=37)
 
     # Copied from tests.models.roberta.test_modeling_roberta.RobertaModelTest.test_config
     def test_config(self):

--- a/tests/models/roberta_prelayernorm/test_modeling_roberta_prelayernorm.py
+++ b/tests/models/roberta_prelayernorm/test_modeling_roberta_prelayernorm.py
@@ -394,7 +394,6 @@ class RobertaPreLayerNormModelTest(ModelTesterMixin, GenerationTesterMixin, Pipe
     fx_compatible = False
     model_split_percents = [0.5, 0.8, 0.9]
 
-    # Copied from tests.models.roberta.test_modeling_roberta.RobertaModelTest.setUp with Roberta->RobertaPreLayerNorm
     @classmethod
     def setUpClass(cls):
         cls.model_tester = RobertaPreLayerNormModelTester(cls)

--- a/tests/models/roc_bert/test_modeling_roc_bert.py
+++ b/tests/models/roc_bert/test_modeling_roc_bert.py
@@ -637,9 +637,10 @@ class RoCBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
                 )
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = RoCBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=RoCBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RoCBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=RoCBertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/roformer/test_modeling_roformer.py
+++ b/tests/models/roformer/test_modeling_roformer.py
@@ -408,9 +408,10 @@ class RoFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = RoFormerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=RoFormerConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RoFormerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=RoFormerConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/rt_detr/test_modeling_rt_detr.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr.py
@@ -283,10 +283,11 @@ class RTDetrModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = RTDetrModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RTDetrModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=RTDetrConfig,
             has_text_modality=False,
             common_properties=["hidden_size", "num_attention_heads"],

--- a/tests/models/rt_detr/test_modeling_rt_detr_resnet.py
+++ b/tests/models/rt_detr/test_modeling_rt_detr_resnet.py
@@ -126,5 +126,6 @@ class RTDetrResNetBackboneTest(BackboneTesterMixin, unittest.TestCase):
     has_attentions = False
     config_class = RTDetrResNetConfig
 
-    def setUp(self):
-        self.model_tester = RTDetrResNetModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RTDetrResNetModelTester(cls)

--- a/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
+++ b/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
@@ -281,10 +281,11 @@ class RTDetrV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = RTDetrV2ModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RTDetrV2ModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=RTDetrV2Config,
             has_text_modality=False,
             common_properties=["hidden_size", "num_attention_heads"],

--- a/tests/models/rwkv/test_modeling_rwkv.py
+++ b/tests/models/rwkv/test_modeling_rwkv.py
@@ -240,10 +240,11 @@ class RwkvModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_pruning = False
     test_head_masking = False  # Rwkv does not support head masking
 
-    def setUp(self):
-        self.model_tester = RwkvModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=RwkvConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = RwkvModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=RwkvConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
 
     def assertInterval(self, member, container, msg=None):

--- a/tests/models/sam/test_modeling_sam.py
+++ b/tests/models/sam/test_modeling_sam.py
@@ -165,9 +165,10 @@ class SamVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_torchscript = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = SamVisionModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SamVisionConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SamVisionModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SamVisionConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/sam/test_processor_sam.py
+++ b/tests/models/sam/test_processor_sam.py
@@ -49,11 +49,12 @@ if is_tf_available():
 class SamProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = SamProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = SamImageProcessor()
         processor = SamProcessor(image_processor)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_image_processor(self, **kwargs):
         return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).image_processor

--- a/tests/models/seamless_m4t/test_feature_extraction_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_feature_extraction_seamless_m4t.py
@@ -112,8 +112,9 @@ class SeamlessM4TFeatureExtractionTester:
 class SeamlessM4TFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = SeamlessM4TFeatureExtractor if is_speech_available() else None
 
-    def setUp(self):
-        self.feat_extract_tester = SeamlessM4TFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = SeamlessM4TFeatureExtractionTester(cls)
 
     def test_feat_extract_from_and_save_pretrained(self):
         feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)

--- a/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_modeling_seamless_m4t.py
@@ -360,9 +360,10 @@ class SeamlessM4TModelWithSpeechInputTest(ModelTesterMixin, unittest.TestCase):
     # Doesn't run generation tests. Custom generation method with a different interface
     all_generative_model_classes = ()
 
-    def setUp(self):
-        self.model_tester = SeamlessM4TModelTester(self, input_modality="speech")
-        self.config_tester = ConfigTester(self, config_class=SeamlessM4TConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SeamlessM4TModelTester(cls, input_modality="speech")
+        cls.config_tester = ConfigTester(cls, config_class=SeamlessM4TConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/seamless_m4t/test_processor_seamless_m4t.py
+++ b/tests/models/seamless_m4t/test_processor_seamless_m4t.py
@@ -28,9 +28,10 @@ from .test_feature_extraction_seamless_m4t import floats_list
 
 @require_torch
 class SeamlessM4TProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.checkpoint = "facebook/hf-seamless-m4t-medium"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "facebook/hf-seamless-m4t-medium"
+        cls.tmpdirname = tempfile.mkdtemp()
 
     def get_tokenizer(self, **kwargs):
         return SeamlessM4TTokenizer.from_pretrained(self.checkpoint, **kwargs)

--- a/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
+++ b/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
@@ -376,9 +376,10 @@ class SeamlessM4Tv2ModelWithSpeechInputTest(ModelTesterMixin, unittest.TestCase)
     # Doesn't run generation tests. Has custom generation method with a different interface
     all_generative_model_classes = ()
 
-    def setUp(self):
-        self.model_tester = SeamlessM4Tv2ModelTester(self, input_modality="speech")
-        self.config_tester = ConfigTester(self, config_class=SeamlessM4Tv2Config)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SeamlessM4Tv2ModelTester(cls, input_modality="speech")
+        cls.config_tester = ConfigTester(cls, config_class=SeamlessM4Tv2Config)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/segformer/test_modeling_segformer.py
+++ b/tests/models/segformer/test_modeling_segformer.py
@@ -182,9 +182,10 @@ class SegformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     test_resize_embeddings = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = SegformerModelTester(self)
-        self.config_tester = SegformerConfigTester(self, config_class=SegformerConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SegformerModelTester(cls)
+        cls.config_tester = SegformerConfigTester(cls, config_class=SegformerConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/seggpt/test_modeling_seggpt.py
+++ b/tests/models/seggpt/test_modeling_seggpt.py
@@ -178,9 +178,10 @@ class SegGptModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         {"feature-extraction": SegGptModel, "mask-generation": SegGptModel} if is_torch_available() else {}
     )
 
-    def setUp(self):
-        self.model_tester = SegGptModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SegGptConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SegGptModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SegGptConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/sew/test_modeling_sew.py
+++ b/tests/models/sew/test_modeling_sew.py
@@ -313,9 +313,10 @@ class SEWModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = SEWModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SEWConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SEWModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SEWConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/sew_d/test_modeling_sew_d.py
+++ b/tests/models/sew_d/test_modeling_sew_d.py
@@ -335,9 +335,10 @@ class SEWDModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_headmasking = False
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = SEWDModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SEWDConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SEWDModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SEWDConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/shieldgemma2/test_processing_shieldgemma2.py
+++ b/tests/models/shieldgemma2/test_processing_shieldgemma2.py
@@ -72,8 +72,9 @@ _SHIELDGEMMA2_POLICIES: Mapping[str, str] = {
 class ShieldGemma2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = ShieldGemma2Processor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = Gemma3ImageProcessor.from_pretrained("google/siglip-so400m-patch14-384")
 
         extra_special_tokens = {
@@ -83,9 +84,9 @@ class ShieldGemma2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         }
         tokenizer = GemmaTokenizer(SAMPLE_VOCAB, keep_accents=True, extra_special_tokens=extra_special_tokens)
 
-        processor_kwargs = self.prepare_processor_dict()
+        processor_kwargs = cls.prepare_processor_dict()
         processor = ShieldGemma2Processor(image_processor=image_processor, tokenizer=tokenizer, **processor_kwargs)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/siglip/test_modeling_siglip.py
+++ b/tests/models/siglip/test_modeling_siglip.py
@@ -193,10 +193,11 @@ class SiglipVisionModelTest(SiglipModelTesterMixin, unittest.TestCase):
     test_disk_offload_safetensors = False
     test_disk_offload_bin = False
 
-    def setUp(self):
-        self.model_tester = SiglipVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=SiglipVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SiglipVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=SiglipVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/siglip/test_modeling_siglip.py
+++ b/tests/models/siglip/test_modeling_siglip.py
@@ -196,9 +196,7 @@ class SiglipVisionModelTest(SiglipModelTesterMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model_tester = SiglipVisionModelTester(cls)
-        cls.config_tester = ConfigTester(
-            cls, config_class=SiglipVisionConfig, has_text_modality=False, hidden_size=37
-        )
+        cls.config_tester = ConfigTester(cls, config_class=SiglipVisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/siglip2/test_modeling_siglip2.py
+++ b/tests/models/siglip2/test_modeling_siglip2.py
@@ -282,10 +282,11 @@ class Siglip2VisionModelTest(Siglip2ModelTesterMixin, unittest.TestCase):
     test_disk_offload_safetensors = False
     test_disk_offload_bin = False
 
-    def setUp(self):
-        self.model_tester = Siglip2VisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=Siglip2VisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Siglip2VisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=Siglip2VisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/smolvlm/test_modeling_smolvlm.py
+++ b/tests/models/smolvlm/test_modeling_smolvlm.py
@@ -173,10 +173,11 @@ class SmolVLMModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = True
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = SmolVLMVisionText2TextModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=SmolVLMConfig, has_text_modality=False, common_properties=["image_token_id"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SmolVLMVisionText2TextModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=SmolVLMConfig, has_text_modality=False, common_properties=["image_token_id"]
         )
 
     def test_config(self):

--- a/tests/models/speech_to_text/test_feature_extraction_speech_to_text.py
+++ b/tests/models/speech_to_text/test_feature_extraction_speech_to_text.py
@@ -106,8 +106,9 @@ class Speech2TextFeatureExtractionTester:
 class Speech2TextFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = Speech2TextFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = Speech2TextFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = Speech2TextFeatureExtractionTester(cls)
 
     def _check_zero_mean_unit_variance(self, input_vector):
         self.assertTrue(np.all(np.mean(input_vector, axis=0) < 1e-3))

--- a/tests/models/speech_to_text/test_modeling_speech_to_text.py
+++ b/tests/models/speech_to_text/test_modeling_speech_to_text.py
@@ -281,10 +281,11 @@ class Speech2TextModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTest
     test_pruning = False
     test_missing_keys = False
 
-    def setUp(self):
-        self.model_tester = Speech2TextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Speech2TextConfig)
-        self.maxDiff = 3000
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Speech2TextModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Speech2TextConfig)
+        cls.maxDiff = 3000
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/speech_to_text/test_processor_speech_to_text.py
+++ b/tests/models/speech_to_text/test_processor_speech_to_text.py
@@ -33,18 +33,19 @@ SAMPLE_SP = get_tests_dir("fixtures/test_sentencepiece.model")
 @require_torchaudio
 @require_sentencepiece
 class Speech2TextProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab = ["<s>", "<pad>", "</s>", "<unk>", "▁This", "▁is", "▁a", "▁t", "est"]
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
-        save_dir = Path(self.tmpdirname)
+        save_dir = Path(cls.tmpdirname)
         save_json(vocab_tokens, save_dir / VOCAB_FILES_NAMES["vocab_file"])
         if not (save_dir / VOCAB_FILES_NAMES["spm_file"]).exists():
             copyfile(SAMPLE_SP, save_dir / VOCAB_FILES_NAMES["spm_file"])
 
-        tokenizer = Speech2TextTokenizer.from_pretrained(self.tmpdirname)
-        tokenizer.save_pretrained(self.tmpdirname)
+        tokenizer = Speech2TextTokenizer.from_pretrained(cls.tmpdirname)
+        tokenizer.save_pretrained(cls.tmpdirname)
 
         feature_extractor_map = {
             "feature_size": 24,

--- a/tests/models/speecht5/test_feature_extraction_speecht5.py
+++ b/tests/models/speecht5/test_feature_extraction_speecht5.py
@@ -142,8 +142,9 @@ class SpeechT5FeatureExtractionTester:
 class SpeechT5FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = SpeechT5FeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = SpeechT5FeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = SpeechT5FeatureExtractionTester(cls)
 
     def _check_zero_mean_unit_variance(self, input_vector):
         self.assertTrue(np.all(np.mean(input_vector, axis=0) < 1e-3))

--- a/tests/models/speecht5/test_modeling_speecht5.py
+++ b/tests/models/speecht5/test_modeling_speecht5.py
@@ -177,9 +177,10 @@ class SpeechT5ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_headmasking = False
     test_resize_embeddings = False
 
-    def setUp(self):
-        self.model_tester = SpeechT5ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SpeechT5Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SpeechT5ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SpeechT5Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/speecht5/test_processor_speecht5.py
+++ b/tests/models/speecht5/test_processor_speecht5.py
@@ -36,11 +36,12 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece_bpe_char.model")
 
 @require_torch
 class SpeechT5ProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         tokenizer = SpeechT5Tokenizer(SAMPLE_VOCAB)
-        tokenizer.save_pretrained(self.tmpdirname)
+        tokenizer.save_pretrained(cls.tmpdirname)
 
         feature_extractor_map = {
             "feature_size": 1,
@@ -58,8 +59,8 @@ class SpeechT5ProcessorTest(unittest.TestCase):
             "return_attention_mask": True,
         }
 
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(feature_extractor_map) + "\n")
 
     def get_tokenizer(self, **kwargs):

--- a/tests/models/splinter/test_modeling_splinter.py
+++ b/tests/models/splinter/test_modeling_splinter.py
@@ -273,9 +273,10 @@ class SplinterModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = SplinterModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SplinterConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SplinterModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SplinterConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/splinter/test_tokenization_splinter.py
+++ b/tests/models/splinter/test_tokenization_splinter.py
@@ -40,7 +40,6 @@ class SplinterTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     test_sentencepiece_ignore_case = False
     pre_trained_model_path = "tau/splinter-base"
 
-    # Copied from transformers.models.siglip.SiglipTokenizationTest.setUp
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/tests/models/squeezebert/test_modeling_squeezebert.py
+++ b/tests/models/squeezebert/test_modeling_squeezebert.py
@@ -243,9 +243,10 @@ class SqueezeBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     test_resize_embeddings = True
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = SqueezeBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SqueezeBertConfig, dim=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SqueezeBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SqueezeBertConfig, dim=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/stablelm/test_modeling_stablelm.py
+++ b/tests/models/stablelm/test_modeling_stablelm.py
@@ -302,9 +302,10 @@ class StableLmModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = StableLmModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=StableLmConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = StableLmModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=StableLmConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/starcoder2/test_modeling_starcoder2.py
+++ b/tests/models/starcoder2/test_modeling_starcoder2.py
@@ -321,9 +321,10 @@ class Starcoder2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = Starcoder2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Starcoder2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Starcoder2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Starcoder2Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/superglue/test_modeling_superglue.py
+++ b/tests/models/superglue/test_modeling_superglue.py
@@ -126,9 +126,10 @@ class SuperGlueModelTest(ModelTesterMixin, unittest.TestCase):
     test_head_masking = False
     has_attentions = True
 
-    def setUp(self):
-        self.model_tester = SuperGlueModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SuperGlueConfig, has_text_modality=False, hidden_size=64)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SuperGlueModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SuperGlueConfig, has_text_modality=False, hidden_size=64)
 
     def test_config(self):
         self.config_tester.create_and_test_config_to_json_string()

--- a/tests/models/superpoint/test_modeling_superpoint.py
+++ b/tests/models/superpoint/test_modeling_superpoint.py
@@ -121,10 +121,11 @@ class SuperPointModelTest(ModelTesterMixin, unittest.TestCase):
     has_attentions = False
     from_pretrained_id = "magic-leap-community/superpoint"
 
-    def setUp(self):
-        self.model_tester = SuperPointModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SuperPointModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=SuperPointConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/swiftformer/test_modeling_swiftformer.py
+++ b/tests/models/swiftformer/test_modeling_swiftformer.py
@@ -149,10 +149,11 @@ class SwiftFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = SwiftFormerModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SwiftFormerModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=SwiftFormerConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/swin/test_modeling_swin.py
+++ b/tests/models/swin/test_modeling_swin.py
@@ -242,10 +242,11 @@ class SwinModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = SwinModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SwinModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=SwinConfig,
             embed_dim=37,
             has_text_modality=False,

--- a/tests/models/swin2sr/test_modeling_swin2sr.py
+++ b/tests/models/swin2sr/test_modeling_swin2sr.py
@@ -174,10 +174,11 @@ class Swin2SRModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     test_torchscript = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = Swin2SRModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Swin2SRModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=Swin2SRConfig,
             embed_dim=37,
             has_text_modality=False,

--- a/tests/models/swinv2/test_modeling_swinv2.py
+++ b/tests/models/swinv2/test_modeling_swinv2.py
@@ -228,10 +228,11 @@ class Swinv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = Swinv2ModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Swinv2ModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=Swinv2Config,
             embed_dim=37,
             has_text_modality=False,

--- a/tests/models/switch_transformers/test_modeling_switch_transformers.py
+++ b/tests/models/switch_transformers/test_modeling_switch_transformers.py
@@ -578,9 +578,10 @@ class SwitchTransformersModelTest(ModelTesterMixin, GenerationTesterMixin, Pipel
     # `SwitchTransformers` is a MOE in which not all experts will get gradients because they are not all used in a single forward pass
     test_all_params_have_gradient = False
 
-    def setUp(self):
-        self.model_tester = SwitchTransformersModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=SwitchTransformersConfig, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = SwitchTransformersModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=SwitchTransformersConfig, d_model=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -579,9 +579,10 @@ class T5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, 
     # The small T5 model needs higher percentages for CPU/MP tests
     model_split_percents = [0.5, 0.8, 0.9]
 
-    def setUp(self):
-        self.model_tester = T5ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=T5Config, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = T5ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=T5Config, d_model=37)
 
     # `QAPipelineTests` is not working well with slow tokenizers (for some models) and we don't want to touch the file
     # `src/transformers/data/processors/squad.py` (where this test fails for this model)

--- a/tests/models/table_transformer/test_modeling_table_transformer.py
+++ b/tests/models/table_transformer/test_modeling_table_transformer.py
@@ -237,9 +237,10 @@ class TableTransformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = TableTransformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=TableTransformerConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TableTransformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=TableTransformerConfig, has_text_modality=False)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/tapas/test_modeling_tapas.py
+++ b/tests/models/tapas/test_modeling_tapas.py
@@ -499,9 +499,10 @@ class TapasModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     ):
         return True
 
-    def setUp(self):
-        self.model_tester = TapasModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=TapasConfig, dim=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TapasModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=TapasConfig, dim=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/textnet/test_modeling_textnet.py
+++ b/tests/models/textnet/test_modeling_textnet.py
@@ -220,9 +220,10 @@ class TextNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     test_torch_exportable = True
     has_attentions = False
 
-    def setUp(self):
-        self.model_tester = TextNetModelTester(self)
-        self.config_tester = TextNetConfigTester(self, config_class=TextNetConfig, has_text_modality=False)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TextNetModelTester(cls)
+        cls.config_tester = TextNetConfigTester(cls, config_class=TextNetConfig, has_text_modality=False)
 
     @unittest.skip(reason="TextNet does not output attentions")
     def test_attention_outputs(self):

--- a/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
+++ b/tests/models/time_series_transformer/test_modeling_time_series_transformer.py
@@ -187,13 +187,14 @@ class TimeSeriesTransformerModelTest(ModelTesterMixin, PipelineTesterMixin, unit
     test_torchscript = False
     test_inputs_embeds = False
 
-    def setUp(self):
-        self.model_tester = TimeSeriesTransformerModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TimeSeriesTransformerModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=TimeSeriesTransformerConfig,
             has_text_modality=False,
-            prediction_length=self.model_tester.prediction_length,
+            prediction_length=cls.model_tester.prediction_length,
         )
 
     def test_config(self):

--- a/tests/models/timesformer/test_modeling_timesformer.py
+++ b/tests/models/timesformer/test_modeling_timesformer.py
@@ -172,9 +172,7 @@ class TimesformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     @classmethod
     def setUpClass(cls):
         cls.model_tester = TimesformerModelTester(cls)
-        cls.config_tester = ConfigTester(
-            cls, config_class=TimesformerConfig, has_text_modality=False, hidden_size=37
-        )
+        cls.config_tester = ConfigTester(cls, config_class=TimesformerConfig, has_text_modality=False, hidden_size=37)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/timesformer/test_modeling_timesformer.py
+++ b/tests/models/timesformer/test_modeling_timesformer.py
@@ -169,10 +169,11 @@ class TimesformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = TimesformerModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=TimesformerConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TimesformerModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=TimesformerConfig, has_text_modality=False, hidden_size=37
         )
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):

--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -104,12 +104,13 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
     test_pruning = False
     has_attentions = False
 
-    def setUp(self):
-        # self.config_class = PretrainedConfig
-        self.config_class = TimmBackboneConfig
-        self.model_tester = TimmBackboneModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=self.config_class, has_text_modality=False, common_properties=["num_channels"]
+    @classmethod
+    def setUpClass(cls):
+        # cls.config_class = PretrainedConfig
+        cls.config_class = TimmBackboneConfig
+        cls.model_tester = TimmBackboneModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=cls.config_class, has_text_modality=False, common_properties=["num_channels"]
         )
 
     def test_config(self):

--- a/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
+++ b/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
@@ -109,12 +109,13 @@ class TimmWrapperModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     has_attentions = False
     test_model_parallel = False
 
-    def setUp(self):
-        self.config_class = TimmWrapperConfig
-        self.model_tester = TimmWrapperModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
-            config_class=self.config_class,
+    @classmethod
+    def setUpClass(cls):
+        cls.config_class = TimmWrapperConfig
+        cls.model_tester = TimmWrapperModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
+            config_class=cls.config_class,
             has_text_modality=False,
             common_properties=[],
             model_name="timm/resnet18.a1_in1k",

--- a/tests/models/trocr/test_modeling_trocr.py
+++ b/tests/models/trocr/test_modeling_trocr.py
@@ -165,9 +165,10 @@ class TrOCRStandaloneDecoderModelTest(ModelTesterMixin, GenerationTesterMixin, P
     fx_compatible = True
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = TrOCRStandaloneDecoderModelTester(self, is_training=False)
-        self.config_tester = ConfigTester(self, config_class=TrOCRConfig)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TrOCRStandaloneDecoderModelTester(cls, is_training=False)
+        cls.config_tester = ConfigTester(cls, config_class=TrOCRConfig)
 
     @unittest.skip(reason="Not yet implemented")
     def test_inputs_embeds(self):

--- a/tests/models/trocr/test_processor_trocr.py
+++ b/tests/models/trocr/test_processor_trocr.py
@@ -27,18 +27,19 @@ class TrOCRProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     text_input_name = "labels"
     processor_class = TrOCRProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]", "want", "##want", "##ed", "wa", "un", "runn", "##ing", ",", "low", "lowest"]  # fmt: skip
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         image_processor = ViTImageProcessor.from_pretrained("hf-internal-testing/tiny-random-vit")
         tokenizer = XLMRobertaTokenizerFast.from_pretrained("FacebookAI/xlm-roberta-base")
         processor = TrOCRProcessor(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)

--- a/tests/models/tvp/test_modeling_tvp.py
+++ b/tests/models/tvp/test_modeling_tvp.py
@@ -179,8 +179,9 @@ class TVPModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     # TODO: Enable this once this model gets more usage
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = TVPModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = TVPModelTester(cls)
 
     def test_model(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/udop/test_modeling_udop.py
+++ b/tests/models/udop/test_modeling_udop.py
@@ -291,9 +291,10 @@ class UdopModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     # The small UDOP model needs higher percentages for CPU/MP tests
     model_split_percents = [0.8, 0.9]
 
-    def setUp(self):
-        self.model_tester = UdopModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=UdopConfig, d_model=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = UdopModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=UdopConfig, d_model=37)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/udop/test_processor_udop.py
+++ b/tests/models/udop/test_processor_udop.py
@@ -56,8 +56,9 @@ class UdopProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = UdopProcessor
     maxDiff = None
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
         image_processor = LayoutLMv3ImageProcessor(
             do_resize=True,
             size=224,
@@ -65,14 +66,14 @@ class UdopProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         tokenizer = UdopTokenizer.from_pretrained("microsoft/udop-large")
         processor = UdopProcessor(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
-        self.tokenizer_pretrained_name = "microsoft/udop-large"
+        cls.tokenizer_pretrained_name = "microsoft/udop-large"
 
-        image_processor = self.get_image_processor()
-        tokenizer = self.get_tokenizers()[0]
+        image_processor = cls.get_image_processor()
+        tokenizer = cls.get_tokenizers()[0]
         processor = UdopProcessor(image_processor=image_processor, tokenizer=tokenizer)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs) -> PreTrainedTokenizer:
         return self.tokenizer_class.from_pretrained(self.tokenizer_pretrained_name, **kwargs)

--- a/tests/models/umt5/test_modeling_umt5.py
+++ b/tests/models/umt5/test_modeling_umt5.py
@@ -316,8 +316,9 @@ class UMT5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     # The small UMT5 model needs higher percentages for CPU/MP tests
     model_split_percents = [0.5, 0.8, 0.9]
 
-    def setUp(self):
-        self.model_tester = UMT5ModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = UMT5ModelTester(cls)
 
     # `QAPipelineTests` is not working well with slow tokenizers (for some models) and we don't want to touch the file
     # `src/transformers/data/processors/squad.py` (where this test fails for this model)

--- a/tests/models/unispeech/test_modeling_unispeech.py
+++ b/tests/models/unispeech/test_modeling_unispeech.py
@@ -316,11 +316,12 @@ class UniSpeechRobustModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.T
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = UniSpeechModelTester(
-            self, conv_stride=(3, 3, 3), feat_extract_norm="layer", do_stable_layer_norm=True
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = UniSpeechModelTester(
+            cls, conv_stride=(3, 3, 3), feat_extract_norm="layer", do_stable_layer_norm=True
         )
-        self.config_tester = ConfigTester(self, config_class=UniSpeechConfig, hidden_size=37)
+        cls.config_tester = ConfigTester(cls, config_class=UniSpeechConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/unispeech_sat/test_modeling_unispeech_sat.py
+++ b/tests/models/unispeech_sat/test_modeling_unispeech_sat.py
@@ -368,9 +368,10 @@ class UniSpeechSatModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     test_headmasking = False
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = UniSpeechSatModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=UniSpeechSatConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = UniSpeechSatModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=UniSpeechSatConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/univnet/test_feature_extraction_univnet.py
+++ b/tests/models/univnet/test_feature_extraction_univnet.py
@@ -151,8 +151,9 @@ class UnivNetFeatureExtractionTester:
 class UnivNetFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = UnivNetFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = UnivNetFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = UnivNetFeatureExtractionTester(cls)
 
     # Copied from tests.models.whisper.test_feature_extraction_whisper.WhisperFeatureExtractionTest.test_feat_extract_from_and_save_pretrained
     def test_feat_extract_from_and_save_pretrained(self):

--- a/tests/models/univnet/test_modeling_univnet.py
+++ b/tests/models/univnet/test_modeling_univnet.py
@@ -117,10 +117,11 @@ class UnivNetModelTest(ModelTesterMixin, unittest.TestCase):
     is_encoder_decoder = False
     has_attentions = False
 
-    def setUp(self):
-        self.model_tester = UnivNetModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=UnivNetConfig, has_text_modality=False, common_properties=["num_mel_bins"]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = UnivNetModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=UnivNetConfig, has_text_modality=False, common_properties=["num_mel_bins"]
         )
 
     @unittest.skip(reason="fix this once it gets more usage")

--- a/tests/models/upernet/test_modeling_upernet.py
+++ b/tests/models/upernet/test_modeling_upernet.py
@@ -159,10 +159,11 @@ class UperNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     has_attentions = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = UperNetModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = UperNetModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=UperNetConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/video_llava/test_modeling_video_llava.py
+++ b/tests/models/video_llava/test_modeling_video_llava.py
@@ -198,11 +198,12 @@ class VideoLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = VideoLlavaVisionText2TextModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VideoLlavaVisionText2TextModelTester(cls)
         common_properties = ["image_token_index", "video_token_index", "vision_feature_layer", "image_seq_length"]
-        self.config_tester = ConfigTester(
-            self, config_class=VideoLlavaConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=VideoLlavaConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/videomae/test_modeling_videomae.py
+++ b/tests/models/videomae/test_modeling_videomae.py
@@ -198,9 +198,10 @@ class VideoMAEModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = VideoMAEModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=VideoMAEConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VideoMAEModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=VideoMAEConfig, has_text_modality=False, hidden_size=37)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/vilt/test_modeling_vilt.py
+++ b/tests/models/vilt/test_modeling_vilt.py
@@ -255,9 +255,10 @@ class ViltModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = ViltModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ViltConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ViltModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ViltConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/vipllava/test_modeling_vipllava.py
+++ b/tests/models/vipllava/test_modeling_vipllava.py
@@ -174,11 +174,12 @@ class VipLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTest
     test_head_masking = False
     _is_composite = True
 
-    def setUp(self):
-        self.model_tester = VipLlavaVisionText2TextModelTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VipLlavaVisionText2TextModelTester(cls)
         common_properties = ["image_token_index", "vision_feature_layers", "image_seq_length"]
-        self.config_tester = ConfigTester(
-            self, config_class=VipLlavaConfig, has_text_modality=False, common_properties=common_properties
+        cls.config_tester = ConfigTester(
+            cls, config_class=VipLlavaConfig, has_text_modality=False, common_properties=common_properties
         )
 
     def test_config(self):

--- a/tests/models/vision_text_dual_encoder/test_processor_vision_text_dual_encoder.py
+++ b/tests/models/vision_text_dual_encoder/test_processor_vision_text_dual_encoder.py
@@ -35,12 +35,13 @@ if is_vision_available():
 class VisionTextDualEncoderProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = VisionTextDualEncoderProcessor
 
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.tmpdirname = tempfile.mkdtemp()
 
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]", "want", "##want", "##ed", "wa", "un", "runn", "##ing", ",", "low", "lowest"]  # fmt: skip
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        with open(cls.vocab_file, "w", encoding="utf-8") as vocab_writer:
             vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
 
         image_processor_map = {
@@ -50,14 +51,14 @@ class VisionTextDualEncoderProcessorTest(ProcessorTesterMixin, unittest.TestCase
             "image_mean": [0.5, 0.5, 0.5],
             "image_std": [0.5, 0.5, 0.5],
         }
-        self.image_processor_file = os.path.join(self.tmpdirname, IMAGE_PROCESSOR_NAME)
-        with open(self.image_processor_file, "w", encoding="utf-8") as fp:
+        cls.image_processor_file = os.path.join(cls.tmpdirname, IMAGE_PROCESSOR_NAME)
+        with open(cls.image_processor_file, "w", encoding="utf-8") as fp:
             json.dump(image_processor_map, fp)
 
-        tokenizer = self.get_tokenizer()
-        image_processor = self.get_image_processor()
+        tokenizer = cls.get_tokenizer()
+        image_processor = cls.get_image_processor()
         processor = VisionTextDualEncoderProcessor(tokenizer=tokenizer, image_processor=image_processor)
-        processor.save_pretrained(self.tmpdirname)
+        processor.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs):
         return BertTokenizer.from_pretrained(self.tmpdirname, **kwargs)

--- a/tests/models/visual_bert/test_modeling_visual_bert.py
+++ b/tests/models/visual_bert/test_modeling_visual_bert.py
@@ -390,9 +390,10 @@ class VisualBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = VisualBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=VisualBertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VisualBertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=VisualBertConfig, hidden_size=37)
 
     def test_attention_outputs(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/models/vit/test_modeling_vit.py
+++ b/tests/models/vit/test_modeling_vit.py
@@ -209,9 +209,10 @@ class ViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ViTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ViTConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ViTModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ViTConfig, has_text_modality=False, hidden_size=37)
 
     @unittest.skip(
         "Since `torch==2.3+cu121`, although this test passes, many subsequent tests have `CUDA error: misaligned address`."

--- a/tests/models/vit_mae/test_modeling_vit_mae.py
+++ b/tests/models/vit_mae/test_modeling_vit_mae.py
@@ -185,9 +185,10 @@ class ViTMAEModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ViTMAEModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ViTMAEConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ViTMAEModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ViTMAEConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/vit_msn/test_modeling_vit_msn.py
+++ b/tests/models/vit_msn/test_modeling_vit_msn.py
@@ -167,9 +167,10 @@ class ViTMSNModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ViTMSNModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ViTMSNConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ViTMSNModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ViTMSNConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/vitdet/test_modeling_vitdet.py
+++ b/tests/models/vitdet/test_modeling_vitdet.py
@@ -171,9 +171,10 @@ class VitDetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = VitDetModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=VitDetConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VitDetModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=VitDetConfig, has_text_modality=False, hidden_size=37)
 
     @is_flaky(max_attempts=3, description="`torch.nn.init.trunc_normal_` is flaky.")
     def test_initialization(self):

--- a/tests/models/vitmatte/test_modeling_vitmatte.py
+++ b/tests/models/vitmatte/test_modeling_vitmatte.py
@@ -145,10 +145,11 @@ class VitMatteModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = VitMatteModelTester(self)
-        self.config_tester = ConfigTester(
-            self,
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VitMatteModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls,
             config_class=VitMatteConfig,
             has_text_modality=False,
             hidden_size=37,

--- a/tests/models/vitpose/test_modeling_vitpose.py
+++ b/tests/models/vitpose/test_modeling_vitpose.py
@@ -156,9 +156,10 @@ class VitPoseModelTest(ModelTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = VitPoseModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=VitPoseConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VitPoseModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=VitPoseConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.create_and_test_config_to_json_string()

--- a/tests/models/vitpose_backbone/test_modeling_vitpose_backbone.py
+++ b/tests/models/vitpose_backbone/test_modeling_vitpose_backbone.py
@@ -133,10 +133,11 @@ class VitPoseBackboneModelTest(ModelTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = VitPoseBackboneModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=VitPoseBackboneConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VitPoseBackboneModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=VitPoseBackboneConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/vits/test_modeling_vits.py
+++ b/tests/models/vits/test_modeling_vits.py
@@ -168,9 +168,10 @@ class VitsModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_torchscript = False
     has_attentions = False
 
-    def setUp(self):
-        self.model_tester = VitsModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=VitsConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VitsModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=VitsConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/vivit/test_modeling_vivit.py
+++ b/tests/models/vivit/test_modeling_vivit.py
@@ -177,9 +177,10 @@ class VivitModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = VivitModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=VivitConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = VivitModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=VivitConfig, has_text_modality=False, hidden_size=37)
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         inputs_dict = copy.deepcopy(inputs_dict)

--- a/tests/models/wav2vec2/test_feature_extraction_wav2vec2.py
+++ b/tests/models/wav2vec2/test_feature_extraction_wav2vec2.py
@@ -99,8 +99,9 @@ class Wav2Vec2FeatureExtractionTester:
 class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = Wav2Vec2FeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = Wav2Vec2FeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = Wav2Vec2FeatureExtractionTester(cls)
 
     def _check_zero_mean_unit_variance(self, input_vector):
         self.assertTrue(np.all(np.mean(input_vector, axis=0) < 1e-3))

--- a/tests/models/wav2vec2/test_modeling_wav2vec2.py
+++ b/tests/models/wav2vec2/test_modeling_wav2vec2.py
@@ -505,9 +505,10 @@ class Wav2Vec2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = Wav2Vec2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Wav2Vec2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Wav2Vec2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Wav2Vec2Config, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/wav2vec2/test_processor_wav2vec2.py
+++ b/tests/models/wav2vec2/test_processor_wav2vec2.py
@@ -31,11 +31,12 @@ class Wav2Vec2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     audio_input_name = "input_values"
     text_input_name = "labels"
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         vocab = "<pad> <s> </s> <unk> | E T A O N I H S R D L U M W C F G Y P B V K ' X J Q Z".split(" ")
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
 
-        self.add_kwargs_tokens_map = {
+        cls.add_kwargs_tokens_map = {
             "pad_token": "<pad>",
             "unk_token": "<unk>",
             "bos_token": "<s>",
@@ -49,17 +50,17 @@ class Wav2Vec2ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "do_normalize": True,
         }
 
-        self.tmpdirname = tempfile.mkdtemp()
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
 
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(feature_extractor_map) + "\n")
 
-        tokenizer = self.get_tokenizer()
-        tokenizer.save_pretrained(self.tmpdirname)
+        tokenizer = cls.get_tokenizer()
+        tokenizer.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs_init):
         kwargs = self.add_kwargs_tokens_map.copy()

--- a/tests/models/wav2vec2_bert/test_modeling_wav2vec2_bert.py
+++ b/tests/models/wav2vec2_bert/test_modeling_wav2vec2_bert.py
@@ -450,9 +450,10 @@ class Wav2Vec2BertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     test_headmasking = False
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = Wav2Vec2BertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Wav2Vec2BertConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Wav2Vec2BertModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Wav2Vec2BertConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/wav2vec2_bert/test_processor_wav2vec2_bert.py
+++ b/tests/models/wav2vec2_bert/test_processor_wav2vec2_bert.py
@@ -32,11 +32,12 @@ class Wav2Vec2BertProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Wav2Vec2BertProcessor
     text_input_name = "labels"
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         vocab = "<pad> <s> </s> <unk> | E T A O N I H S R D L U M W C F G Y P B V K ' X J Q Z".split(" ")
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
 
-        self.add_kwargs_tokens_map = {
+        cls.add_kwargs_tokens_map = {
             "pad_token": "<pad>",
             "unk_token": "<unk>",
             "bos_token": "<s>",
@@ -50,17 +51,17 @@ class Wav2Vec2BertProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             "do_normalize": True,
         }
 
-        self.tmpdirname = tempfile.mkdtemp()
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
 
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(feature_extractor_map) + "\n")
 
-        tokenizer = self.get_tokenizer()
-        tokenizer.save_pretrained(self.tmpdirname)
+        tokenizer = cls.get_tokenizer()
+        tokenizer.save_pretrained(cls.tmpdirname)
 
     def get_tokenizer(self, **kwargs_init):
         kwargs = self.add_kwargs_tokens_map.copy()

--- a/tests/models/wav2vec2_conformer/test_modeling_wav2vec2_conformer.py
+++ b/tests/models/wav2vec2_conformer/test_modeling_wav2vec2_conformer.py
@@ -441,9 +441,10 @@ class Wav2Vec2ConformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest
     test_headmasking = False
     test_torchscript = False
 
-    def setUp(self):
-        self.model_tester = Wav2Vec2ConformerModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Wav2Vec2ConformerConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Wav2Vec2ConformerModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Wav2Vec2ConformerConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/wav2vec2_with_lm/test_processor_wav2vec2_with_lm.py
+++ b/tests/models/wav2vec2_with_lm/test_processor_wav2vec2_with_lm.py
@@ -47,11 +47,12 @@ if is_torch_available():
 
 @require_pyctcdecode
 class Wav2Vec2ProcessorWithLMTest(unittest.TestCase):
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         vocab = "| <pad> <unk> <s> </s> a b c d e f g h i j k".split()
         vocab_tokens = dict(zip(vocab, range(len(vocab))))
 
-        self.add_kwargs_tokens_map = {
+        cls.add_kwargs_tokens_map = {
             "unk_token": "<unk>",
             "bos_token": "<s>",
             "eos_token": "</s>",
@@ -64,17 +65,17 @@ class Wav2Vec2ProcessorWithLMTest(unittest.TestCase):
             "do_normalize": True,
         }
 
-        self.tmpdirname = tempfile.mkdtemp()
-        self.vocab_file = os.path.join(self.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
-        self.feature_extraction_file = os.path.join(self.tmpdirname, FEATURE_EXTRACTOR_NAME)
-        with open(self.vocab_file, "w", encoding="utf-8") as fp:
+        cls.tmpdirname = tempfile.mkdtemp()
+        cls.vocab_file = os.path.join(cls.tmpdirname, VOCAB_FILES_NAMES["vocab_file"])
+        cls.feature_extraction_file = os.path.join(cls.tmpdirname, FEATURE_EXTRACTOR_NAME)
+        with open(cls.vocab_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(vocab_tokens) + "\n")
 
-        with open(self.feature_extraction_file, "w", encoding="utf-8") as fp:
+        with open(cls.feature_extraction_file, "w", encoding="utf-8") as fp:
             fp.write(json.dumps(feature_extractor_map) + "\n")
 
         # load decoder from hub
-        self.decoder_name = "hf-internal-testing/ngram-beam-search-decoder"
+        cls.decoder_name = "hf-internal-testing/ngram-beam-search-decoder"
 
     def get_tokenizer(self, **kwargs_init):
         kwargs = self.add_kwargs_tokens_map.copy()

--- a/tests/models/wavlm/test_modeling_wavlm.py
+++ b/tests/models/wavlm/test_modeling_wavlm.py
@@ -336,9 +336,10 @@ class WavLMModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_headmasking = False
 
-    def setUp(self):
-        self.model_tester = WavLMModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=WavLMConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = WavLMModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=WavLMConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/whisper/test_feature_extraction_whisper.py
+++ b/tests/models/whisper/test_feature_extraction_whisper.py
@@ -109,8 +109,9 @@ class WhisperFeatureExtractionTester:
 class WhisperFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest.TestCase):
     feature_extraction_class = WhisperFeatureExtractor
 
-    def setUp(self):
-        self.feat_extract_tester = WhisperFeatureExtractionTester(self)
+    @classmethod
+    def setUpClass(cls):
+        cls.feat_extract_tester = WhisperFeatureExtractionTester(cls)
 
     def test_feat_extract_from_and_save_pretrained(self):
         feat_extract_first = self.feature_extraction_class(**self.feat_extract_dict)

--- a/tests/models/whisper/test_modeling_flax_whisper.py
+++ b/tests/models/whisper/test_modeling_flax_whisper.py
@@ -736,15 +736,16 @@ class WhisperEncoderModelTest(FlaxModelTesterMixin, unittest.TestCase):
 
     input_name = "input_features"
 
-    def setUp(self):
-        self.model_tester = FlaxWhisperEncoderModelTester(self)
-        _, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        self.init_shape = (1,) + inputs_dict["input_features"].shape[1:]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = FlaxWhisperEncoderModelTester(cls)
+        _, inputs_dict = cls.model_tester.prepare_config_and_inputs_for_common()
+        cls.init_shape = (1,) + inputs_dict["input_features"].shape[1:]
 
-        self.all_model_classes = (
-            make_partial_class(model_class, input_shape=self.init_shape) for model_class in self.all_model_classes
+        cls.all_model_classes = (
+            make_partial_class(model_class, input_shape=cls.init_shape) for model_class in cls.all_model_classes
         )
-        self.config_tester = ConfigTester(self, config_class=WhisperConfig)
+        cls.config_tester = ConfigTester(cls, config_class=WhisperConfig)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -429,10 +429,11 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         beam_kwargs["num_return_sequences"] = beam_kwargs["num_beams"]
         return beam_kwargs
 
-    def setUp(self):
-        self.model_tester = WhisperModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=WhisperConfig)
-        self.maxDiff = 3000
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = WhisperModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=WhisperConfig)
+        cls.maxDiff = 3000
 
     def prepare_config_and_inputs_for_generate(self, batch_size=2):
         config, inputs_dict = super().prepare_config_and_inputs_for_generate(batch_size=batch_size)

--- a/tests/models/whisper/test_processor_whisper.py
+++ b/tests/models/whisper/test_processor_whisper.py
@@ -36,9 +36,10 @@ NOTIMESTAMPS = 50362
 @require_torchaudio
 @require_sentencepiece
 class WhisperProcessorTest(unittest.TestCase):
-    def setUp(self):
-        self.checkpoint = "openai/whisper-small.en"
-        self.tmpdirname = tempfile.mkdtemp()
+    @classmethod
+    def setUpClass(cls):
+        cls.checkpoint = "openai/whisper-small.en"
+        cls.tmpdirname = tempfile.mkdtemp()
 
     def get_tokenizer(self, **kwargs):
         return WhisperTokenizer.from_pretrained(self.checkpoint, **kwargs)

--- a/tests/models/x_clip/test_modeling_x_clip.py
+++ b/tests/models/x_clip/test_modeling_x_clip.py
@@ -151,9 +151,7 @@ class XCLIPVisionModelTest(ModelTesterMixin, unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.model_tester = XCLIPVisionModelTester(cls)
-        cls.config_tester = ConfigTester(
-            cls, config_class=XCLIPVisionConfig, has_text_modality=False, hidden_size=37
-        )
+        cls.config_tester = ConfigTester(cls, config_class=XCLIPVisionConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/x_clip/test_modeling_x_clip.py
+++ b/tests/models/x_clip/test_modeling_x_clip.py
@@ -148,10 +148,11 @@ class XCLIPVisionModelTest(ModelTesterMixin, unittest.TestCase):
     test_resize_embeddings = False
     test_head_masking = False
 
-    def setUp(self):
-        self.model_tester = XCLIPVisionModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=XCLIPVisionConfig, has_text_modality=False, hidden_size=37
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = XCLIPVisionModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=XCLIPVisionConfig, has_text_modality=False, hidden_size=37
         )
 
     def test_config(self):

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -290,9 +290,10 @@ class XGLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     test_missing_keys = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = XGLMModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=XGLMConfig, n_embd=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = XGLMModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=XGLMConfig, n_embd=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/xlm/test_modeling_xlm.py
+++ b/tests/models/xlm/test_modeling_xlm.py
@@ -426,9 +426,10 @@ class XLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = XLMModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=XLMConfig, emb_dim=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = XLMModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=XLMConfig, emb_dim=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
+++ b/tests/models/xlm_roberta_xl/test_modeling_xlm_roberta_xl.py
@@ -404,9 +404,10 @@ class XLMRobertaXLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTes
 
         return False
 
-    def setUp(self):
-        self.model_tester = XLMRobertaXLModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=XLMRobertaXLConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = XLMRobertaXLModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=XLMRobertaXLConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/xlnet/test_modeling_xlnet.py
+++ b/tests/models/xlnet/test_modeling_xlnet.py
@@ -569,9 +569,10 @@ class XLNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = XLNetModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=XLNetConfig, d_inner=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = XLNetModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=XLNetConfig, d_inner=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/xmod/test_modeling_xmod.py
+++ b/tests/models/xmod/test_modeling_xmod.py
@@ -399,9 +399,10 @@ class XmodModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
 
         return False
 
-    def setUp(self):
-        self.model_tester = XmodModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=XmodConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = XmodModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=XmodConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/yolos/test_modeling_yolos.py
+++ b/tests/models/yolos/test_modeling_yolos.py
@@ -200,9 +200,10 @@ class YolosModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
         return inputs_dict
 
-    def setUp(self):
-        self.model_tester = YolosModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=YolosConfig, has_text_modality=False, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = YolosModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=YolosConfig, has_text_modality=False, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/yoso/test_modeling_yoso.py
+++ b/tests/models/yoso/test_modeling_yoso.py
@@ -309,9 +309,10 @@ class YosoModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         else {}
     )
 
-    def setUp(self):
-        self.model_tester = YosoModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=YosoConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = YosoModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=YosoConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -305,9 +305,10 @@ class ZambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = ZambaModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ZambaConfig, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ZambaModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=ZambaConfig, hidden_size=37)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -315,9 +315,10 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     test_headmasking = False
     test_pruning = False
 
-    def setUp(self):
-        self.model_tester = Zamba2ModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Zamba2Config, hidden_size=37)
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = Zamba2ModelTester(cls)
+        cls.config_tester = ConfigTester(cls, config_class=Zamba2Config, hidden_size=37)
 
     @unittest.skip("position_ids cannot be used to pad due to Mamba2 layers")
     def test_flash_attention_2_padding_matches_padding_free_with_position_ids(self):

--- a/tests/models/zoedepth/test_modeling_zoedepth.py
+++ b/tests/models/zoedepth/test_modeling_zoedepth.py
@@ -149,10 +149,11 @@ class ZoeDepthModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
     test_head_masking = False
     test_torch_exportable = True
 
-    def setUp(self):
-        self.model_tester = ZoeDepthModelTester(self)
-        self.config_tester = ConfigTester(
-            self, config_class=ZoeDepthConfig, has_text_modality=False, hidden_size=37, common_properties=[]
+    @classmethod
+    def setUpClass(cls):
+        cls.model_tester = ZoeDepthModelTester(cls)
+        cls.config_tester = ConfigTester(
+            cls, config_class=ZoeDepthConfig, has_text_modality=False, hidden_size=37, common_properties=[]
         )
 
     def test_config(self):


### PR DESCRIPTION
A lot of our test suites use `SetUp` and `TearDown` methods. These are called **before and after every test**. In a lot of cases, this is unnecessary because the contents do not change between tests. This is particularly important when the setup has expensive steps, like initializing models or processors, or loading test files/images from the Hub.

I made a PR at #37209 to change this for Fuyu, which was frequently timing out or being throttled because it kept loading the same image by URL from the Hub. This PR reduced the runtime of the Fuyu test suite on my local machine to 30% of the previous amount, so I figured I'd try it for other classes too.

This is a repo-wide search replace to turn setUp into setUpClass. It will break **everything**, but I'm hoping that with some tweaks we can make the CI pass.