### PR TITLE
[timm] new timm pin

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -30,6 +30,8 @@ RUN python3 -m pip install --no-cache-dir -e ./transformers[dev,onnxruntime] && 
 
 RUN python3 -m pip uninstall -y flax jax
 
+RUN python3 -m pip install --no-cache-dir -U timm
+
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 

--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -30,8 +30,6 @@ RUN python3 -m pip install --no-cache-dir -e ./transformers[dev,onnxruntime] && 
 
 RUN python3 -m pip uninstall -y flax jax
 
-RUN python3 -m pip install --no-cache-dir -U timm
-
 RUN python3 -m pip install --no-cache-dir git+https://github.com/facebookresearch/detectron2.git pytesseract
 RUN python3 -m pip install -U "itsdangerous<2.1.0"
 

--- a/setup.py
+++ b/setup.py
@@ -188,7 +188,7 @@ _deps = [
     "tf2onnx",
     "timeout-decorator",
     "tiktoken",
-    "timm<=1.0.11",
+    "timm<=1.0.19,!=1.0.18",
     "tokenizers>=0.21,<0.22",
     "torch>=2.1",
     "torchaudio",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -90,7 +90,7 @@ deps = {
     "tf2onnx": "tf2onnx",
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
-    "timm": "timm<=1.0.11",
+    "timm": "timm<=1.0.19,!=1.0.18",
     "tokenizers": "tokenizers>=0.21,<0.22",
     "torch": "torch>=2.1",
     "torchaudio": "torchaudio",


### PR DESCRIPTION
# What does this PR do?

Updates the pin in timm to allow the latest version (1.0.19), but excludes a version that's incompatible with older python versions (1.0.18).

NOTE: `timm==1.0.18` is causing red CI e.g. [here](https://app.circleci.com/pipelines/github/huggingface/transformers/139243/workflows/33c8dbbb-e29b-429c-8cfb-61e28591f902/jobs/1845235/steps) 