### PR TITLE
Slack CI bot: set default result for non-existing artifacts

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1427,12 +1427,12 @@ if __name__ == "__main__":
         target_results = matrix_job_results
     else:
         default_result = {
-        "failed": {"unclassified": 0, "single": 0, "multi": 0},
-        "success": 0,
-        "time_spent": "",
-        "error": False,
-        "failures": {},
-        "job_link": {},
+            "failed": {"unclassified": 0, "single": 0, "multi": 0},
+            "success": 0,
+            "time_spent": "",
+            "error": False,
+            "failures": {},
+            "job_link": {},
         }
 
         key = job_to_test_map.get(job_name)

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1436,7 +1436,7 @@ if __name__ == "__main__":
         }
 
         key = job_to_test_map.get(job_name)
-        target_results = additional_results.get(key, default_result) if key else default_result
+        target_results = additional_results.get(key, default_result) if key is not None else default_result
 
     # Make the format uniform between `model_results` and `additional_results[XXX]`
     if "failures" in target_results:

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1426,7 +1426,17 @@ if __name__ == "__main__":
     if len(matrix_job_results) > 0:
         target_results = matrix_job_results
     else:
-        target_results = additional_results[job_to_test_map[job_name]]
+        default_result = {
+        "failed": {"unclassified": 0, "single": 0, "multi": 0},
+        "success": 0,
+        "time_spent": "",
+        "error": False,
+        "failures": {},
+        "job_link": {},
+        }
+
+        key = job_to_test_map.get(job_name)
+        target_results = additional_results.get(key, default_result) if key else default_result
 
     # Make the format uniform between `model_results` and `additional_results[XXX]`
     if "failures" in target_results:


### PR DESCRIPTION
# What does this PR do?

Since https://github.com/huggingface/transformers/pull/39198 the notification service works based on the downloaded artifacts instead of a pre-compiled list. This resulted in key errors in the AMD CI where some of the tests pipelines are not run and the artifacts are not produced. This PR sets a default for those cases.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
