### PR TITLE
Fix bugs in DynamicCache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -471,7 +471,7 @@ class DynamicCache(Cache):
     """
 
     def __init__(
-        self, _distributed_cache_data: Optional[Iterable] = None, config: Optional[PretrainedConfig] = None
+        self, _distributed_cache_data: Optional[Iterable] = None
     ) -> None:
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -470,7 +470,7 @@ class DynamicCache(Cache):
         ```
     """
 
-    def __init__(self, _distributed_cache_data: Optional[Iterable] = None) -> None:
+    def __init__(self, _distributed_cache_data: Optional[Iterable] = None, num_layers: Optional[int] = None) -> None:
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
         self.key_cache: list[torch.Tensor] = []
@@ -695,7 +695,7 @@ def _flatten_dynamic_cache_for_fx(cache, spec):
         "key_cache": getattr(cache, "key_cache"),
         "value_cache": getattr(cache, "value_cache"),
     }
-    return torch.utils._pytree.tree_flatten(dictionary)[0]
+    return torch.fx._pytree._dict_flatten_spec(dictionary, spec)
 
 
 if is_torch_greater_or_equal("2.3"):

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -470,9 +470,7 @@ class DynamicCache(Cache):
         ```
     """
 
-    def __init__(
-        self, _distributed_cache_data: Optional[Iterable] = None
-    ) -> None:
+    def __init__(self, _distributed_cache_data: Optional[Iterable] = None) -> None:
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
         self.key_cache: list[torch.Tensor] = []

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -470,7 +470,9 @@ class DynamicCache(Cache):
         ```
     """
 
-    def __init__(self, _distributed_cache_data: Optional[Iterable] = None, num_layers: Optional[int] = None) -> None:
+    def __init__(
+        self, _distributed_cache_data: Optional[Iterable] = None, config: Optional[PretrainedConfig] = None
+    ) -> None:
         super().__init__()
         self._seen_tokens = 0  # Used in `generate` to keep tally of how many tokens the cache has seen
         self.key_cache: list[torch.Tensor] = []

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -665,7 +665,7 @@ class CacheExportIntegrationTest(unittest.TestCase):
         past_key_values = res.past_key_values
 
         shapes = torch.export.ShapesCollection()
-        dyn = torch.export.Dim("seq")
+        dyn = torch.export.Dim("seq", max=512)
 
         for ix in range(len(past_key_values.key_cache)):
             shapes[past_key_values.key_cache[ix]] = (None, None, dyn, None)
@@ -716,8 +716,6 @@ class CacheExportIntegrationTest(unittest.TestCase):
         for v1, v2 in zip(res_export_2.past_key_values.value_cache, res_eager_2.past_key_values.value_cache):
             self.assertTrue(torch.allclose(v1, v2))
 
-    @slow
-    @require_read_token
     def test_static_cache_exportability(self):
         """
         Tests that static cache works with `torch.export()`

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -626,7 +626,7 @@ class CacheExportIntegrationTest(unittest.TestCase):
         for v1, v2 in zip(res.past_key_values.value_cache, res_eager.past_key_values.value_cache):
             self.assertTrue(torch.allclose(v1, v2))
 
-    def test_dynamic_cache_exportability_dynamic_cache(self):
+    def test_dynamic_cache_exportability_multiple_run(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
         model = model.eval()
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -637,7 +637,6 @@ class CacheExportIntegrationTest(unittest.TestCase):
         attention_mask = inputs.attention_mask
         input_ids = inputs.input_ids
 
-
         past_key_values = DynamicCache()
         ep = torch.export.export(
             model,
@@ -669,7 +668,7 @@ class CacheExportIntegrationTest(unittest.TestCase):
             ),
         )
 
-        shapes = torch.export.ShapesCollection() 
+        shapes = torch.export.ShapesCollection()
         dyn = torch.export.Dim("seq")
 
         for ix in range(len(past_key_values.key_cache)):
@@ -715,7 +714,6 @@ class CacheExportIntegrationTest(unittest.TestCase):
 
         for v1, v2 in zip(past_key_values.value_cache, past_key_values.value_cache):
             self.assertTrue(torch.allclose(v1, v2))
-
 
     @slow
     @require_read_token

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -626,8 +626,6 @@ class CacheExportIntegrationTest(unittest.TestCase):
         for v1, v2 in zip(res.past_key_values.value_cache, res_eager.past_key_values.value_cache):
             self.assertTrue(torch.allclose(v1, v2))
 
