### PR TITLE
[performance_optim] define flash attention mask on NPU device directly

### DIFF
--- a/src/transformers/integrations/npu_flash_attention.py
+++ b/src/transformers/integrations/npu_flash_attention.py
@@ -171,7 +171,7 @@ def npu_flash_attn_func(
         head_num = q.shape[2]
         output = torch_npu.npu_fusion_attention(q, k, v, head_num, "BSND", keep_prob=keep_prob, scale=softmax_scale)[0]
     else:
-        attn_mask_npu = torch.triu(torch.ones([2048, 2048]), diagonal=1).bool().to(q.device)
+        attn_mask_npu = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()
         head_num = q.shape[2]
         output = torch_npu.npu_fusion_attention(
             q,
@@ -222,7 +222,7 @@ def npu_flash_attn_varlen_func(
             actual_seq_kvlen=tuple(cu_seqlens_k[1:].cpu().numpy().tolist()),
         )[0]
     else:
-        attn_mask_npu = torch.triu(torch.ones([2048, 2048]), diagonal=1).bool().to(q.device)
+        attn_mask_npu = torch.triu(torch.ones([2048, 2048], device=q.device), diagonal=1).bool()
         head_num = q.shape[1]
         output = torch_npu.npu_fusion_attention(
             q,


### PR DESCRIPTION
# What does this PR do?

When using Flash Attention2 on Ascend NPU, we have found that CPU memory keep increasing when calling func `npu_flash_attn_varlen_func` or `npu_flash_attn_func`. 

The root cause is that the attention mask generated by func `torch.ones()` is initially defined on the CPU side, occupying CPU memory before being transferred to the NPU device. As the func `npu_flash_attn_varlen_func` or `npu_flash_attn_func` is called repeatedly, the CPU memory consumption continues to accumulate, which is not optimal solution. Below is one example: https://github.com/huggingface/transformers/blob/12f65ee7520404b511c7fe716bc5d48d93d8297d/src/transformers/integrations/npu_flash_attention.py#L225

Therefore, this PR is committed for solving this problem by defining attention mask tensor with `torch.ones()` on NPU device directy.

Fixes # (issue)
Not releated.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
