### PR TITLE
[dependencies] Update `datasets` pin

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -18,6 +18,9 @@ jobs:
       notebook_folder: transformers_doc
       languages: ar de en es fr hi it ko pt tr zh ja te
       custom_container: huggingface/transformers-doc-builder
+      # Temporary pin to work around datasets exception in the docbuilder. Remove after 2025-07-25. See
+      # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
+      pre_command: uv pip install datasets>=2.15.0
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -18,7 +18,8 @@ jobs:
       notebook_folder: transformers_doc
       languages: ar de en es fr hi it ko pt tr zh ja te
       custom_container: huggingface/transformers-doc-builder
-      # Temporary pin to work around datasets exception in the docbuilder. Remove after 2025-07-25. See
+      # Temporary pin to work around datasets exception in the docbuilder.Remove after docker images and main have
+      # the right dependencies (which **should** be the case by 2025-07-20). See
       # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
       pre_command: uv pip install datasets>=2.15.0
     secrets:

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,3 +15,4 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: transformers
       languages: en
+      pre_build_command: uv pip install pyarrow==20.0.0

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,4 +15,4 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: transformers
       languages: en
-      pre_build_command: uv pip install pyarrow==20.0.0
+      pre_command: uv pip install pyarrow==20.0.0

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,4 +15,6 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: transformers
       languages: en
+      # temporary pin to work around datasets exception in the docbuilder. See
+      # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
       pre_command: uv pip install pyarrow==20.0.0

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,6 +15,7 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: transformers
       languages: en
-      # Temporary pin to work around datasets exception in the docbuilder. Remove after 2025-07-25. See
+      # Temporary pin to work around datasets exception in the docbuilder. Remove after docker images and main have
+      # the right dependencies (which **should** be the case by 2025-07-20). See
       # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
       pre_command: uv pip install datasets>=2.15.0

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -15,6 +15,6 @@ jobs:
       pr_number: ${{ github.event.number }}
       package: transformers
       languages: en
-      # temporary pin to work around datasets exception in the docbuilder. See
+      # Temporary pin to work around datasets exception in the docbuilder. Remove after 2025-07-25. See
       # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
-      pre_command: uv pip install pyarrow==20.0.0
+      pre_command: uv pip install datasets>=2.15.0

--- a/setup.py
+++ b/setup.py
@@ -148,6 +148,9 @@ _deps = [
     "phonemizer",
     "protobuf",
     "psutil",
+    # temporary pin to work around datasets exception in the docbuilder. See
+    # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
+    "pyarrow<21.0.0",
     "pyyaml>=5.1",
     "pydantic>=2",
     "pytest>=7.2.0",

--- a/setup.py
+++ b/setup.py
@@ -150,7 +150,7 @@ _deps = [
     "psutil",
     # temporary pin to work around datasets exception in the docbuilder. See
     # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
-    "pyarrow<21.0.0",
+    "pyarrow<=20.0.0",
     "pyyaml>=5.1",
     "pydantic>=2",
     "pytest>=7.2.0",

--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ _deps = [
     "codecarbon>=2.8.1",
     "cookiecutter==1.7.3",
     "dataclasses",
-    "datasets!=2.5.0",
+    "datasets>=2.15.0",  # We need either this pin or pyarrow<21.0.0
     "deepspeed>=0.9.3",
     "diffusers",
     "dill<0.3.5",

--- a/setup.py
+++ b/setup.py
@@ -148,9 +148,6 @@ _deps = [
     "phonemizer",
     "protobuf",
     "psutil",
-    # temporary pin to work around datasets exception in the docbuilder. See
-    # https://github.com/huggingface/transformers/actions/runs/16365952006/job/46243081358?pr=38545
-    "pyarrow<=20.0.0",
     "pyyaml>=5.1",
     "pydantic>=2",
     "pytest>=7.2.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -54,7 +54,6 @@ deps = {
     "phonemizer": "phonemizer",
     "protobuf": "protobuf",
     "psutil": "psutil",
-    "pyarrow": "pyarrow<=20.0.0",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic>=2",
     "pytest": "pytest>=7.2.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -10,7 +10,7 @@ deps = {
     "codecarbon": "codecarbon>=2.8.1",
     "cookiecutter": "cookiecutter==1.7.3",
     "dataclasses": "dataclasses",
-    "datasets": "datasets!=2.5.0",
+    "datasets": "datasets>=2.15.0",
     "deepspeed": "deepspeed>=0.9.3",
     "diffusers": "diffusers",
     "dill": "dill<0.3.5",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -54,6 +54,7 @@ deps = {
     "phonemizer": "phonemizer",
     "protobuf": "protobuf",
     "psutil": "psutil",
+    "pyarrow": "pyarrow<21.0.0",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic>=2",
     "pytest": "pytest>=7.2.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -54,7 +54,7 @@ deps = {
     "phonemizer": "phonemizer",
     "protobuf": "protobuf",
     "psutil": "psutil",
-    "pyarrow": "pyarrow<21.0.0",
+    "pyarrow": "pyarrow<=20.0.0",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic>=2",
     "pytest": "pytest>=7.2.0",


### PR DESCRIPTION
# What does this PR do?

(follow-up to #39496 with a more thorough fix)

With the release of `pyarrow==21.0.0`, whose most recent version is installed in `datasets` by default, `datasets<2.15.0` starts throwing exceptions.

This means we need `datasets>=2.15.0` or `pyarrow<21.0.0`. Maximum version pins may limit other packages, so I'm adding a minimum version pin.

Relevant commit in `datasets`: https://github.com/huggingface/datasets/commit/c096bd288d07ed86f340ae090e5d4d9c5351f76f (`pyarrow==21.0.0` isn't compatible before this commit)