### PR TITLE
Fix TypeError in save_pretrained error handling (fixes #38422)

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3746,7 +3746,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
                     error_names.append(unknown)
 
             if shared_names:
-                error_names.append(set(shared_names))
+                error_names.extend(shared_names)
 
             if len(error_names) > 0:
                 raise RuntimeError(


### PR DESCRIPTION
## Summary

Fixes a TypeError in the `save_pretrained` error handling routine that occurs when `shared_names` contains shared tensors.

## Problem

In `src/transformers/modeling_utils.py` line 3747, the code attempts to call `set(shared_names)` where `shared_names` is `List[Set[str]]`. This raises:

TypeError: unhashable type: 'set'


The bug occurs because you can't create a set from a list of sets (sets are unhashable).

## Solution

Replace `error_names.append(set(shared_names))` with `error_names.extend(shared_names)` to properly handle the `List[Set[str]]` structure.

This preserves the intended behavior where `error_names` is a list of sets, with each set representing a group of tensors that share memory/storage.

## Testing

- [x] Verified syntax and imports work correctly
- [x] Tested the logic with sample data
- [x] Confirmed backward compatibility
- [x] Single line change with minimal impact

## Related Issue

Fixes #38422

## Changes

- `src/transformers/modeling_utils.py`: Replace `append(set(shared_names))` with `extend(shared_names)`