### PR TITLE
fix: Catch correct ConnectionError for additional_chat_templates

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -176,7 +176,7 @@ def list_repo_templates(
             ]
         except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError):
             raise  # valid errors => do not catch
-        except (ConnectionError, HTTPError):
+        except (HTTPError, requests.exceptions.ConnectionError, requests.exceptions.Timeout):
             pass  # offline mode, internet down, etc. => try local files
 
     # check local files

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -176,14 +176,12 @@ def list_repo_templates(
             ]
         except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError):
             raise  # valid errors => do not catch
-        except (HTTPError, requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+        except (HTTPError, requests.exceptions.ConnectionError):
             pass  # offline mode, internet down, etc. => try local files
 
     # check local files
     try:
-        snapshot_dir = snapshot_download(
-            repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True
-        )
+        snapshot_dir = snapshot_download(repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True)
     except LocalEntryNotFoundError:  # No local repo means no local files
         return []
     templates_dir = Path(snapshot_dir, CHAT_TEMPLATE_DIR)

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -181,7 +181,9 @@ def list_repo_templates(
 
     # check local files
     try:
-        snapshot_dir = snapshot_download(repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True)
+        snapshot_dir = snapshot_download(
+            repo_id=repo_id, revision=revision, cache_dir=cache_dir, local_files_only=True
+        )
     except LocalEntryNotFoundError:  # No local repo means no local files
         return []
     templates_dir = Path(snapshot_dir, CHAT_TEMPLATE_DIR)


### PR DESCRIPTION
# What does this PR do?

Catch the correct `ConnectionError` when checking for `additional_chat_templates`.

Fixes #39873 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
