### PR TITLE
Chat schemas

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1656,9 +1656,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         )
 
         if return_assistant_tokens_mask and chat_schema:
+            # TODO This probably needs to be reverted - in cases with tool calls or thinking, we are unlikely to
+            #      correctly capture the assistant boundaries with the regexes, without making them a lot more
+            #      failure-prone. Generation tags in the template are more reliable and should be fully embraced.
             generation_indices = []  # This takes priority over jinja generation parsing
-            # TODO Check the schema actually has regexes/parsers for the assistant turns, not just that a schema exists
-            # TODO Make a test comparing the indices we get from this to the ones we get from % generation % tags
             for chat in rendered_chat:
                 parsed_chat = recursive_parse(chat, chat_schema, offset=0)
                 assistant_messages = [

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1686,7 +1686,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         input_ids = [out["input_ids"]]
                     for i in range(len(input_ids)):
                         current_mask = [0] * len(input_ids[i])
-                        for assistant_start_char, assistant_end_char in generation_indices[i]:
+                        for assistant_start_char, assistant_end_char in jinja_generation_indices[i]:
                             start_token = out.char_to_token(i, assistant_start_char)
                             end_token = out.char_to_token(i, assistant_end_char - 1)
                             if start_token is None:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -65,8 +65,8 @@ from .utils import (
     requires_backends,
     to_py_obj,
 )
-from .utils.chat_template_utils import render_jinja_template
 from .utils.chat_parsing_utils import recursive_parse
+from .utils.chat_template_utils import render_jinja_template
 from .utils.import_utils import PROTOBUF_IMPORT_ERROR
 
 
@@ -1661,11 +1661,10 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             # TODO Make a test comparing the indices we get from this to the ones we get from % generation % tags
             for chat in rendered_chat:
                 parsed_chat = recursive_parse(chat, chat_schema, offset=0)
-                assistant_messages = [message['content'] for message in parsed_chat.get("messages", [])
-                                      if message["role"] == "assistant"]
-                generation_indices.append(
-                    [(message.start, message.end) for message in assistant_messages]
-                )
+                assistant_messages = [
+                    message["content"] for message in parsed_chat.get("messages", []) if message["role"] == "assistant"
+                ]
+                generation_indices.append([(message.start, message.end) for message in assistant_messages])
 
         if not is_batched:
             rendered_chat = rendered_chat[0]

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -65,8 +65,13 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict, scope_va
             # TODO eval is obviously enormously insecure and only used for prototyping here
             #      make a safer parser before merging
             return _parse_type_hint(eval(node_content))
+        elif parser == "python_function":
+            fn = eval(node_content)
         else:
             raise ValueError(f"Unknown parser {parser} for schema node: {node_schema}")
+
+
+
 
 
 

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -1,20 +1,12 @@
-import ast
 import json
 import re
 import jmespath  # TODO Make this a proper optional dependency
-from collections import namedtuple
 
 # Next line only used because eval might grab them. Can be removed once we have something better than eval
 from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
-from .chat_template_utils import _parse_type_hint, parse_google_format_docstring
 
-
-offset_content = namedtuple("offset_content", ["content", "offset"])
-location_content = namedtuple("location_content", ["content", "start", "end"])
-
-
-def _parse_re_match(node_match, offset, require_groups: list[str] | None = None):
+def _parse_re_match(node_match, require_groups: list[str] | None = None):
     if require_groups:
         if not node_match.groupdict():
             raise ValueError(f"Regex has no named groups, but require_groups was set to {require_groups}")
@@ -23,35 +15,20 @@ def _parse_re_match(node_match, offset, require_groups: list[str] | None = None)
                 raise ValueError(f"Regex missing required group {group}!\nGroups: {node_match.groupdict().keys()}\n")
     # If the regex has named groups, return a dict of those groups
     if node_match.groupdict():
-        if offset is not None:
-            return {
-                group: offset_content(content, node_match.start(group) + offset)
-                for group, content in node_match.groupdict().items()
-                if content is not None
-            }
-        else:
-            return {key: val for key, val in node_match.groupdict().items() if val is not None}
+        return {key: val for key, val in node_match.groupdict().items() if val is not None}
     # If the regex has unnamed groups, it MUST only have one, and we return that group
     elif groups := list(node_match.groups()):
         if len(groups) > 1:
             raise ValueError(f"Regex has multiple unnamed groups!\nGroups: {groups}\n")
-        if offset is not None:
-            return offset_content(groups[0], node_match.start(1) + offset)  # TODO Is (1) right here?
-        else:
-            return groups[0]
+        return groups[0]
     # If no groups, use the whole match
     else:
-        if offset is not None:
-            return offset_content(node_match.group(0), node_match.start(0) + offset)
-        else:
-            return node_match.group(0)
+        return node_match.group(0)
 
 
 def recursive_parse(
-    node_content: str | list | dict | offset_content,
+    node_content: str | list | dict,
     node_schema: dict,
-    scope_vars: dict | None = None,
-    offset: int | None = None,
 ):
     """
     This function takes content and a JSON schema node which includes
@@ -64,7 +41,6 @@ def recursive_parse(
                       we generally pass the capture groups straight through to the children of this node
                       and don't do any parsing at this level.
         node_schema: The schema node controlling the parsing.
-        scope_vars: A dictionary of variables in scope at the current node
 
     Returns:
         The parsed data structure for the current node.
@@ -78,19 +54,9 @@ def recursive_parse(
     if node_content is None:
         return None
 
-    # If we need to parse scope vars, now is the time to do it because they need to go to all child nodes
-    if "x-scope-vars" in node_schema:
-        if scope_vars is None:
-            scope_vars = {}
-        # Make sure we create a new dict so we don't accidentally send modifications up the tree
-        scope_vars = scope_vars | {
-            key: recursive_parse(node_content, value, scope_vars) for key, value in node_schema["x-scope-vars"].items()
-        }
-
     # Next, if the node has a parser we can just use that and ignore everything else.
     if "x-parser" in node_schema:
         parser = node_schema["x-parser"]
-        offset = None  # We cannot track offsets through parsers, so stop trying
         if parser == "json":
             parser_args = node_schema.get("x-parser-args", {})
             try:
@@ -102,13 +68,6 @@ def recursive_parse(
             if "transform" in parser_args:
                 parsed_json = jmespath.search(parser_args["transform"], parsed_json)
             node_content = parsed_json
-        elif parser == "python_type":
-            # TODO eval is obviously enormously insecure and only used for prototyping here
-            #      make a safer parser before merging
-            node_content = _parse_type_hint(eval(node_content))
-        elif parser == "python_function":
-            parser_args = node_schema.get("x-parser-args", {})
-            node_content = _extract_args_and_docstring_from_function_text(node_content, **parser_args)
         else:
             raise ValueError(f"Unknown parser {parser} for schema node: {node_schema}")
 
@@ -129,16 +88,13 @@ def recursive_parse(
         node_match = re.search(node_regex, node_content, flags=re.DOTALL)
         if not node_match:
             return None  # TODO Is this correct? Should I raise an error?
-        node_content = _parse_re_match(node_match, offset)
-        if isinstance(node_content, offset_content):
-            offset = node_content.offset
-            node_content = node_content.content
+        node_content = _parse_re_match(node_match)
     if node_regex_iterator is not None:
         if node_type != "array":
             raise TypeError(f"Schema node with type {node_type} cannot use x-regex-iterator.\nSchema: {node_schema}")
         # Note that this can be applied after a standard node-regex search
         node_content = [
-            _parse_re_match(node_match, offset)
+            _parse_re_match(node_match)
             for node_match in re.finditer(node_regex_iterator, node_content, flags=re.DOTALL)
         ]
         if not node_content:
@@ -149,7 +105,7 @@ def recursive_parse(
         # Note that this can be applied after a standard node-regex search
         output_content = {}
         for node_match in re.finditer(node_regex_to_dict, node_content, flags=re.DOTALL):
-            match_groups = _parse_re_match(node_match, offset, require_groups=["key", "value"])
+            match_groups = _parse_re_match(node_match, require_groups=["key", "value"])
             output_content[match_groups["key"]] = match_groups["value"]
         node_content = output_content
         if not node_content:
@@ -166,7 +122,6 @@ def recursive_parse(
         mapping = node_schema["x-mapping"]
         if node_content in mapping:
             node_content = mapping[node_content]
-            offset = None  # Don't try to track offsets through mappings
 
     if "x-mapping-regex" in node_schema:
         if not isinstance(node_content, str):
@@ -177,10 +132,7 @@ def recursive_parse(
             )
         mapping_regex = node_schema["x-mapping-regex"]
         for pattern, replacement in mapping_regex.items():
-            substitution = re.sub(pattern, replacement, node_content, flags=re.DOTALL)
-            if substitution != node_content:
-                offset = None  # If we make a substitution, we can't track offsets anymore
-                node_content = substitution
+            node_content = re.sub(pattern, replacement, node_content, flags=re.DOTALL)
 
     # Finally, handle parsed content based on schema type and recurse if required
     if node_type == "object":
@@ -197,18 +149,12 @@ def recursive_parse(
                     f"Schema: {node_schema}"
                 )
             for key, child_node in node_schema["properties"].items():
-                parsed_schema[key] = recursive_parse(node_content, node_schema["properties"][key], scope_vars, offset)
+                parsed_schema[key] = recursive_parse(node_content, node_schema["properties"][key])
             return parsed_schema
         for key, child_node in node_schema.get("properties", {}).items():
             # TODO Error if required keys are not present
             if key in node_content:
-                key_content = node_content[key]
-                if isinstance(key_content, offset_content):
-                    key_offset = key_content.offset
-                    key_content = key_content.content
-                else:
-                    key_offset = offset
-                parsed_schema[key] = recursive_parse(key_content, child_node, scope_vars, key_offset)
+                parsed_schema[key] = recursive_parse(node_content[key], child_node)
             elif "default" in child_node:
                 # TODO Do I want to allow defaults?
                 parsed_schema[key] = child_node["default"]
@@ -217,14 +163,7 @@ def recursive_parse(
         if "additionalProperties" in node_schema:
             for key, value in node_content.items():
                 if key not in node_schema.get("properties", {}):
-                    if isinstance(value, offset_content):
-                        value_offset = value.offset
-                        value = value.content
-                    else:
-                        value_offset = offset
-                    parsed_schema[key] = recursive_parse(
-                        value, node_schema["additionalProperties"], scope_vars, offset=value_offset
-                    )
+                    parsed_schema[key] = recursive_parse(value, node_schema["additionalProperties"])
         return parsed_schema
     elif node_type == "array":
         if not node_content:
@@ -234,13 +173,7 @@ def recursive_parse(
             if not isinstance(node_content, list):
                 raise TypeError(f"Expected a list or regex for schema node with type array, got {node_content}")
             for item in node_content:
-                if isinstance(item, offset_content):
-                    item_content = item.content
-                    item_offset = item.offset
-                else:
-                    item_content = item
-                    item_offset = offset
-                parsed_schema.append(recursive_parse(item_content, node_schema["items"], scope_vars, item_offset))
+                parsed_schema.append(recursive_parse(item, node_schema["items"]))
             return parsed_schema
         elif "prefixItems" in node_schema:
             if not isinstance(node_content, list):
@@ -257,13 +190,7 @@ def recursive_parse(
                     f"Schema: {node_schema}"
                 )
             for item, item_schema in zip(node_content, node_schema["prefixItems"]):
-                if isinstance(item, offset_content):
-                    item_content = item.content
-                    item_offset = item.offset
-                else:
-                    item_content = item
-                    item_offset = offset
-                parsed_schema.append(recursive_parse(item_content, item_schema, scope_vars, item_offset))
+                parsed_schema.append(recursive_parse(item, item_schema))
             return parsed_schema
         else:
             raise ValueError(f"Array node has no items or prefixItems schema defined.\nSchema: {node_schema}")
@@ -271,78 +198,21 @@ def recursive_parse(
         if not isinstance(node_content, str):
             raise TypeError(f"Expected a string for schema node with type {node_type}, got {node_content}")
         if node_type == "integer":
-            if offset is not None:
-                return location_content(int(node_content), offset, offset + len(node_content))
-            else:
-                return int(node_content)
+            return int(node_content)
         elif node_type == "number":
-            if offset is not None:
-                return location_content(float(node_content), offset, offset + len(node_content))
-            else:
-                return float(node_content)
+            return float(node_content)
         elif node_type == "boolean":
             if node_content.lower() in ("true", "1"):
-                value = True
+                return True
             elif node_content.lower() in ("false", "0"):
-                value = False
+                return False
             else:
                 raise ValueError(f"Invalid boolean value: {node_content}")
-            if offset is not None:
-                return location_content(value, offset, offset + len(node_content))
-            else:
-                return value
         else:
-            if offset is not None:
-                return location_content(node_content, offset, offset + len(node_content))
-            else:
-                return node_content
+            # String type
+            return node_content
     elif node_type == "any":
         return node_content
     else:
         # TODO Should we handle null types?
         raise TypeError(f"Unsupported schema type {node_type} for node: {node_content}")
-
-
-def _extract_args_and_docstring_from_function_text(function_text: str, include_return: bool = True) -> dict:
-    tree = ast.parse(function_text)
-    func = next((n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)), None)
-    if func is None:
-        raise ValueError("Parser `python_function` couldn't find a function def: \n\n", function_text)
-
-    docstring = ast.get_docstring(func)
-    if docstring:
-        description, args_dict, return_description = parse_google_format_docstring(docstring)
-        args_dict = {key: {"description": value} for key, value in args_dict.items()}
-    else:
-        description = args_dict = return_description = None
-
-    required_args = []
-    # Right-align defaults to args
-    defaults = [None] * (len(func.args.args) - len(func.args.defaults)) + func.args.defaults
-    for arg, default in zip(func.args.args, defaults):
-        if not default:
-            required_args.append(arg.arg)
-        # TODO This is a horrific temporary hack, write a better function to parse the AST and not eval the unparse
-        #      like some kind of hobgoblin
-        arg_type = _parse_type_hint(eval(ast.unparse(arg.annotation))) if arg.annotation else None
-        if arg_type:
-            args_dict[arg.arg] = args_dict.get(arg.arg, {})
-            args_dict[arg.arg]["type"] = arg_type["type"]
-    if func.returns:
-        return_type = _parse_type_hint(eval(ast.unparse(func.returns)))
-    else:
-        return_type = None
-
-    parameters_dict = {"type": "object", "properties": args_dict}
-    if required_args:
-        parameters_dict["required"] = required_args
-
-    out = {"name": func.name, "description": description, "parameters": parameters_dict}
-    if include_return and (return_type or return_description):
-        returns = {}
-        if return_type:
-            returns["type"] = return_type["type"]
-        if return_description:
-            returns["description"] = return_description
-        out["return"] = returns
-    return out

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -1,0 +1,92 @@
+import re
+
+# TODO Need to clarify what's getting passed around - is "text" a string or a dict of capture groups?
+#      At the root it's a string, but maybe we can make that a dict with a single entry?
+#      A regex can either have one capture group, multiple numbered groups, or multiple named groups
+# TODO Cases to handle:
+#      1) Model has multiple chat templates
+#      2) Alternate RE flags
+#      3) Supporting possessive operators
+
+def recursive_parse(node_content: str | list | dict, node_schema: dict):
+    """
+    This function takes content and a JSON schema node which includes
+    regex extractors, and recursively parses the content according to the schema. It uses recursion to handle
+    nested schemas.
+
+    Args:
+        node_content: The content corresponding to this node. Usually a string, but can be something else
+                      if the parent node has multiple capture groups or named groups. In that case,
+                      we generally pass the capture groups straight through to the children of this node
+                      and don't do any parsing at this level.
+        node_schema: The schema node controlling the parsing.
+
+    Returns:
+        The parsed data structure for the current node.
+    """
+    # First, do some basic validation
+    has_regex = hasattr(node_schema, "x-regex") or hasattr(node_schema, "x-regex-iterator")
+    if has_regex and isinstance(node_content, str):
+        raise TypeError("Schema node got a string input, but has no regex for parsing.")
+    elif not has_regex and not isinstance(node_content, str):
+        raise TypeError("Schema node got a non-string input, but has a regex for parsing.")
+
+    # Next, if we have a regex, apply it to parse node_content
+    if node_regex := getattr(node_schema, "x-regex", None) is not None:
+        node_match = re.search(node_regex, node_content)
+        if not node_match:
+            return None  # TODO Is this correct? Should I raise an error?
+        # If the regex has named groups, return a dict of those groups
+        if node_match.groupdict():
+            node_content = node_match.groupdict()
+        # If the regex has numbered groups, return a list of those groups
+        # TODO Is there ambiguity between a string match and a list match with a single element?
+        elif node_match.groups():
+            node_content = list(node_match.groups())
+        # If no groups, use the whole match
+        else:
+            node_content = node_match.group(0)
+
+    elif node_regex := getattr(node_schema, "x-regex-iterator", None) is not None:
+        # TODO Parse groups in here too
+        node_content = list(re.finditer(node_regex, node_content))
+
+    # Finally, handle parsed content based on schema type and recurse if required
+    if node_type := node_schema["type"] == "object":
+        if not isinstance(node_content, dict):
+            raise TypeError(f"Expected a dict for schema node {node_schema['title']}, got {type(node_content)}")
+        parsed_schema = {}
+        for key, child_node in node_schema["properties"].items():
+            # TODO Error if required keys are not present
+            if key in node_content:
+                parsed_schema[key] = recursive_parse(node_content[key], child_node)
+            elif "default" in child_node:
+                # TODO Do I want to allow defaults?
+                parsed_schema[key] = child_node["default"]
+        return parsed_schema
+    elif node_type == "array":
+        if not isinstance(node_content, list):
+            raise TypeError(f"Expected a list for schema node {node_schema['title']}, got {type(node_content)}")
+        parsed_schema = []
+        # TODO Handle tuples/prefixItems?
+        for item in node_content:
+            parsed_schema.append(recursive_parse(item, node_schema["items"]))
+        return parsed_schema
+    elif node_type in ("string", "integer", "number", "boolean"):
+        if not isinstance(node_content, str):
+            raise TypeError(f"Expected a string for schema node {node_schema['title']}, got {type(node_content)}")
+        if node_type == "integer":
+            return int(node_content)
+        elif node_type == "number":
+            return float(node_content)
+        elif node_type == "boolean":
+            if node_content.lower() in ("true", "1"):
+                return True
+            elif node_content.lower() in ("false", "0"):
+                return False
+            else:
+                raise ValueError(f"Invalid boolean value: {node_content}")
+        return node_content
+    else:
+        # TODO Should we handle null types?
+        raise TypeError(f"Unsupported schema type {node_type} for node {node_schema['title']}")

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -1,10 +1,11 @@
 import re
 import json
+from .chat_template_utils import _parse_type_hint
 
-# TODO Cases to handle:
-#      1) Model has multiple chat templates
+# Next line only used because eval might grab them. Can be removed once we have something better than eval
+from typing import Any, Dict, List, Optional, Tuple, Union  # noqa: F401
 
-def recursive_parse(node_content: str | list | dict, node_schema: dict):
+def recursive_parse(node_content: str | list | dict, node_schema: dict, scope_vars: dict = None):
     """
     This function takes content and a JSON schema node which includes
     regex extractors, and recursively parses the content according to the schema. It uses recursion to handle
@@ -16,6 +17,7 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
                       we generally pass the capture groups straight through to the children of this node
                       and don't do any parsing at this level.
         node_schema: The schema node controlling the parsing.
+        scope_vars: A dictionary of variables in scope at the current node
 
     Returns:
         The parsed data structure for the current node.
@@ -34,17 +36,44 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
         # If no groups, use the whole match
         else:
             return node_match.group(0)
-    # If the schema has a const, we just return that value
+    # If the schema has a const, we just return that value and do absolutely nothing else
     if "const" in node_schema:
         return node_schema["const"]
+
+    # If the node content is None, we return None. EZ.
+    if node_content is None:
+        return None
+
+    # If we need to parse scope vars, now is the time to do it because they need to go to all child nodes
+    if "x-scope-vars" in node_schema:
+        if scope_vars is None:
+            scope_vars = {}
+        # Make sure we create a new dict so we don't accidentally send modifications up the tree
+        scope_vars = scope_vars | {key: recursive_parse(node_content, value, scope_vars)
+                          for key, value in node_schema["x-scope-vars"].items()}
+
+    # Next, if the node has a parser we can just use that and ignore everything else.
+    if "x-parser" in node_schema:
+        parser = node_schema["x-parser"]
+        if parser == "json":
+            try:
+                return json.loads(node_content)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Node has JSON parser but could not parse its contents as JSON: {node_content}\n"
+                                 f"Error: {e}")
+        elif parser == "python_type":
+            # TODO eval is obviously enormously insecure and only used for prototyping here
+            #      make a safer parser before merging
+            return _parse_type_hint(eval(node_content))
+        else:
+            raise ValueError(f"Unknown parser {parser} for schema node: {node_schema}")
+
+
+
     # If not, we have to do a little parsing. First, set some vars and do basic validation
     node_type = node_schema["type"]
