### PR TITLE
Fix Flash Attention guard

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1037,8 +1037,8 @@ def is_flash_attn_2_available():
     if torch.version.cuda:
         is_compatible = version.parse(flash_attn_version) >= version.parse("2.1.0")
     elif torch.version.hip:
-        is_compatible = version.parse(flash_attn_version) >= version.parse("2.0.4")
         # TODO: Bump the requirement to 2.1.0 once released in https://github.com/ROCmSoftwarePlatform/flash-attention
+        is_compatible = version.parse(flash_attn_version) >= version.parse("2.0.4")
     elif is_torch_mlu_available():
         is_compatible = version.parse(flash_attn_version) >= version.parse("2.3.3")
     else:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1034,12 +1034,17 @@ def is_flash_attn_2_available():
         return False
 
     flash_attn_version = importlib.metadata.version("flash_attn")
-    if torch.version.cuda and not version.parse(flash_attn_version) >= version.parse("2.1.0"):
-        return False
-    elif torch.version.hip and not version.parse(flash_attn_version) >= version.parse("2.0.4"):
+    if torch.version.cuda:
+        is_compatible = version.parse(flash_attn_version) >= version.parse("2.1.0")
+    elif torch.version.hip:
+        is_compatible = version.parse(flash_attn_version) >= version.parse("2.0.4")
         # TODO: Bump the requirement to 2.1.0 once released in https://github.com/ROCmSoftwarePlatform/flash-attention
-        return False
-    elif is_torch_mlu_available() and not version.parse(flash_attn_version) >= version.parse("2.3.3"):
+    elif is_torch_mlu_available():
+        is_compatible = version.parse(flash_attn_version) >= version.parse("2.3.3")
+    else:
+        is_compatible = False
+
+    if not is_compatible:
         return False
 
     # finally try import flash_attn

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1033,15 +1033,25 @@ def is_flash_attn_2_available():
     if not (torch.cuda.is_available() or is_torch_mlu_available()):
         return False
 
-    if torch.version.cuda:
-        return version.parse(importlib.metadata.version("flash_attn")) >= version.parse("2.1.0")
-    elif torch.version.hip:
-        # TODO: Bump the requirement to 2.1.0 once released in https://github.com/ROCmSoftwarePlatform/flash-attention
-        return version.parse(importlib.metadata.version("flash_attn")) >= version.parse("2.0.4")
-    elif is_torch_mlu_available():
-        return version.parse(importlib.metadata.version("flash_attn")) >= version.parse("2.3.3")
-    else:
+    flash_attn_version = importlib.metadata.version("flash_attn")
+    if torch.version.cuda and not version.parse(flash_attn_version) >= version.parse("2.1.0"):
         return False
+    elif torch.version.hip and not version.parse(flash_attn_version) >= version.parse("2.0.4"):
+        # TODO: Bump the requirement to 2.1.0 once released in https://github.com/ROCmSoftwarePlatform/flash-attention
+        return False
+    elif is_torch_mlu_available() and not version.parse(flash_attn_version) >= version.parse("2.3.3"):
+        return False
+
+    # finally try import flash_attn
+    try:
+        import flash_attn  # noqa: F401
+    except ImportError as e:
+        logger.warning_once(
+            f"[WARN] Flash-attention seems to be installed but not available due to the following error: {e}"
+        )
+        return False
+
+    return True
 
 
 @lru_cache()


### PR DESCRIPTION
# What does this PR do?

Transformers import crash if flash attention is installed but not compatible with current torch+cuda version, while we should catch this with `is_flash_attention_2_avaliable`

Fixes #37227
