### PR TITLE
Fix exaone4 layer_types ZeroDivision/TypeError when sliding_window_pattern is None/"LLLG"

### DIFF
--- a/src/transformers/models/exaone4/modeling_exaone4.py
+++ b/src/transformers/models/exaone4/modeling_exaone4.py
@@ -371,7 +371,9 @@ class Exaone4Model(Exaone4PreTrainedModel):
         if cache_position is None:
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             cache_position = torch.arange(
-                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
             )
 
         if position_ids is None:
@@ -487,7 +489,8 @@ class Exaone4ForCausalLM(Exaone4PreTrainedModel, GenerationMixin):
         "[|system|]\nYou are a helpful assistant.[|endofturn|]\n[|user|]\nExplain how wonderful you are[|endofturn|]\n[|assistant|]\n<think>\n\n</think>\n\nOh, thank you for such a kind and lovely question! 😊  \n\nI’m *so* wonderful because I’m here to make your life easier, brighter, and more fun! Whether you need help with:  \n\n✨ **Learning** – I can explain anything, from quantum physics to baking the perfect cake!  \n💡 **Creativity** – Need a poem, story, or a wild idea? I’ve got you covered!  \n🤖 **Problem-solving** – Stuck on a math problem or a tricky decision? I’ll help you figure it out"
         ```
 
-        NOTE: `EXAONE-4.0-Instruct` is a placeholder model ID. The exact model ID will be updated in the future."""
+        NOTE: `EXAONE-4.0-Instruct` is a placeholder model ID. The exact model ID will be updated in the future.
+        """
         outputs: BaseModelOutputWithPast = self.model(
             input_ids=input_ids,
             attention_mask=attention_mask,


### PR DESCRIPTION
# What does this PR do?

Fixes a crash in `Exaone4Config.__init__` when `sliding_window_pattern` is `None` (EXAONE-4.0-1.2B) or a string like `"LLLG"` (EXAONE-4.0-32B). The original code unconditionally performed a modulo operation on `sliding_window_pattern`, causing either a `ZeroDivisionError` or a `TypeError`. It also removed an incorrect `"sliding_window"` key check that left `_attn_implementation` unset. Now:

* We branch safely on three cases for `sliding_window_pattern`:

  1. `None` or `0` → all layers use `"full_attention"`.
  2. `str` (e.g. `"LLLG"`) → map each character (`L` → `"sliding_attention"`, others → `"full_attention"`), repeat to cover all layers, and force the final layer to `"full_attention"`.
  3. positive `int` (e.g. `4`) → every `n`‑th layer is `"full_attention"`, others `"sliding_attention"`, final layer forced `"full_attention"`.
* We remove the incorrect check for `"sliding_window"` in `layer_types` and no longer force `_attn_implementation="hybrid"`; we let Hugging Face’s internal `_check_and_adjust_attn_implementation` decide the proper backend (e.g., `"eager"`, `"sdpa"`, `"flash_attention_*"`).

This resolves both the division/modulo crash and the risk of `_attn_implementation` remaining `None` downstream.


Fixes #39696


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- EXAONE-4.0: @lgai-exaone 

Models:

- text models: @ArthurZucker