### PR TITLE
Support FP8 accelerate config

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1952,20 +1952,14 @@ class Trainer:
             logger.warning_once(warning_str)
 
     def _wrap_model(self, model, training=True, dataloader=None):
-        print(f"Start of _wrap_model: {type(model)}")
-
         if is_sagemaker_mp_enabled():
             # Wrapping the base model twice in a DistributedModel will raise an error.
             if isinstance(self.model_wrapped, smp.model.DistributedModel):
-                print(f"End of _wrap_model: {type(model)}")
-                import sys; sys.exit()
                 return self.model_wrapped
             return smp.DistributedModel(model, backward_passes_per_step=self.args.gradient_accumulation_steps)
 
         # train/eval could be run multiple-times - if already wrapped, don't re-wrap it again
         if self.accelerator.unwrap_model(model, keep_torch_compile=False) is not model:
-            print(f"End of _wrap_model: {type(model)}")
-            import sys; sys.exit()
             return model
 
         # Mixed precision training with apex
@@ -1986,8 +1980,6 @@ class Trainer:
         # Note: in torch.distributed mode, there's no point in wrapping the model
         # inside a DistributedDataParallel as we'll be under `no_grad` anyways.
         if not training:
-            print(f"End of _wrap_model: {type(model)}")
-            import sys; sys.exit()
             return model
 
         # Distributed training (should be after apex fp16 initialization)
@@ -2043,8 +2035,6 @@ class Trainer:
                 # Apply gradient checkpointing to auto-wrapped sub-modules if specified
                 def auto_wrapper_callable(m, *args, **kwargs):
                     target_cls = FSDP if not self.is_fsdp_xla_v2_enabled else FSDPv2
-                    print(f"End of _wrap_model: {type(model)}")
-                    import sys; sys.exit()
                     return target_cls(checkpoint_module(m), *args, **kwargs)
 
             # Wrap the base model with an outer FSDP wrapper
@@ -2345,21 +2335,12 @@ class Trainer:
         if args.gradient_checkpointing:
             self.model.gradient_checkpointing_enable(gradient_checkpointing_kwargs=args.gradient_checkpointing_kwargs)
 
-        print("before _wrap_model")
-        print(type(self.model_wrapped))
-        import ipdb; ipdb.set_trace()
         model = self._wrap_model(self.model_wrapped)
-        print("after _wrap_model")
-        print(type(model))
 
         # as the model is wrapped, don't use `accelerator.prepare`
         # this is for unhandled cases such as
         # FSDP-XLA, SageMaker MP/DP, DataParallel, IPEX
-        if model is self.model or True:
-            use_accelerator_prepare = True
-        else:
-            use_accelerator_prepare = False
-        # use_accelerator_prepare = True if model is self.model else False
+        use_accelerator_prepare = True if model is self.model else False
 
         if use_accelerator_prepare and self.is_fsdp_enabled:
             # In case of auto_find_batch_size=True
@@ -2375,7 +2356,6 @@ class Trainer:
             self.create_optimizer_and_scheduler(num_training_steps=max_steps)
 
         # prepare using `accelerator` prepare
-        print(f"use_accelerator_prepare: {use_accelerator_prepare}")
         if use_accelerator_prepare:
             self.model.train()
             if hasattr(self.lr_scheduler, "step"):
@@ -2395,9 +2375,6 @@ class Trainer:
         elif self.args.optim in [OptimizerNames.LOMO, OptimizerNames.ADALOMO]:
             # In this case we are in DDP + LOMO, which should be supported
             self.optimizer = self.accelerator.prepare(self.optimizer)
-
-        if self.args.torch_compile:
-            model = torch.compile(model, **compile_kwargs)
 
         if self.is_fsdp_enabled:
             self.model = self.model_wrapped = model
