### PR TITLE
Add Expectations for three AMD tests

### DIFF
--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -19,6 +19,7 @@ import pytest
 
 from transformers import AutoModelForCausalLM, AutoTokenizer, GlmConfig, is_torch_available
 from transformers.testing_utils import (
+    Expectations,
     require_flash_attn,
     require_torch,
     require_torch_large_accelerator,
@@ -127,10 +128,17 @@ class GlmIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     def test_model_9b_eager(self):
-        EXPECTED_TEXTS = [
-            "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
-            "Hi today I am going to show you how to make a simple and easy to make a DIY paper flower.",
-        ]
+        expected_texts = Expectations({
+            ("cuda", None): [
+                "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
+                "Hi today I am going to show you how to make a simple and easy to make a DIY paper flower.",
+            ],
+            ("rocm", (9,5)) : [
+                "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
+                "Hi today I am going to show you how to make a simple and easy to make a paper airplane. First",
+            ]
+        })  # fmt: skip
+        EXPECTED_TEXTS = expected_texts.get_expectation()
 
         model = AutoModelForCausalLM.from_pretrained(
             self.model_id,

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -133,7 +133,7 @@ class GlmIntegrationTest(unittest.TestCase):
                 "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
                 "Hi today I am going to show you how to make a simple and easy to make a DIY paper flower.",
             ],
-            ("rocm", (9,5)) : [
+            ("rocm", (9, 5)) : [
                 "Hello I am doing a project on the history of the internetSolution:\n\nStep 1: Introduction\nThe history of the",
                 "Hi today I am going to show you how to make a simple and easy to make a paper airplane. First",
             ]

--- a/tests/models/siglip2/test_modeling_siglip2.py
+++ b/tests/models/siglip2/test_modeling_siglip2.py
@@ -23,6 +23,7 @@ from pytest import mark
 
 from transformers import Siglip2Config, Siglip2TextConfig, Siglip2VisionConfig
 from transformers.testing_utils import (
+    Expectations,
     is_flaky,
     require_flash_attn,
     require_torch,
@@ -760,17 +761,19 @@ class Siglip2ModelIntegrationTest(unittest.TestCase):
 
         # verify the logits values
         # fmt: off
-        expected_logits_per_text = torch.tensor(
-            [
-                [  1.0195,  -0.0280,  -1.4468],
-                [ -4.5395,  -6.2269,  -1.5667],
-                [  4.1757,   5.0358,   3.5159],
-                [  9.4264,  10.1879,   6.3353],
-                [  2.4409,   3.1058,   4.5491],
-                [-12.3230, -13.7355, -13.4632],
+        expected_logits_per_texts = Expectations({
+            ("cuda", None): [
+                [  1.0195,  -0.0280,  -1.4468], [ -4.5395,  -6.2269,  -1.5667], [  4.1757,   5.0358,   3.5159],
+                [  9.4264,  10.1879,   6.3353], [  2.4409,   3.1058,   4.5491], [-12.3230, -13.7355, -13.4632],
                 [  1.1520,   1.1687,  -1.9647],
-            ]
-        ).to(torch_device)
+            ],
+            ("rocm", (9, 5)): [
+                [  1.0236,  -0.0376,  -1.4464], [ -4.5358,  -6.2235,  -1.5628], [  4.1708,   5.0334,   3.5187],
+                [  9.4241,  10.1828,   6.3366], [  2.4371,   3.1062,   4.5530], [-12.3173, -13.7240, -13.4580],
+                [  1.1502,   1.1716,  -1.9623]
+            ],
+        })
+        EXPECTED_LOGITS_PER_TEXT = torch.tensor(expected_logits_per_texts.get_expectation()).to(torch_device)
         # fmt: on
 
-        torch.testing.assert_close(outputs.logits_per_text, expected_logits_per_text, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(outputs.logits_per_text, EXPECTED_LOGITS_PER_TEXT, rtol=1e-3, atol=1e-3)

--- a/tests/pipelines/test_pipelines_mask_generation.py
+++ b/tests/pipelines/test_pipelines_mask_generation.py
@@ -26,6 +26,7 @@ from transformers import (
 )
 from transformers.pipelines import MaskGenerationPipeline
 from transformers.testing_utils import (
+    Expectations,
     is_pipeline_test,
     nested_simplify,
     require_tf,
@@ -120,6 +121,11 @@ class MaskGenerationPipelineTests(unittest.TestCase):
             new_outupt += [{"mask": mask_to_test_readable(o), "scores": outputs["scores"][i]}]
 
         # fmt: off
+        last_output = Expectations({
+            ("cuda", None): {'mask': {'hash': 'b5f47c9191', 'shape': (480, 640)}, 'scores': 0.8871},
+            ("rocm", (9, 5)): {'mask': {'hash': 'b5f47c9191', 'shape': (480, 640)}, 'scores': 0.8872}
+        }).get_expectation()
+
         self.assertEqual(
             nested_simplify(new_outupt, decimals=4),
             [
@@ -152,7 +158,7 @@ class MaskGenerationPipelineTests(unittest.TestCase):
                 {'mask': {'hash': '7b9e8ddb73', 'shape': (480, 640)}, 'scores': 0.8986},
                 {'mask': {'hash': 'cd24047c8a', 'shape': (480, 640)}, 'scores': 0.8984},
                 {'mask': {'hash': '6943e6bcbd', 'shape': (480, 640)}, 'scores': 0.8873},
-                {'mask': {'hash': 'b5f47c9191', 'shape': (480, 640)}, 'scores': 0.8871}
+                last_output
             ],
         )
         # fmt: on


### PR DESCRIPTION
This PR fixes three tests failing on AMD:
- tests/models/glm/test_modeling_glm.py - test_model_9b_eager
- tests/models/siglip2/test_modeling_siglip2.py - test_inference
- tests/pipelines/test_pipelines_mask_generation.py - test_small_model_pt

cc. @mht-sharma 