### PR TITLE
[caches] Raise exception on offloaded static caches + multi device

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2029,6 +2029,8 @@ class OffloadedHybridCache(HybridChunkedCache):
     ):
         super().__init__(config, max_batch_size, max_cache_len, device, dtype, layer_device_map)
 
+        # TODO (joao): to enable this cache on multiple devicesuse the pattern from `OffloadedCache`, which keeps
+        # track of the original device of each layer
         unique_devices = set(layer_device_map.values())
         if len(unique_devices) > 1:
             raise ValueError(f"OffloadedHybridCache does not support multiple devices. Got devices: {unique_devices}")
@@ -2286,6 +2288,8 @@ class OffloadedStaticCache(StaticCache):
     ) -> None:
         super(Cache, self).__init__()
 
+        # TODO (joao): to enable this cache on multiple devicesuse the pattern from `OffloadedCache`, which keeps
+        # track of the original device of each layer
         unique_devices = set(layer_device_map.values())
         if len(unique_devices) > 1:
             raise ValueError(f"OffloadedStaticCache does not support multiple devices. Got devices: {unique_devices}")

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -2028,6 +2028,11 @@ class OffloadedHybridCache(HybridChunkedCache):
         layer_device_map: Optional[Dict[int, Union[str, torch.device, int]]] = None,
     ):
         super().__init__(config, max_batch_size, max_cache_len, device, dtype, layer_device_map)
+
+        unique_devices = set(layer_device_map.values())
+        if len(unique_devices) > 1:
+            raise ValueError(f"OffloadedHybridCache does not support multiple devices. Got devices: {unique_devices}")
+
         self.offload_device = torch.device(offload_device)
         # Create new CUDA stream for parallel prefetching.
         self._prefetch_stream = torch.cuda.Stream() if torch._C._get_accelerator().type == "cuda" else None
@@ -2280,6 +2285,11 @@ class OffloadedStaticCache(StaticCache):
         layer_device_map: Optional[Dict[int, Union[str, torch.device, int]]] = None,
     ) -> None:
         super(Cache, self).__init__()
+
+        unique_devices = set(layer_device_map.values())
+        if len(unique_devices) > 1:
+            raise ValueError(f"OffloadedStaticCache does not support multiple devices. Got devices: {unique_devices}")
+
         self.max_batch_size = max_batch_size
         self.max_cache_len = config.max_position_embeddings if max_cache_len is None else max_cache_len
         self.device = torch.device(device) if layer_device_map is None else torch.device(layer_device_map[0])


### PR DESCRIPTION
# What does this PR do?

Follow-up to this comment: https://github.com/huggingface/transformers/pull/37922#issuecomment-2854023534

Tests for offloaded static caches are failing on multiple devices because the implementation of these caches doesn't work with multiple devices. This PR raises an informative exception and skips the tests when this happens.

Although I think it is fixable (see added TODO), I don't think it's worth the effort for now.