### PR TITLE
[Whisper + beam search] fix usage of `beam_indices`

### DIFF
--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -255,13 +255,16 @@ class WhisperGenerationMixin(GenerationMixin):
             # Let's unfold the first `beam_indices` accordingly.
             if num_input_ids is not None:
                 # -1 because the original length would be correct if `num_input_ids` is 1
-                weight_length += (num_input_ids - 1)
-                prepend_beam_indices = torch.ones(
-                    generate_outputs.beam_indices.shape[0],
-                    num_input_ids - 1,
-                    device=generate_outputs.beam_indices.device,
-                    dtype=torch.long,
-                ) * (generate_outputs.beam_indices[:, 0])
+                weight_length += num_input_ids - 1
+                prepend_beam_indices = (
+                    torch.ones(
+                        generate_outputs.beam_indices.shape[0],
+                        num_input_ids - 1,
+                        device=generate_outputs.beam_indices.device,
+                        dtype=torch.long,
+                    )
+                    * (generate_outputs.beam_indices[:, 0:1])
+                )
                 beam_indices = torch.cat([prepend_beam_indices, generate_outputs.beam_indices], dim=-1)
             else:
                 beam_indices = generate_outputs.beam_indices

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -231,20 +231,20 @@ class WhisperGenerationMixin(GenerationMixin):
             tensor containing the timestamps in seconds for each predicted token
         """
         # Create a list with `decoder_layers` elements, each a tensor of shape
-        # (batch size * num_beams, attention_heads, output length, input length).
+        # (batch size * num beams, attention_heads, output length, input length).
         cross_attentions = []
         for i in range(self.config.decoder_layers):
             cross_attentions.append(torch.cat([x[i] for x in generate_outputs.cross_attentions], dim=2))
 
         # Select specific cross-attention layers and heads. This is a tensor
-        # of shape (batch size * num_beams, num selected, output length, input length).
+        # of shape (batch size * num beams, num selected heads, output length, input length).
         weights = torch.stack([cross_attentions[l][:, h] for l, h in alignment_heads])
         weights = weights.permute([1, 0, 2, 3])
 
         weight_length = None
 
         if "beam_indices" in generate_outputs:
-            # If beam search has been used, the sequence length of the outputs may not be the real sequence length:
+            # If beam search was used, the sequence length of the outputs may not be the real sequence length:
             # beam search may end up returning a sequence that finished a few steps earlier while decoding.
             # In that case, the `cross_attentions` weights are too long and we have to make sure that they have
             # the right `output_length`

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -2174,7 +2174,8 @@ class WhisperModelIntegrationTests(unittest.TestCase):
             num_return_sequences=num_return_sequences,
         )
 
-        self.assertEqual(generate_outputs["sequences"].shape[-1], generate_outputs["token_timestamps"].shape[-1])
+        # task id and lang id prompts should not have timestamp tokens
+        self.assertEqual(generate_outputs["sequences"].shape[-1] - 2, generate_outputs["token_timestamps"].shape[-1])
         self.assertEqual(len(generate_outputs["sequences"]), num_return_sequences * num_samples)
 
     @slow

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -2174,9 +2174,7 @@ class WhisperModelIntegrationTests(unittest.TestCase):
             num_return_sequences=num_return_sequences,
         )
 
-        # task id and lang id prompts should not have timestamp tokens
-        self.assertEqual(generate_outputs["sequences"].shape[-1] - 2, generate_outputs["token_timestamps"].shape[-1])
-
+        self.assertEqual(generate_outputs["sequences"].shape[-1], generate_outputs["token_timestamps"].shape[-1])
         self.assertEqual(len(generate_outputs["sequences"]), num_return_sequences * num_samples)
 
     @slow


### PR DESCRIPTION
# What does this PR do?

Fixes the shape issues reported in #36093, which have been around since [the code was added](https://github.com/huggingface/transformers/pull/33665) 👀 . It doesn't fix the quality of word timestamp outputs (see e.g. #36632), but rather how we gather the cross attentions from the right beams with beam search, which was broken.

`test_tiny_token_timestamp_batch_generation` is a test that has the same pattern, beam search + timestamps, and is failing on `main` with the same exception as reported in #36093. This PR does NOT fix that test, but allows the test to move past the shape exception until the output quality checks, which are broken 🙃 