### PR TITLE
[CI] fix docs

### DIFF
--- a/docs/source/ko/_toctree.yml
+++ b/docs/source/ko/_toctree.yml
@@ -225,7 +225,7 @@
 - sections:
   - local: philosophy
     title: 이념과 목표
-  - local: in_translation
+  - local: glossary
     title: (번역중) Glossary
   - local: task_summary
     title: 🤗 Transformers로 할 수 있는 작업

--- a/src/transformers/models/aimv2/modeling_aimv2.py
+++ b/src/transformers/models/aimv2/modeling_aimv2.py
@@ -504,8 +504,6 @@ class Aimv2VisionModel(Aimv2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
     ) -> BaseModelOutputWithPooling:
         r"""
-        Returns:
-
         Examples:
 
         ```python

--- a/src/transformers/models/aimv2/modular_aimv2.py
+++ b/src/transformers/models/aimv2/modular_aimv2.py
@@ -501,8 +501,6 @@ class Aimv2VisionModel(Aimv2PreTrainedModel):
         output_hidden_states: Optional[bool] = None,
     ) -> BaseModelOutputWithPooling:
         r"""
-        Returns:
-
         Examples:
 
         ```python


### PR DESCRIPTION
# What does this PR do?

Fixes docs, causing red CI
- aimv2 bad return docstring (from #36625)
- `glossary` missing from the Korean table of contents (from #38804)