### PR TITLE
Reduce atol values in test_dynamic_cache_exportability

### DIFF
--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -643,10 +643,10 @@ class CacheExportIntegrationTest(unittest.TestCase):
             past_key_values=past_key_values_eager,
             use_cache=True,
         )
-        self.assertTrue(torch.allclose(res.logits, res_eager.logits, atol=1e-5))
+        self.assertTrue(torch.allclose(res.logits, res_eager.logits, atol=1e-7))
         for l1, l2 in zip(res.past_key_values.layers, res_eager.past_key_values.layers):
-            self.assertTrue(torch.allclose(l1.keys, l2.keys, atol=1e-5))
-            self.assertTrue(torch.allclose(l1.values, l2.values, atol=1e-5))
+            self.assertTrue(torch.allclose(l1.keys, l2.keys))
+            self.assertTrue(torch.allclose(l1.values, l2.values))
 
     def test_dynamic_cache_exportability_multiple_run(self):
         # When exporting with DynamicCache, you should export two graphs:
@@ -739,8 +739,8 @@ class CacheExportIntegrationTest(unittest.TestCase):
         )
 
         for l1, l2 in zip(res_export_2.past_key_values.layers, res_eager_2.past_key_values.layers):
-            self.assertTrue(torch.allclose(l1.keys, l2.keys, atol=1e-5))
-            self.assertTrue(torch.allclose(l1.values, l2.values, atol=1e-5))
+            self.assertTrue(torch.allclose(l1.keys, l2.keys))
+            self.assertTrue(torch.allclose(l1.values, l2.values))
 
     @unittest.skip("Runs on my machine locally, passed, no idea why it does not online")
     def test_static_cache_exportability(self):

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -645,8 +645,8 @@ class CacheExportIntegrationTest(unittest.TestCase):
         )
         self.assertTrue(torch.allclose(res.logits, res_eager.logits, atol=1e-7))
         for l1, l2 in zip(res.past_key_values.layers, res_eager.past_key_values.layers):
-            self.assertTrue(torch.allclose(l1.keys, l2.keys))
-            self.assertTrue(torch.allclose(l1.values, l2.values))
+            self.assertTrue(torch.allclose(l1.keys, l2.keys, atol=1e-7))
+            self.assertTrue(torch.allclose(l1.values, l2.values, atol=1e-7))
 
     def test_dynamic_cache_exportability_multiple_run(self):
         # When exporting with DynamicCache, you should export two graphs:
@@ -739,8 +739,8 @@ class CacheExportIntegrationTest(unittest.TestCase):
         )
 
         for l1, l2 in zip(res_export_2.past_key_values.layers, res_eager_2.past_key_values.layers):
-            self.assertTrue(torch.allclose(l1.keys, l2.keys))
-            self.assertTrue(torch.allclose(l1.values, l2.values))
+            self.assertTrue(torch.allclose(l1.keys, l2.keys, atol=1e-7))
+            self.assertTrue(torch.allclose(l1.values, l2.values, atol=1e-7))
 
     @unittest.skip("Runs on my machine locally, passed, no idea why it does not online")
     def test_static_cache_exportability(self):


### PR DESCRIPTION
# What does this PR do?

The `atol` values were increased in #39412, but this change doesn't actually increase the difference between original and exported model key value layers. The logits `atol` was also set too high at 1e-5 when 1e-7 is sufficient.

After this change, the test still passes.

```sh
$ python3 -m pytest tests/utils/test_cache_utils.py  -k test_dynamic_cache_exportability
======================================================================================= test session starts ========================================================================================
platform linux -- Python 3.12.11, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/shutotakahashi/projects/transformers-uv/transformers
configfile: pyproject.toml
collected 61 items / 59 deselected / 2 selected                                                                                                                                                    

tests/utils/test_cache_utils.py::CacheExportIntegrationTest::test_dynamic_cache_exportability PASSED                                                                                         [ 50%]
tests/utils/test_cache_utils.py::CacheExportIntegrationTest::test_dynamic_cache_exportability_multiple_run PASSED       
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- @vasqu
- generate: @zucchini-nlp