### PR TITLE
WIP: Initial support for bnb 4bit on any nn.Parameter

### DIFF
--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -150,7 +150,9 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             # bias could be loaded by regular set_module_tensor_to_device() from accelerate,
             # but it would wrongly use uninitialized weight there.
             return True
-        elif self.quantization_config.bnb_4bit_target_parameters is not None:            # Check if the parameter name is in the list of target parameters for quantization
+        elif (
+            self.quantization_config.bnb_4bit_target_parameters is not None
+        ):  # Check if the parameter name is in the list of target parameters for quantization
             return any(
                 target_param
                 for target_param in self.quantization_config.bnb_4bit_target_parameters
@@ -343,10 +345,12 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             matched_params = [
                 param_name
                 for param_name, _ in model.named_parameters()
-                if any(filter(
-                    lambda target_param: param_name.endswith("." + target_param) or param_name == target_param,
-                    self.quantization_config.bnb_4bit_target_parameters,
-                ))
+                if any(
+                    filter(
+                        lambda target_param: param_name.endswith("." + target_param) or param_name == target_param,
+                        self.quantization_config.bnb_4bit_target_parameters,
+                    )
+                )
             ]
 
             if any(matched_params):

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -151,11 +151,11 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             # but it would wrongly use uninitialized weight there.
             return True
         elif (
-            self.quantization_config.bnb_4bit_target_parameters is not None
+            self.quantization_config.target_parameters is not None
         ):  # Check if the parameter name is in the list of target parameters for quantization
             return any(
                 target_param
-                for target_param in self.quantization_config.bnb_4bit_target_parameters
+                for target_param in self.quantization_config.target_parameters
                 if param_name.endswith("." + target_param) or param_name == target_param
             )
 
@@ -242,7 +242,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                     device=target_device,
                     **param_kwargs,
                 )
-            elif self.quantization_config.bnb_4bit_target_parameters:
+            elif self.quantization_config.target_parameters:
                 # Normal nn.Parameter, i.e. outside of a Linear4bit layer.
                 import bitsandbytes.nn.parametrize
 
@@ -357,7 +357,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         )
         # TODO: consider bringing replace_with_bnb_linear() code from ..integrations/bitsandbyter.py to here
 
-        if self.quantization_config.bnb_4bit_target_parameters:
+        if self.quantization_config.target_parameters:
             # TODO: consider when param is in a module specified by modules_to_not_convert
             matched_params = [
                 param_name
@@ -365,7 +365,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                 if any(
                     filter(
                         lambda target_param: param_name.endswith("." + target_param) or param_name == target_param,
-                        self.quantization_config.bnb_4bit_target_parameters,
+                        self.quantization_config.target_parameters,
                     )
                 )
             ]
@@ -419,7 +419,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
     def _dequantize(self, model):
         from ..integrations import dequantize_and_replace
 
-        # TODO: support bnb_4bit_target_parameters
+        # TODO: support target_parameters
 
         model = dequantize_and_replace(
             model, self.modules_to_not_convert, quantization_config=self.quantization_config

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -307,7 +307,6 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             )
         return device_map
 
