### PR TITLE
[tests] tag serve tests as slow 

### DIFF
--- a/tests/commands/test_serving.py
+++ b/tests/commands/test_serving.py
@@ -197,7 +197,7 @@ class ServeCompletionsMixin:
     # TODO: speed-based test to confirm that KV cache is working across requests
 
 
-@slow
+@slow  # TODO (joao): this shouldn't be needed
 class ServeCompletionsGenerateTest(ServeCompletionsMixin, unittest.TestCase):
     """Tests the `generate` version of the Completions API."""
 
@@ -287,7 +287,7 @@ class ServeCompletionsGenerateTest(ServeCompletionsMixin, unittest.TestCase):
         self.assertTrue(all(reason is None for reason in finish_reasons[:-1]))
 
 
-@slow
+@slow  # TODO (joao): this shouldn't be needed
 class ServeCompletionsContinuousBatchingTest(ServeCompletionsMixin, unittest.TestCase):
     """Tests the `continuous_batching` version of the Completions API."""
 

--- a/tests/commands/test_serving.py
+++ b/tests/commands/test_serving.py
@@ -197,6 +197,7 @@ class ServeCompletionsMixin:
     # TODO: speed-based test to confirm that KV cache is working across requests
 
 
+@slow
 class ServeCompletionsGenerateTest(ServeCompletionsMixin, unittest.TestCase):
     """Tests the `generate` version of the Completions API."""
 
@@ -286,6 +287,7 @@ class ServeCompletionsGenerateTest(ServeCompletionsMixin, unittest.TestCase):
         self.assertTrue(all(reason is None for reason in finish_reasons[:-1]))
 
 
+@slow
 class ServeCompletionsContinuousBatchingTest(ServeCompletionsMixin, unittest.TestCase):
     """Tests the `continuous_batching` version of the Completions API."""
 


### PR DESCRIPTION
# What does this PR do?

These tests are not slow and don't require GPUs, but they're being flaky on the CI setup. This PR tags them as slow to unblock CI.