### PR TITLE
update `test_can_load_with_global_device_set` with a hack

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4550,7 +4550,8 @@ class ModelTesterMixin:
             self.assertEqual(
                 unique_devices, {device}, f"All parameters should be on {device}, but found {unique_devices}."
             )
-
+    # here we need to run with a subprocess as otherwise setting back the default device to the default value ("cpu")
+    # may bring unwanted consequences on other tests
     @run_test_using_subprocess
     @require_torch_accelerator
     def test_can_load_with_global_device_set(self):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4550,8 +4550,9 @@ class ModelTesterMixin:
             self.assertEqual(
                 unique_devices, {device}, f"All parameters should be on {device}, but found {unique_devices}."
             )
-    # here we need to run with a subprocess as otherwise setting back the default device to the default value ("cpu")
-    # may bring unwanted consequences on other tests
+
+    # Here we need to run with a subprocess as otherwise setting back the default device to the default value ("cpu")
+    # may bring unwanted consequences on other tests. See PR #37553
     @run_test_using_subprocess
     @require_torch_accelerator
     def test_can_load_with_global_device_set(self):


### PR DESCRIPTION
# What does this PR do?

`torch.set_default_device` has some unexpected impacts on other tests even if we try to restore the origin value by calling it at the end of the test. See #37551 for one example that is fixed there.

This PR uses `torch._GLOBAL_DEVICE_CONTEXT` to do something more close to the internal mechanism in `torch.set_default_device` to perform the cleanup, see

https://github.com/pytorch/pytorch/blob/e229ce34c4ab8cd4e2800227615be32fb362b1e6/torch/__init__.py#L1205-L1218



Running 

> RUN_SLOW=1 python3 -m pytest -v tests/models/mask2former/test_modeling_mask2former.py

will pass on this PR while it fails on the base commit (b33edf1b) of this PR.

> FAILED tests/models/mask2former/test_modeling_mask2former.py::Mask2FormerModelTest::test_torch_export - AttributeError: module 'torch._tensor' has no attribute 'split'

>FAILED tests/models/mask2former/test_modeling_mask2former.py::Mask2FormerModelIntegrationTest::test_export - AttributeError: module 'torch._tensor' has no attribute 'split'






