### PR TITLE
Hot fix for AMD CI workflow

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1313,7 +1313,7 @@ if __name__ == "__main__":
             event_payload = json.load(fp)
             # The event that triggers the `workflow_run` event.
             if "workflow_run" in event_payload:
-                is_scheduled_ci_run = event_payload["event"] == "schedule"
+                is_scheduled_ci_run = event_payload["workflow_run"]["event"] == "schedule"
 
     # The values are used as the file names where to save the corresponding CI job results.
     test_to_result_name = {


### PR DESCRIPTION
# What does this PR do?

I made a mistake in #38298 and the slack reports is broken for AMD at this moment due to a dict key error.

We should access `event_payload["workflow_run"]["event"]` instead where `event_payload` looks like


```python
{
  "action": "completed",
  "workflow": {
    "created_at": "2024-04-23T08:01:31.000Z",
    "html_url": "https://github.com/ydshieh/transformers/blob/main/.github/workflows/self-scheduled-amd-caller.yml",
    "id": 95041645,
    "name": "Self-hosted runner (AMD scheduled CI caller)",
    "node_id": "W_kwDOEW1XxM4Fqjht",
    "path": ".github/workflows/self-scheduled-amd-caller.yml",
    "state": "active",
    "updated_at": "2025-05-23T12:11:50.000Z",
    "url": "https://api.github.com/repos/ydshieh/transformers/actions/workflows/95041645"
  },
  "workflow_run": {
    "actor": {
      "html_url": "https://github.com/ydshieh",
      "id": 2521628,
      "login": "ydshieh",
    },
    "artifacts_url": "https://api.github.com/repos/ydshieh/transformers/actions/runs/15211635268/artifacts",
    "cancel_url": "https://api.github.com/repos/ydshieh/transformers/actions/runs/15211635268/cancel",
    "conclusion": "success",
    "created_at": "2025-05-23T13:37:05Z",
    "display_title": "Self-hosted runner (AMD scheduled CI caller)",
    "event": "schedule",
    "head_branch": "main",
    "head_commit": {
      "author": {
        "email": "2521628+ydshieh@users.noreply.github.com",
        "name": "Yih-Dar"
      }
    },
    "updated_at": "2025-05-23T13:37:12Z",
    "url": "https://api.github.com/repos/ydshieh/transformers/actions/runs/15211635268",
    "workflow_id": 95041645,
    "workflow_url": "https://api.github.com/repos/ydshieh/transformers/actions/workflows/95041645"
  }
}
```