### PR TITLE
Fix pil dependency torch extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -289,7 +289,7 @@ extras["tf-cpu"] = deps_list(
     "tensorflow-probability",
 )
 
-extras["torch"] = deps_list("torch", "accelerate")
+extras["torch"] = deps_list("torch", "accelerate", "Pillow")
 extras["accelerate"] = deps_list("accelerate")
 extras["hf_xet"] = deps_list("hf_xet")
 


### PR DESCRIPTION
## What does this PR do?

Fixes [[#39779](https://github.com/huggingface/transformers/issues/39779)]:
`ModuleNotFoundError: No module named 'PIL'` when running `transformers env` (or any CLI command) after installing `transformers[torch]` in a fresh environment.

---

## Problem

This error occurs because:

1. The `torch` extra in `setup.py` only includes `torch` and `accelerate`.
2. CLI commands eventually import `PIL` through the following chain:
   `transformers_cli.py → chat.py → serving.py → from PIL import Image`
3. `Pillow` is only included in the `vision` extra, not in the `torch` extra.

**Reproduction steps:**

```bash
docker run --rm -it python:3.13-slim-bookworm bash -c "python3 -m pip install transformers[torch]; transformers env"
```

---

## Solution

Added `Pillow` to the `torch` extra in `setup.py`:

<details>
<summary>Diff</summary>

```python
# Before
extras["torch"] = deps_list("torch", "accelerate")

# After
extras["torch"] = deps_list("torch", "accelerate", "Pillow")
```

</details>

This ensures that users who install with `pip install transformers[torch]` get a fully functional CLI environment without encountering missing dependencies.

---

## Testing

* ✅ Reproduced the original error in a fresh install
* ✅ Verified fix: `pip install transformers[torch]` now includes Pillow
* ✅ Confirmed `transformers env` works without errors
* ✅ No breaking changes to existing functionality

---

## Checklist (Before submitting)

* [x] Fixes a packaging bug (dependency)
* [x] Read the [[Pull Request section of the contributing guide](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)
* [x] Linked to related issue: [[#39779](https://github.com/huggingface/transformers/issues/39779)](https://github.com/huggingface/transformers/issues/39779)
* [x] No documentation updates needed
* [x] No new tests needed (existing coverage is sufficient)

---

## Who can review?

@ArthurZucker @SunMarc – This is a small but important fix to the `torch` extra dependencies that prevents CLI errors in fresh installs.
