### PR TITLE
Fix quantized model dispatch with device_map='auto'

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4931,7 +4931,14 @@ class PreTrainedModel(nn.Module, ModuleUtilsMixin, PushToHubMixin, PeftAdapterMi
             ):
                 device_map_kwargs["offload_buffers"] = True
 
-            if not is_fsdp_enabled() and not is_deepspeed_zero3_enabled():
+            # Check if model is quantized with bitsandbytes
+            is_quantized_bnb = (
+                hf_quantizer is not None and 
+                hf_quantizer.quantization_config.quant_method == QuantizationMethod.BITS_AND_BYTES
+            )
+
+            # Skip dispatch_model for quantized models as they're already on correct devices
+            if not is_fsdp_enabled() and not is_deepspeed_zero3_enabled() and not is_quantized_bnb:
                 dispatch_model(model, **device_map_kwargs)
 
         if hf_quantizer is not None:


### PR DESCRIPTION
# What does this PR do?

Fixes issue #39461 where quantized models fail to load with `device_map="auto"` on Linux but work on Windows.

**Root cause:** `dispatch_model` calls `model.to(device)` on bitsandbytes quantized models, which isn't supported. Platform differences in device detection/handling cause this code path to be hit on Linux but not Windows.

**Fix:** Skip `dispatch_model` for bitsandbytes quantized models since they're already correctly placed during quantization.

Fixes #39461


please verify quantization experts (bitsandbytes, autogpt): @SunMarc @MekkCyber 