-    parser = node_schema.get("x-parser", None)
-    has_regex = "x-regex" in node_schema or "x-regex-iterator" in node_schema
-    if has_regex and parser is not None:
-        raise ValueError("Schema node has both a regex and a parser.\n"
-                         f"Schema: {node_schema}")
-    if parser is None and not has_regex and isinstance(node_content, str) and node_type == "array":
+    has_regex = "x-regex" in node_schema or "x-regex-iterator" in node_schema or "x-regex-to-dict" in node_schema
+    if not has_regex and isinstance(node_content, str) and node_type == "array":
         raise TypeError(f"array node got a string input, but has no parser or regex.\n"
                         f"Input: {node_content}\n",
                         f"Schema: {node_schema}")
@@ -54,25 +83,41 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
                         f"Schema: {node_schema}")
 
 
-    if node_content and parser == "json":
-        try:
-            node_content = json.loads(node_content)
-        except json.JSONDecodeError as e:
-            raise ValueError(f"Node has JSON parser but could not parse its contents as JSON: {node_content}\n"
-                             f"Error: {e}")
-
-    node_regex = node_schema.get("x-regex", None)
-    node_regex_iterator = node_schema.get("x-regex-iterator", None)
+    node_regex = node_schema.get("x-regex")
+    node_regex_iterator = node_schema.get("x-regex-iterator")
+    node_regex_to_dict = node_schema.get("x-regex-to-dict")
     if node_regex is not None:
         node_match = re.search(node_regex, node_content, flags=re.DOTALL)
         if not node_match:
             return None  # TODO Is this correct? Should I raise an error?
         node_content = _parse_re_match(node_match)
     if node_regex_iterator is not None:
