### PR TITLE
Add kernelize to transformers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ _deps = [
     # Keras pin - this is to make sure Keras 3 doesn't destroy us. Remove or change when we have proper support.
     "keras>2.9,<2.16",
     "keras-nlp>=0.3.1,<0.14.0",  # keras-nlp 0.14 doesn't support keras 2, see pin on keras.
-    "kernels>=0.4.4,<0.5",
+    "kernels>=0.6.1,<0.7",
     "librosa",
     "natten>=0.14.6,<0.15.0",
     "nltk<=3.8.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -34,7 +34,7 @@ deps = {
     "kenlm": "kenlm",
     "keras": "keras>2.9,<2.16",
     "keras-nlp": "keras-nlp>=0.3.1,<0.14.0",
-    "kernels": "kernels>=0.4.4,<0.5",
+    "kernels": "kernels>=0.6.1,<0.7",
     "librosa": "librosa",
     "natten": "natten>=0.14.6,<0.15.0",
     "nltk": "nltk<=3.8.1",

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 from typing import Union
 
-from ..utils import is_torchdynamo_compiling
-
 
 try:
     from kernels import (
@@ -22,9 +20,7 @@ try:
         LayerRepository,
         register_kernel_mapping,
         replace_kernel_forward_from_hub,
-    )
-    from kernels import (
-        use_kernel_forward_from_hub as original_use_kernel_forward_from_hub,
+        use_kernel_forward_from_hub,
     )
 
     _hub_kernels_available = True
@@ -59,39 +55,6 @@ try:
     }
 
     register_kernel_mapping(_KERNEL_MAPPING)
