### PR TITLE
Avoid incorrect generations for KV caches containing more than sliding_window tokens

### DIFF
--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -593,7 +593,13 @@ class Gemma3TextModel(Gemma2Model):
             )
 
         if cache_position is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            if past_key_values is not None:
+                past_seen_tokens = past_key_values.get_seq_length()
+                if past_seen_tokens == past_key_values.config.sliding_window - 1:
+                    raise ValueError("You must provide cache_position when using KV cache with more than sliding_window tokens.")
+            else:
+                past_seen_tokens = 0
+            
             cache_position = torch.arange(
                 past_seen_tokens,
                 past_seen_tokens + inputs_embeds.shape[1],


### PR DESCRIPTION
# What does this PR do?

Gemma3 generates incoherent output when manually calling `forward` with an instance of `HybridCache` which contains more than `sliding_window` tokens of content. 

This is because the call to `past_key_values.get_seq_len()` always returns the sequence length as measured by the cache of the very first layer. Because this is a local attention layer, its `sequence_length` never extends beyond `config.sliding_window`. This leads to an incorrect computation of `cache_position` and incoherent generations down the line. 

To fix it you can simply provide the correct `cache_position` manually.
This behavior is impossible to fix without changing `get_seq_len` of `HybridCache`, so I propose to simply raise an informative error message for now. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
 @ArthurZucker