### PR TITLE
Fix pytorch DTensor import issue.(version 2)

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -29,6 +29,7 @@ ALL_LAYERNORM_LAYERS = [nn.LayerNorm]
 logger = logging.get_logger(__name__)
 
 is_torch_greater_or_equal_than_2_6 = is_torch_greater_or_equal("2.6", accept_dev=True)
+is_torch_greater_or_equal_than_2_5 = is_torch_greater_or_equal("2.5", accept_dev=True)
 is_torch_greater_or_equal_than_2_4 = is_torch_greater_or_equal("2.4", accept_dev=True)
 is_torch_greater_or_equal_than_2_3 = is_torch_greater_or_equal("2.3", accept_dev=True)
 is_torch_greater_or_equal_than_2_2 = is_torch_greater_or_equal("2.2", accept_dev=True)
@@ -296,7 +297,7 @@ def id_tensor_storage(tensor: torch.Tensor) -> tuple[torch.device, int, int]:
     guaranteed to be unique and constant for this tensor's storage during its lifetime. Two tensor storages with
     non-overlapping lifetimes may have the same id.
     """
-    if is_torch_greater_or_equal_than_2_0:
+    if is_torch_greater_or_equal_than_2_5:
         from torch.distributed.tensor import DTensor
 
         if isinstance(tensor, DTensor):


### PR DESCRIPTION
# Resolve DTensor Import Path Inconsistency Across PyTorch Versions

Summary:
This pull request addresses an import issue for DTensor arising from its path change across different PyTorch versions. It implements a conditional import mechanism to ensure compatibility.

Problem:
The location of the DTensor module has been refactored within the PyTorch library:

In PyTorch versions prior to 2.5, DTensor is accessible via torch.distributed._tensor.DTensor.
In PyTorch versions 2.5 and newer, DTensor has been moved to torch.distributed.tensor.DTensor.
This discrepancy can cause ImportError exceptions when code expecting one path is run with a different PyTorch version.

Solution:
Only when pytorch version is lagger or equal to 2.5, we will use (import) DTensor.

Evidence of PyTorch Internal Change:
The change in DTensor's import path is evident in PyTorch's own codebase. The following links point to the relevant lines in torch/_dynamo/variables/torch.py for different versions, illustrating the path modification:

PyTorch 2.4.x (and earlier relevant versions):
DTensor is referenced from torch.distributed._tensor.
See: [[GitHub - pytorch/pytorch (branch dcfa77... for v2.4)](https://github.com/pytorch/pytorch/blob/dcfa7702c3ecd8754e8a66bc49142de00c8474ee/torch/_dynamo/variables/torch.py#L563)](https://github.com/pytorch/pytorch/blob/dcfa7702c3ecd8754e8a66bc49142de00c8474ee/torch/_dynamo/variables/torch.py#L563)

PyTorch 2.5.x (and later relevant versions):
DTensor is referenced from torch.distributed.tensor.
See: [[GitHub - pytorch/pytorch (branch cfc227... for v2.5)](https://github.com/pytorch/pytorch/blob/cfc227ad43c8a39e52463ef06029dddc00919eae/torch/_dynamo/variables/torch.py#L631)](https://github.com/pytorch/pytorch/blob/cfc227ad43c8a39e52463ef06029dddc00919eae/torch/_dynamo/variables/torch.py#L631)