### PR TITLE
Fix eval thread fork bomb

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1034,17 +1034,16 @@ class Trainer:
                     seed_worker, num_workers=self.args.dataloader_num_workers, rank=self.args.process_index
                 )
 
-        dataloader = DataLoader(dataset, **dataloader_params)
+        dataloader = self.accelerator.prepare(DataLoader(dataset, **dataloader_params))
 
-        # Accelerator.free_memory() will destroy the references, so
-        # we need to store the non-prepared version for eval dataloaders.
+        # Store the prepared dataloader for subsequent evaluations if using persistent workers.
         if dataloader_key is not None and self.args.dataloader_persistent_workers:
             if hasattr(self, "_eval_dataloaders"):
                 self._eval_dataloaders[dataloader_key] = dataloader
             else:
                 self._eval_dataloaders = {dataloader_key: dataloader}
 
-        return self.accelerator.prepare(dataloader)
+        return dataloader
 
     def get_train_dataloader(self) -> DataLoader:
         """
@@ -1132,7 +1131,7 @@ class Trainer:
             and dataloader_key in self._eval_dataloaders
             and self.args.dataloader_persistent_workers
         ):
-            return self.accelerator.prepare(self._eval_dataloaders[dataloader_key])
+            return self._eval_dataloaders[dataloader_key]
 
         eval_dataset = (
             self.eval_dataset[eval_dataset]


### PR DESCRIPTION
# What does this PR do?

Currently a fork bomb is being created due to the accelerator preparing a new dataloader at each evaluation when dataloader_persistent_workers=True.

It appears there was an attempt to fix this issue #29538 but the problem seems to still exist. I tried using version 4.39.0 which was the first release version that included that fix along with the most recent version of accelerate for that point in time (0.27.2) and was still able to reproduce the fork bomb.

This PR makes a minor change to the original fix by storing the prepared dataloader rather than the dataloader prior to preparing it with the accelerator.

The author of the original fix left a comment in the code specifically about storing the dataloader prior to being prepared due to accelerator.free_memory() destroying the references. I was unable to reproduce that problem when storing the prepared dataloader (even when calling accelerator.free_memory() before each evaluation), but wouldn't mind hearing from @muellerzr  on why they did that in case I have missed something. Though at the same time he left [this comment](https://github.com/huggingface/transformers/issues/28469#issuecomment-2040363029) on the GitHub Issue suggesting he intended to make these same proposed changes.

Fixes #28469 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @amyeroberts 