### PR TITLE
fix: remove CHAT_TEMPLATE import in tests for deepseek-vl

### DIFF
--- a/tests/models/deepseek_vl/test_processing_deepseek_vl.py
+++ b/tests/models/deepseek_vl/test_processing_deepseek_vl.py
@@ -16,7 +16,6 @@ import tempfile
 import unittest
 
 from transformers import DeepseekVLProcessor, LlamaTokenizer
-from transformers.models.deepseek_vl.convert_deepseek_vl_weights_to_hf import CHAT_TEMPLATE
 from transformers.testing_utils import get_tests_dir
 from transformers.utils import is_vision_available
 
@@ -46,9 +45,12 @@ class DeepseekVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor = self.processor_class(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            chat_template=CHAT_TEMPLATE,
+            chat_template="dummy_template",
         )
         processor.save_pretrained(self.tmpdirname)
 
     def prepare_processor_dict(self):
-        return {"chat_template": CHAT_TEMPLATE, "num_image_tokens": 576}
+        return {
+            "chat_template": "{% set seps = ['\n\n', '<\uff5cend\u2581of\u2581sentence\uff5c>'] %}{% set i = 0 %}You are a helpful language and vision assistant. You are able to understand the visual content that the user provides, and assist the user with a variety of tasks using natural language.\n\n{% for message in messages %}{% if message['role']|lower == 'user' %}User: {% elif message['role']|lower == 'assistant' %}Assistant:{% if not (loop.last and not add_generation_prompt and message['content'][0]['type']=='text' and message['content'][0]['text']=='') %} {% endif %}{% else %}{{ message['role'].capitalize() }}: {% endif %}{% for content in message['content'] %}{% if content['type'] == 'image' %}<image_placeholder>{% elif content['type'] == 'text' %}{% set text = content['text'] %}{% if loop.first %}{% set text = text.lstrip() %}{% endif %}{% if loop.last %}{% set text = text.rstrip() %}{% endif %}{% if not loop.first and message['content'][loop.index0-1]['type'] == 'text' %}{{ ' ' + text }}{% else %}{{ text }}{% endif %}{% endif %}{% endfor %}{% if not loop.last or add_generation_prompt %}{% if message['role']|lower == 'user' %}{{ seps[0] }}{% else %}{{ seps[1] }}{% endif %}{% endif %}{% endfor %}{% if add_generation_prompt %}Assistant:{% endif %}",
+            "num_image_tokens": 576,
+        }

--- a/tests/models/deepseek_vl/test_processing_deepseek_vl.py
+++ b/tests/models/deepseek_vl/test_processing_deepseek_vl.py
@@ -42,15 +42,17 @@ class DeepseekVLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                 "image_token": "<image_placeholder>",
             },
         )
+        processor_kwargs = self.prepare_processor_dict()
         processor = self.processor_class(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            chat_template="dummy_template",
+            **processor_kwargs,
         )
         processor.save_pretrained(self.tmpdirname)
 
-    def prepare_processor_dict(self):
+    @staticmethod
+    def prepare_processor_dict():
         return {
             "chat_template": "{% set seps = ['\n\n', '<\uff5cend\u2581of\u2581sentence\uff5c>'] %}{% set i = 0 %}You are a helpful language and vision assistant. You are able to understand the visual content that the user provides, and assist the user with a variety of tasks using natural language.\n\n{% for message in messages %}{% if message['role']|lower == 'user' %}User: {% elif message['role']|lower == 'assistant' %}Assistant:{% if not (loop.last and not add_generation_prompt and message['content'][0]['type']=='text' and message['content'][0]['text']=='') %} {% endif %}{% else %}{{ message['role'].capitalize() }}: {% endif %}{% for content in message['content'] %}{% if content['type'] == 'image' %}<image_placeholder>{% elif content['type'] == 'text' %}{% set text = content['text'] %}{% if loop.first %}{% set text = text.lstrip() %}{% endif %}{% if loop.last %}{% set text = text.rstrip() %}{% endif %}{% if not loop.first and message['content'][loop.index0-1]['type'] == 'text' %}{{ ' ' + text }}{% else %}{{ text }}{% endif %}{% endif %}{% endfor %}{% if not loop.last or add_generation_prompt %}{% if message['role']|lower == 'user' %}{{ seps[0] }}{% else %}{{ seps[1] }}{% endif %}{% endif %}{% endfor %}{% if add_generation_prompt %}Assistant:{% endif %}",
             "num_image_tokens": 576,
-        }
+        }  # fmt: skip

--- a/tests/models/deepseek_vl_hybrid/test_processing_deepseek_vl_hybrid.py
+++ b/tests/models/deepseek_vl_hybrid/test_processing_deepseek_vl_hybrid.py
@@ -42,15 +42,17 @@ class DeepseekVLHybridProcessorTest(ProcessorTesterMixin, unittest.TestCase):
                 "image_token": "<image_placeholder>",
             },
         )
