### PR TITLE
Fix temporal padding in Qwen2VLImageProcessor when the number of frames is not divisible by temporal_patch_size

### DIFF
--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -275,7 +275,9 @@ class Qwen2VLImageProcessor(BaseImageProcessor):
         if data_format == ChannelDimension.LAST:
             patches = patches.transpose(0, 3, 1, 2)
         if patches.shape[0] % temporal_patch_size != 0:
-            repeats = np.repeat(patches[-1][np.newaxis], temporal_patch_size - 1, axis=0)
+            repeats = np.repeat(
+                patches[-1][np.newaxis], temporal_patch_size - (patches.shape[0] % temporal_patch_size), axis=0
+            )
             patches = np.concatenate([patches, repeats], axis=0)
         channel = patches.shape[1]
         grid_t = patches.shape[0] // temporal_patch_size


### PR DESCRIPTION
This PR fixes an issue in Qwen2VLImageProcessor where the current implementation does not correctly handle cases when the number of video frames is not divisible by `temporal_patch_size`.

### Problem:
The existing logic repeats the last frame `temporal_patch_size` - 1 times. This works correctly when `temporal_patch_size` equals 2 but fails when the size is greater.

### Solution:
The fix replaces:

```repeats = np.repeat(patches[-1][np.newaxis], temporal_patch_size - 1, axis=0)```
with:

```repeats = np.repeat(patches[-1][np.newaxis], temporal_patch_size - (patches.shape[0] % temporal_patch_size), axis=0)```

This ensures that the correct number of padding frames are added when the frame count is not divisible by the `temporal_patch_size`.

#### Additional Changes:
Added a unit test to verify the padding logic for edge cases where the number of frames is not divisible by the patch size.

#### Issue Reference:
Fixes #38003