### PR TITLE
Fix the test fetcher

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2378,6 +2378,7 @@ def spread_import_structure(nested_import_structure):
     return flattened_import_structure
 
 
+@lru_cache()
 def define_import_structure(module_path: str, prefix: str = None) -> IMPORT_STRUCTURE_T:
     """
     This method takes a module_path as input and creates an import structure digestible by a _LazyModule.


### PR DESCRIPTION
The list of tests to fetch became an infinitely growing list with the new init approach; this instead converts it to a dict, and completes the list of importable objects of each key in the dict.

If the key wasn't here previously, it adds it with the list of objects; otherwise, it checks whether the list is incomplete, and completes it.