### PR TITLE
[modular] small fixes

### DIFF
--- a/docs/source/en/modular_transformers.md
+++ b/docs/source/en/modular_transformers.md
@@ -24,7 +24,7 @@ A linter "unravels" the modular file into a `modeling.py` file to preserve the s
 Run the command below to automatically generate a `modeling.py` file from a modular file.
 
 ```bash
-python utils/modular_model_converter.py --files-to-parse src/transformers/models/<your_model>/modular_<your_model>.py
+python utils/modular_model_converter.py -f <model_name>
 ```
 
 For example:

--- a/utils/create_dependency_mapping.py
+++ b/utils/create_dependency_mapping.py
@@ -51,6 +51,10 @@ def extract_classes_and_imports(file_path):
             module = node.module if isinstance(node, ast.ImportFrom) else None
             if module and (".modeling_" in module or "transformers.models" in module):
                 imports.add(module)
+                
+    if len(imports) == 0:
+        raise Exception(f"No imports from the modeling files found in {file_path}. Please check your imports in the modular file.")
+
     return imports
 
 


### PR DESCRIPTION
Some small fixes:

1. If there are no imports from the modeling files, an exception is raised https://github.com/huggingface/transformers/blob/ff76b6a07fb0d16ee9b31b5f1cd7ddb5f02b6774/utils/create_dependency_mapping.py#L47-L58 Otherwise, the users currently see the assert message only, which is not helpful https://github.com/huggingface/transformers/blob/f90de364c2484c7c325bbe05befdcf487bd75b63/utils/modular_model_converter.py#L1774

2. The cli command for converting the modular files should have the name of the file not the path as per the code in modular_model_converter.py . 

Pinging @Cyrilvallez, for being the last editor of these parts of code. 