### PR TITLE
remove broken block

### DIFF
--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -365,6 +365,7 @@ class SuperTransformer(cst.CSTTransformer):
             return updated_node.with_changes(body=new_body, params=updated_node.params)
         return updated_node
 
+
 def find_all_dependencies(
     dependency_mapping: dict[str, set],
     start_entity: Optional[str] = None,

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -365,22 +365,6 @@ class SuperTransformer(cst.CSTTransformer):
             return updated_node.with_changes(body=new_body, params=updated_node.params)
         return updated_node
 
-    def leave_Return(self, original_node: cst.Return, updated_node: cst.Return) -> cst.Return:
-        """ "When a return statement is reached, it is replaced with the unrolled super code"""
-        if m.matches(updated_node.value, m.Call(func=m.Attribute(attr=m.Name("super")))):
-            func_def = self.get_metadata(ParentNodeProvider, original_node)
-            if m.matched(func_def, m.FunctionDef()) and func_def.name.value in self.original_modeling_methods:
-                updated_return_value = updated_node.value.with_changes(
-                    args=[
-                        cst.Arg(
-                            value=cst.Call(func=cst.Name("super"), args=[cst.Arg(value=cst.Name(func_def.name.value))])
-                        )
-                    ]
-                )
-                return updated_node.with_changes(value=updated_return_value)
-        return updated_node
-
-
 def find_all_dependencies(
     dependency_mapping: dict[str, set],
     start_entity: Optional[str] = None,


### PR DESCRIPTION
# What does this PR do?

Removes an unused (and broken) block in modular model converter. Tested on a few modular conversions, as long as we don't use `return super().<...method...>` it will not cause issues. 

