### PR TITLE
Stop TF weight rename reDOS

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -82,12 +82,10 @@ def convert_tf_weight_name_to_pt_weight_name(
     if tf_name.count("___") == 1:
         old_name, new_name = tf_name.split("___")
         if "/" in old_name and "/" in new_name:
-            name_base = old_name.rsplit("/", 1)[-1]  + "/"
+            name_base = old_name.rsplit("/", 1)[-1] + "/"
             tf_name = name_base + new_name
 
-    regex_tf_name = re.sub(
-        r"/[^/]*___([^/]*)/", r"/\1/", tf_name
-    )
+    regex_tf_name = re.sub(r"/[^/]*___([^/]*)/", r"/\1/", tf_name)
     assert regex_tf_name == tf_name
     tf_name = tf_name.replace(
         "_._", "/"

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -79,8 +79,11 @@ def convert_tf_weight_name_to_pt_weight_name(
         tf_name = tf_name.lstrip("/")
     tf_name = tf_name.replace(":0", "")  # device ids
     # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
-    if tf_name.count("___") == 1:
-        old_name, new_name = tf_name.split("___")
+    if "___" in tf_name:
+        name_segments = tf_name.split("___")
+        # There should almost always be only one instance of "___" in the name, but in pathological cases
+        # using [-1] here matches the original (blowup-prone) regex: re.sub(r"/[^/]*___([^/]*)/", r"/\1/")
+        old_name, new_name = name_segments[0], name_segments[-1]
         if "/" in old_name and "/" in new_name:
             name_base = old_name.rsplit("/", 1)[-1] + "/"
             tf_name = name_base + new_name

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -78,9 +78,17 @@ def convert_tf_weight_name_to_pt_weight_name(
         tf_name = tf_name[len(name_scope) :]
         tf_name = tf_name.lstrip("/")
     tf_name = tf_name.replace(":0", "")  # device ids
-    tf_name = re.sub(
+    # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
+    if tf_name.count("___") == 1:
+        old_name, new_name = tf_name.split("___")
+        if "/" in old_name and "/" in new_name:
+            name_base = old_name.rsplit("/", 1)[-1]  + "/"
+            tf_name = name_base + new_name
+
+    regex_tf_name = re.sub(
         r"/[^/]*___([^/]*)/", r"/\1/", tf_name
-    )  # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
+    )
+    assert regex_tf_name == tf_name
     tf_name = tf_name.replace(
         "_._", "/"
     )  # '_._' is replaced by a level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -78,18 +78,11 @@ def convert_tf_weight_name_to_pt_weight_name(
         tf_name = tf_name[len(name_scope) :]
         tf_name = tf_name.lstrip("/")
     tf_name = tf_name.replace(":0", "")  # device ids
-    # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
-    if "___" in tf_name:
-        name_segments = tf_name.split("___")
-        # There should almost always be only one instance of "___" in the name, but in pathological cases
-        # using [-1] here matches the original (blowup-prone) regex: re.sub(r"/[^/]*___([^/]*)/", r"/\1/")
-        old_name, new_name = name_segments[0], name_segments[-1]
-        if "/" in old_name and "/" in new_name:
-            name_base = old_name.rsplit("/", 1)[-1] + "/"
-            tf_name = name_base + new_name
-
-    regex_tf_name = re.sub(r"/[^/]*___([^/]*)/", r"/\1/", tf_name)
-    assert regex_tf_name == tf_name
+    if len(tf_name) > 2048 or tf_name.count("___") > 10:
+        raise ValueError("TF variable name is too long or contains too many ___ separators: " + tf_name)
+    tf_name = re.sub(
+        r"/[^/]*___([^/]*)/", r"/\1/", tf_name
+    )  # '$1___$2' is replaced by $2 (can be used to duplicate or remove layers in TF2.0 vs PyTorch)
     tf_name = tf_name.replace(
         "_._", "/"
     )  # '_._' is replaced by a level separation (can be used to convert TF2.0 lists in PyTorch nn.ModulesList)

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -78,7 +78,7 @@ def convert_tf_weight_name_to_pt_weight_name(
         tf_name = tf_name[len(name_scope) :]
         tf_name = tf_name.lstrip("/")
     tf_name = tf_name.replace(":0", "")  # device ids
-    if len(tf_name) > 2048 or tf_name.count("___") > 10:
+    if (len(tf_name) > 2048 and "___" in tf_name) or tf_name.count("___") > 10:
         raise ValueError("TF variable name is too long or contains too many ___ separators: " + tf_name)
     tf_name = re.sub(
         r"/[^/]*___([^/]*)/", r"/\1/", tf_name

--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -79,6 +79,7 @@ def convert_tf_weight_name_to_pt_weight_name(
         tf_name = tf_name.lstrip("/")
     tf_name = tf_name.replace(":0", "")  # device ids
     if (len(tf_name) > 2048 and "___" in tf_name) or tf_name.count("___") > 10:
+        # ReDOS check
         raise ValueError("TF variable name is too long or contains too many ___ separators: " + tf_name)
     tf_name = re.sub(
         r"/[^/]*___([^/]*)/", r"/\1/", tf_name


### PR DESCRIPTION
The regex to convert TF names to Pytorch names has potential runtime blowup for malicious inputs, so we add a check to make sure nothing too big or malformed gets passed to it.