### PR TITLE
Fix Typos in Comments: "quantitation" → "quantization", "averege" → "average"

### DIFF
--- a/src/transformers/models/llama4/convert_llama4_weights_to_hf.py
+++ b/src/transformers/models/llama4/convert_llama4_weights_to_hf.py
@@ -421,7 +421,7 @@ def write_model(
                 tqdm.write(f"Processing: {key.ljust(50)}  ->\t {v}, {values.shape}")
                 state_dict[v] = values
             elif _OFFLINE_QUANT_COMPATIBLE and "feed_forward.experts." in new_key:
-                # for experts, we need to split expert for offline quantiation purpose and don't need to fuse
+                # for experts, we need to split expert for offline quantization purpose and don't need to fuse
                 expert_lists = []
                 for k in current_parameter:
                     expert_lists.append(

--- a/src/transformers/models/visual_bert/modeling_visual_bert.py
+++ b/src/transformers/models/visual_bert/modeling_visual_bert.py
@@ -131,7 +131,7 @@ class VisualBertEmbeddings(nn.Module):
                 visual_position_embeddings *= image_text_alignment_mask.to(dtype=dtype).unsqueeze(-1)
                 visual_position_embeddings = visual_position_embeddings.sum(2)
 
-                # We want to averge along the alignment_number dimension.
+                # We want to average along the alignment_number dimension.
                 image_text_alignment_mask = image_text_alignment_mask.to(dtype=dtype).sum(2)
 
                 if (image_text_alignment_mask == 0).sum() != 0:


### PR DESCRIPTION



Description:  
This pull request corrects minor spelling mistakes in code comments across two files:
- In `convert_llama4_weights_to_hf.py`, the word "quantitation" is corrected to "quantization".
- In `modeling_visual_bert.py`, the word "averege" is corrected to "average".

These changes improve code readability and maintain consistency in terminology. No functional code changes are included.
