### PR TITLE
enhance require_deterministic_for_xpu

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -1083,6 +1083,7 @@ def require_deterministic_for_xpu(test_case):
                 torch.use_deterministic_algorithms(original_state)
         else:
             return test_case(*args, **kwargs)
+
     return wrapper
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -139,7 +139,6 @@ from .utils import (
     is_torch_available,
     is_torch_bf16_available_on_device,
     is_torch_bf16_gpu_available,
-    is_torch_deterministic,
     is_torch_fp16_available_on_device,
     is_torch_greater_or_equal,
     is_torch_hpu_available,

--- a/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
+++ b/tests/models/encoder_decoder/test_modeling_encoder_decoder.py
@@ -936,6 +936,7 @@ class BertGenerationEncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCa
         }
 
     @slow
+    @require_deterministic_for_xpu
     def test_roberta2roberta_summarization(self):
         model = EncoderDecoderModel.from_pretrained("google/roberta2roberta_L-24_bbc")
         model.to(torch_device)
@@ -1080,6 +1081,7 @@ class GPT2EncoderDecoderModelTest(EncoderDecoderMixin, unittest.TestCase):
         pass
 
     @slow
+    @require_deterministic_for_xpu
     def test_bert2gpt2_summarization(self):
         model = EncoderDecoderModel.from_pretrained("patrickvonplaten/bert2gpt2-cnn_dailymail-fp16")
 

--- a/tests/models/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
+++ b/tests/models/speech_encoder_decoder/test_modeling_speech_encoder_decoder.py
@@ -634,6 +634,7 @@ class Speech2TextBertModelTest(EncoderDecoderMixin, unittest.TestCase):
     def test_encoder_decoder_model_from_pretrained_configs(self):
         pass
 
+    @require_deterministic_for_xpu
     @unittest.skip(reason="Cannot save full model as Speech2TextModel != Speech2TextEncoder")
     def test_save_and_load_from_pretrained(self):
         pass


### PR DESCRIPTION
While revisiting this PR https://github.com/huggingface/transformers/pull/30774,  we are for "still try to set it to deterministic for XPU (in the decorator body) and use it (despite you might get some failures at some points as I mentioned). You might get lucky" option from @ydshieh. XPU is seeking the same level of usability and coverage as CUDA. So, we need enable these numerical cases w/ deterministic enabled, if some still fail, we Intel guys need investigate.

I enhance the require_deterministic_for_xpu decorator, so if it's XPU, while enter the body, we will save the deterministic state and set it to True; while leaving, we will restore the prior deterministic state. So, we don't impact the global setting, just make it case specific.

@ydshieh , pls help review, thx.