### PR TITLE
Object detection experiment for transformers

### DIFF
--- a/examples/pytorch/object-detection/README.md
+++ b/examples/pytorch/object-detection/README.md
@@ -67,7 +67,8 @@ python run_object_detection.py \
 
 > Note:  
 `--eval_do_concat_batches false` is required for correct evaluation of detection models;  
-`--ignore_mismatched_sizes true` is required to load detection model for finetuning with different number of classes.
+`--ignore_mismatched_sizes true` is required to load detection model for finetuning with different number of classes;
+`--image_square_size` should be multiples of 64 in rtdetr model.
 
 The resulting model can be seen here: https://huggingface.co/qubvel-hf/qubvel-hf/detr-resnet-50-finetuned-10k-cppe5. The corresponding Weights and Biases report [here](https://api.wandb.ai/links/qubvel-hf-co/bnm0r5ex). Note that it's always advised to check the original paper to know the details regarding training hyperparameters. Hyperparameters for current example were not tuned. To improve model quality you could try:
  - changing image size parameters (`--shortest_edge`/`--longest_edge`)

--- a/examples/pytorch/object-detection/run_object_detection_no_trainer.py
+++ b/examples/pytorch/object-detection/run_object_detection_no_trainer.py
@@ -208,6 +208,7 @@ def evaluation_loop(
 
         metric.update(predictions, target)
 
+    metric.to(accelerator.device)
     metrics = metric.compute()
 
     # Replace list of per class metrics with separate metric for each class

--- a/setup.py
+++ b/setup.py
@@ -466,7 +466,12 @@ setup(
     package_data={"": ["**/*.cu", "**/*.cpp", "**/*.cuh", "**/*.h", "**/*.pyx", "py.typed"]},
     zip_safe=False,
     extras_require=extras,
-    entry_points={"console_scripts": ["transformers=transformers.commands.transformers_cli:main", "transformers-cli=transformers.commands.transformers_cli:main_cli"]},
+    entry_points={
+        "console_scripts": [
+            "transformers=transformers.commands.transformers_cli:main",
+            "transformers-cli=transformers.commands.transformers_cli:main_cli",
+        ]
+    },
     python_requires=">=3.9.0",
     install_requires=list(install_requires),
     classifiers=[

--- a/src/transformers/loss/loss_d_fine.py
+++ b/src/transformers/loss/loss_d_fine.py
@@ -371,9 +371,7 @@ def DFineForObjectDetectionLoss(
             outputs_loss["auxiliary_outputs"].extend(
                 _set_aux_loss([enc_topk_logits], [enc_topk_bboxes.clamp(min=0, max=1)])
             )
-            outputs_loss["auxiliary_outputs"].extend(
-                _set_aux_loss([out_scores], [out_bboxes.clamp(min=0, max=1)])
-            )
+            outputs_loss["auxiliary_outputs"].extend(_set_aux_loss([out_scores], [out_bboxes.clamp(min=0, max=1)]))
 
             dn_auxiliary_outputs = _set_aux_loss2(
                 dn_out_class.transpose(0, 1),

--- a/src/transformers/models/d_fine/modeling_d_fine.py
+++ b/src/transformers/models/d_fine/modeling_d_fine.py
@@ -1283,7 +1283,7 @@ class DFineDecoder(DFinePreTrainedModel):
         initial_reference_points = ()
         initial_scores = ()
         initial_bboxes = ()
-        
+
         output_detach = pred_corners_undetach = 0
 
         project = weighting_function(self.max_num_bins, self.up, self.reg_scale)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

@qubvel As we discussed, I will generate the standard metric for 

**how well the transformers object detection model finetune in diverse domain of data?**

In this step I will focus on 

batch_size | learning rate | model | dataset | AP | training time | required memory
-- | -- | -- | -- | -- | -- | --

on different domain of dataset.
https://www.notion.so/sangbumchoi/HuggingFace-OD-train-1afb8ded2e1680daa2dcfdc3e11aa15d?pvs=4

For the part that changed is

In this step D-Fine was not perfectly finished for the finetune feature. You can see the https://github.com/Peterande/D-FINE/blob/4a1f73a8bcfac736a88abde9596d87f116d780a7/src/zoo/dfine/dfine_criterion.py#L357. This is `pre_output` related auxiliary layer which is related to first layer to use `pre_bbox_head` .https://github.com/huggingface/transformers/blob/2932f318a20d9e54cc7aea052e040164d85de7d6/src/transformers/models/d_fine/modeling_d_fine.py#L1195

This is initial experiment of four models that you have suggested.

![Screenshot 2025-05-05 at 2 54 56 PM](https://github.com/user-attachments/assets/65c59088-45ae-4af2-85a6-1a2f2c3694f8)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