+        if node_type != "array":
+            raise TypeError(f"Schema node with type {node_type} cannot use x-regex-iterator.\n"
+                            f"Schema: {node_schema}")
         # Note that this can be applied after a standard node-regex search
         node_content = [_parse_re_match(node_match) for node_match in re.finditer(node_regex_iterator, node_content, flags=re.DOTALL)]
         if not node_content:
             return None  # TODO Is this correct? Should I raise an error?
+    if node_regex_to_dict is not None:
+        if node_type != "object":
+            raise TypeError(f"Schema node with type {node_type} cannot use x-regex-to-dict.\n"
+                            f"Schema: {node_schema}")
+        # Note that this can be applied after a standard node-regex search
+        output_content = {}
+        for node_match in re.finditer(node_regex_to_dict, node_content, flags=re.DOTALL):
+            if not (match_keys := node_match.groupdict()):
+                raise ValueError(f"Regex for x-regex-to-dict must return groups named \"key\" and \"value\".\n"
+                                 f"Regex: {node_regex_to_dict}\n"
+                                 f"Match: {node_match.group(0)}\n")
+            if not set(match_keys.keys()) == {"key", "value"}:
+                raise ValueError(f"Regex for x-regex-to-dict must return groups named \"key\" and \"value\".\n"
+                                 f"Regex: {node_regex_to_dict}\n"
+                                 f"Match: {node_match.group(0)}\n")
+            output_content[match_keys["key"]] = match_keys["value"]
+        node_content = output_content
+        if not node_content:
+            return None
 
     # Finally, handle parsed content based on schema type and recurse if required
     if node_type == "object":
