### PR TITLE
[Fix] import two missing typos in `models/__init__.py` for typo checking

### DIFF
--- a/src/transformers/models/__init__.py
+++ b/src/transformers/models/__init__.py
@@ -262,6 +262,7 @@ if TYPE_CHECKING:
     from .pvt_v2 import *
     from .qwen2 import *
     from .qwen2_5_vl import *
+    from .qwen2_5_omni import *
     from .qwen2_audio import *
     from .qwen2_moe import *
     from .qwen2_vl import *

--- a/src/transformers/models/__init__.py
+++ b/src/transformers/models/__init__.py
@@ -261,8 +261,8 @@ if TYPE_CHECKING:
     from .pvt import *
     from .pvt_v2 import *
     from .qwen2 import *
-    from .qwen2_5_vl import *
     from .qwen2_5_omni import *
+    from .qwen2_5_vl import *
     from .qwen2_audio import *
     from .qwen2_moe import *
     from .qwen2_vl import *

--- a/src/transformers/models/__init__.py
+++ b/src/transformers/models/__init__.py
@@ -128,6 +128,7 @@ if TYPE_CHECKING:
     from .gemma import *
     from .gemma2 import *
     from .gemma3 import *
+    from .gemma3n import *
     from .git import *
     from .glm import *
     from .glm4 import *


### PR DESCRIPTION
# What does this PR do?

I find Pylance in VSCode cannot import the `Gemma3NForConditionalGeneration` and `Qwen2_5OmniModel` automatically. The reason is that these symbols are not exported for type checking. When running in lazy import mode, this symbols will not be exported and thus no type hint.

<img width="741" height="85" alt="image" src="https://github.com/user-attachments/assets/e3901a31-d101-40a1-bc81-24cea04b0e49" />


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker

