### PR TITLE
[`Attention`] Small fix on output attentions

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -338,7 +338,7 @@ class PretrainedConfig(PushToHubMixin):
 
     @output_attentions.setter
     def output_attentions(self, value):
-        if self._attn_implementation != "eager":
+        if value is True and self._attn_implementation != "eager":
             raise ValueError(
                 "The `output_attentions` attribute is not supported when using the `attn_implementation` set to "
                 f"{self._attn_implementation}. Please set it to 'eager' instead."


### PR DESCRIPTION
Currently, anytime a user sets `output_attentions` in the config it errors out when not using eager. However, it should only error if the value is actually invalid (ie `True`).

cc @ArthurZucker 