### PR TITLE
Ignore extra position embeddings weights for ESM

### DIFF
--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -738,7 +738,7 @@ class EsmPreTrainedModel(PreTrainedModel):
     base_model_prefix = "esm"
     supports_gradient_checkpointing = True
     _no_split_modules = ["EsmLayer", "EsmFoldTriangularSelfAttentionBlock", "EsmEmbeddings"]
-    _keys_to_ignore_on_load_unexpected = ["esm.embeddings.position_embeddings.weight"]
+    _keys_to_ignore_on_load_unexpected = ["position_embeddings.weight"]
     _supports_flash_attn = True
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights with BertLMPredictionHead->EsmLMHead

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -738,6 +738,7 @@ class EsmPreTrainedModel(PreTrainedModel):
     base_model_prefix = "esm"
     supports_gradient_checkpointing = True
     _no_split_modules = ["EsmLayer", "EsmFoldTriangularSelfAttentionBlock", "EsmEmbeddings"]
+    _keys_to_ignore_on_load_unexpected = ["esm.embeddings.position_embeddings.weight"]
     _supports_flash_attn = True
 
     # Copied from transformers.models.bert.modeling_bert.BertPreTrainedModel._init_weights with BertLMPredictionHead->EsmLMHead


### PR DESCRIPTION
Before #38089, ESM created `self.position_embeddings` even when `config.position_embedding_type == "rotary"`. This weight was not used. The error was fixed in #38089, but most ESM checkpoints still have the unused `self.position_embeddings` weight. This PR adds that it the unexpected_ignore list, so users don't get scary warnings for a benign issue.