### PR TITLE
Skip all `AriaForConditionalGenerationIntegrationTest` on `T4`

### DIFF
--- a/tests/models/aria/test_modeling_aria.py
+++ b/tests/models/aria/test_modeling_aria.py
@@ -30,8 +30,8 @@ from transformers import (
 from transformers.models.idefics3 import Idefics3VisionConfig
 from transformers.testing_utils import (
     require_bitsandbytes,
-    require_torch_large_accelerator,
     require_torch,
+    require_torch_large_accelerator,
     require_vision,
     slow,
     torch_device,

--- a/tests/models/aria/test_modeling_aria.py
+++ b/tests/models/aria/test_modeling_aria.py
@@ -30,6 +30,7 @@ from transformers import (
 from transformers.models.idefics3 import Idefics3VisionConfig
 from transformers.testing_utils import (
     require_bitsandbytes,
+    require_torch_large_accelerator,
     require_torch,
     require_vision,
     slow,
@@ -291,6 +292,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         torch.cuda.empty_cache()
 
     @slow
+    @require_torch_large_accelerator
     @require_bitsandbytes
     def test_small_model_integration_test(self):
         # Let's make sure we test the preprocessing to replace what is used
@@ -313,6 +315,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         )
 
     @slow
+    @require_torch_large_accelerator
     @require_bitsandbytes
     def test_small_model_integration_test_llama_single(self):
         # Let's make sure we test the preprocessing to replace what is used
@@ -335,6 +338,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         )
 
     @slow
+    @require_torch_large_accelerator
     @require_bitsandbytes
     def test_small_model_integration_test_llama_batched(self):
         # Let's make sure we test the preprocessing to replace what is used
@@ -362,6 +366,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         )
 
     @slow
+    @require_torch_large_accelerator
     @require_bitsandbytes
     def test_small_model_integration_test_batch(self):
         # Let's make sure we test the preprocessing to replace what is used
@@ -388,6 +393,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         )
 
     @slow
+    @require_torch_large_accelerator
     @require_bitsandbytes
     def test_small_model_integration_test_llama_batched_regression(self):
         # Let's make sure we test the preprocessing to replace what is used
@@ -416,7 +422,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         )
 
     @slow
-    @require_torch
+    @require_torch_large_accelerator
     @require_vision
     @require_bitsandbytes
     def test_batched_generation(self):
@@ -501,6 +507,7 @@ class AriaForConditionalGenerationIntegrationTest(unittest.TestCase):
         self.assertEqual(fast_tokenizer.tokenize(prompt), EXPECTED_OUTPUT)
 
     @slow
+    @require_torch_large_accelerator
     @require_bitsandbytes
     def test_generation_no_images(self):
         model_id = "rhymes-ai/Aria"


### PR DESCRIPTION
# What does this PR do?

Follow up of [this commment](https://github.com/huggingface/transformers/pull/37444#issuecomment-2801489013)

Skip all `AriaForConditionalGenerationIntegrationTest` except `test_tokenizer_integration` on `T4` runner.

These tests uses [this repository](https://huggingface.co/rhymes-ai/Aria/tree/main) that doesn't fit into T4 or even A10, even using  `load_in_4bit=True`.

(The `require_torch_large_accelerator` or `require_torch_large_gpu` is not well-written to specify the min. memory requirement despite it has an argument `memory`.)
 

 