### PR TITLE
Fix linalg.norm for CovnNextV2

### DIFF
--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -100,7 +100,7 @@ class ConvNextV2GRN(nn.Module):
 
     def forward(self, hidden_states: torch.FloatTensor) -> torch.FloatTensor:
         # Compute and normalize global spatial feature maps
-        global_features = torch.linalg.norm(hidden_states, ord=2, dim=(1, 2), keepdim=True)
+        global_features = torch.linalg.vector_norm(hidden_states, ord=2, dim=(1, 2), keepdim=True)
         norm_features = global_features / (global_features.mean(dim=-1, keepdim=True) + 1e-6)
         hidden_states = self.weight * (hidden_states * norm_features) + self.bias + hidden_states
 


### PR DESCRIPTION
# What does this PR do?

Bug introduced in 
 - https://github.com/huggingface/transformers/pull/37041

While we are normalizing on multiple dimensions
1.  `torch.linlag.norm` much slower than `torch.norm`
2. `torch.linlag.norm` **is not equivalent** to `torch.norm`

Instead, `torch.linlag.vector_norm` should be used

Fixes: https://github.com/huggingface/transformers/issues/37748

cc @Rocketknight1 