### PR TITLE
Small fix on context manager detection

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4170,7 +4170,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         if device_map is None and not is_deepspeed_zero3_enabled():
             device_in_context = get_torch_context_manager_or_global_device()
             if device_in_context == torch.device("meta"):
-                # TODO Cyril: raise an error instead of the warning in v4.53
+                # TODO Cyril: raise an error instead of the warning in v4.53 (and change the test to check for raise instead of success)
                 logger.warning(
                     "We detected that you are using `from_pretrained` with a meta device context manager or `torch.set_default_device('meta')`\n"
                     "This is an anti-pattern and will raise an Error in version v4.53\nIf you want to initialize a model on the meta device, use "

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5837,11 +5837,10 @@ def is_accelerator_device(device: Union[str, int, torch.device]) -> bool:
     """Check if the device is an accelerator. We need to function, as device_map can be "disk" as well, which is not
     a proper `torch.device`.
     """
-    try:
-        return torch.device(device).type not in ["meta", "cpu"]
-    # Handle `device="disk"` case
-    except RuntimeError:
+    if device == "disk":
         return False
+    else:
+        return torch.device(device).type not in ["meta", "cpu"]
 
 
 def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: Dict, factor=2):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4167,15 +4167,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             _adapter_model_path = None
 
         # Potentially detect context manager or global device, and use it (only if no device_map was provided)
-        if device_map is None:
+        if device_map is None and not is_deepspeed_zero3_enabled():
             device_in_context = get_torch_context_manager_or_global_device()
             if device_in_context == torch.device("meta"):
-                raise ValueError(
-                    (
-                        "`from_pretrained` is not compatible with a meta device context manager or `torch.set_default_device('meta')` "
-                        "as its purpose is to load weights. If you want to initialize a model on the meta device, use the context manager "
-                        "or global device with `from_config`, or `ModelClass(config)`"
-                    )
+                # TODO Cyril: raise this error instead of the warning in v4.53
+                # raise ValueError(
+                #     (
+                #         "`from_pretrained` is not compatible with a meta device context manager or `torch.set_default_device('meta')` "
+                #         "as its purpose is to load weights. If you want to initialize a model on the meta device, use the context manager "
+                #         "or global device with `from_config`, or `ModelClass(config)`"
+                #     )
+                # )
+                logger.warning(
+                    "We detected that you are using `from_pretrained` with a meta device context manager or `torch.set_default_device('meta')`\n"
+                    "This is an anti-pattern and will raise an Error in version v4.53\nIf you want to initialize a model on the meta device, use "
+                    "the context manager or global device with `from_config`, or `ModelClass(config)`"
                 )
             device_map = device_in_context
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4170,14 +4170,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         if device_map is None and not is_deepspeed_zero3_enabled():
             device_in_context = get_torch_context_manager_or_global_device()
             if device_in_context == torch.device("meta"):
-                # TODO Cyril: raise this error instead of the warning in v4.53
-                # raise ValueError(
-                #     (
-                #         "`from_pretrained` is not compatible with a meta device context manager or `torch.set_default_device('meta')` "
-                #         "as its purpose is to load weights. If you want to initialize a model on the meta device, use the context manager "
-                #         "or global device with `from_config`, or `ModelClass(config)`"
-                #     )
-                # )
+                # TODO Cyril: raise an error instead of the warning in v4.53
                 logger.warning(
                     "We detected that you are using `from_pretrained` with a meta device context manager or `torch.set_default_device('meta')`\n"
                     "This is an anti-pattern and will raise an Error in version v4.53\nIf you want to initialize a model on the meta device, use "

--- a/src/transformers/models/deprecated/nat/modeling_nat.py
+++ b/src/transformers/models/deprecated/nat/modeling_nat.py
@@ -545,7 +545,7 @@ class NatEncoder(nn.Module):
         super().__init__()
         self.num_levels = len(config.depths)
         self.config = config
-        dpr = [x.item() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths))]
+        dpr = [x.item() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths), device="cpu")]
         self.levels = nn.ModuleList(
             [
                 NatStage(

--- a/src/transformers/models/deprecated/van/modeling_van.py
+++ b/src/transformers/models/deprecated/van/modeling_van.py
@@ -311,7 +311,9 @@ class VanEncoder(nn.Module):
         hidden_sizes = config.hidden_sizes
         depths = config.depths
         mlp_ratios = config.mlp_ratios
-        drop_path_rates = [x.item() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths))]
+        drop_path_rates = [
+            x.item() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths), device="cpu")
+        ]
 
         for num_stage, (patch_size, stride, hidden_size, depth, mlp_expantion, drop_path_rate) in enumerate(
             zip(patch_sizes, strides, hidden_sizes, depths, mlp_ratios, drop_path_rates)

--- a/src/transformers/models/dinat/modeling_dinat.py
+++ b/src/transformers/models/dinat/modeling_dinat.py
@@ -553,7 +553,7 @@ class DinatEncoder(nn.Module):
         super().__init__()
         self.num_levels = len(config.depths)
         self.config = config
-        dpr = [x.item() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths))]
+        dpr = [x.item() for x in torch.linspace(0, config.drop_path_rate, sum(config.depths), device="cpu")]
         self.levels = nn.ModuleList(
             [
                 DinatStage(

--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -177,7 +177,7 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
         pass
 
     @unittest.skip(reason="TimmBackbone uses its own `from_pretrained` without device_map support")
-    def test_cannot_load_with_meta_device_context_manager(self):
+    def test_can_load_with_meta_device_context_manager(self):
         pass
 
     @unittest.skip(reason="model weights aren't tied in TimmBackbone.")

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4583,7 +4583,7 @@ class ModelTesterMixin:
                 unique_devices, {device}, f"All parameters should be on {device}, but found {unique_devices}."
             )
 
-    def test_cannot_load_with_meta_device_context_manager(self):
+    def test_can_load_with_meta_device_context_manager(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:
             # Need to deepcopy here as it is modified in-place in save_pretrained (it sets sdpa for default attn, which
@@ -4593,10 +4593,15 @@ class ModelTesterMixin:
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
 
-                # This should raise an error with meta device
-                with self.assertRaises(ValueError, msg="`from_pretrained` is not compatible with a meta device"):
-                    with torch.device("meta"):
-                        _ = model_class.from_pretrained(tmpdirname)
+                with torch.device("meta"):
+                    new_model = model_class.from_pretrained(tmpdirname)
+                unique_devices = {param.device for param in new_model.parameters()} | {
+                    buffer.device for buffer in new_model.buffers()
+                }
+
+            self.assertEqual(
+                unique_devices, {torch.device("meta")}, f"All parameters should be on meta device, but found {unique_devices}."
+            )
 
 
 global_rng = random.Random()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4600,7 +4600,9 @@ class ModelTesterMixin:
                 }
 
             self.assertEqual(
-                unique_devices, {torch.device("meta")}, f"All parameters should be on meta device, but found {unique_devices}."
+                unique_devices,
+                {torch.device("meta")},
+                f"All parameters should be on meta device, but found {unique_devices}.",
             )
 
 


### PR DESCRIPTION
# What does this PR do?

Following feedback in https://github.com/huggingface/transformers/pull/37216!
cc @SunMarc
In the meantime, I switched the test to ensure we _can_ load on meta so that it works for 3rd party libs until we remove it (because it was not the case before https://github.com/huggingface/transformers/pull/37216, as we need to explicitly pass a `device_map=torch.device("meta")`, which is weird and an anti-pattern)
BTW, do you have concrete examples of 3rd party libs using such meta context managers? 🤔