### PR TITLE
Updated the model card for ViTMAE

### DIFF
--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -26,7 +26,7 @@ rendered properly in your Markdown viewer.
 
 # ViTMAE
 
-[ViTMAE (Vision Transformer - Masked AutoEncoder)](https://huggingface.co/papers/2111.06377) is a self-supervised vision model that learns by hiding large portions of images and training itself to reconstruct them. It masks around 75% of the input image patches and learns to reconstruct the missing pixels from the remaining visible ones. After pretraining, the encoder can be reused for downstream tasks like image classification or object detection — often outperforming models trained with supervised learning.
+[ViTMAE](https://huggingface.co/papers/2111.06377) is a self-supervised vision model that is pretrained by masking large portions of an image (~75%). An encoder processes the visible image patches and a decoder reconstructs the missing pixels from the encoded patches and mask tokens. After pretraining, the encoder can be reused for downstream tasks like image classification or object detection — often outperforming models trained with supervised learning.
 
 You can find all the original ViTMAE checkpoints under the [vit-mae](https://huggingface.co/facebook/vit-mae-base) collection.
 

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -28,6 +28,9 @@ rendered properly in your Markdown viewer.
 
 [ViTMAE](https://huggingface.co/papers/2111.06377) is a self-supervised vision model that is pretrained by masking large portions of an image (~75%). An encoder processes the visible image patches and a decoder reconstructs the missing pixels from the encoded patches and mask tokens. After pretraining, the encoder can be reused for downstream tasks like image classification or object detection — often outperforming models trained with supervised learning.
 
+<img src="https://user-images.githubusercontent.com/11435359/146857310-f258c86c-fde6-48e8-9cee-badd2b21bd2c.png"
+alt="drawing" width="600"/> 
+
 You can find all the original ViTMAE checkpoints under the [AI at Meta](https://huggingface.co/facebook?search_models=vit-mae) organization.
 
 > [!TIP]
@@ -36,10 +39,6 @@ You can find all the original ViTMAE checkpoints under the [AI at Meta](https://
 The example below demonstrates how to reconstruct the missing pixels with the [`AutoModel`] class.
 
 <hfoptions id="usage">
-
-<!-- This model is not currently supported via pipeline. -->
-
-</hfoption>
 <hfoption id="AutoModel">
 
 ```python
@@ -52,7 +51,8 @@ url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/
 image = Image.open(requests.get(url, stream=True).raw)
 
 processor = ViTImageProcessor.from_pretrained("facebook/vit-mae-base")
-inputs = processor(image, return_tensors="pt").to("cuda")
+inputs = processor(image, return_tensors="pt")
+inputs = {k: v.to("cuda") for k, v in inputs.items()}
 
 model = ViTMAEForPreTraining.from_pretrained("facebook/vit-mae-base", attn_implementation="sdpa").to("cuda")
 with torch.no_grad():
@@ -62,21 +62,12 @@ reconstruction = outputs.logits
 ```
 
 </hfoption>
-<hfoption id="transformers-cli">
-
-<!-- This model is not currently supported via transformers-cli. -->
-
-</hfoption>
 </hfoptions>
 
 ## Notes
 - ViTMAE is typically used in two stages. Self-supervised pretraining with [`ViTMAEForPreTraining`], and then discarding the decoder and fine-tuning the encoder. After fine-tuning, the weights can be plugged into a model like [`ViTForImageClassification`].
 - Use [`ViTImageProcessor`] for input preparation.
 
-```python
-from transformers import ViTMAEModel
-model = ViTMAEModel.from_pretrained("facebook/vit-mae-base", attn_implementation="sdpa", torch_dtype=torch.float16)
-...
 ## Resources
 
 - Refer to this [notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/ViTMAE/ViT_MAE_visualization_demo.ipynb) to learn how to visualize the reconstructed pixels from [`ViTMAEForPreTraining`].

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -71,10 +71,7 @@ reconstruction = outputs.logits
 
 ## Notes
 - ViTMAE is typically used in two stages. Self-supervised pretraining with [`ViTMAEForPreTraining`], and then discarding the decoder and fine-tuning the encoder. After fine-tuning, the weights can be plugged into a model like [`ViTForImageClassification`].
-- The model reconstructs masked image patches (typically 75%) during pretraining and discards the decoder afterward.
-- Only visible patches are encoded, and learned mask tokens are used in the decoder.
-- Use `ViTImageProcessor` for input preparation.
-- For faster inference on supported hardware, SDPA can be enabled via `attn_implementation="sdpa"`.
+- Use [`ViTImageProcessor`] for input preparation.
 
 ```python
 from transformers import ViTMAEModel

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -54,7 +54,7 @@ image = Image.open(requests.get(url, stream=True).raw)
 processor = ViTImageProcessor.from_pretrained("facebook/vit-mae-base")
 inputs = processor(image, return_tensors="pt").to("cuda")
 
-model = ViTMAEForPreTraining.from_pretrained("facebook/vit-mae-base").to("cuda")
+model = ViTMAEForPreTraining.from_pretrained("facebook/vit-mae-base", attn_implementation="sdpa").to("cuda")
 with torch.no_grad():
     outputs = model(**inputs)
 

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -36,7 +36,6 @@ You can find all the original ViTMAE checkpoints under the [AI at Meta](https://
 The example below demonstrates how to use ViTMAE with the [`AutoModel`] class.
 
 <hfoptions id="usage">
-<hfoption id="Pipeline">
 
 <!-- This model is not currently supported via pipeline. -->
 

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -36,7 +36,7 @@ You can find all the original ViTMAE checkpoints under the [AI at Meta](https://
 > [!TIP]
 > Click on the ViTMAE models in the right sidebar for more examples of how to apply ViTMAE to vision tasks.
 
-The example below demonstrates how to reconstruct the missing pixels with the [`AutoModel`] class.
+The example below demonstrates how to reconstruct the missing pixels with the [`ViTMAEForPreTraining`] class.
 
 <hfoptions id="usage">
 <hfoption id="AutoModel">

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -33,7 +33,7 @@ You can find all the original ViTMAE checkpoints under the [AI at Meta](https://
 > [!TIP]
 > Click on the ViTMAE models in the right sidebar for more examples of how to apply ViTMAE to vision tasks.
 
-The example below demonstrates how to use ViTMAE with the [`AutoModel`] class.
+The example below demonstrates how to reconstruct the missing pixels with the [`AutoModel`] class.
 
 <hfoptions id="usage">
 

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -77,7 +77,9 @@ reconstruction = outputs.logits
 from transformers import ViTMAEModel
 model = ViTMAEModel.from_pretrained("facebook/vit-mae-base", attn_implementation="sdpa", torch_dtype=torch.float16)
 ...
-```
+## Resources
+
+- Refer to this [notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/ViTMAE/ViT_MAE_visualization_demo.ipynb) to learn how to visualize the reconstructed pixels from [`ViTMAEForPreTraining`].
 
 ## ViTMAEConfig
 

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -70,7 +70,7 @@ reconstruction = outputs.logits
 </hfoptions>
 
 ## Notes
-- ViTMAE is used in two stages: self-supervised pretraining with    `ViTMAEForPreTraining`, then finetuning using the encoder with `ViTForImageClassification`.
+- ViTMAE is typically used in two stages. Self-supervised pretraining with [`ViTMAEForPreTraining`], and then discarding the decoder and fine-tuning the encoder. After fine-tuning, the weights can be plugged into a model like [`ViTForImageClassification`].
 - The model reconstructs masked image patches (typically 75%) during pretraining and discards the decoder afterward.
 - Only visible patches are encoded, and learned mask tokens are used in the decoder.
 - Use `ViTImageProcessor` for input preparation.

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -28,7 +28,7 @@ rendered properly in your Markdown viewer.
 
 [ViTMAE](https://huggingface.co/papers/2111.06377) is a self-supervised vision model that is pretrained by masking large portions of an image (~75%). An encoder processes the visible image patches and a decoder reconstructs the missing pixels from the encoded patches and mask tokens. After pretraining, the encoder can be reused for downstream tasks like image classification or object detection — often outperforming models trained with supervised learning.
 
-You can find all the original ViTMAE checkpoints under the [vit-mae](https://huggingface.co/facebook/vit-mae-base) collection.
+You can find all the original ViTMAE checkpoints under the [AI at Meta](https://huggingface.co/facebook?search_models=vit-mae) organization.
 
 > [!TIP]
 > Click on the ViTMAE models in the right sidebar for more examples of how to apply ViTMAE to different image classification and reconstruction tasks.

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -31,7 +31,7 @@ rendered properly in your Markdown viewer.
 You can find all the original ViTMAE checkpoints under the [AI at Meta](https://huggingface.co/facebook?search_models=vit-mae) organization.
 
 > [!TIP]
-> Click on the ViTMAE models in the right sidebar for more examples of how to apply ViTMAE to different image classification and reconstruction tasks.
+> Click on the ViTMAE models in the right sidebar for more examples of how to apply ViTMAE to vision tasks.
 
 The example below demonstrates how to use ViTMAE with the [`AutoModel`] class.
 

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -14,11 +14,14 @@ rendered properly in your Markdown viewer.
 
 -->
 
-<div class="flex flex-wrap space-x-1">
-<img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
-<img alt="FlashAttention" src="https://img.shields.io/badge/%E2%9A%A1%EF%B8%8E%20FlashAttention-eae0c8?style=flat">
-<img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
+
+<div style="float: right;">
+    <div class="flex flex-wrap space-x-1">
+        <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
+        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
+        <img alt="FlashAttention" src="https://img.shields.io/badge/%E2%9A%A1%EF%B8%8E%20FlashAttention-eae0c8?style=flat">
+        <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
+    </div>
 </div>
 
 # ViTMAE


### PR DESCRIPTION
# What does this PR do?

As suggested in this issue - https://github.com/huggingface/transformers/issues/36979#issue-2947704577 - this PR updates the documentation of the [ViTMAE](https://huggingface.co/docs/transformers/v4.52.1/en/model_doc/vit_mae) model, which will now be aligned with the standardized format for all the docs.

## Check list

- [x] Include a brief description of the model
- [x] Ready to use code examples (`Pipeline` **not** available, `AutoModel` available, and `transformers-cli` **not** available) 
- [ ] For large models, provide a quantization example
- [ ] Include an attention mask visualizer


## Who can review?

Hello @stevhliu! 👋

I updated the ViTMAE model card following the standard format. Since `ViTMAEForPreTraining` isn’t compatible with `Pipeline`, because it is designed for masked autoencoding rather than classification tasks. 

I’ve tried to follow all formatting and content guidelines, but I'm not sure if I did it correctly.

Happy to revise. Thanks! 


