### PR TITLE
Use torch._check instead of a test to make the model Gemma3 exportable

### DIFF
--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -999,7 +999,7 @@ class AriaModel(AriaPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -996,10 +996,12 @@ class AriaModel(AriaPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/aya_vision/modeling_aya_vision.py
+++ b/src/transformers/models/aya_vision/modeling_aya_vision.py
@@ -263,7 +263,7 @@ class AyaVisionModel(AyaVisionPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/aya_vision/modeling_aya_vision.py
+++ b/src/transformers/models/aya_vision/modeling_aya_vision.py
@@ -260,10 +260,12 @@ class AyaVisionModel(AyaVisionPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @check_model_inputs

--- a/src/transformers/models/chameleon/modeling_chameleon.py
+++ b/src/transformers/models/chameleon/modeling_chameleon.py
@@ -905,10 +905,12 @@ class ChameleonModel(ChameleonPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+            ),
+        )
         return special_image_mask
 
     @auto_docstring

--- a/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py
@@ -218,7 +218,7 @@ class Cohere2VisionModel(Cohere2VisionPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py
@@ -215,10 +215,12 @@ class Cohere2VisionModel(Cohere2VisionPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @check_model_inputs

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -1401,10 +1401,12 @@ class Emu3Model(Emu3PreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/emu3/modular_emu3.py
+++ b/src/transformers/models/emu3/modular_emu3.py
@@ -983,10 +983,12 @@ class Emu3Model(Emu3PreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/fuyu/modeling_fuyu.py
+++ b/src/transformers/models/fuyu/modeling_fuyu.py
@@ -165,10 +165,12 @@ class FuyuModel(FuyuPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+            ),
+        )
         return special_image_mask
 
     @auto_docstring

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -818,7 +818,10 @@ class Gemma3Model(Gemma3PreTrainedModel):
         n_image_features = image_features.shape[0] * image_features.shape[1]
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
-            message=f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
+                f"features {n_image_features}.",
+            ),
         )
         return special_image_mask
 

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -819,8 +819,7 @@ class Gemma3Model(Gemma3PreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
-                f"features {n_image_features}.",
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
             ),
         )
         return special_image_mask

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -819,7 +819,7 @@ class Gemma3Model(Gemma3PreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -816,10 +816,10 @@ class Gemma3Model(Gemma3PreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/got_ocr2/modeling_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/modeling_got_ocr2.py
@@ -594,7 +594,7 @@ class GotOcr2Model(GotOcr2PreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/got_ocr2/modeling_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/modeling_got_ocr2.py
@@ -591,10 +591,12 @@ class GotOcr2Model(GotOcr2PreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/internvl/modeling_internvl.py
+++ b/src/transformers/models/internvl/modeling_internvl.py
@@ -652,7 +652,7 @@ class InternVLModel(InternVLPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/internvl/modeling_internvl.py
+++ b/src/transformers/models/internvl/modeling_internvl.py
@@ -649,10 +649,12 @@ class InternVLModel(InternVLPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -236,10 +236,13 @@ class LlavaModel(LlavaPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
+                f"features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -239,8 +239,7 @@ class LlavaModel(LlavaPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
-                f"features {n_image_features}",
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
             ),
         )
         return special_image_mask

--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -239,7 +239,7 @@ class LlavaModel(LlavaPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/mistral3/modeling_mistral3.py
+++ b/src/transformers/models/mistral3/modeling_mistral3.py
@@ -283,7 +283,7 @@ class Mistral3Model(Mistral3PreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/mistral3/modeling_mistral3.py
+++ b/src/transformers/models/mistral3/modeling_mistral3.py
@@ -280,10 +280,13 @@ class Mistral3Model(Mistral3PreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
+                f"features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/mistral3/modeling_mistral3.py
+++ b/src/transformers/models/mistral3/modeling_mistral3.py
@@ -283,8 +283,7 @@ class Mistral3Model(Mistral3PreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
-                f"features {n_image_features}",
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
             ),
         )
         return special_image_mask

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -268,10 +268,13 @@ class PaliGemmaModel(PaliGemmaPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
+                f"features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @can_return_tuple

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -271,7 +271,7 @@ class PaliGemmaModel(PaliGemmaPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -271,8 +271,7 @@ class PaliGemmaModel(PaliGemmaPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, "
-                f"features {n_image_features}",
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
             ),
         )
         return special_image_mask

--- a/src/transformers/models/vipllava/modeling_vipllava.py
+++ b/src/transformers/models/vipllava/modeling_vipllava.py
@@ -204,10 +204,12 @@ class VipLlavaModel(VipLlavaPreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            message=(
+                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+            ),
+        )
         return special_image_mask
 
     @auto_docstring

--- a/src/transformers/models/vipllava/modeling_vipllava.py
+++ b/src/transformers/models/vipllava/modeling_vipllava.py
@@ -207,7 +207,7 @@ class VipLlavaModel(VipLlavaPreTrainedModel):
         torch._check(
             inputs_embeds[special_image_mask].numel() == image_features.numel(),
             message=(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+                lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
             ),
         )
         return special_image_mask

--- a/tests/models/chameleon/test_modeling_chameleon.py
+++ b/tests/models/chameleon/test_modeling_chameleon.py
@@ -347,7 +347,7 @@ class ChameleonVision2SeqModelTest(ModelTesterMixin, GenerationTesterMixin, unit
 
             # remove one image but leave the image token in text
             curr_input_dict["pixel_values"] = curr_input_dict["pixel_values"][-1:, ...]
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(**curr_input_dict)
 
             # simulate multi-image case by concatenating inputs where each has exactly one image/image-token
@@ -356,7 +356,7 @@ class ChameleonVision2SeqModelTest(ModelTesterMixin, GenerationTesterMixin, unit
             input_ids = torch.cat([input_ids, input_ids], dim=0)
 
             # one image and two image tokens raise an error
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(input_ids=input_ids, pixel_values=pixel_values)
 
             # two images and two image tokens don't raise an error

--- a/tests/models/llava/test_modeling_llava.py
+++ b/tests/models/llava/test_modeling_llava.py
@@ -211,7 +211,7 @@ class LlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTesterM
 
             # remove one image but leave the image token in text
             curr_input_dict["pixel_values"] = curr_input_dict["pixel_values"][-1:, ...]
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(**curr_input_dict)
 
             # simulate multi-image case by concatenating inputs where each has exactly one image/image-token
@@ -220,7 +220,7 @@ class LlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTesterM
             input_ids = torch.cat([input_ids, input_ids], dim=0)
 
             # one image and two image tokens raise an error
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(input_ids=input_ids, pixel_values=pixel_values)
 
             # two images and two image tokens don't raise an error

--- a/tests/models/paligemma/test_modeling_paligemma.py
+++ b/tests/models/paligemma/test_modeling_paligemma.py
@@ -214,7 +214,7 @@ class PaliGemmaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
 
             # remove one image but leave the image token in text
             curr_input_dict["pixel_values"] = curr_input_dict["pixel_values"][-1:, ...]
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(**curr_input_dict)
 
             # simulate multi-image case by concatenating inputs where each has exactly one image/image-token
@@ -223,7 +223,7 @@ class PaliGemmaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
             input_ids = torch.cat([input_ids, input_ids], dim=0)
 
             # one image and two image tokens raise an error
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(input_ids=input_ids, pixel_values=pixel_values)
 
             # two images and two image tokens don't raise an error

--- a/tests/models/paligemma2/test_modeling_paligemma2.py
+++ b/tests/models/paligemma2/test_modeling_paligemma2.py
@@ -198,7 +198,7 @@ class PaliGemma2ForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
 
             # remove one image but leave the image token in text
             curr_input_dict["pixel_values"] = curr_input_dict["pixel_values"][-1:, ...]
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(**curr_input_dict)
 
             # simulate multi-image case by concatenating inputs where each has exactly one image/image-token
@@ -207,7 +207,7 @@ class PaliGemma2ForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
             input_ids = torch.cat([input_ids, input_ids], dim=0)
 
             # one image and two image tokens raise an error
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(input_ids=input_ids, pixel_values=pixel_values)
 
             # two images and two image tokens don't raise an error

--- a/tests/models/vipllava/test_modeling_vipllava.py
+++ b/tests/models/vipllava/test_modeling_vipllava.py
@@ -207,7 +207,7 @@ class VipLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTest
 
             # remove one image but leave the image token in text
             curr_input_dict["pixel_values"] = curr_input_dict["pixel_values"][-1:, ...]
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(**curr_input_dict)
 
             # simulate multi-image case by concatenating inputs where each has exactly one image/image-token
@@ -216,7 +216,7 @@ class VipLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTest
             input_ids = torch.cat([input_ids, input_ids], dim=0)
 
             # one image and two image tokens raise an error
-            with self.assertRaises(ValueError):
+            with self.assertRaises(RuntimeError):
                 _ = model(input_ids=input_ids, pixel_values=pixel_values)
 
             # two images and two image tokens don't raise an error


### PR DESCRIPTION
# What does this PR do?

torch.export.export fails on a tests used to raise an exception if not true. This is replaced by torch._check to avoid torch.export.export complain about it.

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
