### PR TITLE
fix `kosmos2` tests

### DIFF
--- a/src/transformers/models/kosmos2/modeling_kosmos2.py
+++ b/src/transformers/models/kosmos2/modeling_kosmos2.py
@@ -719,7 +719,7 @@ class KosmosTextAttention(nn.Module):
         encoder_hidden_states: Optional[torch.Tensor] = None,
         past_key_value: Optional[tuple[torch.Tensor]] = None,
         attention_mask: Optional[torch.Tensor] = None,
-        layer_head_mask: Optional[torch.Tensor] = None,
+        is_causal: Optional[bool] = None,
         output_attentions: bool = False,
         **kwargs,
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
@@ -777,6 +777,7 @@ class KosmosTextAttention(nn.Module):
             attention_mask,
             dropout=0.0 if not self.training else self.dropout,
             scaling=self.scaling,
+            is_causal=is_causal,
             **kwargs,
         )
 
@@ -1548,6 +1549,7 @@ class Kosmos2ImageToTextProjection(nn.Module):
         hidden_states, attn_weights, _ = self.x_attn(
             hidden_states=latent_query,
             encoder_hidden_states=key_value_states,
+            is_causal=False,
             past_key_value=None,
             attention_mask=None,
             output_attentions=None,

--- a/tests/models/kosmos2/test_modeling_kosmos2.py
+++ b/tests/models/kosmos2/test_modeling_kosmos2.py
@@ -893,15 +893,16 @@ class Kosmos2ModelIntegrationTest(unittest.TestCase):
         with torch.no_grad():
             outputs = model(**inputs, interpolate_pos_encoding=True)
 
-        # verify the logits
-        expected_shape = torch.Size((1, 145, 1024))
+        # (PR 37743 makes `kosmos2` not returning anymore `vision_model_output`)
+        # verify `image_embeds`
+        expected_shape = torch.Size((1, 64, 2048))
 
-        self.assertEqual(outputs.vision_model_output.last_hidden_state.shape, expected_shape)
+        self.assertEqual(outputs.image_embeds.shape, expected_shape)
 
         expected_slice = torch.tensor(
-            [[0.9148, -1.4148, 3.8040], [3.3443, 1.9478, 0.2080], [1.6604, 2.8184, -0.3618]]
+            [[-0.0382,  0.2119,  0.1090], [0.2132, -0.0848, -0.0337], [0.1235, -0.0659,  0.0739]]
         ).to(torch_device)
 
         torch.testing.assert_close(
-            outputs.vision_model_output.last_hidden_state[0, :3, :3], expected_slice, rtol=1e-2, atol=1e-2
+            outputs.image_embeds[0, :3, :3], expected_slice, rtol=1e-4, atol=1e-4
         )

--- a/tests/models/kosmos2/test_modeling_kosmos2.py
+++ b/tests/models/kosmos2/test_modeling_kosmos2.py
@@ -900,9 +900,7 @@ class Kosmos2ModelIntegrationTest(unittest.TestCase):
         self.assertEqual(outputs.image_embeds.shape, expected_shape)
 
         expected_slice = torch.tensor(
-            [[-0.0382,  0.2119,  0.1090], [0.2132, -0.0848, -0.0337], [0.1235, -0.0659,  0.0739]]
+            [[0.1154, -0.1370, -0.2142], [-0.0703, 0.1632, -0.0770], [0.0269, -0.0356, -0.1243]]
         ).to(torch_device)
 
-        torch.testing.assert_close(
-            outputs.image_embeds[0, :3, :3], expected_slice, rtol=1e-4, atol=1e-4
-        )
+        torch.testing.assert_close(outputs.image_embeds[0, :3, :3], expected_slice, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
# What does this PR do?

[VLMs]  support attention backends (#37576) actually breaks `kosmos2` as `KosmosTextAttention` is used in the decoder (`Kosmos2TextBlock`) as well as `Kosmos2ImageToTextProjection` (which should attend to all image places).

But without `is_causal`, the `sdpa_attention_forward` will treat it as `causal` due to

```
    if torch.jit.is_tracing() and isinstance(is_causal, torch.Tensor):
        is_causal = is_causal.item()
```

Maybe there is a better way to handle this. But I would not spend too much time but just adding `is_causal` arugment and pass it.

All tests pass on A10 now