### PR TITLE
fix: add __bool__ operator to tokenizer to avoid bloated asserts

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -280,7 +280,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
     def __bool__(self) -> bool:
         """
-        Returns True, to avoid expensive `assert tokenizer` gotcha's.
+        Returns True, to avoid expensive `assert tokenizer` gotchas.
         """
         return True
 

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -278,6 +278,12 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         """
         return {k.content: v for v, k in sorted(self.added_tokens_decoder.items(), key=lambda item: item[0])}
 
+    def __bool__(self) -> bool:
+        """
+        Returns True, to avoid expensive `assert tokenizer` gotcha's.
+        """
+        return True
+
     def __len__(self) -> int:
         """
         Size of the full vocabulary with the added tokens.


### PR DESCRIPTION
When a user does `assert tokenizer` to ensure that the tokenizer is not None, they inadvertently set off a rather expensive process in the `__len__()` operator. This fix adds a trivial `__bool__()` that returns True, so that a `None` tokenizer asserts and an actual tokenizer returns True when asserted, without calling length op.

A user can already address this by doing `assert tokenizer is not None`, but failing to do so is a big unexpected gotcha that shot me personally in the foot so I figured I'd at least propose a fix, which is trivial.

# What does this PR do?

This PR results in a roughly 300,000x speed-up when trying to `assert` a tokenizer object:

```python
import time
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("some-tokenizer")
start = time.perf_counter()
for i in range(4000):
    assert tokenizer
elapsed = time.perf_counter() - start
print(elapsed)
# PRE PR:  50.92993460899743
# POST PR:  0.0001564559934195131
```

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker or @n1t0 might have opinions, otherwise not sure who might review this. It's very trivial.
