### PR TITLE
Skip `test_initialization` for `SwiftFormer`

### DIFF
--- a/tests/models/swiftformer/test_modeling_swiftformer.py
+++ b/tests/models/swiftformer/test_modeling_swiftformer.py
@@ -250,7 +250,7 @@ class SwiftFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
         for model_class in self.all_model_classes:
             model = model_class(config=configs_no_init)
             for name, param in model.named_parameters():
-                if name == "swiftformer.encoder.network.2.blocks.0.attn.w_g":
+                if name.endswith(".w_g"):
                     continue
                 if param.requires_grad:
                     self.assertIn(

--- a/tests/models/swiftformer/test_modeling_swiftformer.py
+++ b/tests/models/swiftformer/test_modeling_swiftformer.py
@@ -250,6 +250,8 @@ class SwiftFormerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
         for model_class in self.all_model_classes:
             model = model_class(config=configs_no_init)
             for name, param in model.named_parameters():
+                if name == "swiftformer.encoder.network.2.blocks.0.attn.w_g":
+                    continue
                 if param.requires_grad:
                     self.assertIn(
                         ((param.data.mean() * 1e9) / 1e9).round().item(),


### PR DESCRIPTION
# What does this PR do?

`SwiftFormer` has

```
class SwiftFormerEfficientAdditiveAttention(nn.Module):
    def __init__(self, config: SwiftFormerConfig, dim: int = 512):
        super().__init__()
        self.w_g = nn.Parameter(torch.randn(dim, 1))

```
and `self.w_g` is not handled by `_init_weights` and also not by any thing like `initializer_range`, so it just a normal distribution with mean 0 and std 1, and make `test_initialization` quite flaky (> 10% failure rate).

This PR just skip `w_g` in the (already overwritten) test.



