### PR TITLE
Restructure torchao quantization examples

### DIFF
--- a/docs/source/en/quantization/torchao.md
+++ b/docs/source/en/quantization/torchao.md
@@ -33,11 +33,11 @@ See the table below for additional torchao features.
 
 torchao supports the [quantization techniques](https://github.com/pytorch/ao/blob/main/torchao/quantization/README.md) below.
 
-- A16W8 Int8 WeightOnly Quantization
-- A16W4 WeightOnly Quantization
-- A8W8 Int8 Dynamic Quantization
 - A16W8 Float8 Dynamic Quantization
 - A16W8 Float8 WeightOnly Quantization
+- A8W8 Int8 Dynamic Quantization
+- A16W8 Int8 Weight Only Quantization
+- A16W4 Int4 Weight Only Quantization
 - Autoquantization
 
 

--- a/docs/source/en/quantization/torchao.md
+++ b/docs/source/en/quantization/torchao.md
@@ -345,32 +345,6 @@ output = quantized_model.generate(**input_ids, max_new_tokens=10, cache_implemen
 print(tokenizer.decode(output[0], skip_special_tokens=True))
 ```
 </hfoption>
-<hfoption id="float8-weight-only cpu">
-```py
-import torch
-from transformers import TorchAoConfig, AutoModelForCausalLM, AutoTokenizer
-from torchao.quantization import Float8WeightOnlyConfig
-
-quant_config = Float8WeightOnlyConfig()
-quantization_config = TorchAoConfig(quant_type=quant_config)
-
-# Load and quantize the model
-quantized_model = AutoModelForCausalLM.from_pretrained(
-    "meta-llama/Llama-3.1-8B-Instruct",
-    torch_dtype="auto",
-    device_map="cpu",
-    quantization_config=quantization_config
-)
-
-tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.1-8B-Instruct")
-input_text = "What are we having for dinner?"
-input_ids = tokenizer(input_text, return_tensors="pt")
-
-# auto-compile the quantized model with `cache_implementation="static"` to get speed up
-output = quantized_model.generate(**input_ids, max_new_tokens=10, cache_implementation="static")
-print(tokenizer.decode(output[0], skip_special_tokens=True))
-```
-</hfoption>
 </hfoptions>
 
 ### Autoquant

--- a/docs/source/en/quantization/torchao.md
+++ b/docs/source/en/quantization/torchao.md
@@ -64,7 +64,7 @@ pip install --upgrade torchao transformers
 <hfoption id="PyTorch Index">
 Stable Release from the PyTorch index
 ```bash
-pip install torchao --extra-index-url https://download.pytorch.org/whl/cu126 # options are cpu/cu118/cu126/cu128
+pip install torchao --index-url https://download.pytorch.org/whl/cu126 # options are cpu/cu118/cu126/cu128
 ```
 </hfoption>
 </hfoptions>

--- a/docs/source/en/quantization/torchao.md
+++ b/docs/source/en/quantization/torchao.md
@@ -122,7 +122,7 @@ import torch
 from transformers import TorchAoConfig, AutoModelForCausalLM, AutoTokenizer
 from torchao.quantization import GemliteUIntXWeightOnlyConfig
 
-# we also integrated with gemlite, which optimizes for batch size N on A100 and H100
+# We integrated with gemlite, which optimizes for batch size N on A100 and H100
 quant_config = GemliteUIntXWeightOnlyConfig(group_size=128)
 quantization_config = TorchAoConfig(quant_type=quant_config)
 
@@ -176,7 +176,7 @@ print(tokenizer.decode(output[0], skip_special_tokens=True))
 ```
 </hfoption>
 
-<hfoption id="int4 weight only">
+<hfoption id="int4-weight-only">
 
 ```py
 import torch
@@ -184,10 +184,11 @@ from transformers import TorchAoConfig, AutoModelForCausalLM, AutoTokenizer
 from torchao.quantization import Int4WeightOnlyConfig
 
 # For batch size N, we recommend gemlite, which may require autotuning
+# default is 4 bit, 8 bit is also supported by passing `bit_width=8`
 quant_config = GemliteUIntXWeightOnlyConfig(group_size=128)
 
 # For batch size 1, we also have custom tinygemm kernel that's only optimized for this
-# We can set use_hqq to True for better accuracy
+# We can set `use_hqq` to `True` for better accuracy
 # quant_config = Int4WeightOnlyConfig(group_size=128, use_hqq=True)
 
 quantization_config = TorchAoConfig(quant_type=quant_config)

--- a/docs/source/en/quantization/torchao.md
+++ b/docs/source/en/quantization/torchao.md
@@ -151,8 +151,9 @@ import torch
 from transformers import TorchAoConfig, AutoModelForCausalLM, AutoTokenizer
 from torchao.quantization import Int4WeightOnlyConfig
 
-# our default int4 weight only quantization option is only optimized for batch size 1
-quant_config = Int4WeightOnlyConfig(group_size=128)
+# Note: our default int4 weight only quantization option is only optimized for batch size 1
+# Note: we can set use_hqq to True for better accuracy
+quant_config = Int4WeightOnlyConfig(group_size=128, use_hqq=True)
 quantization_config = TorchAoConfig(quant_type=quant_config)
 
 # Load and quantize the model


### PR DESCRIPTION
Summary:
Mainly structured the examples by hardwares and then listed the recommended quantization methods for each hardware H100 GPU, A100 GPU and CPU

Also added example for push_to_hub

Test Plan:
not required

Reviewers:

Subscribers:

Tasks:

Tags:

