### PR TITLE
Detect and use device context manager or global device in `from_pretrained`

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -287,6 +287,16 @@ def restore_default_torch_dtype(func):
     return _wrapper
 
 
+def get_torch_device_context_manager():
+    """
+    Test if a device context manager is currently in use.
+    """
+    test = torch.zeros(1)
+    if test.device == torch.get_default_device():
+        return None
+    return test.device
+
+
 def get_parameter_device(parameter: Union[nn.Module, "ModuleUtilsMixin"]):
     try:
         return next(parameter.parameters()).device
@@ -4152,6 +4162,11 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
                     pretrained_model_name_or_path = json.load(f)["base_model_name_or_path"]
         else:
             _adapter_model_path = None
+
+        # Potentially detect device context manager and use it
+        if device_map is None:
+            device_in_context = get_torch_device_context_manager()
+            device_map = device_in_context
 
         # change device_map into a map if we passed an int, a str or a torch.device
         if isinstance(device_map, torch.device):

--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -168,6 +168,18 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
     def test_save_load_low_cpu_mem_usage_no_safetensors(self):
         pass
 
+    @unittest.skip(reason="TimmBackbone uses its own `from_pretrained` without device_map support")
+    def test_can_load_with_device_context_manager(self):
+        pass
+
+    @unittest.skip(reason="TimmBackbone uses its own `from_pretrained` without device_map support")
+    def test_can_load_with_global_device_set(self):
+        pass
+
+    @unittest.skip(reason="TimmBackbone uses its own `from_pretrained` without device_map support")
+    def test_cannot_load_with_meta_device_context_manager(self):
+        pass
+
     @unittest.skip(reason="model weights aren't tied in TimmBackbone.")
     def test_tie_model_weights(self):
         pass

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4457,9 +4457,12 @@ class ModelTesterMixin:
     @require_torch_accelerator
     def test_can_load_with_device_context_manager(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        device = torch.device(torch_device)
+        # Need to specify index 0 here, as `torch_device` is simply the str of the type, e.g. "cuda"
+        device = torch.device(torch_device, index=0)
         for model_class in self.all_model_classes:
-            model = model_class(config)
+            # Need to deepcopy here as it is modified in-place in save_pretrained (it sets sdpa for default attn, which
+            # is not supported for e.g. dpt_hybrid)
+            model = model_class(copy.deepcopy(config))
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
@@ -4477,12 +4480,15 @@ class ModelTesterMixin:
     @require_torch_accelerator
     def test_can_load_with_global_device_set(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        device = torch.device(torch_device)
+        # Need to specify index 0 here, as `torch_device` is simply the str of the type, e.g. "cuda"
+        device = torch.device(torch_device, index=0)
         default_device = torch.get_default_device()
         # set a global gpu device
         torch.set_default_device(device)
         for model_class in self.all_model_classes:
-            model = model_class(config)
+            # Need to deepcopy here as it is modified in-place in save_pretrained (it sets sdpa for default attn, which
+            # is not supported for e.g. dpt_hybrid)
+            model = model_class(copy.deepcopy(config))
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
@@ -4502,7 +4508,9 @@ class ModelTesterMixin:
     def test_cannot_load_with_meta_device_context_manager(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:
-            model = model_class(config)
+            # Need to deepcopy here as it is modified in-place in save_pretrained (it sets sdpa for default attn, which
+            # is not supported for e.g. dpt_hybrid)
+            model = model_class(copy.deepcopy(config))
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4499,7 +4499,7 @@ class ModelTesterMixin:
                     buffer.device for buffer in new_model.buffers()
                 }
 
-            # set back the correct device to avoid polluting other tests
+            # set back the correct device
             torch.set_default_device(default_device)
 
             self.assertEqual(

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4499,7 +4499,7 @@ class ModelTesterMixin:
                     buffer.device for buffer in new_model.buffers()
                 }
 
-            # set back the correct device
+            # set back the correct device to avoid polluting other tests
             torch.set_default_device(default_device)
 
             self.assertEqual(

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4483,12 +4483,13 @@ class ModelTesterMixin:
         # Need to specify index 0 here, as `torch_device` is simply the str of the type, e.g. "cuda"
         device = torch.device(torch_device, index=0)
         default_device = torch.get_default_device()
-        # set a global gpu device
-        torch.set_default_device(device)
         for model_class in self.all_model_classes:
             # Need to deepcopy here as it is modified in-place in save_pretrained (it sets sdpa for default attn, which
             # is not supported for e.g. dpt_hybrid)
             model = model_class(copy.deepcopy(config))
+
+            # set a global gpu device
+            torch.set_default_device(device)
 
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4454,6 +4454,39 @@ class ModelTesterMixin:
                 ),
             )
 
+    @require_torch_accelerator
+    def test_can_load_with_device_context_manager(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        device = torch.device(torch_device)
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                model.save_pretrained(tmpdirname)
+
+                with device:
+                    new_model = model_class.from_pretrained(tmpdirname)
+                unique_devices = {param.device for param in new_model.parameters()} | {
+                    buffer.device for buffer in new_model.buffers()
+                }
+
+            self.assertEqual(
+                unique_devices, {device}, f"All parameters should be on {device}, but found {unique_devices}."
+            )
+
+    def test_cannot_load_with_meta_device_context_manager(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            model = model_class(config)
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                model.save_pretrained(tmpdirname)
+
+                # This should raise an error with meta device
+                with self.assertRaises(ValueError, msg="`from_pretrained` is not compatible with a meta device"):
+                    with torch.device("meta"):
+                        _ = model_class.from_pretrained(tmpdirname)
+
 
 global_rng = random.Random()
 


### PR DESCRIPTION
# What does this PR do?

As per the title. See https://github.com/huggingface/transformers/pull/37213 as well.
Note that this will only ever be used when no `device_map` is provided, otherwise the `device_map` always take precedence.
This behavior should be aligned with what PyTorch does with contetx manager/globally setting the default device. It it also what will happen to the buffers (they are not initialized on meta during loading, so they will go to whatever default device torch knows based on context/global device), so makes total sense IMO (see the example).

This script:

```python
import torch
from transformers import AutoModelForCausalLM

with torch.device(2):
    model = AutoModelForCausalLM.from_pretrained("meta-llama/Meta-Llama-3-8B-Instruct", torch_dtype=torch.float16)

unique_devices = {v.device for v in model.parameters()} | {v.device for v in model.buffers()}
print(unique_devices)
```

returns
```python
>>> {device(type='cuda', index=2)}
```

And before, only the non-persistent buffers would be moved (because we entirely control the rest)
```python
>>> {device(type='cuda', index=2), device(type='cpu')}
```
