### PR TITLE
Use np.pad instead of np.lib.pad.

### DIFF
--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -1157,7 +1157,7 @@ def fram_wave(waveform: np.array, hop_length: int = 160, fft_window_size: int = 
             frame = waveform[i : i + fft_window_size]
             frame_width = frame.shape[0]
             if frame_width < waveform.shape[0]:
-                frame = np.lib.pad(
+                frame = np.pad(
                     frame, pad_width=(0, fft_window_size - frame_width), mode="constant", constant_values=0
                 )
         frames.append(frame)

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -1157,9 +1157,7 @@ def fram_wave(waveform: np.array, hop_length: int = 160, fft_window_size: int = 
             frame = waveform[i : i + fft_window_size]
             frame_width = frame.shape[0]
             if frame_width < waveform.shape[0]:
-                frame = np.pad(
-                    frame, pad_width=(0, fft_window_size - frame_width), mode="constant", constant_values=0
-                )
+                frame = np.pad(frame, pad_width=(0, fft_window_size - frame_width), mode="constant", constant_values=0)
         frames.append(frame)
 
     frames = np.stack(frames, 0)


### PR DESCRIPTION
# What does this PR do?

`audio_utils.py` still uses `np.lib.pad` from numpy 1.X rather than `np.pad`. This fixes the single remaining call in `transformers` to use `np.pad`.


## Who can review?

cc: @ArthurZucker, @Rocketknight1
