### PR TITLE
Fix mamba regression

### DIFF
--- a/src/transformers/models/falcon_mamba/configuration_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/configuration_falcon_mamba.py
@@ -160,6 +160,8 @@ class FalconMambaConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.use_falcon_mambapy = use_falcon_mambapy
         self.mixer_rms_eps = mixer_rms_eps
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
 
 __all__ = ["FalconMambaConfig"]

--- a/src/transformers/models/falcon_mamba/configuration_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/configuration_falcon_mamba.py
@@ -142,7 +142,11 @@ class FalconMambaConfig(PretrainedConfig):
         self.conv_kernel = conv_kernel
         self.expand = expand
         # This is needed since mamba overrides the intermediate_size attribute
-        self.intermediate_size = int(expand * self.hidden_size) if expand is None else expand
+        self.intermediate_size = (
+            int(expand * self.hidden_size)
+            if kwargs.get("intermediate_size") is None
+            else kwargs.get("intermediate_size")
+        )
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id

--- a/src/transformers/models/falcon_mamba/configuration_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/configuration_falcon_mamba.py
@@ -141,7 +141,8 @@ class FalconMambaConfig(PretrainedConfig):
         self.layer_norm_epsilon = layer_norm_epsilon
         self.conv_kernel = conv_kernel
         self.expand = expand
-        self.intermediate_size = int(expand * self.hidden_size)
+        # This is needed since mamba overrides the intermediate_size attribute
+        self.intermediate_size = int(expand * self.hidden_size) if expand is None else expand
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
         self.pad_token_id = pad_token_id
@@ -160,8 +161,6 @@ class FalconMambaConfig(PretrainedConfig):
         self.use_cache = use_cache
         self.use_falcon_mambapy = use_falcon_mambapy
         self.mixer_rms_eps = mixer_rms_eps
-        for k, v in kwargs.items():
-            setattr(self, k, v)
 
 
 __all__ = ["FalconMambaConfig"]

--- a/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
@@ -192,8 +192,8 @@ class FalconMambaConfig(MambaConfig):
             **kwargs,
         )
         self.mixer_rms_eps = mixer_rms_eps
-        for k, v in kwargs.items():
-            setattr(self, k, v)
+        # This is needed since mamba overrides the intermediate_size attribute
+        self.intermediate_size = int(expand * self.hidden_size) if expand is None else expand
 
 
 class FalconMambaCache(MambaCache):

--- a/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
@@ -192,6 +192,8 @@ class FalconMambaConfig(MambaConfig):
             **kwargs,
         )
         self.mixer_rms_eps = mixer_rms_eps
+        for k, v in kwargs.items():
+            setattr(self, k, v)
 
 
 class FalconMambaCache(MambaCache):

--- a/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modular_falcon_mamba.py
@@ -193,7 +193,11 @@ class FalconMambaConfig(MambaConfig):
         )
         self.mixer_rms_eps = mixer_rms_eps
         # This is needed since mamba overrides the intermediate_size attribute
-        self.intermediate_size = int(expand * self.hidden_size) if expand is None else expand
+        self.intermediate_size = (
+            int(expand * self.hidden_size)
+            if kwargs.get("intermediate_size") is None
+            else kwargs.get("intermediate_size")
+        )
 
 
 class FalconMambaCache(MambaCache):

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -39,6 +39,10 @@ from .configuration_mamba import MambaConfig
 
 logger = logging.get_logger(__name__)
 
+if is_mambapy_available():
+    from mambapy.pscan import pscan
+else:
+    pscan = None
 
 if is_mamba_ssm_available():
     from mamba_ssm.ops.selective_scan_interface import mamba_inner_fn, selective_scan_fn
@@ -330,10 +334,6 @@ class MambaMixer(nn.Module):
 
     # fmt: off
     def slow_forward(self, input_states, cache_params: Optional[MambaCache]=None, cache_position:Optional[torch.LongTensor]=None, attention_mask: Optional[torch.LongTensor] = None):
-        if is_mambapy_available():
-            from mambapy.pscan import pscan
-        else:
-            pscan = None
         batch_size, seq_len, _ = input_states.shape
         dtype = input_states.dtype
         # 1. Gated MLP's linear projection


### PR DESCRIPTION
This fixes the sneaky regression introduced in #38086 causing loading errors for falcon_mamba:
```
 "line": "tests/models/falcon_mamba/test_modeling_falcon_mamba.py::FalconMambaModelTest::test_model_from_pretrained",
                "trace": "(line 2593)  RuntimeError: Error(s) in loading state_dict for FalconMambaMixer:"
            },
            {
                "line": "tests/models/falcon_mamba/test_modeling_falcon_mamba.py::FalconMambaIntegrationTests::test_batched_generation",
                "trace": "(line 2593)  RuntimeError: Error(s) in loading state_dict for FalconMambaMixer:"
            },
            {
                "line": "tests/models/falcon_mamba/test_modeling_falcon_mamba.py::FalconMambaIntegrationTests::test_generation_4bit",
                "trace": "(line 2593)  RuntimeError: Error(s) in loading state_dict for FalconMambaMixer:"
            },
            {
                "line": "tests/models/falcon_mamba/test_modeling_falcon_mamba.py::FalconMambaIntegrationTests::test_generation_fp16",
                "trace": "(line 2593)  RuntimeError: Error(s) in loading state_dict for FalconMambaMixer:"
            },
            {
                "line": "tests/models/falcon_mamba/test_modeling_falcon_mamba.py::FalconMambaIntegrationTests::test_generation_torch_compile",
                "trace": "(line 2593)  RuntimeError: Error(s) in loading state_dict for FalconMambaMixer:"
```

The gist of the problem is: modular forces the `super().__init__` call to be on top of FalconMambaConfig. However, before modular rewrite, it was at the bottom, which was critical for the `intermediate_size` property from the config file to take effect.

Second bug fixed: `tests/models/mamba/test_modeling_mamba.py::MambaIntegrationTests::test_compile_mamba_cache ` was failing due to a missplaced import.