### PR TITLE
Expectation changes and more AMD expectations

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3215,7 +3215,7 @@ def cleanup(device: str, gc_collect=False):
 
 
 # Type definition of key used in `Expectations` class.
-DeviceProperties = tuple[Union[str, None], Union[int, None]]
+DeviceProperties = tuple[Union[str, None], Union[None, int, tuple[int, int]]]
 
 
 @cache
@@ -3226,11 +3226,11 @@ def get_device_properties() -> DeviceProperties:
     if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
         import torch
 
-        major, _ = torch.cuda.get_device_capability()
+        major, minor = torch.cuda.get_device_capability()
         if IS_ROCM_SYSTEM:
-            return ("rocm", major)
+            return ("rocm", (major, minor))
         else:
-            return ("cuda", major)
+            return ("cuda", (major, minor))
     elif IS_XPU_SYSTEM:
         import torch
 
@@ -3249,6 +3249,20 @@ class Expectations(UserDict[DeviceProperties, Any]):
         Find best matching expectation based on environment device properties.
         """
         return self.find_expectation(get_device_properties())
+    
+    @staticmethod
+    def unpack(key: DeviceProperties) -> tuple[Optional[str], Optional[int], Optional[int]]:
+        """
+        Unpack a `DeviceProperties` tuple into a `device_type`, `major`, and `minor`.
+        """
+        device_type, major_minor = key
+        if major_minor is None:
+            major, minor = None, None
+        elif isinstance(major_minor, int):
+            major, minor = major_minor, None
+        else:
+            major, minor = major_minor
+        return device_type, major, minor
 
     @staticmethod
     def is_default(key: DeviceProperties) -> bool:
@@ -3258,29 +3272,29 @@ class Expectations(UserDict[DeviceProperties, Any]):
     def score(key: DeviceProperties, other: DeviceProperties) -> int:
         """
         Returns score indicating how similar two instances of the `Properties` tuple are.
-        Points are calculated using bits, but documented as int.
         Rules are as follows:
-            * Matching `type` gives 8 points.
-            * Semi-matching `type`, for example cuda and rocm, gives 4 points.
-            * Matching `major` (compute capability major version) gives 2 points.
-            * Default expectation (if present) gives 1 points.
+            * Matching `type` adds one point, semi-matching `type` adds half a point (e.g. cuda and rocm).
+            * If types match, matching `major` adds another point, and then matching `minor` adds another.
+            * Default expectation (if present) is worth 0.1 point to distinguish it from a straight-up zero.
         """
-        (device_type, major) = key
-        (other_device_type, other_major) = other
+        device_type, major, minor = Expectations.unpack(key)
+        other_device_type, other_major, other_minor = Expectations.unpack(other)
 
-        score = 0b0
-        if device_type == other_device_type:
-            score |= 0b1000
+        score = 0
+        # Matching device type, maybe major and minor
+        if device_type is not None and device_type == other_device_type:
+            score += 1
+            if major is not None and major == other_major:
+                score += 1
+                if minor is not None and minor == other_minor:
+                    score += 1
+        # Semi-matching device type
         elif device_type in ["cuda", "rocm"] and other_device_type in ["cuda", "rocm"]:
-            score |= 0b100
-
-        if major == other_major and other_major is not None:
-            score |= 0b10
-
+            score = 0.5
+        # Default expectation
         if Expectations.is_default(other):
-            score |= 0b1
-
-        return int(score)
+            score = 0.1
+        return score
 
     def find_expectation(self, key: DeviceProperties = (None, None)) -> Any:
         """

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3249,7 +3249,7 @@ class Expectations(UserDict[DeviceProperties, Any]):
         Find best matching expectation based on environment device properties.
         """
         return self.find_expectation(get_device_properties())
-    
+
     @staticmethod
     def unpack(key: DeviceProperties) -> tuple[Optional[str], Optional[int], Optional[int]]:
         """

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -821,6 +821,7 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("rocm", None): 'Today is a nice day and we can do this again."\n\nDana said that she will',
+                ("rocm", (9, 5)): "Today is a nice day and if you don't know anything about the state of play during your holiday",
                 ("cuda", None): "Today is a nice day and if you don't know anything about the state of play during your holiday",
             }
         )  # fmt: skip

