### PR TITLE
[CI] remove duplicated message on GH comment to run slow tests

### DIFF
--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -145,7 +145,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MODELS: ${{ needs.get-tests.outputs.models }}
-          BODY: "This comment contains run-slow, running the specified jobs:\n\nmodels: ${{ needs.get-tests.outputs.models }}\nquantizations: ${{ needs.get-tests.outputs.quantizations }}"
+          BODY: "\n\nmodels: ${{ needs.get-tests.outputs.models }}\nquantizations: ${{ needs.get-tests.outputs.quantizations }}"
         run: |
           gh api \
             --method POST \


### PR DESCRIPTION
# What does this PR do?

`This comment contains run-slow, running the specified jobs:` appears twice on the GH comment to trigger slow tests ([example](https://github.com/huggingface/transformers/pull/37922#issuecomment-2853876256)).

This PR removes one of the copies 🤗 