### PR TITLE
Expose AutoModelForTimeSeriesPrediction for import

### DIFF
--- a/docs/source/en/model_doc/auto.md
+++ b/docs/source/en/model_doc/auto.md
@@ -389,3 +389,9 @@ The following auto classes are available for the following multimodal tasks.
 ### AutoModelForImageTextToText
 
 [[autodoc]] AutoModelForImageTextToText
+
+## Time Series
+
+### AutoModelForTimeSeriesPrediction
+
+[[autodoc]] AutoModelForTimeSeriesPrediction

--- a/docs/source/ja/model_doc/auto.md
+++ b/docs/source/ja/model_doc/auto.md
@@ -372,3 +372,10 @@ AutoModel.register(NewModelConfig, NewModel)
 ### AutoModelForImageTextToText
 
 [[autodoc]] AutoModelForImageTextToText
+
+## Time Series
+
+### AutoModelForTimeSeriesPrediction
+
+[[autodoc]] AutoModelForTimeSeriesPrediction
+

--- a/docs/source/ko/model_doc/auto.md
+++ b/docs/source/ko/model_doc/auto.md
@@ -373,3 +373,10 @@ AutoModel.register(NewModelConfig, NewModel)
 ### FlaxAutoModelForVision2Seq[[transformers.FlaxAutoModelForVision2Seq]]
 
 [[autodoc]] FlaxAutoModelForVision2Seq
+
+## Time Series
+
+### AutoModelForTimeSeriesPrediction[[transformers.AutoModelForTimeSeriesPrediction]]
+
+[[autodoc]] AutoModelForTimeSeriesPrediction
+

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -2103,6 +2103,7 @@ __all__ = [
     "AutoModelForTableQuestionAnswering",
     "AutoModelForTextToSpectrogram",
     "AutoModelForTextToWaveform",
+    "AutoModelForTimeSeriesPrediction",
     "AutoModelForTokenClassification",
     "AutoModelForUniversalSegmentation",
     "AutoModelForVideoClassification",


### PR DESCRIPTION
Add `AutoModelForTimeSeriesPrediction` to `__all__` in `modeling_auto` so that it can be imported:
```
from transformers import AutoModelForTimeSeriesPrediction
```
This class will be the portal to all time series models in Hugging Face. 

It is a missing part of #34082 and this PR aims to fix it. 