@@ -83,12 +128,12 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
             # This means we don't have a regex at this level, so all of our child nodes need to parse the whole
             # string themselves to extract their value.
             for key, child_node in node_schema["properties"].items():
-                parsed_schema[key] = recursive_parse(node_content, node_schema["properties"][key])
+                parsed_schema[key] = recursive_parse(node_content, node_schema["properties"][key], scope_vars)
             return parsed_schema
         for key, child_node in node_schema.get("properties", {}).items():
             # TODO Error if required keys are not present
             if key in node_content:
-                parsed_schema[key] = recursive_parse(node_content[key], child_node)
+                parsed_schema[key] = recursive_parse(node_content[key], child_node, scope_vars)
             elif "default" in child_node:
                 # TODO Do I want to allow defaults?
                 parsed_schema[key] = child_node["default"]
@@ -98,7 +143,7 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
             # TODO Allow untyped additional properties with a parser where we just dump the entire parser output?
             for key, value in node_content.items():
                 if key not in node_schema.get("properties", {}):
-                    parsed_schema[key] = recursive_parse(value, node_schema["additionalProperties"])
+                    parsed_schema[key] = recursive_parse(value, node_schema["additionalProperties"], scope_vars)
         return parsed_schema
     elif node_type == "array":
         if not node_content:
@@ -108,7 +153,7 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
         parsed_schema = []
         # TODO Handle tuples/prefixItems?
         for item in node_content:
-            parsed_schema.append(recursive_parse(item, node_schema["items"]))
+            parsed_schema.append(recursive_parse(item, node_schema["items"], scope_vars))
         return parsed_schema
     elif node_type in ("string", "integer", "number", "boolean"):
         if not isinstance(node_content, str):
@@ -128,3 +173,121 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict):
     else:
         # TODO Should we handle null types?
         raise TypeError(f"Unsupported schema type {node_type} for node: {node_type}")
+
+
+def _split_at_top_level(s: str, delimiter: str) -> list[str]:
+    """
+    Splits a string by a delimiter, but only at the top level (not inside brackets).
+
+    For example:
+    _split_at_top_level("int | list[str, int]", "|") -> ["int", "list[str, int]"]
+    _split_at_top_level("str, list[str, int]", ",") -> ["str", "list[str, int]"]
+
+    Args:
+        s: The string to split.
+        delimiter: The character to split on.
+
+    Returns:
+        A list of substrings.
+    """
+    parts = []
+    bracket_level = 0
+    current_part_start_index = 0
+    for i, char in enumerate(s):
+        if char == '[':
+            bracket_level += 1
+        elif char == ']':
+            bracket_level -= 1
+            if bracket_level < 0:
+                # This indicates a malformed string like "str]]"
+                # We'll let it be handled as a simple name later.
+                pass
+        elif char == delimiter and bracket_level == 0:
+            parts.append(s[current_part_start_index:i].strip())
+            current_part_start_index = i + 1
+
+    # Add the final part of the string
+    parts.append(s[current_part_start_index:].strip())
+    return parts
+
+
+def parse_type_string(type_str: str) -> dict:
+    """
+    Recursively parses a Python type hint string into a structured dictionary.
+
+    This parser specifically handles:
+    - Simple types (e.g., 'int', 'str')
+    - The union operator '|' (e.g., 'int | str')
+    - Generic types like 'Optional[T]', 'Union[S, T]', and 'list[U]'
+
+    It does NOT use `eval()` or `ast.parse()`.
+
+    Args:
+        type_str: The string representation of the type hint.
+
+    Returns:
+        A dictionary representing the parsed type structure.
+    """
+    # Clean up any leading/trailing whitespace
+    type_str = type_str.strip()
+
+    # 1. Handle unions with the '|' operator first, as it has lower precedence
+    #    than the generic type syntax (e.g., list[...]).
+    top_level_or_parts = _split_at_top_level(type_str, '|')
+    if len(top_level_or_parts) > 1:
+        return {
+            "type": "union",
+            "args": [parse_type_string(part) for part in top_level_or_parts]
+        }
+
+    # 2. Handle generic types (e.g., Optional[...], Union[...], list[...])
+    if type_str.endswith(']'):
+        try:
+            first_bracket_index = type_str.index('[')
+            base_type = type_str[:first_bracket_index].strip()
+
+            # Extract the content within the brackets
+            args_str = type_str[first_bracket_index + 1:-1].strip()
+
+            if not args_str:
+                # Handle cases like list[] with no arguments
+                return {"type": "generic", "base": base_type, "args": []}
+
+            # Split the arguments inside the brackets, respecting nested structures
+            arg_parts = _split_at_top_level(args_str, ',')
+
+            # Special handling for Union[...] syntax
+            if base_type == "Union":
+                return {
+                    "type": "union",
+                    "args": [parse_type_string(part) for part in arg_parts]
+                }
+
+            # Special handling for Optional[...] syntax
+            if base_type == "Optional":
+                if len(arg_parts) != 1:
+                    raise ValueError("Parser error: Optional[] must have exactly one argument.")
+                # We can represent it as a specific "optional" type or as a union with None.
+                # Here, we'll keep it distinct.
+                return {
+                    "type": "generic",
+                    "base": "Optional",
+                    "args": [parse_type_string(arg_parts[0])]
+                }
+
+            # Handle all other generic types like list, dict, etc.
+            return {
+                "type": "generic",
+                "base": base_type,
+                "args": [parse_type_string(part) for part in arg_parts]
+            }
+        except ValueError:
+            # This can happen if '[' is not found or if the string is malformed.
+            # In such cases, we fall through to treat it as a simple name.
+            pass
+
+    # 3. Base case: The string is a simple type name (e.g., 'int', 'str', 'MyClass')
+    return {
+        "type": "name",
+        "value": type_str
+    }

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -27,9 +27,10 @@ def _parse_re_match(node_match, offset, require_groups: list[str] | None = None)
             return {
                 group: offset_content(content, node_match.start(group) + offset)
                 for group, content in node_match.groupdict().items()
+                if content is not None
             }
         else:
-            return node_match.groupdict()
+            return {key: val for key, val in node_match.groupdict().items() if val is not None}
     # If the regex has unnamed groups, it MUST only have one, and we return that group
     elif groups := list(node_match.groups()):
         if len(groups) > 1:
