### PR TITLE
Support `typing.Literal` as type of tool parameters or return value

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -20,7 +20,16 @@ from contextlib import contextmanager
 from datetime import datetime
 from functools import lru_cache
 from inspect import isfunction
-from typing import Any, Callable, Optional, Union, get_args, get_origin, get_type_hints
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    Optional,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from packaging import version
 
@@ -75,7 +84,7 @@ class DocstringParsingException(Exception):
     pass
 
 
-def _get_json_schema_type(param_type: str) -> dict[str, str]:
+def _get_json_schema_type(param_type: type) -> dict[str, str]:
     type_mapping = {
         int: {"type": "integer"},
         float: {"type": "number"},
@@ -118,6 +127,9 @@ def _parse_type_hint(hint: str) -> dict:
         if type(None) in args:
             return_dict["nullable"] = True
         return return_dict
+
+    elif origin is Literal and len(args) > 0:
+        return {"enum": list(args)}
 
     elif origin is list:
         if not args:

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -129,6 +129,11 @@ def _parse_type_hint(hint: str) -> dict:
         return return_dict
 
     elif origin is Literal and len(args) > 0:
+        LITERAL_TYPES = (int, float, str, bool, type(None))
+        if any(type(arg) not in LITERAL_TYPES for arg in args):
+            raise TypeHintParsingException(
+                "Only the valid python literals can be listed in typing.Literal."
+            )
         return {"enum": list(args)}
 
     elif origin is list:

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -130,11 +130,19 @@ def _parse_type_hint(hint: str) -> dict:
 
     elif origin is Literal and len(args) > 0:
         LITERAL_TYPES = (int, float, str, bool, type(None))
-        if any(type(arg) not in LITERAL_TYPES for arg in args):
-            raise TypeHintParsingException(
-                "Only the valid python literals can be listed in typing.Literal."
-            )
-        return {"enum": list(args)}
+        args_types = []
+        for arg in args:
+            if type(arg) not in LITERAL_TYPES:
+                raise TypeHintParsingException(
+                    "Only the valid python literals can be listed in typing.Literal."
+                )
+            arg_type = _get_json_schema_type(type(arg)).get("type")
+            if arg_type is not None and arg_type not in args_types:
+                args_types.append(arg_type)
+        return {
+            "type": args_types.pop() if len(args_types) == 1 else list(args_types),
+            "enum": list(args),
+        }
 
     elif origin is list:
         if not args:

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -133,9 +133,7 @@ def _parse_type_hint(hint: str) -> dict:
         args_types = []
         for arg in args:
             if type(arg) not in LITERAL_TYPES:
-                raise TypeHintParsingException(
-                    "Only the valid python literals can be listed in typing.Literal."
-                )
+                raise TypeHintParsingException("Only the valid python literals can be listed in typing.Literal.")
             arg_type = _get_json_schema_type(type(arg)).get("type")
             if arg_type is not None and arg_type not in args_types:
                 args_types.append(arg_type)

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 from transformers.utils import DocstringParsingException, TypeHintParsingException, get_json_schema
 
@@ -374,6 +374,39 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
                 "properties": {
                     "temperature_format": {
                         "type": "string",
+                        "enum": ["celsius", "fahrenheit"],
+                        "description": "The temperature format to use",
+                    }
+                },
+                "required": ["temperature_format"],
+            },
+        }
+
+        self.assertEqual(schema["function"], expected_schema)
+
+    def test_literal(self):
+        def fn(temperature_format: Literal["celsius", "fahrenheit"]):
+            """
+            Test function
+
+            Args:
+                temperature_format: The temperature format to use
+
+
+            Returns:
+                The temperature
+            """
+            return -40.0
+
+        # Let's see if that gets correctly parsed as an enum
+        schema = get_json_schema(fn)
+        expected_schema = {
+            "name": "fn",
+            "description": "Test function",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "temperature_format": {
                         "enum": ["celsius", "fahrenheit"],
                         "description": "The temperature format to use",
                     }

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -407,6 +407,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
                 "type": "object",
                 "properties": {
                     "temperature_format": {
+                        "type": "string",
                         "enum": ["celsius", "fahrenheit"],
                         "description": "The temperature format to use",
                     }

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -385,12 +385,16 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         self.assertEqual(schema["function"], expected_schema)
 
     def test_literal(self):
-        def fn(temperature_format: Literal["celsius", "fahrenheit"]):
+        def fn(
+            temperature_format: Literal["celsius", "fahrenheit"],
+            booleanish: Literal[True, False, 0, 1, "y", "n"] = False,
+        ):
             """
             Test function
 
             Args:
                 temperature_format: The temperature format to use
+                booleanish: A value that can be regarded as boolean
 
 
             Returns:
@@ -410,7 +414,12 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
                         "type": "string",
                         "enum": ["celsius", "fahrenheit"],
                         "description": "The temperature format to use",
-                    }
+                    },
+                    "booleanish": {
+                        "type": ["boolean", "integer", "string"],
+                        "enum": [True, False, 0, 1, "y", "n"],
+                        "description": "A value that can be regarded as boolean",
+                    },
                 },
                 "required": ["temperature_format"],
             },


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

This PR adds support for using `typing.Literal` as a type hint of tool function written in python.

I realized that using `typing.Literal` for argument's type hint is currently not supported during my tries to use tools as the python function(referring [Document 'Tools and RAG'](https://huggingface.co/docs/transformers/v4.51.3/en/chat_extras)).

The error I got is:
```
in _parse_type_hint
    raise TypeHintParsingException("Couldn't parse this type hint, likely due to a custom class or object: ", hint)
transformers.utils.chat_template_utils.TypeHintParsingException: ("Couldn't parse this type hint, likely due to a custom class or object: ", typing.Literal[...])
```

Fortunately, there is already a feature to deal with the 'complex' type hints like `list[str]`, `Union[List[int], Dict[int, str]]`.
So I just added case for `origin is Literal`, just putting its `args` as value of the key `"enum"` in json schema is fine.

Putting `"type"` in that was not a good idea, because we could accidentally filter a valid case when the types are heterogeneous in `args`. But a rough type validation could be valuable for the case using no static typing tool.

Additionally, as I see, there was a glitch in the related function `_get_json_schema_type(param_type: str)`, which is that the type hint of argument `param_type` need to be `type` instead of `str`. This tiny change is also in this PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @Rocketknight1

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