-    # Copied from transformers.quantizers.quantizer_bnb_8bit.Bnb8BitHfQuantizer._process_model_before_weight_loading
     def _process_model_before_weight_loading(
         self,
         model: "PreTrainedModel",

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -150,8 +150,14 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             # bias could be loaded by regular set_module_tensor_to_device() from accelerate,
             # but it would wrongly use uninitialized weight there.
             return True
-        else:
-            return False
+        elif self.quantization_config.bnb_4bit_target_parameters is not None:            # Check if the parameter name is in the list of target parameters for quantization
+            return any(
+                target_param
+                for target_param in self.quantization_config.bnb_4bit_target_parameters
+                if param_name.endswith("." + target_param) or param_name == target_param
+            )
+
+        return False
 
     def create_quantized_param(
         self,
@@ -187,8 +193,9 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             module._parameters[tensor_name] = new_value
             return
 
-        if not isinstance(module._parameters[tensor_name], bnb.nn.Params4bit):
-            raise ValueError("this function only loads `Linear4bit components`")
+        # if not isinstance(module._parameters[tensor_name], bnb.nn.Params4bit):
+        #    raise ValueError("this function only loads `Linear4bit components`")
+
         if (
             old_value.device == torch.device("meta")
             and target_device not in ["meta", torch.device("meta")]
@@ -203,7 +210,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
 
             if not self.is_serializable:
                 raise ValueError(
-                    "Detected int4 weights but the version of bitsandbytes is not compatible with int4 serialization. "
+                    "Detected 4bit weights but the version of bitsandbytes is not compatible with 4bit serialization. "
                     "Make sure to download the latest `bitsandbytes` version. `pip install --upgrade bitsandbytes`."
                 )
 
@@ -225,7 +232,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             if self.is_bnb_supports_quant_storage_module:
                 param_kwargs["module"] = module
 
-            new_value = bnb.nn.Params4bit.from_prequantized(
+            module._parameters[tensor_name] = bnb.nn.Params4bit.from_prequantized(
                 data=param_value,
                 quantized_stats=quantized_stats,
                 requires_grad=False,
@@ -237,13 +244,27 @@ class Bnb4BitHfQuantizer(HfQuantizer):
 
             # Support models using `Conv1D` in place of `nn.Linear` (e.g. openai-community/gpt2) by transposing the weight matrix prior to quantization.
             # Since weights are saved in the correct "orientation", we skip transposing when loading.
-            if issubclass(module.source_cls, Conv1D):
+            if hasattr(module, "source_cls") and issubclass(module.source_cls, Conv1D):
                 new_value = new_value.T
 
-            kwargs = old_value.__dict__
-            new_value = bnb.nn.Params4bit(new_value, requires_grad=False, **kwargs).to(target_device)
+            if isinstance(module._parameters[tensor_name], bnb.nn.Params4bit):
+                kwargs = old_value.__dict__
+                module._parameters[tensor_name] = bnb.nn.Params4bit(new_value, requires_grad=False, **kwargs).to(
+                    target_device
+                )
+            else:
+                # This is a regular parameter, i.e. outside of a Linear4bit layer.
+                import bitsandbytes.nn.parametrize
 
-        module._parameters[tensor_name] = new_value
+                module._parameters[tensor_name] = torch.nn.Parameter(
+                    param_value.to(target_device), requires_grad=False
+                )
+                bitsandbytes.nn.parametrize.replace_parameter_4bit(
+                    module,
+                    tensor_name,
+                    compress_statistics=self.quantization_config.bnb_4bit_use_double_quant,
+                    quant_type=self.quantization_config.bnb_4bit_quant_type,
+                )
 
     # Copied from transformers.quantizers.quantizer_bnb_8bit.Bnb8BitHfQuantizer.adjust_max_memory
     def adjust_max_memory(self, max_memory: dict[str, Union[int, str]]) -> dict[str, Union[int, str]]:
@@ -317,6 +338,33 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         )
         # TODO: consider bringing replace_with_bnb_linear() code from ..integrations/bitsandbyter.py to here
 
+        if self.quantization_config.bnb_4bit_target_parameters:
+            # TODO: consider when param is in a module specified by modules_to_not_convert
+            matched_params = [
+                param_name
+                for param_name, _ in model.named_parameters()
+                if any(filter(
+                    lambda target_param: param_name.endswith("." + target_param) or param_name == target_param,
+                    self.quantization_config.bnb_4bit_target_parameters,
+                ))
+            ]
+
+            if any(matched_params):
+                import bitsandbytes.nn.parametrize
+
+                for param_name in matched_params:
+                    module, tensor_name = get_module_from_name(model, param_name)
+
+                    # Fake quantize/replace parameter - we're in `init_empty_weights`
+                    # TODO: we could probably just infer the dtype/shape
+                    quantized_data, quant_state = bitsandbytes.functional.quantize_4bit(
+                        model.get_parameter(param_name).data,
+                        compress_statistics=self.quantization_config.bnb_4bit_use_double_quant,
+                        quant_type=self.quantization_config.bnb_4bit_quant_type,
+                    )
+
+                    setattr(module, tensor_name, torch.nn.Parameter(quantized_data, requires_grad=False))
+
         model.config.quantization_config = self.quantization_config
 
     # Copied from transformers.quantizers.quantizer_bnb_8bit.Bnb8BitHfQuantizer._process_model_after_weight_loading with 8bit->4bit
@@ -352,6 +400,8 @@ class Bnb4BitHfQuantizer(HfQuantizer):
 
     def _dequantize(self, model):
         from ..integrations import dequantize_and_replace
+
+        # TODO: support bnb_4bit_target_parameters
 
         model = dequantize_and_replace(
             model, self.modules_to_not_convert, quantization_config=self.quantization_config

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -242,7 +242,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                     device=target_device,
                     **param_kwargs,
                 )
-            elif self.quantization_config.bnb_4bit_target_paarameters:
+            elif self.quantization_config.bnb_4bit_target_parameters:
                 # Normal nn.Parameter, i.e. outside of a Linear4bit layer.
                 import bitsandbytes.nn.parametrize
 

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -141,9 +141,16 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         **kwargs,
     ) -> bool:
         import bitsandbytes as bnb
+        import bitsandbytes.nn.parametrize as bnb_parametrize
+
+        parametrizations = model.parametrizations.get(param_name, None)
+        has_bnb_4bit = any(isinstance(p, bnb_parametrize.Bnb4bitParametrization) for p in parametrizations) if isinstance(parametrizations, ModuleDict) else False
 
         module, tensor_name = get_module_from_name(model, param_name)
-        if isinstance(module._parameters.get(tensor_name, None), bnb.nn.Params4bit):
+        if has_bnb_4bit:
+            # explicit parametrization registered already
+            return True
+        elif isinstance(module._parameters.get(tensor_name, None), bnb.nn.Params4bit):
             # Add here check for loaded components' dtypes once serialization is implemented
             return True
         elif isinstance(module, bnb.nn.Linear4bit) and tensor_name == "bias":

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -358,7 +358,6 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         # TODO: consider bringing replace_with_bnb_linear() code from ..integrations/bitsandbyter.py to here
 
         if self.quantization_config.target_parameters:
-            # TODO: consider when param is in a module specified by modules_to_not_convert
             matched_params = [
                 param_name
                 for param_name, _ in model.named_parameters()
@@ -367,6 +366,9 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                         lambda target_param: param_name.endswith("." + target_param) or param_name == target_param,
                         self.quantization_config.target_parameters,
                     )
+                )
+                and not any(
+                    (key + "." in param_name) or (key == param_name) for key in self.modules_to_not_convert
                 )
             ]
 
@@ -419,9 +421,22 @@ class Bnb4BitHfQuantizer(HfQuantizer):
     def _dequantize(self, model):
         from ..integrations import dequantize_and_replace
 
-        # TODO: support target_parameters
-
         model = dequantize_and_replace(
             model, self.modules_to_not_convert, quantization_config=self.quantization_config
         )
+
+        # Remove parametrizations applied to target parameters, leaving the dequantized values
+        if self.quantization_config.target_parameters:
+            import torch.nn.utils.parametrize as P
+
+            for module_name, module in model.named_modules():
+                if P.is_parametrized(module):
+                    for param_name in list(module.parametrizations.keys()):
+                        full_name = f"{module_name}.{param_name}" if module_name else param_name
+                        if any(
+                            full_name.endswith("." + tp) or full_name == tp
+                            for tp in self.quantization_config.target_parameters
+                        ):
+                            P.remove_parametrizations(module, param_name, leave_parametrized=True)
+
         return model

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -581,9 +581,9 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
                 "4 bit quantization requires bitsandbytes>=0.39.0 - please upgrade your bitsandbytes version"
             )
 
