### PR TITLE
Fix CTRL model DataParallel compatibility

### DIFF
--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -145,7 +145,7 @@ class MultiHeadAttention(nn.Module):
             v = torch.cat((past_value, v), dim=-2)
 
         if use_cache is True:
-            present = torch.stack((k, v))
+            present = (k, v)
         else:
             present = (None,)
 


### PR DESCRIPTION
# Problem
CTRL model fails with torch.nn.DataParallel when batch sizes don't divide evenly across GPUs, particularly affecting ROCm users.
Error:
`RuntimeError: Input tensor at index 2 has invalid shape [2, 1, 4, 7, 8], but expected [2, 2, 4, 7, 8]`
# Root Cause
CTRL model returns past_key_values as 5D tensors [2, batch, heads, seq, head_dim] instead of tuple format (key_4d, value_4d) used by other transformer models. This non-standard format is incompatible with DataParallel's gather operation when batches split unevenly across GPUs.
# Solution
File: src/transformers/models/ctrl/modeling_ctrl.py
Line 148: Changed present = torch.stack((k, v)) to present = (k, v)
Before: 5D tensor [2, batch, heads, seq, head_dim] 
After: Tuple of 4D tensors ([batch, heads, seq, head_dim], [batch, heads, seq, head_dim]) 
@remi-or 