### PR TITLE
TST PEFT integration tests with pipeline generate

### DIFF
--- a/tests/peft_integration/test_peft_integration.py
+++ b/tests/peft_integration/test_peft_integration.py
@@ -531,7 +531,7 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
             peft_params = list(peft_pipe.model.parameters())
             base_params = list(base_pipe.model.parameters())
             self.assertNotEqual(len(peft_params), len(base_params))  # Assert we actually loaded the adapter too
-            _ = peft_pipe("Hello")
+            _ = peft_pipe("Hello", max_new_tokens=20)
 
     def test_peft_add_adapter_with_state_dict(self):
         """
@@ -858,4 +858,4 @@ class PeftIntegrationTester(unittest.TestCase, PeftTesterMixin):
             )
 
             # Generate text to verify pipeline works
-            _ = lora_generator(text)
+            _ = lora_generator(text, max_new_tokens=20)


### PR DESCRIPTION
# What does this PR do?

Some PEFT integration tests involving text generation pipelines were failing since #38129 because the base model is too small to generate longer sequences. Setting max_new_tokens fixes this.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.  <= internally on slack
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? <= already there


## Who can review?