### PR TITLE
update gemma tests

### DIFF
--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -30,7 +30,6 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
-    require_torch_sdpa,
     slow,
     torch_device,
 )

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -167,11 +167,12 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the 1990s and I need to know what the most popular music",
-            "Hi today I have a question about the new 2019 1000rr. I",
+            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Kaju Kat",
         ]
 
+        # bfloat16 gives strange values, likely due to it has lower precision + very short prompts
         model = AutoModelForCausalLM.from_pretrained(
-            model_id, low_cpu_mem_usage=True, torch_dtype=torch.bfloat16, attn_implementation="eager"
+            model_id, low_cpu_mem_usage=True, torch_dtype=torch.float16, attn_implementation="eager"
         )
         model.to(torch_device)
 

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -184,29 +184,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_torch_sdpa
-    @require_read_token
-    def test_model_2b_sdpa(self):
-        model_id = "google/gemma-2b"
-
-        EXPECTED_TEXTS = [
-            "Hello I am doing a project on the 1990s and I need to know what the most popular music",
-            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Kaju Kat",
-        ]
-
-        model = AutoModelForCausalLM.from_pretrained(
-            model_id, low_cpu_mem_usage=True, torch_dtype=torch.bfloat16, attn_implementation="sdpa"
-        )
-        model.to(torch_device)
-
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(torch_device)
-
-        output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
-        output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
-
-        self.assertEqual(output_text, EXPECTED_TEXTS)
-
     @require_flash_attn
     @require_read_token
     @pytest.mark.flash_attn_test

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -147,7 +147,7 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the 1990s and I need to know what the most popular music",
-            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Khichdi",
+            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Kaju Kat",
         ]
 
         model = AutoModelForCausalLM.from_pretrained(model_id, low_cpu_mem_usage=True, torch_dtype=torch.bfloat16).to(
@@ -168,7 +168,7 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the 1990s and I need to know what the most popular music",
-            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Khichdi",
+            "Hi today I have a question about the new 2019 1000rr. I",
         ]
 
         model = AutoModelForCausalLM.from_pretrained(
@@ -191,7 +191,7 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         EXPECTED_TEXTS = [
             "Hello I am doing a project on the 1990s and I need to know what the most popular music",
-            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Khichdi",
+            "Hi today I am going to share with you a very easy and simple recipe of <strong><em>Kaju Kat",
         ]
 
         model = AutoModelForCausalLM.from_pretrained(


### PR DESCRIPTION
# What does this PR do?

All tests now pass, except the following one

Detect and fix most `_init_weights()` issues - make it work for composite models (#37070)

fails

> tests/models/gemma/test_modeling_gemma.py::GemmaModelTest::test_sdpa_equivalence

2e-3 --> 4e-3, which is larger than 3e-3.

Let's deal with this in a separate PR.