### PR TITLE
Don't auto-assign reviewers when the author is in HF

### DIFF
--- a/.github/scripts/assign_reviewers.py
+++ b/.github/scripts/assign_reviewers.py
@@ -54,6 +54,21 @@ def get_file_owners(file_path, codeowners_lines):
             return owners  # Remember, can still be empty!
     return []  # Should never happen, but just in case
 
+def pr_author_is_in_hf(pr_author, codeowners_lines):
+    # Check if the PR author is in the codeowners file
+    for line in codeowners_lines:
+        line = line.split('#')[0].strip()
+        if not line:
+            continue
+
+        # Split into pattern and owners
+        parts = line.split()
+        owners = [owner.removeprefix("@") for owner in parts[1:]]
+
+        if pr_author in owners:
+            return True
+    return False
+
 def main():
     script_dir = Path(__file__).parent.absolute()
     with open(script_dir / "codeowners_for_review_action") as f:
@@ -68,6 +83,9 @@ def main():
     pr_number = event['pull_request']['number']
     pr = repo.get_pull(pr_number)
     pr_author = pr.user.login
+    if pr_author_is_in_hf(pr_author, codeowners_lines):
+        print(f"PR author {pr_author} is in codeowners, skipping review request.")
+        return
 
     existing_reviews = list(pr.get_reviews())
     if existing_reviews:


### PR DESCRIPTION
As the title says, we don't want to auto-assign reviewers for staff authors because they can do it themselves (and probably more accurately)