--- a/tests/models/helium/test_modeling_helium.py
+++ b/tests/models/helium/test_modeling_helium.py
@@ -17,6 +17,7 @@ import unittest
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, HeliumConfig, is_torch_available
 from transformers.testing_utils import (
+    Expectations,
     require_read_token,
     require_torch,
     slow,
@@ -92,9 +93,13 @@ class HeliumIntegrationTest(unittest.TestCase):
     @require_read_token
     def test_model_2b(self):
         model_id = "kyutai/helium-1-preview"
-        EXPECTED_TEXTS = [
-            "Hello, today is a great day to start a new project. I have been working on a new project for a while now and I have"
-        ]
+        expected_texts = Expectations(
+            {
+                ("rocm", (9, 5)): ["Hello, today is a great day to start a new project. I have been working on a new project for a while now, and I"],
+                ("cuda", None): ["Hello, today is a great day to start a new project. I have been working on a new project for a while now and I have"],
+            }
+        )  # fmt: skip
+        EXPECTED_TEXTS = expected_texts.get_expectation()
 
         model = AutoModelForCausalLM.from_pretrained(
             model_id, low_cpu_mem_usage=True, torch_dtype=torch.bfloat16, revision="refs/pr/1"

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -113,7 +113,7 @@ class LlamaIntegrationTest(unittest.TestCase):
         """
         # diff on `EXPECTED_TEXT`:
         # 2024-08-26: updating from torch 2.3.1 to 2.4.0 slightly changes the results.
-        EXPECTED_TEXT = (
+        expected_base_text = (
             "Tell me about the french revolution. The french revolution was a period of radical political and social "
             "upheaval in France that lasted from 1789 until 1799. It was a time of great change and upheaval, marked "
             "by the overthrow of the monarchy, the rise of the middle class, and the eventual establishment of the "
@@ -122,6 +122,13 @@ class LlamaIntegrationTest(unittest.TestCase):
             "demanded greater representation and eventually broke away to form the National Assembly. This marked "
             "the beginning of the end of the absolute monarchy and the rise of the middle class.\n"
         )
+        expected_texts = Expectations(
+            {
+                ("rocm", (9, 5)): expected_base_text.replace("political and social", "social and political"),
+                ("cuda", None): expected_base_text,
+            }
+        )  # fmt: skip
+        EXPECTED_TEXT = expected_texts.get_expectation()
 
         tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3.1-8B-Instruct")
         model = LlamaForCausalLM.from_pretrained(

--- a/tests/models/paligemma/test_modeling_paligemma.py
+++ b/tests/models/paligemma/test_modeling_paligemma.py
@@ -27,6 +27,7 @@ from transformers import (
     is_vision_available,
 )
 from transformers.testing_utils import (
+    Expectations,
     cleanup,
     require_read_token,
     require_torch,
@@ -602,7 +603,13 @@ class PaliGemmaForConditionalGenerationIntegrationTest(unittest.TestCase):
 
         output = model.generate(**inputs, max_new_tokens=20)
 
-        EXPECTED_DECODED_TEXT = "detect shoe\n<loc0051><loc0309><loc0708><loc0646> shoe"  # fmt: skip
+        expected_decoded_texts = Expectations(
+            {
+                ("rocm", (9, 5)): "detect shoe\n<loc0051><loc0309><loc0708><loc0644> shoe",
+                ("cuda", None): "detect shoe\n<loc0051><loc0309><loc0708><loc0646> shoe",
+            }
+        )  # fmt: skip
+        EXPECTED_DECODED_TEXT = expected_decoded_texts.get_expectation()
         self.assertEqual(self.processor.decode(output[0], skip_special_tokens=True), EXPECTED_DECODED_TEXT)
 
     def test_paligemma_index_error_bug(self):

--- a/tests/models/phi3/test_modeling_phi3.py
+++ b/tests/models/phi3/test_modeling_phi3.py
@@ -19,6 +19,7 @@ import unittest
 from transformers import Phi3Config, StaticCache, is_torch_available
 from transformers.models.auto.configuration_auto import AutoConfig
 from transformers.testing_utils import (
+    Expectations,
     require_torch,
     slow,
     torch_device,
@@ -353,9 +354,14 @@ class Phi3IntegrationTest(unittest.TestCase):
         model_id = "microsoft/Phi-4-mini-instruct"
 
         tokenizer = AutoTokenizer.from_pretrained(model_id, pad_token="</s>", padding_side="right")
-        EXPECTED_TEXT_COMPLETION = [
-            "You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user. A 45-year-old patient with a 10-year history of type 2 diabetes mellitus, who is currently on metformin and a SGLT2 inhibitor, presents with a 2-year history"
-        ]
+
+        expected_text_completions = Expectations(
+            {
+                ("rocm", (9, 5)): ["You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user. A 45-year-old patient with a 10-year history of type 2 diabetes mellitus presents with a 2-year history of progressive, non-healing, and painful, 2.5 cm"],
+                ("cuda", None): ["You are a helpful digital assistant. Please provide safe, ethical and accurate information to the user. A 45-year-old patient with a 10-year history of type 2 diabetes mellitus, who is currently on metformin and a SGLT2 inhibitor, presents with a 2-year history"],
+            }
+        )  # fmt: skip
+        EXPECTED_TEXT_COMPLETION = expected_text_completions.get_expectation()
         max_generation_length = tokenizer(EXPECTED_TEXT_COMPLETION, return_tensors="pt", padding=True)[
             "input_ids"
         ].shape[-1]

--- a/tests/models/qwen3/test_modeling_qwen3.py
+++ b/tests/models/qwen3/test_modeling_qwen3.py
@@ -22,8 +22,8 @@ from packaging import version
 from transformers import AutoTokenizer, Qwen3Config, is_torch_available, set_seed
 from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
-    backend_empty_cache,
     Expectations,
+    backend_empty_cache,
     require_bitsandbytes,
     require_flash_attn,
     require_torch,

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -17,8 +17,8 @@ import unittest
 
 from transformers import XGLMConfig, is_torch_available
 from transformers.testing_utils import (
-    cleanup,
     Expectations,
+    cleanup,
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
@@ -422,7 +422,6 @@ class XGLMModelLanguageGenerationTest(unittest.TestCase):
         input_ids = tokenized.input_ids
         output_ids = model.generate(input_ids, do_sample=True, num_beams=1)
         output_str = tokenizer.decode(output_ids[0], skip_special_tokens=True)
-
 
         expected_output_strings = Expectations(
             { # Here, rocm 9.5 diverge a lot from cuda, dont hesitate to change the expectation. TODO: investigate

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -18,6 +18,7 @@ import unittest
 from transformers import XGLMConfig, is_torch_available
 from transformers.testing_utils import (
     cleanup,
+    Expectations,
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
@@ -422,10 +423,14 @@ class XGLMModelLanguageGenerationTest(unittest.TestCase):
         output_ids = model.generate(input_ids, do_sample=True, num_beams=1)
         output_str = tokenizer.decode(output_ids[0], skip_special_tokens=True)
 
-        EXPECTED_OUTPUT_STR = (
-            "Today is a nice day and the water is still cold. We just stopped off for some fresh coffee. This place"
-            " looks like a"
-        )
+
+        expected_output_strings = Expectations(
+            { # Here, rocm 9.5 diverge a lot from cuda, dont hesitate to change the expectation. TODO: investigate
+                ("rocm", (9, 5)): "Today is a nice day and the sun is shining. A nice day with warm rainy and windy weather today." ,
+                ("cuda", None): "Today is a nice day and the water is still cold. We just stopped off for some fresh coffee. This place looks like a",
+            }
+        )  # fmt: skip
+        EXPECTED_OUTPUT_STR = expected_output_strings.get_expectation()
         self.assertEqual(output_str, EXPECTED_OUTPUT_STR)
 
     @require_torch_accelerator


### PR DESCRIPTION
This PR adds support for minor version in the `Expectations` system and changes the way the score is computed to avoid cross-device comparison. It also uses the revamped system to fix 6 tests on AMD devices.

cc. @mht-sharma