### PR TITLE
Clarify per_device_train_batch_size scaling in TrainingArguments (#38…

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -246,7 +246,8 @@ class TrainingArguments:
         prediction_loss_only (`bool`, *optional*, defaults to `False`):
             When performing evaluation and generating predictions, only returns the loss.
         per_device_train_batch_size (`int`, *optional*, defaults to 8):
-            The batch size per device accelerator core/CPU for training.
+            The batch size *per device*. The **global batch size** is computed as:
+            `per_device_train_batch_size * number_of_devices` in multi-GPU or distributed setups.
         per_device_eval_batch_size (`int`, *optional*, defaults to 8):
             The batch size per device accelerator core/CPU for evaluation.
         gradient_accumulation_steps (`int`, *optional*, defaults to 1):


### PR DESCRIPTION
## What does this PR do?

This PR clarifies in the `TrainingArguments` docstring that `per_device_train_batch_size`
is multiplied by the number of devices when training on multiple GPUs or with distributed training.

Closes #38484

## Before submitting

- [x] This PR fixes a typo or improves the docs

## Who can review?

- @zach-huggingface  
- @SunMarc  
- @qgallouedec  
