### PR TITLE
Don't run `AriaForConditionalGenerationModelTest` on CircleCI

### DIFF
--- a/tests/models/aria/test_modeling_aria.py
+++ b/tests/models/aria/test_modeling_aria.py
@@ -171,6 +171,7 @@ class AriaVisionText2TextModelTester:
         return config, inputs_dict
 
 
+@slow
 @require_torch
 class AriaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     """


### PR DESCRIPTION
# What does this PR do?

Let's just simply get rid of this model tests on CircleCI. Cause the slowest job to finish in `13m 25s`.

![Screenshot 2025-06-05 165750](https://github.com/user-attachments/assets/21c7f1d2-a7bc-4f53-93ee-929748dfbb75)


We still have it on dailly CI


```bash
148.80s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_model_outputs_equivalence
120.40s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_model_outputs_equivalence
55.83s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_resize_tokens_embeddings
36.21s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_attention_outputs
28.76s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_resize_embeddings_untied
23.11s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_training
22.56s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_retain_grad_hidden_states_attentions
22.27s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_hidden_states_output
22.15s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_determinism
14.41s call     tests/models/aria/test_modeling_aria.py::AriaForConditionalGenerationModelTest::test_save_load
```