### PR TITLE
[docs] Model contribution

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -17,10 +17,10 @@
       title: Customizing model components
     - local: model_sharing
       title: Sharing
-    - local: add_new_model
-      title: Adding a new model to Transformers
     - local: modular_transformers
-      title: Modular Transformers
+      title: Contributing a new model to Transformers
+    - local: add_new_model
+      title: Legacy model contribution
     - local: auto_docstring
       title: Document your models
     - local: attention_interface

--- a/docs/source/en/add_new_model.md
+++ b/docs/source/en/add_new_model.md
@@ -13,7 +13,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Adding a new model to Transformers
+# Legacy model contribution
 
 > [!TIP]
 > Try adding new models with a more [modular](./modular_transformers) approach first. This makes it significantly easier to contribute a model to Transformers!

--- a/docs/source/en/modular_transformers.md
+++ b/docs/source/en/modular_transformers.md
@@ -1,4 +1,4 @@
-# Modular Transformers
+# Contributing a new model to Transformers
 
 Modular Transformers lowers the bar for contributing models and significantly reduces the code required to add a model by allowing imports and inheritance.
 


### PR DESCRIPTION
Follows up on internal discussion (cc @Vaibhavs10) about clarifying `add_new_model.md` and `modular_transformers.md` by:

* renaming `modular_transformers.md` in the toctree to "Contributing a new model to Transformers" so users easily understand what the doc is versus "Modular Transformers" which may not be as clear to users what it is based on just the name
* renaming `add_new_model.md` in the toctree to "Legacy model contribution" so users understand this is an older method and should probably read the "Contributing a new model to Transformers" guide first