### PR TITLE
Torchdec RuntimeError catch 

### DIFF
--- a/utils/print_env.py
+++ b/utils/print_env.py
@@ -80,6 +80,6 @@ try:
     versions = torchcodec._core.get_ffmpeg_library_versions()
     print("FFmpeg version:", versions["ffmpeg_version"])
 except (ImportError, RuntimeError):
-    print("TorchCodec could not be loaded:")
+    print("FFmpeg version:", None)
 except (AttributeError, KeyError):
     print("Failed to get FFmpeg version")

--- a/utils/print_env.py
+++ b/utils/print_env.py
@@ -79,7 +79,7 @@ try:
 
     versions = torchcodec._core.get_ffmpeg_library_versions()
     print("FFmpeg version:", versions["ffmpeg_version"])
-except ImportError:
-    print("FFmpeg version:", None)
+except (ImportError, RuntimeError):
+    print("TorchCodec could not be loaded:")
 except (AttributeError, KeyError):
     print("Failed to get FFmpeg version")

--- a/utils/print_env.py
+++ b/utils/print_env.py
@@ -79,7 +79,7 @@ try:
 
     versions = torchcodec._core.get_ffmpeg_library_versions()
     print("FFmpeg version:", versions["ffmpeg_version"])
-except (ImportError):
+except ImportError:
     print("FFmpeg version:", None)
 except (AttributeError, KeyError, RuntimeError):
     print("Failed to get FFmpeg version")

--- a/utils/print_env.py
+++ b/utils/print_env.py
@@ -79,7 +79,7 @@ try:
 
     versions = torchcodec._core.get_ffmpeg_library_versions()
     print("FFmpeg version:", versions["ffmpeg_version"])
-except (ImportError, RuntimeError):
+except (ImportError):
     print("FFmpeg version:", None)
-except (AttributeError, KeyError):
+except (AttributeError, KeyError, RuntimeError):
     print("Failed to get FFmpeg version")


### PR DESCRIPTION
# What does this PR do ? 

This PR fixes an issue with torchcodec in print_env.py. We forgot to deal with the case where torchcodec raises a RuntimeError error. Currently some of our training [ci](https://github.com/huggingface/transformers/actions/runs/16433389284/job/46438805785) are not running because of that. 