### PR TITLE
updated hidden_features for FlaxDinov2SwiGLUFFN in Dinov2 

### DIFF
--- a/src/transformers/models/dinov2/modeling_flax_dinov2.py
+++ b/src/transformers/models/dinov2/modeling_flax_dinov2.py
@@ -403,7 +403,7 @@ class FlaxDinov2SwiGLUFFN(nn.Module):
 
     def setup(self):
         hidden_features = int(self.config.hidden_size * self.config.mlp_ratio)
-        hidden_features = (int(self.hidden_features * 2 / 3) + 7) // 8 * 8
+        hidden_features = (int(hidden_features * 2 / 3) + 7) // 8 * 8
 
         self.weights_in = nn.Dense(
             2 * hidden_features,


### PR DESCRIPTION
# What does this PR do?

Fixes #37745 

## Changes made

[FlaxDinov2SwiGLUFFN](https://github.com/huggingface/transformers/blob/b6d65e40b256d98d9621707762b94bc8ad83b7a7/src/transformers/models/dinov2/modeling_flax_dinov2.py#L400) has only 2 attributes (config,dtype).  It doesn't have hidden_features attribute. So, the previously calculated hidden_feature value is used. This change removes the error faced in the above linked issue

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@gante  @Rocketknight1 