### PR TITLE
Add missing flag for CacheLayer

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -307,6 +307,8 @@ class SlidingWindowLayer(StaticLayer):
     See `CacheLayerMixin` for details on common methods that are implemented by all cache layers.
     """
 
+    is_sliding = True
+
     def __init__(self, sliding_window, *args, **kwargs):
         """
         Args:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -73,6 +73,8 @@ class DynamicLayer(CacheLayerMixin):
     See `CacheLayerMixin` for details on common methods that are implemented by all cache layers.
     """
 
+    is_sliding = False
+
     def update(
         self,
         key_states: torch.Tensor,


### PR DESCRIPTION
# What does this PR do?

The flag is absolutely critical to work correctly, as the mask creation functions rely on it.
This fixes all the `generate_beyond_sliding_window` tests

cc @manueldeprada @ydshieh for viz