### PR TITLE
fix flaky `test_generate_compile_model_forward`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2088,6 +2088,7 @@ class GenerationTesterMixin:
 
         ⚠️ Runs two sequential generations to ensure the cache doesn't get stuck after the first compiled run! ⚠️
         """
+        set_model_tester_for_less_flaky_test(self)
         for model_class in self.all_generative_model_classes:
             # 1. Test exclusion criteria
             if not model_class._supports_static_cache:
@@ -2095,7 +2096,9 @@ class GenerationTesterMixin:
 
             # 2. Prepares two sets of inputs
             config, inputs_dict = self.prepare_config_and_inputs_for_generate(batch_size=4)
+            set_config_for_less_flaky_test(config)
             model = model_class(config).to(torch_device)
+            set_model_for_less_flaky_test(model)
             model.eval()  # otherwise `self.training` is `True` -- this flag is used at attn mask creation time
 
             # Some composite models have a custom generate and will call an inner model's generate -> that inner model


### PR DESCRIPTION
# What does this PR do?

Found it flaky today in https://app.circleci.com/jobs/github/huggingface/transformers/1816845

(7 failed in a run of 5000 times)

After this PR, all 5000 runs pass