### PR TITLE
Fix Llama4

### DIFF
--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -144,7 +144,7 @@ class Llama4TextMoe(nn.Module):
 
     def forward(self, hidden_states):
         batch, seq_len, hidden_dim = hidden_states.shape
-        hidden_states = hidden_states.view(-1, self.hidden_dim)
+        hidden_states = hidden_states.reshape(-1, self.hidden_dim)
         router_logits = self.router(hidden_states)
         tokens_per_expert = batch * seq_len
 


### PR DESCRIPTION
# What does this PR do?

As per the title. It would currently fail with `RuntimeError: view size is not compatible with input tensor's size and stride (at least one dimension spans across two contiguous subspaces). Use .reshape(...) instead.`, at least when using TP.

Unfortunately, flex block mask and generate got broken as well, but this will be solved by the mask refactor. Solving it here would involve a lot of duplicated efforts.