@@ -295,6 +296,8 @@ def recursive_parse(
                 return location_content(node_content, offset, offset + len(node_content))
             else:
                 return node_content
+    elif node_type == "any":
+        return node_content
     else:
         # TODO Should we handle null types?
         raise TypeError(f"Unsupported schema type {node_type} for node: {node_content}")

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -147,6 +147,10 @@ def recursive_parse(node_content: str | list | dict, node_schema: dict, scope_va
         if isinstance(node_content, str):
             # This means we don't have a regex at this level, so all of our child nodes need to parse the whole
             # string themselves to extract their value.
+            if "properties" not in node_schema:
+                raise ValueError(f"Object node received string content but has no regex or parser to handle it.\n"
+                                 f"Content: {node_content}\n"
+                                 f"Schema: {node_schema}")
             for key, child_node in node_schema["properties"].items():
                 parsed_schema[key] = recursive_parse(node_content, node_schema["properties"][key], scope_vars)
             return parsed_schema

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -101,7 +101,7 @@ def _get_json_schema_type(param_type: type) -> dict[str, str]:
     return type_mapping.get(param_type, {"type": "object"})
 
 
-def _parse_type_hint(hint: str) -> dict:
+def _parse_type_hint(hint) -> dict:
     origin = get_origin(hint)
     args = get_args(hint)
 

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -62,10 +62,13 @@ args_re = re.compile(r"\n\s*Args:\n\s*(.*?)[\n\s]*(Returns:|Raises:|\Z)", re.DOT
 # Splits the Args: block into individual arguments
 args_split_re = re.compile(
     r"""
-(?:^|\n)  # Match the start of the args block, or a newline
-\s*(\w+):\s*  # Capture the argument name and strip spacing
-(.*?)\s*  # Capture the argument description, which can span multiple lines, and strip trailing spacing
-(?=\n\s*\w+:|\Z)  # Stop when you hit the next argument or the end of the block
+(?:^|\n)                 # Start of the args block or a newline
+\s*(\w+)                 # Capture the argument name
+(?:\s*\([^)]*\))?        # Optional (type) with optional surrounding spaces
+\s*:\s*                  # Colon (allowing spaces around it)
+(.*?)\s*                 # Capture the description (multi-line), trim trailing spaces
+(?=\n\s*\w+(?:\s*\([^)]*\))?\s*:|\Z)  # Next arg (optionally with type) or end
+
 """,
     re.DOTALL | re.VERBOSE,
 )

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -1,0 +1,146 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from transformers.utils.chat_parsing_utils import recursive_parse
+from transformers.utils.chat_template_utils import get_json_schema
+from transformers import AutoTokenizer
+
+import unittest
+
+basic_template = """
+{%- for message in messages %}
+    {{- "<|im_start|>" + message["role"] + "\n" }}
+    {{- message["content"] }}
+    {{- "<|im_end|>\n" }}
+{%- endfor %}
+""".strip()
+
+tool_template = """
+{{- tools|tojson(indent=2) }}
+{{- "\n" }}
+{%- for message in messages %}
+    {{- "<|im_start|>" + message["role"] + "\n" }}
+    {{- message["content"] }}
+    {{- "<|im_end|>\n" }}
+{%- endfor %}
+""".strip()
+
+basic_schema = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "role": {"type": "string", "x-regex": r"<\|im_start\|>(.*?)\n"},
+            "content": {"type": "string", "x-regex": r"<\|im_start\|>.*?\n(.*?)<\|im_end\|>\n"}
+        },
+        "required": ["role", "content"]
+    },
+    "x-regex-iterator": r"\<\|im_start\|\>.*?\<\|im_end\|\>\n",
+}
+
+basic_schema_with_named_groups = {
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "role": {"type": "string"},
+            "content": {"type": "string"}
+        },
+        "required": ["role", "content"]
+    },
+    "x-regex-iterator": r"<\|im_start\|>(?P<role>.*?)\n(?P<content>.*?)<\|im_end\|>\n",
+}
+
+tools_schema_with_named_groups = {
+    # TODO Add regexes
+    "type": "object",
+    "properties": {
+        "tools": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "description": {"type": "string"},
+                    "arguments": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "type": {"type": "string"},
+                                "description": {"type": "string"}
+                            },
+                            "required": ["name", "type"]
+                        }
+                    }
+                },
+            }
+        },
+        "messages": basic_schema_with_named_groups
+    },
+}
+
+class ChatSchemaParserTest(unittest.TestCase):
+    def setUp(self):
+        # This tokenizer has no chat template by default
+        self.tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+
+    def test_basic_chat(self):
+        chat = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi there! How can I help you today?"},
+        ]
+        self.tokenizer.chat_template = basic_template
+        formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False)
+        parsed_chat = recursive_parse(formatted_chat, basic_schema)
+        self.assertEqual(parsed_chat, chat)
+
+    def test_named_groups(self):
+        chat = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi there! How can I help you today?"},
+        ]
+        self.tokenizer.chat_template = basic_template
+        formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False)
+        parsed_chat = recursive_parse(formatted_chat, basic_schema_with_named_groups)
+        self.assertEqual(parsed_chat, chat)
+
+    def test_tool_def_parsing(self):
+        def tool(temperature_format: str):
+            """
+            Test function
+
+            Args:
+                temperature_format: The temperature format to use (Choices: ["celsius", "fahrenheit"])
+
+
+            Returns:
+                The temperature
+            """
+            return -40.0
+
+        chat = [
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi there! How can I help you today?"},
+        ]
+        self.tokenizer.chat_template = tool_template
+        formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False, tools=[tool])
+        parsed_chat = recursive_parse(formatted_chat, tools_schema_with_named_groups)
+        self.assertEqual(parsed_chat['messages'], chat)
+        self.assertEqual(parsed_chat['tools'], [get_json_schema(tool)])
+
+    # TODO Tests where groups can be missing (e.g. tools group that isn't necessarily present)

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -504,23 +504,3 @@ class ChatSchemaParserTest(unittest.TestCase):
         )
         parsed_chat = recursive_parse(formatted_chat, gpt_oss_schema)
         self.assertEqual(parsed_chat["messages"], chat)
