### PR TITLE
Fix L270 - hasattr("moe_args") returning False error

### DIFF
--- a/src/transformers/models/llama4/convert_llama4_weights_to_hf.py
+++ b/src/transformers/models/llama4/convert_llama4_weights_to_hf.py
@@ -267,7 +267,7 @@ def write_model(
 
     num_key_value_heads = params["n_kv_heads"]  # for GQA / MQA
 
-    if hasattr(params, "moe_args"):
+    if params.get("moe_args", ""):
         num_experts = params["moe_args"]["num_experts"]
         interleave_moe_layer_step = params["moe_args"].get("interleave_moe_layer_step", 1)
     else:

--- a/src/transformers/models/llama4/convert_llama4_weights_to_hf.py
+++ b/src/transformers/models/llama4/convert_llama4_weights_to_hf.py
@@ -267,7 +267,7 @@ def write_model(
 
     num_key_value_heads = params["n_kv_heads"]  # for GQA / MQA
 
-    if params.get("moe_args", ""):
+    if params.get("moe_args", False):
         num_experts = params["moe_args"]["num_experts"]
         interleave_moe_layer_step = params["moe_args"].get("interleave_moe_layer_step", 1)
     else:


### PR DESCRIPTION
Hi, I've been trying to convert the Llama-4 weights to HF using the `convert_llama4_weights_to_hf.py` and I've been having an error that causes the `num_experts` to be set to 0 due to the problem in L270 as referenced below:

https://github.com/huggingface/transformers/blame/81799d8b556b3c810ed314187674bc439c0582b4/src/transformers/models/llama4/convert_llama4_weights_to_hf.py#L270

The `if hasattr(params, "moe_args")` in L270 always returns false since "moe_args" is a key of the params dict (not an attribute). I changed the line to `if params.get("moe_args", None):` and the error is gone. I do recommend the change. Thank you.

Tag: @ArthurZucker
