### PR TITLE
Stop autoconverting custom code checkpoints

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4555,7 +4555,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             revision=revision,
             commit_hash=commit_hash,
             transformers_explicit_filename=transformers_explicit_filename,
-            is_remote_code=cls.__module__.startswith("transformers_modules"),  # This might be fragile?
+            is_remote_code=cls._auto_class is not None,
         )
 
         is_sharded = sharded_metadata is not None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1005,6 +1005,7 @@ def _get_resolved_checkpoint_files(
     user_agent: dict,
     revision: str,
     commit_hash: Optional[str],
+    is_remote_code: bool,  # Because we can't determine this inside this function, we need it to be passed in
     transformers_explicit_filename: Optional[str] = None,
 ) -> Tuple[Optional[List[str]], Optional[Dict]]:
     """Get all the checkpoint filenames based on `pretrained_model_name_or_path`, and optional metadata if the
@@ -1201,7 +1202,7 @@ def _get_resolved_checkpoint_files(
                                 "_commit_hash": commit_hash,
                                 **has_file_kwargs,
                             }
-                            if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs):
+                            if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs) and not is_remote_code:
                                 Thread(
                                     target=auto_conversion,
                                     args=(pretrained_model_name_or_path,),
@@ -4551,6 +4552,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             revision=revision,
             commit_hash=commit_hash,
             transformers_explicit_filename=transformers_explicit_filename,
+            is_remote_code=cls.__module__.startswith("transformers_modules")  # This might be fragile?
         )
 
         is_sharded = sharded_metadata is not None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4554,8 +4554,8 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             user_agent=user_agent,
             revision=revision,
             commit_hash=commit_hash,
-            transformers_explicit_filename=transformers_explicit_filename,
             is_remote_code=cls._auto_class is not None,
+            transformers_explicit_filename=transformers_explicit_filename,
         )
 
         is_sharded = sharded_metadata is not None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1202,7 +1202,10 @@ def _get_resolved_checkpoint_files(
                                 "_commit_hash": commit_hash,
                                 **has_file_kwargs,
                             }
-                            if not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs) and not is_remote_code:
+                            if (
+                                not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs)
+                                and not is_remote_code
+                            ):
                                 Thread(
                                     target=auto_conversion,
                                     args=(pretrained_model_name_or_path,),
@@ -4552,7 +4555,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             revision=revision,
             commit_hash=commit_hash,
             transformers_explicit_filename=transformers_explicit_filename,
-            is_remote_code=cls.__module__.startswith("transformers_modules")  # This might be fragile?
+            is_remote_code=cls.__module__.startswith("transformers_modules"),  # This might be fragile?
         )
 
         is_sharded = sharded_metadata is not None


### PR DESCRIPTION
Our Space for autoconverting code fails with custom code models, which causes problems when a custom code model only has Pytorch checkpoints!

This PR resolves this by not launching the autoconversion thread when the model is custom code!