### PR TITLE
[docs] fix korean docs yet again

### DIFF
--- a/docs/source/ko/_toctree.yml
+++ b/docs/source/ko/_toctree.yml
@@ -357,7 +357,7 @@
     title: 메인 클래스
   - sections:
     - sections:
-      - local: in_translation
+      - local: model_doc/albert
         title: ALBERT
       - local: in_translation
         title: Arcee
@@ -1081,7 +1081,7 @@
         title: TrOCR
       - local: in_translation
         title: TVLT
-      - local: in_translation
+      - local: model_doc/tvp
         title: TVP
       - local: in_translation
         title: UDOP


### PR DESCRIPTION
# What does this PR do?

Something went wrong merging main into #39660 , and CI is still red.

`doc-builder build transformers docs/source/ko/ --language ko --clean` is green on my side.