### PR TITLE
Make `train_dataset` attribute in `_get_train_sampler` optional 

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -972,7 +972,9 @@ class Trainer:
         )
         return remove_columns_collator
 
-    def _get_train_sampler(self, train_dataset) -> Optional[torch.utils.data.Sampler]:
+    def _get_train_sampler(self, train_dataset: Optional[Dataset] = None) -> Optional[torch.utils.data.Sampler]:
+        if train_dataset is None:
+            train_dataset = self.train_dataset
         if train_dataset is None or not has_length(train_dataset):
             return None
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes a breaking change that was caused by https://github.com/huggingface/transformers/pull/38090. We removed in that PR `train_dataset` arg but TRL lib uses it. We make it optional instead now