### PR TITLE
Revert "Trigger doc-builder job after style bot"

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -2,15 +2,6 @@ name: Build PR Documentation
 
 on:
   pull_request:
-  workflow_call:
-    inputs:
-      pr_number:
-        type: string
-        required: true
-      commit_sha:
-        type: string
-        required: true
-
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -18,9 +9,9 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@6e2eb04a2604817c97be03786efa494fe3acae90
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
     with:
-      commit_sha: ${{ inputs.commit_sha || github.event.pull_request.head.sha }}
-      pr_number: ${{ inputs.pr_number || github.event.number }}
+      commit_sha: ${{ github.event.pull_request.head.sha }}
+      pr_number: ${{ github.event.number }}
       package: transformers
       languages: en

--- a/.github/workflows/pr-style-bot.yml
+++ b/.github/workflows/pr-style-bot.yml
@@ -11,24 +11,9 @@ permissions:
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@639ee721e149a281fe726a50a2cc1354b48bc463
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@main
     with:
       python_quality_dependencies: "[quality]"
       style_command_type: "default"
     secrets:
       bot_token: ${{ secrets.GITHUB_TOKEN }}
-
-  check-outputs:
-    runs-on: ubuntu-latest
-    needs: style
-    steps:
-      - run: echo ${{ needs.style.outputs.pr_number }}
-      - run: echo ${{ needs.style.outputs.new_commit_sha }}
-
-  trigger:
-    needs: style
-    if: needs.style.outputs.new_commit_sha != ''
-    uses: "./.github/workflows/build_pr_documentation.yml"
-    with:
-      pr_number: ${{ needs.style.outputs.pr_number }}
-      commit_sha: ${{ needs.style.outputs.new_commit_sha }}


### PR DESCRIPTION
Reverts huggingface/transformers#38398

Unfortunately, this is not working.

That PR use `workflow_call` event to call the `PR documentation build` inside the triggered `Style bot` workflow. This would be identified as a different job than `PR documentation build` itself (which is a required check), and PRs could not be merged anyway.

I talk to infra team with using a PAT token, but I don't get a response yet.

This PR is also causing some issues:  for the last commit on a PR, if there is any other new PR merged into `main`, and we approve the workflow run for the PR, it will fail to fetch the corresponding commits.

Like https://github.com/huggingface/transformers/actions/runs/15487007776/job/43623404484
