### PR TITLE
Fix audio-related config naming for Gemma3n 

### DIFF
--- a/src/transformers/models/gemma3n/configuration_gemma3n.py
+++ b/src/transformers/models/gemma3n/configuration_gemma3n.py
@@ -575,7 +575,7 @@ class Gemma3nConfig(PretrainedConfig):
             Custom vision config or dict.
         audio_config (`Union[AutoConfig, dict]`,  *optional*):
             Custom audio config or dict.
-        audio_soft_tokens_per_image (`int`, *optional*, defaults to 188):
+        audio_soft_tokens_per_audio (`int`, *optional*, defaults to 188):
             The number of soft tokens per audio clip.
         vision_soft_tokens_per_image (`int`, *optional*, defaults to 256):
             The number of soft tokens per image.
@@ -631,7 +631,7 @@ class Gemma3nConfig(PretrainedConfig):
         text_config: Optional[Union[Gemma3nTextConfig, dict[str, Any]]] = None,
         vision_config: Optional[Union[Gemma3nVisionConfig, dict[str, Any]]] = None,
         audio_config: Optional[Union[Gemma3nAudioConfig, dict[str, Any]]] = None,
-        audio_soft_tokens_per_image: int = 188,
+        audio_soft_tokens_per_audio: int = 188,
         vision_soft_tokens_per_image: int = 256,
         boi_token_id: int = 255_999,
         eoi_token_id: int = 262_144,
@@ -666,7 +666,7 @@ class Gemma3nConfig(PretrainedConfig):
         self.vision_config = vision_config
         self.audio_config = audio_config
 
-        self.audio_soft_tokens_per_image = audio_soft_tokens_per_image
+        self.audio_soft_tokens_per_audio = audio_soft_tokens_per_audio
         self.vision_soft_tokens_per_image = vision_soft_tokens_per_image
         self.boi_token_id = boi_token_id
         self.eoi_token_id = eoi_token_id

--- a/src/transformers/models/gemma3n/modeling_gemma3n.py
+++ b/src/transformers/models/gemma3n/modeling_gemma3n.py
@@ -937,7 +937,7 @@ class Gemma3nAudioEncoder(PreTrainedModel):
 
         Returns:
             audio_encodings: a torch.Tensor of shape
-                `[batch_size, self.config.audio_soft_tokens_per_image,
+                `[batch_size, self.config.audio_soft_tokens_per_audio,
                 self.config.audio_config.hidden_size]`
             audio_mel_mask: a torch.BoolTensor of shape [batch, num_frames].
         """
@@ -2114,7 +2114,7 @@ class Gemma3nModel(Gemma3nPreTrainedModel):
             audio_features = torch.where(audio_mask.unsqueeze(-1), audio_padding_embs, audio_features)
 
             audio_batch_size, audio_seq_len, audio_embed_dim = audio_features.shape
-            extra_padding_tokens = self.config.audio_soft_tokens_per_image - audio_seq_len
+            extra_padding_tokens = self.config.audio_soft_tokens_per_audio - audio_seq_len
             extra_padding_features = audio_padding_embs.expand(audio_batch_size, extra_padding_tokens, audio_embed_dim)
 
             audio_features = torch.cat((audio_features, extra_padding_features), dim=1)

--- a/src/transformers/models/gemma3n/modular_gemma3n.py
+++ b/src/transformers/models/gemma3n/modular_gemma3n.py
@@ -538,7 +538,7 @@ class Gemma3nConfig(PretrainedConfig):
             Custom vision config or dict.
         audio_config (`Union[AutoConfig, dict]`,  *optional*):
             Custom audio config or dict.
-        audio_soft_tokens_per_image (`int`, *optional*, defaults to 188):
+        audio_soft_tokens_per_audio (`int`, *optional*, defaults to 188):
             The number of soft tokens per audio clip.
         vision_soft_tokens_per_image (`int`, *optional*, defaults to 256):
             The number of soft tokens per image.
@@ -594,7 +594,7 @@ class Gemma3nConfig(PretrainedConfig):
         text_config: Optional[Union[Gemma3nTextConfig, dict[str, Any]]] = None,
         vision_config: Optional[Union[Gemma3nVisionConfig, dict[str, Any]]] = None,
         audio_config: Optional[Union[Gemma3nAudioConfig, dict[str, Any]]] = None,
-        audio_soft_tokens_per_image: int = 188,
+        audio_soft_tokens_per_audio: int = 188,
         vision_soft_tokens_per_image: int = 256,
         boi_token_id: int = 255_999,
         eoi_token_id: int = 262_144,
@@ -629,7 +629,7 @@ class Gemma3nConfig(PretrainedConfig):
         self.vision_config = vision_config
         self.audio_config = audio_config
 
-        self.audio_soft_tokens_per_image = audio_soft_tokens_per_image
+        self.audio_soft_tokens_per_audio = audio_soft_tokens_per_audio
         self.vision_soft_tokens_per_image = vision_soft_tokens_per_image
         self.boi_token_id = boi_token_id
         self.eoi_token_id = eoi_token_id
@@ -1499,7 +1499,7 @@ class Gemma3nAudioEncoder(PreTrainedModel):
 
         Returns:
             audio_encodings: a torch.Tensor of shape
-                `[batch_size, self.config.audio_soft_tokens_per_image,
+                `[batch_size, self.config.audio_soft_tokens_per_audio,
                 self.config.audio_config.hidden_size]`
             audio_mel_mask: a torch.BoolTensor of shape [batch, num_frames].
         """
@@ -2383,7 +2383,7 @@ class Gemma3nModel(PaliGemmaModel):
             audio_features = torch.where(audio_mask.unsqueeze(-1), audio_padding_embs, audio_features)
 
             audio_batch_size, audio_seq_len, audio_embed_dim = audio_features.shape
-            extra_padding_tokens = self.config.audio_soft_tokens_per_image - audio_seq_len
+            extra_padding_tokens = self.config.audio_soft_tokens_per_audio - audio_seq_len
             extra_padding_features = audio_padding_embs.expand(audio_batch_size, extra_padding_tokens, audio_embed_dim)
 
             audio_features = torch.cat((audio_features, extra_padding_features), dim=1)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

While working on adding multimodal support for Gemma3n on vLLM, I noticed `audio_soft_tokens_per_image` should really be renamed to `audio_soft_tokens_per_audio`. This PR updates the variable naming but we'll also need to update this field in the model repository.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
