### PR TITLE
Fix broken notebooks link in Italian training docs

### DIFF
--- a/docs/source/it/training.md
+++ b/docs/source/it/training.md
@@ -373,4 +373,4 @@ Per altri esempi sul fine-tuning, fai riferimento a:
 
 - [🤗 Transformers Examples](https://github.com/huggingface/transformers/tree/main/examples) include scripts per addestrare compiti comuni di NLP in PyTorch e TensorFlow.
 
-- [🤗 Transformers Notebooks](notebooks) contiene diversi notebooks su come mettere a punto un modello per compiti specifici in PyTorch e TensorFlow.
+- [🤗 Transformers Notebooks](https://github.com/huggingface/notebooks) contiene diversi notebooks su come mettere a punto un modello per compiti specifici in PyTorch e TensorFlow.


### PR DESCRIPTION
Replaced the relative link to the notebooks directory in docs/source/it/training.md with an external link to the official Hugging Face Notebooks repository on GitHub. This ensures users can always access the latest and correct set of example notebooks.