### PR TITLE
Fix wrong example in grounding dino

### DIFF
--- a/docs/source/en/model_doc/grounding-dino.md
+++ b/docs/source/en/model_doc/grounding-dino.md
@@ -60,7 +60,8 @@ Here's how to use the model for zero-shot object detection:
 >>> image_url = "http://images.cocodataset.org/val2017/000000039769.jpg"
 >>> image = Image.open(requests.get(image_url, stream=True).raw)
 >>> # Check for cats and remote controls
->>> text_labels = [["a cat", "a remote control"]]
+>>> # VERY important: text queries need to be lowercased + end with a dot
+>>> text_labels = "a cat. a remote control."
 
 >>> inputs = processor(images=image, text=text_labels, return_tensors="pt").to(device)
 >>> with torch.no_grad():
@@ -79,8 +80,9 @@ Here's how to use the model for zero-shot object detection:
 >>> for box, score, labels in zip(result["boxes"], result["scores"], result["labels"]):
 ...     box = [round(x, 2) for x in box.tolist()]
 ...     print(f"Detected {labels} with confidence {round(score.item(), 3)} at location {box}")
-Detected a cat with confidence 0.468 at location [344.78, 22.9, 637.3, 373.62]
-Detected a cat with confidence 0.426 at location [11.74, 51.55, 316.51, 473.22]
+Detected a cat with confidence 0.479 at location [344.7, 23.11, 637.18, 374.27]
+Detected a cat with confidence 0.438 at location [12.27, 51.91, 316.86, 472.43]
+Detected a remote control with confidence 0.476 at location [38.58, 70.01, 176.78, 118.18]
 ```
 
 ## Grounded SAM


### PR DESCRIPTION
# What does this PR do?

Fix wrong example in grounding dino. the more objects can be detected with this modification.


Test Input Image:

![image](https://github.com/user-attachments/assets/d226f186-14da-401d-a36f-e0b1e69fd0e9)

With `text_labels` in example, it only can detect cats when using grounding-dino-base,

<img width="881" alt="스크린샷 2025-05-02 112340_bad" src="https://github.com/user-attachments/assets/8ffda0ed-6e9f-427f-b523-eb9ad4227ab3" />

After modification via an [official guide](https://huggingface.co/IDEA-Research/grounding-dino-base#how-to-use), it can detect remote controls also.

<img width="889" alt="스크린샷 2025-05-02 112340_good" src="https://github.com/user-attachments/assets/eaa59255-6f12-4bf9-8204-3b32a21ec62a" />



- https://huggingface.co/IDEA-Research/grounding-dino-base#how-to-use
 


## Before submitting
- [v] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@amyeroberts, @qubvel

Library:
@zucchini-nlp

Documentation: @stevhliu

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
