### PR TITLE
fix: remove classmethod from `Qwen2_5OmniConfig.get_text_config`

### DIFF
--- a/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
@@ -1045,7 +1045,6 @@ class Qwen2_5OmniConfig(PretrainedConfig):
 
         super().__init__(**kwargs)
 
-    @classmethod
     def get_text_config(self, decoder=False) -> "PretrainedConfig":
         """
         Returns the config that is meant to be used with text IO. On most models, it is the original config instance

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -1030,7 +1030,6 @@ class Qwen2_5OmniConfig(PretrainedConfig):
 
         super().__init__(**kwargs)
 
-    @classmethod
     def get_text_config(self, decoder=False) -> "PretrainedConfig":
         """
         Returns the config that is meant to be used with text IO. On most models, it is the original config instance


### PR DESCRIPTION
# What does this PR do?

  - Since the `get_text_config` references an instance variable within the class (`self.thinker_config`), the `get_text_config` method should not be a classmethod.

  - Before this fix, users were getting the following error:

    ''' AttributeError: type object 'Qwen2_5OmniConfig' has no attribute 'thinker_config' '''

  - This commit simply removes the `classmethod` wrapper from the `get_text_config` method