### PR TITLE
Fix device mismatch by moving num_items_in_batch to loss device in fixed_cross_entropy (#37886)

### DIFF
--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -35,6 +35,8 @@ def fixed_cross_entropy(
     reduction = "sum" if num_items_in_batch is not None else "mean"
     loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction=reduction)
     if reduction == "sum":
+        if num_items_in_batch.device != loss.device:
+            num_items_in_batch = num_items_in_batch.to(loss.device)
         loss = loss / num_items_in_batch
     return loss
 


### PR DESCRIPTION
Fixes: #37886 

This PR ensures that the num_items_in_batch tensor is moved to the same device as the loss tensor before performing division inside the fixed_cross_entropy function. This prevents runtime device mismatch errors when models are trained on non-default devices (e.g., CUDA).

🔧 Changes made:
Updated fixed_cross_entropy to move num_items_in_batch to loss.device before division when reduction is set to 'sum'.

This fix is particularly relevant for ForCausalLMLoss, where num_items_in_batch may be on a different device than logits or loss.