### PR TITLE
Improve `test_initialization`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -716,8 +716,15 @@ class ModelTesterMixin:
             model = model_class(config=configs_no_init)
             for name, param in model.named_parameters():
                 if param.requires_grad:
+                    data = torch.flatten(param.data)
+                    n_elements = torch.numel(data)
+                    # skip 2.5% of elements on each side to avoid issues caused by `nn.init.trunc_normal_` described in
+                    # https://github.com/huggingface/transformers/pull/27906#issuecomment-1846951332
+                    n_elements_to_skip_on_each_side = int(n_elements * 0.025)
+                    sorted_data = torch.sort(data).values
+                    data_to_check = sorted_data[n_elements_to_skip_on_each_side:-n_elements_to_skip_on_each_side]
                     self.assertIn(
-                        ((param.data.mean() * 1e9).round() / 1e9).item(),
+                        ((data_to_check.mean() * 1e9).round() / 1e9).item(),
                         [0.0, 1.0],
                         msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                     )

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -721,8 +721,9 @@ class ModelTesterMixin:
                     # skip 2.5% of elements on each side to avoid issues caused by `nn.init.trunc_normal_` described in
                     # https://github.com/huggingface/transformers/pull/27906#issuecomment-1846951332
                     n_elements_to_skip_on_each_side = int(n_elements * 0.025)
-                    sorted_data = torch.sort(data).values
-                    data_to_check = sorted_data[n_elements_to_skip_on_each_side:-n_elements_to_skip_on_each_side]
+                    data_to_check = torch.sort(data).values
+                    if n_elements_to_skip_on_each_side > 0:
+                        data_to_check = data_to_check[n_elements_to_skip_on_each_side:-n_elements_to_skip_on_each_side]
                     self.assertIn(
                         ((data_to_check.mean() * 1e9).round() / 1e9).item(),
                         [0.0, 1.0],


### PR DESCRIPTION
# What does this PR do?

(See ##27906 too)

`torch.nn.init.trunc_normal_` could produce values like `+/- 2.0`  even if `mean=0.0` and `std=1e-10`. This causes `test_initialization` flaky if a model has `_init_weights` using `torch.nn.init.trunc_normal_`.

This PR improves the test by checking the 95% of the elements of the (sorted) parameters' data, which should do the job and avoid the flakiness.

For `ViTModel`, running 3000 times:

  - before: 13 failures (0.43%)
  - after: 0 failure

For `CvtModel`, running 3000 times:

  - before:  135 failures (4.5 %)
  - after: 0 failure