### PR TITLE
Fix logger warnings in Gemma model test files

### DIFF
--- a/src/transformers/models/gemma/modeling_flax_gemma.py
+++ b/src/transformers/models/gemma/modeling_flax_gemma.py
@@ -350,7 +350,7 @@ class FlaxGemmaMLP(nn.Module):
 
         kernel_init = jax.nn.initializers.normal(self.config.initializer_range)
         if self.config.hidden_activation is None:
-            logger.warning_once(
+            logger.warning(
                 "Gemma's activation function should be approximate GeLU and not exact GeLU. "
                 "Changing the activation function to `gelu_pytorch_tanh`."
                 f"if you want to use the legacy `{self.config.hidden_act}`, "

--- a/src/transformers/models/gemma/modeling_gemma.py
+++ b/src/transformers/models/gemma/modeling_gemma.py
@@ -602,7 +602,7 @@ class GemmaForSequenceClassification(GemmaPreTrainedModel):
             last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
-            logger.warning_once(
+            logger.warning(
                 f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                 "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
             )

--- a/src/transformers/models/gemma2/modeling_gemma2.py
+++ b/src/transformers/models/gemma2/modeling_gemma2.py
@@ -415,7 +415,7 @@ class Gemma2Model(Gemma2PreTrainedModel):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once(
+            logger.warning(
                 "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
             )
             use_cache = False
@@ -571,7 +571,7 @@ class Gemma2ForCausalLM(Gemma2PreTrainedModel, GenerationMixin):
         ```"""
 
         if self.training and self.config._attn_implementation != "eager":
-            logger.warning_once(
+            logger.warning(
                 "It is strongly recommended to train Gemma2 models with the `eager` attention implementation "
                 f"instead of `{self.config._attn_implementation}`. Use `eager` with `AutoModelForCausalLM.from_pretrained('<path-to-checkpoint>', attn_implementation='eager')`."
             )
@@ -693,7 +693,7 @@ class Gemma2ForSequenceClassification(Gemma2PreTrainedModel):
             last_non_pad_token = (token_indices * non_pad_mask).argmax(-1)
         else:
             last_non_pad_token = -1
-            logger.warning_once(
+            logger.warning(
                 f"{self.__class__.__name__} will not detect padding tokens in `inputs_embeds`. Results may be "
                 "unexpected if using padding tokens in conjunction with `inputs_embeds.`"
             )

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -393,7 +393,7 @@ class Gemma2Model(GemmaModel):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once(
+            logger.warning(
                 "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
             )
             use_cache = False
@@ -520,7 +520,7 @@ class Gemma2ForCausalLM(GemmaForCausalLM):
         ```"""
 
         if self.training and self.config._attn_implementation != "eager":
-            logger.warning_once(
+            logger.warning(
                 "It is strongly recommended to train Gemma2 models with the `eager` attention implementation "
                 f"instead of `{self.config._attn_implementation}`. Use `eager` with `AutoModelForCausalLM.from_pretrained('<path-to-checkpoint>', attn_implementation='eager')`."
             )

--- a/src/transformers/models/gemma3/image_processing_gemma3.py
+++ b/src/transformers/models/gemma3/image_processing_gemma3.py
@@ -359,7 +359,7 @@ class Gemma3ImageProcessor(BaseImageProcessor):
         images = [to_numpy_array(image) for image in images]
 
         if do_rescale and is_scaled_image(images[0]):
-            logger.warning_once(
+            logger.warning(
                 "It looks like you are trying to rescale already rescaled images. If the input"
                 " images have pixel values between 0 and 1, set `do_rescale=False` to avoid rescaling them again."
             )

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -520,7 +520,7 @@ class Gemma3TextModel(Gemma3PreTrainedModel):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once(
+            logger.warning(
                 "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
             )
             use_cache = False
@@ -676,7 +676,7 @@ class Gemma3ForCausalLM(Gemma3PreTrainedModel, GenerationMixin):
         ```"""
 
         if self.training and self.config._attn_implementation != "eager":
-            logger.warning_once(
+            logger.warning(
                 "It is strongly recommended to train Gemma3 models with the `eager` attention implementation "
                 f"instead of `{self.config._attn_implementation}`. Use `eager` with `AutoModelForCausalLM.from_pretrained('<path-to-checkpoint>', attn_implementation='eager')`."
             )

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -586,7 +586,7 @@ class Gemma3TextModel(Gemma2Model):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once(
+            logger.warning(
                 "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
             )
             use_cache = False

--- a/src/transformers/models/gemma3n/modeling_gemma3n.py
+++ b/src/transformers/models/gemma3n/modeling_gemma3n.py
@@ -1619,7 +1619,7 @@ class Gemma3nTextModel(Gemma3nPreTrainedModel):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
         if self.gradient_checkpointing and self.training and use_cache:
-            logger.warning_once(
+            logger.warning(
                 "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
             )
             use_cache = False
@@ -1848,7 +1848,7 @@ class Gemma3nForCausalLM(Gemma3nPreTrainedModel, GenerationMixin):
         ```"""
 
         if self.training and self.config._attn_implementation != "eager":
-            logger.warning_once(
+            logger.warning(
                 "It is strongly recommended to train Gemma3n models with the `eager` attention implementation "
                 f"instead of `{self.config._attn_implementation}`. Use `eager` with `AutoModelForCausalLM.from_pretrained('<path-to-checkpoint>', attn_implementation='eager')`."
             )


### PR DESCRIPTION
This PR fixes logger warning issues in the test files for Gemma, Gemma2, Gemma3, and Gemma3n models under tests/models/. Updated the use of deprecated logger.warn() to logger.warning() to remove Deprecation Warnings during test runs.
