### PR TITLE
Fixes issue #38709 for CLIP and XCLIP

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -938,6 +938,9 @@ class CLIPModel(CLIPPreTrainedModel):
             output_hidden_states=output_hidden_states,
         )
 
+        if output_hidden_states:
+            return text_outputs
+
         pooled_output = text_outputs.pooler_output
         text_features = self.text_projection(pooled_output)
 
@@ -985,6 +988,9 @@ class CLIPModel(CLIPPreTrainedModel):
             output_hidden_states=output_hidden_states,
             interpolate_pos_encoding=interpolate_pos_encoding,
         )
+
+        if output_hidden_states:
+            return vision_outputs
 
         pooled_output = vision_outputs.pooler_output
         image_features = self.visual_projection(pooled_output)

--- a/src/transformers/models/clip/modeling_tf_clip.py
+++ b/src/transformers/models/clip/modeling_tf_clip.py
@@ -915,6 +915,9 @@ class TFCLIPMainLayer(keras.layers.Layer):
             training=training,
         )
 
+        if output_hidden_states:
+            return text_outputs
+
         pooled_output = text_outputs[1]
         text_features = self.text_projection(inputs=pooled_output)
 
@@ -939,6 +942,9 @@ class TFCLIPMainLayer(keras.layers.Layer):
             return_dict=return_dict,
             training=training,
         )
+
+        if output_hidden_states:
+            return vision_outputs
 
         pooled_output = vision_outputs[1]  # pooled_output
         image_features = self.visual_projection(inputs=pooled_output)

--- a/src/transformers/models/x_clip/modeling_x_clip.py
+++ b/src/transformers/models/x_clip/modeling_x_clip.py
@@ -1257,6 +1257,9 @@ class XCLIPModel(XCLIPPreTrainedModel):
             return_dict=return_dict,
         )
 
+        if output_hidden_states:
+            return text_outputs
+
         text_embeds = text_outputs[1]
         text_embeds = self.text_projection(text_embeds)
 
@@ -1373,6 +1376,10 @@ class XCLIPModel(XCLIPPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
         )
+
+        if output_hidden_states:
+            return mit_outputs
+
         video_embeds = mit_outputs[1]
 
         return video_embeds


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #38709 (at least for CLIP and XCLIP for now and is fully backward compatible and existing functionality remains unaffected).

Previously, `get_<>_features` function in CLIP and XCLIP always return the `pooled_output`.  Now, if `output_hidden_states` is set, the function returns a dict. It is set to `None` by default, so the existing behavior will be unaffected.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface and @SunMarc
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
