### PR TITLE
[mllama] fix loading and inference

### DIFF
--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -486,8 +486,6 @@ class MllamaTextCrossAttention(nn.Module):
             value_states = self.v_proj(cross_attention_states)
             key_states = key_states.view(bsz, -1, self.num_key_value_heads, self.head_dim).transpose(1, 2)
             value_states = value_states.view(bsz, -1, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-            key_states = repeat_kv(key_states, self.num_key_value_groups)
-            value_states = repeat_kv(value_states, self.num_key_value_groups)
 
             key_states = self.k_norm(key_states)
             if past_key_value is not None:
@@ -850,7 +848,7 @@ class MllamaRotaryEmbedding(nn.Module):
 @auto_docstring
 class MllamaPreTrainedModel(PreTrainedModel):
     config_class = MllamaConfig
-    base_model_prefix = "model"
+    base_model_prefix = ""
     supports_gradient_checkpointing = True
     _no_split_modules = [
         "MllamaVisionEncoderLayer",


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/38220, it's a shame we couldn't see it earlier in CI. Probably because mllama isn't available in EU 🥲 

We should not repeat keys before calling attn, otherwise it is repeated twice. And remove `base_model_prefix` so the model can load old state dicts by manual remapping