### PR TITLE
Expand quantized data type support for tensor parallelism 

### DIFF
--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -307,7 +307,8 @@ class ColwiseParallel(TensorParallelLayer):
             parameter = parameter.contiguous()
         if self.use_dtensor:
             parameter = DTensor.from_local(parameter, device_mesh, shard, run_check=False)
-        return nn.Parameter(parameter)
+        requires_grad = True if parameter.is_floating_point() else False
+        return nn.Parameter(parameter, requires_grad=requires_grad)
 
     @staticmethod
     def _prepare_output_fn(output_layouts, use_local_output, mod, outputs, device_mesh):
@@ -329,7 +330,8 @@ class PackedColwiseParallel(ColwiseParallel):
             parameter = parameter.contiguous()
         if self.use_dtensor:
             parameter = DTensor.from_local(parameter, device_mesh, [Shard(-2)], run_check=False)
-        return nn.Parameter(parameter)
+        requires_grad = True if parameter.is_floating_point() else False
+        return nn.Parameter(parameter, requires_grad=requires_grad)
 
 
 class RowwiseParallel(TensorParallelLayer):
@@ -381,7 +383,8 @@ class RowwiseParallel(TensorParallelLayer):
             parameter = parameter.contiguous()
         if self.use_dtensor:
             parameter = DTensor.from_local(parameter, device_mesh, shard, run_check=False)
-        return nn.Parameter(parameter)
+        requires_grad = True if parameter.is_floating_point() else False
+        return nn.Parameter(parameter, requires_grad=requires_grad)
 
     @staticmethod
     def _prepare_input_fn(input_layouts, desired_input_layouts, mod, inputs, device_mesh):
@@ -443,7 +446,8 @@ class PackedRowwiseParallel(RowwiseParallel):
             parameter = parameter.contiguous()
         if self.use_dtensor:
             parameter = DTensor.from_local(parameter, device_mesh, [Shard(-1)], run_check=False)
-        return nn.Parameter(parameter)
+        requires_grad = True if parameter.is_floating_point() else False
+        return nn.Parameter(parameter, requires_grad=requires_grad)
 
 
 class SequenceParallel(TensorParallelLayer):
@@ -521,13 +525,14 @@ class SequenceParallel(TensorParallelLayer):
         # colwise shard weight/bias to Shard(0), weight be Shard(-2) (0 if you have 1 dim only)
         # means Colwise as Linear is input * weight^T + bias, where
         # weight would become Shard(1)
-        parameter = param[:]
+        parameter = param[...]
         parameter = parameter.to(param_casting_dtype)
         if to_contiguous:
             parameter = parameter.contiguous()
         if self.use_dtensor:
             parameter = DTensor.from_local(parameter, device_mesh, [Replicate()], run_check=False)
-        return nn.Parameter(parameter)
+        requires_grad = True if parameter.is_floating_point() else False
+        return nn.Parameter(parameter, requires_grad=requires_grad)
 
 
 SUPPORTED_TP_STYLES = {


### PR DESCRIPTION
# What does this PR do?
Update the tensor parallel for support generic quantized tensor with data type like int8 and scalar tensor.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
- [#37720]
[rank0]: File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformers/integrations/tensor_parallel.py", line 658, in shard_and_distribute_module
[rank0]: param = tp_layer.partition_tensor(
[rank0]: File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/transformers/integrations/tensor_parallel.py", line 385, in partition_tensor
[rank0]: return nn.Parameter(parameter) #, requires_grad=False)
[rank0]: File "/opt/conda/envs/py_3.10/lib/python3.10/site-packages/torch/nn/parameter.py", line 49, in new
[rank0]: t = data.detach().requires_grad_(requires_grad)
[rank0]: RuntimeError: only Tensors of floating point dtype can require gradients

- 0-dim tensor not support [:]
Get the scaler value of a 0-dim PySafeSlice [#380]


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
