### PR TITLE
Enable RUF013 to enforce optional typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,9 @@ line-length = 119
 [tool.ruff.lint]
 # Never enforce `E501` (line length violations).
 ignore = ["C901", "E501", "E741", "F402", "F823" ]
-select = ["C", "E", "F", "I", "W"]
+# RUF013: Checks for the use of implicit Optional
+#  in type annotations when the default parameter value is None.
+select = ["C", "E", "F", "I", "W", "RUF013"]
 
 # Ignore import violations in all `__init__.py` files.
 [tool.ruff.lint.per-file-ignores]

--- a/src/transformers/models/d_fine/convert_d_fine_original_pytorch_checkpoint_to_hf.py
+++ b/src/transformers/models/d_fine/convert_d_fine_original_pytorch_checkpoint_to_hf.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import re
 from pathlib import Path
+from typing import Optional
 
 import requests
 import torch
@@ -319,7 +320,7 @@ ORIGINAL_TO_CONVERTED_KEY_MAPPING = {
 }
 
 
-def convert_old_keys_to_new_keys(state_dict_keys: dict = None):
+def convert_old_keys_to_new_keys(state_dict_keys: Optional[dict] = None):
     # Use the mapping to rename keys
     for original_key, converted_key in ORIGINAL_TO_CONVERTED_KEY_MAPPING.items():
         for key in list(state_dict_keys.keys()):

--- a/src/transformers/models/d_fine/modeling_d_fine.py
+++ b/src/transformers/models/d_fine/modeling_d_fine.py
@@ -1972,8 +1972,8 @@ class DFineConvNormLayer(nn.Module):
         kernel_size: int,
         stride: int,
         groups: int = 1,
-        padding: int = None,
-        activation: str = None,
+        padding: Optional[int] = None,
+        activation: Optional[str] = None,
     ):
         super().__init__()
         self.conv = nn.Conv2d(

--- a/src/transformers/models/d_fine/modular_d_fine.py
+++ b/src/transformers/models/d_fine/modular_d_fine.py
@@ -1054,8 +1054,8 @@ class DFineConvNormLayer(RTDetrConvNormLayer):
         kernel_size: int,
         stride: int,
         groups: int = 1,
-        padding: int = None,
-        activation: str = None,
+        padding: Optional[int] = None,
+        activation: Optional[str] = None,
     ):
         super().__init__(config, in_channels, out_channels, kernel_size, stride, padding=None, activation=activation)
         self.conv = nn.Conv2d(

--- a/src/transformers/models/flava/image_processing_flava_fast.py
+++ b/src/transformers/models/flava/image_processing_flava_fast.py
@@ -66,7 +66,7 @@ class FlavaMaskingGenerator:
         mask_group_max_patches: Optional[int] = None,
         mask_group_min_patches: int = 16,
         mask_group_min_aspect_ratio: Optional[float] = 0.3,
-        mask_group_max_aspect_ratio: float = None,
+        mask_group_max_aspect_ratio: Optional[float] = None,
     ):
         if not isinstance(input_size, tuple):
             input_size = (input_size,) * 2

