### PR TITLE
Don't drop dataset columns for custom collate functions

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -610,6 +610,7 @@ class Trainer:
             else default_data_collator
         )
         self.data_collator = data_collator if data_collator is not None else default_collator
+        self._using_default_data_collator = self.data_collator is default_data_collator
         self.train_dataset = train_dataset
         self.eval_dataset = eval_dataset
         self.processing_class = processing_class
@@ -1015,7 +1016,9 @@ class Trainer:
         data_collator = self.data_collator
         if is_datasets_available() and isinstance(train_dataset, datasets.Dataset):
             train_dataset = self._remove_unused_columns(train_dataset, description="training")
-        else:
+
+        # Don't drop cols when a custom data collator is passed.
+        if self._using_default_data_collator:
             data_collator = self._get_collator_with_removed_columns(data_collator, description="training")
 
         dataloader_params = {
@@ -1115,7 +1118,7 @@ class Trainer:
 
         if is_datasets_available() and isinstance(eval_dataset, datasets.Dataset):
             eval_dataset = self._remove_unused_columns(eval_dataset, description="evaluation")
-        else:
+        if self._using_default_data_collator:
             data_collator = self._get_collator_with_removed_columns(data_collator, description="evaluation")
 
         dataloader_params = {


### PR DESCRIPTION
# What does this PR do?

The existing logic is we inspect model's forward and dataset's return dict keys() and drop unused keys. A simplest scenario where this logic will fail is if I return raw text and label from dataset class and then tokenize in collate_fn. Since model is not expecting the raw text as an input, we drop it but collate func code will break as there is no text to tokenize. 

So, don't drop unused cols if a custom collate func is passed as the user might have other intentions and we can safely assume the user can handle any errors caused then on.

Actually the existing logic won't break for the above case if a tuple is passed from dataset to the data collator :sweat_smile:  coz we don't know the columns names to drop in that case. So, better to standardize this when we also return dict

CC: @muellerzr for trainer and @ArthurZucker  for core stuff