### PR TITLE
Fix duplicate init self attention in Qwen3 MoE

### DIFF
--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -325,8 +325,6 @@ class Qwen3MoeDecoderLayer(nn.Module):
         self.self_attn = Qwen3MoeAttention(config, layer_idx)
         self.mlp = Qwen3MoeMLP(config)
 
-        self.self_attn = Qwen3MoeAttention(config, layer_idx)
-
         if (layer_idx not in config.mlp_only_layers) and (
             config.num_experts > 0 and (layer_idx + 1) % config.decoder_sparse_step == 0
         ):


### PR DESCRIPTION
# What does this PR do?

Remove the duplicated lines, maybe due to a manual error.
