### PR TITLE
Fix broken tag in Longformer model card

### DIFF
--- a/docs/source/en/model_doc/longformer.md
+++ b/docs/source/en/model_doc/longformer.md
@@ -83,7 +83,7 @@ echo -e "San Francisco 49ers cornerback Shawntae Spencer will miss the rest of t
 ```
 
 </hfoption>
-</hfoptions
+</hfoptions>
 
 
 ## Notes


### PR DESCRIPTION
# What does this PR do?
Fixes a broken closing tag in the Longformer model card. The broken tag caused the code examples to display incorrectly on the [model card page](https://huggingface.co/docs/transformers/main/en/model_doc/longformer).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?
@stevhliu 