### PR TITLE
fix(pipelines): QA pipeline returns fewer than top_k results in batch mode

### DIFF
--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -542,7 +542,10 @@ class QuestionAnsweringPipeline(ChunkPipeline):
         align_to_words=True,
     ):
         min_null_score = 1000000  # large and positive
-        answers = []
+
+        n_best_per_chunk = top_k + 20
+
+        all_candidates = []
         for output in model_outputs:
             if self.framework == "pt" and output["start"].dtype == torch.bfloat16:
                 start_ = output["start"].to(torch.float32)
@@ -550,90 +553,91 @@ class QuestionAnsweringPipeline(ChunkPipeline):
             else:
                 start_ = output["start"]
                 end_ = output["end"]
-            example = output["example"]
+
             p_mask = output["p_mask"]
             attention_mask = (
                 output["attention_mask"].numpy() if output.get("attention_mask", None) is not None else None
             )
 
             starts, ends, scores, min_null_score = select_starts_ends(
-                start_, end_, p_mask, attention_mask, min_null_score, top_k, handle_impossible_answer, max_answer_len
+                start_,
+                end_,
+                p_mask,
+                attention_mask,
+                min_null_score,
+                n_best_per_chunk,
+                handle_impossible_answer,
+                max_answer_len,
             )
+
+            for s, e, score in zip(starts, ends, scores):
+                all_candidates.append(
+                    {
+                        "score": score.item(),
+                        "start_token": s,
+                        "end_token": e,
+                        "metadata": output,
+                    }
+                )
+
+        all_candidates = sorted(all_candidates, key=lambda x: x["score"], reverse=True)
+
+        answers = {}
+        for cand in all_candidates:
+            if len(answers) >= top_k:
+                break
+
+            metadata = cand["metadata"]
+            example = metadata["example"]
 
             if not self.tokenizer.is_fast:
                 char_to_word = np.array(example.char_to_word_offset)
-
-                # Convert the answer (tokens) back to the original text
-                # Score: score from the model
-                # Start: Index of the first character of the answer in the context string
-                # End: Index of the character following the last character of the answer in the context string
-                # Answer: Plain text of the answer
-                for s, e, score in zip(starts, ends, scores):
-                    token_to_orig_map = output["token_to_orig_map"]
-                    answers.append(
-                        {
-                            "score": score.item(),
-                            "start": np.where(char_to_word == token_to_orig_map[s])[0][0].item(),
-                            "end": np.where(char_to_word == token_to_orig_map[e])[0][-1].item(),
-                            "answer": " ".join(example.doc_tokens[token_to_orig_map[s] : token_to_orig_map[e] + 1]),
-                        }
-                    )
+                token_to_orig_map = metadata["token_to_orig_map"]
+                start_char_idx = np.where(char_to_word == token_to_orig_map[cand["start_token"]])[0][0].item()
+                end_char_idx = np.where(char_to_word == token_to_orig_map[cand["end_token"]])[0][-1].item()
+                answer_text = " ".join(
+                    example.doc_tokens[
+                        token_to_orig_map[cand["start_token"]] : token_to_orig_map[cand["end_token"]] + 1
+                    ]
+                )
             else:
-                # Convert the answer (tokens) back to the original text
-                # Score: score from the model
-                # Start: Index of the first character of the answer in the context string
-                # End: Index of the character following the last character of the answer in the context string
-                # Answer: Plain text of the answer
+                enc = metadata["encoding"]
                 question_first = bool(self.tokenizer.padding_side == "right")
-                enc = output["encoding"]
+                sequence_index = 1 if question_first else 0
 
-                # Encoding was *not* padded, input_ids *might*.
-                # It doesn't make a difference unless we're padding on
-                # the left hand side, since now we have different offsets
-                # everywhere.
                 if self.tokenizer.padding_side == "left":
-                    offset = (output["input_ids"] == self.tokenizer.pad_token_id).numpy().sum()
+                    offset = (metadata["input_ids"] == self.tokenizer.pad_token_id).numpy().sum()
                 else:
                     offset = 0
 
