### PR TITLE
[tests, `qwen2_5_omni`] fix flaky tests

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -134,7 +134,7 @@ VLM_CLASS_NAMES = [
     "mistral3",
     "chameleon",
     "internvl",
-    "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model is `qwen2_5omni`
+    "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model class is `Qwen2_5Omni`
 ]
 
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -134,7 +134,7 @@ VLM_CLASS_NAMES = [
     "mistral3",
     "chameleon",
     "internvl",
-    "qwen2_5_omni",
+    "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model is `qwen2_5omni`
 ]
 
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -230,6 +230,7 @@ class GenerationTesterMixin:
             for key in [
                 "image_token_id",
                 "video_token_id",
+                "audio_token_id",
                 "vision_start_token_id",
                 "audio_start_token_id",
                 "audio_end_token_id",


### PR DESCRIPTION
# What does this PR do?

cc @zucchini-nlp 

Fixes two `qwen2_5_omni` flaky issues:
1. Typo in the model name in `VLM_CLASS_NAMES` (used to skip tests) -> model was not being skipped -> flaky tests
2. `qwen2_5_omni` has a new config attribute corresponding to a token that can't be used in the output