### PR TITLE
bad_words_ids no longer slow on mps

### DIFF
--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1309,12 +1309,10 @@ class NoBadWordsLogitsProcessor(SequenceBiasLogitsProcessor):
                     eos_token_id = [eos_token_id]
                 eos_token_id = torch.tensor(eos_token_id)
 
-            eos_set = set(eos_token_id)
-            bad_words_ids = [
-                bad_token_seq
-                for bad_token_seq in bad_words_ids
-                if len(bad_token_seq) != 1 or bad_token_seq[0] not in eos_set
-            ]
+            eos_token_id_list = eos_token_id.tolist() # convert to python list before
+            bad_words_ids = list(
+                filter(lambda bad_token_seq: all(bad_token_seq != [i] for i in eos_token_id_list), bad_words_ids)
+            )
         # Forbidding a sequence is equivalent to setting its bias to -inf
         sequence_bias = {tuple(sequence): float("-inf") for sequence in bad_words_ids}
         super().__init__(sequence_bias=sequence_bias)

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1303,10 +1303,11 @@ class NoBadWordsLogitsProcessor(SequenceBiasLogitsProcessor):
                     eos_token_id = [eos_token_id]
                 eos_token_id = torch.tensor(eos_token_id)
 
-            bad_words_ids = list(
-                filter(lambda bad_token_seq: all(bad_token_seq != [i] for i in eos_token_id), bad_words_ids)
-            )
-
+            eos_set = set(eos_token_id)
+            bad_words_ids = [
+                bad_token_seq for bad_token_seq in bad_words_ids
+                if len(bad_token_seq) != 1 or bad_token_seq[0] not in eos_set
+            ]
         # Forbidding a sequence is equivalent to setting its bias to -inf
         sequence_bias = {tuple(sequence): float("-inf") for sequence in bad_words_ids}
         super().__init__(sequence_bias=sequence_bias)

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1309,7 +1309,7 @@ class NoBadWordsLogitsProcessor(SequenceBiasLogitsProcessor):
                     eos_token_id = [eos_token_id]
                 eos_token_id = torch.tensor(eos_token_id)
 
-            eos_token_id_list = eos_token_id.tolist() # convert to python list before
+            eos_token_id_list = eos_token_id.tolist()  # convert to python list before
             bad_words_ids = list(
                 filter(lambda bad_token_seq: all(bad_token_seq != [i] for i in eos_token_id_list), bad_words_ids)
             )

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -1181,6 +1181,9 @@ class SequenceBiasLogitsProcessor(LogitsProcessor):
                 f"The model vocabulary size is {vocabulary_size}, but the following tokens were being biased: "
                 f"{invalid_biases}"
             )
+
+        # Precompute the bias tensors to be applied. Sequences of length 1 are kept separately, as they can be applied
+        # with simpler logic.
         self.length_1_bias = torch.zeros((vocabulary_size,), dtype=torch.float, device=scores.device)
         # Extract single-token sequences and their biases
         single_token_ids = []


### PR DESCRIPTION
# What does this PR do?
Using the `bad_words_ids` on mps is slowing down a lot the text generation, this PR tries to address that.

Fixes https://github.com/huggingface/transformers/issues/39512


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

 @ArthurZucker
