### PR TITLE
[docs] only build `en` docs in push CI

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -14,4 +14,4 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: transformers
-      languages: ar de en es fr hi it ko pt tr zh ja te
+      languages: en


### PR DESCRIPTION
# What does this PR do?

In our push CI, restrict the doc builder to `en`
- All languages: ~26 mins ([data point](https://github.com/huggingface/transformers/actions/runs/14597021526/job/40945447156))
- `en`: ~12 mins (this PR)

Pros:
- `en` has the full doc reference to class/methods (in other languages it is a copy)
- source of truth is tested at a fraction of the time
- `main` still builds all languages (different CI workflow)

Cons:
- PRs to other languages won’t build the corresponding docs at push time