### PR TITLE
Relaxed the output_attention condition for ValueError

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -340,7 +340,8 @@ class PretrainedConfig(PushToHubMixin):
 
     @output_attentions.setter
     def output_attentions(self, value):
-        if self._attn_implementation != "eager":
+        # We always allow updates with the default value, which is False
+        if (self._attn_implementation != "eager") and (value is not False):
             raise ValueError(
                 "The `output_attentions` attribute is not supported when using the `attn_implementation` set to "
                 f"{self._attn_implementation}. Please set it to 'eager' instead."


### PR DESCRIPTION
In the `GenerationConfig` object, the `output_attentions` attribute is not meant to evaluate to true when `attn_implementation` is not eager, eg. it is SDPA. 
An issue arises we have a `GenerationConfig` object `gen_cfg_0` with `attn_implementation == "sdpa"` and want to update some of its keys with another `gen_cfg_1` object. Since `GenerationConfig` sets `self.output_attentions = False` by default, when when doing the update, `gen_cfg_0` thinks we are trying to update `output_attention` to `True` even though we are updating it from `False` to `False`, which is totally ok. 
To avoid this, we added a very restrictive check (`value is False` which more restrictive than just checking if value evaluates to false) to always allow update of `output_attentions` with the default value `False`. 

cc. @mht-sharma 