### PR TITLE
Fix tp error when torch distributed is already initialized

### DIFF
--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -52,6 +52,7 @@ def initialize_tensor_parallelism(tp_plan, tp_size=None):
 
     # Detect the accelerator on the machine. If no accelerator is available, it returns CPU.
     device_type = torch._C._get_accelerator().type
+    current_device = getattr(torch, device_type)
     if not torch.distributed.is_initialized():
         try:
             rank = int(os.environ["RANK"])
@@ -73,6 +74,9 @@ def initialize_tensor_parallelism(tp_plan, tp_size=None):
                 "We tried to initialize torch.distributed for you, but it failed. Make "
                 "sure you init torch distributed in your script to use `tp_plan='auto'`."
             ) from e
+
+    if device_type != "cpu":
+        current_device.set_device(int(os.environ["LOCAL_RANK"]))
     index = current_device.current_device() if device_type != "cpu" else None
     tp_device = torch.device(device_type, index)
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue when the torch distributed is already initialized. current_device is referenced before assignment. 

Getting the following traceback in accelerate when testing tp training. 
```
[rank1]:     tp_plan, device_map, device_mesh = initialize_tensor_parallelism(tp_plan, tp_size=None)
[rank1]:   File "/home/marc/transformers/src/transformers/integrations/tensor_parallel.py", line 79, in initialize_tensor_parallelism
[rank1]:     index = current_device.current_device() if device_type != "cpu" else None
[rank1]: UnboundLocalError: local variable 'current_device' referenced before assignment
```
