### PR TITLE
Fix Llama4 offset

### DIFF
--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -754,7 +754,7 @@ class Llama4TextModel(Llama4PreTrainedModel):
 
         if self.config._attn_implementation == "flex_attention":
             if isinstance(attention_mask, torch.Tensor):
-                offsets = (first_cache_position, max(last_cache_position - key_length, 0))
+                offsets = (first_cache_position, max(last_cache_position + 1  - key_length, 0))
                 chunked_attention_mask = make_flex_block_causal_mask(
                     attention_mask, self.config.attention_chunk_size, sequence_length, key_length, offsets=offsets
                 )
@@ -780,10 +780,8 @@ class Llama4TextModel(Llama4PreTrainedModel):
             batch_size=input_tensor.shape[0],
         )
         if full_cache_length > self.config.attention_chunk_size:
-            start_idx = max(last_cache_position - key_length, 0)
-            end_idx = last_cache_position + 1 if sequence_length > 1 else last_cache_position
-            # We always need a mask of at least attention_chunk_size, so we use the max here
-            end_idx = max(end_idx, start_idx + attention_chunk_size)
+            start_idx = max(last_cache_position + 1 - key_length, 0)
+            end_idx = start_idx + key_length
             chunked_attention_mask = self.create_chunked_attention_mask(
                 self.config.attention_chunk_size,
                 start=start_idx,  # same offset as with flex

--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -731,7 +731,6 @@ class Llama4TextModel(Llama4PreTrainedModel):
         attention_chunk_size = self.config.attention_chunk_size
 
         first_cache_position = cache_position[0]
-        last_cache_position = cache_position[-1]
 
         if past_key_values is not None:
             full_cache_length = past_key_values.get_max_cache_shape() or sequence_length
@@ -754,7 +753,7 @@ class Llama4TextModel(Llama4PreTrainedModel):
 
         if self.config._attn_implementation == "flex_attention":
             if isinstance(attention_mask, torch.Tensor):
-                offsets = (first_cache_position, max(last_cache_position + 1  - key_length, 0))
+                offsets = (first_cache_position, max(first_cache_position - attention_chunk_size + 1, 0))
                 chunked_attention_mask = make_flex_block_causal_mask(
                     attention_mask, self.config.attention_chunk_size, sequence_length, key_length, offsets=offsets
                 )
@@ -780,7 +779,7 @@ class Llama4TextModel(Llama4PreTrainedModel):
             batch_size=input_tensor.shape[0],
         )
         if full_cache_length > self.config.attention_chunk_size:
-            start_idx = max(last_cache_position + 1 - key_length, 0)
+            start_idx = max(first_cache_position - attention_chunk_size + 1, 0)
             end_idx = start_idx + key_length
             chunked_attention_mask = self.create_chunked_attention_mask(
                 self.config.attention_chunk_size,


### PR DESCRIPTION
# What does this PR do?

See title. It's the same as before + 1. Indeed, we need to add the +1 to match correctly the positions, it's also what is done in gemma2 here https://github.com/huggingface/transformers/blob/main/src/transformers/models/gemma2/modeling_gemma2.py#L912-L913 as it uses the length (which is equal to cache_position[-1] + 1).
I used `first_cache_position - attention_chunk_size + 1` here as I feel it simpler to understand when looking at the cache code (see the 1-offset here https://github.com/huggingface/transformers/blob/main/src/transformers/cache_utils.py#L1921-L1922), but it is striclty equal. I.e. we always have `max(first_cache_position - attention_chunk_size + 1, 0) == max(last_cache_position + 1 - key_length, 0)`