### PR TITLE
fix `test_compare_unprocessed_logit_scores`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -3806,7 +3806,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         logits_gen = outputs.logits[0][0]
 
         # assert that unprocessed logits from generate() are same as those from modal eval()
-        self.assertListEqual(logits_fwd.tolist(), logits_gen.tolist())
+        torch.testing.assert_allclose(logits_fwd.tolist(), logits_gen.tolist())
 
     def test_return_unprocessed_logit_scores(self):
         # tell model to generate text and return unprocessed/unwarped logit scores


### PR DESCRIPTION
# What does this PR do?

With #39016, this test

> tests/generation/test_utils.py::GenerationIntegrationTests::test_compare_unprocessed_logit_scores

is failing.

However, the difference is in the range of 1e-7

```
(Pdb) torch.amax(torch.abs(logits_fwd - logits_gen))
tensor(5.9605e-08, device='cuda:0')
```

The test was using `assertListEqual`  which is not good for float numbers.