### PR TITLE
Set `torch.backends.cudnn.allow_tf32 = False` for CI

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -23,7 +23,7 @@ from os.path import abspath, dirname, join
 import _pytest
 import pytest
 
-from transformers.testing_utils import HfDoctestModule, HfDocTestParser
+from transformers.testing_utils import HfDoctestModule, HfDocTestParser, is_torch_available
 
 
 NOT_DEVICE_TESTS = {
@@ -128,3 +128,9 @@ class CustomOutputChecker(OutputChecker):
 doctest.OutputChecker = CustomOutputChecker
 _pytest.doctest.DoctestModule = HfDoctestModule
 doctest.DocTestParser = HfDocTestParser
+
+if is_torch_available():
+    import torch
+    # The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+    # We set it to `False` for CI.
+    torch.backends.cudnn.allow_tf32 = False

--- a/conftest.py
+++ b/conftest.py
@@ -132,5 +132,5 @@ doctest.DocTestParser = HfDocTestParser
 if is_torch_available():
     import torch
     # The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
-    # We set it to `False` for CI.
+    # We set it to `False` for CI. See https://github.com/pytorch/pytorch/issues/157274#issuecomment-3090791615
     torch.backends.cudnn.allow_tf32 = False


### PR DESCRIPTION
# What does this PR do?

See https://github.com/pytorch/pytorch/issues/157274#issuecomment-3090791615

(if we don't do this, we have to increase the thresholds in many tests when torch 2.8 is released) 