### PR TITLE
[Bugfix] Fix `AutoModel.from_pretrained(..., quantization_config=None)` regression

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -541,7 +541,7 @@ class _BaseAutoModelClass:
             if kwargs.get("torch_dtype") == "auto":
                 _ = kwargs.pop("torch_dtype")
             # to not overwrite the quantization_config if config has a quantization_config
-            _ = kwargs.pop("quantization_config")
+            _ = kwargs.pop("quantization_config", None)
 
             config, kwargs = AutoConfig.from_pretrained(
                 pretrained_model_name_or_path,

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -541,8 +541,7 @@ class _BaseAutoModelClass:
             if kwargs.get("torch_dtype") == "auto":
                 _ = kwargs.pop("torch_dtype")
             # to not overwrite the quantization_config if config has a quantization_config
-            if kwargs.get("quantization_config") is not None:
-                _ = kwargs.pop("quantization_config")
+            _ = kwargs.pop("quantization_config")
 
             config, kwargs = AutoConfig.from_pretrained(
                 pretrained_model_name_or_path,


### PR DESCRIPTION
## Purpose ##
* Fix bug where passing `quantization_config=None` to `AutoModelForCausalLM` will lead to an error
```
Traceback (most recent call last):
  File "/home/kyle/llm-compressor/asdf.py", line 2, in <module>
    model = AutoModelForCausalLM.from_pretrained("RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16", quantization_config=None)
  File "/home/kyle/transformers/src/transformers/models/auto/auto_factory.py", line 547, in from_pretrained
    config, kwargs = AutoConfig.from_pretrained(
  File "/home/kyle/transformers/src/transformers/models/auto/configuration_auto.py", line 1277, in from_pretrained
    return config_class.from_dict(config_dict, **unused_kwargs)
  File "/home/kyle/transformers/src/transformers/configuration_utils.py", line 817, in from_dict
    logger.info(f"Model config {config}")
  File "/home/kyle/transformers/src/transformers/configuration_utils.py", line 851, in __repr__
    return f"{self.__class__.__name__} {self.to_json_string()}"
  File "/home/kyle/transformers/src/transformers/configuration_utils.py", line 963, in to_json_string
    config_dict = self.to_diff_dict()
  File "/home/kyle/transformers/src/transformers/configuration_utils.py", line 865, in to_diff_dict
    config_dict = self.to_dict()
  File "/home/kyle/transformers/src/transformers/configuration_utils.py", line 942, in to_dict
    self.quantization_config.to_dict()
AttributeError: 'NoneType' object has no attribute 'to_dict'
```

* This option was supported in previous releases, and is documented in docstring
```
quantization_config (`Union[QuantizationConfigMixin,Dict]`, *optional*):
```

* I'm not exactly sure what change caused the regression, still trying to track that down

## Changes ##
* Ensuring that the quantization config is never overwritten when instantiating from `_BaseAutoModelClass`

## Testing ##
```python3
from transformers import AutoModelForCausalLM
model = AutoModelForCausalLM.from_pretrained("RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w4a16", quantization_config=None)
```