### PR TITLE
Fixes: Corrects file path for CUDA kernels

### DIFF
--- a/src/transformers/models/deprecated/deta/modeling_deta.py
+++ b/src/transformers/models/deprecated/deta/modeling_deta.py
@@ -57,7 +57,7 @@ def load_cuda_kernels():
 
     global MultiScaleDeformableAttention
 
-    root = Path(__file__).resolve().parent.parent.parent / "kernels" / "deta"
+    root = Path(__file__).resolve().parent.parent.parent.parent / "kernels" / "deta"
     src_files = [
         root / filename
         for filename in [


### PR DESCRIPTION
# What does this PR do?
Corrects the file path used to locate the CUDA kernels for the Deformable Attention module. This ensures that the kernels are loaded correctly, resolving potential errors during module initialization and usage.

## Who can review?

- vision models: @amyeroberts, @qubvel