### PR TITLE
Fix attn_implementation setter for models with `backbone_config`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -422,6 +422,10 @@ class PretrainedConfig(PushToHubMixin):
                 )
                 subconfig._attn_implementation = sub_implementation
 
+        # special case for `backbone_config`
+        if hasattr(self, "backbone_config") and isinstance(self.backbone_config, PretrainedConfig):
+            self.backbone_config._attn_implementation = attn_implementation
+
     def save_pretrained(self, save_directory: Union[str, os.PathLike], push_to_hub: bool = False, **kwargs):
         """
         Save a configuration object to the directory `save_directory`, so that it can be re-loaded using the

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -422,10 +422,6 @@ class PretrainedConfig(PushToHubMixin):
                 )
                 subconfig._attn_implementation = sub_implementation
 
-        # special case for `backbone_config`
-        if hasattr(self, "backbone_config") and isinstance(self.backbone_config, PretrainedConfig):
-            self.backbone_config._attn_implementation = attn_implementation
-
     def save_pretrained(self, save_directory: Union[str, os.PathLike], push_to_hub: bool = False, **kwargs):
         """
         Save a configuration object to the directory `save_directory`, so that it can be re-loaded using the

--- a/src/transformers/models/conditional_detr/configuration_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/configuration_conditional_detr.py
@@ -253,6 +253,10 @@ class ConditionalDetrConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 class ConditionalDetrOnnxConfig(OnnxConfig):
     torch_onnx_minimum_version = version.parse("1.11")

--- a/src/transformers/models/conditional_detr/configuration_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/configuration_conditional_detr.py
@@ -255,7 +255,11 @@ class ConditionalDetrConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 class ConditionalDetrOnnxConfig(OnnxConfig):

--- a/src/transformers/models/d_fine/configuration_d_fine.py
+++ b/src/transformers/models/d_fine/configuration_d_fine.py
@@ -406,7 +406,11 @@ class DFineConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/d_fine/configuration_d_fine.py
+++ b/src/transformers/models/d_fine/configuration_d_fine.py
@@ -404,6 +404,10 @@ class DFineConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`DFineConfig`] (or a derived class) from a pre-trained backbone model configuration and DETR model

--- a/src/transformers/models/d_fine/modular_d_fine.py
+++ b/src/transformers/models/d_fine/modular_d_fine.py
@@ -425,7 +425,11 @@ class DFineConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/d_fine/modular_d_fine.py
+++ b/src/transformers/models/d_fine/modular_d_fine.py
@@ -423,6 +423,10 @@ class DFineConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`DFineConfig`] (or a derived class) from a pre-trained backbone model configuration and DETR model

--- a/src/transformers/models/dab_detr/configuration_dab_detr.py
+++ b/src/transformers/models/dab_detr/configuration_dab_detr.py
@@ -256,5 +256,9 @@ class DabDetrConfig(PretrainedConfig):
         self.initializer_bias_prior_prob = initializer_bias_prior_prob
         super().__init__(is_encoder_decoder=is_encoder_decoder, **kwargs)
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["DabDetrConfig"]

--- a/src/transformers/models/dab_detr/configuration_dab_detr.py
+++ b/src/transformers/models/dab_detr/configuration_dab_detr.py
@@ -258,7 +258,11 @@ class DabDetrConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["DabDetrConfig"]

--- a/src/transformers/models/deformable_detr/configuration_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/configuration_deformable_detr.py
@@ -280,7 +280,11 @@ class DeformableDetrConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["DeformableDetrConfig"]

--- a/src/transformers/models/deformable_detr/configuration_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/configuration_deformable_detr.py
@@ -278,5 +278,9 @@ class DeformableDetrConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["DeformableDetrConfig"]

--- a/src/transformers/models/deprecated/deta/configuration_deta.py
+++ b/src/transformers/models/deprecated/deta/configuration_deta.py
@@ -268,7 +268,11 @@ class DetaConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["DetaConfig"]

--- a/src/transformers/models/deprecated/deta/configuration_deta.py
+++ b/src/transformers/models/deprecated/deta/configuration_deta.py
@@ -266,5 +266,9 @@ class DetaConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["DetaConfig"]

--- a/src/transformers/models/deprecated/vit_hybrid/configuration_vit_hybrid.py
+++ b/src/transformers/models/deprecated/vit_hybrid/configuration_vit_hybrid.py
@@ -168,5 +168,9 @@ class ViTHybridConfig(PretrainedConfig):
         self.num_channels = num_channels
         self.qkv_bias = qkv_bias
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["ViTHybridConfig"]

