### PR TITLE
Avoid overwrite existing local implementation when loading remote custom model

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -442,8 +442,11 @@ class _BaseAutoModelClass:
             else:
                 repo_id = config.name_or_path
             model_class = get_class_from_dynamic_module(class_ref, repo_id, **kwargs)
-            model_class.register_for_auto_class(auto_class=cls)
-            cls.register(config.__class__, model_class, exist_ok=True)
+            # Only register the model class if it hasn't been registered in auto_cls,
+            # otherwise it will overwrite local implementations, causing unexpected results.
+            if not has_local_code:
+                cls.register(config.__class__, model_class, exist_ok=True)
+                model_class.register_for_auto_class(auto_class=cls)
             _ = kwargs.pop("code_revision", None)
             model_class = add_generation_mixin_to_remote_model(model_class)
             return model_class._from_config(config, **kwargs)
@@ -579,8 +582,11 @@ class _BaseAutoModelClass:
                 class_ref, pretrained_model_name_or_path, code_revision=code_revision, **hub_kwargs, **kwargs
             )
             _ = hub_kwargs.pop("code_revision", None)
-            cls.register(config.__class__, model_class, exist_ok=True)
-            model_class.register_for_auto_class(auto_class=cls)
+            # Only register the model class if it hasn't been registered in auto_cls,
+            # otherwise it will overwrite local implementations, causing unexpected results.
+            if not has_local_code:
+                cls.register(config.__class__, model_class, exist_ok=True)
+                model_class.register_for_auto_class(auto_class=cls)
             model_class = add_generation_mixin_to_remote_model(model_class)
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -442,8 +442,9 @@ class _BaseAutoModelClass:
             else:
                 repo_id = config.name_or_path
             model_class = get_class_from_dynamic_module(class_ref, repo_id, **kwargs)
-            # Only register the model class if it hasn't been registered in auto_cls,
-            # otherwise it will overwrite local implementations, causing unexpected results.
+            # This block handles the case where the user is loading a model with `trust_remote_code=True`
+            # but a library model exists with the same name. We don't want to override the autoclass
+            # mappings in this case, or all future loads of that model will be the remote code model.
             if not has_local_code:
                 cls.register(config.__class__, model_class, exist_ok=True)
                 model_class.register_for_auto_class(auto_class=cls)
@@ -582,8 +583,9 @@ class _BaseAutoModelClass:
                 class_ref, pretrained_model_name_or_path, code_revision=code_revision, **hub_kwargs, **kwargs
             )
             _ = hub_kwargs.pop("code_revision", None)
-            # Only register the model class if it hasn't been registered in auto_cls,
-            # otherwise it will overwrite local implementations, causing unexpected results.
+            # This block handles the case where the user is loading a model with `trust_remote_code=True`
+            # but a library model exists with the same name. We don't want to override the autoclass
+            # mappings in this case, or all future loads of that model will be the remote code model.
             if not has_local_code:
                 cls.register(config.__class__, model_class, exist_ok=True)
                 model_class.register_for_auto_class(auto_class=cls)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes https://github.com/vllm-project/vllm/pull/18720#discussion_r2113399427
- After loading `Alibaba-NLP/gte-Qwen2-1.5B-instruct` with `trust_remote_code=True`, the local Qwen2 implementation in HF is overwritten by its custom implementation, initializing any original Qwen2 models again will use the custom module, which causes unexpected results even if setting `trust_remote_code=False`.
- This PR adds protection to avoid overwriting any existing local model implementation in `Transformers`.

**Reproduce code:**
```python3
from sentence_transformers import SentenceTransformer

model = SentenceTransformer("Qwen/Qwen2.5-0.5B-Instruct", trust_remote_code=False, device="cuda")
print(model[0].auto_model.__class__)

model = SentenceTransformer("Alibaba-NLP/gte-Qwen2-1.5B-instruct", trust_remote_code=True)
print(model[0].auto_model.__class__)

model = SentenceTransformer("Qwen/Qwen2.5-0.5B-Instruct", trust_remote_code=False, device="cuda")
print(model[0].auto_model.__class__)
```

**Output without this PR**
```
<class 'transformers.models.qwen2.modeling_qwen2.Qwen2Model'>
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 23.80it/s]
<class 'transformers_modules.Alibaba-NLP.gte-Qwen2-1.5B-instruct.a9af15a6372d7d6b25e9fb07c2ccb9e1fe645644.modeling_qwen.Qwen2Model'>
<class 'transformers_modules.Alibaba-NLP.gte-Qwen2-1.5B-instruct.a9af15a6372d7d6b25e9fb07c2ccb9e1fe645644.modeling_qwen.Qwen2Model'>
```

**Output with this PR**
```
<class 'transformers.models.qwen2.modeling_qwen2.Qwen2Model'>
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:00<00:00, 23.64it/s]
<class 'transformers_modules.Alibaba-NLP.gte-Qwen2-1.5B-instruct.a9af15a6372d7d6b25e9fb07c2ccb9e1fe645644.modeling_qwen.Qwen2Model'>
<class 'transformers.models.qwen2.modeling_qwen2.Qwen2Model'>
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
