### PR TITLE
fix glm4v image process

### DIFF
--- a/src/transformers/models/glm4v/image_processing_glm4v.py
+++ b/src/transformers/models/glm4v/image_processing_glm4v.py
@@ -139,11 +139,13 @@ class Glm4vImageProcessor(BaseImageProcessor):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if size is not None and ("shortest_edge" not in size or "longest_edge" not in size):
-            raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+        if size is not None:
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+            else:
+                self.size = size
         else:
             size = {"shortest_edge": 112 * 112, "longest_edge": 28 * 28 * 15000}
-        self.size = size
 
         self.do_resize = do_resize
         self.resample = resample

--- a/src/transformers/models/glm4v/image_processing_glm4v.py
+++ b/src/transformers/models/glm4v/image_processing_glm4v.py
@@ -139,13 +139,11 @@ class Glm4vImageProcessor(BaseImageProcessor):
         **kwargs,
     ) -> None:
         super().__init__(**kwargs)
-        if size is not None:
-            if "shortest_edge" not in size or "longest_edge" not in size:
-                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
-            else:
-                self.size = size
-        else:
+        if size is not None and ("shortest_edge" not in size or "longest_edge" not in size):
+            raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+        elif size is None:
             size = {"shortest_edge": 112 * 112, "longest_edge": 28 * 28 * 15000}
+        self.size = size
 
         self.do_resize = do_resize
         self.resample = resample


### PR DESCRIPTION
@amyeroberts , @qubvel 

Issue: shortest_edge and longest_edge in preprocess_config.json are being ignored during GLM-4V image preprocessing. Please investigate and fix.