-                # Sometimes the max probability token is in the middle of a word so:
-                # - we start by finding the right word containing the token with `token_to_word`
-                # - then we convert this word in a character span with `word_to_chars`
-                sequence_index = 1 if question_first else 0
+                start_token = cand["start_token"] - offset
+                end_token = cand["end_token"] - offset
 
-                for s, e, score in zip(starts, ends, scores):
-                    s = s - offset
-                    e = e - offset
+                start_char_idx, end_char_idx = self.get_indices(
+                    enc, start_token, end_token, sequence_index, align_to_words
+                )
+                answer_text = example.context_text[start_char_idx:end_char_idx]
 
-                    start_index, end_index = self.get_indices(enc, s, e, sequence_index, align_to_words)
+            key = answer_text.lower()
+            if key in answers:
+                answers[key]["score"] += cand["score"]
+            else:
+                answers[key] = {
+                    "score": cand["score"],
+                    "start": start_char_idx,
+                    "end": end_char_idx,
+                    "answer": answer_text,
+                }
 
-                    target_answer = example.context_text[start_index:end_index]
-                    answer = self.get_answer(answers, target_answer)
-
-                    if answer:
-                        answer["score"] += score.item()
-                    else:
-                        answers.append(
-                            {
-                                "score": score.item(),
-                                "start": start_index,
-                                "end": end_index,
-                                "answer": example.context_text[start_index:end_index],
-                            }
-                        )
-
+        final_answers = list(answers.values())
         if handle_impossible_answer:
-            answers.append({"score": min_null_score, "start": 0, "end": 0, "answer": ""})
-        answers = sorted(answers, key=lambda x: x["score"], reverse=True)[:top_k]
-        if len(answers) == 1:
-            return answers[0]
-        return answers
+            final_answers.append({"score": min_null_score, "start": 0, "end": 0, "answer": ""})
 
-    def get_answer(self, answers: list[dict], target: str) -> Optional[dict]:
-        for answer in answers:
-            if answer["answer"].lower() == target.lower():
-                return answer
-        return None
+        final_answers = sorted(final_answers, key=lambda x: x["score"], reverse=True)[:top_k]
+
+        if len(final_answers) == 1:
+            return final_answers[0]
+        return final_answers
 
     def get_indices(
         self, enc: "tokenizers.Encoding", s: int, e: int, sequence_index: int, align_to_words: bool

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -556,9 +556,18 @@ class QuestionAnsweringPipeline(ChunkPipeline):
                 output["attention_mask"].numpy() if output.get("attention_mask", None) is not None else None
             )
 
-            pre_topk = top_k * 2 + 10 if align_to_words else top_k  # Some candidates may be deleted if we align to words
+            pre_topk = (
+                top_k * 2 + 10 if align_to_words else top_k
+            )  # Some candidates may be deleted if we align to words
             starts, ends, scores, min_null_score = select_starts_ends(
-                start_, end_, p_mask, attention_mask, min_null_score, pre_topk, handle_impossible_answer, max_answer_len
+                start_,
+                end_,
+                p_mask,
+                attention_mask,
+                min_null_score,
+                pre_topk,
+                handle_impossible_answer,
+                max_answer_len,
             )
 
             if not self.tokenizer.is_fast:

--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -542,10 +542,7 @@ class QuestionAnsweringPipeline(ChunkPipeline):
         align_to_words=True,
     ):
         min_null_score = 1000000  # large and positive
-
-        n_best_per_chunk = top_k + 20
-
-        all_candidates = []
+        answers = []
         for output in model_outputs:
             if self.framework == "pt" and output["start"].dtype == torch.bfloat16:
                 start_ = output["start"].to(torch.float32)
@@ -553,91 +550,91 @@ class QuestionAnsweringPipeline(ChunkPipeline):
             else:
                 start_ = output["start"]
                 end_ = output["end"]
-
+            example = output["example"]
             p_mask = output["p_mask"]
             attention_mask = (
                 output["attention_mask"].numpy() if output.get("attention_mask", None) is not None else None
             )
 
