### PR TITLE
Add support to Marimo Notebooks and Enverge.ai

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1207,18 +1207,11 @@ def is_keras_nlp_available():
     return is_tensorflow_text_available() and _keras_nlp_available
 
 
-def is_in_marimo():
-    """Check if code is running inside Marimo (in any mode)."""
-    # Check for environment variables that might indicate Marimo
-    if os.getenv('MARIMO_RUNTIME') is not None:
-        return True
-    
-    # Check if marimo module is importable and loaded
-    return 'marimo' in sys.modules
-
-
 def is_in_notebook():
     try:
+        # Check if we are running inside Marimo
+        if 'marimo' in sys.modules:
+            return True
         # Test adapted from tqdm.autonotebook: https://github.com/tqdm/tqdm/blob/master/tqdm/autonotebook.py
         get_ipython = sys.modules["IPython"].get_ipython
         if "IPKernelApp" not in get_ipython().config:
@@ -1229,9 +1222,9 @@ def is_in_notebook():
             # https://docs.microsoft.com/en-us/azure/databricks/notebooks/ipython-kernel
             raise ImportError("databricks")
 
-        return importlib.util.find_spec("IPython") is not None or is_in_marimo()
+        return importlib.util.find_spec("IPython") is not None
     except (AttributeError, ImportError, KeyError):
-        return is_in_marimo()
+        return False
 
 
 def is_pytorch_quantization_available():

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1231,9 +1231,7 @@ def is_in_notebook():
 
         return importlib.util.find_spec("IPython") is not None or is_in_marimo()
     except (AttributeError, ImportError, KeyError):
-        if is_in_marimo():
-            return True
-        return False
+        return is_in_marimo()
 
 
 def is_pytorch_quantization_available():

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1207,6 +1207,16 @@ def is_keras_nlp_available():
     return is_tensorflow_text_available() and _keras_nlp_available
 
 
+def is_in_marimo():
+    """Check if code is running inside Marimo (in any mode)."""
+    # Check for environment variables that might indicate Marimo
+    if os.getenv('MARIMO_RUNTIME') is not None:
+        return True
+    
+    # Check if marimo module is importable and loaded
+    return 'marimo' in sys.modules
+
+
 def is_in_notebook():
     try:
         # Test adapted from tqdm.autonotebook: https://github.com/tqdm/tqdm/blob/master/tqdm/autonotebook.py
@@ -1219,8 +1229,10 @@ def is_in_notebook():
             # https://docs.microsoft.com/en-us/azure/databricks/notebooks/ipython-kernel
             raise ImportError("databricks")
 
-        return importlib.util.find_spec("IPython") is not None
+        return importlib.util.find_spec("IPython") is not None or is_in_marimo()
     except (AttributeError, ImportError, KeyError):
+        if is_in_marimo():
+            return True
         return False
 
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1210,7 +1210,7 @@ def is_keras_nlp_available():
 def is_in_notebook():
     try:
         # Check if we are running inside Marimo
-        if 'marimo' in sys.modules:
+        if "marimo" in sys.modules:
             return True
         # Test adapted from tqdm.autonotebook: https://github.com/tqdm/tqdm/blob/master/tqdm/autonotebook.py
         get_ipython = sys.modules["IPython"].get_ipython


### PR DESCRIPTION
# What does this PR do?

Adding support to Marimo notebooks so output rendering happens in Python instead of CLI mode.
This is necessary for anyone using Marimo notebooks or doing training at Enverge.ai

This is how using train() at Marimo current looks:

https://github.com/user-attachments/assets/316cc614-b731-4bea-a810-981e0b43b478

This is what this PR delivers:

https://github.com/user-attachments/assets/0706e352-45c5-45f0-914f-0ae7c551c5e3


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Library:
- trainer:
Hi @zach-huggingface and @SunMarc, any feedback would be appreciated, is a very small PR, but my first contribution here :)
