### PR TITLE
Fix convert Phi4MM to HF Format Script

### DIFF
--- a/src/transformers/models/phi4_multimodal/convert_phi4_multimodal_weights_to_hf.py
+++ b/src/transformers/models/phi4_multimodal/convert_phi4_multimodal_weights_to_hf.py
@@ -223,9 +223,16 @@ def extract_adapters_data(input_dir: str, output_dir: str):
         for k, v in original_state_dict.items():
             if "lora" in k:
                 if "speech" in k:
-                    speech_lora[k.replace("speech.", "")] = v
+                    new_key_name = k.replace("speech.", "")
+                    new_key_name = f"base_model.model.{new_key_name}"
+
+                    speech_lora[new_key_name] = v
+
                 elif "vision" in k:
-                    vision_lora[k.replace("vision.", "")] = v
+                    new_key_name = k.replace("vision.", "")
+                    new_key_name = f"base_model.model.{new_key_name}"
+
+                    vision_lora[new_key_name] = v
 
     # Create and save the lora configs
     speech_lora_config = LoraConfig(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes
- Load all `lora_B` weights with 0 due to difference in the adapter name. 

Using the script below to load converted weights
```python
model = AutoModelForCausalLM.from_pretrained(CONVERTED_MODEL_PATH, trust_remote_code=True)
model = PeftModel.from_pretrained(model, CONVERTED_LORA_PATH_SPEECH).cuda()

count = 0
lora_params = { n: p for n, p in model.named_parameters() if 'lora_B' in n }

for n, p in lora_params.items():
    count += 1
    print(n, p.sum())

print(f"Lora_B count: {count}")
```
will have following output

```python
base_model.model.model.layers.30.mlp.gate_up_proj.lora_B.default.weight tensor(0., device='cuda:0')
base_model.model.model.layers.30.mlp.down_proj.lora_B.default.weight tensor(0., device='cuda:0')
base_model.model.model.layers.31.self_attn.o_proj.lora_B.default.weight tensor(0., device='cuda:0')
base_model.model.model.layers.31.self_attn.qkv_proj.lora_B.default.weight tensor(0., device='cuda:0')
base_model.model.model.layers.31.mlp.gate_up_proj.lora_B.default.weight tensor(0., device='cuda:0')
base_model.model.model.layers.31.mlp.down_proj.lora_B.default.weight tensor(0., device='cuda:0')
```

By appending the `base_model.model.` in front of the adapter keys' names, HF can load the adapter weights correctly for downstream finetuning, etc. Please note that the `lora_A` weights are loaded correctly, but `lora_B` weights are all with values of 0 in both `speech-lora` and `vision-lora`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
