### PR TITLE
Add bnb to the list of supported quantization methods for LLama4

### DIFF
--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -304,12 +304,12 @@ class HfQuantizer(ABC):
         for name, module in model.named_modules():
             module_class_name = module.__class__.__name__
             if module_class_name in MODULES_TO_PATCH_FOR_QUANTIZATION.keys() and (
-                self.quantization_config.quant_method == QuantizationMethod.COMPRESSED_TENSORS
-                or self.quantization_config.quant_method == QuantizationMethod.BITS_AND_BYTES
+                self.quantization_config.quant_method
+                in MODULES_TO_PATCH_FOR_QUANTIZATION[module_class_name]["quantization_methods"]
             ):
                 with init_empty_weights():
                     parent_module, name = get_module_from_name(model, name)
-                    parent_module._modules[name] = MODULES_TO_PATCH_FOR_QUANTIZATION[module_class_name](
+                    parent_module._modules[name] = MODULES_TO_PATCH_FOR_QUANTIZATION[module_class_name]["module_name"](
                         model.config.get_text_config()
                     )
 
@@ -337,4 +337,9 @@ class SequentialLlama4TextExperts(ModuleList):
         return routed_out
 
 
-MODULES_TO_PATCH_FOR_QUANTIZATION = {"Llama4TextExperts": SequentialLlama4TextExperts}
+MODULES_TO_PATCH_FOR_QUANTIZATION = {
+    "Llama4TextExperts": {
+        "module_name": SequentialLlama4TextExperts,
+        "quantization_methods": [QuantizationMethod.COMPRESSED_TENSORS, QuantizationMethod.BITS_AND_BYTES],
+    }
+}

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -303,9 +303,9 @@ class HfQuantizer(ABC):
 
         for name, module in model.named_modules():
             module_class_name = module.__class__.__name__
-            if (
-                module_class_name in MODULES_TO_PATCH_FOR_QUANTIZATION.keys()
-                and (self.quantization_config.quant_method == QuantizationMethod.COMPRESSED_TENSORS or self.quantization_config.quant_method == QuantizationMethod.BITS_AND_BYTES)
+            if module_class_name in MODULES_TO_PATCH_FOR_QUANTIZATION.keys() and (
+                self.quantization_config.quant_method == QuantizationMethod.COMPRESSED_TENSORS
+                or self.quantization_config.quant_method == QuantizationMethod.BITS_AND_BYTES
             ):
                 with init_empty_weights():
                     parent_module, name = get_module_from_name(model, name)

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -305,7 +305,7 @@ class HfQuantizer(ABC):
             module_class_name = module.__class__.__name__
             if (
                 module_class_name in MODULES_TO_PATCH_FOR_QUANTIZATION.keys()
-                and self.quantization_config.quant_method == QuantizationMethod.COMPRESSED_TENSORS
+                and (self.quantization_config.quant_method == QuantizationMethod.COMPRESSED_TENSORS or self.quantization_config.quant_method == QuantizationMethod.BITS_AND_BYTES)
             ):
                 with init_empty_weights():
                     parent_module, name = get_module_from_name(model, name)

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -220,7 +220,9 @@ class HfQuantizer(ABC):
         """
         model.is_quantized = True
         model.quantization_method = self.quantization_config.quant_method
-        self._convert_model_for_quantization(model)
+        print("self.pre_quantized", self.pre_quantized)
+        if self.pre_quantized:
+            self._convert_model_for_quantization(model)
         return self._process_model_before_weight_loading(model, **kwargs)
 
     def postprocess_model(self, model: "PreTrainedModel", **kwargs):


### PR DESCRIPTION
# What does this PR do?
This pr adds support for bitsandbytes quantization, and loading bnb quantized models in transformers.

Some quantized Llama4 models can be found here : 

- https://huggingface.co/bnb-community/Llama-4-Scout-17B-16E-Instruct-bnb-4bit
- https://huggingface.co/bnb-community/Llama-4-Scout-17B-16E-Instruct-bnb-8bit