### PR TITLE
Fix convert to original state dict for VLMs

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3657,7 +3657,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
                         elif depth == 0 and char not in ["^", "$"]:
                             replacement_str.append(char)
 
-                    replacement_str = ''.join(replacement_str)
+                    replacement_str = "".join(replacement_str)
                     key, n_replace = re.subn(pattern, replacement_str, key)
                     # Early exit of the loop
                     if n_replace > 0:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3647,18 +3647,9 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             original_state_dict = {}
             for key, value in state_dict.items():
                 for pattern, replacement in reverse_key_mapping.items():
-                    depth = 0
-                    replacement_str = []
-                    for char in replacement:  # strip off un-needed chars and patterns
-                        if char == "(":
-                            depth += 1
-                        elif char == ")":
-                            depth = max(0, depth - 1)
-                        elif depth == 0 and char not in ["^", "$"]:
-                            replacement_str.append(char)
-
-                    replacement_str = "".join(replacement_str)
-                    key, n_replace = re.subn(pattern, replacement_str, key)
+                    replacement = replacement.lstrip("^")  # strip off un-needed chars and patterns
+                    replacement = re.sub(r"\(.*\)", "", replacement)
+                    key, n_replace = re.subn(pattern, replacement, key)
                     # Early exit of the loop
                     if n_replace > 0:
                         break

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3648,7 +3648,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             for key, value in state_dict.items():
                 for pattern, replacement in reverse_key_mapping.items():
                     replacement = replacement.lstrip("^")  # strip off un-needed chars and patterns
-                    replacement = re.sub(r"\(.*?\)", "", pattern)
+                    replacement = re.sub(r"\(.*?\)", "", replacement)
                     key, n_replace = re.subn(pattern, replacement, key)
                     # Early exit of the loop
                     if n_replace > 0:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3647,9 +3647,18 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             original_state_dict = {}
             for key, value in state_dict.items():
                 for pattern, replacement in reverse_key_mapping.items():
-                    replacement = replacement.lstrip("^")  # strip off un-needed chars and patterns
-                    replacement = re.sub(r"\(.*?\)", "", replacement)
-                    key, n_replace = re.subn(pattern, replacement, key)
+                    depth = 0
+                    replacement_str = []
+                    for char in replacement:  # strip off un-needed chars and patterns
+                        if char == "(":
+                            depth += 1
+                        elif char == ")":
+                            depth = max(0, depth - 1)
+                        elif depth == 0 and char not in ["^", "$"]:
+                            replacement_str.append(char)
+
+                    replacement_str = ''.join(replacement_str)
+                    key, n_replace = re.subn(pattern, replacement_str, key)
                     # Early exit of the loop
                     if n_replace > 0:
                         break


### PR DESCRIPTION
# What does this PR do?

#37033 introduces the base models for all VLMs. The model weights will be converted by mapping the original keys according to
https://github.com/huggingface/transformers/blob/701caef704e356dc2f9331cc3fd5df0eccb4720a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L1735-L1738

However, the previous implementation of Transformers could not properly convert the weights back due to existing bugs (`replacement = re.sub(r"\(.*?\)", "", pattern)` -> `replacement = re.sub(r"\(.*?\)", "", replacement)`) and the lack of support for nested parentheses
https://github.com/huggingface/transformers/blob/701caef704e356dc2f9331cc3fd5df0eccb4720a/src/transformers/modeling_utils.py#L3644-L3657

We want to provide a more accurate weight conversion implementation to prevent issues with third-party apps.
https://github.com/hiyouga/LLaMA-Factory/issues/8147

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @zucchini-nlp 