### PR TITLE
Fixing Bitnet after use_rms_norm introduction

### DIFF
--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -355,7 +355,7 @@ def _replace_with_bitnet_linear(
                         )
                         if quantization_config.quantization_mode == "offline":
                             model._modules[name].requires_grad_(False)
-                    else :
+                    else:
                         model._modules[name] = BitLinear(
                             in_features=in_features,
                             out_features=out_features,

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -355,15 +355,15 @@ def _replace_with_bitnet_linear(
                         )
                         if quantization_config.quantization_mode == "offline":
                             model._modules[name].requires_grad_(False)
-                    else:
+                    else :
                         model._modules[name] = BitLinear(
                             in_features=in_features,
                             out_features=out_features,
                             bias=module.bias is not None,
                             device=module.weight.device,
                             dtype=module.weight.dtype,
-                            use_rms_norm=quantization_config.use_rms_norm,
-                            rms_norm_eps=quantization_config.rms_norm_eps,
+                            use_rms_norm=quantization_config.use_rms_norm if quantization_config else False,
+                            rms_norm_eps=quantization_config.rms_norm_eps if quantization_config else 1e-6,
                         )
                         model._modules[name].requires_grad_(False)
                     has_been_replaced = True


### PR DESCRIPTION
# What does this PR do?

This pr simply fixes an issue related to using `_replace_with_bitnet_linear` outside of the quantizer in tests. It checks if `quantization_config` is not None before accessing `use_rms_norm`

Action : https://github.com/huggingface/transformers/actions/runs/15127726788/job/42523132728