### PR TITLE
Remove trust_remote_code=True tests from bnb quantization tests (MPT now integrated)

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -139,24 +139,6 @@ class MixedInt8Test(BaseMixedInt8Test):
         gc.collect()
         torch.cuda.empty_cache()
 
-    def test_get_keys_to_not_convert_trust_remote_code(self):
-        r"""
-        Test the `get_keys_to_not_convert` function with `trust_remote_code` models.
-        """
-        from accelerate import init_empty_weights
-
-        from transformers.integrations.bitsandbytes import get_keys_to_not_convert
-
-        model_id = "mosaicml/mpt-7b"
-        config = AutoConfig.from_pretrained(
-            model_id, trust_remote_code=True, revision="ada218f9a93b5f1c6dce48a4cc9ff01fcba431e7"
-        )
-        with init_empty_weights():
-            model = AutoModelForCausalLM.from_config(
-                config, trust_remote_code=True, code_revision="ada218f9a93b5f1c6dce48a4cc9ff01fcba431e7"
-            )
-        self.assertEqual(get_keys_to_not_convert(model), ["transformer.wte"])
-
     def test_get_keys_to_not_convert(self):
         r"""
         Test the `get_keys_to_not_convert` function.


### PR DESCRIPTION
This PR removes all tests in the bitsandbytes (bnb) quantization test suite that rely on `trust_remote_code=True`, specifically the `test_get_keys_to_not_convert_trust_remote_code` test and its usage of the MosaicML MPT model.

**Context and reasoning:**
- The MPT model is now directly integrated into Transformers and no longer requires `trust_remote_code=True` or custom code from the Hub.
- The removed test was the only one using `trust_remote_code=True` and was causing CI failures due to missing dependencies (e.g., `triton_pre_mlir`).
- As discussed [here](https://huggingface.slack.com/archives/C06ALV91VML/p1747668043103049?thread_ts=1744637333.150599&cid=C06ALV91VML) and agreed by the team.

This should help stabilize the CI and avoid unnecessary dependency issues for the bnb quantization tests.