### PR TITLE
TP support for Quark quantized model 

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4986,6 +4986,22 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
                         device_mesh,
                     )
 
+            // convert missing buffers of LLama model to tp_device  
+            if  model.model.embed_tokens.weight.device != tp_device:
+                model.model.embed_tokens.weight.data = model.model.embed_tokens.weight.data.to(tp_device)
+            if  model.model.norm.weight.device != tp_device:
+                model.model.norm.weight.data = model.model.norm.weight.data.to(tp_device)
+            if  model.lm_head.weight.device != tp_device:
+                model.lm_head.weight.data = model.lm_head.weight.data.to(tp_device)
+
+            for layer in model.model.layers:
+                if  layer.input_layernorm.weight.device != tp_device:
+                    layer.input_layernorm.weight.data =\
+                    layer.input_layernorm.weight.data.to(tp_device)
+                if  layer.post_attention_layernorm.weight.device != tp_device:
+                    layer.post_attention_layernorm.weight.data =\
+                    layer.post_attention_layernorm.weight.data.to(tp_device)
+
         # All potential warnings/infos
         if len(error_msgs) > 0:
             error_msg = "\n\t".join(error_msgs)

--- a/tests/quantization/quark_integration/test_quark_tp.py
+++ b/tests/quantization/quark_integration/test_quark_tp.py
@@ -1,0 +1,71 @@
+import torch
+import os
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from transformers import AutoConfig, GenerationConfig, QuarkConfig
+import transformers
+from torch.distributed.tensor import DTensor, Placement, Replicate
+
+model_id = "amd/Llama-3.1-8B-Instruct-w-int8-a-int8-sym-test"
+
+config = AutoConfig.from_pretrained(model_id)
+
+quant_config = QuarkConfig(**config.quantization_config)
+print("ak mode:", quant_config.custom_mode)
+
+rank = None
+world_size = -1
+tp_plan = None
+device = None
+
+try:
+   rank = int(os.environ["RANK"])
+   world_size = int(os.environ["WORLD_SIZE"])
+   tp_plan = "auto"
+except Exception as e:
+   print(e)
+
+if rank is not None and rank == 1:
+   print("torch: ", torch.__version__)
+   print("tf: ", transformers.__version__)
+   print("tf: ", transformers.__file__)
+
+if rank is not None:
+   device = torch.device(f"cuda:{rank}")
+   torch.cuda.set_device(device)
+   torch.distributed.init_process_group("nccl", rank=rank, world_size=world_size)
+
+dtype = "auto"
+dtype = torch.float16
+
+model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=dtype, tp_plan=tp_plan,
+                                             #quantization_config=quant_config,
+                                             device_map = None)
+
+if rank is not None:
+   torch.distributed.barrier()
+   device_mesh = None
+   has_dtensor = 0
+   for name, parameter in model.named_parameters():
+      if isinstance(parameter.data, torch.distributed.tensor.DTensor):
+         has_dtensor = 1
+         break
+   assert has_dtensor == 1, "TP model must has DTensor"
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+prompt = "Can I help"
+
+if device is None:
+   device  = model.device
+
+inputs = tokenizer(prompt, return_tensors="pt").input_ids.to(device)
+outputs = model(inputs)
+
+next_token_logits = outputs[0][:, -1, :]
+next_token = torch.argmax(next_token_logits, dim=-1)
+response = tokenizer.decode(next_token)
+
+print("\n response = ",response)
+
+if rank is not None:
+   torch.distributed.barrier()
+   torch.distributed.destroy_process_group()


### PR DESCRIPTION
# What does this PR do?

After integrating the AMD Quark quantizer, we aim to leverage the HF tensor parallelism feature to accelerate the inference of the Quark-quantized model. I have identified several areas where modifications are necessary to support model TP. The changes made serve as a demonstration of the required adjustments. Please review and provide feedback.

For the shard_and_distribute_module() function in tensor_parallel.py, please consider adding quantizer awareness. There are several unique Quark parameters that need to be addressed. Refer to the updated version for details. I suggest adding a quantizer parameter to this function and allowing a quantizer-specific function to be used in column-wise and row-wise partition functions.

The modification for src/transformers/modeling_utils.py is temporary changes to make the test code work.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
