### PR TITLE
Fix missing fsdp & trainer jobs in daily CI

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -135,6 +135,7 @@ jobs:
       folder_slices: ${{ needs.setup.outputs.folder_slices }}
       machine_type: ${{ matrix.machine_type }}
       slice_id: ${{ matrix.slice_id }}
+      runner_map: ${{ needs.setup.outputs.runner_map }}
       docker: ${{ inputs.docker }}
       report_name_prefix: run_trainer_and_fsdp_gpu
     secrets: inherit


### PR DESCRIPTION
# What does this PR do?

It's missing, as one can see in 

https://huggingface.slack.com/archives/C06SZSGL2AF/p1750393112155819

It's caused by

Switch to use A10 progressively (#38936)

where we add an extra variable `runner_map`