### PR TITLE
Fix Docstring of BarkProcessor

### DIFF
--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -255,8 +255,9 @@ class BarkProcessor(ProcessorMixin):
                 - `'np'`: Return NumPy `np.ndarray` objects.
 
         Returns:
-            Tuple([`BatchEncoding`], [`BatchFeature`]): A tuple composed of a [`BatchEncoding`], i.e the output of the
-            `tokenizer` and a [`BatchFeature`], i.e the voice preset with the right tensors type.
+            [`BatchEncoding`]: A [`BatchEncoding`] object containing the output of the `tokenizer`.
+            If a voice preset is provided, the returned object will include a `"history_prompt"` key
+            containing a [`BatchFeature`] , i.e the voice preset with the right tensors type.
         """
         if voice_preset is not None and not isinstance(voice_preset, dict):
             if (

--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -257,7 +257,7 @@ class BarkProcessor(ProcessorMixin):
         Returns:
             [`BatchEncoding`]: A [`BatchEncoding`] object containing the output of the `tokenizer`.
             If a voice preset is provided, the returned object will include a `"history_prompt"` key
-            containing a [`BatchFeature`] , i.e the voice preset with the right tensors type.
+            containing a [`BatchFeature`], i.e the voice preset with the right tensors type.
         """
         if voice_preset is not None and not isinstance(voice_preset, dict):
             if (

--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -24,6 +24,7 @@ import numpy as np
 
 from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import ProcessorMixin
+from ...tokenization_utils_base import BatchEncoding
 from ...utils import logging
 from ...utils.hub import cached_file
 from ..auto import AutoTokenizer
@@ -232,7 +233,7 @@ class BarkProcessor(ProcessorMixin):
         return_attention_mask=True,
         return_token_type_ids=False,
         **kwargs,
-    ):
+    ) -> BatchEncoding:
         """
         Main method to prepare for the model one or several sequences(s). This method forwards the `text` and `kwargs`
         arguments to the AutoTokenizer's [`~AutoTokenizer.__call__`] to encode the text. The method also proposes a


### PR DESCRIPTION
# What does this PR do?

This PR corrects the return type hint in the docstring of `BarkProcessor.__call__`. The current docstring incorrectly stated that the method returns a `Tuple(BatchEncoding, BatchFeature)`, but it actually returns a `BatchEncoding` object.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- speech models: @eustlb
- Documentation: @stevhliu