### PR TITLE
Fix link in "Inference server backends" doc

### DIFF
--- a/docs/source/en/transformers_as_backend.md
+++ b/docs/source/en/transformers_as_backend.md
@@ -40,7 +40,7 @@ vllm serve meta-llama/Llama-3.2-1B \
     --model-impl transformers
 ```
 
-Refer to the [vLLM docs](https://docs.vllm.ai/en/latest/models/transformers_backend.html) for more usage examples and tips on using a Transformers as the backend.
+Refer to the [vLLM docs](https://docs.vllm.ai/en/latest/models/supported_models.html#transformers) for more usage examples and tips on using a Transformers as the backend.
 
 
 ## SGLang


### PR DESCRIPTION
The link now points to the correct place in the vLLM docs