### PR TITLE
Fix indentation bug in SmolVLM image processor causing KeyError

### DIFF
--- a/src/transformers/models/idefics3/image_processing_idefics3_fast.py
+++ b/src/transformers/models/idefics3/image_processing_idefics3_fast.py
@@ -441,7 +441,7 @@ class Idefics3ImageProcessorFast(BaseImageProcessorFast):
                     size=SizeDict(height=max_image_size["longest_edge"], width=max_image_size["longest_edge"]),
                     interpolation=interpolation,
                 )
-            split_images_grouped[shape] = stacked_images
+                split_images_grouped[shape] = stacked_images
             processed_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
             rows = [[0] * len(images) for images in processed_images]
             cols = [[0] * len(images) for images in processed_images]

--- a/src/transformers/models/smolvlm/image_processing_smolvlm_fast.py
+++ b/src/transformers/models/smolvlm/image_processing_smolvlm_fast.py
@@ -431,7 +431,7 @@ class SmolVLMImageProcessorFast(BaseImageProcessorFast):
                     size=SizeDict(height=max_image_size["longest_edge"], width=max_image_size["longest_edge"]),
                     interpolation=interpolation,
                 )
-            split_images_grouped[shape] = stacked_images
+                split_images_grouped[shape] = stacked_images
             processed_images = reorder_images(split_images_grouped, grouped_images_index, is_nested=True)
             rows = [[0] * len(images) for images in processed_images]
             cols = [[0] * len(images) for images in processed_images]


### PR DESCRIPTION
# What does this PR do?

This PR fixes an indentation bug in `SmolVLMImageProcessorFast` that causes a `KeyError` when `do_image_splitting=False`.

The issue was in line 434 where `split_images_grouped[shape] = stacked_images` was incorrectly indented outside the loop, causing only the last shape to be stored in the dictionary. When `reorder_images()` tries to access other shapes, it fails with a KeyError.

**Fix:** Move the assignment inside the loop with proper indentation (add 4 spaces).

**Before:**
```python
for shape, stacked_images in grouped_images.items():
    # ... resize code ...
split_images_grouped[shape] = stacked_images  # Outside loop - bug!
```
**After:**
```python
for shape, stacked_images in grouped_images.items():
    # ... resize code ...
    split_images_grouped[shape] = stacked_images  # Inside loop - fixed!
```

Fixes #39442
Before submitting

This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
 Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
 Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
 Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
 Did you write any new necessary tests?

Who can review?
@yonigozlan @amyeroberts @qubvel