### PR TITLE
docs: clarify compute_loss parameter num_items_in_batch

### DIFF
--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -187,7 +187,7 @@ from torch import nn
 from transformers import Trainer
 
 class CustomTrainer(Trainer):
-    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None, num_items_in_batch=None):
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
         labels = inputs.pop("labels")
         # forward pass
         outputs = model(**inputs)
@@ -197,8 +197,6 @@ class CustomTrainer(Trainer):
         loss = loss_fct(logits.view(-1, self.model.config.num_labels), labels.view(-1))
         return (loss, outputs) if return_outputs else loss
 ```
-[!NOTE]
-> As of Transformers version 4.48, if you override [`~Trainer.compute_loss`], you should include the `num_items_in_batch` parameter in the method signature to ensure compatibility with batch size calculations and avoid potential errors.
 
 ### Callbacks
 

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -187,7 +187,7 @@ from torch import nn
 from transformers import Trainer
 
 class CustomTrainer(Trainer):
-    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None):
+    def compute_loss(self, model, inputs, return_outputs=False, num_items_in_batch=None, num_items_in_batch=None):
         labels = inputs.pop("labels")
         # forward pass
         outputs = model(**inputs)
@@ -197,6 +197,8 @@ class CustomTrainer(Trainer):
         loss = loss_fct(logits.view(-1, self.model.config.num_labels), labels.view(-1))
         return (loss, outputs) if return_outputs else loss
 ```
+[!NOTE]
+> As of Transformers version 4.48, if you override [`~Trainer.compute_loss`], you should include the `num_items_in_batch` parameter in the method signature to ensure compatibility with batch size calculations and avoid potential errors.
 
 ### Callbacks
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3800,6 +3800,9 @@ class Trainer:
         How the loss is computed by Trainer. By default, all models return the loss in the first element.
 
         Subclass and override for custom behavior.
+
+        As of Transformers v4.48, this method includes the `num_items_in_batch` argument to support dynamic batch sizes. If you override this method, include this argument to avoid compatibility issues.
+
         """
         if (self.label_smoother is not None or self.compute_loss_func is not None) and "labels" in inputs:
             labels = inputs.pop("labels")


### PR DESCRIPTION
# What does this PR do?

This PR addresses [huggingface/hub-docs#1600](https://github.com/huggingface/hub-docs/issues/1600).

The issue relates to the [`Trainer.compute_loss`](https://huggingface.co/docs/transformers/v4.48.2/en/trainer) documentation, which is maintained in the `transformers` repository.

I have added a clarifying note in the "Customize" section of the Trainer documentation to mention that the `num_items_in_batch` parameter should be included when overriding `compute_loss`, as of version 4.48. This is to help users avoid potential errors.


Fixes # (issue)

Fixes: See [huggingface/hub-docs#1600](https://github.com/huggingface/hub-docs/issues/1600)

## Before submitting
- [ ✅] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).



- trainer: @zach-huggingface and @SunMarc
Documentation: @stevhliu 



