### PR TITLE
fix: Add einops as a core dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -410,6 +410,7 @@ extras["dev-torch"] = (
     + extras["modelcreation"]
     + extras["onnxruntime"]
     + extras["num2words"]
+    + deps_list("einops")
 )
 extras["dev-tensorflow"] = (
     extras["testing"]


### PR DESCRIPTION
# What does this PR do?

This PR addresses the `ModuleNotFoundError` for the `einops` library by adding it as a core dependency.

It fixes issue #39811, where certain parts of the `transformers` library, specifically in the flash attention code, were trying to import `einops` without it being a declared dependency. This bug prevented users from successfully running models that rely on this library.

By adding `einops` to `setup.py`, this PR ensures that the library is automatically installed for all users, making the `transformers` package more robust and reliable.

Fixes #39811


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. This PR fixes issue #39811.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
    > This change is a dependency fix and does not require a documentation update.
- [ ] Did you write any new necessary tests?
    > This change is a dependency fix and does not require a new test. The existing test suite was used to confirm that the `einops` dependency is now correctly installed.


## Who can review?

@ArthurZucker 
@ivarflakstad 
@iforgetmyname 