### PR TITLE
Fix Float64 RuntimeError on Integrated Graphics when using DirectML

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1501,7 +1501,7 @@ class ModuleUtilsMixin:
         # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
         # encoder_extended_attention_mask.transpose(-1, -2))
         encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-        encoder_extended_attention_mask = (1.0 - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
+        encoder_extended_attention_mask = (torch.tensor(1.0, dtype=dtype) - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
 
         return encoder_extended_attention_mask
 
@@ -1581,7 +1581,7 @@ class ModuleUtilsMixin:
         # Since we are adding it to the raw scores before the softmax, this is
         # effectively the same as removing these entirely.
         extended_attention_mask = extended_attention_mask.to(dtype=dtype)  # fp16 compatibility
-        extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
+        extended_attention_mask = (torch.tensor(1.0, dtype=dtype) - extended_attention_mask) * torch.finfo(dtype).min
         return extended_attention_mask
 
     def get_head_mask(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1501,7 +1501,7 @@ class ModuleUtilsMixin:
         # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
         # encoder_extended_attention_mask.transpose(-1, -2))
         encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-        encoder_extended_attention_mask = (torch.tensor(1.0, dtype=dtype) - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
+        encoder_extended_attention_mask = (torch.tensor(1.0, dtype=self.dtype) - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
 
         return encoder_extended_attention_mask
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1501,7 +1501,9 @@ class ModuleUtilsMixin:
         # encoder_extended_attention_mask = (encoder_extended_attention_mask ==
         # encoder_extended_attention_mask.transpose(-1, -2))
         encoder_extended_attention_mask = encoder_extended_attention_mask.to(dtype=self.dtype)  # fp16 compatibility
-        encoder_extended_attention_mask = (torch.tensor(1.0, dtype=self.dtype) - encoder_extended_attention_mask) * torch.finfo(self.dtype).min
+        encoder_extended_attention_mask = (
+            torch.tensor(1.0, dtype=self.dtype) - encoder_extended_attention_mask
+        ) * torch.finfo(self.dtype).min
 
         return encoder_extended_attention_mask
 


### PR DESCRIPTION
# What does this PR do?

Fix Float64 RuntimeError on Integrated Graphics when using DirectML:

```
  File "C:\Users\xxx\Downloads\MaterialSearchWindowsLarge\MaterialSearchWindows\Lib\site-packages\transformers\models\chinese_clip\modeling_chinese_clip.py", line 1277, in forward
    extended_attention_mask: torch.Tensor = self.get_extended_attention_mask(attention_mask, input_shape)
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Downloads\MaterialSearchWindowsLarge\MaterialSearchWindows\Lib\site-packages\transformers\modeling_utils.py", line 1603, in get_extended_attention_mask
    extended_attention_mask = (1.0 - extended_attention_mask) * torch.finfo(dtype).min
                               ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
  File "C:\Users\xxx\Downloads\MaterialSearchWindowsLarge\MaterialSearchWindows\Lib\site-packages\torch\_tensor.py", line 41, in wrapped
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "C:\Users\xxx\Downloads\MaterialSearchWindowsLarge\MaterialSearchWindows\Lib\site-packages\torch\_tensor.py", line 962, in __rsub__
    return _C._VariableFunctions.rsub(self, other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: The GPU device does not support Double (Float64) operations!
```

Even though `extended_attention_mask` is of type `Float32`, the literal `1.0` in Python is treated as a `Double`. As a result, the expression `1.0 - extended_attention_mask` is promoted to a `Float64` operation, which will trigger a `RuntimeError` if the device does not support `Float64`.

To avoid this error, `1.0` should be cast to a tensor with the correct `dtype`.

@ydshieh 