### PR TITLE
smolvlm video processing

### DIFF
--- a/src/transformers/models/smolvlm/processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/processing_smolvlm.py
@@ -120,6 +120,9 @@ class SmolVLMProcessorKwargs(ProcessingKwargs, total=False):
         "images_kwargs": {
             "return_row_col_info": True,
         },
+        "videos_kwargs": {
+            "return_row_col_info": True,
+        },
     }
 
 


### PR DESCRIPTION
There's a bug in smolvlm2 video processing (but keep reading, there's more): the list of frames that make up the prompt is malformed. While debugging transformers `v4.52.4`, this appeared to be because the `return_row_col_info` was removed from the kwargs, possibly in #38105.

**However**, this fix only works if we apply it on top of `v4.52.4`, but not on `main`. On `main`, the chat template goes through a new path and generation is wrong (before or after the fix). In addition, `main` seems to decode **all the frames in the video at full resolution**, I got a tensor with shape `(559, 730, 1920, 3)` [here](https://github.com/huggingface/transformers/blob/bdf5fb70aa11782cce22027d76879f71f4e41c1e/src/transformers/processing_utils.py#L1537). This is not the case in `v4.52.4` (I get 9 frames for the same video, already downscaled).

cc @zucchini-nlp, happy to take a deeper look if you have any hints on how to proceed.

Reported in https://github.com/Blaizzy/mlx-vlm/issues/388
Processing works in https://github.com/huggingface/transformers/pull/37291, but it looks out of date with `main`.