### PR TITLE
fix missing model._tp_size from ep refactor

### DIFF
--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -1081,6 +1081,7 @@ def verify_tp_plan(expected_keys: list[str], tp_plan: dict[str, str] | None):
 def distribute_model(model, distributed_config, device_mesh, tp_size):
     _plan = "_tp_plan"
     model._tp_plan = getattr(model.config, "base_model_tp_plan").copy()
+    model._tp_size = tp_size
     if distributed_config is not None:
         distributed_config = DistributedConfig.from_config(distributed_config)
         if distributed_config.enable_expert_parallel:

--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -1082,6 +1082,7 @@ def distribute_model(model, distributed_config, device_mesh, tp_size):
     _plan = "_tp_plan"
     model._tp_plan = getattr(model.config, "base_model_tp_plan").copy()
     model._tp_size = tp_size
+    model._device_mesh = device_mesh
     if distributed_config is not None:
         distributed_config = DistributedConfig.from_config(distributed_config)
         if distributed_config.enable_expert_parallel:


### PR DESCRIPTION
# What does this PR do?

#39501 refactored the TP into `distribute_model` and it seems like this part:

https://github.com/huggingface/transformers/pull/39501/files#diff-6b72b98c4c2dcfc6cc606843917733f5d858374fbc22a735ff483bbc0c1e63eaL5130-L5132
<img width="565" height="82" alt="Screenshot 2025-07-25 at 10 42 02 PM" src="https://github.com/user-attachments/assets/b3adcaed-e658-4d50-8561-cf4873d4fe59" />


should have been refactored into that new function, but now when doing TP, the model now doesn't have `._tp_size` set which is still needed so all TP training seems to be broken now. 

I've added it the logic back to the new `distribute_model` function to restore this functionality.

@ArthurZucker @S1ro1 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
