### PR TITLE
remove `triton_kernels` dep with `kernels` instead

### DIFF
--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -56,8 +56,12 @@ def quantize_to_mxfp4(w):
     return w, w_scale
 
 
-def swizzle_mxfp4(w, w_scale):    
-    FP4, convert_layout, wrap_torch_tensor = triton_kernels_hub.tensor.FP4, triton_kernels_hub.tensor.convert_layout, triton_kernels_hub.tensor.wrap_torch_tensor
+def swizzle_mxfp4(w, w_scale):
+    FP4, convert_layout, wrap_torch_tensor = (
+        triton_kernels_hub.tensor.FP4,
+        triton_kernels_hub.tensor.convert_layout,
+        triton_kernels_hub.tensor.wrap_torch_tensor,
+    )
     layout = triton_kernels_hub.tensor_details.layout
     StridedLayout = triton_kernels_hub.tensor_details.layout.StridedLayout
 
@@ -173,7 +177,11 @@ class Mxfp4GptOssExperts(nn.Module):
         self.down_proj_precision_config = None
 
     def forward(self, hidden_states: torch.Tensor, routing_data, gather_idx, scatter_idx) -> torch.Tensor:
-        FnSpecs, FusedActivation, matmul_ogs = triton_kernels_hub.matmul_ogs.FnSpecs, triton_kernels_hub.matmul_ogs.FusedActivation, triton_kernels_hub.matmul_ogs.matmul_ogs
+        FnSpecs, FusedActivation, matmul_ogs = (
+            triton_kernels_hub.matmul_ogs.FnSpecs,
+            triton_kernels_hub.matmul_ogs.FusedActivation,
+            triton_kernels_hub.matmul_ogs.matmul_ogs,
+        )
         swiglu_fn = triton_kernels_hub.swiglu.swiglu_fn
 
         with torch.cuda.device(hidden_states.device):
@@ -210,8 +218,14 @@ def routing_torch_dist(
     n_expts_act,
 ):
     import os
-    GatherIndx, RoutingData, ScatterIndx, compute_expt_data_torch = triton_kernels_hub.routing.GatherIndx, triton_kernels_hub.routing.RoutingData, triton_kernels_hub.routing.ScatterIndx, triton_kernels_hub.routing.compute_expt_data_torch
-    
+
+    GatherIndx, RoutingData, ScatterIndx, compute_expt_data_torch = (
+        triton_kernels_hub.routing.GatherIndx,
+        triton_kernels_hub.routing.RoutingData,
+        triton_kernels_hub.routing.ScatterIndx,
+        triton_kernels_hub.routing.compute_expt_data_torch,
+    )
+
     with torch.cuda.device(logits.device):
         world_size = torch.distributed.get_world_size()
         rank = int(os.environ.get("LOCAL_RANK", 0))
