### PR TITLE
[tests] fix flaky pattern in `test_generate_continue_from_past_key_values`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1994,34 +1994,6 @@ class GenerationTesterMixin:
                         )
                     )
 
-    @parameterized.expand([("offloaded",)])  # ("offloaded_static",) TODO: @raushan fixme in some models (eg T5)
-    @require_torch_accelerator
-    @pytest.mark.generate
-    def test_offloaded_cache_implementation(self, cache_implementation):
-        """Tests we can generate by indicating `cache_implementation` for each possible cache class"""
-        for model_class in self.all_generative_model_classes:
-            if not model_class._supports_cache_class:
-                self.skipTest(reason="This model does not support the new cache format")
-
-            config, inputs_dict = self.prepare_config_and_inputs_for_generate()
-
-            model = model_class(config).to(torch_device).eval()
-            generation_kwargs = {
-                "max_new_tokens": 5,
-                "use_cache": True,
-                "cache_implementation": cache_implementation,
-                "return_dict_in_generate": True,
-                "output_scores": True,
-            }
-
-            legacy_results = model.generate(**generation_kwargs, **inputs_dict)
-
-            # Most cache classes have their own tests except for some that are tested here
-            # The ones here do not need special treatment when passing `cache_implementation`
-            # and are not bound to specific models only
-            new_results = model.generate(**generation_kwargs, **inputs_dict)
-            self._check_similar_generate_outputs(legacy_results, new_results)
-
     @pytest.mark.generate
     def test_generate_with_static_cache(self):
         """


### PR DESCRIPTION
# What does this PR do?

Fixes the flakiness pattern behind a [common flaky test](https://app.circleci.com/insights/github/huggingface/transformers/workflows/run_tests/tests?branch=main), `tests/models/kosmos2/test_modeling_kosmos2.py::Kosmos2ModelTest::test_generate_continue_from_past_key_values`

flakiness pattern TL;DR: 
- on mixin tests, the models have random weights
- different input shapes can cause slightly different outputs (see [here](https://github.com/huggingface/transformers/issues/25420#issuecomment-1775317535))
- in `generate`, tiny differences in the logits can lead to a different token, changing generation from that point onward
- equivalence checks for `generate` shouldn't naively look at the output sequences, but rather at the output sequences up to the point where they diverge, if they diverge 👉 corrects all equivalence checks using the right pattern (this pattern was already present in most tests, but a few ones still had the old pattern)