### PR TITLE
Fixes #39204: add fallback if get_base_model missing

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -132,7 +132,6 @@ from .trainer_utils import (
     seed_worker,
     set_seed,
     speed_metrics,
-    try_get_base_model,
 )
 from .training_args import OptimizerNames, ParallelMode, TrainingArguments
 from .utils import (
@@ -631,7 +630,12 @@ class Trainer:
         unwrapped_model = self.accelerator.unwrap_model(model)
         # We also unwrap peft model
         if _is_peft_model(unwrapped_model):
-            unwrapped_model = try_get_base_model(unwrapped_model)
+            if hasattr(unwrapped_model, "get_base_model"):
+                unwrapped_model = unwrapped_model.get_base_model()
+            elif hasattr(unwrapped_model, "base_model") and hasattr(unwrapped_model.base_model, "model"):
+                unwrapped_model = unwrapped_model.base_model.model
+            else:
+                raise AttributeError("Cannot extract base model safely from this PEFT wrapper.")
 
         # Check if the model has explicit setup for loss kwargs,
         # if not, check if `**kwargs` are in model.forward

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -132,6 +132,7 @@ from .trainer_utils import (
     seed_worker,
     set_seed,
     speed_metrics,
+    try_get_base_model,
 )
 from .training_args import OptimizerNames, ParallelMode, TrainingArguments
 from .utils import (
@@ -630,7 +631,7 @@ class Trainer:
         unwrapped_model = self.accelerator.unwrap_model(model)
         # We also unwrap peft model
         if _is_peft_model(unwrapped_model):
-            unwrapped_model = unwrapped_model.get_base_model()
+            unwrapped_model = try_get_base_model(unwrapped_model)
 
         # Check if the model has explicit setup for loss kwargs,
         # if not, check if `**kwargs` are in model.forward

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -223,6 +223,7 @@ def get_last_checkpoint(folder):
         return
     return os.path.join(folder, max(checkpoints, key=lambda x: int(_re_checkpoint.search(x).groups()[0])))
 
+
 class IntervalStrategy(ExplicitEnum):
     NO = "no"
     STEPS = "steps"

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -223,6 +223,17 @@ def get_last_checkpoint(folder):
         return
     return os.path.join(folder, max(checkpoints, key=lambda x: int(_re_checkpoint.search(x).groups()[0])))
 
+def try_get_base_model(model):
+    """
+    Tries to extract the underlying Hugging Face model from a PEFT-wrapped model.
+    Works with both standard PeftModel and PeftMixedModel.
+    """
+    if hasattr(model, "get_base_model"):
+        return model.get_base_model()
+    elif hasattr(model, "base_model") and hasattr(model.base_model, "model"):
+        return model.base_model.model
+    else:
+        raise AttributeError("Cannot extract base model safely from this PEFT wrapper.")
 
 class IntervalStrategy(ExplicitEnum):
     NO = "no"

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -223,18 +223,6 @@ def get_last_checkpoint(folder):
         return
     return os.path.join(folder, max(checkpoints, key=lambda x: int(_re_checkpoint.search(x).groups()[0])))
 
-def try_get_base_model(model):
-    """
-    Tries to extract the underlying Hugging Face model from a PEFT-wrapped model.
-    Works with both standard PeftModel and PeftMixedModel.
-    """
-    if hasattr(model, "get_base_model"):
-        return model.get_base_model()
-    elif hasattr(model, "base_model") and hasattr(model.base_model, "model"):
-        return model.base_model.model
-    else:
-        raise AttributeError("Cannot extract base model safely from this PEFT wrapper.")
-
 class IntervalStrategy(ExplicitEnum):
     NO = "no"
     STEPS = "steps"


### PR DESCRIPTION
This PR adds a fallback mechanism to extract the base model from a PEFT-wrapped model in case the get_base_model() method is missing. Specifically, it attempts to retrieve model.base_model.model if get_base_model is not available. This improves compatibility with different PEFT wrappers and custom model classes.

The logic has been extracted into a dedicated try_get_base_model utility function to improve code reuse and robustness.

Fixes #39204.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://github.com/huggingface/transformers/issues/39204)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.