### PR TITLE
Remove super call from EncoderDecoderCache init

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1731,7 +1731,6 @@ class EncoderDecoderCache(Cache):
     is_compileable = None
 
     def __init__(self, self_attention_cache: Cache, cross_attention_cache: Cache):
-        super().__init__(layer_classes=DynamicLayer)
         self.self_attention_cache = self_attention_cache
         self.cross_attention_cache = cross_attention_cache
         self.is_compileable = getattr(self.self_attention_cache, "is_compileable", False)


### PR DESCRIPTION
`EncoderDecoderCache` is a wrapper around two caches. Thus, it should not call super() to initialize `self.layers` or `self.layer_classes`.

This can create bugs since other parts of the code might try to access those attributes.

The call was added on https://github.com/huggingface/transformers/pull/39590