### PR TITLE
Correctly raise error for awq quantization

### DIFF
--- a/src/transformers/quantizers/quantizer_awq.py
+++ b/src/transformers/quantizers/quantizer_awq.py
@@ -82,7 +82,9 @@ class AwqQuantizer(HfQuantizer):
                     "your model on a GPU device in order to run your model."
                 )
             elif device_map is not None:
-                if isinstance(device_map, dict) and ("cpu" in device_map.values() or "disk" in device_map.values()):
+                if isinstance(device_map, dict) and any(
+                    forbidden in device_map.values() for forbidden in ("cpu", torch.device("cpu"), "disk")
+                ):
                     raise ValueError(
                         "You are attempting to load an AWQ model with a device_map that contains a CPU or disk device."
                         " This is not supported. Please remove the CPU or disk device from the device_map."


### PR DESCRIPTION
# What does this PR do?

Without it, the following would run correctly:

```python
from transformers import AutoModelForCausalLM
import torch

model_id = "hugging-quants/Meta-Llama-3.1-8B-Instruct-AWQ-INT4"
model = AutoModelForCausalLM.from_pretrained(model_id, device_map="cpu", torch_dtype=torch.bfloat16)
```

and crash later during forward, whereas it should actually fail early

cc @MekkCyber @SunMarc for viz