### PR TITLE
[Meta MTIA] Support hoisted rotary embeddings.

### DIFF
--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -782,8 +782,16 @@ class AriaTextModel(AriaTextPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -825,7 +833,10 @@ class AriaTextModel(AriaTextPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -389,8 +389,16 @@ class BitNetModel(BitNetPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -432,7 +440,10 @@ class BitNetModel(BitNetPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -426,8 +426,16 @@ class CohereModel(CoherePreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -469,7 +477,10 @@ class CohereModel(CoherePreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -448,6 +448,12 @@ class Cohere2Model(Cohere2PreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/csm/modeling_csm.py
+++ b/src/transformers/models/csm/modeling_csm.py
@@ -898,6 +898,8 @@ class CsmBackboneModel(CsmPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
         r"""
@@ -911,6 +913,10 @@ class CsmBackboneModel(CsmPreTrainedModel):
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
         """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
@@ -953,7 +959,10 @@ class CsmBackboneModel(CsmPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/csm/modular_csm.py
+++ b/src/transformers/models/csm/modular_csm.py
@@ -471,6 +471,10 @@ class CsmBackboneModel(LlamaModel):
             [`PreTrainedTokenizer.__call__`] for details.
 
             [What are input IDs?](../glossary#input-ids)
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
         """
         return super().forward(**super_kwargs)
 

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -572,8 +572,16 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -615,7 +623,10 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -672,8 +672,16 @@ class DiffLlamaModel(DiffLlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -715,7 +723,10 @@ class DiffLlamaModel(DiffLlamaPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -1243,8 +1243,16 @@ class Emu3TextModel(Emu3PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -1286,7 +1294,10 @@ class Emu3TextModel(Emu3PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -392,6 +392,12 @@ class GemmaModel(GemmaPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs,  # NOOP kwarg for now
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -449,6 +449,12 @@ class Gemma2Model(Gemma2PreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -576,6 +576,12 @@ class Gemma3TextModel(Gemma3PreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -407,8 +407,16 @@ class GlmModel(GlmPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -450,7 +458,10 @@ class GlmModel(GlmPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/glm4/modeling_glm4.py
+++ b/src/transformers/models/glm4/modeling_glm4.py
@@ -415,8 +415,16 @@ class Glm4Model(Glm4PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -458,7 +466,10 @@ class Glm4Model(Glm4PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -378,6 +378,12 @@ class GPTNeoXModel(GPTNeoXPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/granite/modeling_granite.py
+++ b/src/transformers/models/granite/modeling_granite.py
@@ -414,6 +414,12 @@ class GraniteModel(GranitePreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -392,8 +392,16 @@ class HeliumModel(HeliumPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -435,7 +443,10 @@ class HeliumModel(HeliumPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -397,8 +397,16 @@ class LlamaModel(LlamaPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -440,7 +448,10 @@ class LlamaModel(LlamaPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -367,8 +367,16 @@ class MistralModel(MistralPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -410,7 +418,10 @@ class MistralModel(MistralPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -491,6 +491,12 @@ class MixtralModel(MixtralPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> MoeModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_router_logits = (
             output_router_logits if output_router_logits is not None else self.config.output_router_logits

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -370,8 +370,16 @@ class OlmoModel(OlmoPreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -413,7 +421,10 @@ class OlmoModel(OlmoPreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/olmo2/modeling_olmo2.py
+++ b/src/transformers/models/olmo2/modeling_olmo2.py
@@ -376,8 +376,16 @@ class Olmo2Model(Olmo2PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -419,7 +427,10 @@ class Olmo2Model(Olmo2PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -370,6 +370,12 @@ class PhiModel(PhiPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -422,8 +422,16 @@ class Phi3Model(Phi3PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -465,7 +473,10 @@ class Phi3Model(Phi3PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -380,8 +380,16 @@ class Qwen2Model(Qwen2PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -423,7 +431,10 @@ class Qwen2Model(Qwen2PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -407,8 +407,16 @@ class Qwen3Model(Qwen3PreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         cache_position: Optional[torch.LongTensor] = None,
+        cos: Optional[torch.LongTensor] = None,
+        sin: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
@@ -450,7 +458,10 @@ class Qwen3Model(Qwen3PreTrainedModel):
         hidden_states = inputs_embeds
 
         # create position embeddings to be shared across the decoder layers
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if cos is None or sin is None:
+            cos, sin = self.rotary_emb(hidden_states, position_ids)
+
+        position_embeddings = (cos, sin)
 
         # decoder layers
         all_hidden_states = () if output_hidden_states else None

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -502,6 +502,12 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> MoeModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_router_logits = (
             output_router_logits if output_router_logits is not None else self.config.output_router_logits

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -374,6 +374,12 @@ class Starcoder2Model(Starcoder2PreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
     ) -> BaseModelOutputWithPast:
+        r"""
+        cos (Optional[torch.LongTensor]):
+            A tensor of cosine values for the rotary embeddings. If not provided, they will be computed on the fly.
+        sin (Optional[torch.LongTensor]):
+            A tensor of sin values for the rotary embeddings. If not provided, they will be computed on the fly.
+        """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -774,6 +774,37 @@ class Mask4DTestHard(unittest.TestCase):
 
         self.assertEqual(decoded, decoded_shared_prefix)
 
+    def test_stacked_causal_mask_hoisted_rotary_embedding(self):
+        (
+            input_ids,
+            position_ids,
+            input_ids_shared_prefix,
+            mask_shared_prefix,
+            position_ids_shared_prefix,
+        ) = self.get_test_data()
+
+        # regular batch
+        logits = self.model.forward(input_ids, position_ids=position_ids).logits
+        logits_last = logits[:, -1, :]  # last tokens in each batch line
+        decoded = [self.tokenizer.decode(t) for t in logits_last.argmax(dim=-1)]
+
+        cos, sin = self.model.rotary_emb(position_ids.to(torch.float32), position_ids)
+
+        # single forward run with 4D custom mask and hoisted rotary embedding.
+        logits_shared_prefix = self.model.forward(
+            input_ids_shared_prefix,
+            attention_mask=mask_shared_prefix,
+            position_ids=position_ids_shared_prefix,
+            cos=cos,
+            sin=sin,
+        ).logits
+        logits_shared_prefix_last = logits_shared_prefix[
+            0, torch.where(position_ids_shared_prefix == position_ids_shared_prefix.max())[1], :
+        ]  # last three tokens
+        decoded_shared_prefix = [self.tokenizer.decode(t) for t in logits_shared_prefix_last.argmax(dim=-1)]
+
+        self.assertEqual(decoded, decoded_shared_prefix)
+
     def test_partial_stacked_causal_mask(self):
         # Same as the test above, but the input is passed in two groups. It tests that we can pass partial 4D attention masks
 


### PR DESCRIPTION
# What does this PR do?
At Meta MTIA, we need support for running the rotary embeddings on CPU. This PR simply allows passing the cos and sin as graph inputs rather than constructing them on accelerator.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- [ ] 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
