### PR TITLE
add `libcst` to `extras["testing"]` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -363,6 +363,7 @@ extras["testing"] = (
         "pydantic",
         "sentencepiece",
         "sacrebleu",  # needed in trainer tests, see references to `run_translation.py`
+        "libcst",
     )
     + extras["retrieval"]
     + extras["modelcreation"]


### PR DESCRIPTION
# What does this PR do?

So tests like `tests/commands/test_serving.py` and `tests/utils/test_add_new_model_like.py`   in the job `tests_non_model` could run.

This job uses `"huggingface/transformers-torch-light` which has `testing` in the docker file.

(see https://app.circleci.com/pipelines/github/huggingface/transformers/139901/workflows/3cbe7abf-c504-458c-85b8-d7de51ded579/jobs/1853203/tests)

