### PR TITLE
Fix a minor security issue

### DIFF
--- a/utils/check_self_hosted_runner.py
+++ b/utils/check_self_hosted_runner.py
@@ -6,10 +6,15 @@ import subprocess
 def get_runner_status(target_runners, token):
     offline_runners = []
 
-    cmd = (
-        f'curl -H "Accept: application/vnd.github+json" -H "Authorization: Bearer {token}"'
-        " https://api.github.com/repos/huggingface/transformers/actions/runners"
-    )
+    cmd = [
+        "curl",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"Authorization: Bearer {token}",
+        "https://api.github.com/repos/huggingface/transformers/actions/runners",
+    ]
+
     output = subprocess.run(cmd, shell=True, stdout=subprocess.PIPE)
     o = output.stdout.decode("utf-8")
     status = json.loads(o)


### PR DESCRIPTION
# What does this PR do?

There is an security report about this. It's not a big deal as `utils/check_self_hosted_runner.py` is only used in some AMD workflow files that could be only triggered by push event `.github/workflows/self-push-amd.yml` (not really used) or in

https://github.com/huggingface/hf-workflows/blob/main/.github/workflows/transformers_amd_ci_scheduled.yaml

But let's still update it anyway.


https://docs.python.org/3/library/subprocess.html

(search ` Unless otherwise stated, it is recommended to pass args as a sequence.`)