### PR TITLE
Fix IndexError in add_import_statement_init

### DIFF
--- a/src/transformers/commands/add_fast_image_processor.py
+++ b/src/transformers/commands/add_fast_image_processor.py
@@ -92,7 +92,12 @@ def add_import_statement_init(content: str, fast_image_processor_name: str, mode
     lines = block_content.strip().split("\n")
     entries = []
 
-    indent = " " * (len(lines[1]) - len(lines[1].lstrip()))
+    if len(lines) > 1:
+        indent = " " * (len(lines[1]) - len(lines[1].lstrip()))
+    elif lines:
+        indent = " " * (len(lines[0]) - len(lines[0].lstrip()))
+    else:
+        indent = ""
     import_structure_header = indent + lines[0]
     entries = lines[1:]
 


### PR DESCRIPTION
# What does this PR do?

#36978 
This PR fixes an issue encountered when running the command:

```bash
transformers-cli add-fast-image-processor --model-name bridgetower
```

During BridgeTower fast image processor integration, an error occurred due to the indent calculation logic in the function `add_import_statement_init`. The original code assumed that at least two lines exist in the block it is processing:

```python
indent = " " * (len(lines[1]) - len(lines[1].lstrip()))
```

In some cases (for example, when the block is very short), `lines[1]` did not exist, which resulted in an `IndexError`.

To address this, the code now checks the length of the `lines` list and computes the indent conditionally. If there is more than one line, it uses the second line; if there is only one line, it uses that one; and if the block is empty, it defaults to an empty indent.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Details

The change in the indent calculation is as follows:

```python
if len(lines) > 1:
    indent = " " * (len(lines[1]) - len(lines[1].lstrip()))
elif lines:
    indent = " " * (len(lines[0]) - len(lines[0].lstrip()))
else:
    indent = ""
```

This fix ensures that the function correctly computes the indent regardless of the number of lines present in the import block. This error was discovered while working on BridgeTower and has been verified to resolve the `IndexError`.

## Who can review?

Anyone in the community familiar with the CLI commands or the internal code of the Transformers repository is welcome to review this change.