+            pre_topk = top_k * 2 + 10 if align_to_words else top_k  # Some candidates may be deleted if we align to words
             starts, ends, scores, min_null_score = select_starts_ends(
-                start_,
-                end_,
-                p_mask,
-                attention_mask,
-                min_null_score,
-                n_best_per_chunk,
-                handle_impossible_answer,
-                max_answer_len,
+                start_, end_, p_mask, attention_mask, min_null_score, pre_topk, handle_impossible_answer, max_answer_len
             )
-
-            for s, e, score in zip(starts, ends, scores):
-                all_candidates.append(
-                    {
-                        "score": score.item(),
-                        "start_token": s,
-                        "end_token": e,
-                        "metadata": output,
-                    }
-                )
-
-        all_candidates = sorted(all_candidates, key=lambda x: x["score"], reverse=True)
-
-        answers = {}
-        for cand in all_candidates:
-            if len(answers) >= top_k:
-                break
-
-            metadata = cand["metadata"]
-            example = metadata["example"]
 
             if not self.tokenizer.is_fast:
                 char_to_word = np.array(example.char_to_word_offset)
-                token_to_orig_map = metadata["token_to_orig_map"]
-                start_char_idx = np.where(char_to_word == token_to_orig_map[cand["start_token"]])[0][0].item()
-                end_char_idx = np.where(char_to_word == token_to_orig_map[cand["end_token"]])[0][-1].item()
-                answer_text = " ".join(
-                    example.doc_tokens[
-                        token_to_orig_map[cand["start_token"]] : token_to_orig_map[cand["end_token"]] + 1
-                    ]
-                )
-            else:
-                enc = metadata["encoding"]
-                question_first = bool(self.tokenizer.padding_side == "right")
-                sequence_index = 1 if question_first else 0
 
+                # Convert the answer (tokens) back to the original text
+                # Score: score from the model
+                # Start: Index of the first character of the answer in the context string
+                # End: Index of the character following the last character of the answer in the context string
+                # Answer: Plain text of the answer
+                for s, e, score in zip(starts, ends, scores):
+                    token_to_orig_map = output["token_to_orig_map"]
+                    answers.append(
+                        {
+                            "score": score.item(),
+                            "start": np.where(char_to_word == token_to_orig_map[s])[0][0].item(),
+                            "end": np.where(char_to_word == token_to_orig_map[e])[0][-1].item(),
+                            "answer": " ".join(example.doc_tokens[token_to_orig_map[s] : token_to_orig_map[e] + 1]),
+                        }
+                    )
+            else:
+                # Convert the answer (tokens) back to the original text
+                # Score: score from the model
+                # Start: Index of the first character of the answer in the context string
+                # End: Index of the character following the last character of the answer in the context string
+                # Answer: Plain text of the answer
+                question_first = bool(self.tokenizer.padding_side == "right")
+                enc = output["encoding"]
+
+                # Encoding was *not* padded, input_ids *might*.
+                # It doesn't make a difference unless we're padding on
+                # the left hand side, since now we have different offsets
+                # everywhere.
                 if self.tokenizer.padding_side == "left":
-                    offset = (metadata["input_ids"] == self.tokenizer.pad_token_id).numpy().sum()
+                    offset = (output["input_ids"] == self.tokenizer.pad_token_id).numpy().sum()
                 else:
                     offset = 0
 
-                start_token = cand["start_token"] - offset
-                end_token = cand["end_token"] - offset
+                # Sometimes the max probability token is in the middle of a word so:
+                # - we start by finding the right word containing the token with `token_to_word`
+                # - then we convert this word in a character span with `word_to_chars`
+                sequence_index = 1 if question_first else 0
 
-                start_char_idx, end_char_idx = self.get_indices(
-                    enc, start_token, end_token, sequence_index, align_to_words
-                )
-                answer_text = example.context_text[start_char_idx:end_char_idx]
+                for s, e, score in zip(starts, ends, scores):
+                    s = s - offset
+                    e = e - offset
 
