### PR TITLE
Fix incorrect width ratio calculation in Llama4 image processor

### DIFF
--- a/src/transformers/models/llama4/image_processing_llama4_fast.py
+++ b/src/transformers/models/llama4/image_processing_llama4_fast.py
@@ -431,7 +431,7 @@ class Llama4ImageProcessorFast(BaseImageProcessorFast):
 
             ratio_h, ratio_w = (
                 target_size[0] // size.height,
-                target_size[1] // size.height,
+                target_size[1] // size.width,
             )
             # split into tiles
             processed_images = split_to_tiles(processed_images, ratio_h, ratio_w)


### PR DESCRIPTION
In the `Llama4ImageProcessorFast` class ([source](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama4/image_processing_llama4_fast.py#L432)), the image resizing ratios for height and width are incorrectly calculated using the image height for both dimensions:

```python
ratio_h, ratio_w = (
    target_size[0] // size.height,
    target_size[1] // size.height,
)
```

Here, `size` is defined as:

```python
size = {"height": 336, "width": 336}
```

This configuration is also present in the [preprocessor_config.json](https://huggingface.co/meta-llama/Llama-4-Scout-17B-16E/blob/main/preprocessor_config.json):

```python
"size": {
  "height": 336,
  "width": 336
}
```

Currently, the bug does not cause visible issues because the height and width are equal. However, this would lead to incorrect behavior if the dimensions were different.

**Suggested Fix**:  
Update the width ratio calculation to use `size.width` instead of `size.height`:

```python
ratio_h, ratio_w = (
    target_size[0] // size.height,
    target_size[1] // size.width,
)
```

This change ensures correct aspect ratio handling in cases where the input size is not square.