-
-    def use_kernel_forward_from_hub(*args, **kwargs):
-        """
-        Expands `kernels`' `use_kernel_forward_from_hub` to NOT use a kernel at compile time. This should be removed
-        when `kernels` supports `torch.compile`.
-
-        If the layer has a `config` attribute, we can also set `config.disable_custom_kernels = True` to disable the
-        kernel.
-        """
-
-        def decorator_with_compile_path(cls):
-            # Keeps a reference to the original forward method
-            original_forward = cls.forward
-
-            # Applies the original decorator
-            decorator = original_use_kernel_forward_from_hub(*args, **kwargs)
-            cls = decorator(cls)
-
-            # Replaces the kernel forward with a compile-friendly version
-            kernel_forward = cls.forward
-
-            # def forward_with_compile_path(*forward_args, **forward_kwargs):
-            #     disable_custom_kernels = hasattr(cls, "config") and getattr(cls.config, "disable_custom_kernels", None)
-            #     if is_torchdynamo_compiling() or disable_custom_kernels:
-            #         return original_forward(*forward_args, **forward_kwargs)
-            #     else:
-            #         return kernel_forward(*forward_args, **forward_kwargs)
-
-            # cls.forward = forward_with_compile_path
-
-            return cls
-
-        return decorator_with_compile_path
 
 
 except ImportError:

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -45,9 +45,9 @@ try:
         },
         "RMSNorm": {
             "cuda": LayerRepository(
-                repo_id="kernels-community/triton-layer-norm",
-                layer_name="LlamaRMSNorm",
-                revision="pure-layer-test",
+                repo_id="kernels-community/liger_kernels",
+                layer_name="LigerRMSNorm",
+                # revision="pure-layer-test",
             )
         },
         "MLP": {
@@ -80,14 +80,14 @@ try:
             # Replaces the kernel forward with a compile-friendly version
             kernel_forward = cls.forward
 
-            def forward_with_compile_path(*forward_args, **forward_kwargs):
-                disable_custom_kernels = hasattr(cls, "config") and getattr(cls.config, "disable_custom_kernels", None)
-                if is_torchdynamo_compiling() or disable_custom_kernels:
-                    return original_forward(*forward_args, **forward_kwargs)
-                else:
-                    return kernel_forward(*forward_args, **forward_kwargs)
+            # def forward_with_compile_path(*forward_args, **forward_kwargs):
+            #     disable_custom_kernels = hasattr(cls, "config") and getattr(cls.config, "disable_custom_kernels", None)
+            #     if is_torchdynamo_compiling() or disable_custom_kernels:
+            #         return original_forward(*forward_args, **forward_kwargs)
+            #     else:
+            #         return kernel_forward(*forward_args, **forward_kwargs)
 
-            cls.forward = forward_with_compile_path
+            # cls.forward = forward_with_compile_path
 
             return cls
 

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -684,8 +684,11 @@ def create_causal_mask(
             useful to easily overlay another mask on top of the causal one, for example for image tokens handling.
     """
     # If we have an HybridCache structure, here we want to create the mask for the full layers
-    if hasattr(past_key_values, "is_sliding") and False in past_key_values.is_sliding:
-        layer_idx = past_key_values.is_sliding.index(False)
+    if past_key_values is not None and hasattr(past_key_values, "is_sliding"):
+        for i, is_sliding in enumerate(past_key_values.is_sliding):
+            if not is_sliding:
+                layer_idx = i
+                break
     else:
         layer_idx = 0
 

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -684,8 +684,8 @@ def create_causal_mask(
             useful to easily overlay another mask on top of the causal one, for example for image tokens handling.
     """
     # If we have an HybridCache structure, here we want to create the mask for the full layers
-    if past_key_values is not None and hasattr(past_key_values, "is_sliding"):
-        layer_idx = next(i for i, is_sliding in enumerate(past_key_values.is_sliding) if not is_sliding)
+    if hasattr(past_key_values, "is_sliding") and False in past_key_values.is_sliding:
+        layer_idx = past_key_values.is_sliding.index(False)
     else:
         layer_idx = 0
 

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -685,10 +685,7 @@ def create_causal_mask(
     """
     # If we have an HybridCache structure, here we want to create the mask for the full layers
     if past_key_values is not None and hasattr(past_key_values, "is_sliding"):
-        for i, is_sliding in enumerate(past_key_values.is_sliding):
-            if not is_sliding:
-                layer_idx = i
-                break
+        layer_idx = next(i for i, is_sliding in enumerate(past_key_values.is_sliding) if not is_sliding)
     else:
         layer_idx = 0
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4737,6 +4737,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         # check if using kernels
         if use_kernels:
             from kernels import Device, kernelize
+
             kernelize(model, device=Device(type=model.device.type))
 
         # If it is a model with generation capabilities, attempt to load generation files (generation config,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4688,16 +4688,17 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         # Prepare the full device map
         if device_map is not None:
             device_map = _get_device_map(model, device_map, max_memory, hf_quantizer, torch_dtype, keep_in_fp32_regex)
-                    
+
         # check if using kernels
         if use_kernels:
-            from kernels import kernelize, Device
+            from kernels import Device, kernelize
+
             if torch.cuda.is_available():
                 kernelize(model, device=Device(type="cuda"))
             # only cuda supported for now
             else:
                 kernelize(model, device=Device(type="cpu"))
-        
+
         # Finalize model weight initialization
         if from_tf:
             model, loading_info = cls._load_from_tf(model, config, checkpoint_files)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -755,11 +755,9 @@ def _load_state_dict_into_meta_model(
     This function takes care of correctly casting dtypes, devices, and sharding tensors in case of tensor parallelism.
     """
     tensor_device = "cpu"
-    device_type = "cpu"
     if device_map is not None and device_map.get("", None) is not None:
         if device_map[""] not in ("cpu", torch.device("cpu")):
             tensor_device = device_map[""].index if isinstance(device_map[""], torch.device) else device_map[""]
-            device_type = device_map[""].type if isinstance(device_map[""], torch.device) else "cpu"
     if device_map is not None:
         device_map_regex = "|".join([re.escape(k) for k in sorted(device_map.keys(), reverse=True)])
 
@@ -776,13 +774,7 @@ def _load_state_dict_into_meta_model(
     for param_name, empty_param in state_dict.items():
         if param_name not in expected_keys:
             continue
-        
-        # using kernels
-        from kernels import kernelize, Device
-        module, param_type = get_module_from_name(model, param_name)
-        if hasattr(module, "kernel_layer_name"):
-            # print(f"tensor_device: {tensor_device}")
-            kernelize(module, device=Device(type=device_type))
+
         # we need to use serialized_param_name as file pointer is untouched
         if is_meta_state_dict:
             # This is the name of the parameter as it appears on disk file
@@ -4289,6 +4281,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         tp_size = kwargs.pop("tp_size", None)
         device_mesh = kwargs.pop("device_mesh", None)
         trust_remote_code = kwargs.pop("trust_remote_code", None)
+        use_kernels = kwargs.pop("use_kernels", False)
 
         key_mapping = kwargs.pop("key_mapping", None)
         # Load models with hardcoded key mapping on class for VLMs only, to keep BC and standardize model
@@ -4695,7 +4688,16 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         # Prepare the full device map
         if device_map is not None:
             device_map = _get_device_map(model, device_map, max_memory, hf_quantizer, torch_dtype, keep_in_fp32_regex)
-
+                    
+        # check if using kernels
+        if use_kernels:
+            from kernels import kernelize, Device
+            if torch.cuda.is_available():
+                kernelize(model, device=Device(type="cuda"))
+            # only cuda supported for now
+            else:
+                kernelize(model, device=Device(type="cpu"))
+        
         # Finalize model weight initialization
         if from_tf:
             model, loading_info = cls._load_from_tf(model, config, checkpoint_files)


### PR DESCRIPTION
# What does this PR do?

Instead of dynamically switching the `forward` methods using a decorator, we are exploring a new approach that performs this replacement statically within `modeling_utils.py`. This allows us to modify the `forward` methods at load time, which makes the kernels compile compatible. 

Also there is no need to check if torch is compiling or not since use_kernels is False by default, and in kernelize we only switch forwards if the kernel is compatible with compile. 

This pr should be merged after : https://github.com/huggingface/kernels/pull/87