### PR TITLE
for now disable compile

### DIFF
--- a/src/transformers/generation/continuous_batching.py
+++ b/src/transformers/generation/continuous_batching.py
@@ -773,7 +773,6 @@ class ContinuousBatchProcessor:
 
     @traced
     @torch.no_grad()
-    @torch.compile()
     def reset_static_tensors(self):
         """Reset static tensors for the next batch."""
         self.input_ids.zero_()
@@ -1226,7 +1225,6 @@ class ContinuousBatchingManager:
         return self.model(**batch_data).logits
 
     @traced(span_name="logit_processing")
-    @torch.compile()
     def _process_logit(self, batch_data, logits):
         return self.logit_processor(batch_data["input_ids"], logits)
 


### PR DESCRIPTION
# What does this PR do?
We should disable compile on CB for now as it breaks on mac. 
Until we have a decorator that only applies it for mac devices