### PR TITLE
fix graph break for torch.compile in attention mask check

### DIFF
--- a/examples/modular-transformers/modeling_new_task_model.py
+++ b/examples/modular-transformers/modeling_new_task_model.py
@@ -247,7 +247,7 @@ class NewTaskModelForNewTask(NewTaskModelPreTrainedModel, GenerationMixin):
         is_training: Optional[bool] = None,
     ):
         if self.config.text_config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         is_training = is_training if is_training is not None else self.training

--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -1294,7 +1294,7 @@ class BambaModel(BambaPreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/bamba/modular_bamba.py
+++ b/src/transformers/models/bamba/modular_bamba.py
@@ -1062,7 +1062,7 @@ class BambaModel(BambaPreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -998,7 +998,7 @@ class FalconModel(FalconPreTrainedModel):
         # `fullgraph=True`. See more context in https://github.com/huggingface/transformers/pull/29114
 
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -1104,7 +1104,7 @@ class GPT2Model(GPT2PreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -1354,7 +1354,7 @@ class JambaModel(JambaPreTrainedModel):
 
     def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/mimi/modeling_mimi.py
+++ b/src/transformers/models/mimi/modeling_mimi.py
@@ -1056,7 +1056,7 @@ class MimiTransformerModel(nn.Module):
                         " this may lead to unexpected behaviour for Flash Attention version of Mimi. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -579,7 +579,7 @@ class MistralModel(MistralPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Mistral. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/mistral/modular_mistral.py
+++ b/src/transformers/models/mistral/modular_mistral.py
@@ -141,7 +141,7 @@ class MistralModel(LlamaModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Mistral. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -721,7 +721,7 @@ class MixtralModel(MixtralPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Mixtral. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/moshi/modeling_moshi.py
+++ b/src/transformers/models/moshi/modeling_moshi.py
@@ -1282,7 +1282,7 @@ class MoshiDepthDecoder(MoshiPreTrainedModel, GenerationMixin):
                         " this may lead to unexpected behaviour for Flash Attention version of Moshi. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":
@@ -1598,7 +1598,7 @@ class MoshiModel(MoshiPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Moshi. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/olmoe/modeling_olmoe.py
+++ b/src/transformers/models/olmoe/modeling_olmoe.py
@@ -1012,7 +1012,7 @@ class OlmoeModel(OlmoePreTrainedModel):
         output_attentions: bool,
     ):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -329,7 +329,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixi
         is_training: Optional[bool] = None,
     ):
         if self.config.text_config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         is_training = is_training if is_training is not None else self.training

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -634,7 +634,7 @@ class Phi3Model(Phi3PreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Phi3. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
@@ -1919,7 +1919,7 @@ class Phi4MultimodalModel(Phi4MultimodalPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Phi4Multimodal. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -1191,7 +1191,7 @@ class PhimoeModel(PhimoePreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Phimoe. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -592,7 +592,7 @@ class Qwen2Model(Qwen2PreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen2. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -2059,7 +2059,7 @@ class Qwen2_5OmniThinkerTextModel(Qwen2_5OmniPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen25OmniThinkerText. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":
@@ -2775,7 +2775,7 @@ class Qwen2_5OmniTalkerModel(Qwen2_5OmniPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen25OmniTalker. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -1236,7 +1236,7 @@ class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen2_5_VL. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -1052,7 +1052,7 @@ class Qwen2MoeModel(Qwen2MoePreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen2Moe. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -1188,7 +1188,7 @@ class Qwen2VLModel(Qwen2VLPreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen2VL. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -619,7 +619,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen3. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -732,7 +732,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Qwen3Moe. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -583,7 +583,7 @@ class Starcoder2Model(Starcoder2PreTrainedModel):
                         " this may lead to unexpected behaviour for Flash Attention version of Starcoder2. Make sure to "
                         " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
                     )
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
         if self.config._attn_implementation == "flex_attention":

--- a/src/transformers/models/zamba/modeling_zamba.py
+++ b/src/transformers/models/zamba/modeling_zamba.py
@@ -1143,7 +1143,7 @@ class ZambaModel(ZambaPreTrainedModel):
     # Copied from transformers.models.jamba.modeling_jamba.JambaModel._update_causal_mask
     def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 

--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1504,7 +1504,7 @@ class Zamba2Model(Zamba2PreTrainedModel):
 
     def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
         if self.config._attn_implementation == "flash_attention_2":
-            if attention_mask is not None and 0.0 in attention_mask:
+            if attention_mask is not None and torch.any(attention_mask == 0.0):
                 return attention_mask
             return None
 


### PR DESCRIPTION
# What does this PR do?

`torch.compile` gives a graph break:
```
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0] Graph break from Tensor.item(), consider setting:
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]     torch._dynamo.config.capture_scalar_outputs = True
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0] or:
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]     env TORCHDYNAMO_CAPTURE_SCALAR_OUTPUTS=1
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0] to include these operations in the captured graph.
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0] Graph break: from user code at:
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/models/qwen3/modeling_qwen3.py", line 540, in torch_dynamo_resume_in_forward_at_526
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]     causal_mask = self._update_causal_mask(
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]   File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/models/qwen3/modeling_qwen3.py", line 617, in updatecausal_mask
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]     if attention_mask is not None and 0.0 in attention_mask:
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]
W0503 22:06:01.020000 30493 site-packages/torch/_dynamo/variables/tensor.py:869] [12/0]
```
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
