### PR TITLE
Fix to tuple conversion with config

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -923,27 +923,6 @@ def is_timm_local_checkpoint(pretrained_model_path: str) -> bool:
     return False
 
 
-def set_attribute_for_modules(module: "torch.nn.Module", key: str, value: Any):
-    """
-    Set a value to a module and all submodules.
-    """
-    setattr(module, key, value)
-    for submodule in module.children():
-        set_attribute_for_modules(submodule, key, value)
-
-
-def del_attribute_from_modules(module: "torch.nn.Module", key: str):
-    """
-    Delete a value from a module and all submodules.
-    """
-    # because we might remove it previously in case it's a shared module, e.g. activation function
-    if hasattr(module, key):
-        delattr(module, key)
-
-    for submodule in module.children():
-        del_attribute_from_modules(submodule, key)
-
-
 def can_return_tuple(func):
     """
     Decorator to wrap model method, to call output.to_tuple() if return_dict=False passed as a kwarg or
@@ -959,7 +938,7 @@ def can_return_tuple(func):
         return_dict_passed = kwargs.pop("return_dict", return_dict)
         if return_dict_passed is not None:
             return_dict = return_dict_passed
-        output = func(self, *args, **kwargs)
+        output = func(self, *args, **kwargs, return_dict=True)
         if not return_dict and not isinstance(output, tuple):
             output = output.to_tuple()
         return output


### PR DESCRIPTION
# What does this PR do?

setting `return_dict=False` with config fails for models with sub-models wrapped with `can_return_tuple` or `check_model_inputs` 

```py
import torch
from transformers import LlamaConfig, LlamaForCausalLM

config = LlamaConfig(vocab_size=256, hidden_size=128, num_hidden_layers=2, num_attention_heads=4, intermediate_size=256)
model = LlamaForCausalLM(config)

# default: ModelOutput
input_ids = torch.tensor([[0, 1, 2, 3]])
with torch.no_grad():
    output = model(input_ids)

print(output)


# passing return_dict=False as a kwarg 
input_ids = torch.tensor([[0, 1, 2, 3]])
with torch.no_grad():
    output = model(input_ids, return_dict=False)

print(output)


# ERROR: setting return_dict=False in the config
model.config.return_dict = False
with torch.no_grad():
    output = model(input_ids)

print(output)

# Traceback (most recent call last):
#   File "/home/ubuntu/projects/transformers/test_llama_small.py", line 17, in <module>
#     output = model(input_ids)
#   File "/home/ubuntu/projects/transformers/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1751, in _wrapped_call_impl
#     return self._call_impl(*args, **kwargs)
#   File "/home/ubuntu/projects/transformers/.venv/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1762, in _call_impl
#     return forward_call(*args, **kwargs)
#   File "/home/ubuntu/projects/transformers/src/transformers/utils/generic.py", line 962, in wrapper
#     output = func(self, *args, **kwargs)
#   File "/home/ubuntu/projects/transformers/src/transformers/models/llama/modeling_llama.py", line 506, in forward
#     hidden_states = outputs.last_hidden_state
# AttributeError: 'tuple' object has no attribute 'last_hidden_state'
```
