### PR TITLE
On branch fix-void-segment-mask-input [WIP]

### DIFF
--- a/void_batch_test.py
+++ b/void_batch_test.py
@@ -10,12 +10,6 @@ from src.adaptive_batch_trainer import AdaptiveBatchSizeTrainer
 
 
 
-import numpy as np
-import torch
-from torch.utils.data import Dataset
-import random
-from typing import Tuple
-
 class DummySegmentationDataset(Dataset):
     """
     Dummy segmentation dataset backed by NumPy, with a few fully-void masks.

--- a/void_batch_test.py
+++ b/void_batch_test.py
@@ -1,0 +1,171 @@
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+from functools import partial
+import random
+from typing import List, Dict, Any, Tuple
+
+from transformers import Mask2FormerConfig, Mask2FormerModel
+from src.adaptive_batch_trainer import AdaptiveBatchSizeTrainer
+
+
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+import random
+from typing import Tuple
+
+class DummySegmentationDataset(Dataset):
+    """
+    Dummy segmentation dataset backed by NumPy, with a few fully-void masks.
+
+    Args:
+        num_samples:       total number of samples in the dataset (>0)
+        image_size:        (H, W) of each image, both >0
+        num_classes:       number of segmentation classes (>0)
+        void_count:        number of samples whose mask is entirely ignore_index
+        ignore_index:      label value in the mask to indicate “void” pixels
+        seed:              random seed for reproducibility
+    """
+    def __init__(
+        self,
+        num_samples: int,
+        image_size: Tuple[int, int] = (4, 4),
+        num_classes: int = 5,
+        void_count: int = 2,
+        ignore_index: int = 255,
+        seed: int = 42,
+    ):
+        self.num_samples   = num_samples
+        self.image_size    = image_size  # (H, W)
+        self.num_classes   = num_classes
+        self.ignore_index  = ignore_index
+
+        # -- Decide which indices are fully void --
+        random.seed(seed)
+        self.void_indices = set(random.sample(range(num_samples), void_count))
+
+    def __len__(self) -> int:
+        return self.num_samples
+
+    def __getitem__(self, idx: int) -> dict:
+        # Let Python naturally raises IndexError if idx is out of bounds
+        H, W = self.image_size
+
+        # 1) Generate a normalized image in NumPy, then convert to torch (C,H,W)
+        image_norm = np.random.rand(H, W, 3).astype(np.float32)
+        pixel_values = torch.from_numpy(image_norm).permute(2, 0, 1)
+
+        # 2) Generate either a random mask or an all-void mask
+        if idx in self.void_indices:
+            semantic_mask = np.full((H, W), fill_value=self.ignore_index, dtype=np.uint8)
+        else:
+            semantic_mask = np.random.randint(
+                low=0,
+                high=self.num_classes,
+                size=(H, W),
+                dtype=np.uint8
+            )
+        labels = torch.from_numpy(semantic_mask).long()
+
+        return {
+            "pixel_values": pixel_values,  # (3, H, W)
+            "labels": labels,              # (H, W)
+            "index": idx
+        }
+
+
+
+def collate_fn(batch: List[Dict[str, Any]]) -> Dict[str, torch.Tensor]:
+    """
+    Collates a list of items into a batch dict:
+      - 'pixel_values': (B, C, H, W) float32
+      - 'labels':       (B, H, W)    int64
+      - 'indices':      (B,)         int64
+
+    How it works on high-level
+    1. Converts any NumPy arrays into PyTorch tensors (so it works if your dataset returns raw NumPy)
+    2. Leaves tensors alone
+    3. Stacks images and masks into batched tensors as 'pixel_values', `labels` respectively
+    """
+    pixel_values, labels, indices = [], [], []
+
+    for item in batch:
+        for key in ("pixel_values", "labels", "index"):
+            if key not in item:
+                raise KeyError(f"Batch item missing '{key}' field")
+
+        img, msk, idx = item["pixel_values"], item["labels"], item["index"]
+
+        # -- convert numpy image H×W×3 → torch C×H×W
+        if isinstance(img, np.ndarray):
+            # cast to float32 if not already
+            img = img.astype(np.float32, copy=False)
+            img = torch.from_numpy(img).permute(2, 0, 1)
+
+        # -- convert numpy mask H×W → torch long
+        if isinstance(msk, np.ndarray):
+            # assume msk is uint8; cast to long for losses
+            msk = torch.from_numpy(msk).long()
+
+        pixel_values.append(img)
+        labels.append(msk)
+        indices.append(idx)
+
+    # stack into batch dims
+    try:
+        batch_images = torch.stack(pixel_values, dim=0)          # (B, C, H, W)
+        batch_masks  = torch.stack(labels,      dim=0)           # (B, H, W)
+        batch_idxs   = torch.tensor(indices,    dtype=torch.long)
+    except Exception as e:
+        raise RuntimeError(f"Error stacking batch tensors: {e}")
+
+    return {
+        "pixel_values": batch_images,
+        "labels":       batch_masks,
+        "indices":      batch_idxs,
+    }
+
+
+
+def custom_batch_size_scheduler(step: int,
+                                batch_size: int,
+                                interval=5,
+                                increment=1):
+    """
+        step: current optimization step to be provided by the trainer.
+        batch_size: current optimization step  to be provided by the trainer.
+    """
+    if step % interval == 0 and step > 0:
+        return batch_size + increment
+    return batch_size
+
+
+
+# -------------------------------------------------------------------
+# main
+# -------------------------------------------------------------------
+# put your training_args here
+config = Mask2FormerConfig()
+model  = Mask2FormerModel(config)
+dummy_data = DummySegmentationDataset(
+    num_samples=100,
+    image_size=(3, 256, 256),
+    num_classes=5
+)
+scheduler = partial(
+    custom_batch_size_scheduler,
+    interval=5,
+    increment=1,
+)
+trainer = AdaptiveBatchSizeTrainer(
+    batch_size_scheduler=scheduler,
+    model=model,
+    args=training_args,      
+    train_dataset=dummy_data,
+    data_collator=collate_fn
+)
+
+# Start training
+trainer.train()


### PR DESCRIPTION
Changes to be committed:
	modified:   src/transformers/models/mask2former/image_processing_mask2former.py

Fix [#30064](https://github.com/huggingface/transformers/issues/30064)
This differ from previous PR fix [#30335](https://github.com/huggingface/transformers/pull/30335)? This fix tackles an edge case where an image's segment map only has background pixel (255 class label) whereas the previous PR fix doesn't.

### How is this PR fix intended to works?
Let's input a batch into `class Mask2FormerImageProcessor`, where `images = [img_1, img_2, img_3,..., img_B]` and its corresponding `segmentation maps = [map_1, map_2,  map_3,... , map_B]`. Suppose `map_1` and `map_2` are void maps, then `def filter_image_with_void_segmentation_map` will pop void maps and its corresponding images, returning only `images = [img_3,..., img_B]` and `segmentation_maps = [map_3,..., map_B]`

I believe several testings will be desired, please advice.

### Before submitting
This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
[documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
[here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

### Who can review?
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@amyeroberts @NielsRogge @Lynsoo 

### Things to work on before this PR works, I think
- [ ] Implement `AdaptiveBatchSizeTrainer` to [continue model's training despite reduced batch size](https://github.com/huggingface/transformers/pull/38532#issuecomment-2937069511)
- [ ] Add a specific condition to only filter void map during validation. That's my interpretation of OP's question in [#30064](https://github.com/huggingface/transformers/issues/30064): "when training segmentation models, shouldn't it be possible to include images with only background/void class?" But this question is never addressed so idk whether you guys want void class when training model or no?
