### PR TITLE
Fix wrong argparse type in modular checker script

### DIFF
--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -115,7 +115,7 @@ def guaranteed_no_diff(modular_file_path, dependencies, models_in_diff):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Compare modular_xxx.py files with modeling_xxx.py files.")
     parser.add_argument(
-        "--files", default=["all"], type=list, nargs="+", help="List of modular_xxx.py files to compare."
+        "--files", default=["all"], type=str, nargs="+", help="List of modular_xxx.py files to compare."
     )
     parser.add_argument(
         "--fix_and_overwrite", action="store_true", help="Overwrite the modeling_xxx.py file if differences are found."


### PR DESCRIPTION
# What does this PR do?

In the `argparse` library, the `type` parameter is applied to each argument individually. When using `type=list` in combination with `nargs="+"`, the command `python utils/check_modular_conversion.py --files abc def` is parsed as `[['a', 'b', 'c'], ['d', 'e', 'f']]`. This behavior occurs because the script typically relies on no arguments being passed, defaulting to `['all']`, which has allowed it to function correctly until now.

This PR corrects this behaviour.

CC: @ArthurZucker
