### PR TITLE
[docs]: update roformer.md model card

### DIFF
--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -76,8 +76,8 @@ print(decoded)
 </hfoption>
 <hfoption id="transformers CLI">
 
-```py
-echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model junnyu/roformer_chinese_base --device 0
+```bash
+echo -e "水在零度时会[MASK]" | transformers-cli run --task fill-mask --model junnyu/roformer_chinese_base --device 0
 ```
 
 </hfoption>
@@ -103,6 +103,9 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 [[autodoc]] RoFormerTokenizerFast
     - build_inputs_with_special_tokens
+
+<frameworkcontent>
+<pt>
 
 ## RoFormerModel
 
@@ -139,6 +142,9 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 [[autodoc]] RoFormerForQuestionAnswering
     - forward
 
+</pt>
+<tf>
+
 ## TFRoFormerModel
 
 [[autodoc]] TFRoFormerModel
@@ -174,6 +180,9 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 [[autodoc]] TFRoFormerForQuestionAnswering
     - call
 
+</tf>
+<jax>
+
 ## FlaxRoFormerModel
 
 [[autodoc]] FlaxRoFormerModel
@@ -203,3 +212,6 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 [[autodoc]] FlaxRoFormerForQuestionAnswering
     - __call__
+
+</jax>
+</frameworkcontent>

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -35,7 +35,7 @@ You can find all the RoFormer checkpoints on the [Hub](https://huggingface.co/mo
 The example below demonstrates how to predict the `[MASK]` token with [`Pipeline`], [`AutoModel`], and from the command line.
 
 <hfoptions id="usage">
-<hfoption id="Pipeline>
+<hfoption id="Pipeline">
 
 ```py
 # uncomment to install rjieba which is needed for the tokenizer

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -34,7 +34,7 @@ You can find all the original [RoFormer](link) checkpoints under the [RoFormer](
 > [!TIP]
 > Click on the [RoFormer] models in the right sidebar for more examples of how to apply [RoFormer] to different NLP tasks.
 
-The example below demonstrates how to generate text with [`Pipeline`] or the [`AutoModel`] class, and from the command line.
+The example below demonstrates how to predict masked tokens using the mask-filling [`Pipeline`] or the [`AutoModel`] class, and from the command line.
 
 <hfoptions id="usage">
 <hfoption id="Pipeline>

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -93,7 +93,7 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## RoFormerTokenizer
 
-[[autodoc]] RoFormerTokenizer 
+[[autodoc]] RoFormerTokenizer
     - build_inputs_with_special_tokens
     - get_special_tokens_mask
     - create_token_type_ids_from_sequences
@@ -101,11 +101,8 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## RoFormerTokenizerFast
 
-[[autodoc]] RoFormerTokenizerFast 
+[[autodoc]] RoFormerTokenizerFast
     - build_inputs_with_special_tokens
-
-<frameworkcontent>
-<pt>
 
 ## RoFormerModel
 
@@ -142,9 +139,6 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 [[autodoc]] RoFormerForQuestionAnswering
     - forward
 
-</pt>
-<tf>
-
 ## TFRoFormerModel
 
 [[autodoc]] TFRoFormerModel
@@ -179,9 +173,6 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 [[autodoc]] TFRoFormerForQuestionAnswering
     - call
-
-</tf>
-<jax>
 
 ## FlaxRoFormerModel
 

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -25,21 +25,21 @@ rendered properly in your Markdown viewer.
 
 # RoFormer
 
-[RoFormer](https://huggingface.co/papers/2104.09864) is an enhansed transformer model with rotary position embeddings applied to the self-attention mechanism (particularly to Query and Key matrices). The purpose of the ReFormer is to represent the benefits of rotary position encoding (RoPE). Benefits include natural incorporation of the relative position and decaying inter-token dependencies (due to being based on complex number ideas), flexibility in sequence length, faster convergence during training, as well as an ability to be integrated into a linear self-attention mechanism.
+[RoFormer](https://huggingface.co/papers/2104.09864) introduces Rotary Position Embedding (RoPE) to encode token positions by rotating the inputs in 2D space. This allows a model to track absolute positions and model relative relationships. RoPE can scale to longer sequences, account for the natural decay of token dependencies, and works with the more efficient linear self-attention.
 
-The RoFormer was originally evaluated on various NLP tasks including both English and Chineese datasets. Some of them mentioned in the paper include machine translation, performance during pre-training, fine-tuning on GLUE tasks and dealing with long texts showed RoFormer outperforming the chosen baseline models like BERTDelvin, model Vaswani et al.[2017], WoBERT Su and others.
-
-You can find all the original [RoFormer](link) checkpoints under the [RoFormer](link) collection.
+You can find all the RoFormer checkpoints on the [Hub](https://huggingface.co/models?search=roformer).
 
 > [!TIP]
-> Click on the [RoFormer] models in the right sidebar for more examples of how to apply [RoFormer] to different NLP tasks.
+> Click on the RoFormer models in the right sidebar for more examples of how to apply RoFormer to different language tasks.
 
-The example below demonstrates how to predict masked tokens using the mask-filling [`Pipeline`] or the [`AutoModel`] class, and from the command line.
+The example below demonstrates how to predict the `[MASK]` token with [`Pipeline`], [`AutoModel`], and from the command line.
 
 <hfoptions id="usage">
 <hfoption id="Pipeline>
 
 ```py
+# uncomment to install rjieba which is needed for the tokenizer
+# !pip install rjieba
 import torch
 from transformers import pipeline
 
@@ -57,6 +57,8 @@ print(output)
 <hfoption id="AutoModel">
 
 ```py
+# uncomment to install rjieba which is needed for the tokenizer
+# !pip install rjieba
 import torch
 from transformers import AutoModelForMaskedLM, AutoTokenizer
 
@@ -83,7 +85,7 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## Notes
 
-- The current implementation of the RoFormer is an encoder-only model. The original code can be found [here](https://github.com/ZhuiyiTechnology/roformer)
+- The current RoFormer implementation is an encoder-only model. The original code can be found in the [ZhuiyiTechnology/roformer](https://github.com/ZhuiyiTechnology/roformer) repository.
 
 ## RoFormerConfig
 
@@ -91,97 +93,122 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## RoFormerTokenizer
 
-[[autodoc]] RoFormerTokenizer - build_inputs_with_special_tokens - get_special_tokens_mask - create_token_type_ids_from_sequences - save_vocabulary
+[[autodoc]] RoFormerTokenizer 
+    - build_inputs_with_special_tokens
+    - get_special_tokens_mask
+    - create_token_type_ids_from_sequences
+    - save_vocabulary
 
 ## RoFormerTokenizerFast
 
-[[autodoc]] RoFormerTokenizerFast - build_inputs_with_special_tokens
+[[autodoc]] RoFormerTokenizerFast 
+    - build_inputs_with_special_tokens
 
 <frameworkcontent>
 <pt>
 
 ## RoFormerModel
 
-[[autodoc]] RoFormerModel - forward
+[[autodoc]] RoFormerModel 
+    - forward
 
 ## RoFormerForCausalLM
 
-[[autodoc]] RoFormerForCausalLM - forward
+[[autodoc]] RoFormerForCausalLM 
+    - forward
 
 ## RoFormerForMaskedLM
 
-[[autodoc]] RoFormerForMaskedLM - forward
+[[autodoc]] RoFormerForMaskedLM 
+    - forward
 
 ## RoFormerForSequenceClassification
 
-[[autodoc]] RoFormerForSequenceClassification - forward
+[[autodoc]] RoFormerForSequenceClassification 
+    - forward
 
 ## RoFormerForMultipleChoice
 
-[[autodoc]] RoFormerForMultipleChoice - forward
+[[autodoc]] RoFormerForMultipleChoice 
+    - forward
 
 ## RoFormerForTokenClassification
 
-[[autodoc]] RoFormerForTokenClassification - forward
+[[autodoc]] RoFormerForTokenClassification 
+    - forward
 
 ## RoFormerForQuestionAnswering
 
-[[autodoc]] RoFormerForQuestionAnswering - forward
+[[autodoc]] RoFormerForQuestionAnswering 
+    - forward
 
 </pt>
 <tf>
 
 ## TFRoFormerModel
 
-[[autodoc]] TFRoFormerModel - call
+[[autodoc]] TFRoFormerModel 
+    - call
 
 ## TFRoFormerForMaskedLM
 
-[[autodoc]] TFRoFormerForMaskedLM - call
+[[autodoc]] TFRoFormerForMaskedLM 
+    - call
 
 ## TFRoFormerForCausalLM
 
-[[autodoc]] TFRoFormerForCausalLM - call
+[[autodoc]] TFRoFormerForCausalLM 
+    - call
 
 ## TFRoFormerForSequenceClassification
 
-[[autodoc]] TFRoFormerForSequenceClassification - call
+[[autodoc]] TFRoFormerForSequenceClassification 
+    - call
 
 ## TFRoFormerForMultipleChoice
 
-[[autodoc]] TFRoFormerForMultipleChoice - call
+[[autodoc]] TFRoFormerForMultipleChoice 
+    - call
 
 ## TFRoFormerForTokenClassification
 
-[[autodoc]] TFRoFormerForTokenClassification - call
+[[autodoc]] TFRoFormerForTokenClassification 
+    - call
 
 ## TFRoFormerForQuestionAnswering
 
-[[autodoc]] TFRoFormerForQuestionAnswering - call
+[[autodoc]] TFRoFormerForQuestionAnswering 
+    - call
 
 </tf>
 <jax>
 
 ## FlaxRoFormerModel
 
-[[autodoc]] FlaxRoFormerModel - **call**
+[[autodoc]] FlaxRoFormerModel 
+    - **call**
 
 ## FlaxRoFormerForMaskedLM
 
-[[autodoc]] FlaxRoFormerForMaskedLM - **call**
+[[autodoc]] FlaxRoFormerForMaskedLM 
+    - **call**
 
 ## FlaxRoFormerForSequenceClassification
 
-[[autodoc]] FlaxRoFormerForSequenceClassification - **call**
+[[autodoc]] FlaxRoFormerForSequenceClassification 
+    - **call**
 
 ## FlaxRoFormerForMultipleChoice
 
-[[autodoc]] FlaxRoFormerForMultipleChoice - **call**
+[[autodoc]] FlaxRoFormerForMultipleChoice 
+    - **call**
 
 ## FlaxRoFormerForTokenClassification
 
-[[autodoc]] FlaxRoFormerForTokenClassification - **call**
+[[autodoc]] FlaxRoFormerForTokenClassification 
+    - **call**
 
 ## FlaxRoFormerForQuestionAnswering
 
-[[autodoc]] FlaxRoFormerForQuestionAnswering - **call**
+[[autodoc]] FlaxRoFormerForQuestionAnswering 
+    - **call**

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -109,37 +109,37 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## RoFormerModel
 
-[[autodoc]] RoFormerModel 
+[[autodoc]] RoFormerModel
     - forward
 
 ## RoFormerForCausalLM
 
-[[autodoc]] RoFormerForCausalLM 
+[[autodoc]] RoFormerForCausalLM
     - forward
 
 ## RoFormerForMaskedLM
 
-[[autodoc]] RoFormerForMaskedLM 
+[[autodoc]] RoFormerForMaskedLM
     - forward
 
 ## RoFormerForSequenceClassification
 
-[[autodoc]] RoFormerForSequenceClassification 
+[[autodoc]] RoFormerForSequenceClassification
     - forward
 
 ## RoFormerForMultipleChoice
 
-[[autodoc]] RoFormerForMultipleChoice 
+[[autodoc]] RoFormerForMultipleChoice
     - forward
 
 ## RoFormerForTokenClassification
 
-[[autodoc]] RoFormerForTokenClassification 
+[[autodoc]] RoFormerForTokenClassification
     - forward
 
 ## RoFormerForQuestionAnswering
 
-[[autodoc]] RoFormerForQuestionAnswering 
+[[autodoc]] RoFormerForQuestionAnswering
     - forward
 
 </pt>
@@ -147,37 +147,37 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## TFRoFormerModel
 
-[[autodoc]] TFRoFormerModel 
+[[autodoc]] TFRoFormerModel
     - call
 
 ## TFRoFormerForMaskedLM
 
-[[autodoc]] TFRoFormerForMaskedLM 
+[[autodoc]] TFRoFormerForMaskedLM
     - call
 
 ## TFRoFormerForCausalLM
 
-[[autodoc]] TFRoFormerForCausalLM 
+[[autodoc]] TFRoFormerForCausalLM
     - call
 
 ## TFRoFormerForSequenceClassification
 
-[[autodoc]] TFRoFormerForSequenceClassification 
+[[autodoc]] TFRoFormerForSequenceClassification
     - call
 
 ## TFRoFormerForMultipleChoice
 
-[[autodoc]] TFRoFormerForMultipleChoice 
+[[autodoc]] TFRoFormerForMultipleChoice
     - call
 
 ## TFRoFormerForTokenClassification
 
-[[autodoc]] TFRoFormerForTokenClassification 
+[[autodoc]] TFRoFormerForTokenClassification
     - call
 
 ## TFRoFormerForQuestionAnswering
 
-[[autodoc]] TFRoFormerForQuestionAnswering 
+[[autodoc]] TFRoFormerForQuestionAnswering
     - call
 
 </tf>
@@ -185,30 +185,30 @@ echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model j
 
 ## FlaxRoFormerModel
 
-[[autodoc]] FlaxRoFormerModel 
-    - **call**
+[[autodoc]] FlaxRoFormerModel
+    - __call__
 
 ## FlaxRoFormerForMaskedLM
 
-[[autodoc]] FlaxRoFormerForMaskedLM 
-    - **call**
+[[autodoc]] FlaxRoFormerForMaskedLM
+    - __call__
 
 ## FlaxRoFormerForSequenceClassification
 
-[[autodoc]] FlaxRoFormerForSequenceClassification 
-    - **call**
+[[autodoc]] FlaxRoFormerForSequenceClassification
+    - __call__
 
 ## FlaxRoFormerForMultipleChoice
 
-[[autodoc]] FlaxRoFormerForMultipleChoice 
-    - **call**
+[[autodoc]] FlaxRoFormerForMultipleChoice
+    - __call__
 
 ## FlaxRoFormerForTokenClassification
 
-[[autodoc]] FlaxRoFormerForTokenClassification 
-    - **call**
+[[autodoc]] FlaxRoFormerForTokenClassification
+    - __call__
 
 ## FlaxRoFormerForQuestionAnswering
 
-[[autodoc]] FlaxRoFormerForQuestionAnswering 
-    - **call**
+[[autodoc]] FlaxRoFormerForQuestionAnswering
+    - __call__

--- a/docs/source/en/model_doc/roformer.md
+++ b/docs/source/en/model_doc/roformer.md
@@ -14,46 +14,76 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# RoFormer
-
-<div class="flex flex-wrap space-x-1">
-<img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
+<div style="float: right;">
+    <div class="flex flex-wrap space-x-1">
+           <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
 <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 <img alt="Flax" src="https://img.shields.io/badge/Flax-29a79b.svg?style=flat&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC0AAAAtCAMAAAANxBKoAAAC7lBMVEUAAADg5vYHPVgAoJH+/v76+v39/f9JbLP///9+AIgAnY3///+mcqzt8fXy9fgkXa3Ax9709fr+///9/f8qXq49qp5AaLGMwrv8/P0eW60VWawxYq8yqJzG2dytt9Wyu9elzci519Lf3O3S2efY3OrY0+Xp7PT///////+dqNCexMc6Z7AGpJeGvbenstPZ5ejQ1OfJzOLa7ejh4+/r8fT29vpccbklWK8PVa0AS6ghW63O498vYa+lsdKz1NDRt9Kw1c672tbD3tnAxt7R6OHp5vDe7OrDyuDn6vLl6/EAQKak0MgATakkppo3ZK/Bz9y8w9yzu9jey97axdvHzeG21NHH4trTwthKZrVGZLSUSpuPQJiGAI+GAI8SWKydycLL4d7f2OTi1+S9xNzL0ePT6OLGzeEAo5U0qJw/aLEAo5JFa7JBabEAp5Y4qZ2QxLyKmsm3kL2xoMOehrRNb7RIbbOZgrGre68AUqwAqZqNN5aKJ5N/lMq+qsd8kMa4pcWzh7muhLMEV69juq2kbKqgUaOTR5uMMZWLLZSGAI5VAIdEAH+ovNDHuNCnxcy3qcaYx8K8msGplrx+wLahjbYdXrV6vbMvYK9DrZ8QrZ8tqJuFms+Sos6sw8ecy8RffsNVeMCvmb43aLltv7Q4Y7EZWK4QWa1gt6meZKUdr6GOAZVeA4xPAISyveLUwtivxtKTpNJ2jcqfvcltiMiwwcfAoMVxhL+Kx7xjdrqTe60tsaNQs6KaRKACrJ6UTZwkqpqTL5pkHY4AloSgsd2ptNXPvNOOncuxxsqFl8lmg8apt8FJcr9EbryGxLqlkrkrY7dRa7ZGZLQ5t6iXUZ6PPpgVpZeJCJFKAIGareTa0+KJod3H0deY2M+esM25usmYu8d2zsJOdcBVvrCLbqcAOaaHaKQAMaScWqKBXqCXMJ2RHpiLF5NmJZAdAHN2kta11dKu1M+DkcZLdb+Mcql3TppyRJdzQ5ZtNZNlIY+DF4+voCOQAAAAZ3RSTlMABAT+MEEJ/RH+/TP+Zlv+pUo6Ifz8+fco/fz6+evr39S9nJmOilQaF/7+/f38+smmoYp6b1T+/v7++vj189zU0tDJxsGzsrKSfv34+Pf27dDOysG9t6+n/vv6+vr59uzr1tG+tZ6Qg9Ym3QAABR5JREFUSMeNlVVUG1EQhpcuxEspXqS0SKEtxQp1d3d332STTRpIQhIISQgJhODu7lAoDoUCpe7u7u7+1puGpqnCPOyZvffbOXPm/PsP9JfQgyCC+tmTABTOcbxDz/heENS7/1F+9nhvkHePG0wNDLbGWwdXL+rbLWvpmZHXD8+gMfBjTh+aSe6Gnn7lwQIOTR0c8wfX3PWgv7avbdKwf/ZoBp1Gp/PvuvXW3vw5ib7emnTW4OR+3D4jB9vjNJ/7gNvfWWeH/TO/JyYrsiKCRjVEZA3UB+96kON+DxOQ/NLE8PE5iUYgIXjFnCOlxEQMaSGVxjg4gxOnEycGz8bptuNjVx08LscIgrzH3umcn+KKtiBIyvzOO2O99aAdR8cF19oZalnCtvREUw79tCd5sow1g1UKM6kXqUx4T8wsi3sTjJ3yzDmmhenLXLpo8u45eG5y4Vvbk6kkC4LLtJMowkSQxmk4ggVJEG+7c6QpHT8vvW9X7/o7+3ELmiJi2mEzZJiz8cT6TBlanBk70cB5GGIGC1gRDdZ00yADLW1FL6gqhtvNXNG5S9gdSrk4M1qu7JAsmYshzDS4peoMrU/gT7qQdqYGZaYhxZmVbGJAm/CS/HloWyhRUlknQ9KYcExTwS80d3VNOxUZJpITYyspl0LbhArhpZCD9cRWEQuhYkNGMHToQ/2Cs6swJlb39CsllxdXX6IUKh/H5jbnSsPKjgmoaFQ1f8wRLR0UnGE/RcDEjj2jXG1WVTwUs8+zxfcrVO+vSsuOpVKxCfYZiQ0/aPKuxQbQ8lIz+DClxC8u+snlcJ7Yr1z1JPqUH0V+GDXbOwAib931Y4Imaq0NTIXPXY+N5L18GJ37SVWu+hwXff8l72Ds9XuwYIBaXPq6Shm4l+Vl/5QiOlV+uTk6YR9PxKsI9xNJny31ygK1e+nIRC1N97EGkFPI+jCpiHe5PCEy7oWqWSwRrpOvhFzcbTWMbm3ZJAOn1rUKpYIt/lDhW/5RHHteeWFN60qo98YJuoq1nK3uW5AabyspC1BcIEpOhft+SZAShYoLSvnmSfnYADUERP5jJn2h5XtsgCRuhYQqAvwTwn33+YWEKUI72HX5AtfSAZDe8F2DtPPm77afhl0EkthzuCQU0BWApgQIH9+KB0JhopMM7bJrdTRoleM2JAVNMyPF+wdoaz+XJpGoVAQ7WXUkcV7gT3oUZyi/ISIJAVKhgNp+4b4veCFhYVJw4locdSjZCp9cPUhLF9EZ3KKzURepMEtCDPP3VcWFx4UIiZIklIpFNfHpdEafIF2aRmOcrUmjohbT2WUllbmRvgfbythbQO3222fpDJoufaQPncYYuqoGtUEsCJZL6/3PR5b4syeSjZMQG/T2maGANlXT2v8S4AULWaUkCxfLyW8iW4kdka+nEMjxpL2NCwsYNBp+Q61PF43zyDg9Bm9+3NNySn78jMZUUkumqE4Gp7JmFOdP1vc8PpRrzj9+wPinCy8K1PiJ4aYbnTYpCCbDkBSbzhu2QJ1Gd82t8jI8TH51+OzvXoWbnXUOBkNW+0mWFwGcGOUVpU81/n3TOHb5oMt2FgYGjzau0Nif0Ss7Q3XB33hjjQHjHA5E5aOyIQc8CBrLdQSs3j92VG+3nNEjbkbdbBr9zm04ruvw37vh0QKOdeGIkckc80fX3KH/h7PT4BOjgCty8VZ5ux1MoO5Cf5naca2LAsEgehI+drX8o/0Nu+W0m6K/I9gGPd/dfx/EN/wN62AhsBWuAAAAAElFTkSuQmCC
 ">
+    </div>
 </div>
 
-## Overview
+# RoFormer
 
-The RoFormer model was proposed in [RoFormer: Enhanced Transformer with Rotary Position Embedding](https://arxiv.org/pdf/2104.09864v1.pdf) by Jianlin Su and Yu Lu and Shengfeng Pan and Bo Wen and Yunfeng Liu.
+[RoFormer](https://huggingface.co/papers/2104.09864) is an enhansed transformer model with rotary position embeddings applied to the self-attention mechanism (particularly to Query and Key matrices). The purpose of the ReFormer is to represent the benefits of rotary position encoding (RoPE). Benefits include natural incorporation of the relative position and decaying inter-token dependencies (due to being based on complex number ideas), flexibility in sequence length, faster convergence during training, as well as an ability to be integrated into a linear self-attention mechanism.
 
-The abstract from the paper is the following:
+The RoFormer was originally evaluated on various NLP tasks including both English and Chineese datasets. Some of them mentioned in the paper include machine translation, performance during pre-training, fine-tuning on GLUE tasks and dealing with long texts showed RoFormer outperforming the chosen baseline models like BERTDelvin, model Vaswani et al.[2017], WoBERT Su and others.
 
-*Position encoding in transformer architecture provides supervision for dependency modeling between elements at
-different positions in the sequence. We investigate various methods to encode positional information in
-transformer-based language models and propose a novel implementation named Rotary Position Embedding(RoPE). The
-proposed RoPE encodes absolute positional information with rotation matrix and naturally incorporates explicit relative
-position dependency in self-attention formulation. Notably, RoPE comes with valuable properties such as flexibility of
-being expand to any sequence lengths, decaying inter-token dependency with increasing relative distances, and
-capability of equipping the linear self-attention with relative position encoding. As a result, the enhanced
-transformer with rotary position embedding, or RoFormer, achieves superior performance in tasks with long texts. We
-release the theoretical analysis along with some preliminary experiment results on Chinese data. The undergoing
-experiment for English benchmark will soon be updated.*
+You can find all the original [RoFormer](link) checkpoints under the [RoFormer](link) collection.
 
-This model was contributed by [junnyu](https://huggingface.co/junnyu). The original code can be found [here](https://github.com/ZhuiyiTechnology/roformer).
+> [!TIP]
+> Click on the [RoFormer] models in the right sidebar for more examples of how to apply [RoFormer] to different NLP tasks.
 
-## Usage tips
-RoFormer is a BERT-like autoencoding model with rotary position embeddings. Rotary position embeddings have shown 
-improved performance on classification tasks with long texts.
+The example below demonstrates how to generate text with [`Pipeline`] or the [`AutoModel`] class, and from the command line.
 
-## Resources
+<hfoptions id="usage">
+<hfoption id="Pipeline>
 
-- [Text classification task guide](../tasks/sequence_classification)
-- [Token classification task guide](../tasks/token_classification)
-- [Question answering task guide](../tasks/question_answering)
-- [Causal language modeling task guide](../tasks/language_modeling)
-- [Masked language modeling task guide](../tasks/masked_language_modeling)
-- [Multiple choice task guide](../tasks/multiple_choice)
+```py
+import torch
+from transformers import pipeline
+
+pipe = pipeline(
+    task="fill-mask",
+    model="junnyu/roformer_chinese_base",
+    torch_dtype=torch.float16,
+    device=0
+)
+output = pipe("水在零度时会[MASK]")
+print(output)
+```
+
+</hfoption>
+<hfoption id="AutoModel">
+
+```py
+import torch
+from transformers import AutoModelForMaskedLM, AutoTokenizer
+
+model = AutoModelForMaskedLM.from_pretrained(
+    "junnyu/roformer_chinese_base", torch_dtype=torch.float16
+)
+tokenizer = AutoTokenizer.from_pretrained("junnyu/roformer_chinese_base")
+
+input_ids = tokenizer("水在零度时会[MASK]", return_tensors="pt").to(model.device)
+outputs = model(**input_ids)
+decoded = tokenizer.batch_decode(outputs.logits.argmax(-1), skip_special_tokens=True)
+print(decoded)
+```
+
+</hfoption>
+<hfoption id="transformers CLI">
+
+```py
+echo -e "水在零度时会[MASK]" | transformers run --task fill-mask --model junnyu/roformer_chinese_base --device 0
+```
+
+</hfoption>
+</hfoptions>
+
+## Notes
+
+- The current implementation of the RoFormer is an encoder-only model. The original code can be found [here](https://github.com/ZhuiyiTechnology/roformer)
 
 ## RoFormerConfig
 
@@ -61,125 +91,97 @@ improved performance on classification tasks with long texts.
 
 ## RoFormerTokenizer
 
-[[autodoc]] RoFormerTokenizer
-    - build_inputs_with_special_tokens
-    - get_special_tokens_mask
-    - create_token_type_ids_from_sequences
-    - save_vocabulary
+[[autodoc]] RoFormerTokenizer - build_inputs_with_special_tokens - get_special_tokens_mask - create_token_type_ids_from_sequences - save_vocabulary
 
 ## RoFormerTokenizerFast
 
-[[autodoc]] RoFormerTokenizerFast
-    - build_inputs_with_special_tokens
+[[autodoc]] RoFormerTokenizerFast - build_inputs_with_special_tokens
 
 <frameworkcontent>
 <pt>
 
 ## RoFormerModel
 
-[[autodoc]] RoFormerModel
-    - forward
+[[autodoc]] RoFormerModel - forward
 
 ## RoFormerForCausalLM
 
-[[autodoc]] RoFormerForCausalLM
-    - forward
+[[autodoc]] RoFormerForCausalLM - forward
 
 ## RoFormerForMaskedLM
 
-[[autodoc]] RoFormerForMaskedLM
-    - forward
+[[autodoc]] RoFormerForMaskedLM - forward
 
 ## RoFormerForSequenceClassification
 
-[[autodoc]] RoFormerForSequenceClassification
-    - forward
+[[autodoc]] RoFormerForSequenceClassification - forward
 
 ## RoFormerForMultipleChoice
 
-[[autodoc]] RoFormerForMultipleChoice
-    - forward
+[[autodoc]] RoFormerForMultipleChoice - forward
 
 ## RoFormerForTokenClassification
 
-[[autodoc]] RoFormerForTokenClassification
-    - forward
+[[autodoc]] RoFormerForTokenClassification - forward
 
 ## RoFormerForQuestionAnswering
 
-[[autodoc]] RoFormerForQuestionAnswering
-    - forward
+[[autodoc]] RoFormerForQuestionAnswering - forward
 
 </pt>
 <tf>
 
 ## TFRoFormerModel
 
-[[autodoc]] TFRoFormerModel
-    - call
+[[autodoc]] TFRoFormerModel - call
 
 ## TFRoFormerForMaskedLM
 
-[[autodoc]] TFRoFormerForMaskedLM
-    - call
+[[autodoc]] TFRoFormerForMaskedLM - call
 
 ## TFRoFormerForCausalLM
 
-[[autodoc]] TFRoFormerForCausalLM
-    - call
+[[autodoc]] TFRoFormerForCausalLM - call
 
 ## TFRoFormerForSequenceClassification
 
-[[autodoc]] TFRoFormerForSequenceClassification
-    - call
+[[autodoc]] TFRoFormerForSequenceClassification - call
 
 ## TFRoFormerForMultipleChoice
 
-[[autodoc]] TFRoFormerForMultipleChoice
-    - call
+[[autodoc]] TFRoFormerForMultipleChoice - call
 
 ## TFRoFormerForTokenClassification
 
-[[autodoc]] TFRoFormerForTokenClassification
-    - call
+[[autodoc]] TFRoFormerForTokenClassification - call
 
 ## TFRoFormerForQuestionAnswering
 
-[[autodoc]] TFRoFormerForQuestionAnswering
-    - call
+[[autodoc]] TFRoFormerForQuestionAnswering - call
 
 </tf>
 <jax>
 
 ## FlaxRoFormerModel
 
-[[autodoc]] FlaxRoFormerModel
-    - __call__
+[[autodoc]] FlaxRoFormerModel - **call**
 
 ## FlaxRoFormerForMaskedLM
 
-[[autodoc]] FlaxRoFormerForMaskedLM
-    - __call__
+[[autodoc]] FlaxRoFormerForMaskedLM - **call**
 
 ## FlaxRoFormerForSequenceClassification
 
-[[autodoc]] FlaxRoFormerForSequenceClassification
-    - __call__
+[[autodoc]] FlaxRoFormerForSequenceClassification - **call**
 
 ## FlaxRoFormerForMultipleChoice
 
-[[autodoc]] FlaxRoFormerForMultipleChoice
-    - __call__
+[[autodoc]] FlaxRoFormerForMultipleChoice - **call**
 
 ## FlaxRoFormerForTokenClassification
 
-[[autodoc]] FlaxRoFormerForTokenClassification
-    - __call__
+[[autodoc]] FlaxRoFormerForTokenClassification - **call**
 
 ## FlaxRoFormerForQuestionAnswering
 
-[[autodoc]] FlaxRoFormerForQuestionAnswering
-    - __call__
-
-</jax>
-</frameworkcontent>
+[[autodoc]] FlaxRoFormerForQuestionAnswering - **call**


### PR DESCRIPTION
# What does this PR do?
Updates the RoFormer card according to the description in #https://github.com/huggingface/transformers/issues/36979 to standardize all model cards' look.
The pr includes:
- Model description
- Examples for Pipeline, AutoModel, and command line usage

Note: Quantization is not applied because of the model's small size
Note: AttentionMaskVisualizer is not applicable either, as RoFormer is currently not supported

- [x] This PR improves the docs 

## Who can review?

@stevhliu Please have a look and let me know if any further work is needed. thank you
