### PR TITLE
Re-Enable `Trigger CircleCI via GitHub Actions when "ready for review" (#37885)`

### DIFF
--- a/.github/workflows/trigger_circleci.yml
+++ b/.github/workflows/trigger_circleci.yml
@@ -1,0 +1,20 @@
+name: Trigger CircleCI
+
+
+on:
+  pull_request:
+    types: [ready_for_review]
+
+
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: trigger CircleCI pipeline via GitHub Actions
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0
+        with:
+          GHA_Meta: "Trigger via GitHub Actions"
+          target-slug: "github/huggingface/transformers"
+          target-branch: "pull/${{ github.event.number }}/head"
+        env:
+          CCI_TOKEN: ${{ secrets.CIRCLECI_PAT }}

--- a/.github/workflows/trigger_circleci.yml
+++ b/.github/workflows/trigger_circleci.yml
@@ -2,8 +2,8 @@ name: Trigger CircleCI
 
 
 on:
-  pull_request:
-    types: [ready_for_review, synchronize]
+  pull_request_target:
+    types: [ready_for_review]
 
 
 jobs:

--- a/.github/workflows/trigger_circleci.yml
+++ b/.github/workflows/trigger_circleci.yml
@@ -3,7 +3,7 @@ name: Trigger CircleCI
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [ready_for_review, synchronize]
 
 
 jobs:


### PR DESCRIPTION
# What does this PR do?

With `CircleCI-Public/trigger-circleci-pipeline-action@v1.2.0`, we could specify `target-branch` 🎉 