### PR TITLE
Fix PerceptionLM image preprocessing for non-tiled image input.

### DIFF
--- a/src/transformers/models/perception_lm/image_processing_perception_lm_fast.py
+++ b/src/transformers/models/perception_lm/image_processing_perception_lm_fast.py
@@ -310,7 +310,7 @@ class PerceptionLMImageProcessorFast(BaseImageProcessorFast):
             )
             processed_images_grouped[shape] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
-
+        processed_images = [p[None] if p.ndim == 3 else p for p in processed_images]  # add tiles dimension if needed
         processed_images = torch.stack(processed_images, dim=0) if return_tensors else processed_images
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 

--- a/tests/models/perception_lm/test_processing_perception_lm.py
+++ b/tests/models/perception_lm/test_processing_perception_lm.py
@@ -120,7 +120,7 @@ class PerceptionLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
 @require_vision
 @require_read_token
-# @unittest.skip("Fequires read token and we didn't requests access yet. FIXME @ydshieh when you are back :)")
+@unittest.skip("Fequires read token and gwe didn't requests access yet. FIXME @ydshieh when you are back :)")
 class PerceptionLMProcessorSingleTileVanillaImageTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = PerceptionLMProcessor
 

--- a/tests/models/perception_lm/test_processing_perception_lm.py
+++ b/tests/models/perception_lm/test_processing_perception_lm.py
@@ -117,7 +117,7 @@ class PerceptionLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(expected_image_tokens, image_tokens)
         self.assertEqual(inputs["pixel_values"].ndim, 5)
 
-    def test_vanilla_image_with_tiles_token_filling(self):
+    def test_vanilla_image_with_no_tiles_token_filling(self):
         processor = self.processor_class.from_pretrained(self.tmpdirname)
         processor.image_processor.vision_input_type = "vanilla"
         # Important to check with non square image

--- a/tests/models/perception_lm/test_processing_perception_lm.py
+++ b/tests/models/perception_lm/test_processing_perception_lm.py
@@ -118,10 +118,9 @@ class PerceptionLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(inputs["pixel_values"].ndim, 5)
 
 
-
 @require_vision
 @require_read_token
-@unittest.skip("Fequires read token and we didn't requests access yet. FIXME @ydshieh when you are back :)")
+# @unittest.skip("Fequires read token and we didn't requests access yet. FIXME @ydshieh when you are back :)")
 class PerceptionLMProcessorSingleTileVanillaImageTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = PerceptionLMProcessor
 
@@ -129,9 +128,7 @@ class PerceptionLMProcessorSingleTileVanillaImageTest(ProcessorTesterMixin, unit
     def setUpClass(cls):
         cls.tmpdirname = tempfile.mkdtemp()
 
-        image_processor = PerceptionLMImageProcessorFast(
-            tile_size=448, max_num_tiles=1, vision_input_type="vanilla"
-        )
+        image_processor = PerceptionLMImageProcessorFast(tile_size=448, max_num_tiles=1, vision_input_type="vanilla")
         video_processor = PerceptionLMVideoProcessor()
         tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_PATH)
         tokenizer.add_special_tokens({"additional_special_tokens": ["<|image|>", "<|video|>"]})
@@ -160,7 +157,6 @@ class PerceptionLMProcessorSingleTileVanillaImageTest(ProcessorTesterMixin, unit
             "patch_size": 14,
             "pooling_ratio": 2,
         }  # fmt: skip
-      
 
     def test_image_token_filling(self):
         processor = self.processor_class.from_pretrained(self.tmpdirname)

--- a/tests/models/perception_lm/test_processing_perception_lm.py
+++ b/tests/models/perception_lm/test_processing_perception_lm.py
@@ -117,49 +117,9 @@ class PerceptionLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(expected_image_tokens, image_tokens)
         self.assertEqual(inputs["pixel_values"].ndim, 5)
 
-
-@require_vision
-@require_read_token
-@unittest.skip("Fequires read token and gwe didn't requests access yet. FIXME @ydshieh when you are back :)")
-class PerceptionLMProcessorSingleTileVanillaImageTest(ProcessorTesterMixin, unittest.TestCase):
-    processor_class = PerceptionLMProcessor
-
-    @classmethod
-    def setUpClass(cls):
-        cls.tmpdirname = tempfile.mkdtemp()
-
-        image_processor = PerceptionLMImageProcessorFast(tile_size=448, max_num_tiles=1, vision_input_type="vanilla")
-        video_processor = PerceptionLMVideoProcessor()
-        tokenizer = AutoTokenizer.from_pretrained(TEST_MODEL_PATH)
-        tokenizer.add_special_tokens({"additional_special_tokens": ["<|image|>", "<|video|>"]})
-        processor_kwargs = cls.prepare_processor_dict()
-        processor = PerceptionLMProcessor(
-            image_processor=image_processor, video_processor=video_processor, tokenizer=tokenizer, **processor_kwargs
-        )
-        processor.save_pretrained(cls.tmpdirname)
-        cls.image_token_id = processor.image_token_id
-        cls.video_token_id = processor.video_token_id
-
-    def get_tokenizer(self, **kwargs):
-        return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).tokenizer
-
-    def get_image_processor(self, **kwargs):
-        return AutoProcessor.from_pretrained(self.tmpdirname, **kwargs).image_processor
-
-    @classmethod
-    def tearDownClass(cls):
-        shutil.rmtree(cls.tmpdirname, ignore_errors=True)
-
-    @staticmethod
-    def prepare_processor_dict():
-        return {
-            "chat_template": CHAT_TEMPLATE,
-            "patch_size": 14,
-            "pooling_ratio": 2,
-        }  # fmt: skip
-
-    def test_image_token_filling(self):
+    def test_vanilla_image_with_tiles_token_filling(self):
         processor = self.processor_class.from_pretrained(self.tmpdirname)
+        processor.image_processor.vision_input_type = "vanilla"
         # Important to check with non square image
         image = torch.randn((1, 3, 450, 500))
         #  1 tile
@@ -184,6 +144,7 @@ class PerceptionLMProcessorSingleTileVanillaImageTest(ProcessorTesterMixin, unit
         image_tokens = (inputs["input_ids"] == image_token_index).sum().item()
         self.assertEqual(expected_image_tokens, image_tokens)
         self.assertEqual(inputs["pixel_values"].ndim, 5)
+        self.assertEqual(inputs["pixel_values"].shape[1], 1)  # 1 tile
 
 
 CHAT_TEMPLATE = (


### PR DESCRIPTION
Add support for vanilla image that only has C,H,W dims but not tiles dim.
This is non-default image shapes used in PLM but it's useful in demos and low-resoure devices.

@zucchini-nlp 