### PR TITLE
Update Mamba configuration to enable bias by default in the mixer blo…

### DIFF
--- a/src/transformers/models/mamba/configuration_mamba.py
+++ b/src/transformers/models/mamba/configuration_mamba.py
@@ -53,7 +53,7 @@ class MambaConfig(PretrainedConfig):
             The id of the end of sentence token in the vocabulary.
         expand (`int`, *optional*, defaults to 2): Expanding factor used to determine the intermediate size.
         conv_kernel (`int`, *optional*, defaults to 4): Size of the convolution kernel.
-        use_bias (`bool`, *optional*, defaults to `False`):
+        use_bias (`bool`, *optional*, defaults to `True`):
             Whether or not to use bias in ["in_proj", "out_proj"] of the mixer block
         use_conv_bias (`bool`, *optional*, defaults to `True`):
             Whether or not to use bias in the convolution layer of the mixer block.
@@ -112,7 +112,7 @@ class MambaConfig(PretrainedConfig):
         eos_token_id=0,
         expand=2,
         conv_kernel=4,
-        use_bias=False,
+        use_bias=True,
         use_conv_bias=True,
         hidden_act="silu",
         initializer_range=0.1,

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -77,36 +77,48 @@ class MambaMixer(nn.Module):
         self.time_step_rank = int(config.time_step_rank)
         self.layer_idx = layer_idx
         self.use_conv_bias = config.use_conv_bias
+        self.use_bias = config.use_bias
+
+        # Initialize conv1d with bias if specified
         self.conv1d = nn.Conv1d(
             in_channels=self.intermediate_size,
             out_channels=self.intermediate_size,
-            bias=config.use_conv_bias,
+            bias=self.use_conv_bias,
             kernel_size=config.conv_kernel,
             groups=self.intermediate_size,
             padding=config.conv_kernel - 1,
         )
+        if self.use_conv_bias:
+            nn.init.zeros_(self.conv1d.bias)
 
         self.activation = config.hidden_act
         self.act = ACT2FN[config.hidden_act]
 
         self.use_mambapy = config.use_mambapy
 
-        # projection of the input hidden states
-        self.in_proj = nn.Linear(self.hidden_size, self.intermediate_size * 2, bias=config.use_bias)
+        # Initialize projections with bias if specified
+        self.in_proj = nn.Linear(self.hidden_size, self.intermediate_size * 2, bias=self.use_bias)
+        if self.use_bias:
+            nn.init.zeros_(self.in_proj.bias)
+
         # selective projection used to make dt, B and C input dependent
         self.x_proj = nn.Linear(self.intermediate_size, self.time_step_rank + self.ssm_state_size * 2, bias=False)
+        
         # time step projection (discretization)
         self.dt_proj = nn.Linear(self.time_step_rank, self.intermediate_size, bias=True)
+        nn.init.zeros_(self.dt_proj.bias)
 
-        # S4D real initialization. These are not discretized!
-        # The core is to load them, compute the discrete states, then write the updated state. Keeps the memory bounded
+        # S4D real initialization
         A = torch.arange(1, self.ssm_state_size + 1, dtype=torch.float32)[None, :]
         A = A.expand(self.intermediate_size, -1).contiguous()
 
         self.A_log = nn.Parameter(torch.log(A))
         self.D = nn.Parameter(torch.ones(self.intermediate_size))
-        self.out_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=config.use_bias)
-        self.use_bias = config.use_bias
+        
+        # Initialize output projection with bias if specified
+        self.out_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=self.use_bias)
+        if self.use_bias:
+            nn.init.zeros_(self.out_proj.bias)
 
         if not is_fast_path_available:
             if self.use_mambapy:
@@ -138,19 +150,32 @@ class MambaMixer(nn.Module):
         projected_states = self.in_proj(hidden_states).transpose(1, 2)
 
         if self.training and cache_params is None:  # Doesn't support outputting the states -> used for training
+            # Ensure all bias terms are properly handled and have correct shapes
+            conv_bias = self.conv1d.bias if self.use_conv_bias else None
+            dt_bias = self.dt_proj.bias if hasattr(self.dt_proj, "bias") else None
+            out_bias = self.out_proj.bias if self.use_bias else None
+
+            # Convert bias terms to float32 to ensure consistent dtype
+            if conv_bias is not None:
+                conv_bias = conv_bias.float()
+            if dt_bias is not None:
+                dt_bias = dt_bias.float()
+            if out_bias is not None:
+                out_bias = out_bias.float()
+
             contextualized_states = mamba_inner_fn(
                 projected_states,
                 self.conv1d.weight,
-                self.conv1d.bias if self.use_conv_bias else None,
+                conv_bias,
                 self.x_proj.weight,
                 self.dt_proj.weight,
                 self.out_proj.weight,
-                self.out_proj.bias.float() if self.use_bias else None,
+                out_bias,
                 -torch.exp(self.A_log.float()),
                 None,  # input-dependent B
                 None,  # input-dependent C
                 self.D.float(),
-                delta_bias=self.dt_proj.bias.float(),
+                delta_bias=dt_bias,
                 delta_softplus=True,
             )
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

This pull request modifies the Mamba model configuration and implementation to enable better handling of bias terms in various layers. The key changes include updating the default value of `use_bias`, ensuring consistent initialization of bias terms, and improving bias handling in forward computations.

### Changes to Configuration:

* Updated the default value of `use_bias` from `False` to `True` in the `MambaConfig` class and its constructor. This change affects both the configuration definition and its initialization.

### Changes to Model Implementation:

* Added explicit initialization of bias terms (e.g., setting them to zeros) for layers such as `conv1d`, `in_proj`, `dt_proj`, and `out_proj` when `use_bias` or `use_conv_bias` is enabled.
* Improved handling of bias terms in the `cuda_kernels_forward` method by ensuring they are properly checked for existence, converted to the correct data type (`float32`), and passed into the computation pipeline.

<!-- Remove if not applicable -->

Fixes #38600


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
