### PR TITLE
Fix hqq issue

### DIFF
--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -135,7 +135,7 @@ class HqqHfQuantizer(HfQuantizer):
 
             # Append new expected layers based on _ref_keys
             _ref_keys = HQQLinear(
-                linear_layer=None, quant_config=None, compute_dtype=torch.float16, device="cpu"
+                linear_layer=None, quant_config=None, compute_dtype=torch.float16, device="cpu", del_orig= False,
             ).state_dict_keys() - {"bias"}
 
             # Clean-up
@@ -224,6 +224,7 @@ class HqqHfQuantizer(HfQuantizer):
                     quant_config=None,
                     compute_dtype=self.torch_dtype,
                     device=target_device,
+                    del_orig= False,
                 )
 
             hqq_layer.load_state_dict(module_state_dict)

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -135,7 +135,11 @@ class HqqHfQuantizer(HfQuantizer):
 
             # Append new expected layers based on _ref_keys
             _ref_keys = HQQLinear(
-                linear_layer=None, quant_config=None, compute_dtype=torch.float16, device="cpu", del_orig= False,
+                linear_layer=None,
+                quant_config=None,
+                compute_dtype=torch.float16,
+                device="cpu",
+                del_orig=False,
             ).state_dict_keys() - {"bias"}
 
             # Clean-up
@@ -224,7 +228,7 @@ class HqqHfQuantizer(HfQuantizer):
                     quant_config=None,
                     compute_dtype=self.torch_dtype,
                     device=target_device,
-                    del_orig= False,
+                    del_orig=False,
                 )
 
             hqq_layer.load_state_dict(module_state_dict)


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue that appeared in the latest release of hqq. As linear_layer=None, we should set del_orig=False. Otherwise, it will consider that linear_layer is actually a layer, triggering an error. 

PR in question https://github.com/mobiusml/hqq/commit/a566c78961ea408c747ad2a9bd4f3a9235ff3b70