-
-    def test_assistant_masking(self):
-        tokenizer = AutoTokenizer.from_pretrained("openai/gpt-oss-20b")
-        chat = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": "Hello!"},
-            {"role": "assistant", "content": "Hi there! How can I help you today?"},
-            {"role": "user", "content": "I'd like to see if you can mask some indices!"},
-            {"role": "assistant", "content": "Sure! Hopefully this response is masked correctly."},
-        ]
-        formatted_chat = tokenizer.apply_chat_template(
-            chat, tokenize=True, return_assistant_tokens_mask=True, chat_schema=gpt_oss_schema, return_dict=True
-        )
-        assistant_tokens = [
-            token for token, mask in zip(formatted_chat["input_ids"], formatted_chat["assistant_masks"]) if mask
-        ]
-        self.assertEqual(
-            tokenizer.decode(assistant_tokens),
-            "Hi there! How can I help you today?Sure! Hopefully this response is masked correctly.",
-        )

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -15,7 +15,7 @@
 import unittest
 
 from transformers import AutoTokenizer
-from transformers.utils.chat_parsing_utils import recursive_parse
+from transformers.utils.chat_parsing_utils import recursive_parse, location_content
 from transformers.utils.chat_template_utils import get_json_schema
 
 
@@ -236,6 +236,27 @@ gpt_oss_schema = {
     },
 }
 
+def remove_offsets(obj):
+    if isinstance(obj, dict):
+        return {k: remove_offsets(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [remove_offsets(v) for v in obj]
+    elif isinstance(obj, location_content):
+        return obj.content
+    else:
+        return obj
+
+def validate_offsets(obj, formatted_chat):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            validate_offsets(v, formatted_chat)
+    elif isinstance(obj, list):
+        for v in obj:
+            validate_offsets(v, formatted_chat)
+    elif isinstance(obj, location_content):
+        # TODO Might need int/float/bool comparison here, may not get a perfect string match
+        if obj.content != formatted_chat[obj.start : obj.end]:
+            raise ValueError(f"Offsets for content '{obj.content}' are incorrect: {obj.start}, {obj.end}")
 
 class ChatSchemaParserTest(unittest.TestCase):
     def setUp(self):
@@ -252,6 +273,19 @@ class ChatSchemaParserTest(unittest.TestCase):
         formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False)
         parsed_chat = recursive_parse(formatted_chat, basic_schema)
         self.assertEqual(parsed_chat, chat)
+
+    def test_basic_chat_with_offsets(self):
+        chat = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi there! How can I help you today?"},
+        ]
+        self.tokenizer.chat_template = basic_template
+        formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False)
+        parsed_chat_without_offsets = recursive_parse(formatted_chat, basic_schema)
+        parsed_chat_with_offsets = recursive_parse(formatted_chat, basic_schema, offset=0)
+        self.assertEqual(remove_offsets(parsed_chat_with_offsets), parsed_chat_without_offsets)
+        validate_offsets(parsed_chat_with_offsets, formatted_chat)
 
     def test_named_groups(self):
         chat = [
@@ -338,6 +372,9 @@ class ChatSchemaParserTest(unittest.TestCase):
         self.assertEqual(
             parsed_chat["tools"], [get_json_schema(simple_tool), get_json_schema(tool_with_everything_all_at_once)]
         )
+        parsed_chat_with_offsets = recursive_parse(formatted_chat, cohere_schema, offset=0)
+        self.assertEqual(remove_offsets(parsed_chat_with_offsets), parsed_chat)
+        validate_offsets(parsed_chat_with_offsets, formatted_chat)
 
     def test_gpt_oss_template(self):
         def simple_tool(temperature_format: str):

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -123,14 +123,14 @@ cohere_schema = {
                     "type": {"const": "function"},
                     "function": {
                         "type": "object",
-                        "x-scope-vars-dict": {
-                            # TODO This is hard because I don't have a way to extract a dict with keys derived from the regex.
-                            #      But I need that if I want to do lookups later.
-                            #      I think that means x-regex-iterator needs to work on objects if the regex returns "key" and "value" groups.
-                            #      Once we have that, we need a way to select from scope-vars-dict by key in other branches of the schema.
+                        "x-scope-vars": {
                             "argument_types": {
                                 "type": "object",
-
+                                "x-regex": r"def \w+\((.*?)\)(?:\:| ->)",
+                                "x-regex-to-dict": r"(?P<key>\w+)\s*:\s*(?P<value>\w+)",
+                                "additionalProperties": {
+                                    "x-parser": "python_type"
+                                }
                             }
                         },
                         "properties": {
@@ -140,7 +140,18 @@ cohere_schema = {
                                 "type": "object",
                                 "x-regex": r"\n\s*Args:\n\s*(.*?)$",
                                 "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "x-regex": r"\s*(\w+*):"
+                                    },
+                                    "description": {
+                                        "type": "string",
+                                        "x-regex": r"\s*:\s*(.*?)(?:\n\s*\w+:|$)"
+                                    },
 
+                                    # TODO There's some way we basically do some horizontal gene transfer from the scope
+                                    #      vars to the properties here but I don't fully grok it yet. I guess we somehow
+                                    #      swap the node content at a given point for a variable from scope vars?
                                 }
                             },
 

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -417,3 +417,16 @@ class ChatSchemaParserTest(unittest.TestCase):
             "number"  # The GPT template maps these all to 'number' so we can't recover int vs float
         )
         self.assertEqual(parsed_chat["tools"][1], complex_schema)
+
+    def test_assistant_masking(self):
+        tokenizer = AutoTokenizer.from_pretrained("openai/gpt-oss-20b")
+        chat = [
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": "Hello!"},
+            {"role": "assistant", "content": "Hi there! How can I help you today?"},
+            {"role": "user", "content": "I'd like to see if you can mask some indices!"},
+            {"role": "assistant", "content": "Sure! Hopefully this response is masked correctly."},
+        ]
+        formatted_chat = tokenizer.apply_chat_template(chat, tokenize=True, return_assistant_tokens_mask=True, chat_schema=gpt_oss_schema, return_dict=True)
+        assistant_tokens = [token for token, mask in zip(formatted_chat['input_ids'], formatted_chat['assistant_masks']) if mask]
+        self.assertEqual(tokenizer.decode(assistant_tokens), "Hi there! How can I help you today?Sure! Hopefully this response is masked correctly.")

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -172,6 +172,7 @@ cohere_schema = {
 }
 
 gpt_oss_schema = {
+    # TODO Doesn't recover thinking blocks yet
     "type": "object",
     "properties": {
         "tools": {

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -127,7 +127,7 @@ cohere_schema = {
                 },
                 "required": ["role", "content"]
             },
-            "x-regex-iterator": "<\|START_OF_TURN_TOKEN\|>(?P<role><\(?SYSTEM|USER|CHATBOT)_TOKEN\|>)(?P<content>.*?)(?<\|END_OF_TURN_TOKEN\|>|\n\n## Available Tools)",
+            "x-regex-iterator": "<\|START_OF_TURN_TOKEN\|>(?P<role><\(?SYSTEM|USER|CHATBOT)_TOKEN\|>(?P<content>.*?)(?:<\|END_OF_TURN_TOKEN\|>|\n\n## Available Tools)",
         }
     }
 }
@@ -234,7 +234,6 @@ class ChatSchemaParserTest(unittest.TestCase):
             {"role": "assistant", "content": "Hi there! How can I help you today?"},
         ]
         formatted_chat = tokenizer.apply_chat_template(chat, tokenize=False, tools=[simple_tool, tool_with_everything_all_at_once], chat_template="tool_use")
