### PR TITLE
[CI] add back `sacrebleu` (and document why)

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -334,8 +334,7 @@ non_model_job = CircleCIJob(
     docker_image=[{"image": "huggingface/transformers-torch-light"}],
     # networkx==3.3 (after #36957) cause some issues
     # TODO: remove this once it works directly
-    # `examples/pytorch/_tests_requirements.txt` is installed for `test_run_seq2seq_no_dist`, which runs an example under the hood.
-    install_steps=["uv venv && uv pip install . && uv pip install networkx==3.2.1 && uv pip install -r examples/pytorch/_tests_requirements.txt"],
+    install_steps=["uv venv && uv pip install . && uv pip install networkx==3.2.1"],
     marker="not generate",
     parallelism=6,
 )

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -334,7 +334,8 @@ non_model_job = CircleCIJob(
     docker_image=[{"image": "huggingface/transformers-torch-light"}],
     # networkx==3.3 (after #36957) cause some issues
     # TODO: remove this once it works directly
-    install_steps=["uv venv && uv pip install . && uv pip install networkx==3.2.1"],
+    # `examples/pytorch/_tests_requirements.txt` is installed for `test_run_seq2seq_no_dist`, which runs an example under the hood.
+    install_steps=["uv venv && uv pip install . && uv pip install networkx==3.2.1 && uv pip install -r examples/pytorch/_tests_requirements.txt"],
     marker="not generate",
     parallelism=6,
 )

--- a/setup.py
+++ b/setup.py
@@ -163,6 +163,10 @@ _deps = [
     "rjieba",
     "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff==0.11.2",
+    # `sacrebleu` not used in `transformers`. However, it is needed in several tests, when a test calls
+    # `evaluate.load("sacrebleu")`. This metric is used in the examples that we use to test the `Trainer` with, in the
+    # `Trainer` tests (see references to `run_translation.py`).
+    "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses",
     "safetensors>=0.4.3",
     "sagemaker>=2.31.0",
@@ -352,6 +356,7 @@ extras["testing"] = (
         "tensorboard",
         "pydantic",
         "sentencepiece",
+        "sacrebleu",  # needed in trainer tests, see references to `run_translation.py`
     )
     + extras["retrieval"]
     + extras["modelcreation"]

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -69,6 +69,7 @@ deps = {
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff==0.11.2",
+    "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",
     "safetensors": "safetensors>=0.4.3",
     "sagemaker": "sagemaker>=2.31.0",


### PR DESCRIPTION
# What does this PR do?

Reverts the removed dep in #37676 , and documents why

(TL;DR: `sacrebleu` is not in present `transformers`. However, calling `evaluate.load("sacrebleu")` requires it, and our `Trainer` tests use it under the hood, through the `run_translation.py` example)