### PR TITLE
Updated model card for wav2vec2-conformer

### DIFF
--- a/docs/source/en/model_doc/wav2vec2-conformer.md
+++ b/docs/source/en/model_doc/wav2vec2-conformer.md
@@ -14,74 +14,154 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Wav2Vec2-Conformer
-
-<div class="flex flex-wrap space-x-1">
-<img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
+<div style="float: right;">
+    <div class="flex flex-wrap space-x-1">
+        <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
+    </div>
 </div>
 
-## Overview
+# Wav2Vec2-Conformer
 
-The Wav2Vec2-Conformer was added to an updated version of [fairseq S2T: Fast Speech-to-Text Modeling with fairseq](https://huggingface.co/papers/2010.05171) by Changhan Wang, Yun Tang, Xutai Ma, Anne Wu, Sravya Popuri, Dmytro Okhonko, Juan Pino.
+[Wav2Vec2-Conformer](https://huggingface.co/papers/2010.05171) is an enhanced version of Wav2Vec2 that replaces the standard attention blocks with Conformer blocks, combining the power of convolution and attention for superior speech recognition performance. It's like upgrading your speech recognition system with a more sophisticated architecture that captures both local and global patterns in audio signals.
 
-The official results of the model can be found in Table 3 and Table 4 of the paper.
+You can find all the original [Wav2Vec2-Conformer](https://huggingface.co/models?search=wav2vec2-conformer) checkpoints on the Hugging Face Hub.
 
+> [!TIP]
+> Click on the Wav2Vec2-Conformer models in the right sidebar for more examples of how to apply Wav2Vec2-Conformer to different speech recognition and audio classification tasks.
+
+The example below demonstrates how to perform automatic speech recognition using the [`Pipeline`] or the [`AutoModel`] class.
+
+<hfoptions id="usage">
+<hfoption id="Pipeline">
+
+```python
+from transformers import pipeline
+
+# Automatic Speech Recognition
+asr = pipeline("automatic-speech-recognition", model="facebook/wav2vec2-conformer-large-960h")
+transcription = asr("path/to/audio.wav")
+
+# Audio Classification
+classifier = pipeline("audio-classification", model="facebook/wav2vec2-conformer-base")
+result = classifier("path/to/audio.wav")
+```
+
+</hfoption>
+<hfoption id="AutoModel">
+
+```python
+from transformers import AutoProcessor, Wav2Vec2ConformerForCTC
+import torch
+
+# Load model and processor
+processor = AutoProcessor.from_pretrained("facebook/wav2vec2-conformer-large-960h")
+model = Wav2Vec2ConformerForCTC.from_pretrained("facebook/wav2vec2-conformer-large-960h")
+
+#Prepare audio input (assuming you have audio data)
+audio_input = load_audio("path/to/audio.wav")
+inputs = processor(audio_input, sampling_rate=16000, return_tensors="pt", padding=True)
+
+Generate logits
+with torch.no_grad():
+    logits = model(**inputs).logits
+
+Decode
+predicted_ids = torch.argmax(logits, dim=-1)
+transcription = processor.batch_decode(predicted_ids)
+```
+
+</hfoption>
+</hfoptions>
+
+Quantization reduces the memory burden of large models by representing the weights in a lower precision. Refer to the [Quantization](../quantization/overview) overview for more available quantization backends.
+
+The example below uses [bitsandbytes quantization](https://huggingface.co/docs/transformers/main/en/main_classes/quantization) to quantize the weights to 8-bit:
+
+```python
+from transformers import Wav2Vec2ConformerForCTC
+import torch
+
+model = Wav2Vec2ConformerForCTC.from_pretrained(
+    "facebook/wav2vec2-conformer-large-960h",
+    load_in_8bit=True,
+    device_map="auto"
+)
+```
+
+## Notes
+
+### Model Architecture
+Wav2Vec2-Conformer follows the same architecture as Wav2Vec2 but replaces the standard attention blocks with Conformer blocks as introduced in [Conformer: Convolution-augmented Transformer for Speech Recognition](https://huggingface.co/papers/2005.08100). This enhancement:
+- Combines convolution and attention mechanisms
+- Captures both local and global patterns in audio
+- Requires more parameters than Wav2Vec2 for the same number of layers
+- Yields improved word error rates
+
+### Position Embeddings
+Wav2Vec2-Conformer supports multiple position embedding types:
+- No relative position embeddings
+- Transformer-XL-like position embeddings
+- Rotary position embeddings
+
+Configure the embedding type using `config.position_embeddings_type`.
+
+### Compatibility
+- Uses the same tokenizer and feature extractor as Wav2Vec2
+- Compatible with existing Wav2Vec2 pipelines and workflows
+- Can be used as a drop-in replacement for Wav2Vec2 models
+
+### Performance
+The official results can be found in Table 3 and Table 4 of the [fairseq S2T paper](https://huggingface.co/papers/2010.05171).
+
+### Model Availability
 The Wav2Vec2-Conformer weights were released by the Meta AI team within the [Fairseq library](https://github.com/pytorch/fairseq/blob/main/examples/wav2vec/README.md#pre-trained-models).
 
-This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).
-The original code can be found [here](https://github.com/pytorch/fairseq/tree/main/examples/wav2vec).
-
-Note: Meta (FAIR) released a new version of [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) - it's pretrained on 4.5M hours of audio. We especially recommend using it for fine-tuning tasks, e.g. as per [this guide](https://huggingface.co/blog/fine-tune-w2v2-bert).
-
-## Usage tips
-
-- Wav2Vec2-Conformer follows the same architecture as Wav2Vec2, but replaces the *Attention*-block with a *Conformer*-block
-  as introduced in [Conformer: Convolution-augmented Transformer for Speech Recognition](https://huggingface.co/papers/2005.08100).
-- For the same number of layers, Wav2Vec2-Conformer requires more parameters than Wav2Vec2, but also yields 
-an improved word error rate.
-- Wav2Vec2-Conformer uses the same tokenizer and feature extractor as Wav2Vec2.
-- Wav2Vec2-Conformer can use either no relative position embeddings, Transformer-XL-like position embeddings, or
-  rotary position embeddings by setting the correct `config.position_embeddings_type`.
+### Note on Wav2Vec2-BERT
+Meta (FAIR) released [Wav2Vec2-BERT 2.0](https://huggingface.co/docs/transformers/en/model_doc/wav2vec2-bert) pretrained on 4.5M hours of audio. We especially recommend using it for fine-tuning tasks, as per [this guide](https://huggingface.co/blog/fine-tune-w2v2-bert).
 
 ## Resources
 
 - [Audio classification task guide](../tasks/audio_classification)
 - [Automatic speech recognition task guide](../tasks/asr)
 
-## Wav2Vec2ConformerConfig
+---
+
+## API Reference
+
+### Wav2Vec2ConformerConfig
 
 [[autodoc]] Wav2Vec2ConformerConfig
 
-## Wav2Vec2Conformer specific outputs
+### Wav2Vec2Conformer specific outputs
 
 [[autodoc]] models.wav2vec2_conformer.modeling_wav2vec2_conformer.Wav2Vec2ConformerForPreTrainingOutput
 
-## Wav2Vec2ConformerModel
+### Wav2Vec2ConformerModel
 
 [[autodoc]] Wav2Vec2ConformerModel
     - forward
 
-## Wav2Vec2ConformerForCTC
+### Wav2Vec2ConformerForCTC
 
 [[autodoc]] Wav2Vec2ConformerForCTC
     - forward
 
-## Wav2Vec2ConformerForSequenceClassification
+### Wav2Vec2ConformerForSequenceClassification
 
 [[autodoc]] Wav2Vec2ConformerForSequenceClassification
     - forward
 
-## Wav2Vec2ConformerForAudioFrameClassification
+### Wav2Vec2ConformerForAudioFrameClassification
 
 [[autodoc]] Wav2Vec2ConformerForAudioFrameClassification
     - forward
 
-## Wav2Vec2ConformerForXVector
+### Wav2Vec2ConformerForXVector
 
 [[autodoc]] Wav2Vec2ConformerForXVector
     - forward
 
-## Wav2Vec2ConformerForPreTraining
+### Wav2Vec2ConformerForPreTraining
 
 [[autodoc]] Wav2Vec2ConformerForPreTraining
     - forward


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

This pull request significantly enhances the documentation for the `Wav2Vec2-Conformer` model by improving its structure, adding usage examples, and providing detailed explanations of its architecture and features. It also introduces quantization support and updates the API reference for better clarity.

### Documentation Enhancements:

* Reorganized the `Wav2Vec2-Conformer` documentation to include a more structured overview, detailed usage examples, and tips for applying the model to different tasks. Examples include automatic speech recognition and audio classification using both the `Pipeline` and `AutoModel` classes.
* Added a section on quantization, demonstrating how to use `bitsandbytes` for 8-bit model quantization to reduce memory usage.

### Architectural and Feature Details:

* Expanded the explanation of the `Wav2Vec2-Conformer` architecture, highlighting its use of Conformer blocks for improved speech recognition performance and its compatibility with Wav2Vec2 workflows.
* Included notes on position embedding types, tokenizer compatibility, and performance improvements, along with links to official results and related resources.

### API Reference Updates:

* Updated the API reference with detailed sections for `Wav2Vec2ConformerConfig`, `Wav2Vec2ConformerModel`, and other related classes, ensuring a clear

<!-- Remove if not applicable -->

#36979


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@stevhliu

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