--- a/src/transformers/models/internvl/convert_internvl_weights_to_hf.py
+++ b/src/transformers/models/internvl/convert_internvl_weights_to_hf.py
@@ -304,7 +304,9 @@ def write_model(
     del model
 
 
-def write_tokenizer(save_dir: str, push_to_hub: bool = False, path: Optional[str] = None, hub_dir: Optional[str] = None):
+def write_tokenizer(
+    save_dir: str, push_to_hub: bool = False, path: Optional[str] = None, hub_dir: Optional[str] = None
+):
     if LM_TYPE_CORRESPONDENCE[path] == "qwen2":
         tokenizer = AutoTokenizer.from_pretrained(
             "Qwen/Qwen2.5-VL-7B-Instruct",

--- a/src/transformers/models/internvl/convert_internvl_weights_to_hf.py
+++ b/src/transformers/models/internvl/convert_internvl_weights_to_hf.py
@@ -15,6 +15,7 @@ import argparse
 import gc
 import os
 import re
+from typing import Optional
 
 import torch
 from einops import rearrange
@@ -116,7 +117,7 @@ chat_template = (
 CONTEXT_LENGTH = 8192
 
 
-def convert_old_keys_to_new_keys(state_dict_keys: dict = None, path: str = None):
+def convert_old_keys_to_new_keys(state_dict_keys: Optional[dict] = None, path: Optional[str] = None):
     """
     This function should be applied only once, on the concatenated keys to efficiently rename using
     the key mappings.
@@ -303,7 +304,7 @@ def write_model(
     del model
 
 
-def write_tokenizer(save_dir: str, push_to_hub: bool = False, path: str = None, hub_dir: str = None):
+def write_tokenizer(save_dir: str, push_to_hub: bool = False, path: Optional[str] = None, hub_dir: Optional[str] = None):
     if LM_TYPE_CORRESPONDENCE[path] == "qwen2":
         tokenizer = AutoTokenizer.from_pretrained(
             "Qwen/Qwen2.5-VL-7B-Instruct",
@@ -355,7 +356,7 @@ def write_tokenizer(save_dir: str, push_to_hub: bool = False, path: str = None, 
         tokenizer.push_to_hub(hub_dir, use_temp_dir=True)
 
 
-def write_image_processor(save_dir: str, push_to_hub: bool = False, hub_dir: str = None):
+def write_image_processor(save_dir: str, push_to_hub: bool = False, hub_dir: Optional[str] = None):
     image_processor = GotOcr2ImageProcessorFast(
         do_resize=True,
         size={"height": 448, "width": 448},

--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -269,7 +269,7 @@ class InternVLProcessor(ProcessorMixin):
         return BatchFeature(data={**text_inputs, **image_videos_inputs}, tensor_type=return_tensors)
 
     def sample_indices_fn(
-        self, metadata: VideoMetadata, num_frames: int = None, initial_shift: Union[bool, float, int] = True
+        self, metadata: VideoMetadata, num_frames: Optional[int] = None, initial_shift: Union[bool, float, int] = True
     ):
         """
         The function to generate indices of frames to sample from a video.

--- a/src/transformers/models/janus/convert_janus_weights_to_hf.py
+++ b/src/transformers/models/janus/convert_janus_weights_to_hf.py
@@ -168,7 +168,9 @@ def convert_state_dict_to_hf(state_dict):
     return converted_state_dict
 
 
-def ensure_model_downloaded(repo_id: Optional[str] = None, revision: Optional[str] = None, local_dir: Optional[str] = None) -> str:
+def ensure_model_downloaded(
+    repo_id: Optional[str] = None, revision: Optional[str] = None, local_dir: Optional[str] = None
+) -> str:
     """
     Ensures model files are downloaded locally, downloads them if not.
     Returns path to local files.

--- a/src/transformers/models/janus/convert_janus_weights_to_hf.py
+++ b/src/transformers/models/janus/convert_janus_weights_to_hf.py
@@ -25,6 +25,7 @@ import gc
 import json
 import os
 import re
+from typing import Optional
 
 import torch
 from accelerate import init_empty_weights
@@ -167,7 +168,7 @@ def convert_state_dict_to_hf(state_dict):
     return converted_state_dict
 
 
-def ensure_model_downloaded(repo_id: str = None, revision: str = None, local_dir: str = None) -> str:
+def ensure_model_downloaded(repo_id: Optional[str] = None, revision: Optional[str] = None, local_dir: Optional[str] = None) -> str:
     """
     Ensures model files are downloaded locally, downloads them if not.
     Returns path to local files.

--- a/src/transformers/models/janus/image_processing_janus.py
+++ b/src/transformers/models/janus/image_processing_janus.py
@@ -98,7 +98,7 @@ class JanusImageProcessor(BaseImageProcessor):
     def __init__(
         self,
         do_resize: bool = True,
-        size: Dict[str, int] = None,
+        size: Optional[Dict[str, int]] = None,
         min_size: int = 14,
         resample: PILImageResampling = PILImageResampling.BICUBIC,
         do_rescale: bool = True,
@@ -106,7 +106,7 @@ class JanusImageProcessor(BaseImageProcessor):
         do_normalize: bool = True,
         image_mean: Optional[Union[float, List[float]]] = None,
         image_std: Optional[Union[float, List[float]]] = None,
-        do_convert_rgb: bool = None,
+        do_convert_rgb: Optional[bool] = None,
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
@@ -411,13 +411,13 @@ class JanusImageProcessor(BaseImageProcessor):
     def postprocess(
         self,
         images: ImageInput,
-        do_rescale: bool = None,
-        rescale_factor: float = None,
-        do_normalize: bool = None,
-        image_mean: List[float] = None,
-        image_std: List[float] = None,
-        input_data_format: str = None,
-        return_tensors: str = None,
+        do_rescale: Optional[bool] = None,
+        rescale_factor: Optional[float] = None,
+        do_normalize: Optional[bool] = None,
+        image_mean: Optional[List[float]] = None,
+        image_std: Optional[List[float]] = None,
+        input_data_format: Optional[str] = None,
+        return_tensors: Optional[str] = None,
     ):
         """Applies post-processing to the decoded image tokens by reversing transformations applied during preprocessing."""
         do_rescale = do_rescale if do_rescale is not None else self.do_rescale

--- a/src/transformers/models/janus/modular_janus.py
+++ b/src/transformers/models/janus/modular_janus.py
@@ -1508,7 +1508,7 @@ class JanusImageProcessor(BlipImageProcessor):
     def __init__(
         self,
         do_resize: bool = True,
-        size: Dict[str, int] = None,
+        size: Optional[Dict[str, int]] = None,
         min_size: int = 14,
         resample: PILImageResampling = PILImageResampling.BICUBIC,
         do_rescale: bool = True,
@@ -1516,7 +1516,7 @@ class JanusImageProcessor(BlipImageProcessor):
         do_normalize: bool = True,
         image_mean: Optional[Union[float, List[float]]] = None,
         image_std: Optional[Union[float, List[float]]] = None,
-        do_convert_rgb: bool = None,
+        do_convert_rgb: Optional[bool] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1673,13 +1673,13 @@ class JanusImageProcessor(BlipImageProcessor):
     def postprocess(
         self,
         images: ImageInput,
-        do_rescale: bool = None,
-        rescale_factor: float = None,
-        do_normalize: bool = None,
-        image_mean: List[float] = None,
-        image_std: List[float] = None,
-        input_data_format: str = None,
-        return_tensors: str = None,
+        do_rescale: Optional[bool] = None,
+        rescale_factor: Optional[float] = None,
+        do_normalize: Optional[bool] = None,
+        image_mean: Optional[List[float]] = None,
+        image_std: Optional[List[float]] = None,
+        input_data_format: Optional[str] = None,
+        return_tensors: Optional[str] = None,
     ):
         """Applies post-processing to the decoded image tokens by reversing transformations applied during preprocessing."""
         do_rescale = do_rescale if do_rescale is not None else self.do_rescale

--- a/src/transformers/models/mobilenet_v2/image_processing_mobilenet_v2_fast.py
+++ b/src/transformers/models/mobilenet_v2/image_processing_mobilenet_v2_fast.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Fast Image processor class for MobileNetV2."""
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from ...image_processing_utils_fast import BASE_IMAGE_PROCESSOR_FAST_DOCSTRING, BaseImageProcessorFast
 from ...image_utils import IMAGENET_STANDARD_MEAN, IMAGENET_STANDARD_STD, PILImageResampling
@@ -42,7 +42,7 @@ class MobileNetV2ImageProcessorFast(BaseImageProcessorFast):
     do_normalize = True
     do_convert_rgb = None
 
-    def post_process_semantic_segmentation(self, outputs, target_sizes: List[Tuple] = None):
+    def post_process_semantic_segmentation(self, outputs, target_sizes: Optional[List[Tuple]] = None):
         """
         Converts the output of [`MobileNetV2ForSemanticSegmentation`] into semantic segmentation maps. Only supports PyTorch.
 


### PR DESCRIPTION
# What does this PR do?

This PR adds Optional to remaining types and add `RUF013` rule to enforce that.

RUFF rule `RUF013` checks for the use of implicit Optional in type annotations when the default parameter value is None.
