### PR TITLE
Add missing special token properties to MistralCommonTokenizer

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -332,7 +332,38 @@ class MistralCommonTokenizer(PushToHubMixin):
         String associated to the padding token in the vocabulary.
         """
         return self.convert_ids_to_tokens(self.pad_token_id)
+    
+    @property
+    def pad_token(self) -> str:
+        """
+        String associated to the padding token in the vocabulary.
+        """
+        return self.convert_ids_to_tokens(self.pad_token_id)
 
+    @property
+    def all_special_ids(self) -> list[int]:
+        """
+        List of all special token ids.
+        For compatibility with vLLM and other frameworks.
+        """
+        return list(self._all_special_ids())
+
+    @property  
+    def all_special_tokens(self) -> list[str]:
+        """
+        List of all special tokens as strings.
+        For compatibility with vLLM and other frameworks.
+        """
+        return self.convert_ids_to_tokens(self.all_special_ids, skip_special_tokens=False)
+
+    @property
+    def all_special_tokens_extended(self) -> list[str]:
+        """  
+        List of all special tokens including user-defined ones.
+        For compatibility with vLLM and other frameworks.
+        """
+        return self.all_special_tokens.copy()
+    
     @property
     def vocab_size(self) -> int:
         """


### PR DESCRIPTION
- Add all_special_ids property for vLLM compatibility
- Add all_special_tokens property
- Add all_special_tokens_extended property
- Fixes AttributeError when using with vLLM

# What does this PR do?

Fixes AttributeError when using `MistralCommonTokenizer` with vLLM by adding missing special token properties.

vLLM expects tokenizers to have `all_special_tokens`, `all_special_ids`, and `all_special_tokens_extended` properties, but `MistralCommonTokenizer` was missing these, causing:

AttributeError: 'MistralCommonTokenizer' object has no attribute 'all_special_tokens'

Fixes #39841


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
