### PR TITLE
Two ReDOS fixes

### DIFF
--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -18,7 +18,6 @@ from pathlib import Path
 from shutil import copyfile
 from typing import Any, Optional, Union
 
-import regex as re
 import sentencepiece
 
 from ...tokenization_utils import PreTrainedTokenizer
@@ -104,7 +103,6 @@ class MarianTokenizer(PreTrainedTokenizer):
 
     vocab_files_names = VOCAB_FILES_NAMES
     model_input_names = ["input_ids", "attention_mask"]
-    language_code_re = re.compile(">>.++<<")  # type: re.Pattern
 
     def __init__(
         self,
@@ -186,9 +184,11 @@ class MarianTokenizer(PreTrainedTokenizer):
 
     def remove_language_code(self, text: str):
         """Remove language codes like >>fr<< before sentencepiece"""
-        match = self.language_code_re.match(text)
-        code: list = [match.group(0)] if match else []
-        return code, self.language_code_re.sub("", text)
+        code = []
+        if text.startswith(">>") and (end_loc := text.find("<<")) != -1:
+            code.append(text[: end_loc + 2])
+            text = text[end_loc + 2 :]
+        return code, text
 
     def _tokenize(self, text: str) -> list[str]:
         code, text = self.remove_language_code(text)

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 import json
 import os
-import regex as re
 import warnings
 from pathlib import Path
 from shutil import copyfile
 from typing import Any, Optional, Union
 
+import regex as re
 import sentencepiece
 
 from ...tokenization_utils import PreTrainedTokenizer

--- a/src/transformers/models/marian/tokenization_marian.py
+++ b/src/transformers/models/marian/tokenization_marian.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import json
 import os
-import re
+import regex as re
 import warnings
 from pathlib import Path
 from shutil import copyfile
@@ -104,7 +104,7 @@ class MarianTokenizer(PreTrainedTokenizer):
 
     vocab_files_names = VOCAB_FILES_NAMES
     model_input_names = ["input_ids", "attention_mask"]
-    language_code_re = re.compile(">>.+<<")  # type: re.Pattern
+    language_code_re = re.compile(">>.++<<")  # type: re.Pattern
 
     def __init__(
         self,

--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -296,12 +296,12 @@ class AdamWeightDecay(Adam):
 
         if self._include_in_weight_decay:
             for r in self._include_in_weight_decay:
-                if re.search(r, param_name) is not None:
+                if r in param_name:
                     return True
 
         if self._exclude_from_weight_decay:
             for r in self._exclude_from_weight_decay:
-                if re.search(r, param_name) is not None:
+                if r in param_name:
                     return False
         return True
 

--- a/src/transformers/optimization_tf.py
+++ b/src/transformers/optimization_tf.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 """Functions and classes related to optimization (weight updates)."""
 
-import re
 from typing import Callable, Optional, Union
 
 import tensorflow as tf


### PR DESCRIPTION
Fixes https://huntr.com/bounties/6a6c933f-9ce8-4ded-8b3b-2c1444c61f36 and https://huntr.com/bounties/287d15a7-6e7c-45d2-8c05-11e305776f1f

The Marian change should be 100% identical, and a lot more performant than using a regex. The TF change has a slight behaviour change if people are passing regex patterns in that field, but I don't think anyone is, and also the class is deprecated anyway!