-        if self.bnb_4bit_target_parameters is not None and bnb_version < version.parse("0.47.0"):
+        if self.bnb_4bit_target_parameters is not None and bnb_version < version.parse("0.48.0"):
             raise ValueError(
-                "bnb_4bit_target_parameters requires bitsandbytes>=0.47.0 - please upgrade your bitsandbytes version"
+                "bnb_4bit_target_parameters requires bitsandbytes>=0.48.0 - please upgrade your bitsandbytes version"
             )
 
     def is_quantizable(self):


### PR DESCRIPTION
# What does this PR do?

This PR adds a new option to `BitsAndBytesConfig` called `target_parameters` with the same spirit as `target_parameters` in huggingface/peft#2638. The intent is to allow quantization of `nn.Parameter` that are not within a `nn.Linear`, e.g. those found commonly in certain MoE model implementations.

Requires bitsandbytes-foundation/bitsandbytes#1720 which is released in bitsandbytes v0.48.0.

Example usage with a Granite MoE:

```python
model = GraniteMoeForCausalLM.from_pretrained(
    "ibm-granite/granite-3.1-3b-a800m-base",
    torch_dtype=torch.bfloat16,
    device_map="cuda:0",
    quantization_config=BitsAndBytesConfig(
        load_in_4bit=True,
        bnb_4bit_quant_type="nf4",
        bnb_4bit_compute_dtype=torch.bfloat16,
        bnb_4bit_use_double_quant=False,
        target_parameters=["block_sparse_moe.input_linear.weight", "block_sparse_moe.output_linear.weight"],
        llm_int8_skip_modules=["lm_head", "block_sparse_moe.router"]
    ),
)
```

**Memory Usage - BF16**
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|------------------|--------------|--------------|-----------|-------------|
| Allocated memory      |   6291 MiB |   6292 MiB |  12583 MiB |   6292 MiB |
| Active memory         |   6291 MiB |   6292 MiB |  12583 MiB |   6292 MiB |
| Requested memory      |   6291 MiB |   6291 MiB |  12583 MiB |   6291 MiB |

**Memory Usage - Before PR**
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|------------------|--------------|--------------|-----------|-------------|
| Allocated memory      |   6019 MiB |   6027 MiB |   9935 MiB |   3916 MiB |
| Active memory         |   6019 MiB |   6027 MiB |   9935 MiB |   3916 MiB |
| Requested memory      |   6015 MiB |   6024 MiB |   9929 MiB |   3913 MiB |

**Memory Usage - After PR**
|        Metric         | Cur Usage  | Peak Usage | Tot Alloc  | Tot Freed  |
|------------------|--------------|--------------|-----------|-------------|
| Allocated memory      |   1894 MiB |   2054 MiB |   9424 MiB |   7530 MiB |
| Active memory         |   1894 MiB |   2054 MiB |   9424 MiB |   7530 MiB |
| Requested memory      |   1875 MiB |   2035 MiB |   9389 MiB |   7513 MiB |


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
   (See Slack discussion)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc @MekkCyber @BenjaminBossan 

