### PR TITLE
Fix the shape of ModernBertForMaskedLM's output hidden_states

### DIFF
--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -1089,6 +1089,10 @@ class ModernBertForMaskedLM(ModernBertPreTrainedModel):
         if self.config._attn_implementation == "flash_attention_2":
             with nullcontext() if self.config.repad_logits_with_grad or labels is None else torch.no_grad():
                 logits = _pad_modernbert_output(inputs=logits, indices=indices, batch=batch_size, seqlen=seq_len)
+                hidden_states = tuple(
+                    _pad_modernbert_output(inputs=hidden_state, indices=indices, batch=batch_size, seqlen=seq_len)
+                    for hidden_state in outputs.hidden_states
+                )
 
         if not return_dict:
             output = (logits,)
@@ -1097,7 +1101,7 @@ class ModernBertForMaskedLM(ModernBertPreTrainedModel):
         return MaskedLMOutput(
             loss=loss,
             logits=logits,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
         )
 

--- a/src/transformers/models/modernbert/modular_modernbert.py
+++ b/src/transformers/models/modernbert/modular_modernbert.py
@@ -1219,8 +1219,10 @@ class ModernBertForMaskedLM(ModernBertPreTrainedModel):
         if self.config._attn_implementation == "flash_attention_2":
             with nullcontext() if self.config.repad_logits_with_grad or labels is None else torch.no_grad():
                 logits = _pad_modernbert_output(inputs=logits, indices=indices, batch=batch_size, seqlen=seq_len)
-                hidden_states = tuple(_pad_modernbert_output(inputs=hidden_state, indices=indices,
-                                      batch=batch_size, seqlen=seq_len) for hidden_state in outputs.hidden_states)
+                hidden_states = tuple(
+                    _pad_modernbert_output(inputs=hidden_state, indices=indices, batch=batch_size, seqlen=seq_len)
+                    for hidden_state in outputs.hidden_states
+                )
 
         if not return_dict:
             output = (logits,)

--- a/src/transformers/models/modernbert/modular_modernbert.py
+++ b/src/transformers/models/modernbert/modular_modernbert.py
@@ -1219,6 +1219,8 @@ class ModernBertForMaskedLM(ModernBertPreTrainedModel):
         if self.config._attn_implementation == "flash_attention_2":
             with nullcontext() if self.config.repad_logits_with_grad or labels is None else torch.no_grad():
                 logits = _pad_modernbert_output(inputs=logits, indices=indices, batch=batch_size, seqlen=seq_len)
+                hidden_states = tuple(_pad_modernbert_output(inputs=hidden_state, indices=indices,
+                                      batch=batch_size, seqlen=seq_len) for hidden_state in outputs.hidden_states)
 
         if not return_dict:
             output = (logits,)
@@ -1227,7 +1229,7 @@ class ModernBertForMaskedLM(ModernBertPreTrainedModel):
         return MaskedLMOutput(
             loss=loss,
             logits=logits,
-            hidden_states=outputs.hidden_states,
+            hidden_states=hidden_states,
             attentions=outputs.attentions,
         )
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Fix the shape of `ModernBertForMaskedLM`'s output `hidden_states` when both having `output_hidden_states=True` and using Flash Attention 2.

Before fix: The output hidden states are linearized to shape similar to `(batch_size * sequence_length, hidden_size)` since the input ids are unpadded before passing to `ModernBertModel`.

Expected behavior: All output `hidden_states` should have shape `(batch_size, sequence_length, hidden_size)` according to the docs.

This PR applies unpadding to the output hidden_states to make the shapes correct.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (There's no issue for this.)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation). (This PR makes the behavior following the current documentation.)
- [ ] Did you write any new necessary tests? (No need for extra tests.)


@ArthurZucker