### PR TITLE
Fix: undefined reference to gelu in `ClippedGELUActivation`

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -109,7 +109,7 @@ class ClippedGELUActivation(nn.Module):
         self.max = max
 
     def forward(self, x: Tensor) -> Tensor:
-        return torch.clip(gelu(x), self.min, self.max)
+        return torch.clip(nn.functional.gelu(x), self.min, self.max)
 
 
 class AccurateGELUActivation(nn.Module):


### PR DESCRIPTION
# Summary of This PR
- [x]  Fixes a typo in `activations.py` that uses an undefined symbol `gelu`.