### PR TITLE
Fix AST parsing when looking for remote code imports

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -157,7 +157,9 @@ def get_imports(filename: Union[str, os.PathLike]) -> list[str]:
         elif isinstance(node, ast.If):
             test = node.test
             for condition_node in ast.walk(test):
-                if isinstance(condition_node, ast.Call) and condition_node.func.id.startswith("is_flash_attn"):
+                if isinstance(condition_node, ast.Call) and getattr(condition_node.func, "id", "").startswith(
+                    "is_flash_attn"
+                ):
                     # Don't recurse into "if flash_attn_available()" blocks and ignore imports in them
                     return
         elif isinstance(node, ast.Import):


### PR DESCRIPTION
The AST parsing code in `dynamic_module_utils` had a bug because it assumed that certain `Call` nodes had to be calling a named function and not something else like a method.