### PR TITLE
Add support to use config dtype in HybridChunkedCache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1803,7 +1803,7 @@ class HybridChunkedCache(Cache):
         self.sliding_window = min(self.sliding_window, self.max_cache_len)
         self.max_batch_size = max_batch_size
         self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
-        self._dtype = dtype
+        self._dtype = getattr(config, "torch_dtype", dtype)
 
         # If the attribute does not exist in the config, fallback to a simple StaticCache
         if hasattr(config, "layer_types"):


### PR DESCRIPTION
# What does this PR do?

This PR fixes the issue with the HybridChunkedCache initialisation since it does not consider the dtype present in the model config. Here: https://github.com/huggingface/transformers/blob/b949747b54b6d81c5e4ab93c4d98ebc7a5901b31/src/transformers/cache_utils.py#L1806