### PR TITLE
fix: (llama4) fix no_split_modules to be picked up for fsdpv1 and v2 sharding

### DIFF
--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -476,6 +476,7 @@ class Llama4PreTrainedModel(PreTrainedModel):
     _supports_quantized_cache = True
     _supports_static_cache = True
     _supports_attention_backend = True
+    _no_split_modules = ["Llama4TextDecoderLayer", "Llama4VisionEncoderLayer"]
 
     def _init_weights(self, module):
         std = (


### PR DESCRIPTION
# What does this PR do?

Currently, FSDP sharding both v1 and v2 would fail to automatically infer which modules to wrap since, the current configuring of no_split_modules for llama4 makes it inaccessible. We should essentially move the `_no_split_modules` to common base class i.e. `Llama4PreTrainedModel`.

Though we can get around this by explicitly passing the classes to wrap, for downstream users who rely on automatic wrapping inference (traditionally working good feature of transformers 😉)  would experience bad training memory costs for llama4 + FSDP and wont realize.

While using fsdp activation checkpointing, there are no workarounds.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- text models: @ArthurZucker
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- trainer: @zach-huggingface and @SunMarc

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR


