### PR TITLE
Fix `Gemma2IntegrationTest`

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -23,6 +23,7 @@ import inspect
 import logging
 import multiprocessing
 import os
+import psutil
 import re
 import shlex
 import shutil
@@ -1050,6 +1051,14 @@ def require_torch_tensorrt_fx(test_case):
 def require_torch_gpu(test_case):
     """Decorator marking a test that requires CUDA and PyTorch."""
     return unittest.skipUnless(torch_device == "cuda", "test requires CUDA")(test_case)
+
+
+def require_large_cpu_ram(test_case, memory: float = 80):
+    """Decorator marking a test that requires a CPU RAM with more than `memory` GiB of memory."""
+    return unittest.skipUnless(
+        psutil.virtual_memory().total / 1024**3 > memory,
+        f"test requires a machine with more than {memory} GiB of CPU RAM memory",
+    )(test_case)
 
 
 def require_torch_large_gpu(test_case, memory: float = 20):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -44,7 +44,6 @@ from unittest import mock
 from unittest.mock import patch
 
 import huggingface_hub.utils
-import psutil
 import requests
 import urllib3
 from huggingface_hub import delete_repo
@@ -1058,6 +1057,8 @@ def require_large_cpu_ram(test_case, memory: float = 80):
     """Decorator marking a test that requires a CPU RAM with more than `memory` GiB of memory."""
     if not is_psutil_available():
         return test_case
