### PR TITLE
[`Generate`] Fix no grad on some models

### DIFF
--- a/src/transformers/models/bark/modeling_bark.py
+++ b/src/transformers/models/bark/modeling_bark.py
@@ -1278,6 +1278,7 @@ class BarkFineModel(BarkPreTrainedModel):
             attentions=all_self_attentions,
         )
 
+    @torch.no_grad()
     def generate(
         self,
         coarse_output: torch.Tensor,

--- a/src/transformers/models/patchtsmixer/modeling_patchtsmixer.py
+++ b/src/transformers/models/patchtsmixer/modeling_patchtsmixer.py
@@ -1720,6 +1720,7 @@ class PatchTSMixerForPrediction(PatchTSMixerPreTrainedModel):
             scale=scale,
         )
 
+    @torch.no_grad()
     def generate(
         self,
         past_values: torch.Tensor,
@@ -2104,6 +2105,7 @@ class PatchTSMixerForRegression(PatchTSMixerPreTrainedModel):
             hidden_states=model_output.hidden_states,
         )
 
+    @torch.no_grad()
     def generate(
         self,
         past_values: torch.Tensor,

--- a/src/transformers/models/patchtst/modeling_patchtst.py
+++ b/src/transformers/models/patchtst/modeling_patchtst.py
@@ -1724,6 +1724,7 @@ class PatchTSTForPrediction(PatchTSTPreTrainedModel):
             scale=scale,
         )
 
+    @torch.no_grad()
     def generate(
         self,
         past_values: torch.Tensor,
@@ -1933,6 +1934,7 @@ class PatchTSTForRegression(PatchTSTPreTrainedModel):
             attentions=model_output.attentions,
         )
 
+    @torch.no_grad()
     def generate(
         self,
         past_values: torch.Tensor,


### PR DESCRIPTION
Generate does not need gradients which is not propagated correctly for a few edge cases when the function itself is inherited and no super call is made. It a TIL for me :D 

Not the most important PR but should be done nonetheless imo.