### PR TITLE
minor docstring fixups

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -168,7 +168,7 @@ def prepare_padding_mask(
     """
     local_padding_mask = attention_mask
     if attention_mask is not None:
-        # Pad it if necesary
+        # Pad it if necessary
         if (padding_length := kv_length + kv_offset - attention_mask.shape[-1]) > 0:
             local_padding_mask = torch.nn.functional.pad(attention_mask, (0, padding_length))
         # For flex, we should not slice them, only use an offset
@@ -490,7 +490,7 @@ def flash_attention_mask(
     **kwargs,
 ):
     """
-    Create the attention mask necesary to use FA2. Since FA2 is un-padded by definition, here we simply return
+    Create the attention mask necessary to use FA2. Since FA2 is un-padded by definition, here we simply return
     `None` if the mask is fully causal, or we return the 2D mask which will then be used to extract the seq_lens.
     We just slice it in case of sliding window.
 

--- a/src/transformers/model_debugging_utils.py
+++ b/src/transformers/model_debugging_utils.py
@@ -409,7 +409,7 @@ def model_addition_debugger_context(
 
     It tracks all forward calls within a model forward and logs a slice of each input and output on a nested JSON file.
     If `use_repr=True` (the default), the JSON file will record a `repr()`-ized version of the tensors as a list of
-    strings. If `use_repr=False`, the full tensors will be stored in spearate SafeTensors files and the JSON file will
+    strings. If `use_repr=False`, the full tensors will be stored in separate SafeTensors files and the JSON file will
     provide a relative path to that file.
 
     To note, this context manager enforces `torch.no_grad()`.

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -562,7 +562,7 @@ class BaseVideoProcessor(BaseImageProcessorFast):
             resolved_video_processor_file = download_url(pretrained_model_name_or_path)
         else:
             try:
-                # Try to load with a new config name first and if not successfull try with
+                # Try to load with a new config name first and if not successful try with
                 # the old file name. In case we can load with old name only, raise a deprecation warning
                 # Deprecated until v5.0
                 video_processor_file = VIDEO_PROCESSOR_NAME


### PR DESCRIPTION
Hey! Fixed errors:

src/transformers/masking_utils.py
`necesary` - `necessary` x2

src/transformers/model_debugging_utils.py
`spearate` - `separate`

src/transformers/video_processing_utils.py 
`successfull` - `successful`