### PR TITLE
Support MetaCLIP 2

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -634,7 +634,7 @@ class CLIPTextTransformer(nn.Module):
         last_hidden_state = encoder_outputs.last_hidden_state
         last_hidden_state = self.final_layer_norm(last_hidden_state)
 
-        if self.eos_token_id == 2:
+        if torch.all(input_ids.max(dim=-1).values == 49407).item():
             # The `eos_token_id` was incorrect before PR #24773: Let's keep what have been done here.
             # A CLIP model with such `eos_token_id` in the config can't work correctly with extra new tokens added
             # ------------------------------------------------------------


### PR DESCRIPTION
# What does this PR do?

Meta just released [MetaCLIP 2 (worldwide)](https://github.com/facebookresearch/MetaCLIP?tab=readme-ov-file#pre-trained-models), new CLIP models trained on 300+ languages.

However, when making them compatible with `modeling_clip.py`, I noticed there's a mistake with the original OpenAI CLIP models.
* they have the EOS token ID set to 2 in the config: https://huggingface.co/openai/clip-vit-large-patch14/blob/main/config.json#L25. However, the OpenAI CLIP models don't use 2 as EOS token ID. They use 49407. You can check this when tokenizing text using `CLIPTokenizer`:
```python
>>> from transformers import CLIPTokenizer
>>> tokenizer = CLIPTokenizer.from_pretrained("openai/clip-vit-base-patch32")
>>> input_ids = tokenizer("hello world", return_tensors="pt")
>>> input_ids
{'input_ids': tensor([[49406,  3306,  1002, 49407]]), 'attention_mask': tensor([[1, 1, 1, 1]])}
```
* this was fixed in #24773. For backwards compatibility, a block of code was kept and it only runs in case a model has wrongly set EOS token ID == 2.
* since MetaCLIP 2 **actually** uses EOS token ID == 2 with a multilingual tokenizer (https://huggingface.co/facebook/xlm-v-base), it needs the "else" block which gets the EOS token from each sequence along the batch dimension.
* this means we'd need to adapt the "if" block. I propose here to simply check whether the max values in each row of the input_ids corresponds to 49407, the value all OpenAI CLIP models use. 

cc @ydshieh 