### PR TITLE
[Bugfix] [Quantization] Remove unused init arg

### DIFF
--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -1342,7 +1342,6 @@ class CompressedTensorsConfig(QuantizationConfigMixin):
                     "kv_cache_scheme": kv_cache_scheme,
                     "global_compression_ratio": global_compression_ratio,
                     "ignore": ignore,
-                    "run_compressed": run_compressed,
                     **kwargs,
                 }
             )


### PR DESCRIPTION
## Purpose ##
* Remove argument which is not used by the CompressedTensors QuantizationConfig
  * https://github.com/neuralmagic/compressed-tensors/blob/main/src/compressed_tensors/quantization/quant_config.py#L138-L144

## Changes ##
* Remove `run_compressed` from list of QuantizationConfig init kwargs