-<<<<<<< HEAD
-=======
     def test_dynamic_cache_exportability_dynamic_cache(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
         model = model.eval()
@@ -637,22 +635,11 @@ class CacheExportIntegrationTest(unittest.TestCase):
         attention_mask = inputs.attention_mask
         input_ids = inputs.input_ids
 
-        past_key_values = DynamicCache()
-        ep = torch.export.export(
-            model,
-            (),
-            {
-                "input_ids": input_ids,
-                "attention_mask": attention_mask,
-                "past_key_values": past_key_values,
-                "use_cache": True,
-            },
-            strict=False,
-        )
+        ep = export_with_dynamic_cache(model, input_ids, attention_mask)
         res = ep.module()(
             input_ids=input_ids,
             attention_mask=attention_mask,
-            past_key_values=past_key_values,
+            past_key_values=DynamicCache(),
             use_cache=True,
         )
         self.assertTrue(len(res.past_key_values.key_cache) == model.config.num_hidden_layers)
@@ -668,14 +655,21 @@ class CacheExportIntegrationTest(unittest.TestCase):
             ),
         )
 
+        res_eager = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=DynamicCache(),
+            use_cache=True,
+        )
+        past_key_values_eager = res_eager.past_key_values
+        past_key_values = res.past_key_values
+
         shapes = torch.export.ShapesCollection()
         dyn = torch.export.Dim("seq")
 
         for ix in range(len(past_key_values.key_cache)):
             shapes[past_key_values.key_cache[ix]] = (None, None, dyn, None)
             shapes[past_key_values.value_cache[ix]] = (None, None, dyn, None)
-
-        past_key_values_eager = copy.deepcopy(past_key_values)
 
         ep_second = torch.export.export(
             model,
@@ -695,6 +689,13 @@ class CacheExportIntegrationTest(unittest.TestCase):
             past_key_values=past_key_values,
             use_cache=True,
         )
+        # It should work with variable len
+        res_export_2 = ep_second.module()(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=res_export.past_key_values,
+            use_cache=True,
+        )
 
         res_eager = model(
             input_ids=input_ids,
@@ -702,22 +703,21 @@ class CacheExportIntegrationTest(unittest.TestCase):
             past_key_values=past_key_values_eager,
             use_cache=True,
         )
+        res_eager_2 = model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=res_eager.past_key_values,
+            use_cache=True,
+        )
 
-        for k1, k2 in zip(res_export.past_key_values.key_cache, res_eager.past_key_values.key_cache):
+        for k1, k2 in zip(res_export_2.past_key_values.key_cache, res_eager_2.past_key_values.key_cache):
             self.assertTrue(torch.allclose(k1, k2))
 
-        for v1, v2 in zip(res_export.past_key_values.value_cache, res_eager.past_key_values.value_cache):
-            self.assertTrue(torch.allclose(v1, v2))
-
-        for k1, k2 in zip(past_key_values.key_cache, past_key_values_eager.key_cache):
-            self.assertTrue(torch.allclose(k1, k2))
-
-        for v1, v2 in zip(past_key_values.value_cache, past_key_values.value_cache):
+        for v1, v2 in zip(res_export_2.past_key_values.value_cache, res_eager_2.past_key_values.value_cache):
             self.assertTrue(torch.allclose(v1, v2))
 
     @slow
     @require_read_token
->>>>>>> cddf1d301 (Update)
     def test_static_cache_exportability(self):
         """
         Tests that static cache works with `torch.export()`

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -602,7 +602,7 @@ class CacheExportIntegrationTest(unittest.TestCase):
         self.assertTrue(len(res.past_key_values.key_cache) == model.config.num_hidden_layers)
         self.assertEqual(2 * model.config.num_hidden_layers + 1, len(ep.graph_signature.output_specs))
         self.assertEqual(
-            3,
+            7,
             len(
                 [
                     x

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -627,6 +627,12 @@ class CacheExportIntegrationTest(unittest.TestCase):
             self.assertTrue(torch.allclose(v1, v2))
 
     def test_dynamic_cache_exportability_multiple_run(self):
+        # When exporting with DynamicCache, you should export two graphs:
+        #   1. A graph without cache
+        #   2. A graph with cache
+        # In the future, we will make improvements to export API to export two graphs
+        # more seamlessly.
+
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")
         model = model.eval()
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-MistralForCausalLM")


### PR DESCRIPTION
# What does this PR do?

When we flatten DynamicCache for export, we never end up flattening the inner tensors of DynamicCache because when we start, there are 0 tensors initialized. As a result, we didn't correctly test the ep.module()(*args, **kwargs) behaviour when we do export when cache is populated. 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