@@ -333,7 +347,11 @@ def dequantize(module, param_name, param_value, target_device, dq_param_name, **
 
 
 def load_and_swizzle_mxfp4(module, param_name, param_value, target_device, **kwargs):
-    PrecisionConfig, FlexCtx, InFlexData = triton_kernels_hub.matmul_ogs.PrecisionConfig, triton_kernels_hub.matmul_ogs.FlexCtx, triton_kernels_hub.matmul_ogs.InFlexData
+    PrecisionConfig, FlexCtx, InFlexData = (
+        triton_kernels_hub.matmul_ogs.PrecisionConfig,
+        triton_kernels_hub.matmul_ogs.FlexCtx,
+        triton_kernels_hub.matmul_ogs.InFlexData,
+    )
     from ..integrations.tensor_parallel import shard_and_distribute_module
 
     model = kwargs.get("model", None)
@@ -447,6 +465,7 @@ def replace_with_mxfp4_linear(
         return model
     else:
         from kernels import get_kernel
+
         global triton_kernels_hub
         triton_kernels_hub = get_kernel("kernels-community/triton_kernels")
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -170,7 +170,6 @@ from .utils import (
     is_torchdynamo_available,
     is_torchvision_available,
     is_triton_available,
-    is_triton_kernels_availalble,
     is_vision_available,
     is_vptq_available,
     strtobool,
@@ -469,13 +468,6 @@ def require_triton(min_version: str = TRITON_MIN_VERSION):
         )
 
     return decorator
-
-
-def require_triton_kernels(test_case):
-    """
-    Decorator marking a test that requires triton_kernels. These tests are skipped when triton_kernels isn't installed.
-    """
-    return unittest.skipUnless(is_triton_kernels_availalble(), "test requires triton_kernels")(test_case)
 
 
 def require_gguf(test_case, min_version: str = GGUF_MIN_VERSION):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -270,7 +270,6 @@ from .import_utils import (
     is_torchvision_v2_available,
     is_training_run_on_sagemaker,
     is_triton_available,
-    is_triton_kernels_availalble,
     is_uroman_available,
     is_vision_available,
     is_vptq_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -238,7 +238,6 @@ _kernels_available = _is_package_available("kernels")
 _matplotlib_available = _is_package_available("matplotlib")
 _mistral_common_available = _is_package_available("mistral_common")
 _triton_available, _triton_version = _is_package_available("triton", return_version=True)
-_triton_kernels_available = _is_package_available("triton_kernels")
 
 _torch_version = "N/A"
 _torch_available = False
@@ -421,10 +420,6 @@ def is_torch_deterministic():
 
 def is_triton_available(min_version: str = TRITON_MIN_VERSION):
     return _triton_available and version.parse(_triton_version) >= version.parse(min_version)
-
-
-def is_triton_kernels_availalble():
-    return _triton_kernels_available
 
 
 def is_hadamard_available():

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -368,12 +368,14 @@ class Mxfp4IntegrationTest(unittest.TestCase):
 
 @require_torch
 @require_torch_large_gpu
+@require_triton(min_version="3.4.0")
+@require_kernels
 @slow
 class Mxfp4ModelTest(unittest.TestCase):
     """Test mxfp4 with actual models (requires specific model and hardware)"""
 
     # These should be paths to real OpenAI MoE models for proper testing
-    model_name_packed = "/fsx/mohamed/oai-hf/tests/20b_converted_packed"  # TODO: Use real packed quantized model
+    model_name = "openai/gpt-oss-20b"
 
     input_text = "Once upon a time"
 
@@ -421,12 +423,12 @@ class Mxfp4ModelTest(unittest.TestCase):
         self.assertFalse(quantization_config.dequantize)
 
         model = GptOssForCausalLM.from_pretrained(
-            self.model_name_packed,
+            self.model_name,
             quantization_config=quantization_config,
             torch_dtype=torch.bfloat16,
             device_map="auto",
         )
-        tokenizer = AutoTokenizer.from_pretrained(self.model_name_packed)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         self.check_inference_correctness_quantized(model, tokenizer)
 
     def test_gpt_oss_model_loading_dequantized_with_device_map(self):
@@ -438,12 +440,12 @@ class Mxfp4ModelTest(unittest.TestCase):
         self.assertTrue(quantization_config.dequantize)
 
         model = GptOssForCausalLM.from_pretrained(
-            self.model_name_packed,
+            self.model_name,
             quantization_config=quantization_config,
             torch_dtype=torch.bfloat16,
             device_map="auto",
         )
-        tokenizer = AutoTokenizer.from_pretrained(self.model_name_packed)
+        tokenizer = AutoTokenizer.from_pretrained(self.model_name)
         self.check_inference_correctness_quantized(model, tokenizer)
 
     def test_model_device_map_validation(self):
@@ -464,12 +466,12 @@ class Mxfp4ModelTest(unittest.TestCase):
         # Expected: quantized < dequantized < unquantized memory usage
         quantization_config = Mxfp4Config(dequantize=True)
         quantized_model = GptOssForCausalLM.from_pretrained(
-            self.model_name_packed,
+            self.model_name,
             torch_dtype=torch.bfloat16,
             device_map="auto",
         )
         dequantized_model = GptOssForCausalLM.from_pretrained(
-            self.model_name_packed,
+            self.model_name,
             torch_dtype=torch.bfloat16,
             device_map="auto",
             quantization_config=quantization_config,

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -22,7 +22,7 @@ from transformers.testing_utils import (
     require_torch_gpu,
     require_torch_large_gpu,
     require_triton,
-    require_triton_kernels,
+    require_kernels,
     slow,
 )
 from transformers.utils import (
@@ -135,7 +135,7 @@ class Mxfp4QuantizerTest(unittest.TestCase):
         """Test quantizer validation when triton is not available"""
         with (
             patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=False),
-            patch("transformers.quantizers.quantizer_mxfp4.is_triton_kernels_availalble", return_value=False),
+            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_availalble", return_value=False),
         ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
@@ -149,7 +149,7 @@ class Mxfp4QuantizerTest(unittest.TestCase):
         """Test quantizer validation when triton is not available but model is pre-quantized and dequantize is False"""
         with (
             patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=False),
-            patch("transformers.quantizers.quantizer_mxfp4.is_triton_kernels_availalble", return_value=False),
+            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_availalble", return_value=False),
         ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
@@ -289,7 +289,7 @@ class Mxfp4IntegrationTest(unittest.TestCase):
         self.assertEqual(result.dtype, torch.bfloat16)
 
     @require_triton(min_version="3.4.0")
-    @require_triton_kernels
+    @require_kernels
     @require_torch_gpu
     @require_torch
     def test_quantize_to_mxfp4(self):

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -18,11 +18,11 @@ from unittest.mock import patch
 
 from transformers import AutoTokenizer, GptOssForCausalLM, Mxfp4Config
 from transformers.testing_utils import (
+    require_kernels,
     require_torch,
     require_torch_gpu,
     require_torch_large_gpu,
     require_triton,
-    require_kernels,
     slow,
 )
 from transformers.utils import (


### PR DESCRIPTION
# What does this PR do?

This PR remove `triton_kernels` dependency with `kernels` instead when using the new oai model gpt-oss