--- a/src/transformers/models/deprecated/vit_hybrid/configuration_vit_hybrid.py
+++ b/src/transformers/models/deprecated/vit_hybrid/configuration_vit_hybrid.py
@@ -170,7 +170,11 @@ class ViTHybridConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["ViTHybridConfig"]

--- a/src/transformers/models/depth_anything/configuration_depth_anything.py
+++ b/src/transformers/models/depth_anything/configuration_depth_anything.py
@@ -151,6 +151,10 @@ class DepthAnythingConfig(PretrainedConfig):
         self.depth_estimation_type = depth_estimation_type
         self.max_depth = max_depth if max_depth else 1
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     def to_dict(self):
         """
         Serializes this instance to a Python dictionary. Override the default [`~PretrainedConfig.to_dict`]. Returns:

--- a/src/transformers/models/depth_anything/configuration_depth_anything.py
+++ b/src/transformers/models/depth_anything/configuration_depth_anything.py
@@ -153,7 +153,11 @@ class DepthAnythingConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     def to_dict(self):
         """

--- a/src/transformers/models/detr/configuration_detr.py
+++ b/src/transformers/models/detr/configuration_detr.py
@@ -254,7 +254,11 @@ class DetrConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/detr/configuration_detr.py
+++ b/src/transformers/models/detr/configuration_detr.py
@@ -252,6 +252,10 @@ class DetrConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`DetrConfig`] (or a derived class) from a pre-trained backbone model configuration.

--- a/src/transformers/models/dpt/configuration_dpt.py
+++ b/src/transformers/models/dpt/configuration_dpt.py
@@ -294,7 +294,11 @@ class DPTConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["DPTConfig"]

--- a/src/transformers/models/dpt/configuration_dpt.py
+++ b/src/transformers/models/dpt/configuration_dpt.py
@@ -294,11 +294,7 @@ class DPTConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return (
-            {"backbone_config": type(self.backbone_config)}
-            if getattr(self, "backbone_config", None) is not None
-            else {}
-        )
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
 
 
 __all__ = ["DPTConfig"]

--- a/src/transformers/models/fsmt/configuration_fsmt.py
+++ b/src/transformers/models/fsmt/configuration_fsmt.py
@@ -134,6 +134,7 @@ class FSMTConfig(PretrainedConfig):
 
     model_type = "fsmt"
     attribute_map = {"num_attention_heads": "encoder_attention_heads", "hidden_size": "d_model"}
