### PR TITLE
Update tiny-agents example

### DIFF
--- a/docs/source/en/serving.md
+++ b/docs/source/en/serving.md
@@ -197,9 +197,7 @@ The first step to use MCP tools is to let the model know which tools are availab
     "servers": [
         {
             "type": "sse",
-            "config": {
-                "url": "https://evalstate-flux1-schnell.hf.space/gradio_api/mcp/sse"
-            }
+            "url": "https://evalstate-flux1-schnell.hf.space/gradio_api/mcp/sse"
         }
     ]
 }


### PR DESCRIPTION
Fix docs example after https://github.com/huggingface/huggingface_hub/pull/3166 / https://github.com/huggingface/huggingface.js/pull/1556. Since release [0.33.2](https://github.com/huggingface/huggingface_hub/releases/tag/v0.33.2) `tiny-agents` config follow VSCode format. We made the change without a proper deprecation warning as it's still experimental and we wanted to harmonize with VSCode as quickly as possible (to avoid future conflicts).  

Related PRs:
- https://github.com/huggingface/hub-docs/pull/1816
- https://github.com/huggingface/transformers/pull/39245
- https://github.com/huggingface/huggingface_hub/pull/3205
- https://github.com/huggingface/huggingface.js/pull/1599