### PR TITLE
Fix incorrect bbox_embed initialization when decoder_bbox_embed_share=False in GroundingDINO

### DIFF
--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -2453,7 +2453,6 @@ class GroundingDinoForObjectDetection(GroundingDinoPreTrainedModel):
         self.model = GroundingDinoModel(config)
         _class_embed = GroundingDinoContrastiveEmbedding(config)
 
-      
         if config.decoder_bbox_embed_share:
             # une seule instance partagée
             shared_head = GroundingDinoMLPPredictionHead(

--- a/src/transformers/models/grounding_dino/modeling_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/modeling_grounding_dino.py
@@ -2454,13 +2454,13 @@ class GroundingDinoForObjectDetection(GroundingDinoPreTrainedModel):
         _class_embed = GroundingDinoContrastiveEmbedding(config)
 
         if config.decoder_bbox_embed_share:
-            # une seule instance partagée
+            # a single shared instance
             shared_head = GroundingDinoMLPPredictionHead(
                 input_dim=config.d_model, hidden_dim=config.d_model, output_dim=4, num_layers=3
             )
             self.bbox_embed = nn.ModuleList([shared_head] * config.decoder_layers)
         else:
-            # ► chaque couche a son propre head  (deep-copy implicite via nouvelle instance)
+            # each layer has its own head (implicit deep copy through a new instance)
             self.bbox_embed = nn.ModuleList(
                 [
                     GroundingDinoMLPPredictionHead(


### PR DESCRIPTION
Fixes #37333

This PR corrects the initialization of the bbox_embed layers in GroundingDinoForObjectDetection when config.decoder_bbox_embed_share is set to False.

 What does this PR do?
Previously, the bbox_embed list was not properly initialized with independent layers when decoder_bbox_embed_share=False. The current implementation mistakenly overwrites the list in each loop iteration, resulting in incorrect behavior.

This PR:

Ensures that a new GroundingDinoMLPPredictionHead is created per decoder layer when decoder_bbox_embed_share=False

Uses nn.ModuleList properly to store separate instances

Preserves shared head behavior when decoder_bbox_embed_share=True

 Motivation
Fixing this ensures that each decoder layer has its own bounding box prediction head when specified, which is essential for the expected decoding behavior and model performance.