### PR TITLE
Fix auto batch size finder test

### DIFF
--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -3300,8 +3300,8 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 --learning_rate 2e-5
                 --num_train_epochs 1
                 --output_dir {tmpdir}
-                --auto_find_batch_size 0
                 --report_to none
+                --auto_find_batch_size 0
                 """.split()
             with self.assertRaises(RuntimeError):
                 with patch.object(sys, "argv", testargs):


### PR DESCRIPTION
`--auto_find_batch_size 0` has to be the last test argument because later the test does `testargs[-1] = "1"` :)