@@ -3766,8 +3743,6 @@ class Trainer:
         Return:
             `torch.Tensor`: The tensor with training loss on this batch.
         """
-        # import ipdb; ipdb.set_trace()
-
         model.train()
         if hasattr(self.optimizer, "train") and callable(self.optimizer.train):
             self.optimizer.train()
@@ -5231,12 +5206,26 @@ class Trainer:
         if "mixed_precision" in accelerator_config:
             args["mixed_precision"] = accelerator_config["mixed_precision"]
         if "fp8_config" in accelerator_config and accelerator_config["fp8_config"] is not None:
-            # import ipdb; ipdb.set_trace()
-
             if "backend" in accelerator_config["fp8_config"]:
                 recipe_kwargs = MP_BACKEND_TO_KWARGS[accelerator_config["fp8_config"]["backend"]]
                 fp8_config = accelerator_config["fp8_config"].copy()
+                if fp8_config["backend"] == "AO":
+                    from torchao.float8 import Float8LinearConfig
+
+                    if "recipe_name" in fp8_config:
+                        recipe_name = fp8_config["recipe_name"]
+                        fp8_config["config"] = (
+                            Float8LinearConfig.from_recipe_name(recipe_name=recipe_name)
+                        )
+                        fp8_config.pop("recipe_name")
+                    elif "config" in accelerator_config["fp8_config"]:
+                        config = fp8_config["config"]
+                        kwargs = {k: v for k, v in config.items() if v is not None}
+                        fp8_config["config"] = Float8LinearConfig(
+                            **kwargs
+                        )
                 fp8_config.pop("backend")
+                print(fp8_config)
                 kwargs_handlers = [recipe_kwargs(**fp8_config)]
                 args["kwargs_handlers"] = kwargs_handlers
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -5209,7 +5209,12 @@ class Trainer:
         }
         if "mixed_precision" in accelerator_config:
             args["mixed_precision"] = accelerator_config["mixed_precision"]
-        if "fp8_config" in accelerator_config:
+        if "fp8_config" in accelerator_config and accelerator_config["fp8_config"] is not None:
+            import torch.distributed as dist
+            if dist.get_rank() == 0:
+                import ipdb; ipdb.set_trace()
+            dist.barrier()
+
             if "backend" in accelerator_config["fp8_config"]:
                 recipe_kwargs = BACKEND_TO_KWARGS[accelerator_config["fp8_config"]["backend"]]
                 fp8_config = accelerator_config["fp8_config"].copy()

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -50,7 +50,6 @@ import numpy as np
 import torch
 import torch.distributed as dist
 from accelerate.utils import AORecipeKwargs, TERecipeKwargs, MSAMPRecipeKwargs
-
 from huggingface_hub import ModelCard, create_repo, upload_folder
 from packaging import version
 from torch import nn
@@ -5225,7 +5224,6 @@ class Trainer:
                             **kwargs
                         )
                 fp8_config.pop("backend")
-                print(fp8_config)
                 kwargs_handlers = [recipe_kwargs(**fp8_config)]
                 args["kwargs_handlers"] = kwargs_handlers
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -5208,6 +5208,7 @@ class Trainer:
             if "backend" in accelerator_config["fp8_config"]:
                 recipe_kwargs = MP_BACKEND_TO_KWARGS[accelerator_config["fp8_config"]["backend"]]
                 fp8_config = accelerator_config["fp8_config"].copy()
+
                 if fp8_config["backend"] == "AO":
                     from torchao.float8 import Float8LinearConfig
 
@@ -5223,6 +5224,7 @@ class Trainer:
                         fp8_config["config"] = Float8LinearConfig(
                             **kwargs
                         )
+
                 fp8_config.pop("backend")
                 kwargs_handlers = [recipe_kwargs(**fp8_config)]
                 args["kwargs_handlers"] = kwargs_handlers

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1256,6 +1256,11 @@ class AcceleratorConfig:
             Whether or not to use a pre-configured `AcceleratorState` or `PartialState` defined
             before calling `TrainingArguments`. If `True`, an `Accelerator` or `PartialState`
             must be initialized. May lead to issues using sweeps or hyperparameter tuning.
+        mixed_precision (`str`, *optional*, defaults to `"no"`):
+            Whether or not to use mixed precision training. Choose from 'no','fp16','bf16' or 'fp8'. Will default to
+            the value in the environment variable `ACCELERATE_MIXED_PRECISION`, which will use the default value in the
+            accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp8'
+            requires the installation of `transformers-engine`.
 
     """
 
@@ -1323,6 +1328,15 @@ class AcceleratorConfig:
         metadata={
             "help": "Whether or not to use a pre-configured `AcceleratorState` or `PartialState` defined before calling `TrainingArguments`."
             "If `True`, an `Accelerator` or `PartialState` must be initialized. May lead to issues using sweeps or hyperparameter tuning."
+        },
+    )
+    mixed_precision: str = field(
+        default="no",
+        metadata={
+            "help": "Whether or not to use mixed precision training. Choose from 'no','fp16','bf16' or 'fp8'. Will default to"
+            "the value in the environment variable `ACCELERATE_MIXED_PRECISION`, which will use the default value in the"
+            "accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp8' requires"
+            "the installation of `transformers-engine`."
         },
     )
 

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -1261,6 +1261,9 @@ class AcceleratorConfig:
             the value in the environment variable `ACCELERATE_MIXED_PRECISION`, which will use the default value in the
             accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp8'
             requires the installation of `transformers-engine`.
+        fp8_config (`dict`, *optional*):
+            Configuration for FP8 mixed precision training.
+            See [`accelerate.utils.dataclasses`] for more details.
 
     """
 
@@ -1337,6 +1340,12 @@ class AcceleratorConfig:
             "the value in the environment variable `ACCELERATE_MIXED_PRECISION`, which will use the default value in the"
             "accelerate config of the current system or the flag passed with the `accelerate.launch` command. 'fp8' requires"
             "the installation of `transformers-engine`."
+        },
+    )
+    fp8_config: Optional[dict] = field(
+        default=None,
+        metadata={
+            "help": "Configuration for FP8 mixed precision training. See [`accelerate.utils.dataclasses`] for more details."
         },
     )
 


### PR DESCRIPTION
# What does this PR do?

Adds config options for mixed precision and fp8 config, which are supported in accelerate's Accelerator object.

Also parses the `config` field for the torchao ("AO") fp8 backend from dictionary values into the required `Float8LinearConfig` object.

This requires also a simple gating change to accelerate, which is actually covered by an existing PR: https://github.com/huggingface/accelerate/pull/3677/files#diff-2d7515874eaecac2687c7fc1a9c720be53f802bf14b4c3dcebe14ad443d075dcR501-R505.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

- @S1ro1
- @SunMarc
- @winglian 

## TODO

- [ ] Add docs (?)
- [ ] Add tests (?)
- [ ] Add quick benchmarks

## Note

I've tested this downstream in [`axolotl`](https://github.com/axolotl-ai-cloud/axolotl) and find that it works. Performance benefits can be had for certain models when setting `torch_compile: true`; it's not yet clear to me which models + hyperparameter settings. I'll add some quick numbers here to demonstrate this.