### PR TITLE
[trainer] ensure special tokens in model configs are aligned with tokenizer at train time

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -823,8 +823,8 @@ class GenerationConfig(PushToHubMixin):
                 )
                 if logging.get_verbosity() >= logging.WARNING:
                     warning_message += " Set `TRANSFORMERS_VERBOSITY=info` for more details."
-                logger.warning(warning_message)
-                logger.info(info_message)
+                logger.warning_once(warning_message)
+                logger.info_once(info_message)
 
     def save_pretrained(
         self,

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -153,32 +153,38 @@ class GenerationConfigTest(unittest.TestCase):
         logger = transformers_logging.get_logger("transformers.generation.configuration_utils")
 
         # A correct configuration will not throw any warning
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             GenerationConfig()
         self.assertEqual(len(captured_logs.out), 0)
 
         # Inconsequent but technically wrong configuration will throw a warning (e.g. setting sampling
         # parameters with `do_sample=False`). May be escalated to an error in the future.
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             GenerationConfig(return_dict_in_generate=False, output_scores=True)
         self.assertNotEqual(len(captured_logs.out), 0)
 
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             generation_config_bad_temperature = GenerationConfig(do_sample=False, temperature=0.5)  # store for later
         self.assertNotEqual(len(captured_logs.out), 0)
 
         # Expanding on the case above, we can update a bad configuration to get rid of the warning. Ideally,
         # that is done by unsetting the parameter (i.e. setting it to None)
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             # BAD - 0.9 means it is still set, we should warn
             generation_config_bad_temperature.update(temperature=0.9)
         self.assertNotEqual(len(captured_logs.out), 0)
 
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             # CORNER CASE - 1.0 is the default, we can't detect whether it is set by the user or not, we shouldn't warn
             generation_config_bad_temperature.update(temperature=1.0)
         self.assertEqual(len(captured_logs.out), 0)
 
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             # OK - None means it is unset, nothing to warn about
             generation_config_bad_temperature.update(temperature=None)
@@ -198,12 +204,14 @@ class GenerationConfigTest(unittest.TestCase):
             GenerationConfig(logits_processor="foo")
 
         # Model-specific parameters will NOT raise an exception or a warning
+        logger.warning_once.cache_clear()
         with CaptureLogger(logger) as captured_logs:
             GenerationConfig(foo="bar")
         self.assertEqual(len(captured_logs.out), 0)
 
         # By default we throw a short warning. However, we log with INFO level the details.
         # Default: we don't log the incorrect input values, only a short summary. We explain how to get more details.
+        logger.warning_once.cache_clear()
         with LoggingLevel(logging.WARNING):
             with CaptureLogger(logger) as captured_logs:
                 GenerationConfig(do_sample=False, temperature=0.5)
@@ -212,6 +220,8 @@ class GenerationConfigTest(unittest.TestCase):
         self.assertIn("Set `TRANSFORMERS_VERBOSITY=info` for more details", captured_logs.out)
 
         # INFO level: we share the full deets
+        logger.warning_once.cache_clear()
+        logger.info_once.cache_clear()
         with LoggingLevel(logging.INFO):
             with CaptureLogger(logger) as captured_logs:
                 GenerationConfig(do_sample=False, temperature=0.5)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -48,8 +48,8 @@ from transformers import (
     default_data_collator,
     enable_full_determinism,
     get_polynomial_decay_schedule_with_warmup,
-    is_torch_available,
     is_datasets_available,
+    is_torch_available,
     logging,
     set_seed,
 )

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -4907,6 +4907,39 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
             assert len(os.listdir(tmpdir)) == trainer.state.global_step // 2
 
+    def test_bnb_compile(self):
+        from peft import LoraConfig, get_peft_model
+
+        # Simply tests if initializing a Trainer with a PEFT + compiled model works out of the box
+        # QLoRA + torch compile is not really supported yet, but we should at least support the model
+        # loading and let torch throw the
+        tiny_model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-LlamaForCausalLM", load_in_4bit=True
+        )
+
+        peft_config = LoraConfig(
+            r=8,
+            lora_alpha=32,
+            target_modules=["q_proj", "k_proj", "v_proj"],
+            lora_dropout=0.05,
+            bias="none",
+            task_type="CAUSAL_LM",
+        )
+        tiny_model = get_peft_model(tiny_model, peft_config)
+
+        tiny_model = torch.compile(tiny_model)
+
+        x = torch.randint(0, 100, (128,))
+        train_dataset = RepeatDataset(x)
+
+        args = TrainingArguments(
+            self.get_auto_remove_tmp_dir(),
+            learning_rate=1e-9,
+            logging_steps=5,
+        )
+        with self.assertRaises(ValueError):
+            _ = Trainer(tiny_model, args, train_dataset=train_dataset)  # noqa
+
 
 @require_torch
 @is_staging_test


### PR DESCRIPTION
# What does this PR do?

It's not uncommon to define new special tokens in the tokenizer at fine-tuning time. e.g. for rounds of conversations in a chat LLM. However, this is a source of misalignment: the tokenizer and the model configs (`model.config` and `model.generation_config`) may have different special tokens, leading to unexpected behavior in downstream applications.

This PR aligns the special tokens model configs at train time, if they happen to be misaligned with the tokenizer. The alignment is done at the start of training, to ensure proper eval steps and serialization 👼 

(From an [issue on Slack](https://huggingface.slack.com/archives/C01N44FJDHT/p1747996479035369) raised by @lewtun )