-        breakpoint()
-        parsed_chat = recursive_parse(formatted_chat, tools_schema_with_named_groups)
+        parsed_chat = recursive_parse(formatted_chat, cohere_schema)
         self.assertEqual(parsed_chat['messages'], chat)
         self.assertEqual(parsed_chat['tools'], [get_json_schema(simple_tool), tool_with_everything_all_at_once])

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -84,6 +84,7 @@ tools_schema_with_named_groups = {
                             "parameters": {
                                 "type": "object",
                                 "properties": {
+                                    # TODO I think this schema is wrong, gotta double check first
                                     "type": {"type": "string", "enum": ["object"]},
                                     "required": {"type": "array", "items": {"type": "string"}},
                                     "properties": {
@@ -148,13 +149,28 @@ cohere_schema = {
                                         "type": "string",
                                         "x-regex": r"\s*:\s*(.*?)(?:\n\s*\w+:|$)"
                                     },
-
-                                    # TODO There's some way we basically do some horizontal gene transfer from the scope
-                                    #      vars to the properties here but I don't fully grok it yet. I guess we somehow
-                                    #      swap the node content at a given point for a variable from scope vars?
+                                    "parameters": {
+                                        # TODO We need to build the "parameters" key here using both their docstring
+                                        #  descriptions and the "argument_types" scope
+                                        #  var, but I don't know what the syntax for that should look like.
+                                        "type": "object",
+                                        "properties": {
+                                            "type": {"const": "object"},
+                                            "required": {"type": "array", "items": {"type": "string"}},
+                                            "properties": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "object",
+                                                    "properties": {
+                                                        "type": {"type": "string"},
+                                                        "description": {"type": "string"},
+                                                    }
+                                                }
+                                            },
+                                        }
+                                    }
                                 }
                             },
-
                         }
                     }
                 }
@@ -223,6 +239,7 @@ class ChatSchemaParserTest(unittest.TestCase):
         self.tokenizer.chat_template = tool_template
         formatted_chat = self.tokenizer.apply_chat_template(chat, tokenize=False, tools=[tool])
         parsed_chat = recursive_parse(formatted_chat, tools_schema_with_named_groups)
+        breakpoint()  # Check we're parsing correctly and the schema is good before we send to GPT-5
         self.assertEqual(parsed_chat['messages'], chat)
         self.assertEqual(parsed_chat['tools'], [get_json_schema(tool)])
 


### PR DESCRIPTION
This is an experimental PR to get feedback on a new potential feature called **Chat Schemas**.

### What problem does this fix?

Since the arrival of chat templates, I've gotten a lot of requests for the same two features:

1) People want a way to detect which inputs a template supports. For example, does it support system messages or tools? Do the tools need special formatting, or is the default okay?
2) People want a way to parse model outputs, especially when the model calls a tool or has thinking blocks. Ideally, people want a way to turn an entire formatted conversation back into a list of messages, tool defs, tool calls, etc.

Right now, people handle these in hacky ways. For example, some code searches the template for references to "tools" to decide if it supports tools or not. Other frameworks use hardcoded functions to infer some common tool call formats and parse them.

### What's the solution?

Models can have a **chat schema** alongside the **chat template**. This is a pure JSON file, containing a JSON schema representing the model's input format. For example, a simple chat schema for a model that only supports messages, not tools, might look like this:

```json
{
    "type": "array",
    "items": {
        "type": "object",
        "properties": {
            "role": {"type": "string"},
            "content": {"type": "string"}
        },
        "required": ["role", "content"]
    },
}
```

There's a twist, though: We allow an [extra field](https://json-schema.org/blog/posts/custom-annotations-will-continue) in the schema: `x-regex`. This specifies the regex used to **extract this schema node**, optionally with named groups that indicate how to extract child nodes as well. For example, for a simple model with ChatML formatting, the regex could be:

```
r"<\|im_start\|>(?P<role>.*?)\n(?P<content>.*?)<\|im_end\|>\n"
```

Using this schema and the regex(es), we can walk the schema and formatted output recursively and reconstruct the original model inputs.

### What do we get?

This resolves both of the long-standing demands: We now have a way to parse formatted chats back to lists of messages. We can also parse tool calls! This means that if models have chat schemas, they can be used in a **universal API that doesn't require any model-specific tool parsing**. This has been a major weakness in chat templates since I made them!

### What are the downsides?

The main downside is that, like with chat templates, someone has to actually add these schemas to models! The base schema is easy enough to write, but the regexes may be harder for complex tool calling models. However, in testing, they weren't too bad. I think writing a chat schema is a lot less work than writing a chat template, especially since you can usually copy the entire schema from another model and just tweak the regexes a little.

### Work still to do in this PR

- [ ] Add a lot more test coverage (50% done)
  - [ ] Make sure we can parse tool defs as well as tool calls, and add more formats!
- [x] Add JSON parser
- [x] Add Python type / tool def parser
- [ ] Add code to tokenizers to load / save chat schemas
- [ ] Add code to pipelines for output / tool call parsing?
- [ ] Overhaul chat template docs to include chat schemas too
- [x] Add code for offset extraction
- [x] Use offsets for assistant turn masking
- [ ] Cleanup code TODOs and remove very insecure `eval` calls

Fixes #40776