+        processor_kwargs = self.prepare_processor_dict()
         processor = self.processor_class(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            chat_template="dummy_template",
+            **processor_kwargs,
         )
         processor.save_pretrained(self.tmpdirname)
 
-    def prepare_processor_dict(self):
+    @staticmethod
+    def prepare_processor_dict():
         return {
             "chat_template": "{% set seps = ['\n\n', '<\uff5cend\u2581of\u2581sentence\uff5c>'] %}{% set i = 0 %}You are a helpful language and vision assistant. You are able to understand the visual content that the user provides, and assist the user with a variety of tasks using natural language.\n\n{% for message in messages %}{% if message['role']|lower == 'user' %}User: {% elif message['role']|lower == 'assistant' %}Assistant:{% if not (loop.last and not add_generation_prompt and message['content'][0]['type']=='text' and message['content'][0]['text']=='') %} {% endif %}{% else %}{{ message['role'].capitalize() }}: {% endif %}{% for content in message['content'] %}{% if content['type'] == 'image' %}<image_placeholder>{% elif content['type'] == 'text' %}{% set text = content['text'] %}{% if loop.first %}{% set text = text.lstrip() %}{% endif %}{% if loop.last %}{% set text = text.rstrip() %}{% endif %}{% if not loop.first and message['content'][loop.index0-1]['type'] == 'text' %}{{ ' ' + text }}{% else %}{{ text }}{% endif %}{% endif %}{% endfor %}{% if not loop.last or add_generation_prompt %}{% if message['role']|lower == 'user' %}{{ seps[0] }}{% else %}{{ seps[1] }}{% endif %}{% endif %}{% endfor %}{% if add_generation_prompt %}Assistant:{% endif %}",
             "num_image_tokens": 576,
-        }
+        }  # fmt: skip

--- a/tests/models/deepseek_vl_hybrid/test_processing_deepseek_vl_hybrid.py
+++ b/tests/models/deepseek_vl_hybrid/test_processing_deepseek_vl_hybrid.py
@@ -16,7 +16,6 @@ import tempfile
 import unittest
 
 from transformers import DeepseekVLHybridProcessor, LlamaTokenizer
-from transformers.models.deepseek_vl.convert_deepseek_vl_weights_to_hf import CHAT_TEMPLATE
 from transformers.testing_utils import get_tests_dir
 from transformers.utils import is_vision_available
 
@@ -46,9 +45,12 @@ class DeepseekVLHybridProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         processor = self.processor_class(
             image_processor=image_processor,
             tokenizer=tokenizer,
-            chat_template=CHAT_TEMPLATE,
+            chat_template="dummy_template",
         )
         processor.save_pretrained(self.tmpdirname)
 
     def prepare_processor_dict(self):
-        return {"chat_template": CHAT_TEMPLATE, "num_image_tokens": 576}
+        return {
+            "chat_template": "{% set seps = ['\n\n', '<\uff5cend\u2581of\u2581sentence\uff5c>'] %}{% set i = 0 %}You are a helpful language and vision assistant. You are able to understand the visual content that the user provides, and assist the user with a variety of tasks using natural language.\n\n{% for message in messages %}{% if message['role']|lower == 'user' %}User: {% elif message['role']|lower == 'assistant' %}Assistant:{% if not (loop.last and not add_generation_prompt and message['content'][0]['type']=='text' and message['content'][0]['text']=='') %} {% endif %}{% else %}{{ message['role'].capitalize() }}: {% endif %}{% for content in message['content'] %}{% if content['type'] == 'image' %}<image_placeholder>{% elif content['type'] == 'text' %}{% set text = content['text'] %}{% if loop.first %}{% set text = text.lstrip() %}{% endif %}{% if loop.last %}{% set text = text.rstrip() %}{% endif %}{% if not loop.first and message['content'][loop.index0-1]['type'] == 'text' %}{{ ' ' + text }}{% else %}{{ text }}{% endif %}{% endif %}{% endfor %}{% if not loop.last or add_generation_prompt %}{% if message['role']|lower == 'user' %}{{ seps[0] }}{% else %}{{ seps[1] }}{% endif %}{% endif %}{% endfor %}{% if add_generation_prompt %}Assistant:{% endif %}",
+            "num_image_tokens": 576,
+        }


### PR DESCRIPTION
# What does this PR do?

Fixes #39966

This PR removes the `CHAT_TEMPLATE` imports from `test_processing_deepseek_vl.py` and `test_processing_deepseek_vl_hybrid.py`. These imports were referencing weight conversion scripts that are not included in the PyPI distribution, which causes the tests to fail in the v4.55.0 release.

The fix aligns with the approach used in [test_processing_emu3.py](https://github.com/huggingface/transformers/blob/main/tests/models/emu3/test_processing_emu3.py)

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you write any new necessary tests?


## Who can review?

@rasmi @zucchini-nlp @ArthurZucker