### PR TITLE
Fix ModuleNotFoundError torchao.prototype.low_bit_optim since torchao  > 0.11.0

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1679,8 +1679,14 @@ class Trainer:
                     "You need to have `torch>2.4` in order to use torch 4-bit optimizers. "
                     "Install it with `pip install --upgrade torch` it is available on pipy. Otherwise, you need to install torch nightly."
                 )
-            from torchao.prototype.low_bit_optim import AdamW4bit, AdamW8bit
-
+            if version.parse(importlib.metadata.version("torchao")) > version.parse(
+                "0.11.0"
+            ):
+                # https://github.com/pytorch/ao/pull/2159
+                from torchao.optim import AdamW4bit, AdamW8bit
+            else :
+                from torchao.prototype.low_bit_optim import AdamW4bit, AdamW8bit
+                
             if args.optim == OptimizerNames.ADAMW_TORCH_4BIT:
                 optimizer_cls = AdamW4bit
             elif args.optim == OptimizerNames.ADAMW_TORCH_8BIT:


### PR DESCRIPTION

# What does this PR do?

Update import path of AdamW4bit and AdamW8bit for torchao > 0.11.0
