### PR TITLE
[Tests] [Bugfix] Make weights tied for `dynamic_tied_weights` test

### DIFF
--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1232,6 +1232,7 @@ class ModelUtilsTest(TestCasePlus):
         transform_a._dynamic_tied_weights_keys = ["weight"]
         transform_b = torch.nn.Linear(1, 1, bias=False)
         transform_b._dynamic_tied_weights_keys = ["weight"]
+        transform_a.weight = transform_b.weight
 
         model.linear.register_module("transform_a", transform_a)
         model.linear.register_module("transform_b", transform_b)


### PR DESCRIPTION
## Background ##
* When I added this test, I neglected to actually tie the weights

## Purpose ##
* The purpose of `test_save_offloaded_model_dynamic_tied_weights_keys` is to test the case when tied weights are dynamically added. While the test achieved its original goal of testing https://github.com/huggingface/transformers/pull/39263, it should also test that saving still works if the weights are actually tied
* Mostly a typo fix