### PR TITLE
Fix AMD dockerfile for audio models

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -3,9 +3,6 @@ LABEL maintainer="Hugging Face"
 
 ARG DEBIAN_FRONTEND=noninteractive
 
-ARG TORCH_VISION='0.22.0'
-ARG TORCH_AUDIO='2.7.0'
-
 RUN apt update && \
     apt install -y --no-install-recommends git libsndfile1-dev tesseract-ocr espeak-ng python3 python3-dev python3-pip python3-dev ffmpeg git-lfs && \
     apt clean && \
@@ -23,9 +20,12 @@ WORKDIR /
 ADD https://api.github.com/repos/huggingface/transformers/git/refs/heads/main version.json
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 
-RUN python3 -m pip install --no-cache-dir torchvision==$TORCH_VISION torchaudio==$TORCH_AUDIO
-RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing,video]
+# On ROCm, torchcodec is required to decode audio files
+RUN python3 -m pip install --no-cache-dir torchcodec
+# Install transformers
+RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing,video,audio]
 
+# Remove tensorflow and flax as they are no longer supported by transformers
 RUN python3 -m pip uninstall -y tensorflow flax
 
 # When installing in editable mode, `transformers` is not recognized as a package.

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ _deps = [
     "optax>=0.0.8,<=0.1.4",
     "pandas<2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
     "packaging>=20.0",
-    "parameterized",
+    "parameterized>=0.9",  # older version of parameterized cause pytest collection to fail on .expand
     "phonemizer",
     "protobuf",
     "psutil",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -50,7 +50,7 @@ deps = {
     "optax": "optax>=0.0.8,<=0.1.4",
     "pandas": "pandas<2.3.0",
     "packaging": "packaging>=20.0",
-    "parameterized": "parameterized",
+    "parameterized": "parameterized>=0.9",
     "phonemizer": "phonemizer",
     "protobuf": "protobuf",
     "psutil": "psutil",


### PR DESCRIPTION
This PR modifies the AMD dockerfile because its base container `rocm/pytorch:rocm6.4.1_ubuntu24.04_py3.12_pytorch_release_2.7.1` has been updated by AMD to include `torchaudio` . Since it also includes `torchvision`, I removed the line installing both those packages again.

I also added  the `audio` dependency to `transformers` and the `torchcodec` package, because it seems necessary on AMD, otherwise test fail when decoding audio. I have tested the Nvidia container on A100 and `torchcodec` does not seem to be needed there, which might be because either AMD has this additional dependency or because its dependecies are older.

Also pinned `parametrized` to 0.9 or above, because otherwise test parametrized this way:
```@parameterized.expand([256, 512, 768, 1024])```
(from `tests/models/gemma3n/test_processing_gemma3n.py` line 106) will fail, for instance with version 8.1 which was in the AMD container.