### PR TITLE
Hotfix: Flash Attention 2 support in Pixtral

### DIFF
--- a/src/transformers/models/pixtral/modeling_pixtral.py
+++ b/src/transformers/models/pixtral/modeling_pixtral.py
@@ -211,6 +211,11 @@ class PixtralAttention(nn.Module):
             else:
                 attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
 
+        # Since we use packing, if flash_attention_2 is selected we rely on position_ids
+        if self.config._attn_implementation == "flash_attention_2":
+            kwargs["position_ids"] = kwargs["position_ids"].to(hidden_states.device, non_blocking=True)
+            attention_mask = None
+
         attn_output, attn_weights = attention_interface(
             self,
             query_states,


### PR DESCRIPTION
## Context

Pixtral support for `ALL_ATTENTION_FUNCTIONS` was added in [this PR](https://github.com/huggingface/transformers/pull/37960), but a subsequent [rebase](https://github.com/huggingface/transformers/pull/37576) unintentionally modified a line that sets `attention_mask` to `None` when using Flash Attention 2. 

Currently, without this condition, using Flash Attention 2 with Pixtral raises the following error:

`RuntimeError: cu_seqlens_q must have shape (batch_size + 1)`

Setting `attention_mask` to `None` resolves the issue. It also appears that the current tests doesn’t catch this case.

cc: @zucchini-nlp, @ArthurZucker
