### PR TITLE
guard size mismatch check to only quantized models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1577,7 +1577,8 @@ def _find_mismatched_keys(
                 # This skips size mismatches for 4-bit weights. Two 4-bit values share an 8-bit container, causing size differences.
                 # Without matching with module type or parameter type it seems like a practical way to detect valid 4bit weights.
                 if not (
-                    new_state_dict[key].shape[-1] == 1
+                    is_quantized
+                    and new_state_dict[key].shape[-1] == 1
                     and new_state_dict[key].numel() * 2 == model_state_dict[key].numel()
                 ):
                     mismatched_keys.append(key)


### PR DESCRIPTION
# What does this PR do?

This PR fixes https://github.com/huggingface/transformers/issues/36960
The issue that we were doing a check that was only supposed to be done on quantized models on all models. 

### To reproduce

```python
from transformers import Mask2FormerConfig, Mask2FormerForUniversalSegmentation

model_config = Mask2FormerConfig(mask_feature_size=512)
model = Mask2FormerForUniversalSegmentation.from_pretrained(
    pretrained_model_name_or_path="facebook/mask2former-swin-tiny-coco-instance",
    config=model_config,
    ignore_mismatched_sizes=True,
)
```