### PR TITLE
Remove python3.7 reference from doc link

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -294,7 +294,7 @@ class HfArgumentParser(ArgumentParser):
         Parse command-line args into instances of the specified dataclass types.
 
         This relies on argparse's `ArgumentParser.parse_known_args`. See the doc at:
-        docs.python.org/3.7/library/argparse.html#argparse.ArgumentParser.parse_args
+        docs.python.org/3/library/argparse.html#argparse.ArgumentParser.parse_args
 
         Args:
             args:


### PR DESCRIPTION
# What does this PR do?

Updates the documentation link in the docstring to reference the general Python 3 docs instead of Python 3.7 which is now end-of-life. Referencing the main Python 3 docs is more appropriate and future-proof.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Documentation: @stevhliu