### PR TITLE
Add maintainers for ROCm/Intel XPU/Ascend NPU

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -57,7 +57,7 @@ body:
           - Big Model Inference: @SunMarc
           - quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber
         
-        Specific backends:
+        Devices/Backends:
         
           - ROCm: @ivarflakstad
           - Intel XPU: @IlyasMoutawwakil

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -59,9 +59,9 @@ body:
         
         Specific backends:
         
-          - ROCm: @IvarFlakstad
+          - ROCm: @ivarflakstad
           - Intel XPU: @IlyasMoutawwakil
-          - Ascend NPU: @IvarFlakstad 
+          - Ascend NPU: @ivarflakstad 
 
         Documentation: @stevhliu
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -59,7 +59,7 @@ body:
         
         Devices/Backends:
         
-          - ROCm: @ivarflakstad
+          - AMD ROCm: @ivarflakstad
           - Intel XPU: @IlyasMoutawwakil
           - Ascend NPU: @ivarflakstad 
 

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -56,6 +56,12 @@ body:
           - ray/raytune: @richardliaw, @amogkam
           - Big Model Inference: @SunMarc
           - quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber
+        
+        Specific backends:
+        
+          - ROCm: @IvarFlakstad
+          - Intel XPU: @IlyasMoutawwakil
+          - Ascend NPU: @IvarFlakstad 
 
         Documentation: @stevhliu
 


### PR DESCRIPTION
We have a list of maintainers for various parts of the library in the issue template; this PR adds maintainers for backends like ROCm, XPU and Ascend NPU.

cc @ivarflakstad @IlyasMoutawwakil - let me know if you're okay with this!