### PR TITLE
Add support for older versions in is_torchdynamo_compiling().

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -974,7 +974,10 @@ def is_torchdynamo_compiling():
 
             return dynamo.is_compiling()
         except Exception:
-            return False
+            try: 
+                return dynamo.external_utils.is_compiling() # Support for older versions.
+            except Exception:
+                return False
 
 
 def is_torchdynamo_exporting():


### PR DESCRIPTION
Support is_torchdynamo_compiling() for older versions.

# What does this PR do?

Fixes error in `is_torchdynamo_compiling()`, which is thrown for older versions of torch, e.g. torch==2.2.2. The support for `torch._dynamo.external_utils.is_compiling()`  was deprecated and torch=2.2.2 does not manage torch.compile() on Llama 3.2 model.

@ArthurZucker 