### PR TITLE
[pipelines] text-to-audio pipeline standardization

### DIFF
--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -411,7 +411,7 @@ class AutoFeatureExtractor:
         Args:
             config_class ([`PretrainedConfig`]):
                 The configuration corresponding to the model to register.
-            feature_extractor_class ([`FeatureExtractorMixin`]): The feature extractor to register.
+            feature_extractor_class ([`FeatureExtractionMixin`]): The feature extractor to register.
         """
         FEATURE_EXTRACTOR_MAPPING.register(config_class, feature_extractor_class, exist_ok=exist_ok)
 

--- a/src/transformers/models/csm/generation_csm.py
+++ b/src/transformers/models/csm/generation_csm.py
@@ -347,7 +347,7 @@ class CsmGenerationMixin(GenerationMixin):
         streamer: Optional["BaseStreamer"] = None,
         output_audio: Optional[bool] = False,
         **kwargs,
-    ) -> Union[GenerateNonBeamOutput, torch.LongTensor]:
+    ) -> Union[CsmGenerateOutput, torch.LongTensor, list[torch.FloatTensor]]:
         r"""
         This method overrides [`~generation.utils.GenerationMixin.generate`] to match the specifics of the Csm model.
         Indeed, Csm model requires a custom generation sampling step:

--- a/src/transformers/models/csm/processing_csm.py
+++ b/src/transformers/models/csm/processing_csm.py
@@ -192,6 +192,9 @@ class CsmProcessor(ProcessorMixin):
         for audio_value, p in zip(audio, saving_path):
             if isinstance(audio_value, torch.Tensor):
                 audio_value = audio_value.cpu().float().numpy()
