### PR TITLE
Trigger doc-builder job after style bot

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@8bbe6439310a830c3a0ac6db0de8f4df03139a30
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@de77d5b682eb0703c3299e1878dbdf4df1c58d58
     with:
       commit_sha: ${{ inputs.commit_sha || github.event.pull_request.head.sha }}
       pr_number: ${{ inputs.pr_number || github.event.number }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@bf7555523dc19a4a24906c0a4d2c7d0e6fa3590a
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@6e2eb04a2604817c97be03786efa494fe3acae90
     with:
       commit_sha: ${{ inputs.commit_sha || github.event.pull_request.head.sha }}
       pr_number: ${{ inputs.pr_number || github.event.number }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@f3f3583caaac988cdf7c30d426a6f5bda4419a99
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@bf7555523dc19a4a24906c0a4d2c7d0e6fa3590a
     with:
       commit_sha: ${{ inputs.commit_sha || github.event.pull_request.head.sha }}
       pr_number: ${{ inputs.pr_number || github.event.number }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -2,6 +2,15 @@ name: Build PR Documentation
 
 on:
   pull_request:
+  workflow_call:
+    inputs:
+      pr_number:
+        type: string
+        required: true
+      commit_sha:
+        type: string
+        required: true
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -9,9 +18,9 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@8bbe6439310a830c3a0ac6db0de8f4df03139a30
     with:
-      commit_sha: ${{ github.event.pull_request.head.sha }}
-      pr_number: ${{ github.event.number }}
+      commit_sha: ${{ inputs.commit_sha || github.event.pull_request.head.sha }}
+      pr_number: ${{ inputs.pr_number || github.event.number }}
       package: transformers
       languages: en

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@de77d5b682eb0703c3299e1878dbdf4df1c58d58
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@f3f3583caaac988cdf7c30d426a6f5bda4419a99
     with:
       commit_sha: ${{ inputs.commit_sha || github.event.pull_request.head.sha }}
       pr_number: ${{ inputs.pr_number || github.event.number }}

--- a/.github/workflows/pr-style-bot.yml
+++ b/.github/workflows/pr-style-bot.yml
@@ -11,9 +11,24 @@ permissions:
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@main
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@639ee721e149a281fe726a50a2cc1354b48bc463
     with:
       python_quality_dependencies: "[quality]"
       style_command_type: "default"
     secrets:
       bot_token: ${{ secrets.GITHUB_TOKEN }}
+
+  check-outputs:
+    runs-on: ubuntu-latest
+    needs: style
+    steps:
+      - run: echo ${{ needs.style.outputs.pr_number }}
+      - run: echo ${{ needs.style.outputs.new_commit_sha }}
+
+  trigger:
+    needs: style
+    if: needs.style.outputs.new_commit_sha != ''
+    uses: "./.github/workflows/build_pr_documentation.yml"
+    with:
+      pr_number: ${{ needs.style.outputs.pr_number }}
+      commit_sha: ${{ needs.style.outputs.new_commit_sha }}


### PR DESCRIPTION
# What does this PR do?

If the style bot push a commit (fixing style issue), it won't trigger doc-builder afterward.
In order to make it trigger, we could use `workflow_call` event, but we need to pass the safe commit (i.e. the new commit sha of the style fix) to prevent the the attack.