### PR TITLE
Fix `aya_vision` test

### DIFF
--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -348,7 +348,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def get_model(cls):
 
         # Use 4-bit on T4
-        load_in_4bit = get_device_properties()[0] == "cuda" and get_device_properties()[1] < 8,
+        load_in_4bit = get_device_properties()[0] == "cuda" and get_device_properties()[1] < 8
 
         if cls.model is None:
             cls.model = AyaVisionForConditionalGeneration.from_pretrained(

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -341,7 +341,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def test_small_model_integration_forward(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
         model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, torch_dtype=torch.float16
+            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
         )
         messages = [
             {
@@ -375,7 +375,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def test_small_model_integration_generate_text_only(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
         model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, torch_dtype=torch.float16
+            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
         )
         messages = [
             {
@@ -410,7 +410,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def test_small_model_integration_generate_chat_template(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
         model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, torch_dtype=torch.float16
+            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
         )
         messages = [
             {
@@ -438,7 +438,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def test_small_model_integration_batched_generate(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
         model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, torch_dtype=torch.float16
+            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
         )
         # Prepare inputs
         messages = [
@@ -499,7 +499,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def test_small_model_integration_batched_generate_multi_image(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
         model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, torch_dtype=torch.float16
+            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
         )
         # Prepare inputs
         messages = [

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -330,19 +330,32 @@ class AyaVisionModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
 @require_read_token
 @require_torch
 class AyaVisionIntegrationTest(unittest.TestCase):
-    def setUp(self):
-        self.model_checkpoint = "CohereForAI/aya-vision-8b"
+    @classmethod
+    def setUpClass(cls):
+        cls.model_checkpoint = "CohereForAI/aya-vision-8b"
+        cls.model = None
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.model_checkpoint
+        cleanup(torch_device, gc_collect=True)
 
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
+
+    @classmethod
+    def get_model(cls):
+        if cls.model is None:
+            cls.model = AyaVisionForConditionalGeneration.from_pretrained(
+                cls.model_checkpoint, device_map=torch_device, load_in_4bit=True,
+            )
+        return cls.model
 
     @slow
     @require_torch_accelerator
     def test_small_model_integration_forward(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
-        model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
-        )
+        model = self.get_model()
         messages = [
             {
                 "role": "user",
@@ -378,9 +391,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     @require_deterministic_for_xpu
     def test_small_model_integration_generate_text_only(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
-        model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
-        )
+        model = self.get_model()
         messages = [
             {
                 "role": "user",
@@ -415,9 +426,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     @require_torch_accelerator
     def test_small_model_integration_generate_chat_template(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
-        model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
-        )
+        model = self.get_model()
         messages = [
             {
                 "role": "user",
@@ -448,9 +457,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     @require_torch_accelerator
     def test_small_model_integration_batched_generate(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
-        model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
-        )
+        model = self.get_model()
         # Prepare inputs
         messages = [
             [
@@ -514,9 +521,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     @require_deterministic_for_xpu
     def test_small_model_integration_batched_generate_multi_image(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
-        model = AyaVisionForConditionalGeneration.from_pretrained(
-            self.model_checkpoint, device_map=torch_device, load_in_4bit=True,
-        )
+        model = self.get_model()
         # Prepare inputs
         messages = [
             [

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -379,9 +379,16 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             output = model(**inputs)
 
         actual_logits = output.logits[0, -1, :5].cpu()
-        expected_logits = torch.tensor([0.4109, 0.1532, 0.8018, 2.1328, 0.5483], dtype=torch.float16)
-        # 4-bit
-        expected_logits = torch.tensor([0.1097, 0.3481, 3.8340, 9.7969, 2.0488], dtype=torch.float16)
+
+        EXPECTED_LOGITS = Expectations(
+            {
+                ("xpu", 3): [0.4109, 0.1532, 0.8018, 2.1328, 0.5483],
+                # 4-bit
+                ("cuda", 7): [0.1097, 0.3481, 3.8340, 9.7969, 2.0488],
+                ("cuda", 8): [0.1097, 0.3481, 3.8340, 9.7969, 2.0488],
+            }
+        )  # fmt: skip
+        expected_logits = torch.tensor(EXPECTED_LOGITS.get_expectation(), dtype=torch.float16)
 
         # breakpoint()
         self.assertTrue(
@@ -420,6 +427,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 ("xpu", 3): "Whispers on the breeze,\nLeaves dance under moonlit sky,\nNature's quiet song.",
                 # 4-bit
                 ("cuda", 7): "Sure, here's a haiku for you:\n\nMorning dew sparkles,\nPetals unfold in sunlight,\n",
+                ("cuda", 8): "",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
@@ -450,10 +458,16 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             decoded_output = processor.decode(
                 generate_ids[0, inputs["input_ids"].shape[1] :], skip_special_tokens=True
             )
-        expected_output = "The image depicts a cozy scene of two cats resting on a bright pink blanket. The cats,"  # fmt: skip
 
-        # 4-bit
-        expected_output = 'The image depicts two cats comfortably resting on a pink blanket spread across a sofa. The cats,'  # fmt: skip
+        expected_outputs = Expectations(
+            {
+                ("xpu", 3): "The image depicts a cozy scene of two cats resting on a bright pink blanket. The cats,",
+                # 4-bit
+                ("cuda", 7): 'The image depicts two cats comfortably resting on a pink blanket spread across a sofa. The cats,',
+                ("cuda", 8): "",
+            }
+        )  # fmt: skip
+        expected_output = expected_outputs.get_expectation()
 
         # breakpoint()
         self.assertEqual(decoded_output, expected_output)
@@ -495,7 +509,9 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("xpu", 3): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest lake.",
+                # 4-bit
                 ("cuda", 7): "Wooden bridge stretches\nMirrored lake below, mountains rise\nPeaceful, serene",
+                ("cuda", 8): "",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
@@ -509,10 +525,16 @@ class AyaVisionIntegrationTest(unittest.TestCase):
 
         # Check second output
         decoded_output = processor.decode(output[1, inputs["input_ids"].shape[1] :], skip_special_tokens=True)
-        expected_output = 'This image captures a vibrant street scene in a bustling urban area, likely in an Asian city. The focal point is a'  # fmt: skip
 
-        # 4-bit
-        expected_output = 'This vibrant image captures a bustling street scene in a multicultural urban area, featuring a traditional Chinese gate adorned with intricate red and'
+        expected_outputs = Expectations(
+            {
+                ("xpu", 3): 'This image captures a vibrant street scene in a bustling urban area, likely in an Asian city. The focal point is a',
+                # 4-bit
+                ("cuda", 7): 'This vibrant image captures a bustling street scene in a multicultural urban area, featuring a traditional Chinese gate adorned with intricate red and',
+                ("cuda", 8): "",
+            }
+        )  # fmt: skip
+        expected_output = expected_outputs.get_expectation()
 
         # breakpoint()
         self.assertEqual(
@@ -570,6 +592,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             {
                 ("xpu", 3): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest lake.",
                 ("cuda", 7): 'Wooden bridge stretches\nMirrored lake below, mountains rise\nPeaceful, serene',
+                ("cuda", 8): "",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
@@ -587,6 +610,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             {
                 ("xpu", 3): "The first image showcases the Statue of Liberty, a colossal neoclassical sculpture on Liberty Island in New York Harbor. Standing at ",
                 ("cuda", 7): 'The first image showcases the Statue of Liberty, a monumental sculpture located on Liberty Island in New York Harbor. Standing atop a',
+                ("cuda", 8): "",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -346,13 +346,14 @@ class AyaVisionIntegrationTest(unittest.TestCase):
 
     @classmethod
     def get_model(cls):
-
         # Use 4-bit on T4
         load_in_4bit = get_device_properties()[0] == "cuda" and get_device_properties()[1] < 8
 
         if cls.model is None:
             cls.model = AyaVisionForConditionalGeneration.from_pretrained(
-                cls.model_checkpoint, device_map=torch_device, load_in_4bit=load_in_4bit,
+                cls.model_checkpoint,
+                device_map=torch_device,
+                load_in_4bit=load_in_4bit,
             )
         return cls.model
 

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -391,7 +391,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_logits = torch.tensor(EXPECTED_LOGITS.get_expectation(), dtype=torch.float16)
 
-        # breakpoint()
+        breakpoint()
         self.assertTrue(
             torch.allclose(actual_logits, expected_logits, atol=0.1),
             f"Actual logits: {actual_logits}"
@@ -433,7 +433,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
+        breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -470,7 +470,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
+        breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -517,7 +517,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -537,7 +537,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -598,7 +598,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -616,7 +616,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -348,11 +348,13 @@ class AyaVisionIntegrationTest(unittest.TestCase):
     def get_model(cls):
         # Use 4-bit on T4
         load_in_4bit = get_device_properties()[0] == "cuda" and get_device_properties()[1] < 8
+        torch_dtype = None if load_in_4bit else torch.float16
 
         if cls.model is None:
             cls.model = AyaVisionForConditionalGeneration.from_pretrained(
                 cls.model_checkpoint,
                 device_map=torch_device,
+                torch_dtype=torch_dtype,
                 load_in_4bit=load_in_4bit,
             )
         return cls.model

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -362,6 +362,8 @@ class AyaVisionIntegrationTest(unittest.TestCase):
 
         actual_logits = output.logits[0, -1, :5].cpu()
         expected_logits = torch.tensor([0.4109, 0.1532, 0.8018, 2.1328, 0.5483], dtype=torch.float16)
+
+        breakpoint()
         self.assertTrue(
             torch.allclose(actual_logits, expected_logits, atol=0.1),
             f"Actual logits: {actual_logits}"
@@ -403,6 +405,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
+        breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -431,6 +434,8 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 generate_ids[0, inputs["input_ids"].shape[1] :], skip_special_tokens=True
             )
         expected_output = "The image depicts a cozy scene of two cats resting on a bright pink blanket. The cats,"  # fmt: skip
+
+        breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -477,6 +482,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -487,6 +493,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         decoded_output = processor.decode(output[1, inputs["input_ids"].shape[1] :], skip_special_tokens=True)
         expected_output = 'This image captures a vibrant street scene in a bustling urban area, likely in an Asian city. The focal point is a'  # fmt: skip
 
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -548,6 +555,7 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -563,6 +571,8 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
+
+        breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -393,7 +393,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_logits = torch.tensor(EXPECTED_LOGITS.get_expectation(), dtype=torch.float16)
 
-        # breakpoint()
         self.assertTrue(
             torch.allclose(actual_logits, expected_logits, atol=0.1),
             f"Actual logits: {actual_logits}"
@@ -435,7 +434,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -472,7 +470,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -519,7 +516,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -539,7 +535,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -600,7 +595,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -618,7 +612,6 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -388,12 +388,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 ("xpu", 3): [0.4109, 0.1532, 0.8018, 2.1328, 0.5483],
                 # 4-bit
                 ("cuda", 7): [0.1097, 0.3481, 3.8340, 9.7969, 2.0488],
-                ("cuda", 8): [0.1097, 0.3481, 3.8340, 9.7969, 2.0488],
+                ("cuda", 8): [1.6396, 0.6094, 3.1992, 8.5234, 2.1875],
             }
         )  # fmt: skip
         expected_logits = torch.tensor(EXPECTED_LOGITS.get_expectation(), dtype=torch.float16)
 
-        breakpoint()
+        # breakpoint()
         self.assertTrue(
             torch.allclose(actual_logits, expected_logits, atol=0.1),
             f"Actual logits: {actual_logits}"
@@ -430,12 +430,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 ("xpu", 3): "Whispers on the breeze,\nLeaves dance under moonlit sky,\nNature's quiet song.",
                 # 4-bit
                 ("cuda", 7): "Sure, here's a haiku for you:\n\nMorning dew sparkles,\nPetals unfold in sunlight,\n",
-                ("cuda", 8): "",
+                ("cuda", 8): "Whispers on the breeze,\nLeaves dance under moonlit skies,\nNature's quiet song.",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -467,12 +467,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 ("xpu", 3): "The image depicts a cozy scene of two cats resting on a bright pink blanket. The cats,",
                 # 4-bit
                 ("cuda", 7): 'The image depicts two cats comfortably resting on a pink blanket spread across a sofa. The cats,',
-                ("cuda", 8): "",
+                ("cuda", 8): 'The image depicts a cozy scene of two cats resting on a bright pink blanket. The cats,',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -514,12 +514,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 ("xpu", 3): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest lake.",
                 # 4-bit
                 ("cuda", 7): "Wooden bridge stretches\nMirrored lake below, mountains rise\nPeaceful, serene",
-                ("cuda", 8): "",
+                ("cuda", 8): 'Wooden path to water,\nMountains echo in stillness,\nPeaceful forest scene.',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -534,12 +534,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
                 ("xpu", 3): 'This image captures a vibrant street scene in a bustling urban area, likely in an Asian city. The focal point is a',
                 # 4-bit
                 ("cuda", 7): 'This vibrant image captures a bustling street scene in a multicultural urban area, featuring a traditional Chinese gate adorned with intricate red and',
-                ("cuda", 8): "",
+                ("cuda", 8): 'This image captures a vibrant street scene in a bustling urban area, likely in an Asian city. The focal point is a',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -595,12 +595,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             {
                 ("xpu", 3): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest lake.",
                 ("cuda", 7): 'Wooden bridge stretches\nMirrored lake below, mountains rise\nPeaceful, serene',
-                ("cuda", 8): "",
+                ("cuda", 8): 'Wooden path to water,\nMountains echo in stillness,\nPeaceful forest scene.',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -613,12 +613,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             {
                 ("xpu", 3): "The first image showcases the Statue of Liberty, a colossal neoclassical sculpture on Liberty Island in New York Harbor. Standing at ",
                 ("cuda", 7): 'The first image showcases the Statue of Liberty, a monumental sculpture located on Liberty Island in New York Harbor. Standing atop a',
-                ("cuda", 8): "",
+                ("cuda", 8): 'The first image showcases the Statue of Liberty, a colossal neoclassical sculpture on Liberty Island in New York Harbor. Standing at ',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -362,8 +362,10 @@ class AyaVisionIntegrationTest(unittest.TestCase):
 
         actual_logits = output.logits[0, -1, :5].cpu()
         expected_logits = torch.tensor([0.4109, 0.1532, 0.8018, 2.1328, 0.5483], dtype=torch.float16)
+        # 4-bit
+        expected_logits = torch.tensor([0.1097, 0.3481, 3.8340, 9.7969, 2.0488], dtype=torch.float16)
 
-        breakpoint()
+        # breakpoint()
         self.assertTrue(
             torch.allclose(actual_logits, expected_logits, atol=0.1),
             f"Actual logits: {actual_logits}"
@@ -400,12 +402,13 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("xpu", 3): "Whispers on the breeze,\nLeaves dance under moonlit sky,\nNature's quiet song.",
-                ("cuda", 7): "Whispers on the breeze,\nLeaves dance under moonlit skies,\nNature's quiet song.",
+                # 4-bit
+                ("cuda", 7): "Sure, here's a haiku for you:\n\nMorning dew sparkles,\nPetals unfold in sunlight,\n",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -435,7 +438,10 @@ class AyaVisionIntegrationTest(unittest.TestCase):
             )
         expected_output = "The image depicts a cozy scene of two cats resting on a bright pink blanket. The cats,"  # fmt: skip
 
-        breakpoint()
+        # 4-bit
+        expected_output = 'The image depicts two cats comfortably resting on a pink blanket spread across a sofa. The cats,'  # fmt: skip
+
+        # breakpoint()
         self.assertEqual(decoded_output, expected_output)
 
     @slow
@@ -477,12 +483,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("xpu", 3): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest lake.",
-                ("cuda", 7): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest scene.",
+                ("cuda", 7): "Wooden bridge stretches\nMirrored lake below, mountains rise\nPeaceful, serene",
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -493,7 +499,10 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         decoded_output = processor.decode(output[1, inputs["input_ids"].shape[1] :], skip_special_tokens=True)
         expected_output = 'This image captures a vibrant street scene in a bustling urban area, likely in an Asian city. The focal point is a'  # fmt: skip
 
-        breakpoint()
+        # 4-bit
+        expected_output = 'This vibrant image captures a bustling street scene in a multicultural urban area, featuring a traditional Chinese gate adorned with intricate red and'
+
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -550,12 +559,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("xpu", 3): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest lake.",
-                ("cuda", 7): "Wooden path to water,\nMountains echo in stillness,\nPeaceful forest scene.",
+                ("cuda", 7): 'Wooden bridge stretches\nMirrored lake below, mountains rise\nPeaceful, serene',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,
@@ -567,12 +576,12 @@ class AyaVisionIntegrationTest(unittest.TestCase):
         expected_outputs = Expectations(
             {
                 ("xpu", 3): "The first image showcases the Statue of Liberty, a colossal neoclassical sculpture on Liberty Island in New York Harbor. Standing at ",
-                ("cuda", 7): "The first image showcases the Statue of Liberty, a colossal neoclassical sculpture on Liberty Island in New York Harbor. Standing at a",
+                ("cuda", 7): 'The first image showcases the Statue of Liberty, a monumental sculpture located on Liberty Island in New York Harbor. Standing atop a',
             }
         )  # fmt: skip
         expected_output = expected_outputs.get_expectation()
 
-        breakpoint()
+        # breakpoint()
         self.assertEqual(
             decoded_output,
             expected_output,

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -27,6 +27,7 @@ from transformers import (
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    get_device_properties,
     require_deterministic_for_xpu,
     require_read_token,
     require_torch,
@@ -345,9 +346,13 @@ class AyaVisionIntegrationTest(unittest.TestCase):
 
     @classmethod
     def get_model(cls):
+
+        # Use 4-bit on T4
+        load_in_4bit = get_device_properties()[0] == "cuda" and get_device_properties()[1] < 8,
+
         if cls.model is None:
             cls.model = AyaVisionForConditionalGeneration.from_pretrained(
-                cls.model_checkpoint, device_map=torch_device, load_in_4bit=True,
+                cls.model_checkpoint, device_map=torch_device, load_in_4bit=load_in_4bit,
             )
         return cls.model
 

--- a/tests/models/aya_vision/test_processor_aya_vision.py
+++ b/tests/models/aya_vision/test_processor_aya_vision.py
@@ -31,7 +31,6 @@ if is_vision_available():
     from transformers import GotOcr2ImageProcessor
 
 
-@require_read_token
 @require_vision
 class AyaVisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = AyaVisionProcessor

--- a/tests/models/aya_vision/test_processor_aya_vision.py
+++ b/tests/models/aya_vision/test_processor_aya_vision.py
@@ -17,7 +17,7 @@ import tempfile
 import unittest
 
 from transformers import AutoProcessor, AutoTokenizer, AyaVisionProcessor
-from transformers.testing_utils import require_read_token, require_torch, require_vision
+from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_processing_common import ProcessorTesterMixin


### PR DESCRIPTION
# What does this PR do?

The processor tests and integration tests are never run due to an issue of `@require_read_token`.

After a fix #38093, I should had update the expected values for integration test but not done at that moment - now it is done.

For processor tests, we no longer need `@require_read_token` as the repository is changed to `hf-internal-testing/namespace-CohereForAI-repo_name_aya-vision-8b` (not including the model weights).
    - currently, `require_read_token` has an issue with `@staticmethod` - I need to fix it.

All tests pass on T4/A10 torch 2.6/2.7
