### PR TITLE
fix: Added code to match interpolation of Google's ViT implementation…

### DIFF
--- a/src/transformers/models/vit/convert_dino_to_pytorch.py
+++ b/src/transformers/models/vit/convert_dino_to_pytorch.py
@@ -22,15 +22,15 @@ import requests
 import torch
 from huggingface_hub import hf_hub_download
 from PIL import Image
-
-from transformers import ViTConfig, ViTForImageClassification, ViTImageProcessor, ViTModel
-from transformers.utils import logging
 from torchvision import transforms
 
+from transformers import ViTConfig, ViTForImageClassification, ViTImageProcessor, ViTModel
 from transformers.image_utils import (
     IMAGENET_STANDARD_MEAN,
     IMAGENET_STANDARD_STD,
 )
+from transformers.utils import logging
+
 
 logging.set_verbosity_info()
 logger = logging.get_logger(__name__)
@@ -194,7 +194,7 @@ def convert_vit_checkpoint(model_name, pytorch_dump_folder_path, base_model=True
             std=IMAGENET_STANDARD_STD # Google ViT uses IMAGENET_STANDARD_STD - [0.5, 0.5, 0.5]
         ),
     ])
-    
+
     original_pixel_values = transformations(image).unsqueeze(0)
     assert torch.allclose(pixel_values, original_pixel_values, atol=1e-3)
 

--- a/src/transformers/models/vit/convert_dino_to_pytorch.py
+++ b/src/transformers/models/vit/convert_dino_to_pytorch.py
@@ -186,14 +186,16 @@ def convert_vit_checkpoint(model_name, pytorch_dump_folder_path, base_model=True
     pixel_values = encoding["pixel_values"]
 
     # Verify that preprocessing matches original Google ViT implementation
-    transformations = transforms.Compose([
-        transforms.Resize((224, 224), interpolation=transforms.InterpolationMode.BICUBIC),
-        transforms.ToTensor(),
-        transforms.Normalize(
-            mean=IMAGENET_STANDARD_MEAN, # Google ViT uses IMAGENET_STANDARD_MEAN - [0.5, 0.5, 0.5]
-            std=IMAGENET_STANDARD_STD # Google ViT uses IMAGENET_STANDARD_STD - [0.5, 0.5, 0.5]
-        ),
-    ])
+    transformations = transforms.Compose(
+        [
+            transforms.Resize((224, 224), interpolation=transforms.InterpolationMode.BICUBIC),
+            transforms.ToTensor(),
+            transforms.Normalize(
+                mean=IMAGENET_STANDARD_MEAN,  # Google ViT uses IMAGENET_STANDARD_MEAN - [0.5, 0.5, 0.5]
+                std=IMAGENET_STANDARD_STD,  # Google ViT uses IMAGENET_STANDARD_STD - [0.5, 0.5, 0.5]
+            ),
+        ]
+    )
 
     original_pixel_values = transformations(image).unsqueeze(0)
     assert torch.allclose(pixel_values, original_pixel_values, atol=1e-3)

--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -231,14 +231,16 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
     if "deit" in vit_name:
         pass
     else:
-        transformations = transforms.Compose([
-            transforms.Resize((224, 224), interpolation=transforms.InterpolationMode.BICUBIC),
-            transforms.ToTensor(),
-            transforms.Normalize(
-                mean=IMAGENET_STANDARD_MEAN, # Google ViT uses IMAGENET_STANDARD_MEAN - [0.5, 0.5, 0.5]
-                std=IMAGENET_STANDARD_STD # Google ViT uses IMAGENET_STANDARD_STD - [0.5, 0.5, 0.5]
-            ),
-        ])
+        transformations = transforms.Compose(
+            [
+                transforms.Resize((224, 224), interpolation=transforms.InterpolationMode.BICUBIC),
+                transforms.ToTensor(),
+                transforms.Normalize(
+                    mean=IMAGENET_STANDARD_MEAN,  # Google ViT uses IMAGENET_STANDARD_MEAN - [0.5, 0.5, 0.5]
+                    std=IMAGENET_STANDARD_STD,  # Google ViT uses IMAGENET_STANDARD_STD - [0.5, 0.5, 0.5]
+                ),
+            ]
+        )
 
     original_pixel_values = transformations(image).unsqueeze(0)
     assert torch.allclose(pixel_values, original_pixel_values, atol=1e-3)

--- a/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
+++ b/src/transformers/models/vit/convert_vit_timm_to_pytorch.py
@@ -22,15 +22,15 @@ import timm
 import torch
 from PIL import Image
 from timm.data import ImageNetInfo, infer_imagenet_subset
-
-from transformers import DeiTImageProcessor, ViTConfig, ViTForImageClassification, ViTImageProcessor, ViTModel
-from transformers.utils import logging
 from torchvision import transforms
 
+from transformers import DeiTImageProcessor, ViTConfig, ViTForImageClassification, ViTImageProcessor, ViTModel
 from transformers.image_utils import (
     IMAGENET_STANDARD_MEAN,
     IMAGENET_STANDARD_STD,
 )
+from transformers.utils import logging
+
 
 logging.set_verbosity_info()
 logger = logging.get_logger(__name__)
@@ -216,7 +216,7 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
     else:
         model = ViTForImageClassification(config).eval()
     model.load_state_dict(state_dict)
-    
+
     # Check outputs on an image, prepared by ViTImageProcessor/DeiTImageProcessor
     if "deit" in vit_name:
         image_processor = DeiTImageProcessor(size=config.image_size)
@@ -239,7 +239,7 @@ def convert_vit_checkpoint(vit_name, pytorch_dump_folder_path):
                 std=IMAGENET_STANDARD_STD # Google ViT uses IMAGENET_STANDARD_STD - [0.5, 0.5, 0.5]
             ),
         ])
