### PR TITLE
enable 6 rt_detr_v2 cases on xpu

### DIFF
--- a/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
+++ b/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
@@ -27,7 +27,13 @@ from transformers import (
     is_torch_available,
     is_vision_available,
 )
-from transformers.testing_utils import require_torch, require_torch_accelerator, require_torch_gpu, require_vision, slow, torch_device
+from transformers.testing_utils import (
+    require_torch,
+    require_torch_accelerator,
+    require_vision,
+    slow,
+    torch_device,
+)
 from transformers.utils import cached_property
 
 from ...test_configuration_common import ConfigTester

--- a/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
+++ b/tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py
@@ -27,7 +27,7 @@ from transformers import (
     is_torch_available,
     is_vision_available,
 )
-from transformers.testing_utils import require_torch, require_torch_gpu, require_vision, slow, torch_device
+from transformers.testing_utils import require_torch, require_torch_accelerator, require_torch_gpu, require_vision, slow, torch_device
 from transformers.utils import cached_property
 
 from ...test_configuration_common import ConfigTester
@@ -636,7 +636,7 @@ class RTDetrV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
         self.assertTrue(not failed_cases, message)
 
     @parameterized.expand(["float32", "float16", "bfloat16"])
-    @require_torch_gpu
+    @require_torch_accelerator
     @slow
     def test_inference_with_different_dtypes(self, torch_dtype_str):
         torch_dtype = {
@@ -658,7 +658,7 @@ class RTDetrV2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
                 _ = model(**self._prepare_for_class(inputs_dict, model_class))
 
     @parameterized.expand(["float32", "float16", "bfloat16"])
-    @require_torch_gpu
+    @require_torch_accelerator
     @slow
     def test_inference_equivalence_for_static_and_dynamic_anchors(self, torch_dtype_str):
         torch_dtype = {


### PR DESCRIPTION
below 6 cases PASSED

tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py::RTDetrV2ModelTest::test_inference_equivalence_for_static_and_dynamic_anchors_0_float32
tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py::RTDetrV2ModelTest::test_inference_equivalence_for_static_and_dynamic_anchors_1_float16
tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py::RTDetrV2ModelTest::test_inference_equivalence_for_static_and_dynamic_anchors_2_bfloat16
tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py::RTDetrV2ModelTest::test_inference_with_different_dtypes_0_float32
tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py::RTDetrV2ModelTest::test_inference_with_different_dtypes_1_float16
tests/models/rt_detr_v2/test_modeling_rt_detr_v2.py::RTDetrV2ModelTest::test_inference_with_different_dtypes_2_bfloat16