### PR TITLE
fix(attention_visualizer): add default value for image_seq_length

### DIFF
--- a/src/transformers/utils/attention_visualizer.py
+++ b/src/transformers/utils/attention_visualizer.py
@@ -178,6 +178,7 @@ class AttentionMaskVisualizer:
     def visualize_attention_mask(self, input_sentence: str, suffix=""):
         model = self.model
         kwargs = {}
+        image_seq_length = None
         if self.config.model_type in PROCESSOR_MAPPING_NAMES:
             img = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/bee.jpg?download=true"
             img = Image.open(requests.get(img, stream=True).raw)


### PR DESCRIPTION
# What does this PR do?
Fixes a small bug in `attention_visualizer.py` where `image_seq_length` may be used before assignment.

# 🐛 Bug Description

Calling `visualize_attention_mask()` triggers:
UnboundLocalError: cannot access local variable 'image_seq_length' where it is not associated with a value

# Fix

Just adds one line code

image_seq_length = None

Fixes  #38576 


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] (N/A) Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] (N/A) Did you write any new necessary tests?


## Who can review?
@ArthurZucker 





