### PR TITLE
Fix missing imports in `transformers add-new-model-like` CLI command

### DIFF
--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -26,6 +26,7 @@ from typing import Optional
 
 import yaml
 
+from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig, TextIteratorStreamer
 from transformers.utils import is_rich_available, is_torch_available
 
 from . import BaseTransformersCLICommand


### PR DESCRIPTION
While working on adding support for a custom model using the `transformers add-new-model-like` CLI command, I encountered an error due to missing imports in `src/transformers/commands/chat.py`. This caused the command to fail because essential components such as `TextIteratorStreamer`, `GenerationConfig`, `AutoTokenizer`, and `AutoModelForCausalLM` were not imported.

This PR fixes the issue by adding the necessary import statements, ensuring the command works correctly when adding new models.