### PR TITLE
Skip torchscript tests for 2 models

### DIFF
--- a/tests/models/canine/test_modeling_canine.py
+++ b/tests/models/canine/test_modeling_canine.py
@@ -241,6 +241,14 @@ class CanineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         # we set has_text_modality to False as the config has no vocab_size attribute
         self.config_tester = ConfigTester(self, config_class=CanineConfig, has_text_modality=False, hidden_size=37)
 
+    @unittest.skip("failing. Will fix only when the community opens an issue for it.")
+    def test_torchscript_output_hidden_state(self):
+        pass
+
+    @unittest.skip("failing. Will fix only when the community opens an issue for it.")
+    def test_torchscript_simple(self):
+        pass
+
     def test_config(self):
         self.config_tester.run_common_tests()
 

--- a/tests/models/moonshine/test_modeling_moonshine.py
+++ b/tests/models/moonshine/test_modeling_moonshine.py
@@ -150,6 +150,14 @@ class MoonshineModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
         self.model_tester = MoonshineModelTester(self)
         self.config_tester = ConfigTester(self, config_class=MoonshineConfig)
 
+    @unittest.skip("failing. Will fix only when the community opens an issue for it.")
+    def test_torchscript_output_hidden_state(self):
+        pass
+
+    @unittest.skip("failing. Will fix only when the community opens an issue for it.")
+    def test_torchscript_simple(self):
+        pass
+
     def test_config(self):
         self.config_tester.run_common_tests()
 


### PR DESCRIPTION
# What does this PR do?

We won't actively maintain the torchscript stuff.

See #35972


Probably I need to do the same as in #35972 but you get the idea :-)