### PR TITLE
Fix Qwen2-VL image/video processor legacy size field handling

### DIFF
--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -137,8 +137,14 @@ class Qwen2VLImageProcessor(BaseImageProcessor):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if size is not None and ("shortest_edge" not in size or "longest_edge" not in size):
-            raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+        if size is not None:
+            # backward compatibility: convert max_pixels/min_pixels to longest_edge/shortest_edge if they're in size
+            if "min_pixels" in size:
+                size["shortest_edge"] = size.pop("min_pixels")
+            if "max_pixels" in size:
+                size["longest_edge"] = size.pop("max_pixels")
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
         else:
             size = {"shortest_edge": 56 * 56, "longest_edge": 28 * 28 * 1280}
         # backward compatibility: override size with min_pixels and max_pixels if they are provided

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -137,21 +137,25 @@ class Qwen2VLImageProcessor(BaseImageProcessor):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if size is not None:
-            # backward compatibility: convert max_pixels/min_pixels to longest_edge/shortest_edge if they're in size
-            if "min_pixels" in size:
-                size["shortest_edge"] = size.pop("min_pixels")
-            if "max_pixels" in size:
-                size["longest_edge"] = size.pop("max_pixels")
-            if "shortest_edge" not in size or "longest_edge" not in size:
-                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
-        else:
-            size = {"shortest_edge": 56 * 56, "longest_edge": 28 * 28 * 1280}
+        size = kwargs.pop("size", {})
+        min_pixels = kwargs.pop("min_pixels", None)
+        max_pixels = kwargs.pop("max_pixels", None)
         # backward compatibility: override size with min_pixels and max_pixels if they are provided
         if min_pixels is not None:
             size["shortest_edge"] = min_pixels
         if max_pixels is not None:
             size["longest_edge"] = max_pixels
+        # backward compatibility: remove unused min_pixels/max_pixels keys from size
+        if "min_pixels" in size:
+            size.pop("min_pixels")
+        if "max_pixels" in size:
+            size.pop("max_pixels")
+
+        if size and ("shortest_edge" not in size or "longest_edge" not in size):
+            raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+        elif not size:
+            size = {"shortest_edge": 56 * 56, "longest_edge": 28 * 28 * 1280}
+
         self.min_pixels = size["shortest_edge"]
         self.max_pixels = size["longest_edge"]
         self.size = size

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
@@ -107,24 +107,21 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
     model_input_names = ["pixel_values", "image_grid_thw", "pixel_values_videos", "video_grid_thw"]
 
     def __init__(self, **kwargs: Unpack[Qwen2VLFastImageProcessorKwargs]):
-        size = kwargs.pop("size", None)
+        size = kwargs.pop("size", self.size)
         min_pixels = kwargs.pop("min_pixels", None)
         max_pixels = kwargs.pop("max_pixels", None)
-        if size is not None:
-            # backward compatibility: convert max_pixels/min_pixels to longest_edge/shortest_edge if they're in size
-            if "min_pixels" in size:
-                size["shortest_edge"] = size.pop("min_pixels")
-            if "max_pixels" in size:
-                size["longest_edge"] = size.pop("max_pixels")
-            if "shortest_edge" not in size or "longest_edge" not in size:
-                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
-        else:
-            size = self.size
         # backward compatibility: override size with min_pixels and max_pixels if they are provided
         if min_pixels is not None:
             size["shortest_edge"] = min_pixels
         if max_pixels is not None:
             size["longest_edge"] = max_pixels
+        # backward compatibility: remove unused min_pixels/max_pixels keys from size
+        if "min_pixels" in size:
+            size.pop("min_pixels")
+        if "max_pixels" in size:
+            size.pop("max_pixels")
+        if size and ("shortest_edge" not in size or "longest_edge" not in size):
+            raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
         super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
 

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
@@ -110,8 +110,14 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
         size = kwargs.pop("size", None)
         min_pixels = kwargs.pop("min_pixels", None)
         max_pixels = kwargs.pop("max_pixels", None)
-        if size is not None and ("shortest_edge" not in size or "longest_edge" not in size):
-            raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+        if size is not None:
+            # backward compatibility: convert max_pixels/min_pixels to longest_edge/shortest_edge if they're in size
+            if "min_pixels" in size:
+                size["shortest_edge"] = size.pop("min_pixels")
+            if "max_pixels" in size:
+                size["longest_edge"] = size.pop("max_pixels")
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
         else:
             size = self.size
         # backward compatibility: override size with min_pixels and max_pixels if they are provided

--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -116,8 +116,17 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
     model_input_names = ["pixel_values_videos", "video_grid_thw"]
 
     def __init__(self, **kwargs: Unpack[Qwen2VLVideoProcessorInitKwargs]):
-        super().__init__(**kwargs)
-        self.size = {"shortest_edge": self.min_pixels, "longest_edge": self.max_pixels}
+        size = kwargs.pop("size", None)
+        if size is not None:
+            # backward compatibility: convert max_pixels/min_pixels to longest_edge/shortest_edge if they're in size
+            if "min_pixels" in size:
+                size["shortest_edge"] = size.pop("min_pixels")
+            if "max_pixels" in size:
+                size["longest_edge"] = size.pop("max_pixels")
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+        super().__init__(size=size, **kwargs)
+        self.size = size or {"shortest_edge": self.min_pixels, "longest_edge": self.max_pixels}
 
     def sample_frames(
         self,


### PR DESCRIPTION
# What does this PR do?

- Fixes https://github.com/vllm-project/vllm/issues/15614#issuecomment-3097032491

Some qwen2-vl based model like `ByteDance-Seed/UI-TARS-2B-SFT` has legacy `size` field in `preprocessor.json` like: 
```
"size": {
    "max_pixels": 2116800,
    "min_pixels": 3136
}
```
Which will raise `ValueError: size must contain 'shortest_edge' and 'longest_edge' keys.` after v4.52

This PR adds backwards compatibility for this kind of `size` field.

**Code to reproduce**
```python3
from transformers import AutoProcessor

processor = AutoProcessor.from_pretrained("ByteDance-Seed/UI-TARS-2B-SFT")
print(processor)

processor = AutoProcessor.from_pretrained("ByteDance-Seed/UI-TARS-2B-SFT", use_fast=True)
print(processor)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
