### PR TITLE
Fix `utils/notification_service.py`

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -615,7 +615,8 @@ class Message:
                         pattern = r"<(https://github.com/huggingface/transformers/actions/runs/.+?/job/.+?)\|(.+?)>"
                         items = re.findall(pattern, line)
                     elif "tests/" in line:
-                        if "tests/models/" in line or "tests/quantization/" in line:
+                        # TODO: Remove `quantization` from the matrix for `Model CI` job, and improve the condition here.
+                        if "tests/models/" in line or ("tests/quantization/" in line and job_name == "run_quantization_torch_gpu"):
                             model = line.split("/")[2]
                         else:
                             model = line.split("/")[1]

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -615,7 +615,7 @@ class Message:
                         pattern = r"<(https://github.com/huggingface/transformers/actions/runs/.+?/job/.+?)\|(.+?)>"
                         items = re.findall(pattern, line)
                     elif "tests/" in line:
-                        # TODO: Remove `quantization` from the matrix for `Model CI` job, and improve the condition here.
+                        # TODO: Improve the condition here.
                         if "tests/models/" in line or (
                             "tests/quantization/" in line and job_name == "run_quantization_torch_gpu"
                         ):

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -616,7 +616,9 @@ class Message:
                         items = re.findall(pattern, line)
                     elif "tests/" in line:
                         # TODO: Remove `quantization` from the matrix for `Model CI` job, and improve the condition here.
-                        if "tests/models/" in line or ("tests/quantization/" in line and job_name == "run_quantization_torch_gpu"):
+                        if "tests/models/" in line or (
+                            "tests/quantization/" in line and job_name == "run_quantization_torch_gpu"
+                        ):
                             model = line.split("/")[2]
                         else:
                             model = line.split("/")[1]


### PR DESCRIPTION
# What does this PR do?

Currently, `Model CI` still include `quantization` in its matrix. And when there is any failure in it, the key in the new failure json report contains the key like `bnb` not `quantization`. 

However, the `job_link` contains the key `quantization` (as it is in `Model CI` job not `Quantization` job, so the whole `quantization` is a single job)


See https://github.com/huggingface/transformers/actions/runs/15407385951/job/43361291899

I think we can remove `quantization` from `Model CI` job, WDYT?

But in the long-term, we still need (a better) way to avoid such failures. This PR still implement a quick fix.