### PR TITLE
Fix: unprotected import of tp plugin

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -230,7 +230,6 @@ if is_accelerate_available():
         AutocastKwargs,
         DistributedDataParallelKwargs,
         DistributedType,
-        TorchTensorParallelPlugin,
         load_fsdp_model,
         load_fsdp_optimizer,
         save_fsdp_model,


### PR DESCRIPTION
Fixes #39077. We only use `TensorParallelPlugin` [here](https://github.com/huggingface/transformers/blob/9c8d3a70b8bf359150c960c4281aaa853498fe8c/src/transformers/trainer.py#L5204) and that is version checked, the matching import that is also version checked is [here](https://github.com/huggingface/transformers/blob/9c8d3a70b8bf359150c960c4281aaa853498fe8c/src/transformers/trainer.py#L242). The import I deleted is non-version checked and not needed.
