### PR TITLE
[cache] fix `HybridCache` init when `device` is passed

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1697,7 +1697,7 @@ class HybridCache(Cache):
             min(config.sliding_window, max_cache_len),
             self.head_dim,
         )
-        device = torch.device(device) if device is not None and isinstance(device, str) else None
+        device = torch.device(device) if device is not None else None
         for i in range(config.num_hidden_layers):
             if layer_device_map is not None:
                 layer_device = layer_device_map[i]


### PR DESCRIPTION
# What does this PR do?

The following example, where we initialize the model with the `device` argument, results in cuda graph skips. It can be traced to a stray change in https://github.com/huggingface/transformers/pull/37007, where the device initialization was incorrectly changed. This PR reverts it.

```py
from transformers import pipeline
import torch

pipe = pipeline(
    "image-text-to-text",
    model="google/gemma-3-4b-it",
    device="cuda",
    torch_dtype=torch.bfloat16
)

output = pipe(text="Write a poem on Hugging Face, the company", max_new_tokens=10)
print(output)
```