-            key = answer_text.lower()
-            if key in answers:
-                answers[key]["score"] += cand["score"]
-            else:
-                answers[key] = {
-                    "score": cand["score"],
-                    "start": start_char_idx,
-                    "end": end_char_idx,
-                    "answer": answer_text,
-                }
+                    start_index, end_index = self.get_indices(enc, s, e, sequence_index, align_to_words)
 
-        final_answers = list(answers.values())
+                    target_answer = example.context_text[start_index:end_index]
+                    answer = self.get_answer(answers, target_answer)
+
+                    if answer:
+                        answer["score"] += score.item()
+                    else:
+                        answers.append(
+                            {
+                                "score": score.item(),
+                                "start": start_index,
+                                "end": end_index,
+                                "answer": example.context_text[start_index:end_index],
+                            }
+                        )
+
         if handle_impossible_answer:
-            final_answers.append({"score": min_null_score, "start": 0, "end": 0, "answer": ""})
+            answers.append({"score": min_null_score, "start": 0, "end": 0, "answer": ""})
+        answers = sorted(answers, key=lambda x: x["score"], reverse=True)[:top_k]
+        if len(answers) == 1:
+            return answers[0]
+        return answers
 
-        final_answers = sorted(final_answers, key=lambda x: x["score"], reverse=True)[:top_k]
-
-        if len(final_answers) == 1:
-            return final_answers[0]
-        return final_answers
+    def get_answer(self, answers: list[dict], target: str) -> Optional[dict]:
+        for answer in answers:
+            if answer["answer"].lower() == target.lower():
+                return answer
+        return None
 
     def get_indices(
         self, enc: "tokenizers.Encoding", s: int, e: int, sequence_index: int, align_to_words: bool

--- a/tests/pipelines/test_pipelines_question_answering.py
+++ b/tests/pipelines/test_pipelines_question_answering.py
@@ -168,10 +168,10 @@ class QAPipelineTests(unittest.TestCase):
         )
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris."
+            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
         )
 
-        self.assertEqual(nested_simplify(outputs), {"score": 0.01, "start": 0, "end": 11, "answer": "HuggingFace"})
+        self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
 
     @require_torch
     def test_small_model_pt_fp16(self):
@@ -182,10 +182,10 @@ class QAPipelineTests(unittest.TestCase):
         )
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris."
+            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
         )
 
-        self.assertEqual(nested_simplify(outputs), {"score": 0.01, "start": 0, "end": 11, "answer": "HuggingFace"})
+        self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
 
     @require_torch
     def test_small_model_pt_bf16(self):
@@ -196,10 +196,10 @@ class QAPipelineTests(unittest.TestCase):
         )
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris."
+            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
         )
 
-        self.assertEqual(nested_simplify(outputs), {"score": 0.01, "start": 0, "end": 11, "answer": "HuggingFace"})
+        self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
 
     @require_torch
     def test_small_model_pt_iterator(self):
@@ -211,7 +211,7 @@ class QAPipelineTests(unittest.TestCase):
                 yield {"question": "Where was HuggingFace founded ?", "context": "HuggingFace was founded in Paris."}
 
         for outputs in pipe(data()):
-            self.assertEqual(nested_simplify(outputs), {"score": 0.01, "start": 0, "end": 11, "answer": "HuggingFace"})
+            self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
 
     @require_torch
     def test_small_model_pt_softmax_trick(self):
@@ -242,10 +242,10 @@ class QAPipelineTests(unittest.TestCase):
         question_answerer.postprocess = ensure_large_logits_postprocess
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris."
+            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
         )
 
-        self.assertEqual(nested_simplify(outputs), {"score": 0.028, "start": 0, "end": 11, "answer": "HuggingFace"})
+        self.assertEqual(nested_simplify(outputs), {"score": 0.111, "start": 0, "end": 11, "answer": "HuggingFace"})
 
     @slow
     @require_torch

