### PR TITLE
Fix no_split_modules for Llama4 pretrained models

### DIFF
--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -474,7 +474,6 @@ class Llama4PreTrainedModel(PreTrainedModel):
     _supports_quantized_cache = True
     _supports_static_cache = True
     _supports_attention_backend = True
-    _no_split_modules = ["Llama4TextDecoderLayer", "Llama4VisionEncoderLayer"]
 
     def _init_weights(self, module):
         std = (
@@ -927,6 +926,7 @@ class Llama4TextModel(Llama4PreTrainedModel):
 
 
 class Llama4ForCausalLM(Llama4PreTrainedModel, GenerationMixin):
+    _no_split_modules = ["Llama4TextDecoderLayer"]
     base_model_prefix = "language_model"
     _tied_weights_keys = ["lm_head.weight"]
     _tp_plan = {"lm_head": "colwise_rep"}
@@ -1583,6 +1583,7 @@ class Llama4VisionModel(Llama4PreTrainedModel):
 
 
 class Llama4ForConditionalGeneration(Llama4PreTrainedModel, GenerationMixin):
+    _no_split_modules = ["Llama4TextDecoderLayer", "Llama4VisionEncoderLayer"]
     _tp_plan = {}
     base_model_prefix = ""
     config_class = Llama4Config


### PR DESCRIPTION
# What does this PR do?

This PR moves the definition of `_no_split_modules` for Llama4 pre-trained models from the base `Llama4PreTrainedModel` class to the subclasses so each model has the correct set of modules.

Otherwise loading the `Llama4ForCausalLM` currently fails because it doesn't have the `Llama4VisionEncoderLayer` module.

Fixes #37672

## Who can review?

@ArthurZucker @amyeroberts @qubvel