### PR TITLE
Add LlamaForSequenceClassification example to docs

### DIFF
--- a/docs/source/en/model_doc/llama.md
+++ b/docs/source/en/model_doc/llama.md
@@ -156,24 +156,7 @@ visualizer("Plants create energy through a process known as")
     - forward
 
 ## LlamaForSequenceClassification
-```python
-from transformers import LlamaForSequenceClassification, LlamaTokenizer
-import torch
 
-# Load model
-model = LlamaForSequenceClassification.from_pretrained("meta-llama/Llama-2-7b-hf")
-tokenizer = LlamaTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
-
-# Prepare input
-inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
-
-# Get prediction
-with torch.no_grad():
-    logits = model(**inputs).logits
-predicted_class = logits.argmax().item()
-
-print(f"Predicted class: {predicted_class}")
-```
 [[autodoc]] LlamaForSequenceClassification
     - forward
 

--- a/docs/source/en/model_doc/llama.md
+++ b/docs/source/en/model_doc/llama.md
@@ -156,6 +156,24 @@ visualizer("Plants create energy through a process known as")
     - forward
 
 ## LlamaForSequenceClassification
+```python
+from transformers import LlamaForSequenceClassification, LlamaTokenizer
+import torch
+
+# Load model
+model = LlamaForSequenceClassification.from_pretrained("meta-llama/Llama-2-7b-hf")
+tokenizer = LlamaTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+
+# Prepare input
+inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
+
+# Get prediction
+with torch.no_grad():
+    logits = model(**inputs).logits
+predicted_class = logits.argmax().item()
+
+print(f"Predicted class: {predicted_class}")
+```
 
 [[autodoc]] LlamaForSequenceClassification
     - forward

--- a/docs/source/en/model_doc/llama.md
+++ b/docs/source/en/model_doc/llama.md
@@ -174,7 +174,6 @@ predicted_class = logits.argmax().item()
 
 print(f"Predicted class: {predicted_class}")
 ```
-
 [[autodoc]] LlamaForSequenceClassification
     - forward
 

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -925,21 +925,7 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
-
-        Example:
-        ```python
-        >>> from transformers import LlamaForSequenceClassification, LlamaTokenizer
-        >>> import torch
-
-        >>> model = LlamaForSequenceClassification.from_pretrained("meta-llama/Llama-2-7b-hf")
-        >>> tokenizer = LlamaTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
-
-        >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
-        >>> with torch.no_grad():
-        ...     logits = model(**inputs).logits
-        >>> predicted_class = logits.argmax().item()
-        >>> print(f"Predicted class: {predicted_class}")
-        ```"""
+        """
 
         transformer_outputs: BaseModelOutputWithPast = self.model(
             input_ids,

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -921,21 +921,25 @@ class LlamaForSequenceClassification(LlamaPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
     ) -> SequenceClassifierOutputWithPast:
         r"""
+        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
+            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
+            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
+            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+
         Example:
+        ```python
         >>> from transformers import LlamaForSequenceClassification, LlamaTokenizer
         >>> import torch
+
         >>> model = LlamaForSequenceClassification.from_pretrained("meta-llama/Llama-2-7b-hf")
         >>> tokenizer = LlamaTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+
         >>> inputs = tokenizer("Hello, my dog is cute", return_tensors="pt")
         >>> with torch.no_grad():
         ...     logits = model(**inputs).logits
         >>> predicted_class = logits.argmax().item()
         >>> print(f"Predicted class: {predicted_class}")
-        labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
-            Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
-            config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
-            `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
-        """
+        ```"""
 
         transformer_outputs: BaseModelOutputWithPast = self.model(
             input_ids,


### PR DESCRIPTION
# What does this PR do?
Ref #36979  
Added a minimal working example for `LlamaForSequenceClassification` in the LLaMA documentation.

**Motivation**:  
This helps users understand how to use LLaMA for classification tasks, as requested in the issue.

**Changes**:  
- Added Python code example showing:  
  - Model loading  
  - Tokenization  
  - Prediction  

## Before submitting
- [x] This PR fixes a typo or improves the docs
- [x] Did you read the contributor guideline?
- [x] Did you make sure to update the documentation?

## Who can review?
@ArthurZucker @stevhliu