### PR TITLE
Fix HfArgumentParser to filter out dict types from Union

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -175,6 +175,9 @@ class HfArgumentParser(ArgumentParser):
                     " the argument parser only supports one type per argument."
                     f" Problem encountered in field '{field.name}'."
                 )
+            # filter `dict` in Union because argparse does not support it
+            if dict in field.type.__args__:
+                field.type = Union[tuple(arg for arg in field.type.__args__ if arg is not dict)]
             if type(None) not in field.type.__args__:
                 # filter `str` in Union
                 field.type = field.type.__args__[0] if field.type.__args__[1] is str else field.type.__args__[1]


### PR DESCRIPTION
# What does this PR do?

This PR updates `HfArgumentParser` to filter out dict types from `Union` annotations. This prevents runtime errors with argparse, which does not support parsing arguments as dicts. Previous work (PR #39467) reordered `Union[str, dict]` to `Union[dict, str]` throughout the codebase, but this approach is fragile and could break if new `Union[str, dict]` annotations are introduced. This change ensures that dict types are always filtered out, making the parser more robust and maintainable.

Fixes https://github.com/huggingface/transformers/issues/39462

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- @SunMarc 
- @qgallouedec

(same as previous PR)