### PR TITLE
Fix typo in `/v1/models` output payload

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -366,7 +366,7 @@ class ServeCommand(BaseTransformersCLICommand):
                         {
                             "id": model.id,
                             "object": "model",
-                            "crated": model.created_at.timestamp(),
+                            "created": model.created_at.timestamp(),
                             "owned_by": model.author,
                         }
                         for model in get_text_gen_models()


### PR DESCRIPTION
# What does this PR do?

This PR fixes a typo affecting the output payload of the `/v1/models` endpoint in `transformers serve`.

## Before submitting

- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker or @gante