### PR TITLE
polishing docs: error fixes for clarity

### DIFF
--- a/utils/deprecate_models.py
+++ b/utils/deprecate_models.py
@@ -31,7 +31,7 @@ def get_last_stable_minor_release():
     url = "https://pypi.org/pypi/transformers/json"
     release_data = requests.get(url).json()
 
-    # Find the last stable release of of transformers (version below current version)
+    # Find the last stable release of transformers (version below current version)
     major_version, minor_version, patch_version, _ = current_version.split(".")
     last_major_minor = f"{major_version}.{int(minor_version) - 1}"
     last_stable_minor_releases = [

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1490,7 +1490,7 @@ class ModularFileMapper(ModuleMapper):
                 suffix = common_partial_suffix(class_name, modeling_bases[0])
                 if len(suffix) > 0 and suffix[0].isupper():
                     cased_model_name = class_name.replace(suffix, "")
-                    # If both the old model and new model share the last part of their name, is is detected as a common
+                    # If both the old model and new model share the last part of their name, is detected as a common
                     # suffix, but it should not be the case -> use the full name in this case
                     if len(cased_model_name) < len(cased_default_name) and cased_default_name in class_name:
                         cased_model_name = cased_default_name


### PR DESCRIPTION
Spotted and fixed a few wording hiccups:

utils/deprecate_models.py
`of of `- `of`  -- fix duplicate

utils/modular_model_converter.py
`is is` - `is` -- fix duplicate