+    sub_configs = {"decoder": DecoderConfig}
 
     # update the defaults from config file
     def __init__(

--- a/src/transformers/models/fsmt/configuration_fsmt.py
+++ b/src/transformers/models/fsmt/configuration_fsmt.py
@@ -28,8 +28,8 @@ class DecoderConfig(PretrainedConfig):
 
     model_type = "fsmt_decoder"
 
-    def __init__(self, vocab_size=0, bos_token_id=0, is_encoder_decoder=True):
-        super().__init__()
+    def __init__(self, vocab_size=0, bos_token_id=0, is_encoder_decoder=True, **common_kwargs):
+        super().__init__(**common_kwargs)
         self.vocab_size = vocab_size
         self.bos_token_id = bos_token_id
         self.is_encoder_decoder = is_encoder_decoder

--- a/src/transformers/models/fsmt/configuration_fsmt.py
+++ b/src/transformers/models/fsmt/configuration_fsmt.py
@@ -28,8 +28,8 @@ class DecoderConfig(PretrainedConfig):
 
     model_type = "fsmt_decoder"
 
-    def __init__(self, vocab_size=0, bos_token_id=0, is_encoder_decoder=True, **common_kwargs):
-        super().__init__(**common_kwargs)
+    def __init__(self, vocab_size=0, bos_token_id=0, is_encoder_decoder=True, **kwargs):
+        super().__init__(**kwargs)
         self.vocab_size = vocab_size
         self.bos_token_id = bos_token_id
         self.is_encoder_decoder = is_encoder_decoder

--- a/src/transformers/models/grounding_dino/configuration_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/configuration_grounding_dino.py
@@ -296,11 +296,12 @@ class GroundingDinoConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return (
-            {"backbone_config": type(self.backbone_config)}
-            if getattr(self, "backbone_config", None) is not None
-            else {}
-        )
+        sub_configs = {}
+        if self.backbone_config is not None and self.backbone_config != {}:
+            sub_configs["backbone_config"] = type(self.backbone_config)
+        if self.text_config is not None and self.text_config != {}:
+            sub_configs["text_config"] = type(self.text_config)
+        return sub_configs
 
 
 __all__ = ["GroundingDinoConfig"]

--- a/src/transformers/models/grounding_dino/configuration_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/configuration_grounding_dino.py
@@ -297,9 +297,11 @@ class GroundingDinoConfig(PretrainedConfig):
     @property
     def sub_configs(self):
         sub_configs = {}
-        if self.backbone_config is not None and self.backbone_config != {}:
-            sub_configs["backbone_config"] = type(self.backbone_config)
-        if self.text_config is not None and self.text_config != {}:
+        backbone_config = getattr(self, "backbone_config", None)
+        text_config = getattr(self, "text_config", None)
+        if isinstance(backbone_config, PretrainedConfig):
+            sub_configs["backbone_config"] = type(backbone_config)
+        if isinstance(text_config, PretrainedConfig):
             sub_configs["text_config"] = type(self.text_config)
         return sub_configs
 

--- a/src/transformers/models/grounding_dino/configuration_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/configuration_grounding_dino.py
@@ -296,7 +296,11 @@ class GroundingDinoConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["GroundingDinoConfig"]

--- a/src/transformers/models/grounding_dino/configuration_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/configuration_grounding_dino.py
@@ -294,5 +294,9 @@ class GroundingDinoConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["GroundingDinoConfig"]

--- a/src/transformers/models/mask2former/configuration_mask2former.py
+++ b/src/transformers/models/mask2former/configuration_mask2former.py
@@ -238,7 +238,11 @@ class Mask2FormerConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/mask2former/configuration_mask2former.py
+++ b/src/transformers/models/mask2former/configuration_mask2former.py
@@ -236,6 +236,10 @@ class Mask2FormerConfig(PretrainedConfig):
 
         super().__init__(**kwargs)
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`Mask2FormerConfig`] (or a derived class) from a pre-trained backbone model configuration.

