### PR TITLE
Fix loop var naming

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -380,10 +380,10 @@ def get_parameter_dtype(parameter: Union[nn.Module, "ModuleUtilsMixin"]):
 
     gen = parameter._named_members(get_members_fn=find_tensor_attributes)
     last_tuple = None
-    for tuple in gen:
-        last_tuple = tuple
-        if tuple[1].is_floating_point():
-            return tuple[1].dtype
+    for gen_tuple in gen:
+        last_tuple = gen_tuple
+        if gen_tuple[1].is_floating_point():
+            return gen_tuple[1].dtype
 
     if last_tuple is not None:
         # fallback to the last dtype


### PR DESCRIPTION
Our code contained the loop `for tuple in gen:` which clobbered the built-in Python `tuple`. This was a silent error that surfaced when we did some recent type hint fixes.

This PR fixes it by renaming the loop variable to something that doesn't overwrite a Python built-in like that!