### PR TITLE
fixed typo for docstring in prepare_inputs method

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -558,7 +558,7 @@ class GenerationMixin(ContinuousMixin):
         **kwargs,
     ):
         """
-        Prepare the model inputs for generation. In includes operations like computing the 4D attention mask or
+        Prepare the model inputs for generation. It includes operations like computing the 4D attention mask or
         slicing inputs given the existing cache.
 
         See the forward pass in the model documentation for expected arguments (different models might have different


### PR DESCRIPTION
fixed typo for docstring in prepare_inputs method

- [x] This PR fixes a typo or improves the docs .


## Who can review?

Documentation: @stevhliu

