### PR TITLE
Pin Scipy version to >=1.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,7 @@ _deps = [
     "sagemaker>=2.31.0",
     "schedulefree>=1.2.6",
     "scikit-learn",
-    "scipy<1.13.0",  # SciPy >= 1.13.0 is not supported with the current jax pin (`jax>=0.4.1,<=0.4.13`)
+    "scipy<1.13.0,>=1.12.0",  # SciPy >= 1.13.0 is not supported with the current jax pin (`jax>=0.4.1,<=0.4.13`)
     "sentencepiece>=0.1.91,!=0.1.92",
     "sigopt",
     "starlette",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -75,7 +75,7 @@ deps = {
     "sagemaker": "sagemaker>=2.31.0",
     "schedulefree": "schedulefree>=1.2.6",
     "scikit-learn": "scikit-learn",
-    "scipy": "scipy<1.13.0",
+    "scipy": "scipy<1.13.0,>=1.12.0",
     "sentencepiece": "sentencepiece>=0.1.91,!=0.1.92",
     "sigopt": "sigopt",
     "starlette": "starlette",


### PR DESCRIPTION
# What does this PR do?

Pins Scippy to fix the batch of `TypeError: gaussian_filter() got an unexpected keyword argument 'axes'` issues.
