### PR TITLE
Fix duplicated weights in fp8 quantization

### DIFF
--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from ..modeling_utils import _load_parameter_into_model
 from ..utils import is_accelerate_available, is_torch_available, logging
 from .base import HfQuantizer
 from .quantizers_utils import get_module_from_name
@@ -8,6 +7,8 @@ from .quantizers_utils import get_module_from_name
 
 if is_torch_available():
     import torch
+
+    from ..modeling_utils import _load_parameter_into_model
 
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -129,6 +129,7 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         # Reshape scale to match the number of blocks
         scale = scale.reshape(scale_orig_shape).squeeze().reciprocal()
 
+        # Load into the model
         _load_parameter_into_model(model, param_name, quantized_param)
         _load_parameter_into_model(model, param_name.rsplit(".", 1)[0] + ".weight_scale_inv", scale)
 

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -8,8 +8,6 @@ from .quantizers_utils import get_module_from_name
 if is_torch_available():
     import torch
 
-    from ..modeling_utils import _load_parameter_into_model
-
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 
@@ -93,6 +91,8 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         """
         Quantizes weights to FP8 format using Block-wise quantization
         """
+        from ..modeling_utils import _load_parameter_into_model
+
         param_value = param_value.to(target_device)
 
         # Get FP8 min/max values


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/35926 moved the fp8 params from buffers to parameters (which makes sense), but the quantizer itself was not updated, so the parameters would still be added as buffers leading to duplicated weights (they would live as both buffers and parameters).

Also, note that we SHOULD NEVER use `set_module_tensor_to_device` as it clears the cuda cache at each call which is really inefficient, and defeats all the purpose of cuda warmup we do in `from_pretrained`

cc @SunMarc @MekkCyber 