--- a/tests/pipelines/test_pipelines_question_answering.py
+++ b/tests/pipelines/test_pipelines_question_answering.py
@@ -168,7 +168,8 @@ class QAPipelineTests(unittest.TestCase):
         )
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
+            question="Where was HuggingFace founded ?",
+            context="HuggingFace was founded in Paris.",
         )
 
         self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
@@ -182,7 +183,8 @@ class QAPipelineTests(unittest.TestCase):
         )
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
+            question="Where was HuggingFace founded ?",
+            context="HuggingFace was founded in Paris.",
         )
 
         self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
@@ -196,7 +198,8 @@ class QAPipelineTests(unittest.TestCase):
         )
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
+            question="Where was HuggingFace founded ?",
+            context="HuggingFace was founded in Paris.",
         )
 
         self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
@@ -211,7 +214,9 @@ class QAPipelineTests(unittest.TestCase):
                 yield {"question": "Where was HuggingFace founded ?", "context": "HuggingFace was founded in Paris."}
 
         for outputs in pipe(data()):
-            self.assertEqual(nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"})
+            self.assertEqual(
+                nested_simplify(outputs), {"score": 0.063, "start": 0, "end": 11, "answer": "HuggingFace"}
+            )
 
     @require_torch
     def test_small_model_pt_softmax_trick(self):
@@ -242,7 +247,8 @@ class QAPipelineTests(unittest.TestCase):
         question_answerer.postprocess = ensure_large_logits_postprocess
 
         outputs = question_answerer(
-            question="Where was HuggingFace founded ?", context="HuggingFace was founded in Paris.",
+            question="Where was HuggingFace founded ?",
+            context="HuggingFace was founded in Paris.",
         )
 
         self.assertEqual(nested_simplify(outputs), {"score": 0.111, "start": 0, "end": 11, "answer": "HuggingFace"})


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #38984

This PR fixes a bug in the `QuestionAnsweringPipeline` where it could return fewer than the requested top_k answers when processing long contexts or batched inputs. The original implementation processed each context chunk independently, asking for only the top_k best spans from each chunk before aggregation. This approach was flawed because if the best candidates within a chunk were later invalidated or identified as duplicates of an answer from another chunk, the pipeline had no other options to fall back on, resulting in an insufficient number of final answers. The fix implements a more robust strategy by first over-fetching a much larger pool of candidates from every chunk, then aggregating this global list, and only then sorting, merging, and selecting the final top_k answers, which guarantees a sufficient number of valid candidates to produce a reliable and complete result.

```py
import transformers

architecture = "csarron/mobilebert-uncased-squad-v2"
tokenizer = transformers.AutoTokenizer.from_pretrained(architecture, low_cpu_mem_usage=True)
model = transformers.MobileBertForQuestionAnswering.from_pretrained(
    architecture, low_cpu_mem_usage=True
)
pipeline = transformers.pipeline(task="question-answering", model=model, tokenizer=tokenizer)


data = [
    {'question': ['What color is it?', 'How do the people go?', "What does the 'wolf' howl at?"],
     'context': [
         "Some people said it was green but I know that it's pink.",
         'The people on the bus go up and down. Up and down.',
         "The pack of 'wolves' stood on the cliff and a 'lone wolf' howled at the moon for hours."
     ]}
]

# prediction result is wrong
pipeline(data, top_k=2, max_answer_len=5)
```

```
[[{'score': 0.5683297514915466, 'start': 51, 'end': 55, 'answer': 'pink'}, {'score': 0.028800610452890396, 'start': 51, 'end': 56, 'answer': 'pink.'}], [{'score': 0.3008899986743927, 'start': 25, 'end': 36, 'answer': 'up and down'}, {'score': 0.12070021033287048, 'start': 38, 'end': 49, 'answer': 'Up and down'}], [{'score': 0.8356598615646362, 'start': 68, 'end': 76, 'answer': 'the moon'}, {'score': 0.0971309095621109, 'start': 72, 'end': 76, 'answer': 'moon'}]]
```

## Who can review?
@Rocketknight1

