### PR TITLE
add fromjson to jinja environments

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -423,6 +423,9 @@ def _compile_jinja_template(chat_template):
         # We also expose some options like custom indents and separators
         return json.dumps(x, ensure_ascii=ensure_ascii, indent=indent, separators=separators, sort_keys=sort_keys)
 
+    def fromjson(x):
+        return json.loads(x)
+
     def strftime_now(format):
         return datetime.now().strftime(format)
 
@@ -430,6 +433,7 @@ def _compile_jinja_template(chat_template):
         trim_blocks=True, lstrip_blocks=True, extensions=[AssistantTracker, jinja2.ext.loopcontrols]
     )
     jinja_env.filters["tojson"] = tojson
+    jinja_env.filters["fromjson"] = fromjson
     jinja_env.globals["raise_exception"] = raise_exception
     jinja_env.globals["strftime_now"] = strftime_now
     return jinja_env.from_string(chat_template)


### PR DESCRIPTION
# What does this PR do?

Adds a `fromjson` filter to the Jinja environments in `chat_template_util`.  
This is particularly useful for handling tool use data that is stored as JSON strings.

## Who can review?

@Rocketknight1

