### PR TITLE
Add warning when failed to acquire other user's lock at model download

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -465,6 +465,12 @@ def cached_files(
                 "for this model name. Check the model page at "
                 f"'https://huggingface.co/{path_or_repo_id}' for available revisions."
             ) from e
+        elif isinstance(e, PermissionError):
+            raise OSError(
+                f"PermissionError at {e.filename} when downloading {path_or_repo_id}. "
+                "Check cache directory permissions. Common causes: 1) another user is downloading the same model (please wait); "
+                "2) a previous download was canceled and the lock file needs manual removal."
+            ) from e
 
         # Now we try to recover if we can find all files correctly in the cache
         resolved_files = [
@@ -870,7 +876,7 @@ class PushToHubMixin:
                 )
             if os.path.isdir(repo_path_or_name):
                 # repo_path: infer repo_id from the path
-                repo_id = repo_id.split(os.path.sep)[-1]
+                repo_id = repo_path_or_name.split(os.path.sep)[-1]
                 working_dir = repo_id
             else:
                 # repo_name: use it as repo_id


### PR DESCRIPTION
In cache directories that are shared between multiple users, it is common that a user starts downloading a model but gets tired and kills the process. This leaves the folder structure and their own locks on the filesystem.

If another user comes later and tries to use the same model, the loading will fail with a cryptic message:
```bash
OSError: meta-llama/Llama-3.1-8B-Instruct does not appear to have a file named pytorch_model.bin, model.safetensors, tf_model.h5, model.ckpt or flax_model.msgpack
```
What is happening under the hood is that it failed to acquire the lock, catches the exception, leaves no trace, then tries to recover here:

https://github.com/huggingface/transformers/blob/f834ca2c19215f1e4fb0959cc3faafeaf56cd4f7/src/transformers/utils/hub.py#L453C4-L472C10

Since it fails to find the files, the user gets the confusing OSError.

This PR just adds proper error handling to make clear what is happening, so that they know they can manually delete the locks. I don't think we should catch the exception and delete the locks ourselves, since the other user might be actually downloading the file, and UNIX locks are not shareable.

## Who can review?

@gante 
