### PR TITLE
fix spelling errors 

### DIFF
--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -366,15 +366,15 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
     def test_assisted_decoding_with_num_logits_to_keep(self):
         pass
 
-    @unittest.skip(reason="Mllama uses self.weights dirrectly causing device mismatch when offloading`")
+    @unittest.skip(reason="Mllama uses self.weights directly causing device mismatch when offloading`")
     def test_cpu_offload(self):
         pass
 
-    @unittest.skip(reason="Mllama uses self.weights dirrectly causing device mismatch when offloading`")
+    @unittest.skip(reason="Mllama uses self.weights directly causing device mismatch when offloading`")
     def test_disk_offload_bin(self):
         pass
 
-    @unittest.skip(reason="Mllama uses self.weights dirrectly causing device mismatch when offloading`")
+    @unittest.skip(reason="Mllama uses self.weights directly causing device mismatch when offloading`")
     def test_disk_offload_safetensors(self):
         pass
 

--- a/tests/models/video_llava/test_modeling_video_llava.py
+++ b/tests/models/video_llava/test_modeling_video_llava.py
@@ -399,7 +399,7 @@ class VideoLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
         for model_class in self.all_model_classes:
             model = model_class(config).to(torch_device)
             curr_input_dict = copy.deepcopy(input_dict)
-            _ = model(**curr_input_dict)  # successfull forward with no modifications
+            _ = model(**curr_input_dict)  # successful forward with no modifications
 
             # remove one image but leave the image token in text
             curr_input_dict["pixel_values_images"] = curr_input_dict["pixel_values_images"][-1:, ...]

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -915,7 +915,7 @@ class ProcessorTesterMixin:
         )
 
     @require_av
-    @parameterized.expand([(1, "pt"), (2, "pt")])  # video processor suports only torchvision
+    @parameterized.expand([(1, "pt"), (2, "pt")])  # video processor supports only torchvision
     def test_apply_chat_template_video(self, batch_size: int, return_tensors: str):
         self._test_apply_chat_template(
             "video", batch_size, return_tensors, "videos_input_name", "video_processor", MODALITY_INPUT_DATA["videos"]


### PR DESCRIPTION
Hey team! Fixed errors in `test_modeling_mllama.py` / `test_modeling_video_llava.py` / `test_processing_common.py`

`dirrectly` - `directly` x3
`successfull` - `successful`
`suports` - `supports`