### PR TITLE
[Tests] Update model_id in AIMv2 Tests

### DIFF
--- a/tests/models/aimv2/test_modeling_aimv2.py
+++ b/tests/models/aimv2/test_modeling_aimv2.py
@@ -622,8 +622,8 @@ class Aimv2ModelIntegrationTest(unittest.TestCase):
         )
 
         # handle device
-        expected_logits = torch.tensor([[34.2415, 24.6724]]).to(model.device)
-        self.assertTrue(torch.allclose(outputs.logits_per_image, expected_logits, atol=1e-3))
+        expected_logits = torch.tensor([[33.3550, 26.4255]]).to(model.device)
+        torch.testing.assert_close(outputs.logits_per_image, expected_logits, atol=1e-3, rtol=1e-3)
 
 
 @require_vision

--- a/tests/models/aimv2/test_modeling_aimv2.py
+++ b/tests/models/aimv2/test_modeling_aimv2.py
@@ -598,7 +598,7 @@ class Aimv2ModelTest(Aimv2ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
 class Aimv2ModelIntegrationTest(unittest.TestCase):
     @slow
     def test_inference(self):
-        model_name = "yaswanthgali/aimv2-large-patch14-224-lit-HF"
+        model_name = "apple/aimv2-large-patch14-224-lit"
         model = Aimv2Model.from_pretrained(model_name, device_map=torch_device)
         processor = AutoProcessor.from_pretrained(model_name)
 
@@ -631,7 +631,7 @@ class Aimv2ModelIntegrationTest(unittest.TestCase):
 class Aimv2VisionModelIntegrationTests(unittest.TestCase):
     @slow
     def test_inference(self):
-        model_name = "yaswanthgali/aimv2-large-patch14-224-HF"
+        model_name = "apple/aimv2-large-patch14-224"
 
         model = Aimv2VisionModel.from_pretrained(model_name, device_map=torch_device)
         processor = AutoImageProcessor.from_pretrained(model_name)
@@ -662,7 +662,7 @@ class Aimv2VisionModelIntegrationTests(unittest.TestCase):
 
     @slow
     def test_inference_for_native_resolution(self):
-        model_name = "yaswanthgali/aimv2-large-patch14-native-HF"
+        model_name = "apple/aimv2-large-patch14-native"
 
         model = Aimv2VisionModel.from_pretrained(model_name, device_map="auto")
         processor = AutoImageProcessor.from_pretrained(model_name)


### PR DESCRIPTION
As per the title, updates model_id in Aimv2 integration tests with that of official ones as the PRs for HF compatible weights are merged.