### PR TITLE
Add `TemplateConstraint` and `OrdredConstraint` features (#27706)

### DIFF
--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -40,6 +40,8 @@ else:
         "ConstraintListState",
         "DisjunctiveConstraint",
         "PhrasalConstraint",
+        "TemplateConstraint",
+        "OrderedConstraint",
     ]
     _import_structure["beam_search"] = [
         "BeamHypotheses",
@@ -205,7 +207,14 @@ if TYPE_CHECKING:
     except OptionalDependencyNotAvailable:
         pass
     else:
-        from .beam_constraints import Constraint, ConstraintListState, DisjunctiveConstraint, PhrasalConstraint
+        from .beam_constraints import (
+            Constraint,
+            ConstraintListState,
+            DisjunctiveConstraint,
+            OrderedConstraint,
+            PhrasalConstraint,
+            TemplateConstraint,
+        )
         from .beam_search import BeamHypotheses, BeamScorer, BeamSearchScorer, ConstrainedBeamSearchScorer
         from .candidate_generator import (
             AssistedCandidateGenerator,

--- a/src/transformers/generation/beam_search.py
+++ b/src/transformers/generation/beam_search.py
@@ -724,7 +724,13 @@ class ConstrainedBeamSearchScorer(BeamScorer):
             advance_state.reset(pre_seq.tolist())
 
             if not advance_state.completed:
-                advance_tokens = torch.tensor(advance_state.advance(), dtype=torch.long, device=device)
+                # Skip when advance() returns None or empty list
+                advance_state_raw = advance_state.advance()
+                if advance_state_raw is None or len(advance_state_raw) == 0:
+                    continue
+                # torch.LongTensor can not take a None value
+                advance_long = torch.LongTensor(advance_state_raw)
+                advance_tokens = advance_long.to(device)
                 for advance_token in advance_tokens:
                     # since adding each `advance_token` leads to a different hypothesis, create new state instance.
                     new_state = advance_state.copy(stateful=True)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -27,6 +27,7 @@ from packaging import version
 from torch import nn
 from torch.nn import functional as F
 
+from transformers.generation.beam_constraints import OrderedConstraint, TemplateConstraint
 from transformers.generation.candidate_generator import AssistantVocabTranslatorCache
 
 from ..cache_utils import (
@@ -88,12 +89,14 @@ from .logits_process import (
     MinPLogitsWarper,
     NoBadWordsLogitsProcessor,
     NoRepeatNGramLogitsProcessor,
+    OrderedConstraintLogitsProcessor,
     PrefixConstrainedLogitsProcessor,
     RepetitionPenaltyLogitsProcessor,
     SequenceBiasLogitsProcessor,
     SuppressTokensAtBeginLogitsProcessor,
     SuppressTokensLogitsProcessor,
     TemperatureLogitsWarper,
+    TemplateConstraintLogitsProcessor,
     TopKLogitsWarper,
     TopPLogitsWarper,
     TypicalLogitsWarper,
@@ -1022,6 +1025,7 @@ class GenerationMixin:
         model_kwargs: Optional[Dict[str, Any]] = None,
         negative_prompt_ids: Optional[torch.Tensor] = None,
         negative_prompt_attention_mask: Optional[torch.Tensor] = None,
+        constraints: Optional[List[str]] = None,
     ) -> LogitsProcessorList:
         """
         This class returns a [`LogitsProcessorList`] list object that contains all relevant [`LogitsProcessor`]
@@ -1242,6 +1246,21 @@ class GenerationMixin:
         # `LogitNormalization` should always be the last logit processor, when present
         if generation_config.renormalize_logits is True:
             processors.append(LogitNormalization())
+
+        if constraints is not None:
+            for constraint in constraints:
+                if isinstance(constraint, TemplateConstraint):
+                    processors.append(
+                        TemplateConstraintLogitsProcessor(
+                            template=constraint.template, vocab_size=self.config.vocab_size
+                        )
+                    )
+                elif isinstance(constraint, OrderedConstraint):
+                    processors.append(
+                        OrderedConstraintLogitsProcessor(
+                            ordered_token_ids=constraint.ordered_token_ids, vocab_size=self.config.vocab_size
+                        )
+                    )
         return processors
 
     def _get_stopping_criteria(
@@ -2397,6 +2416,7 @@ class GenerationMixin:
             model_kwargs=model_kwargs,
             negative_prompt_ids=negative_prompt_ids,
             negative_prompt_attention_mask=negative_prompt_attention_mask,
+            constraints=kwargs.get("constraints", []),
         )
         prepared_stopping_criteria = self._get_stopping_criteria(
             generation_config=generation_config, stopping_criteria=stopping_criteria, tokenizer=tokenizer, **kwargs

--- a/tests/generation/test_beam_constraints.py
+++ b/tests/generation/test_beam_constraints.py
@@ -22,7 +22,7 @@ from transformers.testing_utils import require_torch
 if is_torch_available():
     import torch
 
-    from transformers.generation import DisjunctiveConstraint
+    from transformers.generation import DisjunctiveConstraint, OrderedConstraint, TemplateConstraint
 
 
 @require_torch
@@ -112,3 +112,310 @@ class ConstraintTest(unittest.TestCase):
         self.assertTrue(dc.completed)  # Completed!
         self.assertTrue(dc.remaining() == 0)
         self.assertTrue(dc.current_seq == [1, 2, 5])
+
+
+@require_torch
+class TemplateConstraintTest(unittest.TestCase):
+    def test_initialization(self):
+        template = [5, None, 3]
+        constraint = TemplateConstraint(template)
+        self.assertEqual(constraint.template, template)
+        self.assertEqual(constraint.seqlen, 3)
+        self.assertEqual(constraint.position, 0)
+        self.assertFalse(constraint.completed)
+
+    def test_advance_before_completion(self):
+        template = [5, None, 3]
+        constraint = TemplateConstraint(template)
+        self.assertEqual(constraint.advance(), 5)
+        constraint.position = 1
+        self.assertIsNone(constraint.advance())
+        constraint.position = 2
+        self.assertEqual(constraint.advance(), 3)
+
+    def test_advance_after_completion(self):
+        template = [5]
+        constraint = TemplateConstraint(template)
+        constraint.update(5)
+        self.assertEqual(constraint.advance(), [])
+
+    def test_does_advance_correct_token(self):
+        template = [5, None, 3]
+        constraint = TemplateConstraint(template)
+        self.assertTrue(constraint.does_advance(5))
+        constraint.position = 1
+        self.assertTrue(constraint.does_advance(100))  # Any token allowed
+        constraint.position = 2
+        self.assertTrue(constraint.does_advance(3))
+        self.assertFalse(constraint.does_advance(4))
+
+    def test_does_advance_when_completed(self):
+        template = [5]
+        constraint = TemplateConstraint(template)
+        constraint.update(5)
+        self.assertFalse(constraint.does_advance(5))
+
+    def test_update_correct_sequence(self):
+        template = [5, None, 3]
+        constraint = TemplateConstraint(template)
+        stepped, completed, reset = constraint.update(5)
+        self.assertTrue(stepped)
+        self.assertFalse(completed)
+        self.assertFalse(reset)
+        self.assertEqual(constraint.position, 1)
+
+        stepped, completed, reset = constraint.update(10)  # None allows any token
+        self.assertTrue(stepped)
+        self.assertFalse(completed)
+        self.assertFalse(reset)
+        self.assertEqual(constraint.position, 2)
+
+        stepped, completed, reset = constraint.update(3)
+        self.assertTrue(stepped)
+        self.assertTrue(completed)
+        self.assertFalse(reset)
+        self.assertEqual(constraint.position, 3)
+
+    def test_update_incorrect_token_resets(self):
+        template = [5, 6]
+        constraint = TemplateConstraint(template)
+        constraint.update(5)
+        stepped, completed, reset = constraint.update(7)  # Incorrect
+        self.assertFalse(stepped)
+        self.assertFalse(completed)
+        self.assertTrue(reset)
+        self.assertEqual(constraint.position, 0)
+        self.assertFalse(constraint.completed)
+
+    def test_reset(self):
+        template = [5, 6]
+        constraint = TemplateConstraint(template)
+        constraint.update(5)
+        constraint.reset()
+        self.assertEqual(constraint.position, 0)
+        self.assertFalse(constraint.completed)
+
+    def test_remaining(self):
+        template = [5, None, 3]
+        constraint = TemplateConstraint(template)
+        self.assertEqual(constraint.remaining(), 3)
+        constraint.update(5)
+        self.assertEqual(constraint.remaining(), 2)
+        constraint.update(10)
+        self.assertEqual(constraint.remaining(), 1)
+        constraint.update(3)
+        self.assertEqual(constraint.remaining(), 0)
+
+    def test_copy_without_state(self):
+        template = [5, None]
+        original = TemplateConstraint(template)
+        original.update(5)
+        copied = original.copy(stateful=False)
+        self.assertEqual(copied.position, 0)
+        self.assertFalse(copied.completed)
+
+    def test_copy_with_state(self):
+        template = [5, None]
+        original = TemplateConstraint(template)
+        original.update(5)
+        copied = original.copy(stateful=True)
+        self.assertEqual(copied.position, 1)
+        self.assertEqual(copied.completed, original.completed)
+
+    def test_all_none_template(self):
+        template = [None, None, None]
+        constraint = TemplateConstraint(template)
+        self.assertTrue(constraint.does_advance(0))
+        constraint.update(0)
+        self.assertTrue(constraint.does_advance(1))
+        constraint.update(1)
+        self.assertTrue(constraint.does_advance(2))
+        constraint.update(2)
+        self.assertTrue(constraint.completed)
+
+    def test_reset_and_retry(self):
+        template = [5, 6]
+        constraint = TemplateConstraint(template)
+        constraint.update(10)  # Incorrect, resets
+        constraint.update(5)
+        constraint.update(6)
+        self.assertTrue(constraint.completed)
+
+    def test_single_token_template(self):
+        template = [10]
+        constraint = TemplateConstraint(template)
+        self.assertTrue(constraint.does_advance(10))
+        stepped, completed, reset = constraint.update(10)
+        self.assertTrue(stepped)
+        self.assertTrue(completed)
+        self.assertFalse(reset)
+
+    def test_position_after_reset(self):
+        template = [5, 6]
+        constraint = TemplateConstraint(template)
+        constraint.update(5)
+        constraint.update(7)  # Resets
+        self.assertEqual(constraint.position, 0)
+        constraint.update(5)
+        constraint.update(6)
+        self.assertTrue(constraint.completed)
+
+
+@require_torch
+class TestOrderedConstraint(unittest.TestCase):
+    def test_initialization(self):
+        tokens = [5, 2, 3]
+        constraint = OrderedConstraint(tokens)
+        self.assertEqual(constraint.ordered_token_ids, tokens)
+        self.assertEqual(constraint.position, 0)
+        self.assertFalse(constraint.completed)
+        self.assertEqual(constraint.seqlen, 3)
+
+    def test_advance_before_completion(self):
+        tokens = [5, 6, 3]
+        constraint = OrderedConstraint(tokens)
+
+        # Position 0
+        self.assertEqual(constraint.advance(), 5)
+        constraint.position = 1
+        self.assertEqual(constraint.advance(), 6)
+        constraint.position = 2
+        self.assertEqual(constraint.advance(), 3)
+
+    def test_advance_after_completion(self):
+        tokens = [5]
+        constraint = OrderedConstraint(tokens)
+        constraint.update(5)  # Completes the sequence
+        self.assertEqual(constraint.advance(), [])
+
+    def test_does_advance_behavior(self):
+        tokens = [5, 6, 3]
+        constraint = OrderedConstraint(tokens)
+
+        # Position 0
+        self.assertTrue(constraint.does_advance(5))
+        self.assertFalse(constraint.does_advance(6))
+
+        # Position 1
+        constraint.position = 1
+        self.assertTrue(constraint.does_advance(6))
+        self.assertFalse(constraint.does_advance(5))
+
+        # Position 2
+        constraint.position = 2
+        self.assertTrue(constraint.does_advance(3))
+        self.assertFalse(constraint.does_advance(4))
+
+    def test_update_correct_sequence(self):
+        tokens = [5, 6, 3]
+        constraint = OrderedConstraint(tokens)
+
+        # First token (5)
+        stepped, completed, reset = constraint.update(5)
+        self.assertTrue(stepped)
+        self.assertFalse(completed)
+        self.assertFalse(reset)
+        self.assertEqual(constraint.position, 1)
+
+        # Second token (6)
+        stepped, completed, reset = constraint.update(6)
+        self.assertTrue(stepped)
+        self.assertFalse(completed)
+        self.assertFalse(reset)
+        self.assertEqual(constraint.position, 2)
+
+        # Third token (3)
+        stepped, completed, reset = constraint.update(3)
+        self.assertTrue(stepped)
+        self.assertTrue(completed)
+        self.assertFalse(reset)
+        self.assertEqual(constraint.position, 3)
+
+    def test_update_incorrect_token_does_not_advance(self):
+        tokens = [5, 6]
+        constraint = OrderedConstraint(tokens)
+
+        # Correct first token
+        constraint.update(5)
+
+        # Incorrect second token
+        stepped, completed, reset = constraint.update(7)
+        self.assertFalse(stepped)
+        self.assertFalse(completed)
+        self.assertFalse(reset)  # No reset, position remains at 1
+        self.assertEqual(constraint.position, 1)
+
+        # Correct token later
+        stepped, completed, _ = constraint.update(6)
+        self.assertTrue(stepped)
+        self.assertTrue(completed)
+        self.assertEqual(constraint.position, 2)
+
+    def test_reset_behavior(self):
+        tokens = [5, 6]
+        constraint = OrderedConstraint(tokens)
+        constraint.update(5)
+        constraint.reset()
+        self.assertEqual(constraint.position, 0)
+        self.assertFalse(constraint.completed)
+
+    def test_remaining_tokens(self):
+        tokens = [5, 6, 3]
+        constraint = OrderedConstraint(tokens)
+        self.assertEqual(constraint.remaining(), 3)
+        constraint.update(5)
+        self.assertEqual(constraint.remaining(), 2)
+        constraint.update(6)
+        self.assertEqual(constraint.remaining(), 1)
+        constraint.update(3)
+        self.assertEqual(constraint.remaining(), 0)
+
+    def test_copy_without_state(self):
+        tokens = [5, 6]
+        original = OrderedConstraint(tokens)
+        original.update(5)
+        copied = original.copy(stateful=False)
+        self.assertEqual(copied.position, 0)
+        self.assertFalse(copied.completed)
+
+    def test_copy_with_state(self):
+        tokens = [5, 6]
+        original = OrderedConstraint(tokens)
+        original.update(5)
+        copied = original.copy(stateful=True)
+        self.assertEqual(copied.position, 1)
+        self.assertEqual(copied.completed, original.completed)
+
+    def test_single_token_completion(self):
+        tokens = [10]
+        constraint = OrderedConstraint(tokens)
+        self.assertTrue(constraint.does_advance(10))
+        stepped, completed, _ = constraint.update(10)
+        self.assertTrue(stepped)
+        self.assertTrue(completed)
+
+    def test_position_overflow(self):
+        tokens = [5, 6]
+        constraint = OrderedConstraint(tokens)
+        constraint.position = 2  # Force beyond sequence length
+        self.assertEqual(constraint.advance(), [])
+        self.assertTrue(constraint.completed)
+
+    def test_no_progress_on_mismatch(self):
+        tokens = [5, 6, 7]
+        constraint = OrderedConstraint(tokens)
+
+        # Correct first token
+        constraint.update(5)
+
+        # Incorrect second token (should block progress)
+        stepped, completed, reset = constraint.update(8)
+        self.assertFalse(stepped)
+        self.assertFalse(completed)
+        self.assertEqual(constraint.position, 1)  # Still at position 1
+
+        # Correct second token later
+        stepped, completed, _ = constraint.update(6)
+        self.assertTrue(stepped)
+        self.assertFalse(completed)
+        self.assertEqual(constraint.position, 2)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

According to issue #27706, `TemplateConstraint` is a useful constraint during beam search for constrained decoding. It's desired by the community. In response to this feature request, we implemented the `TemplateConstraint and OrderedConstraint` classes in `src/transformers/generation/beam_constraints.py`. We integrated the constraint workflow with `model.generate()` via corresponding logits processors in `src/transformers/generations/logits_process.py` and test cases in `tests/generation/test_beam_constraints.py`.


Contributors:
Junyao (@jychen630), Raavi (@raavi02) and Pranitha (@NPranitha) 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Hello!  We noticed @ArthurZucker and @gante 's discussion around template constraints in the issue #27706  - may you please kindly review this a bit? Thanks!  

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
