### PR TITLE
refactor: remove `set_tracer_provider` and `set_meter_provider` calls

### DIFF
--- a/src/transformers/utils/metrics.py
+++ b/src/transformers/utils/metrics.py
@@ -20,26 +20,8 @@ class RequestStatus(Enum):
 
 
 try:
-    from opentelemetry import metrics, trace
-    from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-    from opentelemetry.sdk.metrics import MeterProvider
-    from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
-    from opentelemetry.sdk.resources import Resource
-    from opentelemetry.sdk.trace import TracerProvider
-    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    from opentelemetry import metrics
     from opentelemetry.trace import Status, StatusCode, get_tracer
-
-    resource = Resource.create({"service.name": "transformers"})
-
-    metrics_exporter = PeriodicExportingMetricReader(OTLPMetricExporter(), export_interval_millis=1000)
-    meter_provider = MeterProvider(resource=resource, metric_readers=[metrics_exporter])
-    metrics.set_meter_provider(meter_provider)
-
-    trace_exporter = OTLPSpanExporter()
-    tracer_provider = TracerProvider(resource=resource)
-    tracer_provider.add_span_processor(BatchSpanProcessor(trace_exporter))
-    trace.set_tracer_provider(tracer_provider)
 
     _has_opentelemetry = True
 except ImportError:


### PR DESCRIPTION
# What does this PR do?

As we are a library, we shouldn't set an OT tracer or a meter, given you can only set one per application.

Removing calls to `set_{tracer|meter}_provider`.

Closes #39115, #39143 