### PR TITLE
[Fix] InternVL3 automodel & InternVLProcessor import

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -151,6 +151,7 @@ MODEL_MAPPING_NAMES = OrderedDict(
         ("ijepa", "IJepaModel"),
         ("imagegpt", "ImageGPTModel"),
         ("informer", "InformerModel"),
+        ("internvl", "InternVLForConditionalGeneration"),
         ("internvl_vision", "InternVLVisionModel"),
         ("jamba", "JambaModel"),
         ("janus", "JanusModel"),

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -151,7 +151,6 @@ MODEL_MAPPING_NAMES = OrderedDict(
         ("ijepa", "IJepaModel"),
         ("imagegpt", "ImageGPTModel"),
         ("informer", "InformerModel"),
-        ("internvl", "InternVLForConditionalGeneration"),
         ("internvl_vision", "InternVLVisionModel"),
         ("jamba", "JambaModel"),
         ("janus", "JanusModel"),

--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -106,9 +106,9 @@ class InternVLProcessor(ProcessorMixin):
         self.image_seq_length = image_seq_length
         self.fake_image_token = fake_image_token
         self.fake_video_token = fake_video_token
-        self.start_image_token = tokenizer.start_image_token
-        self.end_image_token = tokenizer.end_image_token
-        self.context_image_token = tokenizer.context_image_token
+        self.start_image_token = "<img>" if not hasattr(tokenizer, "start_image_token") else tokenizer.start_image_token
+        self.end_image_token = "</img>" if not hasattr(tokenizer, "end_image_token") else tokenizer.end_image_token
+        self.context_image_token = "<IMG_CONTEXT>" if not hasattr(tokenizer, "context_image_token") else tokenizer.context_image_token
 
         super().__init__(image_processor, tokenizer, chat_template=chat_template, **kwargs)
 


### PR DESCRIPTION
# What does this PR do?

This PR is to fix a model import problem mentioned in #37595 relating InternVL3 models

Fixes # (issue)

* Fixed loading InternVL model via AutoModel by adding ("internvl", "InternVLForConditionalGeneration") in MODEL_MAPPING_NAMES
* Fixed loading InternVLProcessor error while attributes "start_image_token", "end_image_token" and "context_image_token" missing from tokenizer.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Especically, I encourage anyone in HuggingFace team, InternVL team to review my PR.