### PR TITLE
[fix] Pass video inputs to plm

### DIFF
--- a/src/transformers/models/perception_lm/processing_perception_lm.py
+++ b/src/transformers/models/perception_lm/processing_perception_lm.py
@@ -170,7 +170,7 @@ class PerceptionLMProcessor(ProcessorMixin):
             mm_token_type_ids[array_ids == self.image_token_id] = 1
             text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
 
-        return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
+        return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 
     def _expand_media_tokens(self, sample, media_token: str, media_iter: Iterable):
         media_count = sample.count(media_token)


### PR DESCRIPTION
1. video_inputs were not being passed to plm, resulting in same results for all videos.
2. This was breaking the official example. more @ https://github.com/huggingface/transformers/issues/40004
3. tested locally with different videos

# Pass video inputs to plm

Fixes # [40004](https://github.com/huggingface/transformers/issues/40004) 

 
## Who can review?
@zucchini-nlp


