### PR TITLE
Fix autoround docs 

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -167,6 +167,8 @@
     title: Quantization concepts
   - local: quantization/aqlm
     title: AQLM
+  - local: quantization/auto_round
+    title: AutoRound
   - local: quantization/awq
     title: AWQ
   - local: quantization/bitnet


### PR DESCRIPTION
# What does this PR do?

This PR adds autoround docs in the _toctree file 