### PR TITLE
update emu3 test

### DIFF
--- a/tests/models/emu3/test_modeling_emu3.py
+++ b/tests/models/emu3/test_modeling_emu3.py
@@ -541,7 +541,7 @@ class Emu3IntegrationTest(unittest.TestCase):
         )
         self.assertTrue(out.shape[1] == 54)
 
-        image = model.decode_image_tokens(out[:, inputs.input_ids.shape[1] :], height=HEIGHT, width=WIDTH)
+        image = model.decode_image_tokens(image_tokens=out[:, inputs.input_ids.shape[1] :], height=HEIGHT, width=WIDTH)
         images = processor.postprocess(list(image.float()), return_tensors="np")
         self.assertTrue(images["pixel_values"].shape == (3, 40, 40))
         self.assertTrue(isinstance(images["pixel_values"], np.ndarray))
@@ -552,4 +552,4 @@ class Emu3IntegrationTest(unittest.TestCase):
             repo_type="dataset",
         )
         original_pixels = np.load(filepath)
-        self.assertTrue(np.allclose(original_pixels, images["pixel_values"]))
+        self.assertTrue(np.allclose(original_pixels, images["pixel_values"], atol=1))


### PR DESCRIPTION
Hi @zucchini-nlp. This PR fixed:
1. The correct usage of [decode_image_tokens](https://github.com/huggingface/transformers/blob/main/src/transformers/models/emu3/modeling_emu3.py#L1619) because the input only supports `**kwagrs`
2. Use atol=1 to check the result to avoid numerical precision error across different devices. The pixel values are uint8, ranging from 0 to 255. atol=1 will only handle very small precision errors, which is in our expectation.