### PR TITLE
[modular] CLI allows positional arguments, and more defaults names for the optional arg

### DIFF
--- a/docs/source/en/modular_transformers.md
+++ b/docs/source/en/modular_transformers.md
@@ -24,7 +24,7 @@ A linter "unravels" the modular file into a `modeling.py` file to preserve the s
 Run the command below to automatically generate a `modeling.py` file from a modular file.
 
 ```bash
-python utils/modular_model_converter.py --files_to_parse src/transformers/models/<your_model>/modular_<your_model>.py
+python utils/modular_model_converter.py --files-to-parse src/transformers/models/<your_model>/modular_<your_model>.py
 ```
 
 For example:

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1794,6 +1794,7 @@ if __name__ == "__main__":
         help="A list of `modular_xxxx` files that should be converted to single model file",
     )
     args = parser.parse_args()
+    # Both arg represent the same data, but as positional and optional
     files_to_parse = args.files if len(args.files) > 0 else args.files_to_parse
 
     if files_to_parse == ["all"]:

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1778,19 +1778,30 @@ def save_modeling_file(modular_file, converted_file):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    # Same arg as both positional and optional, just for convenience
     parser.add_argument(
+        "files",
+        nargs="*",
+        help="A list of `modular_xxxx` files that should be converted to single model file",
+    )
+    parser.add_argument(
+        "--files-to-parse",
         "--files_to_parse",
+        "--files",
+        "-f",
         default=["all"],
         nargs="+",
         help="A list of `modular_xxxx` files that should be converted to single model file",
     )
     args = parser.parse_args()
-    if args.files_to_parse == ["all"]:
-        args.files_to_parse = glob.glob("src/transformers/models/**/modular_*.py", recursive=True)
-    if args.files_to_parse == ["examples"]:
-        args.files_to_parse = glob.glob("examples/**/modular_*.py", recursive=True)
+    files_to_parse = args.files if len(args.files) > 0 else args.files_to_parse
+
+    if files_to_parse == ["all"]:
+        files_to_parse = glob.glob("src/transformers/models/**/modular_*.py", recursive=True)
+    if files_to_parse == ["examples"]:
+        files_to_parse = glob.glob("examples/**/modular_*.py", recursive=True)
     else:
-        for i, model_name in enumerate(args.files_to_parse):
+        for i, model_name in enumerate(files_to_parse):
             if os.sep not in model_name:
                 full_path = os.path.join("src", "transformers", "models", model_name, f"modular_{model_name}.py")
                 # If it does not exist, try in the examples section
@@ -1799,10 +1810,10 @@ if __name__ == "__main__":
                 # We did not find it anywhere
                 if not os.path.isfile(full_path):
                     raise ValueError(f"Cannot find a modular file for {model_name}. Please provide the full path.")
-                args.files_to_parse[i] = full_path
+                files_to_parse[i] = full_path
 
-    priority_list, _ = find_priority_list(args.files_to_parse)
-    assert len(priority_list) == len(args.files_to_parse), "Some files will not be converted"
+    priority_list, _ = find_priority_list(files_to_parse)
+    assert len(priority_list) == len(files_to_parse), "Some files will not be converted"
 
     for file_name in priority_list:
         print(f"Converting {file_name} to a single model single file format")


### PR DESCRIPTION
# What does this PR do?

As per the title. Allows to do `python modular_model_converter.py <model>` instead of always `python modular_model_converter.py --files_to_parse <model>`.

cc @ArthurZucker 