### PR TITLE
Fix MoE gradient test

### DIFF
--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -102,6 +102,7 @@ class PhimoeModelTest(CausalLMModelTest, unittest.TestCase):
 
     test_headmasking = False
     test_pruning = False
+    test_all_params_have_gradient = False
     model_tester_class = PhimoeModelTester
     pipeline_model_mapping = (
         {

--- a/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
+++ b/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
@@ -83,6 +83,7 @@ class Qwen2MoeModelTest(CausalLMModelTest, unittest.TestCase):
 
     test_headmasking = False
     test_pruning = False
+    test_all_params_have_gradient = False
     model_tester_class = Qwen2MoeModelTester
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146

--- a/tests/models/qwen3_moe/test_modeling_qwen3_moe.py
+++ b/tests/models/qwen3_moe/test_modeling_qwen3_moe.py
@@ -82,6 +82,7 @@ class Qwen3MoeModelTest(CausalLMModelTest, unittest.TestCase):
 
     test_headmasking = False
     test_pruning = False
+    test_all_params_have_gradient = False
     model_tester_class = Qwen3MoeModelTester
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146


### PR DESCRIPTION
Some MoE models get flaky failures because the gradient checkpointing test tests that all parameters have gradient, which is not true when some experts are not activated. This PR skips those tests correctly for those models.