### PR TITLE
feat: Support tensor inputs in ImageClassificationPipeline

### DIFF
--- a/src/transformers/pipelines/image_classification.py
+++ b/src/transformers/pipelines/image_classification.py
@@ -189,9 +189,12 @@ class ImageClassificationPipeline(Pipeline):
         return super().__call__(inputs, **kwargs)
 
     def preprocess(self, image, timeout=None):
-        image = load_image(image, timeout=timeout)
-        model_inputs = self.image_processor(images=image, return_tensors=self.framework)
-        if self.framework == "pt":
+        if isinstance(image, (np.ndarray, torch.Tensor)):
+            model_inputs = self.image_processor(images=image, return_tensors=self.framework)
+        else:
+            image = load_image(image, timeout=timeout)
+            model_inputs = self.image_processor(images=image, return_tensors=self.framework)
+        if self.framework == "pt" and self.torch_dtype is not None:
             model_inputs = model_inputs.to(self.torch_dtype)
         return model_inputs
 

--- a/tests/pipelines/test_pipelines_image_classification.py
+++ b/tests/pipelines/test_pipelines_image_classification.py
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 import unittest
-
+import os
+import numpy as np
 import datasets
 from huggingface_hub import ImageClassificationOutputElement
 
@@ -173,6 +174,27 @@ class ImageClassificationPipelineTests(unittest.TestCase):
                 [{"label": "LABEL_1", "score": 0.574}, {"label": "LABEL_0", "score": 0.426}],
             ],
         )
+    
+    @require_torch
+    def test_image_classification_pipeline_with_tensors(self):
+        # Create a dummy pipeline
+        pipe = pipeline("image-classification", model="hf-internal-testing/tiny-random-vit")
+        
+        # Create a dummy image tensor/array
+        dummy_tensor_pt = torch.rand(3, 224, 224)
+        dummy_array_np = np.random.rand(224, 224, 3).astype(np.float32)
+    
+        # Assert that the pipeline works with a PyTorch tensor
+        output_pt = pipe(dummy_tensor_pt)
+        self.assertIsInstance(output_pt, list)
+        self.assertGreater(len(output_pt), 0)
+        self.assertIsInstance(output_pt[0], dict)
+
+        # Assert that the pipeline works with a NumPy array
+        output_np = pipe(dummy_array_np)
+        self.assertIsInstance(output_np, list)
+        self.assertGreater(len(output_np), 0)
+        self.assertIsInstance(output_np[0], dict)
 
     def test_custom_tokenizer(self):
         tokenizer = PreTrainedTokenizerBase()


### PR DESCRIPTION
# What does this PR do?
Adds support for accepting numpy arrays and pytorch tensors as direct inputs to the 'ImageClassificationPipeline'. Currently the pipelines 'preprocess' function only accepts PIL images or file paths. Made the pipeline flexible to use with existing datasets and data pipelines as requested in the issue

Fixes #39607 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (This was discussed in issue [#39607).](https://github.com/huggingface/transformers/issues/39607)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@Rocketknight1 
@zucchini-nlp 
