### PR TITLE
[glm4v] fix video inference

### DIFF
--- a/src/transformers/models/glm4v/modeling_glm4v.py
+++ b/src/transformers/models/glm4v/modeling_glm4v.py
@@ -1269,13 +1269,13 @@ class Glm4vModel(Glm4vPreTrainedModel):
 
             if input_ids is None:
                 video_mask = inputs_embeds == self.get_input_embeddings()(
-                    torch.tensor(self.config.video_token_id, dtype=torch.long, device=inputs_embeds.device)
+                    torch.tensor(self.config.image_token_id, dtype=torch.long, device=inputs_embeds.device)
                 )
                 video_mask = video_mask.all(-1)
             else:
-                video_mask = input_ids == self.config.video_token_id
+                video_mask = input_ids == self.config.image_token_id
 
-            n_video_tokens = (video_mask).sum()
+            n_video_tokens = video_mask.sum()
             n_video_features = video_embeds.shape[0]
             video_mask = video_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
             if not is_torchdynamo_compiling() and n_video_tokens != n_video_features:

--- a/src/transformers/models/glm4v/modular_glm4v.py
+++ b/src/transformers/models/glm4v/modular_glm4v.py
@@ -1269,13 +1269,13 @@ class Glm4vModel(Qwen2_5_VLModel):
 
             if input_ids is None:
                 video_mask = inputs_embeds == self.get_input_embeddings()(
-                    torch.tensor(self.config.video_token_id, dtype=torch.long, device=inputs_embeds.device)
+                    torch.tensor(self.config.image_token_id, dtype=torch.long, device=inputs_embeds.device)
                 )
                 video_mask = video_mask.all(-1)
             else:
-                video_mask = input_ids == self.config.video_token_id
+                video_mask = input_ids == self.config.image_token_id
 
-            n_video_tokens = (video_mask).sum()
+            n_video_tokens = video_mask.sum()
             n_video_features = video_embeds.shape[0]
             video_mask = video_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
             if not is_torchdynamo_compiling() and n_video_tokens != n_video_features:


### PR DESCRIPTION
# What does this PR do?

I broke video inference in a recent PR by copying from Qwen2-VL. Comes out GLM4V doesn't have a video token and instead uses image token id repeated many times per frame

No need for patching, only the main branch is broken