### PR TITLE
Default processor message

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1687,6 +1687,7 @@ class ProcessorMixin(PushToHubMixin):
         """
         Returns a single formatted prompt string using the processor's default chat template,
         containing one image (hf logo) and one user text message (Please describe this image.).
+        If available, adds the generation prompt as well.
         Falls back to a minimal `<image>` string if no template is available.
         Args:
             full_output (`bool`, *optional*, defaults to `False`):

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1742,7 +1742,7 @@ class ProcessorMixin(PushToHubMixin):
             else:
                 return image_token_run_pattern.sub(replacement_function, decoded_message)
 
-        except ValueError:  # what is raised if there's no chat template
+        except ValueError:
             image_token_string = getattr(
                 self, "image_token", getattr(getattr(self, "tokenizer", None), "image_token", "<image>")
             )


### PR DESCRIPTION
# What does this PR do?

Small PR adding a `.default_message` method to all multimodal processors. Handles just image and text input for now, expandable to videos if there's interest. 

Example usage:

<img width="1099" height="481" alt="image" src="https://github.com/user-attachments/assets/96b6197f-795f-4326-b6f3-49e767620215" />
