### PR TITLE
fix `check_bad commit.py` gives wrong results

### DIFF
--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -55,7 +55,7 @@ if len(result.stderr) > 0:
     else:
         print(f"pytest failed to run: {{result.stderr}}")
         exit(-1)
-elif f"{target_test} FAILED" in result.stdout:
+elif f"FAILED {target_test}" in result.stdout:
     print("test failed")
     exit(2)
 


### PR DESCRIPTION
# What does this PR do?

During bisecting, it uses

> elif f"{target_test} FAILED" in result.stdout:

to determine a commit fails a test or not.

However, since #35912, the output is kind altered with `live log call`, and the results are wrong (it think every commit passes).

This PR fixes the issue by checking 

> elif f"FAILED {target_test}" in result.stdout:

(at `short test summary info`)

#### current output running on main

> tests/models/instructblipvideo/test_modeling_instructblipvideo.py::InstructBlipVideoModelIntegrationTest::test_expansion_in_processing 
-------------------------------- live log call ---------------------------------
WARNING  transformers.video_processing_utils:logging.py:[32](https://github.com/huggingface/transformers/actions/runs/14999267405/job/42141539393#step:5:33)8 You have video processor config saved in `preprocessor.json` file which is deprecated. Video processor configs should be saved in their own `video_preprocessor.json` file. You can rename the file or load and save the processor back which renames it automatically. Loading from `preprocessor.json` will be removed in v5.0.
FAILED