### PR TITLE
Fix tied weight test

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2565,7 +2565,6 @@ class ModelTesterMixin:
 
     def test_tied_weights_keys(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
-        config.get_text_config().tie_word_embeddings = True
         for model_class in self.all_model_classes:
             model_tied = model_class(copy.deepcopy(config))
 


### PR DESCRIPTION
# What does this PR do?

No reason to force to tie the embeddings, as then the test will fail for models that do NOT tie the weights by default
