### PR TITLE
[Dinov2] Enable device_map="auto" support

### DIFF
--- a/src/transformers/models/dinov2/modeling_dinov2.py
+++ b/src/transformers/models/dinov2/modeling_dinov2.py
@@ -491,7 +491,7 @@ class Dinov2PreTrainedModel(PreTrainedModel):
     base_model_prefix = "dinov2"
     main_input_name = "pixel_values"
     supports_gradient_checkpointing = True
-    _no_split_modules = ["Dinov2SwiGLUFFN"]
+    _no_split_modules = ["Dinov2Layer"]
     _supports_sdpa = True
     _supports_flash_attn_2 = True
 

--- a/src/transformers/models/dinov2_with_registers/modeling_dinov2_with_registers.py
+++ b/src/transformers/models/dinov2_with_registers/modeling_dinov2_with_registers.py
@@ -509,7 +509,7 @@ class Dinov2WithRegistersPreTrainedModel(PreTrainedModel):
     base_model_prefix = "dinov2_with_registers"
     main_input_name = "pixel_values"
     supports_gradient_checkpointing = True
-    _no_split_modules = ["Dinov2WithRegistersSwiGLUFFN"]
+    _no_split_modules = ["Dinov2WithRegistersLayer"]
     _supports_sdpa = True
     _supports_flash_attn_2 = True
 

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -21,7 +21,6 @@ from transformers import Dinov2Config, Dinov2Model
 from transformers.testing_utils import (
     is_flaky,
     require_torch,
-    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -348,14 +348,4 @@ class Dinov2BackboneTest(unittest.TestCase, BackboneTesterMixin):
         self.model_tester = Dinov2ModelTester(self)
 
 
-@require_torch_multi_gpu
-@slow
-class Dinov2ModelDeviceMapTest(unittest.TestCase):
-    def test_model_parallelism(self):
-        model = Dinov2Model.from_pretrained("facebook/dinov2-base", device_map="auto")
-        self.assertTrue(hasattr(model, "hf_device_map"))
-        self.assertIsInstance(model.hf_device_map, dict)
 
-        dummy_input = torch.randn(1, 3, 224, 224).to(model.device)
-        outputs = model(pixel_values=dummy_input)
-        self.assertIsNotNone(outputs.last_hidden_state)

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -15,10 +15,13 @@
 
 import unittest
 
-from transformers import Dinov2Config
+import torch
+
+from transformers import Dinov2Config, Dinov2Model
 from transformers.testing_utils import (
     is_flaky,
     require_torch,
+    require_torch_multi_gpu,
     require_vision,
     slow,
     torch_device,
@@ -343,3 +346,18 @@ class Dinov2BackboneTest(unittest.TestCase, BackboneTesterMixin):
 
     def setUp(self):
         self.model_tester = Dinov2ModelTester(self)
+
+
+
+
+@require_torch_multi_gpu
+@slow
+class Dinov2ModelDeviceMapTest(unittest.TestCase):
+    def test_model_parallelism(self):
+        model = Dinov2Model.from_pretrained("facebook/dinov2-base", device_map="auto")
+        self.assertTrue(hasattr(model, "hf_device_map"))
+        self.assertIsInstance(model.hf_device_map, dict)
+
+        dummy_input = torch.randn(1, 3, 224, 224).to(model.device)
+        outputs = model(pixel_values=dummy_input)
+        self.assertIsNotNone(outputs.last_hidden_state)

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -15,8 +15,6 @@
 
 import unittest
 
-import torch
-
 from transformers import Dinov2Config, Dinov2Model
 from transformers.testing_utils import (
     is_flaky,
@@ -345,6 +343,3 @@ class Dinov2BackboneTest(unittest.TestCase, BackboneTesterMixin):
 
     def setUp(self):
         self.model_tester = Dinov2ModelTester(self)
-
-
-

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from transformers import Dinov2Config, Dinov2Model
+from transformers import Dinov2Config
 from transformers.testing_utils import (
     is_flaky,
     require_torch,

--- a/tests/models/dinov2/test_modeling_dinov2.py
+++ b/tests/models/dinov2/test_modeling_dinov2.py
@@ -348,8 +348,6 @@ class Dinov2BackboneTest(unittest.TestCase, BackboneTesterMixin):
         self.model_tester = Dinov2ModelTester(self)
 
 
-
-
 @require_torch_multi_gpu
 @slow
 class Dinov2ModelDeviceMapTest(unittest.TestCase):


### PR DESCRIPTION
This PR adds support for `device_map="auto"` to the Dinov2 model by defining `_no_split_modules = ["Dinov2Layer"]`, which enables inference across multiple devices using Accelerate and Transformers.

### ✔️ Summary

- Adds `_no_split_modules = ["Dinov2Layer"]` to `Dinov2PreTrainedModel`
- Includes a test `test_model_parallelism` for multi-GPU `device_map="auto"` behavior using a dummy input

### 🔬 Why this matters

Large models like Dinov2 can now be used efficiently on limited memory setups using Transformers' `device_map` feature.

Closes #29786