-    
+
     original_pixel_values = transformations(image).unsqueeze(0)
     assert torch.allclose(pixel_values, original_pixel_values, atol=1e-3)
 

--- a/src/transformers/models/vit/image_processing_vit.py
+++ b/src/transformers/models/vit/image_processing_vit.py
@@ -52,7 +52,7 @@ class ViTImageProcessor(BaseImageProcessor):
         size (`dict`, *optional*, defaults to `{"height": 224, "width": 224}`):
             Size of the output image after resizing. Can be overridden by the `size` parameter in the `preprocess`
             method.
-        resample (`PILImageResampling`, *optional*, defaults to `Resampling.BILINEAR`):
+        resample (`PILImageResampling`, *optional*, defaults to `Resampling.BICUBIC`):
             Resampling filter to use if resizing the image. Can be overridden by the `resample` parameter in the
             `preprocess` method.
         do_rescale (`bool`, *optional*, defaults to `True`):
@@ -80,7 +80,7 @@ class ViTImageProcessor(BaseImageProcessor):
         self,
         do_resize: bool = True,
         size: Optional[Dict[str, int]] = None,
-        resample: PILImageResampling = PILImageResampling.BILINEAR,
+        resample: PILImageResampling = PILImageResampling.BICUBIC,
         do_rescale: bool = True,
         rescale_factor: Union[int, float] = 1 / 255,
         do_normalize: bool = True,
@@ -106,7 +106,7 @@ class ViTImageProcessor(BaseImageProcessor):
         self,
         image: np.ndarray,
         size: Dict[str, int],
-        resample: PILImageResampling = PILImageResampling.BILINEAR,
+        resample: PILImageResampling = PILImageResampling.BICUBIC,
         data_format: Optional[Union[str, ChannelDimension]] = None,
         input_data_format: Optional[Union[str, ChannelDimension]] = None,
         **kwargs,
@@ -119,8 +119,8 @@ class ViTImageProcessor(BaseImageProcessor):
                 Image to resize.
             size (`Dict[str, int]`):
                 Dictionary in the format `{"height": int, "width": int}` specifying the size of the output image.
-            resample (`PILImageResampling`, *optional*, defaults to `PILImageResampling.BILINEAR`):
-                `PILImageResampling` filter to use when resizing the image e.g. `PILImageResampling.BILINEAR`.
+            resample (`PILImageResampling`, *optional*, defaults to `PILImageResampling.BICUBIC`):
+                `PILImageResampling` filter to use when resizing the image e.g. `PILImageResampling.BICUBIC`.
             data_format (`ChannelDimension` or `str`, *optional*):
                 The channel dimension format for the output image. If unset, the channel dimension format of the input
                 image is used. Can be one of:
@@ -180,7 +180,7 @@ class ViTImageProcessor(BaseImageProcessor):
                 Dictionary in the format `{"height": h, "width": w}` specifying the size of the output image after
                 resizing.
             resample (`PILImageResampling` filter, *optional*, defaults to `self.resample`):
-                `PILImageResampling` filter to use if resizing the image e.g. `PILImageResampling.BILINEAR`. Only has
+                `PILImageResampling` filter to use if resizing the image e.g. `PILImageResampling.BICUBIC`. Only has
                 an effect if `do_resize` is set to `True`.
             do_rescale (`bool`, *optional*, defaults to `self.do_rescale`):
                 Whether to rescale the image values between [0 - 1].

--- a/src/transformers/models/vit/image_processing_vit_fast.py
+++ b/src/transformers/models/vit/image_processing_vit_fast.py
@@ -29,7 +29,7 @@ from ...utils import (
 
 @auto_docstring
 class ViTImageProcessorFast(BaseImageProcessorFast):
-    resample = PILImageResampling.BILINEAR
+    resample = PILImageResampling.BICUBIC
     image_mean = IMAGENET_STANDARD_MEAN
     image_std = IMAGENET_STANDARD_STD
     size = {"height": 224, "width": 224}


### PR DESCRIPTION
Fixes #28180

# What does this PR do?

Fixes the interpolation method in ViT image processors to match the original Google ViT implementation. Changes the default resampling from BILINEAR to BICUBIC interpolation.

## Implementation Notes

This implementation follows @NielsRogge's comments from #28180:
- Added pixel value verification using `torch.allclose` similar to the DINOv2 conversion  
- Verification ensures HuggingFace preprocessing matches the reference implementation
- DeiT verification is currently skipped with `pass` - can be updated in a follow-up PR if needed

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@NielsRogge @amyeroberts @qubvel 
