### PR TITLE
enable static cache on vision encoder decoder

### DIFF
--- a/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
+++ b/src/transformers/models/vision_encoder_decoder/modeling_vision_encoder_decoder.py
@@ -113,6 +113,7 @@ class VisionEncoderDecoderModel(PreTrainedModel, GenerationMixin):
 
         self.encoder = encoder
         self.decoder = decoder
+        self._can_compile_fullgraph = decoder._can_compile_fullgraph
 
         if self.encoder.config.to_dict() != self.config.encoder.to_dict():
             logger.warning(


### PR DESCRIPTION
After the issue #39746 fixed, the vision encoder decoder model can support static cache and can got more significant speed-up

```python
import time
import requests
import torch
import PIL.Image
from transformers import pipeline

model_id = "nlpconnect/vit-gpt2-image-captioning"
image_to_text = pipeline("image-to-text", model=model_id, device="cpu", torch_dtype=torch.float16)
image_url = "https://ankur3107.github.io/assets/images/image-captioning-example.png"
image = PIL.Image.open(requests.get(image_url, stream=True, timeout=3000).raw)
generation_config = image_to_text.model.generation_config
generation_config.cache_implementation = "static"

for _ in range(10):
    output = image_to_text(image, generate_kwargs={"generation_config": generation_config})

start = time.time()
output = image_to_text(image, generate_kwargs={"generation_config": generation_config})
end = time.time()
print(f"eager mode pipeline latency {end - start}")

image_to_text.model.forward = torch.compile(image_to_text.model.forward)

for _ in range(10):
    output = image_to_text(image, generate_kwargs={"generation_config": generation_config})

start = time.time()
output = image_to_text(image, generate_kwargs={"generation_config": generation_config})
end = time.time()
print(f"compile mode pipeline latency {end - start}")
```