### PR TITLE
Fix pytorch DTensor import issue.

### DIFF
--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -31,8 +31,11 @@ logger = logging.get_logger(__name__)
 _torch_distributed_available = torch.distributed.is_available()
 
 
-if is_torch_greater_or_equal("2.5") and _torch_distributed_available:
-    from torch.distributed.tensor import DTensor, Placement, Replicate, Shard
+if is_torch_greater_or_equal("2.0") and _torch_distributed_available:
+    if is_torch_greater_or_equal("2.5"):
+        from torch.distributed.tensor import DTensor, Placement, Replicate, Shard
+    else:
+        from torch.distributed._tensor import DTensor, Placement, Replicate, Shard
 
 
 def _blocks_to_block_sizes(total_size: int, blocks: Union[int, List[int]]) -> List[int]:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -172,8 +172,11 @@ _is_quantized = False
 _is_ds_init_called = False
 _torch_distributed_available = torch.distributed.is_available()
 
-if _torch_distributed_available and is_torch_greater_or_equal("2.5"):
-    from torch.distributed.tensor import DTensor
+if _torch_distributed_available and is_torch_greater_or_equal("2.0"):
+    if is_torch_greater_or_equal("2.0"):
+        from torch.distributed.tensor import DTensor
+    else:
+        from torch.distributed._tensor import DTensor
 
 
 def is_fsdp_enabled():

--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -29,6 +29,7 @@ ALL_LAYERNORM_LAYERS = [nn.LayerNorm]
 logger = logging.get_logger(__name__)
 
 is_torch_greater_or_equal_than_2_6 = is_torch_greater_or_equal("2.6", accept_dev=True)
+is_torch_greater_or_equal_than_2_5 = is_torch_greater_or_equal("2.5", accept_dev=True)
 is_torch_greater_or_equal_than_2_4 = is_torch_greater_or_equal("2.4", accept_dev=True)
 is_torch_greater_or_equal_than_2_3 = is_torch_greater_or_equal("2.3", accept_dev=True)
 is_torch_greater_or_equal_than_2_2 = is_torch_greater_or_equal("2.2", accept_dev=True)
@@ -297,7 +298,10 @@ def id_tensor_storage(tensor: torch.Tensor) -> tuple[torch.device, int, int]:
     non-overlapping lifetimes may have the same id.
     """
     if is_torch_greater_or_equal_than_2_0:
-        from torch.distributed.tensor import DTensor
+        if is_torch_greater_or_equal_than_2_5:
+            from torch.distributed.tensor import DTensor
+        else:
+            from torch.distributed._tensor import DTensor
 
         if isinstance(tensor, DTensor):
             local_tensor = tensor.to_local()


### PR DESCRIPTION
## Resolve DTensor Import Path Inconsistency Across PyTorch Versions

**Summary:**
This pull request addresses an import issue for `DTensor` arising from its path change across different PyTorch versions. It implements a conditional import mechanism to ensure compatibility.

**Problem:**
The location of the `DTensor` module has been refactored within the PyTorch library:
*   In PyTorch versions **prior to 2.5**, `DTensor` is accessible via `torch.distributed._tensor.DTensor`.
*   In PyTorch versions **2.5 and newer**, `DTensor` has been moved to `torch.distributed.tensor.DTensor`.

This discrepancy can cause `ImportError` exceptions when code expecting one path is run with a different PyTorch version.

**Solution:**
To maintain compatibility across PyTorch versions, this PR introduces a version-aware import for `DTensor`:
*   If the installed PyTorch version is less than 2.5, `DTensor` will be imported from `torch.distributed._tensor`.
*   If the installed PyTorch version is 2.5 or greater, `DTensor` will be imported from `torch.distributed.tensor`.

This approach ensures that the correct import path is used dynamically, based on the runtime environment.

**Evidence of PyTorch Internal Change:**
The change in `DTensor`'s import path is evident in PyTorch's own codebase. The following links point to the relevant lines in `torch/_dynamo/variables/torch.py` for different versions, illustrating the path modification:

*   **PyTorch 2.4.x (and earlier relevant versions):**
    `DTensor` is referenced from `torch.distributed._tensor`.
    See: [[GitHub - pytorch/pytorch (branch dcfa77... for v2.4)](https://github.com/pytorch/pytorch/blob/dcfa7702c3ecd8754e8a66bc49142de00c8474ee/torch/_dynamo/variables/torch.py#L563)](https://github.com/pytorch/pytorch/blob/dcfa7702c3ecd8754e8a66bc49142de00c8474ee/torch/_dynamo/variables/torch.py#L563)

*   **PyTorch 2.5.x (and later relevant versions):**
    `DTensor` is referenced from `torch.distributed.tensor`.
    See: [[GitHub - pytorch/pytorch (branch cfc227... for v2.5)](https://github.com/pytorch/pytorch/blob/cfc227ad43c8a39e52463ef06029dddc00919eae/torch/_dynamo/variables/torch.py#L631)](https://github.com/pytorch/pytorch/blob/cfc227ad43c8a39e52463ef06029dddc00919eae/torch/_dynamo/variables/torch.py#L631)