### PR TITLE
Fix new failure reports not including anything other than `tests/models/`

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -544,7 +544,7 @@ class Message:
                 if "https://github.com/huggingface/transformers/actions/runs" in line:
                     pattern = r"<(https://github.com/huggingface/transformers/actions/runs/.+?/job/.+?)\|(.+?)>"
                     items = re.findall(pattern, line)
-                elif "tests/models/" in line:
+                elif "tests/" in line:
                     model = line.split("/")[2]
                     if model not in new_failed_tests:
                         new_failed_tests[model] = {"single-gpu": [], "multi-gpu": []}

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -545,7 +545,10 @@ class Message:
                     pattern = r"<(https://github.com/huggingface/transformers/actions/runs/.+?/job/.+?)\|(.+?)>"
                     items = re.findall(pattern, line)
                 elif "tests/" in line:
-                    model = line.split("/")[2]
+                    if "tests/models/" in line:
+                        model = line.split("/")[2]
+                    else:
+                        model = line.split("/")[1]
                     if model not in new_failed_tests:
                         new_failed_tests[model] = {"single-gpu": [], "multi-gpu": []}
                     for url, device in items:


### PR DESCRIPTION
# What does this PR do?

Fix new failure reports not including anything other than `tests/models/`