### PR TITLE
refine `transformers env` output

### DIFF
--- a/src/transformers/commands/env.py
+++ b/src/transformers/commands/env.py
@@ -30,9 +30,9 @@ from ..utils import (
     is_safetensors_available,
     is_tf_available,
     is_torch_available,
-    is_torch_xpu_available,
     is_torch_hpu_available,
     is_torch_npu_available,
+    is_torch_xpu_available,
 )
 from . import BaseTransformersCLICommand
 

--- a/src/transformers/commands/env.py
+++ b/src/transformers/commands/env.py
@@ -30,6 +30,7 @@ from ..utils import (
     is_safetensors_available,
     is_tf_available,
     is_torch_available,
+    is_torch_xpu_available,
     is_torch_hpu_available,
     is_torch_npu_available,
 )
@@ -89,14 +90,24 @@ class EnvironmentCommand(BaseTransformersCLICommand):
 
         pt_version = "not installed"
         pt_cuda_available = "NA"
+        pt_accelerator = "NA"
         if is_torch_available():
             import torch
 
             pt_version = torch.__version__
             pt_cuda_available = torch.cuda.is_available()
-            pt_xpu_available = torch.xpu.is_available()
+            pt_xpu_available = is_torch_xpu_available()
             pt_npu_available = is_torch_npu_available()
             pt_hpu_available = is_torch_hpu_available()
+
+            if pt_cuda_available:
+                pt_accelerator = "CUDA"
+            elif pt_xpu_available:
+                pt_accelerator = "XPU"
+            elif pt_npu_available:
+                pt_accelerator = "NPU"
+            elif pt_hpu_available:
+                pt_accelerator = "HPU"
 
         tf_version = "not installed"
         tf_cuda_available = "NA"
@@ -141,7 +152,7 @@ class EnvironmentCommand(BaseTransformersCLICommand):
             "Accelerate version": f"{accelerate_version}",
             "Accelerate config": f"{accelerate_config_str}",
             "DeepSpeed version": f"{deepspeed_version}",
-            "PyTorch version (GPU?)": f"{pt_version} ({pt_cuda_available})",
+            "PyTorch version (accelerator?)": f"{pt_version} ({pt_accelerator})",
             "Tensorflow version (GPU?)": f"{tf_version} ({tf_cuda_available})",
             "Flax version (CPU?/GPU?/TPU?)": f"{flax_version} ({jax_backend})",
             "Jax version": f"{jax_version}",


### PR DESCRIPTION
@ydshieh , pls help review, thx.

And one more thing is, I can see there is a [print_env.py](https://github.com/huggingface/transformers/blob/711d78d104366c16dd99ef11084c27848f7a4133/utils/print_env.py#L35) in `utils`, I am curious in which situation I should use `transformers env` and in which i should use `print_env.py`? Pls let me know your insights, thx very much.