### PR TITLE
fix dead NVIDIA link 

### DIFF
--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -527,7 +527,7 @@ class MambaPreTrainedModel(PreTrainedModel):
                 #   > the weights of residual layers at initialization by a factor of 1/√N where N is the # of residual layers.
                 #   >   -- GPT-2 :: https://openai.com/blog/better-language-models/
                 #
-                # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
+                # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/legacy/model/gpt_model.py
                 # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                 # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
                 # We need to reinit p since this code could be called multiple times


### PR DESCRIPTION
Hey team! Found and fixed dead link in src/transformers/models/mamba/modeling_mamba.py

https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py - old
https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/legacy/model/gpt_model.py - new