### PR TITLE
fix `Gemma3nProcessorTest`

### DIFF
--- a/tests/models/gemma3n/test_processing_gemma3n.py
+++ b/tests/models/gemma3n/test_processing_gemma3n.py
@@ -36,7 +36,7 @@ if is_speech_available():
 class Gemma3nProcessorTest(unittest.TestCase):
     def setUp(self):
         # TODO: update to google?
-        self.model_id = "Google/gemma-3n-E4B-it"
+        self.model_id = "hf-internal-testing/namespace-google-repo_name-gemma-3n-E4B-it"
         self.tmpdirname = tempfile.mkdtemp(suffix="gemma3n")
         self.maxDiff = None
 

--- a/tests/models/gemma3n/test_processing_gemma3n.py
+++ b/tests/models/gemma3n/test_processing_gemma3n.py
@@ -71,6 +71,9 @@ class Gemma3nProcessorTest(unittest.TestCase):
         self.assertIsInstance(processor.tokenizer, GemmaTokenizerFast)
         self.assertEqual(processor.tokenizer.get_vocab(), tokenizer.get_vocab())
 
+        # `disable_grouping` is a new attribute that got added on main while gemma3n was being released - so was
+        # not part of the saved processor 
+        del processor.feature_extractor.disable_grouping
         self.assertIsInstance(processor.feature_extractor, Gemma3nAudioFeatureExtractor)
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor.to_json_string())
 
@@ -94,6 +97,9 @@ class Gemma3nProcessorTest(unittest.TestCase):
         self.assertEqual(processor.tokenizer.get_vocab(), tokenizer_add_kwargs.get_vocab())
         self.assertIsInstance(processor.tokenizer, GemmaTokenizerFast)
 
+        # `disable_grouping` is a new attribute that got added on main while gemma3n was being released - so was
+        # not part of the saved processor 
+        del processor.feature_extractor.disable_grouping
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor_add_kwargs.to_json_string())
         self.assertIsInstance(processor.feature_extractor, Gemma3nAudioFeatureExtractor)
 

--- a/tests/models/gemma3n/test_processing_gemma3n.py
+++ b/tests/models/gemma3n/test_processing_gemma3n.py
@@ -72,7 +72,7 @@ class Gemma3nProcessorTest(unittest.TestCase):
         self.assertEqual(processor.tokenizer.get_vocab(), tokenizer.get_vocab())
 
         # `disable_grouping` is a new attribute that got added on main while gemma3n was being released - so was
-        # not part of the saved processor 
+        # not part of the saved processor
         del processor.feature_extractor.disable_grouping
         self.assertIsInstance(processor.feature_extractor, Gemma3nAudioFeatureExtractor)
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor.to_json_string())
@@ -98,7 +98,7 @@ class Gemma3nProcessorTest(unittest.TestCase):
         self.assertIsInstance(processor.tokenizer, GemmaTokenizerFast)
 
         # `disable_grouping` is a new attribute that got added on main while gemma3n was being released - so was
-        # not part of the saved processor 
+        # not part of the saved processor
         del processor.feature_extractor.disable_grouping
         self.assertEqual(processor.feature_extractor.to_json_string(), feature_extractor_add_kwargs.to_json_string())
         self.assertIsInstance(processor.feature_extractor, Gemma3nAudioFeatureExtractor)


### PR DESCRIPTION
# What does this PR do?

Use  [a new repository](https://huggingface.co/hf-internal-testing/namespace-google-repo_name-gemma-3n-E4B-it/tree/main) to run processor tests on CircleCI.

or if @RyanMullins could check these maybe?

There are still 2 failures, could you take a look on these 2 please?

> FAILED tests/models/gemma3n/test_processing_gemma3n.py::Gemma3nProcessorTest::test_save_load_pretrained_additional_features - AssertionError: '{\n [107 chars]  "disable_grouping": null,\n  "dither": 5.0,\[1044 chars]n}\n' != '{\n [107 chars]  "dither": 5.0,\n  "do_center_crop": null,\n [1015 chars]n}\n'

> FAILED tests/models/gemma3n/test_processing_gemma3n.py::Gemma3nProcessorTest::test_save_load_pretrained_default - AssertionError: '{\n [107 chars]  "disable_grouping": null,\n  "dither": 0.0,\[1044 chars]n}\n' != '{\n [107 chars]  "dither": 0.0,\n  "do_center_crop": null,\n [1015 chars]n}\n'