+
+    import psutil
 
     return unittest.skipUnless(
         psutil.virtual_memory().total / 1024**3 > memory,

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -117,6 +117,7 @@ from .utils import (
     is_peft_available,
     is_phonemizer_available,
     is_pretty_midi_available,
+    is_psutil_available,
     is_pyctcdecode_available,
     is_pytesseract_available,
     is_pytest_available,
@@ -1055,6 +1056,9 @@ def require_torch_gpu(test_case):
 
 def require_large_cpu_ram(test_case, memory: float = 80):
     """Decorator marking a test that requires a CPU RAM with more than `memory` GiB of memory."""
+    if not is_psutil_available():
+        return test_case
+
     return unittest.skipUnless(
         psutil.virtual_memory().total / 1024**3 > memory,
         f"test requires a machine with more than {memory} GiB of CPU RAM memory",

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -23,7 +23,6 @@ import inspect
 import logging
 import multiprocessing
 import os
-import psutil
 import re
 import shlex
 import shutil
@@ -45,6 +44,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import huggingface_hub.utils
+import psutil
 import requests
 import urllib3
 from huggingface_hub import delete_repo

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -24,6 +24,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, Cohere2Config, is_
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
     Expectations,
+    is_flash_attn_2_available,
     require_flash_attn,
     require_read_token,
     require_torch,
@@ -282,6 +283,9 @@ class Cohere2IntegrationTest(unittest.TestCase):
         we need to correctly slice the attention mask in all cases (because we use a HybridCache).
         Outputs for every attention functions should be coherent and identical.
         """
+        if attn_implementation == "flash_attention_2" and not is_flash_attn_2_available():
+            self.skipTest("FlashAttention2 is required for this test.")
+
         if torch_device == "xpu" and attn_implementation == "flash_attention_2":
             self.skipTest(reason="Intel XPU doesn't support falsh_attention_2 as of now.")
 

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -312,7 +312,8 @@ class Gemma2IntegrationTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained("google/gemma-2-2b", pad_token="</s>", padding_side="right")
         EXPECTED_TEXT_COMPLETIONS = Expectations(
             {
-                ("cuda", 8): ['Hello I am doing a project for my class and I am having trouble with the code. I am trying to make a']
+                ("cuda", 7): ['Hello I am doing a project for my school and I need to know how to make a program that will take a number'],
+                ("cuda", 8): ['Hello I am doing a project for my class and I am having trouble with the code. I am trying to make a'],
             }
 
         )

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -23,6 +23,7 @@ from pytest import mark
 from transformers import AutoModelForCausalLM, AutoTokenizer, Gemma2Config, is_torch_available, pipeline
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
+    is_flash_attn_2_available,
     require_flash_attn,
     require_read_token,
     require_torch,
@@ -407,6 +408,8 @@ class Gemma2IntegrationTest(unittest.TestCase):
         we need to correctly slice the attention mask in all cases (because we use a HybridCache).
         Outputs for every attention functions should be coherent and identical.
         """
+        if attn_implementation == "flash_attention_2" and not is_flash_attn_2_available():
+            self.skipTest("FlashAttention2 is required for this test.")
 
         if torch_device == "xpu" and attn_implementation == "flash_attention_2":
             self.skipTest(reason="Intel XPU doesn't support falsh_attention_2 as of now.")

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -23,6 +23,7 @@ from pytest import mark
 from transformers import AutoModelForCausalLM, AutoTokenizer, Gemma2Config, is_torch_available, pipeline
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
+    cleanup,
     is_flash_attn_2_available,
     require_flash_attn,
     require_large_cpu_ram,
@@ -178,6 +179,9 @@ class Gemma2ModelTest(CausalLMModelTest, unittest.TestCase):
 @require_torch_accelerator
 class Gemma2IntegrationTest(unittest.TestCase):
     input_text = ["Hello I am doing", "Hi today"]
+
+    def tearDown(self):
+        cleanup()
 
     @tooslow
     @require_read_token

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -23,6 +23,7 @@ from pytest import mark
 from transformers import AutoModelForCausalLM, AutoTokenizer, Gemma2Config, is_torch_available, pipeline
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
+    Expectations,
     cleanup,
     is_flash_attn_2_available,
     require_flash_attn,
@@ -31,9 +32,11 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
+    require_torch_large_accelerator,
+    run_test_using_subprocess,
     slow,
     tooslow,
-    torch_device, Expectations, require_torch_large_accelerator, run_test_using_subprocess,
+    torch_device,
 )
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -255,7 +258,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
         EXPECTED_BATCH_TEXTS = Expectations(
             {
                 ("cuda", 8): [
-                    'Hello I am doing a project on the 1960s and I am trying to find out what the average',
+                    "Hello I am doing a project on the 1960s and I am trying to find out what the average",
                     "Hi today I'm going to be talking about the 10 most powerful characters in the Naruto series.",
                 ]
             }
@@ -312,10 +315,13 @@ class Gemma2IntegrationTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained("google/gemma-2-2b", pad_token="</s>", padding_side="right")
         EXPECTED_TEXT_COMPLETIONS = Expectations(
             {
-                ("cuda", 7): ['Hello I am doing a project for my school and I need to know how to make a program that will take a number'],
-                ("cuda", 8): ['Hello I am doing a project for my class and I am having trouble with the code. I am trying to make a'],
+                ("cuda", 7): [
+                    "Hello I am doing a project for my school and I need to know how to make a program that will take a number"
+                ],
+                ("cuda", 8): [
+                    "Hello I am doing a project for my class and I am having trouble with the code. I am trying to make a"
+                ],
             }
-
         )
         EXPECTED_TEXT_COMPLETION = EXPECTED_TEXT_COMPLETIONS.get_expectation()
         max_generation_length = tokenizer(EXPECTED_TEXT_COMPLETION, return_tensors="pt", padding=True)[

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -188,6 +188,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_torch_large_accelerator
     @require_read_token
+    @tooslow
     def test_model_9b_bf16(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -209,6 +210,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_torch_large_accelerator
     @require_read_token
+    @tooslow
     def test_model_9b_fp16(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -230,6 +232,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_read_token
     @require_torch_large_accelerator
+    @tooslow
     def test_model_9b_pipeline_bf16(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Gemma2 before this PR
         model_id = "google/gemma-2-9b"

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -33,7 +33,7 @@ from transformers.testing_utils import (
     require_torch_gpu,
     slow,
     tooslow,
-    torch_device, Expectations, require_torch_large_accelerator,
+    torch_device, Expectations, require_torch_large_accelerator, run_test_using_subprocess,
 )
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -419,6 +419,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
     @require_read_token
+    @run_test_using_subprocess
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a HybridCache).

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -402,6 +402,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
         eager_generated_text = tokenizer.decode(eager_outputs[0], skip_special_tokens=True)
         self.assertEqual(export_generated_text, eager_generated_text)
 
+    @require_torch_large_accelerator
     @require_read_token
     def test_model_9b_bf16_flex_attention(self):
         model_id = "google/gemma-2-9b"

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -33,7 +33,6 @@ from transformers.testing_utils import (
     require_torch_accelerator,
     require_torch_gpu,
     require_torch_large_accelerator,
-    run_test_using_subprocess,
     slow,
     tooslow,
     torch_device,
@@ -183,8 +182,11 @@ class Gemma2ModelTest(CausalLMModelTest, unittest.TestCase):
 class Gemma2IntegrationTest(unittest.TestCase):
     input_text = ["Hello I am doing", "Hi today"]
 
+    def setUp(self):
+        cleanup(torch_device, gc_collect=True)
+
     def tearDown(self):
-        cleanup(torch_device)
+        cleanup(torch_device, gc_collect=True)
 
     @require_torch_large_accelerator
     @require_read_token
@@ -428,7 +430,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
     @require_read_token
-    @run_test_using_subprocess
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a HybridCache).

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -181,7 +181,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
     input_text = ["Hello I am doing", "Hi today"]
 
     def tearDown(self):
-        cleanup()
+        cleanup(torch_device)
 
     @tooslow
     @require_read_token

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -183,7 +183,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device)
 
-    @tooslow
+    @require_torch_large_accelerator
     @require_read_token
     def test_model_9b_bf16(self):
         model_id = "google/gemma-2-9b"
@@ -204,7 +204,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @tooslow
+    @require_torch_large_accelerator
     @require_read_token
     def test_model_9b_fp16(self):
         model_id = "google/gemma-2-9b"
@@ -226,7 +226,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_read_token
-    @tooslow
+    @require_torch_large_accelerator
     def test_model_9b_pipeline_bf16(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Gemma2 before this PR
         model_id = "google/gemma-2-9b"

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -25,13 +25,14 @@ from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
     is_flash_attn_2_available,
     require_flash_attn,
+    require_large_cpu_ram,
     require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
     slow,
     tooslow,
-    torch_device, Expectations,
+    torch_device, Expectations, require_torch_large_accelerator,
 )
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -353,6 +354,7 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @slow
     @require_read_token
+    @require_large_cpu_ram
     def test_export_hybrid_cache(self):
         from transformers.integrations.executorch import TorchExportableModuleForDecoderOnlyLM
         from transformers.pytorch_utils import is_torch_greater_or_equal

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -31,10 +31,9 @@ from transformers.testing_utils import (
     require_read_token,
     require_torch,
     require_torch_accelerator,
-    require_torch_gpu,
     require_torch_large_accelerator,
+    require_torch_large_gpu,
     slow,
-    tooslow,
     torch_device,
 )
 
@@ -190,7 +189,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_torch_large_accelerator
     @require_read_token
-    @tooslow
     def test_model_9b_bf16(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -212,7 +210,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_torch_large_accelerator
     @require_read_token
-    @tooslow
     def test_model_9b_fp16(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -234,7 +231,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_read_token
     @require_torch_large_accelerator
-    @tooslow
     def test_model_9b_pipeline_bf16(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Gemma2 before this PR
         model_id = "google/gemma-2-9b"
@@ -283,16 +279,15 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @require_read_token
     @require_flash_attn
-    @require_torch_gpu
+    @require_torch_large_gpu
     @mark.flash_attn_test
     @slow
-    @tooslow
     def test_model_9b_flash_attn(self):
         # See https://github.com/huggingface/transformers/issues/31953 --- flash attn was generating garbage for gemma2, especially in long context
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
             '<bos>Hello I am doing a project on the 1918 flu pandemic and I am trying to find out how many people died in the United States. I have found a few sites that say 500,000 but I am not sure if that is correct. I have also found a site that says 675,000 but I am not sure if that is correct either. I am trying to find out how many people died in the United States. I have found a few',
-            "<pad><pad><bos>Hi today I'm going to be talking about the history of the United States. The United States of America is a country in North America. It is the third largest country in the world by total area and the third most populous country with over 320 million people. The United States is a federal republic consisting of 50 states and a federal district. The 48 contiguous states and the district of Columbia are in central North America between Canada and Mexico. The state of Alaska is in the"
+            "<pad><pad><bos>Hi today I'm going to be talking about the history of the United States. The United States of America is a country in North America. It is the third largest country in the world by total area and the third most populous country with over 320 million people. The United States is a federal republic composed of 50 states and a federal district. The 48 contiguous states and the district of Columbia are in central North America between Canada and Mexico. The state of Alaska is in the",
         ]  # fmt: skip
 
         model = AutoModelForCausalLM.from_pretrained(
@@ -408,7 +403,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(export_generated_text, eager_generated_text)
 
     @require_read_token
-    @tooslow
     def test_model_9b_bf16_flex_attention(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [


### PR DESCRIPTION
# What does this PR do?

Currently on singe-gpu T4 runner, `test_export_hybrid_cache` use more than 60G CPU RAM memory and the process is killed, so we don't receive any report.

This PR skips this tests by introducing a new `require_large_cpu_ram`. I also update some tests to make them pass and to avoid some OOM.

On T4: only 2 flex attn. related tests are failing.
On A10: only 1 flex attn. related test is failing.