### PR TITLE
[kernels] use original forward at compile time

### DIFF
--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -81,7 +81,8 @@ try:
             kernel_forward = cls.forward
 
             def forward_with_compile_path(*forward_args, **forward_kwargs):
-                if is_torchdynamo_compiling() or (hasattr(cls, "config") and cls.config.disable_custom_kernels):
+                disable_custom_kernels = hasattr(cls, "config") and getattr(cls.config, "disable_custom_kernels")
+                if is_torchdynamo_compiling() or disable_custom_kernels:
                     return original_forward(*forward_args, **forward_kwargs)
                 else:
                     return kernel_forward(*forward_args, **forward_kwargs)

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -64,6 +64,9 @@ try:
         """
         Expands `kernels`' `use_kernel_forward_from_hub` to NOT use a kernel at compile time. This should be removed
         when `kernels` supports `torch.compile`.
+
+        If the layer has a `config` attribute, we can also set `disable_custom_kernels` to `True` to disable the
+        kernel.
         """
 
         def decorator_with_compile_path(cls):
@@ -78,7 +81,7 @@ try:
             kernel_forward = cls.forward
 
             def forward_with_compile_path(*forward_args, **forward_kwargs):
-                if is_torchdynamo_compiling():
+                if is_torchdynamo_compiling() or (hasattr(cls, "config") and cls.config.disable_custom_kernels):
                     return original_forward(*forward_args, **forward_kwargs)
                 else:
                     return kernel_forward(*forward_args, **forward_kwargs)

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -81,7 +81,7 @@ try:
             kernel_forward = cls.forward
 
             def forward_with_compile_path(*forward_args, **forward_kwargs):
-                disable_custom_kernels = hasattr(cls, "config") and getattr(cls.config, "disable_custom_kernels")
+                disable_custom_kernels = hasattr(cls, "config") and getattr(cls.config, "disable_custom_kernels", None)
                 if is_torchdynamo_compiling() or disable_custom_kernels:
                     return original_forward(*forward_args, **forward_kwargs)
                 else:

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -65,7 +65,7 @@ try:
         Expands `kernels`' `use_kernel_forward_from_hub` to NOT use a kernel at compile time. This should be removed
         when `kernels` supports `torch.compile`.
 
-        If the layer has a `config` attribute, we can also set `config.disable_custom_kernels =True` to disable the
+        If the layer has a `config` attribute, we can also set `config.disable_custom_kernels = True` to disable the
         kernel.
         """
 

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -65,7 +65,7 @@ try:
         Expands `kernels`' `use_kernel_forward_from_hub` to NOT use a kernel at compile time. This should be removed
         when `kernels` supports `torch.compile`.
 
-        If the layer has a `config` attribute, we can also set `disable_custom_kernels` to `True` to disable the
+        If the layer has a `config` attribute, we can also set `config.disable_custom_kernels =True` to disable the
         kernel.
         """
 


### PR DESCRIPTION
# What does this PR do?

`kernels` and `torch.compile` are not yet compatible with each other. Although we can skip custom kernels when the package is not installed, adding an error message is also not feasible -- we can't throw exceptions at compile time.

This PR hijacks the `kernels` decorator to add a compile-friendly path: until `kernels` supports `torch.compile`, let's use the original `forward`. 