### PR TITLE
Skip red Internvl tests

### DIFF
--- a/tests/models/internvl/test_processor_internvl.py
+++ b/tests/models/internvl/test_processor_internvl.py
@@ -18,6 +18,7 @@ import tempfile
 import unittest
 
 from huggingface_hub import hf_hub_download
+from parameterized import parameterized
 
 from transformers import AutoProcessor, AutoTokenizer, InternVLProcessor
 from transformers.testing_utils import require_av, require_torch, require_vision
@@ -85,6 +86,7 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     @require_av
     @require_torch
+    @unittest.skip("Broken on main! Should be fixed")
     def test_process_interleaved_images_videos(self):
         processor = self.get_processor()
 
@@ -325,3 +327,8 @@ class InternVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
         self.assertTrue(self.videos_input_name in out_dict_with_video)
         self.assertEqual(len(out_dict_with_video[self.videos_input_name]), 2)
+
+    @parameterized.expand([(1, "np"), (1, "pt"), (2, "np"), (2, "pt")])
+    @unittest.skip("Broken on main! Should be fixed.")
+    def test_apply_chat_template_image(self):
+        pass


### PR DESCRIPTION
Right now, a couple of InternVL tests are failing on `main`. I'm going to skip them for now to stop blocking other PRs, but it would be good to fix and un-skip them! cc @yonigozlan @zucchini-nlp