### PR TITLE
Fix an error in STOPPING_CRITERIA_INPUTS_DOCSTRING

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -38,7 +38,7 @@ STOPPING_CRITERIA_INPUTS_DOCSTRING = r"""
 
     Return:
         `torch.BoolTensor`. (`torch.BoolTensor` of shape `(batch_size, 1)`), where `True` indicates we stop generation
-            for a particular row, `True` indicates we should continue.
+            for a particular row, `False` indicates we should continue.
 
 """
 


### PR DESCRIPTION
# What does this PR do?
There is an error in the comment `STOPPING_CRITERIA_INPUTS_DOCSTRING` for `StoppingCriteria`: 
```
`True` indicates we should continue. 
```
Should be
```
`False` indicates we should continue.
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@gante @stevhliu 

