### PR TITLE
FIX: Register image processing kwargs in DonutProcessor

### DIFF
--- a/src/transformers/models/donut/image_processing_donut_fast.py
+++ b/src/transformers/models/donut/image_processing_donut_fast.py
@@ -16,6 +16,8 @@
 
 from typing import Optional, Union
 
+import numpy as np
+
 from ...image_processing_utils_fast import (
     BASE_IMAGE_PROCESSOR_FAST_DOCSTRING,
     BASE_IMAGE_PROCESSOR_FAST_DOCSTRING_PREPROCESS,
@@ -58,6 +60,7 @@ class DonutFastImageProcessorKwargs(DefaultFastImageProcessorKwargs):
     do_thumbnail: Optional[bool]
     do_align_long_axis: Optional[bool]
     do_pad: Optional[bool]
+    random_padding: Optional[bool]
 
 
 @add_start_docstrings(
@@ -171,8 +174,8 @@ class DonutImageProcessorFast(BaseImageProcessorFast):
         delta_height = output_height - input_height
 
         if random_padding:
-            pad_top = torch.random.randint(low=0, high=delta_height + 1)
-            pad_left = torch.random.randint(low=0, high=delta_width + 1)
+            pad_top = np.random.randint(low=0, high=delta_height + 1)
+            pad_left = np.random.randint(low=0, high=delta_width + 1)
         else:
             pad_top = delta_height // 2
             pad_left = delta_width // 2
@@ -236,6 +239,7 @@ class DonutImageProcessorFast(BaseImageProcessorFast):
         do_thumbnail: bool,
         do_align_long_axis: bool,
         do_pad: bool,
+        random_padding: bool,
         size: SizeDict,
         interpolation: Optional["F.InterpolationMode"],
         do_center_crop: bool,
@@ -262,7 +266,7 @@ class DonutImageProcessorFast(BaseImageProcessorFast):
             if do_thumbnail:
                 stacked_images = self.thumbnail(image=stacked_images, size=size)
             if do_pad:
-                stacked_images = self.pad_image(image=stacked_images, size=size, random_padding=False)
+                stacked_images = self.pad_image(image=stacked_images, size=size, random_padding=random_padding)
 
             resized_images_grouped[shape] = stacked_images
         resized_images = reorder_images(resized_images_grouped, grouped_images_index)

--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -22,13 +22,23 @@ from contextlib import contextmanager
 from typing import List, Optional, Union
 
 from ...image_utils import ImageInput
-from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
+from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import logging
 
 
+class DonutImagesKwargs(ImagesKwargs, total=False):
+    random_padding: bool
+    do_thumbnail: Optional[bool]
+    do_align_long_axis: Optional[bool]
+
+
 class DonutProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: DonutImagesKwargs
     _defaults = {}
+
+
+DonutProcessorKwargs.__annotations__["images_kwargs"] = DonutImagesKwargs
 
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -38,9 +38,6 @@ class DonutProcessorKwargs(ProcessingKwargs, total=False):
     _defaults = {}
 
 
-DonutProcessorKwargs.__annotations__["images_kwargs"] = DonutImagesKwargs
-
-
 logger = logging.get_logger(__name__)
 
 


### PR DESCRIPTION
# What does this PR do?
This PR addresses an issue where `DonutProcessor` ignores certain valid image preprocessing keyword arguments, such as `random_padding`, `do_thumbnail`, and `do_align_long_axis`, when they are passed directly during the processor call.

**Problem:**
When using the processor as shown below, the specified keyword arguments are ignored, and warning messages like `Keyword argument '...' is not a valid argument for this processor and will be ignored.` are displayed:

```python
from PIL import Image
from transformers import DonutProcessor

image = Image.open('hf.png')
processor = DonutProcessor.from_pretrained("naver-clova-ix/donut-base")

processed_output = processor(image, random_padding=True, do_thumbnail=True, do_align_long_axis=True)
```

Solution:
This PR fixes the issue by explicitly adding these keyword arguments (random_padding, do_thumbnail, do_align_long_axis) to the set of arguments that DonutProcessor recognizes and can handle. This ensures that the processor accepts these arguments without warnings and correctly passes them down to the image processing component.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
