### PR TITLE
[bugfix] fix flex-attention not supported on Ascend NPU, update BlockMask type annotations to str

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -582,11 +582,11 @@ ALL_MASK_ATTENTION_FUNCTIONS: AttentionMaskInterface = AttentionMaskInterface()
 def _preprocess_mask_arguments(
     config: PretrainedConfig,
     input_embeds: torch.Tensor,
-    attention_mask: Optional[Union[torch.Tensor, BlockMask]],
+    attention_mask: Optional[Union[torch.Tensor, "BlockMask"]],
     cache_position: torch.Tensor,
     past_key_values: Optional[Cache],
     layer_idx: Optional[int],
-) -> tuple[bool, Optional[Union[torch.Tensor, BlockMask]], int, int]:
+) -> tuple[bool, Optional[Union[torch.Tensor, "BlockMask"]], int, int]:
     """
     Perform some common pre-processing of the mask arguments we get from the modeling code. Mostly determine the
     key-value length and offsets, and if we should early exit or not.

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -414,6 +414,8 @@ def is_torch_flex_attn_available():
         return False
     elif _torch_version == "N/A":
         return False
+    elif is_torch_npu_available():
+        return False
 
     # TODO check if some bugs cause push backs on the exact version
     # NOTE: We require torch>=2.5.0 as it is the first release


### PR DESCRIPTION
# What does this PR do?

**1. Problem 1**
Flex-attention has not been fully verified on Ascend NPU yet. In PR #37866 , the func `is_torch_flex_attn_available` defined in below code does not contain logical judgment about Ascend NPU. In this situation, when we use torch>=2.5.0, this func will return `True` on Ascend NPU, which is not correct.
https://github.com/huggingface/transformers/blob/d03a3ca69226a776d9ed69cd90cbe8f6ebe8fa34/src/transformers/utils/import_utils.py#L412

**2. Problem 2**
If func `is_torch_flex_attn_available` return `False` on Ascend NPU as expected, object `BlockMask` will not be imported in below code
https://github.com/huggingface/transformers/blob/a5a0c7b88828a7273bdedbdcaa2c7a252084c0d8/src/transformers/masking_utils.py#L29

But this object is directly called in type annotations in below code now, directly causing importance error.
https://github.com/huggingface/transformers/blob/a5a0c7b88828a7273bdedbdcaa2c7a252084c0d8/src/transformers/masking_utils.py#L585

**Therefore, this PR is committed for solving above two problems**. By adding flex-attention not supported on Ascend NPU logic in `is_torch_flex_attn_available`,  and updating `BlockMask` type annotations to string format.

Fixes # (issue)
#38362 

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
