### PR TITLE
Provide clearer instructions on how to specify target language.

### DIFF
--- a/docs/source/en/model_doc/madlad-400.md
+++ b/docs/source/en/model_doc/madlad-400.md
@@ -50,10 +50,35 @@ One can directly use MADLAD-400 weights without finetuning the model:
 >>> model = AutoModelForSeq2SeqLM.from_pretrained("google/madlad400-3b-mt")
 >>> tokenizer = AutoTokenizer.from_pretrained("google/madlad400-3b-mt")
 
->>> inputs = tokenizer("<2pt> I love pizza!", return_tensors="pt")
+>>> inputs = tokenizer("<2it> I love pizza!", return_tensors="pt")
 >>> outputs = model.generate(**inputs)
 >>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
 ['Eu amo pizza!']
+```
+
+Note that in the input sentence, "`<2it>`" is a token determining the target language of the translation. To see all supported language codes and their corresponding tokens:
+```python
+>>> tokens = [tokenizer.decode(i) for i in range(4,459)]
+>>> lang_codes = [token[2:-1] for token in tokens]
+>>> tokens
+
+    ['<2ace>',
+     '<2ace_Arab>',
+     '<2af>',
+      ...
+     '<2zh_Latn>',
+     '<2zne>',
+     '<2zza>']
+
+>>> lang_codes
+
+    ['ace',
+     'ace_Arab',
+     'af',
+      ...
+     'zh_Latn',
+     'zne',
+     'zza']
 ```
 
 Google has released the following variants:

--- a/docs/source/en/model_doc/madlad-400.md
+++ b/docs/source/en/model_doc/madlad-400.md
@@ -50,13 +50,13 @@ One can directly use MADLAD-400 weights without finetuning the model:
 >>> model = AutoModelForSeq2SeqLM.from_pretrained("google/madlad400-3b-mt")
 >>> tokenizer = AutoTokenizer.from_pretrained("google/madlad400-3b-mt")
 
->>> inputs = tokenizer("<2it> I love pizza!", return_tensors="pt")
+>>> inputs = tokenizer("<2pt> I love pizza!", return_tensors="pt")
 >>> outputs = model.generate(**inputs)
 >>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
 ['Eu amo pizza!']
 ```
 
-Note that in the input sentence, "`<2it>`" is a token determining the target language of the translation. To see all supported language codes and their corresponding tokens:
+Note that in the input sentence, "`<2pt>`" is a token determining the target language of the translation. To see all supported language codes and their corresponding tokens:
 ```python
 >>> tokens = [tokenizer.decode(i) for i in range(4,459)]
 >>> lang_codes = [token[2:-1] for token in tokens]


### PR DESCRIPTION
In the current documentation, I believe there is an error in the sample code. While the language token of the input is specified as `<2pt>` (Portuguese), the returned translation is in Italian, so actually the language should be `<2it>`.

I didn't initially understand that this was a token for the target language, so I have added an explanation of this to the documentation as well as instructions on how to get the available languages based on the [code](https://huggingface.co/spaces/jbochi/madlad400-3b-mt/blob/main/app.py) in Juarez Bochi's demo space.

It would be good to check that I have retrieved the correct range of tokens (4-459) and not omitted any (there were some additional tokens that looked to refer to scripts instead of languages, but I was not sure).

If these changes are approved, then they should also be perpetuated to the documentation of the different model checkpoints from google and jbochi.
