### PR TITLE
Add packed tensor format support for flex/sdpa/eager through the mask!

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -656,6 +656,7 @@ class GenerationMixin(ContinuousMixin):
             # If it's not defined, it means the model uses the new general mask API
             if causal_mask_creation_function is None:  # can't be found
                 token_type_ids = getattr(model_input, "token_type_ids", None)
+                position_ids = getattr(model_input, position_ids_key, None)
                 # Some models may overwrite the general one
                 causal_mask_creation_function = getattr(self, "create_masks_for_generate", create_masks_for_generate)
                 attention_mask = causal_mask_creation_function(
@@ -665,6 +666,7 @@ class GenerationMixin(ContinuousMixin):
                     attention_mask=attention_mask,
                     cache_position=cache_position,
                     past_key_values=past_key_values,
+                    position_ids=position_ids,
                     token_type_ids=token_type_ids,
                 )
             else:

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -706,6 +706,10 @@ def _preprocess_mask_arguments(
     # and we don't have past_key_values, i.e. generally a training setup)
     packed_sequence_mask = None
     if position_ids is not None and attention_mask is None and past_key_values is None:
+        batch_size = input_embeds.shape[0]
+        # The position ids are sometimes just unsqueezed, without being expanded
+        if batch_size != position_ids.shape[0]:
+            position_ids = position_ids.expand(batch_size, -1)
         packed_sequence_mask = find_packed_sequence_indices(position_ids)
 
     return False, attention_mask, packed_sequence_mask, kv_length, kv_offset

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -115,6 +115,7 @@ def padding_mask_function(padding_mask: torch.Tensor) -> Callable:
     """
     This return the mask_function function corresponding to a 2D padding mask.
     """
+
     def inner_mask(batch_idx: int, head_idx: int, q_idx: int, kv_idx: int) -> bool:
         # Note that here the mask should ALWAYS be at least of the max `kv_index` size in the dimension 1. This is because
         # we cannot pad it here in the mask_function as we don't know the final size, and we cannot try/except, as it is not
@@ -128,6 +129,7 @@ def packed_sequence_mask_function(packed_sequence_mask: torch.Tensor) -> Callabl
     """
     This return the mask_function function corresponding to a 1D packed sequence mask.
     """
+
     def inner_mask(batch_idx: int, head_idx: int, q_idx: int, kv_idx: int) -> bool:
         return packed_sequence_mask[q_idx] == packed_sequence_mask[kv_idx]
 
@@ -622,7 +624,7 @@ def find_packed_sequence_indices(position_ids: torch.Tensor) -> Optional[torch.T
     # Packed format is always on batch of size 1 so we can early exit if not the case
     if not position_ids.shape[0] == 1:
         return None
-    
+
     position_ids = position_ids.squeeze(0)
     # What separate different sequences is when 2 consecutive positions_ids are separated by more than 1. So
     # taking the diff (by prepending the first value - 1 to keep correct indexing) and applying cumsum to the result
@@ -636,6 +638,7 @@ def find_packed_sequence_indices(position_ids: torch.Tensor) -> Optional[torch.T
         return None
 
     return packed_sequence_mask
+
 
 def _preprocess_mask_arguments(
     config: PretrainedConfig,

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -629,7 +629,7 @@ def find_packed_sequence_indices(position_ids: torch.Tensor) -> Optional[torch.T
     # gives exactly the sequence indices
     first_dummy_value = position_ids[:1] - 1  # We just need the diff on this first value to be 1
     position_diff = torch.diff(position_ids, prepend=first_dummy_value)
-    packed_sequence_mask = (position_diff != 1).cumsum()
+    packed_sequence_mask = (position_diff != 1).cumsum(0)
 
     # If the last index is 0, then all tokens belong to the same sequence, i.e. no packed format -> return None
     if packed_sequence_mask[-1] == 0:

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -633,10 +633,8 @@ def find_packed_sequence_indices(position_ids: torch.Tensor) -> Optional[torch.T
     position_diff = torch.diff(position_ids, prepend=first_dummy_value)
     packed_sequence_mask = (position_diff != 1).cumsum(0)
 
-    # If the last index is 0, then all tokens belong to the same sequence, i.e. no packed format -> return None
-    if packed_sequence_mask[-1] == 0:
-        return None
-
+    # Here it would be nice to return None if we did not detect packed sequence format, i.e. if `packed_sequence_mask[-1] == 0`
+    # but it causes issues with export
     return packed_sequence_mask
 
 

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -772,7 +772,7 @@ def create_causal_mask(
     allow_is_causal_skip = not past_key_values.is_compileable if past_key_values is not None else True
 
     # If we detected packing format
-    if packed_sequence_mask is not None:
+    if packed_sequence_mask is not None and _is_torch_greater_or_equal_than_2_6:
         mask_factory_function = and_masks(mask_factory_function, packed_sequence_mask_function(packed_sequence_mask))
         allow_is_causal_skip = False
 
@@ -866,7 +866,7 @@ def create_sliding_window_causal_mask(
     allow_is_causal_skip = not past_key_values.is_compileable if past_key_values is not None else True
 
     # If we detected packing format
-    if packed_sequence_mask is not None:
+    if packed_sequence_mask is not None and _is_torch_greater_or_equal_than_2_6:
         mask_factory_function = and_masks(mask_factory_function, packed_sequence_mask_function(packed_sequence_mask))
         allow_is_causal_skip = False
 
@@ -968,7 +968,7 @@ def create_chunked_causal_mask(
     allow_is_causal_skip = not past_key_values.is_compileable if past_key_values is not None else True
 
     # If we detected packing format
-    if packed_sequence_mask is not None:
+    if packed_sequence_mask is not None and _is_torch_greater_or_equal_than_2_6:
         mask_factory_function = and_masks(mask_factory_function, packed_sequence_mask_function(packed_sequence_mask))
         allow_is_causal_skip = False
 

--- a/src/transformers/models/arcee/modeling_arcee.py
+++ b/src/transformers/models/arcee/modeling_arcee.py
@@ -423,6 +423,7 @@ class ArceeModel(ArceePreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -806,6 +806,7 @@ class AriaTextModel(AriaTextPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/bitnet/modeling_bitnet.py
+++ b/src/transformers/models/bitnet/modeling_bitnet.py
@@ -420,6 +420,7 @@ class BitNetModel(BitNetPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/cohere/modeling_cohere.py
+++ b/src/transformers/models/cohere/modeling_cohere.py
@@ -457,6 +457,7 @@ class CohereModel(CoherePreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/cohere2/modeling_cohere2.py
+++ b/src/transformers/models/cohere2/modeling_cohere2.py
@@ -434,6 +434,7 @@ class Cohere2Model(Cohere2PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/cohere2/modular_cohere2.py
+++ b/src/transformers/models/cohere2/modular_cohere2.py
@@ -455,6 +455,7 @@ class Cohere2Model(Gemma2Model):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/csm/modeling_csm.py
+++ b/src/transformers/models/csm/modeling_csm.py
@@ -500,6 +500,7 @@ class CsmDepthDecoderModel(CsmPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds
@@ -811,6 +812,7 @@ class CsmBackboneModel(CsmPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/csm/modular_csm.py
+++ b/src/transformers/models/csm/modular_csm.py
@@ -238,6 +238,7 @@ class CsmDepthDecoderModel(LlamaModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -610,6 +610,7 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/dia/modeling_dia.py
+++ b/src/transformers/models/dia/modeling_dia.py
@@ -629,6 +629,7 @@ class DiaDecoder(DiaPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
         encoder_attention_mask = self._update_cross_attn_mask(
             encoder_hidden_states,

--- a/src/transformers/models/dia/modular_dia.py
+++ b/src/transformers/models/dia/modular_dia.py
@@ -455,6 +455,7 @@ class DiaDecoder(DiaPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
         encoder_attention_mask = self._update_cross_attn_mask(
             encoder_hidden_states,

--- a/src/transformers/models/diffllama/modeling_diffllama.py
+++ b/src/transformers/models/diffllama/modeling_diffllama.py
@@ -697,6 +697,7 @@ class DiffLlamaModel(DiffLlamaPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/dots1/modeling_dots1.py
+++ b/src/transformers/models/dots1/modeling_dots1.py
@@ -532,6 +532,7 @@ class Dots1Model(Dots1PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -1264,6 +1264,7 @@ class Emu3TextModel(Emu3PreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -416,6 +416,7 @@ class GemmaModel(GemmaPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         # embed positions

--- a/src/transformers/models/gemma/modular_gemma.py
+++ b/src/transformers/models/gemma/modular_gemma.py
@@ -418,6 +418,7 @@ class GemmaModel(LlamaModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         # embed positions

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -440,6 +440,7 @@ class Gemma2Model(Gemma2PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -422,6 +422,7 @@ class Gemma2Model(GemmaModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -540,6 +540,7 @@ class Gemma3TextModel(Gemma3PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {
@@ -1182,6 +1183,7 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
         attention_mask: Optional[torch.Tensor],
         cache_position: torch.Tensor,
         past_key_values: Optional[Cache],
+        position_ids: Optional[torch.Tensor],
         token_type_ids: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> dict:
@@ -1192,6 +1194,7 @@ class Gemma3ForConditionalGeneration(Gemma3PreTrainedModel, GenerationMixin):
             "attention_mask": attention_mask,
             "cache_position": cache_position,
             "past_key_values": past_key_values,
+            "position_ids": position_ids,
         }
         # Add the token type ids mask for generate as well
         if token_type_ids is not None and input_embeds.shape[1] != 1:

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -924,6 +924,7 @@ class Gemma3Model(Gemma3PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             if token_type_ids is not None and inputs_embeds.shape[1] != 1:
                 # We need to pass an additional mask function to account for token type ids, and it needs to be an `or`

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -826,6 +826,7 @@ class Gemma3Model(PaliGemmaModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             if token_type_ids is not None and inputs_embeds.shape[1] != 1:
                 # We need to pass an additional mask function to account for token type ids, and it needs to be an `or`

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -607,6 +607,7 @@ class Gemma3TextModel(Gemma2Model):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {
@@ -1034,6 +1035,7 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
         attention_mask: Optional[torch.Tensor],
         cache_position: torch.Tensor,
         past_key_values: Optional[Cache],
+        position_ids: Optional[torch.Tensor],
         token_type_ids: Optional[torch.Tensor] = None,
         **kwargs,
     ) -> dict:
@@ -1044,6 +1046,7 @@ class Gemma3ForConditionalGeneration(PaliGemmaForConditionalGeneration):
             "attention_mask": attention_mask,
             "cache_position": cache_position,
             "past_key_values": past_key_values,
+            "position_ids": position_ids,
         }
         # Add the token type ids mask for generate as well
         if token_type_ids is not None and input_embeds.shape[1] != 1:

--- a/src/transformers/models/gemma3n/modeling_gemma3n.py
+++ b/src/transformers/models/gemma3n/modeling_gemma3n.py
@@ -1649,6 +1649,7 @@ class Gemma3nTextModel(Gemma3nPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/gemma3n/modular_gemma3n.py
+++ b/src/transformers/models/gemma3n/modular_gemma3n.py
@@ -2088,6 +2088,7 @@ class Gemma3nTextModel(Gemma3TextModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/glm/modeling_glm.py
+++ b/src/transformers/models/glm/modeling_glm.py
@@ -437,6 +437,7 @@ class GlmModel(GlmPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/glm4/modeling_glm4.py
+++ b/src/transformers/models/glm4/modeling_glm4.py
@@ -445,6 +445,7 @@ class Glm4Model(Glm4PreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/glm4v/modeling_glm4v.py
+++ b/src/transformers/models/glm4v/modeling_glm4v.py
@@ -902,6 +902,7 @@ class Glm4vTextModel(Glm4vPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/glm4v/modular_glm4v.py
+++ b/src/transformers/models/glm4v/modular_glm4v.py
@@ -956,6 +956,7 @@ class Glm4vTextModel(Qwen2_5_VLTextModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -392,6 +392,7 @@ class GPTNeoXModel(GPTNeoXPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         # Prepare head mask if needed

--- a/src/transformers/models/gpt_neox/modular_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modular_gpt_neox.py
@@ -338,6 +338,7 @@ class GPTNeoXModel(LlamaModel, nn.Module):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         # Prepare head mask if needed

--- a/src/transformers/models/granite/modeling_granite.py
+++ b/src/transformers/models/granite/modeling_granite.py
@@ -440,6 +440,7 @@ class GraniteModel(GranitePreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/granite/modular_granite.py
+++ b/src/transformers/models/granite/modular_granite.py
@@ -181,6 +181,7 @@ class GraniteModel(LlamaModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/helium/modeling_helium.py
+++ b/src/transformers/models/helium/modeling_helium.py
@@ -422,6 +422,7 @@ class HeliumModel(HeliumPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -422,6 +422,7 @@ class LlamaModel(LlamaPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -552,6 +552,7 @@ class Llama4TextModel(Llama4PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/mimi/modeling_mimi.py
+++ b/src/transformers/models/mimi/modeling_mimi.py
@@ -1120,6 +1120,7 @@ class MimiTransformerModel(nn.Module):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         # decoder layers

--- a/src/transformers/models/minimax/modeling_minimax.py
+++ b/src/transformers/models/minimax/modeling_minimax.py
@@ -731,6 +731,7 @@ class MiniMaxModel(MiniMaxPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/minimax/modular_minimax.py
+++ b/src/transformers/models/minimax/modular_minimax.py
@@ -536,6 +536,7 @@ class MiniMaxModel(MixtralModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/mistral/modeling_mistral.py
+++ b/src/transformers/models/mistral/modeling_mistral.py
@@ -399,6 +399,7 @@ class MistralModel(MistralPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/mistral/modular_mistral.py
+++ b/src/transformers/models/mistral/modular_mistral.py
@@ -160,6 +160,7 @@ class MistralModel(LlamaModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -520,6 +520,7 @@ class MixtralModel(MixtralPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/mixtral/modular_mixtral.py
+++ b/src/transformers/models/mixtral/modular_mixtral.py
@@ -370,6 +370,7 @@ class MixtralModel(MistralModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/moonshine/modeling_moonshine.py
+++ b/src/transformers/models/moonshine/modeling_moonshine.py
@@ -743,6 +743,7 @@ class MoonshineDecoder(MoonshinePreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/moonshine/modular_moonshine.py
+++ b/src/transformers/models/moonshine/modular_moonshine.py
@@ -749,6 +749,7 @@ class MoonshineDecoder(LlamaModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/olmo/modeling_olmo.py
+++ b/src/transformers/models/olmo/modeling_olmo.py
@@ -401,6 +401,7 @@ class OlmoModel(OlmoPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/olmo2/modeling_olmo2.py
+++ b/src/transformers/models/olmo2/modeling_olmo2.py
@@ -407,6 +407,7 @@ class Olmo2Model(Olmo2PreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -395,6 +395,7 @@ class PhiModel(PhiPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         inputs_embeds = self.embed_dropout(inputs_embeds)  # diff with Llama

--- a/src/transformers/models/phi/modular_phi.py
+++ b/src/transformers/models/phi/modular_phi.py
@@ -245,6 +245,7 @@ class PhiModel(LlamaModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         inputs_embeds = self.embed_dropout(inputs_embeds)  # diff with Llama

--- a/src/transformers/models/phi3/modeling_phi3.py
+++ b/src/transformers/models/phi3/modeling_phi3.py
@@ -454,6 +454,7 @@ class Phi3Model(Phi3PreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modeling_phi4_multimodal.py
@@ -1762,6 +1762,7 @@ class Phi4MultimodalModel(Phi4MultimodalPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
@@ -1577,6 +1577,7 @@ class Phi4MultimodalModel(Phi3Model, nn.Module):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -406,6 +406,7 @@ class Qwen2Model(Qwen2PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/qwen2/modular_qwen2.py
+++ b/src/transformers/models/qwen2/modular_qwen2.py
@@ -167,6 +167,7 @@ class Qwen2Model(MistralModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -1629,6 +1629,7 @@ class Qwen2_5OmniThinkerTextModel(Qwen2_5OmniPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {
@@ -2189,6 +2190,7 @@ class Qwen2_5OmniTalkerModel(Qwen2_5OmniPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -893,6 +893,7 @@ class Qwen2_5_VLTextModel(Qwen2_5_VLPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py
@@ -868,6 +868,7 @@ class Qwen2VLTextModel(Qwen2VLPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -432,6 +432,7 @@ class Qwen3Model(Qwen3PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -527,6 +527,7 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/smollm3/modeling_smollm3.py
+++ b/src/transformers/models/smollm3/modeling_smollm3.py
@@ -436,6 +436,7 @@ class SmolLM3Model(SmolLM3PreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values,
+                "position_ids": position_ids,
             }
             # Create the masks
             causal_mask_mapping = {

--- a/src/transformers/models/starcoder2/modeling_starcoder2.py
+++ b/src/transformers/models/starcoder2/modeling_starcoder2.py
@@ -400,6 +400,7 @@ class Starcoder2Model(Starcoder2PreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/starcoder2/modular_starcoder2.py
+++ b/src/transformers/models/starcoder2/modular_starcoder2.py
@@ -214,6 +214,7 @@ class Starcoder2Model(MistralModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         hidden_states = inputs_embeds

--- a/src/transformers/models/t5gemma/modeling_t5gemma.py
+++ b/src/transformers/models/t5gemma/modeling_t5gemma.py
@@ -892,7 +892,7 @@ class T5GemmaDecoder(T5GemmaEncoder):
                 "attention_mask": encoder_attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": None,
-                "position_ids": position_ids,
+                "position_ids": None,
             }
             cross_attn_mask_mapping = {
                 "full_attention": create_causal_mask(

--- a/src/transformers/models/t5gemma/modeling_t5gemma.py
+++ b/src/transformers/models/t5gemma/modeling_t5gemma.py
@@ -731,6 +731,7 @@ class T5GemmaEncoder(T5GemmaPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": None,
+                "position_ids": position_ids,
             }
             # Create the masks
             self_attn_mask_mapping = {
@@ -874,6 +875,7 @@ class T5GemmaDecoder(T5GemmaEncoder):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values.self_attention_cache if past_key_values is not None else None,
+                "position_ids": position_ids,
             }
             # Create the masks
             self_attn_mask_mapping = {
@@ -890,6 +892,7 @@ class T5GemmaDecoder(T5GemmaEncoder):
                 "attention_mask": encoder_attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": None,
+                "position_ids": position_ids,
             }
             cross_attn_mask_mapping = {
                 "full_attention": create_causal_mask(

--- a/src/transformers/models/t5gemma/modular_t5gemma.py
+++ b/src/transformers/models/t5gemma/modular_t5gemma.py
@@ -678,6 +678,7 @@ class T5GemmaEncoder(T5GemmaPreTrainedModel):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": None,
+                "position_ids": position_ids,
             }
             # Create the masks
             self_attn_mask_mapping = {
@@ -821,6 +822,7 @@ class T5GemmaDecoder(T5GemmaEncoder):
                 "attention_mask": attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": past_key_values.self_attention_cache if past_key_values is not None else None,
+                "position_ids": position_ids,
             }
             # Create the masks
             self_attn_mask_mapping = {
@@ -837,6 +839,7 @@ class T5GemmaDecoder(T5GemmaEncoder):
                 "attention_mask": encoder_attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": None,
+                "position_ids": position_ids,
             }
             cross_attn_mask_mapping = {
                 "full_attention": create_causal_mask(

--- a/src/transformers/models/t5gemma/modular_t5gemma.py
+++ b/src/transformers/models/t5gemma/modular_t5gemma.py
@@ -839,7 +839,7 @@ class T5GemmaDecoder(T5GemmaEncoder):
                 "attention_mask": encoder_attention_mask,
                 "cache_position": cache_position,
                 "past_key_values": None,
-                "position_ids": position_ids,
+                "position_ids": None,
             }
             cross_attn_mask_mapping = {
                 "full_attention": create_causal_mask(

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -927,6 +927,7 @@ class WhisperDecoder(WhisperPreTrainedModel):
             attention_mask=attention_mask,
             cache_position=cache_position,
             past_key_values=past_key_values,
+            position_ids=position_ids,
         )
 
         if self.gradient_checkpointing and self.training:

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -14,14 +14,14 @@
 
 import unittest
 
-from transformers.testing_utils import is_torch_available, require_read_token, require_torch
+from transformers.testing_utils import is_torch_available, require_torch
 
 
 if is_torch_available():
     import torch
     from torch.nn.attention.flex_attention import create_block_mask
 
-    from transformers import AutoConfig
+    from transformers import LlamaConfig
     from transformers.masking_utils import create_causal_mask
 
 
@@ -54,10 +54,9 @@ EXPECTED_PACKED_MASK = torch.tensor([[[
 
 
 @require_torch
-@require_read_token
 class MaskTest(unittest.TestCase):
     def test_packed_sequence_mask_sdpa(self):
-        config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
+        config = LlamaConfig()
         config._attn_implementation = "sdpa"
 
         batch_size = 2
@@ -77,10 +76,10 @@ class MaskTest(unittest.TestCase):
             position_ids=position_ids,
         )
 
-        self.assertEqual(causal_mask, EXPECTED_PACKED_MASK)
+        self.assertTrue((causal_mask == EXPECTED_PACKED_MASK).all())
 
     def test_packed_sequence_mask_eager(self):
-        config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
+        config = LlamaConfig()
         config._attn_implementation = "eager"
 
         batch_size = 2
@@ -101,10 +100,10 @@ class MaskTest(unittest.TestCase):
         )
 
         min_dtype = torch.finfo(torch.float16).min
-        self.assertEqual(causal_mask, torch.where(EXPECTED_PACKED_MASK, 0.0, min_dtype))
+        self.assertTrue((causal_mask == torch.where(EXPECTED_PACKED_MASK, 0.0, min_dtype)).all())
 
     def test_packed_sequence_mask_flex_attention(self):
-        config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
+        config = LlamaConfig()
         config._attn_implementation = "flex_attention"
 
         batch_size = 2

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -14,7 +14,7 @@
 
 import unittest
 
-from transformers.testing_utils import is_torch_available, require_torch
+from transformers.testing_utils import is_torch_available, require_read_token, require_torch
 
 
 if is_torch_available():
@@ -54,6 +54,7 @@ EXPECTED_PACKED_MASK = torch.tensor([[[
 
 
 @require_torch
+@require_read_token
 class MaskTest(unittest.TestCase):
     def test_packed_sequence_mask_sdpa(self):
         config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -16,12 +16,15 @@ import unittest
 
 from transformers.testing_utils import is_torch_available, require_torch
 
+
 if is_torch_available():
     import torch
-    from transformers import AutoConfig
-    from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
-        
 
+    from transformers import AutoConfig
+    from transformers.masking_utils import create_causal_mask
+
+
+# fmt: off
 EXPECTED_PACKED_MASK = torch.tensor([[[
     [ True, False, False, False, False, False, False, False, False, False],
     [ True,  True, False, False, False, False, False, False, False, False],
@@ -35,7 +38,7 @@ EXPECTED_PACKED_MASK = torch.tensor([[[
     [False, False, False, False, False, False,  True,  True,  True,  True]]],
 
 
-    [[[ True, False, False, False, False, False, False, False, False, False],
+  [[[ True, False, False, False, False, False, False, False, False, False],
     [ True,  True, False, False, False, False, False, False, False, False],
     [ True,  True,  True, False, False, False, False, False, False, False],
     [ True,  True,  True,  True, False, False, False, False, False, False],
@@ -46,13 +49,12 @@ EXPECTED_PACKED_MASK = torch.tensor([[[
     [False, False, False, False, False, False,  True,  True,  True, False],
     [False, False, False, False, False, False,  True,  True,  True,  True]
 ]]], dtype=torch.bool)
+# fmt: on
 
 
 @require_torch
 class MaskTest(unittest.TestCase):
-
     def test_packed_sequence_mask_sdpa(self):
-
         config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
         config._attn_implementation = "sdpa"
 
@@ -61,7 +63,7 @@ class MaskTest(unittest.TestCase):
         cache_position = torch.arange(sequence_length)
 
         # First batch has 3 packed sequences of 4, 2 and 4 tokens respectively, second has 2 of 6 and 4 tokens
-        position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3], [0,1,2,3,4,5,0,1,2,3,]])
+        position_ids = torch.tensor([[0, 1, 2, 3, 0, 1, 0, 1, 2, 3], [0, 1, 2, 3, 4, 5, 0, 1, 2, 3]])
 
         causal_mask = create_causal_mask(
             config=config,
@@ -76,7 +78,6 @@ class MaskTest(unittest.TestCase):
         self.assertEqual(causal_mask, EXPECTED_PACKED_MASK)
 
     def test_packed_sequence_mask_eager(self):
-
         config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
         config._attn_implementation = "eager"
 
@@ -85,7 +86,7 @@ class MaskTest(unittest.TestCase):
         cache_position = torch.arange(sequence_length)
 
         # First batch has 3 packed sequences of 4, 2 and 4 tokens respectively, second has 2 of 6 and 4 tokens
-        position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3], [0,1,2,3,4,5,0,1,2,3,]])
+        position_ids = torch.tensor([[0, 1, 2, 3, 0, 1, 0, 1, 2, 3], [0, 1, 2, 3, 4, 5, 0, 1, 2, 3]])
 
         causal_mask = create_causal_mask(
             config=config,
@@ -98,10 +99,9 @@ class MaskTest(unittest.TestCase):
         )
 
         min_dtype = torch.finfo(torch.float16).min
-        self.assertEqual(causal_mask, torch.where(EXPECTED_PACKED_MASK, 0., min_dtype))
+        self.assertEqual(causal_mask, torch.where(EXPECTED_PACKED_MASK, 0.0, min_dtype))
 
     def test_packed_sequence_mask_flex_attention(self):
-
         config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
         config._attn_implementation = "flex_attention"
 
@@ -110,7 +110,7 @@ class MaskTest(unittest.TestCase):
         cache_position = torch.arange(sequence_length)
 
         # First batch has 3 packed sequences of 4, 2 and 4 tokens respectively, second has 2 of 6 and 4 tokens
-        position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3], [0,1,2,3,4,5,0,1,2,3,]])
+        position_ids = torch.tensor([[0, 1, 2, 3, 0, 1, 0, 1, 2, 3], [0, 1, 2, 3, 4, 5, 0, 1, 2, 3]])
 
         causal_mask = create_causal_mask(
             config=config,

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -1,0 +1,126 @@
+# Copyright 2025 HuggingFace Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers.testing_utils import is_torch_available, require_torch
+
+if is_torch_available():
+    import torch
+    from transformers import AutoConfig
+    from transformers.masking_utils import create_causal_mask, create_sliding_window_causal_mask
+        
+
+EXPECTED_PACKED_MASK = torch.tensor([[[
+    [ True, False, False, False, False, False, False, False, False, False],
+    [ True,  True, False, False, False, False, False, False, False, False],
+    [ True,  True,  True, False, False, False, False, False, False, False],
+    [ True,  True,  True,  True, False, False, False, False, False, False],
+    [False, False, False, False,  True, False, False, False, False, False],
+    [False, False, False, False,  True,  True, False, False, False, False],
+    [False, False, False, False, False, False,  True, False, False, False],
+    [False, False, False, False, False, False,  True,  True, False, False],
+    [False, False, False, False, False, False,  True,  True,  True, False],
+    [False, False, False, False, False, False,  True,  True,  True,  True]]],
+
+
+    [[[ True, False, False, False, False, False, False, False, False, False],
+    [ True,  True, False, False, False, False, False, False, False, False],
+    [ True,  True,  True, False, False, False, False, False, False, False],
+    [ True,  True,  True,  True, False, False, False, False, False, False],
+    [ True,  True,  True,  True,  True, False, False, False, False, False],
+    [ True,  True,  True,  True,  True,  True, False, False, False, False],
+    [False, False, False, False, False, False,  True, False, False, False],
+    [False, False, False, False, False, False,  True,  True, False, False],
+    [False, False, False, False, False, False,  True,  True,  True, False],
+    [False, False, False, False, False, False,  True,  True,  True,  True]
+]]], dtype=torch.bool)
+
+
+@require_torch
+class MaskTest(unittest.TestCase):
+
+    def test_packed_sequence_mask_sdpa(self):
+
+        config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
+        config._attn_implementation = "sdpa"
+
+        batch_size = 2
+        sequence_length = 10
+        cache_position = torch.arange(sequence_length)
+
+        # First batch has 3 packed sequences of 4, 2 and 4 tokens respectively, second has 2 of 6 and 4 tokens
+        position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3], [0,1,2,3,4,5,0,1,2,3,]])
+
+        causal_mask = create_causal_mask(
+            config=config,
+            # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
+            input_embeds=torch.empty((batch_size, sequence_length), dtype=torch.float16),
+            attention_mask=None,
+            cache_position=cache_position,
+            past_key_values=None,
+            position_ids=position_ids,
+        )
+
+        self.assertEqual(causal_mask, EXPECTED_PACKED_MASK)
+
+    def test_packed_sequence_mask_eager(self):
+
+        config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
+        config._attn_implementation = "eager"
+
+        batch_size = 2
+        sequence_length = 10
+        cache_position = torch.arange(sequence_length)
+
+        # First batch has 3 packed sequences of 4, 2 and 4 tokens respectively, second has 2 of 6 and 4 tokens
+        position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3], [0,1,2,3,4,5,0,1,2,3,]])
+
+        causal_mask = create_causal_mask(
+            config=config,
+            # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
+            input_embeds=torch.empty((batch_size, sequence_length), dtype=torch.float16),
+            attention_mask=None,
+            cache_position=cache_position,
+            past_key_values=None,
+            position_ids=position_ids,
+        )
+
+        min_dtype = torch.finfo(torch.float16).min
+        self.assertEqual(causal_mask, torch.where(EXPECTED_PACKED_MASK, 0., min_dtype))
+
+    def test_packed_sequence_mask_flex_attention(self):
+
+        config = AutoConfig.from_pretrained("meta-llama/Llama-3.2-1B")
+        config._attn_implementation = "flex_attention"
+
+        batch_size = 2
+        sequence_length = 10
+        cache_position = torch.arange(sequence_length)
+
+        # First batch has 3 packed sequences of 4, 2 and 4 tokens respectively, second has 2 of 6 and 4 tokens
+        position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3], [0,1,2,3,4,5,0,1,2,3,]])
+
+        causal_mask = create_causal_mask(
+            config=config,
+            # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
+            input_embeds=torch.empty((batch_size, sequence_length), dtype=torch.float16),
+            attention_mask=None,
+            cache_position=cache_position,
+            past_key_values=None,
+            position_ids=position_ids,
+        )
+
+        block_mask = causal_mask.to_dense()
+        self.assertEqual(block_mask, EXPECTED_PACKED_MASK)


### PR DESCRIPTION
# What does this PR do?

As per the title.

```python
import torch
from transformers import AutoModelForCausalLM
from transformers.masking_utils import create_causal_mask

model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B", torch_dtype=torch.float16)


batch_size = 1
sequence_length = 10
cache_position = torch.arange(sequence_length)
position_ids = torch.tensor([[0,1,2,3,0,1,0,1,2,3]])  # This corresponds to 3 packed sequences

attention_mask = create_causal_mask(
    config=model.config,
    # we only need batch size, seq_length and dtype here - we don't care about the values of the embeddings
    input_embeds=torch.empty((batch_size, sequence_length), dtype=model.dtype),
    attention_mask=None,
    cache_position=cache_position,
    past_key_values=None,
    position_ids=position_ids,
)
attention_mask

>>> tensor([[[[ True, False, False, False, False, False, False, False, False, False],
          [ True,  True, False, False, False, False, False, False, False, False],
          [ True,  True,  True, False, False, False, False, False, False, False],
          [ True,  True,  True,  True, False, False, False, False, False, False],
          [False, False, False, False,  True, False, False, False, False, False],
          [False, False, False, False,  True,  True, False, False, False, False],
          [False, False, False, False, False, False,  True, False, False, False],
          [False, False, False, False, False, False,  True,  True, False, False],
          [False, False, False, False, False, False,  True,  True,  True, False],
          [False, False, False, False, False, False,  True,  True,  True,  True]]]])
```

<img width="542" alt="Screenshot 2025-07-03 at 11 56 22" src="https://github.com/user-attachments/assets/d6b2b62f-5937-4afb-a36c-e9f510d4d6cd" />

