### PR TITLE
Fix TypeError: 'NoneType' object is not iterable for esm (#38667)

### DIFF
--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -1023,6 +1023,8 @@ class EsmForMaskedLM(EsmPreTrainedModel):
 
         self.init_weights()
 
+        self.post_init()
+
     def get_output_embeddings(self):
         return self.lm_head.decoder
 
@@ -1127,6 +1129,8 @@ class EsmForSequenceClassification(EsmPreTrainedModel):
 
         self.init_weights()
 
+        self.post_init()
+
     @auto_docstring
     def forward(
         self,
@@ -1209,6 +1213,8 @@ class EsmForTokenClassification(EsmPreTrainedModel):
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
 
         self.init_weights()
+
+        self.post_init()
 
     @auto_docstring
     def forward(


### PR DESCRIPTION
Add post_init() calls to EsmForMaskedLM, EsmForTokenClassification and EsmForSequenceClassification.

# What does this PR do?

Adds `post_init()` calls to esm models in order to prevent the error "TypeError: 'NoneType' object is not iterable".

Fixes # 38667

## Before submitting
- [:x:  ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [:heavy_check_mark:  ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [:x: ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [:white_check_mark:  ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ :x:] Did you write any new necessary tests?


## Who can review?

@MekkCyber @Cyrilvallez since they're active in the referenced PR from the bug, or anyone familiar with the situation.
