### PR TITLE
[offload] respect `max_memory` argument when factoring in unused reserved memory

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -114,6 +114,7 @@ from .utils import (
     is_torch_npu_available,
     is_torch_sdpa_available,
     is_torch_xla_available,
+    is_torch_xpu_available,
     logging,
     replace_return_docstrings,
     strtobool,
@@ -1286,11 +1287,14 @@ def _get_device_map(
         if hf_quantizer is not None:
             inferred_max_memory = hf_quantizer.adjust_max_memory(inferred_max_memory)
 
-        # CUDA: `max_memory` contains non-reserved memory. There may be *unused* reserved memory in the GPU, which we
+        # `max_memory` contains non-reserved memory. There may be *unused* reserved memory in the GPU, which we
         # can use to allocate parameters.
         for device_name in inferred_max_memory.keys():
             if isinstance(device_name, int):  # it's a GPU device
-                unused_memory = torch.cuda.memory_reserved(device_name) - torch.cuda.memory_allocated(device_name)
+                if is_torch_xpu_available():
+                    unused_memory = torch.xpu.memory_reserved(device_name) - torch.xpu.memory_allocated(device_name)
+                else:
+                    unused_memory = torch.cuda.memory_reserved(device_name) - torch.cuda.memory_allocated(device_name)
                 inferred_max_memory[device_name] += unused_memory
             # respect the max_memory passed by the user
             if max_memory is not None and device_name in max_memory:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1287,8 +1287,8 @@ def _get_device_map(
         if hf_quantizer is not None:
             inferred_max_memory = hf_quantizer.adjust_max_memory(inferred_max_memory)
 
-        # `max_memory` contains non-reserved memory. There may be *unused* reserved memory in the GPU, which we
-        # can use to allocate parameters.
+        # `inferred_max_memory` contains non-reserved memory. There may be *unused* reserved memory in the GPU,
+        # which we can use to allocate parameters.
         for device_name in inferred_max_memory.keys():
             if isinstance(device_name, int):  # it's a GPU device
                 if is_torch_xpu_available():
@@ -1296,7 +1296,7 @@ def _get_device_map(
                 else:
                     unused_memory = torch.cuda.memory_reserved(device_name) - torch.cuda.memory_allocated(device_name)
                 inferred_max_memory[device_name] += unused_memory
-            # respect the max_memory passed by the user
+            # respect the `max_memory` passed by the user
             if max_memory is not None and device_name in max_memory:
                 inferred_max_memory[device_name] = min(inferred_max_memory[device_name], max_memory[device_name])
         device_map_kwargs["max_memory"] = inferred_max_memory

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1293,7 +1293,7 @@ def _get_device_map(
                 unused_memory = torch.cuda.memory_reserved(device_name) - torch.cuda.memory_allocated(device_name)
                 inferred_max_memory[device_name] += unused_memory
             # respect the max_memory passed by the user
-            if device_name in max_memory:
+            if max_memory is not None and device_name in max_memory:
                 inferred_max_memory[device_name] = min(inferred_max_memory[device_name], max_memory[device_name])
         device_map_kwargs["max_memory"] = inferred_max_memory
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -114,7 +114,6 @@ from .utils import (
     is_torch_npu_available,
     is_torch_sdpa_available,
     is_torch_xla_available,
-    is_torch_xpu_available,
     logging,
     replace_return_docstrings,
     strtobool,
@@ -1275,7 +1274,7 @@ def _get_device_map(
             )
 
         if device_map != "sequential":
-            max_memory = get_balanced_memory(
+            inferred_max_memory = get_balanced_memory(
                 model,
                 dtype=target_dtype,
                 low_zero=(device_map == "balanced_low_0"),
@@ -1283,20 +1282,20 @@ def _get_device_map(
                 **device_map_kwargs,
             )
         else:
-            max_memory = get_max_memory(max_memory)
+            inferred_max_memory = get_max_memory(max_memory)
         if hf_quantizer is not None:
-            max_memory = hf_quantizer.adjust_max_memory(max_memory)
+            inferred_max_memory = hf_quantizer.adjust_max_memory(inferred_max_memory)
 
-        # `max_memory` contains non-reserved memory. There may be *unused* reserved memory in the GPU, which we
+        # CUDA: `max_memory` contains non-reserved memory. There may be *unused* reserved memory in the GPU, which we
         # can use to allocate parameters.
-        for device_name in max_memory.keys():
+        for device_name in inferred_max_memory.keys():
             if isinstance(device_name, int):  # it's a GPU device
-                if is_torch_xpu_available():
-                    unused_memory = torch.xpu.memory_reserved(device_name) - torch.xpu.memory_allocated(device_name)
-                else:
-                    unused_memory = torch.cuda.memory_reserved(device_name) - torch.cuda.memory_allocated(device_name)
-                max_memory[device_name] += unused_memory
-        device_map_kwargs["max_memory"] = max_memory
+                unused_memory = torch.cuda.memory_reserved(device_name) - torch.cuda.memory_allocated(device_name)
+                inferred_max_memory[device_name] += unused_memory
+            # respect the max_memory passed by the user
+            if device_name in max_memory:
+                inferred_max_memory[device_name] = min(inferred_max_memory[device_name], max_memory[device_name])
+        device_map_kwargs["max_memory"] = inferred_max_memory
 
         device_map = infer_auto_device_map(model, dtype=target_dtype, **device_map_kwargs)
 


### PR DESCRIPTION
# What does this PR do?

Our daily CI had >1000 new failures since #37920, on tests that use the `max_memory` argument in `from_pretrained`. This is because we now recapture unused reserved GPU memory, which caused us to go beyond the user-defined `max_memory`. This PR fixes it.

Affected tests, which set `max_memory`:
- `test_cpu_offload`
- `test_disk_offload_bin`
- `test_model_parallelism`