### PR TITLE
Allow make-fixup on main branch, albeit slowly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,15 +9,15 @@ exclude_folders :=  ""
 
 modified_only_fixup:
 	@current_branch=$$(git branch --show-current); \
-	if [ "$$(current_branch)" = "main" ]; then \
-		echo "On main branch, running style target instead..."; \
+	if [ "$$current_branch" = "main" ]; then \
+		echo "On main branch, running 'style' target instead..."; \
 		$(MAKE) style; \
 	else \
-		modified_py_files=$$(python utils/get_modified_files.py $(check_dirs)) && \
+		modified_py_files=$$(python utils/get_modified_files.py $(check_dirs)); \
 		if [ -n "$$modified_py_files" ]; then \
-			echo "Checking/fixing $${modified_py_files}"; \
+			echo "Checking/fixing files: $${modified_py_files}"; \
 			ruff check $${modified_py_files} --fix --exclude $(exclude_folders); \
-			ruff format $${modified_py_files} --exclude $(exclude_folders);\
+			ruff format $${modified_py_files} --exclude $(exclude_folders); \
 		else \
 			echo "No library .py files were modified"; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -8,13 +8,19 @@ check_dirs := examples tests src utils
 exclude_folders :=  ""
 
 modified_only_fixup:
-	$(eval modified_py_files := $(shell python utils/get_modified_files.py $(check_dirs)))
-	@if test -n "$(modified_py_files)"; then \
-		echo "Checking/fixing $(modified_py_files)"; \
-		ruff check $(modified_py_files) --fix --exclude $(exclude_folders); \
-		ruff format $(modified_py_files) --exclude $(exclude_folders);\
+	$(eval current_branch := $(shell git branch --show-current))
+		@if [ "$(current_branch)" = "main" ]; then \
+		echo "On main branch, running style target instead..."; \
+		$(MAKE) style; \
 	else \
-		echo "No library .py files were modified"; \
+		modified_py_files=$$(python utils/get_modified_files.py $(check_dirs)) && \
+		if [ -n "$$modified_py_files" ]; then \
+			echo "Checking/fixing $${modified_py_files}"; \
+			ruff check $${modified_py_files} --fix --exclude $(exclude_folders); \
+			ruff format $${modified_py_files} --exclude $(exclude_folders);\
+		else \
+			echo "No library .py files were modified"; \
+		fi; \
 	fi
 
 # Update src/transformers/dependency_versions_table.py

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ check_dirs := examples tests src utils
 exclude_folders :=  ""
 
 modified_only_fixup:
-	$(eval current_branch := $(shell git branch --show-current))
-		@if [ "$(current_branch)" = "main" ]; then \
+	@current_branch=$$(git branch --show-current); \
+	if [ "$$(current_branch)" = "main" ]; then \
 		echo "On main branch, running style target instead..."; \
 		$(MAKE) style; \
 	else \

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -138,7 +138,7 @@ if __name__ == "__main__":
         console.print(
             "[bold red]You are developing on the main branch. We cannot identify the list of changed files and will have to check all files. This may take a while.[/bold red]"
         )
-        models_in_diff = args.files
+        models_in_diff = {file_path.split("/")[-2] for file_path in args.files}
     else:
         models_in_diff = get_models_in_diff()
         if not models_in_diff:
@@ -158,7 +158,8 @@ if __name__ == "__main__":
                 skipped_models.add(model_name)
                 continue
             non_matching_files += compare_files(modular_file_path, args.fix_and_overwrite)
-            models_in_diff = get_models_in_diff()  # When overwriting, the diff changes
+            if current_branch != "main":
+                models_in_diff = get_models_in_diff()  # When overwriting, the diff changes
     else:
         new_ordered_files = []
         for modular_file_path in ordered_files:

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -133,10 +133,19 @@ if __name__ == "__main__":
     # Assuming there is a topological sort on the dependency mapping: if the file being checked and its dependencies
     # are not in the diff, then there it is guaranteed to have no differences. If no models are in the diff, then this
     # script will do nothing.
-    models_in_diff = get_models_in_diff()
-    if not models_in_diff:
-        console.print("[bold green]No models files or model tests in the diff, skipping modular checks[/bold green]")
-        exit(0)
+    current_branch = subprocess.check_output(["git", "branch", "--show-current"], text=True).strip()
+    if current_branch == "main":
+        console.print(
+            "[bold red]You are developing on the main branch. We cannot identify the list of changed files and will have to check all files. This may take a while.[/bold red]"
+        )
+        models_in_diff = args.files
+    else:
+        models_in_diff = get_models_in_diff()
+        if not models_in_diff:
+            console.print(
+                "[bold green]No models files or model tests in the diff, skipping modular checks[/bold green]"
+            )
+            exit(0)
 
     skipped_models = set()
     non_matching_files = 0


### PR DESCRIPTION
I've seen a couple of cases of users making a fork and then developing on their `main` branch. This causes problems, but one of the more confusing ones is that our style tools stop working because they compare against `main` to generate a diff. Ideally, people wouldn't do this, but we can reduce the errors a little with a couple of tweaks.

This PR updates the behaviour - if you're running on `main`, no diff is generated and all files are checked. This is slow, but at least it's correct and doesn't throw an error!