### PR TITLE
Add zero dim tensor check when using flash_attention

### DIFF
--- a/src/transformers/integrations/flash_attention.py
+++ b/src/transformers/integrations/flash_attention.py
@@ -24,9 +24,11 @@ def flash_attention_forward(
     seq_len = query.shape[2]
 
     if any(dim == 0 for dim in query.shape):
-        raise ValueError("Tensor query has shape  with a zero dimension.\n"
-                         "FlashAttention does not support inputs with dim=0.\n"
-                         "Please check your input shapes or use SDPA instead.")
+        raise ValueError(
+            "Tensor query has shape  with a zero dimension.\n"
+            "FlashAttention does not support inputs with dim=0.\n"
+            "Please check your input shapes or use SDPA instead."
+        )
 
     # FA2 uses non-transposed inputs
     query = query.transpose(1, 2)

--- a/src/transformers/integrations/flash_attention.py
+++ b/src/transformers/integrations/flash_attention.py
@@ -23,6 +23,11 @@ def flash_attention_forward(
     # This is before the transpose
     seq_len = query.shape[2]
 
+    if any(dim == 0 for dim in query.shape):
+        raise ValueError("Tensor query has shape  with a zero dimension.\n"
+                         "FlashAttention does not support inputs with dim=0.\n"
+                         "Please check your input shapes or use SDPA instead.")
+
     # FA2 uses non-transposed inputs
     query = query.transpose(1, 2)
     key = key.transpose(1, 2)


### PR DESCRIPTION
 The cuda or triton kernel can not support this case: dimensions of size is 0, but traditional SDPA is implemented using PyTorch's tensor operations, which have robust support for tensors with dimensions of size 0. We need to add this check and error tips for developers when using flash_attention. Related issue is in https://github.com/deepspeedai/DeepSpeed/issues/7275