### PR TITLE
Do not erase a cache_position passed explicitly to generate(), if there is one

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1711,6 +1711,8 @@ class GenerationMixin:
     def _get_initial_cache_position(self, seq_length, device, model_kwargs):
         """Calculates `cache_position` for the pre-fill stage based on `input_ids` and optionally past length"""
         # `torch.compile`-friendly `torch.arange` from a shape -- the lines below are equivalent to `torch.arange`
+        if "cache_position" in model_kwargs and model_kwargs["cache_position"]:
+            return model_kwargs
         if "inputs_embeds" in model_kwargs and not self.config.is_encoder_decoder:
             cache_position = torch.ones_like(model_kwargs["inputs_embeds"][0, :, 0], dtype=torch.int64).cumsum(0) - 1
         elif "decoder_inputs_embeds" in model_kwargs and self.config.is_encoder_decoder:


### PR DESCRIPTION
# What does this PR do?

Currently, any `cache_position` passed to `model.generate()` is silently replaced by the initial initialization. This seems wrong, since there is no need to reinitialize an argument that has already been passed. In some models, being able to pass custom cache_positions which are not 0-initialized is required for proper behavior.

This PR adds a check to the initialization code of model_kwargs['cache_position'] to return early if that argument was already provided.

There is no linked issue because I fixed the bug before filing an issue. PR is thus easier.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

I don't think that this warrants any documentation change, the current behavior is not described anywhere. I could add a test, but it would be very artificial. I think merging as-is is fine, but I welcome feedback.

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @zucchini-nlp @gante