--- a/src/transformers/models/maskformer/configuration_maskformer.py
+++ b/src/transformers/models/maskformer/configuration_maskformer.py
@@ -202,7 +202,11 @@ class MaskFormerConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_and_decoder_configs(

--- a/src/transformers/models/maskformer/configuration_maskformer.py
+++ b/src/transformers/models/maskformer/configuration_maskformer.py
@@ -202,11 +202,12 @@ class MaskFormerConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return (
-            {"backbone_config": type(self.backbone_config)}
-            if getattr(self, "backbone_config", None) is not None
-            else {}
-        )
+        sub_configs = {}
+        if self.backbone_config is not None and self.backbone_config != {}:
+            sub_configs["backbone_config"] = type(self.backbone_config)
+        if self.decoder_config is not None and self.decoder_config != {}:
+            sub_configs["decoder_config"] = type(self.decoder_config)
+        return sub_configs
 
     @classmethod
     def from_backbone_and_decoder_configs(

--- a/src/transformers/models/maskformer/configuration_maskformer.py
+++ b/src/transformers/models/maskformer/configuration_maskformer.py
@@ -200,6 +200,10 @@ class MaskFormerConfig(PretrainedConfig):
         self.backbone_kwargs = backbone_kwargs
         super().__init__(**kwargs)
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_and_decoder_configs(
         cls, backbone_config: PretrainedConfig, decoder_config: PretrainedConfig, **kwargs

--- a/src/transformers/models/mm_grounding_dino/configuration_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/configuration_mm_grounding_dino.py
@@ -288,5 +288,9 @@ class MMGroundingDinoConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["MMGroundingDinoConfig"]

--- a/src/transformers/models/mm_grounding_dino/configuration_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/configuration_mm_grounding_dino.py
@@ -290,7 +290,11 @@ class MMGroundingDinoConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["MMGroundingDinoConfig"]

--- a/src/transformers/models/mm_grounding_dino/configuration_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/configuration_mm_grounding_dino.py
@@ -290,11 +290,14 @@ class MMGroundingDinoConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return (
-            {"backbone_config": type(self.backbone_config)}
-            if getattr(self, "backbone_config", None) is not None
-            else {}
-        )
+        sub_configs = {}
+        backbone_config = getattr(self, "backbone_config", None)
+        text_config = getattr(self, "text_config", None)
+        if isinstance(backbone_config, PretrainedConfig):
+            sub_configs["backbone_config"] = type(backbone_config)
+        if isinstance(text_config, PretrainedConfig):
+            sub_configs["text_config"] = type(self.text_config)
+        return sub_configs
 
 
 __all__ = ["MMGroundingDinoConfig"]

--- a/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
@@ -288,14 +288,6 @@ class MMGroundingDinoConfig(GroundingDinoConfig, PretrainedConfig):
         self.init_std = init_std
         self.layer_norm_eps = layer_norm_eps
 
-    @property
-    def sub_configs(self):
-        return (
-            {"backbone_config": type(self.backbone_config)}
-            if getattr(self, "backbone_config", None) is not None
-            else {}
-        )
-
 
 class MMGroundingDinoContrastiveEmbedding(GroundingDinoContrastiveEmbedding):
     def __init__(self, config):

--- a/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
@@ -288,6 +288,10 @@ class MMGroundingDinoConfig(GroundingDinoConfig, PretrainedConfig):
         self.init_std = init_std
         self.layer_norm_eps = layer_norm_eps
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 class MMGroundingDinoContrastiveEmbedding(GroundingDinoContrastiveEmbedding):
     def __init__(self, config):

--- a/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
+++ b/src/transformers/models/mm_grounding_dino/modular_mm_grounding_dino.py
@@ -290,7 +290,11 @@ class MMGroundingDinoConfig(GroundingDinoConfig, PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 class MMGroundingDinoContrastiveEmbedding(GroundingDinoContrastiveEmbedding):

--- a/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
@@ -291,7 +291,11 @@ class OmDetTurboConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["OmDetTurboConfig"]

--- a/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
@@ -291,11 +291,14 @@ class OmDetTurboConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return (
-            {"backbone_config": type(self.backbone_config)}
-            if getattr(self, "backbone_config", None) is not None
-            else {}
-        )
+        sub_configs = {}
+        backbone_config = getattr(self, "backbone_config", None)
+        text_config = getattr(self, "text_config", None)
+        if isinstance(backbone_config, PretrainedConfig):
+            sub_configs["backbone_config"] = type(backbone_config)
+        if isinstance(text_config, PretrainedConfig):
+            sub_configs["text_config"] = type(text_config)
+        return sub_configs
 
 
 __all__ = ["OmDetTurboConfig"]

--- a/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
@@ -289,5 +289,9 @@ class OmDetTurboConfig(PretrainedConfig):
 
         super().__init__(is_encoder_decoder=is_encoder_decoder, **kwargs)
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["OmDetTurboConfig"]

--- a/src/transformers/models/oneformer/configuration_oneformer.py
+++ b/src/transformers/models/oneformer/configuration_oneformer.py
@@ -275,7 +275,11 @@ class OneFormerConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["OneFormerConfig"]

--- a/src/transformers/models/oneformer/configuration_oneformer.py
+++ b/src/transformers/models/oneformer/configuration_oneformer.py
@@ -273,5 +273,9 @@ class OneFormerConfig(PretrainedConfig):
 
         super().__init__(**kwargs)
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["OneFormerConfig"]

--- a/src/transformers/models/pix2struct/configuration_pix2struct.py
+++ b/src/transformers/models/pix2struct/configuration_pix2struct.py
@@ -293,6 +293,7 @@ class Pix2StructConfig(PretrainedConfig):
     ```"""
 
     model_type = "pix2struct"
+    sub_configs = {"text_config": Pix2StructTextConfig, "vision_config": Pix2StructVisionConfig}
 
     def __init__(
         self,

--- a/src/transformers/models/prompt_depth_anything/configuration_prompt_depth_anything.py
+++ b/src/transformers/models/prompt_depth_anything/configuration_prompt_depth_anything.py
@@ -156,7 +156,11 @@ class PromptDepthAnythingConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     def to_dict(self):
         """

--- a/src/transformers/models/prompt_depth_anything/configuration_prompt_depth_anything.py
+++ b/src/transformers/models/prompt_depth_anything/configuration_prompt_depth_anything.py
@@ -154,6 +154,10 @@ class PromptDepthAnythingConfig(PretrainedConfig):
         self.depth_estimation_type = depth_estimation_type
         self.max_depth = max_depth if max_depth else 1
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     def to_dict(self):
         """
         Serializes this instance to a Python dictionary. Override the default [`~PretrainedConfig.to_dict`]. Returns:

--- a/src/transformers/models/rt_detr/configuration_rt_detr.py
+++ b/src/transformers/models/rt_detr/configuration_rt_detr.py
@@ -343,6 +343,10 @@ class RTDetrConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`RTDetrConfig`] (or a derived class) from a pre-trained backbone model configuration and DETR model

--- a/src/transformers/models/rt_detr/configuration_rt_detr.py
+++ b/src/transformers/models/rt_detr/configuration_rt_detr.py
@@ -345,7 +345,11 @@ class RTDetrConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/rt_detr_v2/configuration_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/configuration_rt_detr_v2.py
@@ -358,6 +358,10 @@ class RTDetrV2Config(PretrainedConfig):
         self.decoder_offset_scale = decoder_offset_scale
         self.decoder_method = decoder_method
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`RTDetrV2Config`] (or a derived class) from a pre-trained backbone model configuration and DETR model

--- a/src/transformers/models/rt_detr_v2/configuration_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/configuration_rt_detr_v2.py
@@ -360,7 +360,11 @@ class RTDetrV2Config(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
@@ -371,7 +371,11 @@ class RTDetrV2Config(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modular_rt_detr_v2.py
@@ -369,6 +369,10 @@ class RTDetrV2Config(PretrainedConfig):
         self.decoder_offset_scale = decoder_offset_scale
         self.decoder_method = decoder_method
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_configs(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`RTDetrV2Config`] (or a derived class) from a pre-trained backbone model configuration and DETR model

--- a/src/transformers/models/superglue/configuration_superglue.py
+++ b/src/transformers/models/superglue/configuration_superglue.py
@@ -114,5 +114,9 @@ class SuperGlueConfig(PretrainedConfig):
 
         super().__init__(**kwargs)
 
+    @property
+    def sub_configs(self):
+        return {"keypoint_detector_config": type(self.keypoint_detector_config)}
+
 
 __all__ = ["SuperGlueConfig"]

--- a/src/transformers/models/table_transformer/configuration_table_transformer.py
+++ b/src/transformers/models/table_transformer/configuration_table_transformer.py
@@ -253,6 +253,10 @@ class TableTransformerConfig(PretrainedConfig):
     def hidden_size(self) -> int:
         return self.d_model
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 # Copied from transformers.models.detr.configuration_detr.DetrOnnxConfig
 class TableTransformerOnnxConfig(OnnxConfig):

--- a/src/transformers/models/table_transformer/configuration_table_transformer.py
+++ b/src/transformers/models/table_transformer/configuration_table_transformer.py
@@ -255,7 +255,11 @@ class TableTransformerConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 # Copied from transformers.models.detr.configuration_detr.DetrOnnxConfig

--- a/src/transformers/models/tvp/configuration_tvp.py
+++ b/src/transformers/models/tvp/configuration_tvp.py
@@ -174,7 +174,11 @@ class TvpConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):

--- a/src/transformers/models/tvp/configuration_tvp.py
+++ b/src/transformers/models/tvp/configuration_tvp.py
@@ -172,6 +172,10 @@ class TvpConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.attention_probs_dropout_prob = attention_probs_dropout_prob
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     @classmethod
     def from_backbone_config(cls, backbone_config: PretrainedConfig, **kwargs):
         """Instantiate a [`TvpConfig`] (or a derived class) from a pre-trained backbone model configuration.

--- a/src/transformers/models/upernet/configuration_upernet.py
+++ b/src/transformers/models/upernet/configuration_upernet.py
@@ -136,5 +136,9 @@ class UperNetConfig(PretrainedConfig):
         self.auxiliary_concat_input = auxiliary_concat_input
         self.loss_ignore_index = loss_ignore_index
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["UperNetConfig"]

--- a/src/transformers/models/upernet/configuration_upernet.py
+++ b/src/transformers/models/upernet/configuration_upernet.py
@@ -138,7 +138,11 @@ class UperNetConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["UperNetConfig"]

--- a/src/transformers/models/vitmatte/configuration_vitmatte.py
+++ b/src/transformers/models/vitmatte/configuration_vitmatte.py
@@ -123,7 +123,11 @@ class VitMatteConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
     def to_dict(self):
         """

--- a/src/transformers/models/vitmatte/configuration_vitmatte.py
+++ b/src/transformers/models/vitmatte/configuration_vitmatte.py
@@ -121,6 +121,10 @@ class VitMatteConfig(PretrainedConfig):
         self.convstream_hidden_sizes = convstream_hidden_sizes
         self.fusion_hidden_sizes = fusion_hidden_sizes
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
     def to_dict(self):
         """
         Serializes this instance to a Python dictionary. Override the default [`~PretrainedConfig.to_dict`]. Returns:

--- a/src/transformers/models/vitpose/configuration_vitpose.py
+++ b/src/transformers/models/vitpose/configuration_vitpose.py
@@ -122,5 +122,9 @@ class VitPoseConfig(PretrainedConfig):
         self.scale_factor = scale_factor
         self.use_simple_decoder = use_simple_decoder
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["VitPoseConfig"]

--- a/src/transformers/models/vitpose/configuration_vitpose.py
+++ b/src/transformers/models/vitpose/configuration_vitpose.py
@@ -124,7 +124,11 @@ class VitPoseConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["VitPoseConfig"]

--- a/src/transformers/models/zoedepth/configuration_zoedepth.py
+++ b/src/transformers/models/zoedepth/configuration_zoedepth.py
@@ -233,5 +233,9 @@ class ZoeDepthConfig(PretrainedConfig):
         self.patch_transformer_intermediate_size = patch_transformer_intermediate_size
         self.patch_transformer_num_attention_heads = patch_transformer_num_attention_heads
 
+    @property
+    def sub_configs(self):
+        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+
 
 __all__ = ["ZOEDEPTH_PRETRAINED_CONFIG_ARCHIVE_MAP", "ZoeDepthConfig"]

--- a/src/transformers/models/zoedepth/configuration_zoedepth.py
+++ b/src/transformers/models/zoedepth/configuration_zoedepth.py
@@ -235,7 +235,11 @@ class ZoeDepthConfig(PretrainedConfig):
 
     @property
     def sub_configs(self):
-        return {"backbone_config": type(self.backbone_config)} if hasattr(self, "backbone_config") else {}
+        return (
+            {"backbone_config": type(self.backbone_config)}
+            if getattr(self, "backbone_config", None) is not None
+            else {}
+        )
 
 
 __all__ = ["ZOEDEPTH_PRETRAINED_CONFIG_ARCHIVE_MAP", "ZoeDepthConfig"]

--- a/tests/test_configuration_common.py
+++ b/tests/test_configuration_common.py
@@ -141,6 +141,7 @@ class ConfigTester:
                 # Verify that loading with subconfig class results in same dict as if we loaded with general composite config class
                 sub_config_loaded_dict = sub_config_loaded.to_dict()
                 sub_config_loaded_dict.pop("transformers_version", None)
+                general_config_dict[sub_config_key].pop("transformers_version", None)
                 self.parent.assertEqual(sub_config_loaded_dict, general_config_dict[sub_config_key])
 
                 # Verify that the loaded config type is same as in the general config

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4812,6 +4812,25 @@ class ModelTesterMixin:
                 f"All parameters should be on meta device, but found {unique_devices}.",
             )
 
+    def test_config_attn_implementation_setter(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+        def check_attn_implementation_setter(config: PretrainedConfig, attn_implementation: str):
+            if not config._attn_implementation == attn_implementation:
+                raise ValueError(
+                    f"Unexpected attn_implementation for config {config.__class__.__name__}: "
+                    f"{config._attn_implementation} != {attn_implementation}"
+                )
+            for attribute_value in config.__dict__.values():
+                if isinstance(attribute_value, PretrainedConfig):
+                    check_attn_implementation_setter(attribute_value, attn_implementation)
+
+        config._attn_implementation = "eager"
+        check_attn_implementation_setter(config, "eager")
+
+        config._attn_implementation = "sdpa"
+        check_attn_implementation_setter(config, "sdpa")
+
     def test_internal_model_config_and_subconfig_are_same(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         subconfig_keys = list(config.sub_configs.keys())


### PR DESCRIPTION
# What does this PR do?

Fix attn_implementation setter for models with `backbone_config`

#### On main:

```python
from transformers import VitPoseForPoseEstimation
model = VitPoseForPoseEstimation.from_pretrained(
    "usyd-community/vitpose-base-simple", attn_implementation="eager"
)

print(model.config._attn_implementation)
# "eager"
print(model.config.backbone_config._attn_implementation)
# "sdpa"
```

#### On branch:

```python
from transformers import VitPoseForPoseEstimation
model = VitPoseForPoseEstimation.from_pretrained(
    "usyd-community/vitpose-base-simple", attn_implementation="eager"
)

print(model.config._attn_implementation)
# "eager"
print(model.config.backbone_config._attn_implementation)
# "eager"
```