### PR TITLE
Add test to ensure unknown exceptions reraising in utils/hub.py::cached_files()

### DIFF
--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -189,3 +189,14 @@ class GetFromCacheTests(unittest.TestCase):
         with self.assertRaisesRegex(EnvironmentError, "is a gated repository"):
             # All files except README.md are protected on a gated repo.
             has_file(GATED_REPO, "gated_file.txt", token=False)
+
+    def test_cached_files_exception_raised(self):
+        """Test that unhadled exceptions, e.g. ModuleNotFoundError, is properly re-raised by cached_files when hf_hub_download fails."""
+        with mock.patch(
+            "transformers.utils.hub.hf_hub_download", side_effect=ModuleNotFoundError("No module named 'MockModule'")
+        ):
+            with self.assertRaises(ModuleNotFoundError):
+                # The error should be re-raised by cached_files, not caught in the exception handling block
+                from transformers.utils.hub import cached_files
+
+                cached_files("Qwen/Qwen2.5-Coder-7B-Instruct", ["config.json"])

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -197,6 +197,4 @@ class GetFromCacheTests(unittest.TestCase):
         ):
             with self.assertRaises(ModuleNotFoundError):
                 # The error should be re-raised by cached_files, not caught in the exception handling block
-                from transformers.utils.hub import cached_files
-
-                cached_files("Qwen/Qwen2.5-Coder-7B-Instruct", ["config.json"])
+                cached_file(RANDOM_BERT, "nonexistent.json")


### PR DESCRIPTION
After fixing #37477 with #37525, a proper test was pending, so we ensure unknown Exceptions are properly re-raised.

Thanks again Cyril for the helpful review and guidance in the previous PR! Let me know if the test is adequate :)

## Who can review?

@Cyrilvallez