### PR TITLE
pin specific `natten` version in docker file 

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -57,7 +57,8 @@ RUN python3 -m pip uninstall -y ninja
 
 # For `dinat` model
 # The `XXX` part in `torchXXX` needs to match `PYTORCH` (to some extent)
-RUN python3 -m pip install --no-cache-dir natten==0.15.1+torch220$CUDA -f https://shi-labs.com/natten/wheels
+# pin `0.17.4` otherwise `cannot import name 'natten2dav' from 'natten.functional'`
+RUN python3 -m pip install --no-cache-dir natten==0.17.4+torch250cu121 -f https://shi-labs.com/natten/wheels
 
 # For `nougat` tokenizer
 RUN python3 -m pip install --no-cache-dir python-Levenshtein


### PR DESCRIPTION
# What does this PR do?

We suddenly get ``cannot import name 'natten2dav' from 'natten.functional'``, so `dinat` test get `Error` at the beginning of pytest collection, not giving any output, and the slack report job fails due to missing files and we don't receive any report.

I will try to avoid such failure in a separate PR, but let's just quickly pin `natten`