### PR TITLE
Skipping `initialize_weights` when model is quantized

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5629,7 +5629,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         unexpected_keys: list[str],
         dtype: Optional[torch.dtype],
         hf_quantizer: Optional[HfQuantizer],
-    ) -> "PreTrainedModel":
+    ) -> None:
         """Move the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts) back
         from meta device to cpu.
         """
@@ -5663,7 +5663,7 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         loaded_keys: list[str],
         ignore_mismatched_sizes: bool,
         is_quantized: bool,
-    ) -> "PreTrainedModel":
+    ) -> None:
         """Initialize the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts), according to
         `_initialize_weights`. Indeed, since the corresponding weights are missing from the state dict, they will not be replaced and need to
         be initialized correctly (i.e. weight initialization distribution).
@@ -5684,20 +5684,21 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
         else:
             not_initialized_submodules = dict(self.named_modules())
         # This will only initialize submodules that are not marked as initialized by the line above.
-        if is_deepspeed_zero3_enabled() and not is_quantized:
-            import deepspeed
+        if not is_quantized:
+            if is_deepspeed_zero3_enabled():
+                import deepspeed
 
-            not_initialized_parameters = list(
-                set(
-                    itertools.chain.from_iterable(
-                        submodule.parameters(recurse=False) for submodule in not_initialized_submodules.values()
+                not_initialized_parameters = list(
+                    set(
+                        itertools.chain.from_iterable(
+                            submodule.parameters(recurse=False) for submodule in not_initialized_submodules.values()
+                        )
                     )
                 )
-            )
-            with deepspeed.zero.GatheredParameters(not_initialized_parameters, modifier_rank=0):
+                with deepspeed.zero.GatheredParameters(not_initialized_parameters, modifier_rank=0):
+                    self.initialize_weights()
+            else:
                 self.initialize_weights()
-        else:
-            self.initialize_weights()
 
     def get_parameter_or_buffer(self, target: str):
         """


### PR DESCRIPTION
# What does this PR do?
Avoids to perform weights initialization when loading a quantized model. The previous implementation was checking the `is_quantized` condition only when trying to initialize weights with deepspeed. 

Fixes #39366


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @zach-huggingface
