### PR TITLE
Qwen2.5-Omni: Update modeling_qwen2_5_omni.py to fix error when loading quantized weights with AutoAWQ. 

### DIFF
--- a/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -149,8 +149,10 @@ class Qwen2_5OmniPreTrainedModel(PreTrainedModel):
             if module.padding_idx is not None:
                 module.weight.data[module.padding_idx].zero_()
         elif isinstance(module, nn.LayerNorm):
-            module.weight.data.fill_(1.0)
-            module.bias.data.zero_()
+            if module.weight is not None:
+                module.weight.data.fill_(1.0)
+            if module.bias is not None:
+                module.bias.data.zero_()
         elif isinstance(module, Qwen2RMSNorm):
             module.weight.data.fill_(1.0)
 

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -1064,8 +1064,10 @@ class Qwen2_5OmniPreTrainedModel(Qwen2_5_VLPreTrainedModel):
             if module.padding_idx is not None:
                 module.weight.data[module.padding_idx].zero_()
         elif isinstance(module, nn.LayerNorm):
-            module.weight.data.fill_(1.0)
-            module.bias.data.zero_()
+            if module.weight is not None:
+                module.weight.data.fill_(1.0)
+            if module.bias is not None:
+                module.bias.data.zero_()
         elif isinstance(module, Qwen2RMSNorm):
             module.weight.data.fill_(1.0)
 


### PR DESCRIPTION
Qwen2.5-Omni: Update modeling_qwen2_5_omni.py to fix loading quantized weights with AutoAWQ.

What does this PR do?
while loading AWQ quantized Qwen-Omni model with AutoAWQ, there will be an error as below:

Traceback (most recent call last):
  File "/nas/yuehu/NEW/AutoAWQ/./examples/quantize_qwen_omni.py", line 188, in <module>
    inference_quantized_model(quant_path)
  File "/nas/yuehu/NEW/AutoAWQ/./examples/quantize_qwen_omni.py", line 123, in inference_quantized_model
    model = AutoAWQForCausalLM.from_quantized(quant_path)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/yuehu/NEW/AutoAWQ/awq/models/auto.py", line 125, in from_quantized
    return AWQ_CAUSAL_LM_MODEL_MAP[model_type].from_quantized(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/yuehu/NEW/AutoAWQ/awq/models/base.py", line 498, in from_quantized
    model = target_cls.from_config(
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/models/auto/auto_factory.py", line 440, in from_config
    return model_class._from_config(config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 280, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2023, in _from_config
    model = cls(config, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 4386, in __init__
    self.post_init()
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 1886, in post_init
    self.init_weights()
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 3149, in init_weights
    self.initialize_weights()
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 116, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2502, in initialize_weights
    self.smart_apply(self._initialize_weights)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2493, in smart_apply
    module.smart_apply(module._initialize_weights)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2493, in smart_apply
    module.smart_apply(module._initialize_weights)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2495, in smart_apply
    module.smart_apply(fn)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2495, in smart_apply
    module.smart_apply(fn)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2495, in smart_apply
    module.smart_apply(fn)
  [Previous line repeated 1 more time]
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2496, in smart_apply
    fn(self)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/modeling_utils.py", line 2470, in _initialize_weights
    self._init_weights(module)
  File "/root/anaconda3/envs/awq/lib/python3.12/site-packages/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 152, in _init_weights
    module.weight.data.fill_(1.0)
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'data'
Fixes # (issue)

this PR can fix the above error.

Who can review?
@ArthurZucker @amyeroberts @qubvel

thanks for your reviewing.