+            if audio_value.ndim == 2 and audio_value.shape[0] in (1, 2):
+                # (nb_channels, audio_length) -> (audio_length, nb_channels), as expected by `soundfile`
+                audio_value = np.transpose(audio_value)
             sf.write(p, audio_value, sampling_rate)
 
     def __call__(

--- a/src/transformers/models/dia/processing_dia.py
+++ b/src/transformers/models/dia/processing_dia.py
@@ -18,6 +18,8 @@ import math
 from pathlib import Path
 from typing import Optional, Union
 
+import numpy as np
+
 from ...audio_utils import AudioInput, make_list_of_audio
 from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import AudioKwargs, ProcessingKwargs, ProcessorMixin, Unpack
@@ -406,6 +408,9 @@ class DiaProcessor(ProcessorMixin):
         for audio_value, p in zip(audio, saving_path):
             if isinstance(audio_value, torch.Tensor):
                 audio_value = audio_value.cpu().float().numpy()
+            if audio_value.ndim == 2 and audio_value.shape[0] in (1, 2):
+                # (nb_channels, audio_length) -> (audio_length, nb_channels), as expected by `soundfile`
+                audio_value = np.transpose(audio_value)
             sf.write(p, audio_value, sampling_rate)
 
     @staticmethod

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -43,7 +43,7 @@ from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLRotaryEmbeddin
 
 from ...cache_utils import Cache
 from ...configuration_utils import PretrainedConfig, layer_type_validation
-from ...generation import GenerationMixin
+from ...generation import GenerateDecoderOnlyOutput, GenerationMixin
 from ...modeling_flash_attention_utils import is_flash_attn_available
 from ...modeling_outputs import BaseModelOutput, ModelOutput
 from ...modeling_rope_utils import rope_config_validation
@@ -3966,6 +3966,38 @@ class Qwen2_5OmniToken2WavModel(Qwen2_5OmniPreTrainedModel):
 ############################
 
 
+@dataclass
+class Qwen2_5OmniGenerateOutput(GenerateDecoderOnlyOutput):
+    """
+    Outputs of Qwen2_5OmniForConditionalGeneration.generate.
+
+    Args:
+        sequences (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+            The generated sequences. The second dimension (sequence_length) is either equal to `max_length` or shorter
+            if all batches finished early due to the `eos_token_id`.
+        scores (`tuple(torch.FloatTensor)` *optional*, returned when `output_scores=True`):
+            Processed prediction scores of the language modeling head (scores for each vocabulary token before SoftMax)
+            at each generation step. Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for
+            each generated token), with each tensor of shape `(batch_size, config.vocab_size)`.
+        logits (`tuple(torch.FloatTensor)` *optional*, returned when `output_logits=True`):
+            Unprocessed prediction scores of the language modeling head (scores for each vocabulary token before SoftMax)
+            at each generation step. Tuple of `torch.FloatTensor` with up to `max_new_tokens` elements (one element for
+            each generated token), with each tensor of shape `(batch_size, config.vocab_size)`.
+        attentions (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_attentions=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, num_heads, generated_length, sequence_length)`.
+        hidden_states (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `output_hidden_states=True`):
+            Tuple (one element for each generated token) of tuples (one element for each layer of the decoder) of
+            `torch.FloatTensor` of shape `(batch_size, generated_length, hidden_size)`.
+        past_key_values (`tuple(tuple(torch.FloatTensor)))`, *optional*, returned when `use_cache=True`):
+            Returns the model cache, used to speed up decoding. Different models have a different cache format, check
+        audio (`torch.FloatTensor` of shape `(sequence_length)`):
+            The generated audio. Qwen2.5Omni does not support batched inference with audio output.
+    """
+
+    audio: Optional[torch.Tensor] = None
+
+
 @auto_docstring(
     custom_intro="""
     The full Qwen2.5Omni model, a multimodal model composed of 3 sub-models:
@@ -4078,8 +4110,9 @@ class Qwen2_5OmniForConditionalGeneration(Qwen2_5OmniPreTrainedModel, Generation
         talker_temperature: float = 0.9,
         talker_eos_token_id: list[int] = [8292, 8294],
         talker_repetition_penalty: float = 1.05,
+        return_dict_in_generate: bool = False,
         **kwargs,
-    ):
+    ) -> Union[Qwen2_5OmniGenerateOutput, torch.LongTensor, tuple[torch.LongTensor, torch.FloatTensor]]:
         r"""
         Generate text response and audio from input.
 
@@ -4097,6 +4130,7 @@ class Qwen2_5OmniForConditionalGeneration(Qwen2_5OmniPreTrainedModel, Generation
                 - With a *thinker_*, *talker_*, *token2wav_* prefix, they will be input for the `generate` method of the
                 thinker, talker and token2wav respectively. It has the priority over the keywords without a prefix.
         Returns:
+            A `Qwen2_5OmniGenerateOutput` when `return_dict_in_generate=True`, otherwise:
             When `return_audio=False`:
                 - **Text** (`torch.Tensor`): Generated text token sequence.
             When `return_audio=True`:
@@ -4165,7 +4199,10 @@ class Qwen2_5OmniForConditionalGeneration(Qwen2_5OmniPreTrainedModel, Generation
         thinker_result = self.thinker.generate(input_ids=input_ids, **thinker_kwargs)
 
         if not generate_audio:
-            return thinker_result
+            if return_dict_in_generate:
+                return Qwen2_5OmniGenerateOutput(sequences=thinker_result)
+            else:
+                return thinker_result
 
         # 2. Generate speech tokens from talker module
         embeds_to_talker = thinker_result.hidden_states[0][0].clone().to(input_ids.device)
@@ -4286,7 +4323,10 @@ class Qwen2_5OmniForConditionalGeneration(Qwen2_5OmniPreTrainedModel, Generation
             **token2wav_kwargs,
         )
 
-        return thinker_result.sequences, wav.float()
+        if return_dict_in_generate:
+            return Qwen2_5OmniGenerateOutput(sequences=thinker_result.sequences, audio=wav.float())
+        else:
+            return thinker_result.sequences, wav.float()
 
 
 __all__ = [

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1427,8 +1427,6 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         is_list = isinstance(inputs, list)
 
         is_iterable = is_dataset or is_generator or is_list
-
-        # TODO make the get_iterator work also for `tf` (and `flax`).
         can_use_iterator = self.framework == "pt" and (is_dataset or is_generator or is_list)
 
         if is_list:

--- a/src/transformers/pipelines/text_to_audio.py
+++ b/src/transformers/pipelines/text_to_audio.py
@@ -142,7 +142,8 @@ class TextToAudioPipeline(Pipeline):
             self.model.can_generate() and "output_audio" in inspect.signature(self.model.generate).parameters
         )
         # 2 - some TTS models use the `role` field of the chat template to select the voice, as a digit.
-        self._has_voice_digit_in_chat_role = "isdigit()" in self.processor.chat_template
+        chat_template = getattr(self.tokenizer, "chat_template", None)
+        self._has_voice_digit_in_chat_role = "isdigit()" in chat_template if chat_template is not None else False
 
     def preprocess(self, text, **kwargs):
         if isinstance(text, str):

--- a/src/transformers/pipelines/text_to_audio.py
+++ b/src/transformers/pipelines/text_to_audio.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.from typing import List, Union
+import inspect
 from typing import Any, Union, overload
 
 from ..generation import GenerationConfig
@@ -25,18 +26,28 @@ if is_torch_available():
     from ..models.speecht5.modeling_speecht5 import SpeechT5HifiGan
 
 DEFAULT_VOCODER_ID = "microsoft/speecht5_hifigan"
+# Models that use the "role" of the chat template as a means to select the voice
+MODELS_WITH_VOICE_IN_CHAT_ROLE = "csm"
 
 
 class TextToAudioPipeline(Pipeline):
     """
     Text-to-audio generation pipeline using any `AutoModelForTextToWaveform` or `AutoModelForTextToSpectrogram`. This
-    pipeline generates an audio file from an input text and optional other conditional inputs.
+    pipeline generates an audio waveform from an input text and optionally other conditional inputs.
+
+    <Tip>
+
+    Different audio generation models may support different conditionining inputs, like `voice` in text-to-speech
+    models. Be sure to check the model card for model-specific information, including custom conditioning inputs,
+    and the documentation in [`~TextToAudioPipeline.__call__`] for common audio conditioning inputs.
+
+    </Tip>
 
     Unless the model you're using explicitly sets these generation parameters in its configuration files
     (`generation_config.json`), the following default values will be used:
     - max_new_tokens: 256
 
-    Example:
+    Examples:
 
     ```python
     >>> from transformers import pipeline
@@ -47,15 +58,6 @@ class TextToAudioPipeline(Pipeline):
     >>> audio = output["audio"]
     >>> sampling_rate = output["sampling_rate"]
     ```
-
-    Learn more about the basics of using a pipeline in the [pipeline tutorial](../pipeline_tutorial)
-
-    <Tip>
-
-    You can specify parameters passed to the model by using [`TextToAudioPipeline.__call__.forward_params`] or
-    [`TextToAudioPipeline.__call__.generate_kwargs`].
-
-    Example:
 
     ```python
     >>> from transformers import pipeline
@@ -69,10 +71,10 @@ class TextToAudioPipeline(Pipeline):
     ...     "max_new_tokens": 35,
     ... }
 
-    >>> outputs = music_generator("Techno music with high melodic riffs", generate_kwargs=generate_kwargs)
+    >>> outputs = music_generator("Techno music with high melodic riffs", **generate_kwargs)
     ```
 
-    </Tip>
+    Learn more about the basics of using a pipeline in the [pipeline tutorial](../pipeline_tutorial)
 
     This pipeline can currently be loaded from [`pipeline`] using the following task identifiers: `"text-to-speech"` or
     `"text-to-audio"`.
@@ -80,11 +82,8 @@ class TextToAudioPipeline(Pipeline):
     See the list of available models on [huggingface.co/models](https://huggingface.co/models?filter=text-to-speech).
     """
 
-    # Introducing the processor at load time for new behaviour
-    _load_processor = True
-
     _pipeline_calls_generate = True
-    _load_processor = False
+    _load_processor = True
     _load_image_processor = False
     _load_feature_extractor = False
     _load_tokenizer = True
@@ -94,11 +93,8 @@ class TextToAudioPipeline(Pipeline):
         max_new_tokens=256,
     )
 
-    def __init__(self, *args, vocoder=None, sampling_rate=None, no_processor=True, **kwargs):
+    def __init__(self, *args, vocoder=None, sampling_rate=None, **kwargs):
         super().__init__(*args, **kwargs)
-
-        # Legacy behaviour just uses the tokenizer while new models use the processor as a whole at any given time
-        self.no_processor = no_processor
 
         if self.framework == "tf":
             raise ValueError("The TextToAudioPipeline is only available in PyTorch.")
@@ -129,8 +125,13 @@ class TextToAudioPipeline(Pipeline):
                     self.sampling_rate = sampling_rate
 
         # last fallback to get the sampling rate based on processor
-        if self.sampling_rate is None and not self.no_processor and hasattr(self.processor, "feature_extractor"):
+        if self.sampling_rate is None and self.processor is not None and hasattr(self.processor, "feature_extractor"):
             self.sampling_rate = self.processor.feature_extractor.sampling_rate
+
+        # some models can output audio directly from `generate`, but need a flag to do so
+        self._has_output_audio_in_generate = (
+            self.model.can_generate() and "output_audio" in inspect.signature(self.model.generate).parameters
+        )
 
     def preprocess(self, text, **kwargs):
         if isinstance(text, str):
@@ -145,43 +146,27 @@ class TextToAudioPipeline(Pipeline):
                 "return_token_type_ids": False,
                 "padding": "max_length",
             }
-
             # priority is given to kwargs
             new_kwargs.update(kwargs)
-
             kwargs = new_kwargs
 
-        preprocessor = self.tokenizer if self.no_processor else self.processor
-        output = preprocessor(text, **kwargs, return_tensors="pt")
+        preprocessor = self.tokenizer if self.processor is None else self.processor
+        if self.model.config.model_type in MODELS_WITH_VOICE_IN_CHAT_ROLE:
+            voice = kwargs.pop("voice", "0")
+            conversation = [{"role": voice, "content": [{"type": "text", "text": text[0]}]}]
+            output = preprocessor.apply_chat_template(
+                conversation, tokenize=True, return_dict=True, return_tensors="pt"
+            )
+        else:
+            output = preprocessor(text, **kwargs, return_tensors="pt")
 
         return output
 
     def _forward(self, model_inputs, **kwargs):
-        # we expect some kwargs to be additional tensors which need to be on the right device
-        kwargs = self._ensure_tensor_on_device(kwargs, device=self.device)
-        forward_params = kwargs["forward_params"]
-        generate_kwargs = kwargs["generate_kwargs"]
-
         if self.model.can_generate():
-            # we expect some kwargs to be additional tensors which need to be on the right device
-            generate_kwargs = self._ensure_tensor_on_device(generate_kwargs, device=self.device)
-
-            # User-defined `generation_config` passed to the pipeline call take precedence
-            if "generation_config" not in generate_kwargs:
-                generate_kwargs["generation_config"] = self.generation_config
-
-            # generate_kwargs get priority over forward_params
-            forward_params.update(generate_kwargs)
-
-            output = self.model.generate(**model_inputs, **forward_params)
+            output = self.model.generate(**model_inputs, **kwargs)
         else:
-            if len(generate_kwargs):
-                raise ValueError(
-                    "You're using the `TextToAudioPipeline` with a forward-only model, but `generate_kwargs` is non "
-                    "empty. For forward-only TTA models, please use `forward_params` instead of `generate_kwargs`. "
-                    f"For reference, the `generate_kwargs` used here are: {generate_kwargs.keys()}"
-                )
-            output = self.model(**model_inputs, **forward_params)[0]
+            output = self.model(**model_inputs, **kwargs)[0]
 
         if self.vocoder is not None:
             # in that case, the output is a spectrogram that needs to be converted into a waveform
@@ -190,28 +175,27 @@ class TextToAudioPipeline(Pipeline):
         return output
 
     @overload
-    def __call__(self, text_inputs: str, **forward_params: Any) -> dict[str, Any]: ...
+    def __call__(self, text_inputs: str, voice: str, **kwargs: Any) -> dict[str, Any]: ...
 
     @overload
-    def __call__(self, text_inputs: list[str], **forward_params: Any) -> list[dict[str, Any]]: ...
+    def __call__(self, text_inputs: list[str], voice: str, **kwargs: Any) -> list[dict[str, Any]]: ...
 
     def __call__(
-        self, text_inputs: Union[str, list[str]], **forward_params
+        self, text_inputs: Union[str, list[str]], voice: str, **kwargs
     ) -> Union[dict[str, Any], list[dict[str, Any]]]:
         """
         Generates speech/audio from the inputs. See the [`TextToAudioPipeline`] documentation for more information.
 
         Args:
             text_inputs (`str` or `list[str]`):
-                The text(s) to generate.
-            forward_params (`dict`, *optional*):
-                Parameters passed to the model generation/forward method. `forward_params` are always passed to the
-                underlying model.
-            generate_kwargs (`dict`, *optional*):
-                The dictionary of ad-hoc parametrization of `generate_config` to be used for the generation call. For a
-                complete overview of generate, check the [following
-                guide](https://huggingface.co/docs/transformers/en/main_classes/text_generation). `generate_kwargs` are
-                only passed to the underlying model if the latter is a generative model.
+                The text(s) to generate audio from.
+            voice (`str`):
+                The voice to use for the generation, if the model is a text-to-speech model that supports multiple
+                voices.
+            kwargs (`dict`, *optional*):
+                Parameters passed to the model generation (if the model supports generation) or forward method
+                (if not). `kwargs` are always passed to the underlying model. For a complete overview of
+                generate, check the [following guide](https://huggingface.co/docs/transformers/en/main_classes/text_generation).
 
         Return:
             A `dict` or a list of `dict`: The dictionaries have two keys:
@@ -219,45 +203,64 @@ class TextToAudioPipeline(Pipeline):
             - **audio** (`np.ndarray` of shape `(nb_channels, audio_length)`) -- The generated audio waveform.
             - **sampling_rate** (`int`) -- The sampling rate of the generated audio waveform.
         """
-        return super().__call__(text_inputs, **forward_params)
+        return super().__call__(text_inputs, **kwargs)
 
     def _sanitize_parameters(
         self,
-        preprocess_params=None,
-        forward_params=None,
-        generate_kwargs=None,
+        voice=None,
+        **kwargs,
     ):
-        if getattr(self, "assistant_model", None) is not None:
-            generate_kwargs["assistant_model"] = self.assistant_model
-        if getattr(self, "assistant_tokenizer", None) is not None:
-            generate_kwargs["tokenizer"] = self.tokenizer
-            generate_kwargs["assistant_tokenizer"] = self.assistant_tokenizer
+        # BC: we accepted `generate_kwargs` as a parameter. This was a more complex way of directly passing generation
+        # parameters, `pipe(..., generate_kwargs={"max_new_tokens"=100})` vs `pipe(..., max_new_tokens=100)`. If the
+        # model can't generate, these kwargs are forwarded to the model's `forward` method.
+        # We also accepted `forward_params` and `preprocess_params`.
+        # From now on, we should try to be **explicit** about the parameters the pipeline accepts, and document the
+        # accepted parameters in `__call__`.
 
-        params = {
-            "forward_params": forward_params if forward_params else {},
-            "generate_kwargs": generate_kwargs if generate_kwargs else {},
-        }
+        preprocess_params = {}
+        if "preprocess_params" in kwargs:  # BC
+            preprocess_params.update(kwargs.pop("preprocess_params"))
+        if voice is not None:
+            preprocess_params["voice"] = voice
 
-        if preprocess_params is None:
-            preprocess_params = {}
+        forward_params = {}
+        if "generate_kwargs" in kwargs:  # BC
+            forward_params.update(kwargs.pop("generate_kwargs"))
+        if "forward_params" in kwargs:  # BC
+            forward_params.update(kwargs.pop("forward_params"))
+        forward_params.update(kwargs)
+
+        # generate-specific input preparation
+        if self.model.can_generate():
+            if getattr(self, "assistant_model", None) is not None:
+                forward_params["assistant_model"] = self.assistant_model
+            if getattr(self, "assistant_tokenizer", None) is not None:
+                forward_params["tokenizer"] = self.tokenizer
+                forward_params["assistant_tokenizer"] = self.assistant_tokenizer
+            if getattr(self, "_has_output_audio_in_generate", False) and "output_audio" not in forward_params:
+                forward_params["output_audio"] = True
+            if "generation_config" not in forward_params:
+                forward_params["generation_config"] = self.generation_config
+
+        forward_params = self._ensure_tensor_on_device(forward_params, device=self.device)
+
         postprocess_params = {}
-
-        return preprocess_params, params, postprocess_params
+        return preprocess_params, forward_params, postprocess_params
 
     def postprocess(self, audio):
         output_dict = {}
 
-        # We directly get the waveform
-        if self.no_processor:
+        # We need to postprocess to get the waveform
+        if self.processor is not None and hasattr(self.processor, "decode"):
+            waveform = self.processor.decode(audio)
+        # Or we can use the waveform directly
+        else:
             if isinstance(audio, dict):
-                waveform = audio["waveform"]
-            elif isinstance(audio, tuple):
+                waveform = audio.get("waveform")
+            elif isinstance(audio, (tuple, list)):
                 waveform = audio[0]
             else:
                 waveform = audio
-        # Or we need to postprocess to get the waveform
-        else:
-            waveform = self.processor.decode(audio)
 
         output_dict["audio"] = waveform.to(device="cpu", dtype=torch.float).numpy()
         output_dict["sampling_rate"] = self.sampling_rate

--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -924,8 +924,8 @@ IMAGE_TEXT_TO_TEXT_GENERATION_SAMPLE = r"""
 
 PIPELINE_TASKS_TO_SAMPLE_DOCSTRINGS = OrderedDict(
     [
-        ("text-to-audio-spectrogram", TEXT_TO_AUDIO_SPECTROGRAM_SAMPLE),
-        ("text-to-audio-waveform", TEXT_TO_AUDIO_WAVEFORM_SAMPLE),
+        ("text-to-audio", TEXT_TO_AUDIO_SPECTROGRAM_SAMPLE),
+        ("text-to-audio", TEXT_TO_AUDIO_WAVEFORM_SAMPLE),
         ("automatic-speech-recognition", AUTOMATIC_SPEECH_RECOGNITION_SAMPLE),
         ("audio-frame-classification", AUDIO_FRAME_CLASSIFICATION_SAMPLE),
         ("audio-classification", AUDIO_CLASSIFICATION_SAMPLE),
@@ -962,8 +962,8 @@ PIPELINE_TASKS_TO_SAMPLE_DOCSTRINGS = OrderedDict(
 MODELS_TO_PIPELINE = OrderedDict(
     [
         # Audio
-        ("MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES", "text-to-audio-spectrogram"),
-        ("MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES", "text-to-audio-waveform"),
+        ("MODEL_FOR_TEXT_TO_SPECTROGRAM_MAPPING_NAMES", "text-to-audio"),
+        ("MODEL_FOR_TEXT_TO_WAVEFORM_MAPPING_NAMES", "text-to-audio"),
         ("MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES", "automatic-speech-recognition"),
         ("MODEL_FOR_CTC_MAPPING_NAMES", "automatic-speech-recognition"),
         ("MODEL_FOR_AUDIO_FRAME_CLASSIFICATION_MAPPING_NAMES", "audio-frame-classification"),

--- a/tests/models/csm/test_modeling_csm.py
+++ b/tests/models/csm/test_modeling_csm.py
@@ -42,6 +42,7 @@ from ...test_modeling_common import (
     _config_zero_init,
     ids_tensor,
 )
+from ...test_pipeline_mixin import PipelineTesterMixin
 
 
 if is_datasets_available():
@@ -141,12 +142,19 @@ class CsmModelTester:
         return config, inputs_dict
 
 
-class CsmForConditionalGenerationTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
+class CsmForConditionalGenerationTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase, PipelineTesterMixin):
     all_model_classes = (CsmForConditionalGeneration,) if is_torch_available() else ()
     test_pruning = False
     test_headmasking = False
     test_resize_embeddings = False
     test_resize_embeddings_untied = False
+    pipeline_model_mapping = (
+        {
+            "text-to-audio": CsmForConditionalGeneration,
+        }
+        if is_torch_available()
+        else {}
+    )
 
     def setUp(self):
         self.model_tester = CsmModelTester(self)

--- a/tests/models/dia/test_modeling_dia.py
+++ b/tests/models/dia/test_modeling_dia.py
@@ -218,9 +218,7 @@ class DiaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     all_model_classes = (DiaModel, DiaForConditionalGeneration) if is_torch_available() else ()
     # We only allow greedy search / sampling with one sequence; see `skip_non_greedy_generate`
     all_generative_model_classes = (DiaForConditionalGeneration,)
-    # TODO: support new pipeline behavior in tests
-    pipeline_model_mapping = {}
-    # pipeline_model_mapping = {"text-to-audio": DiaForConditionalGeneration} if is_torch_available() else {}
+    pipeline_model_mapping = {"text-to-audio": DiaForConditionalGeneration} if is_torch_available() else {}
     test_pruning = False
     test_head_masking = False
     test_resize_embeddings = False

--- a/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
+++ b/tests/models/fastspeech2_conformer/test_modeling_fastspeech2_conformer.py
@@ -34,6 +34,7 @@ from transformers.testing_utils import (
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, _config_zero_init, ids_tensor
+from ...test_pipeline_mixin import PipelineTesterMixin
 
 
 if is_torch_available():
@@ -123,13 +124,20 @@ class FastSpeech2ConformerModelTester:
 
 
 @require_torch
-class FastSpeech2ConformerModelTest(ModelTesterMixin, unittest.TestCase):
+class FastSpeech2ConformerModelTest(ModelTesterMixin, unittest.TestCase, PipelineTesterMixin):
     all_model_classes = (FastSpeech2ConformerModel,) if is_torch_available() else ()
     test_pruning = False
     test_headmasking = False
     test_torchscript = False
     test_resize_embeddings = False
     is_encoder_decoder = True
+    pipeline_model_mapping = (
+        {
+            "text-to-audio": FastSpeech2ConformerModel,
+        }
+        if is_torch_available()
+        else {}
+    )
 
     def setUp(self):
         self.model_tester = FastSpeech2ConformerModelTester(self)
@@ -560,13 +568,20 @@ class FastSpeech2ConformerWithHifiGanTester:
 
 
 @require_torch
-class FastSpeech2ConformerWithHifiGanTest(ModelTesterMixin, unittest.TestCase):
+class FastSpeech2ConformerWithHifiGanTest(ModelTesterMixin, unittest.TestCase, PipelineTesterMixin):
     all_model_classes = (FastSpeech2ConformerWithHifiGan,) if is_torch_available() else ()
     test_pruning = False
     test_headmasking = False
     test_torchscript = False
     test_resize_embeddings = False
     is_encoder_decoder = True
+    pipeline_model_mapping = (
+        {
+            "text-to-audio": FastSpeech2ConformerWithHifiGan,
+        }
+        if is_torch_available()
+        else {}
+    )
 
     def setUp(self):
         self.model_tester = FastSpeech2ConformerWithHifiGanTester(self)

--- a/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py
@@ -49,6 +49,7 @@ from ...test_modeling_common import (
     floats_tensor,
     ids_tensor,
 )
+from ...test_pipeline_mixin import PipelineTesterMixin
 
 
 if is_torch_available():
@@ -249,7 +250,9 @@ class Qwen2_5OmniThinkerForConditionalGenerationTester:
 
 
 @require_torch
-class Qwen2_5OmniThinkerForConditionalGenerationModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
+class Qwen2_5OmniThinkerForConditionalGenerationModelTest(
+    ModelTesterMixin, GenerationTesterMixin, unittest.TestCase, PipelineTesterMixin
+):
     """
     Model tester for `Qwen2_5OmniThinkerForConditionalGeneration`.
     """
@@ -259,6 +262,14 @@ class Qwen2_5OmniThinkerForConditionalGenerationModelTest(ModelTesterMixin, Gene
     test_pruning = False
     test_head_masking = False
     _is_composite = True
+    pipeline_model_mapping = (
+        {
+            "text-to-audio": Qwen2_5OmniThinkerForConditionalGeneration,
+            # TODO (joao, raushan): add other pipelines here
+        }
+        if is_torch_available()
+        else {}
+    )
 
     def setUp(self):
         self.model_tester = Qwen2_5OmniThinkerForConditionalGenerationTester(self)

--- a/tests/models/speecht5/test_modeling_speecht5.py
+++ b/tests/models/speecht5/test_modeling_speecht5.py
@@ -169,7 +169,16 @@ class SpeechT5ModelTester:
 class SpeechT5ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     all_model_classes = (SpeechT5Model,) if is_torch_available() else ()
     pipeline_model_mapping = (
-        {"automatic-speech-recognition": SpeechT5ForSpeechToText, "feature-extraction": SpeechT5Model}
+        {
+            "automatic-speech-recognition": SpeechT5ForSpeechToText,
+            "feature-extraction": SpeechT5Model,
+            # TODO: two issues here:
+            # - major: with datasets 4.0.0, the main source of speaker embeddings (`Matthijs/cmu-arctic-xvectors`) can
+            #   no longer be loaded
+            # - minor: speecht5 requires `speaker_embeddings` to be passed as a parameter. It would be nice to use the
+            #   pipeline's `voice` parameter.
+            # "text-to-audio": SpeechT5ForTextToSpeech,
+        }
         if is_torch_available()
         else {}
     )

--- a/tests/pipelines/test_pipelines_text_to_audio.py
+++ b/tests/pipelines/test_pipelines_text_to_audio.py
@@ -212,7 +212,7 @@ class TextToAudioPipelineTests(unittest.TestCase):
         forward_params = {"speaker_id": 5}
         generate_kwargs = {"do_sample": True}
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             # assert error if generate_kwargs with forward-only models
             outputs = speech_generator(
                 "This is a test", forward_params=forward_params, generate_kwargs=generate_kwargs
@@ -245,7 +245,7 @@ class TextToAudioPipelineTests(unittest.TestCase):
         # for reproducibility
         set_seed(555)
         outputs = music_generator("This is a test", forward_params=forward_params, generate_kwargs=generate_kwargs)
-        self.assertListEqual(outputs["audio"].tolist(), audio.tolist())
+        self.assertTrue(np.abs(outputs["audio"] - audio).max() < 1e-5)
 
     def get_test_pipeline(
         self,


### PR DESCRIPTION
# What does this PR do?

⚠️ TODO before merging: after settling on the design, update pipeline usage in model docs accordingly.

This PR standardizes `text-to-audio` such that the following lines work with most* text-to-audio models:

```py
from transformers import pipeline

synthesiser = pipeline("text-to-audio", "facebook/musicgen-large")
music = synthesiser("A low-fi song with a strong bassline")
synthesiser.save_audio(music, "test.wav")
```

On most* models where voice control is possible, it is possible to control it through the `voice` pipeline argument. The valid values for `voice` are model-dependent, and this argument is documented accordingly

```py
from transformers import pipeline

tts_pipeline = pipeline("text-to-audio", "sesame/csm-1b")
audio = tts_pipeline("I just got bamboozled by my cat.", voice="1")
tts_pipeline.save_audio(audio, "test.wav")
```

## Core changes

Prior to this PR, recent models with `text-to-audio` capabilities had no pipeline support (e.g. CSM, Dia, Qwen2.5 Omni). There was also not a standardized way to control the voice, if the model generates speech.

With this PR, `TextToAudioPipeline`:
- Uses a `processor` whenever possible, automatically (as opposed to needing a flag to control it);
- Takes a `voice` argument, which a few models can use out of the box. Whether a model can take `voice` in the pipeline is specified by properties of the model (if future models have the same properties, they will also have `voice` support);
- Standardizes outputs: ALL models using the pipeline will return `{"audio": <np.array with shape (audio_channels, sequence_length)>, "sampling_rate": <int>}`.  Different models return different array formats, and as a result we can see different saving scripts in the model cards -- the pipeline standardizes it;
- Adds a function to save the audio, for convenience. This way, users don't need to learn about `soundfile` or alternatives. Uses the processor's `save_audio` whenever it is available.

## Model support

Models with out-of-the-box pipeline support:
  - TTS Models with `voice` support:
    - CSM
    - Qwen2.5 Omni
    - Bark
  - TTS Models w/o `voice` support:
    - Dia  -- voice is set in the prompt; needs chat templates? (we can hardcode it in the pipeline, though 🤔 )
    - FastSpeech2Conformer (model has no voice control)
    - SeamlessM4T and variants (model has no voice control)
    - Vits (model has no voice control)
  - TTA Models:
    - Musicgen and variants

Models that have special requirements:
- SpeechT5 (requires `speaker_embeddings` argument; we could hide the complexity and accept `voice: int`, but the voice dataset most commonly used to pull the embeddings from isn't compatible with `datasets==4.0.0` 💔 )
