### PR TITLE
Fix Layer device placement in Caches

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -347,7 +347,7 @@ class SlidingWindowLayer(StaticLayer):
         cache_position = cache_kwargs.get("cache_position") if cache_kwargs else None
         if cache_position is None:
             raise ValueError("`cache_position` must be provided for SlidingWindowLayer.")
-        
+
         # This may be needed if the Layer was not created with the right device at the beginning. However, if it
         # is the case, it should only run once, because then the new states receive will always have the same device
         if self.device != key_states.device:
@@ -424,7 +424,7 @@ class ChunkedSlidingLayer(SlidingWindowLayer):
         cache_position = cache_kwargs.get("cache_position") if cache_kwargs else None
         if cache_position is None:
             raise ValueError("`cache_position` must be provided for ChunkedSlidingLayer.")
-        
+
         # This may be needed if the Layer was not created with the right device at the beginning. However, if it
         # is the case, it should only run once, because then the new states receive will always have the same device
         if self.device != key_states.device:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -263,8 +263,9 @@ class StaticLayer(CacheLayerMixin):
         key_states = key_states.to(self.keys.dtype)
         value_states = value_states.to(self.values.dtype)
 
-        # This may be needed if the Layer was not created with the right device at the beginning. However, if it
-        # is the case, it should only run once, because then the new states receive will always have the same device
+        # This may be needed if the Layer was not created with the right device in the beginning, i.e. if it did not respect
+        # the device_map. However, even if it is the case, this will only run once, because then the new states received
+        # will always have the same device
         if self.device != key_states.device:
             self.device = key_states.device
             self.keys = self.keys.to(self.device)
@@ -348,8 +349,9 @@ class SlidingWindowLayer(StaticLayer):
         if cache_position is None:
             raise ValueError("`cache_position` must be provided for SlidingWindowLayer.")
 
-        # This may be needed if the Layer was not created with the right device at the beginning. However, if it
-        # is the case, it should only run once, because then the new states receive will always have the same device
+        # This may be needed if the Layer was not created with the right device in the beginning, i.e. if it did not respect
+        # the device_map. However, even if it is the case, this will only run once, because then the new states received
+        # will always have the same device
         if self.device != key_states.device:
             self.device = key_states.device
             self.keys = self.keys.to(self.device)
@@ -425,8 +427,9 @@ class ChunkedSlidingLayer(SlidingWindowLayer):
         if cache_position is None:
             raise ValueError("`cache_position` must be provided for ChunkedSlidingLayer.")
 
-        # This may be needed if the Layer was not created with the right device at the beginning. However, if it
-        # is the case, it should only run once, because then the new states receive will always have the same device
+        # This may be needed if the Layer was not created with the right device in the beginning, i.e. if it did not respect
+        # the device_map. However, even if it is the case, this will only run once, because then the new states received
+        # will always have the same device
         if self.device != key_states.device:
             self.device = key_states.device
             self.keys = self.keys.to(self.device)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/39730!
If the Layer were initialized on the correct device in the beginning, this should not be needed. However, as explained in the comment and as was the case before, sometimes `generate` does not initialize them correctly (this should be fixable in the future and would be the preffered way, I will investigate this week)