### PR TITLE
Fix donut backtracking

### DIFF
--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -156,10 +156,14 @@ class DonutProcessor(ProcessorMixin):
         output = {}
 
         while tokens:
-            start_token = re.search(r"<s_(.*?)>", tokens, re.IGNORECASE)
-            if start_token is None:
+            potential_start = re.search(r"<s_", tokens, re.IGNORECASE)
+            if potential_start is None:
                 break
-            key = start_token.group(1)
+            potential_end = re.search(r">", tokens[potential_start.end():], re.IGNORECASE)
+            if potential_end is None:
+                break
+            start_token = tokens[potential_start.start(): potential_start.end() + potential_end.end()]
+            key = start_token[len("<s_") : -len(">")]
             key_escaped = re.escape(key)
 
             end_token = re.search(rf"</s_{key_escaped}>", tokens, re.IGNORECASE)

--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -159,10 +159,10 @@ class DonutProcessor(ProcessorMixin):
             potential_start = re.search(r"<s_", tokens, re.IGNORECASE)
             if potential_start is None:
                 break
-            potential_end = re.search(r">", tokens[potential_start.end():], re.IGNORECASE)
+            potential_end = re.search(r">", tokens[potential_start.end() :], re.IGNORECASE)
             if potential_end is None:
                 break
-            start_token = tokens[potential_start.start(): potential_start.end() + potential_end.end()]
+            start_token = tokens[potential_start.start() : potential_start.end() + potential_end.end()]
             key = start_token[len("<s_") : -len(">")]
             key_escaped = re.escape(key)
 

--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -167,7 +167,6 @@ class DonutProcessor(ProcessorMixin):
             key_escaped = re.escape(key)
 
             end_token = re.search(rf"</s_{key_escaped}>", tokens, re.IGNORECASE)
-            start_token = start_token.group()
             if end_token is None:
                 tokens = tokens.replace(start_token, "")
             else:

--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -160,7 +160,7 @@ class DonutProcessor(ProcessorMixin):
             potential_start = re.search(r"<s_", tokens, re.IGNORECASE)
             if potential_start is None:
                 break
-            start_token = tokens[: potential_start.start()]
+            start_token = tokens[potential_start.start() :]
             if ">" not in start_token:
                 break
             start_token = start_token[: start_token.index(">") + 1]

--- a/src/transformers/models/donut/processing_donut.py
+++ b/src/transformers/models/donut/processing_donut.py
@@ -156,13 +156,14 @@ class DonutProcessor(ProcessorMixin):
         output = {}
 
         while tokens:
+            # We want r"<s_(.*?)>" but without ReDOS risk, so do it manually in two parts
             potential_start = re.search(r"<s_", tokens, re.IGNORECASE)
             if potential_start is None:
                 break
-            potential_end = re.search(r">", tokens[potential_start.end() :], re.IGNORECASE)
-            if potential_end is None:
+            start_token = tokens[: potential_start.start()]
+            if ">" not in start_token:
                 break
-            start_token = tokens[potential_start.start() : potential_start.end() + potential_end.end()]
+            start_token = start_token[: start_token.index(">") + 1]
             key = start_token[len("<s_") : -len(">")]
             key_escaped = re.escape(key)
 


### PR DESCRIPTION
There's an exploitable regex in the donut processor, this replaces it with less blowup-prone code!