### PR TITLE
Update get device properties and types

### DIFF
--- a/tests/models/musicgen/test_modeling_musicgen.py
+++ b/tests/models/musicgen/test_modeling_musicgen.py
@@ -31,7 +31,6 @@ from transformers import (
     T5Config,
 )
 from transformers.testing_utils import (
-    Expectations,
     get_device_properties,
     is_torch_available,
     require_flash_attn,
@@ -1052,8 +1051,7 @@ class MusicgenTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
         if not self.has_attentions:
             self.skipTest(reason="Model architecture does not support attentions")
 
-        device_properties = get_device_properties()
-        device_type, major, minor = Expectations.unpack(device_properties)
+        device_type, major, _ = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
         elif device_type == "rocm" and major < 9:

--- a/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
+++ b/tests/models/musicgen_melody/test_modeling_musicgen_melody.py
@@ -30,7 +30,6 @@ from transformers import (
     T5Config,
 )
 from transformers.testing_utils import (
-    Expectations,
     get_device_properties,
     is_torch_available,
     is_torchaudio_available,
@@ -1052,8 +1051,7 @@ class MusicgenMelodyTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         if not self.has_attentions:
             self.skipTest(reason="Model architecture does not support attentions")
 
-        device_properties = get_device_properties()
-        device_type, major, minor = Expectations.unpack(device_properties)
+        device_type, major, _ = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
         elif device_type == "rocm" and major < 9:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -73,7 +73,6 @@ from transformers.models.auto.modeling_auto import (
 )
 from transformers.testing_utils import (
     CaptureLogger,
-    Expectations,
     backend_empty_cache,
     get_device_properties,
     hub_retry,
@@ -3836,8 +3835,7 @@ class ModelTesterMixin:
         if not self.has_attentions:
             self.skipTest(reason="Model architecture does not support attentions")
 
-        device_properties = get_device_properties()
-        device_type, major, minor = Expectations.unpack(device_properties)
+        device_type, major, _ = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
         elif device_type == "rocm" and major < 9:
@@ -3885,8 +3883,7 @@ class ModelTesterMixin:
         if not self.has_attentions:
             self.skipTest(reason="Model architecture does not support attentions")
 
-        device_properties = get_device_properties()
-        device_type, major, minor = Expectations.unpack(device_properties)
+        device_type, major, _ = get_device_properties()
         if device_type == "cuda" and major < 8:
             self.skipTest(reason="This test requires an NVIDIA GPU with compute capability >= 8.0")
         elif device_type == "rocm" and major < 9:


### PR DESCRIPTION
By using the more consistent `tuple[Optional[str], Optional[int], Optional[int]]` format @remi-or introduced as the functional type of the class we can simplify a lot of code.
We keep the old `tuple[Optional[str], Union[None, int, tuple[int, int]]]` as the internal type of `Expectations` because it helps us create instances of the class elegantly.