### PR TITLE
Fixes for EncoderDecoderCache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1464,7 +1464,25 @@ class EncoderDecoderCache(Cache):
     ```
     """
 
-    def __init__(self, self_attention_cache: Cache, cross_attention_cache: Cache):
+    # Override @property from Cache -> this will be set in __init__ on the instances
+    is_compileable = False
+
+    def __init__(self, *caches) -> None:
+        # If only one argument is passed, it should be a legacy cache ie. an iterable of tuples of tensors
+        # This is not only for legacy reason, but also to be compatible with nn.DataParallel
+        if len(caches) == 1:
+            self_attention_cache, cross_attention_cache = self.create_dynamic_caches_from_legacy_cache(caches[0])
+        # Otherwise, we should get two arguments, a self-attention cache and a cross-attention cache
+        elif len(caches) == 2:
+            assert isinstance(caches[0], Cache), f"{type(caches[0]) = } is not a Cache"
+            assert isinstance(caches[1], Cache), f"{type(caches[1]) = } is not a Cache"
+            self_attention_cache = caches[0]
+            cross_attention_cache = caches[1]
+        # Error case
+        else:
+            raise ValueError(f"Expected 1 or 2 arguments, got {len(caches)}")
+
+        # Initialize caches
         self.self_attention_cache = self_attention_cache
         self.cross_attention_cache = cross_attention_cache
 
@@ -1526,25 +1544,35 @@ class EncoderDecoderCache(Cache):
         return legacy_cache
 
     @classmethod
+    def create_dynamic_caches_from_legacy_cache(
+        cls, past_key_values: Iterable[tuple[torch.FloatTensor, ...]]
+    ) -> tuple[Cache, Cache]:
+        """Create a self-attention cache and a cross-attention cache from (past_key_values), which is an iterable of
+        tuples of tensors. Legacy cache is a tuple of tuples of tensors but this also supports Iterables of tensor to
+        be compatible with nn.DataParallel.gather."""
+        self_attention_cache = DynamicCache()
+        cross_attention_cache = DynamicCache()
+
+        for layer_idx, key_value_states in enumerate(past_key_values):
+            key_states, value_states = key_value_states[:2]
+            self_attention_cache.update(key_states, value_states, layer_idx)
+            if len(key_value_states) > 2:
+                key_states, value_states = key_value_states[2:]
+                cross_attention_cache.update(key_states, value_states, layer_idx)
+                # cross_attention_cache.is_updated[layer_idx] = True # NOTE: this is handled in __init__
+        return self_attention_cache, cross_attention_cache
+
+    @classmethod
     def from_legacy_cache(
-        cls, past_key_values: tuple[tuple[torch.FloatTensor, torch.FloatTensor], ...]
+        cls, past_key_values: Optional[Iterable[tuple[torch.FloatTensor, ...]]],
     ) -> "EncoderDecoderCache":
         """Converts a cache in the legacy cache format into an equivalent `EncoderDecoderCache`."""
         if past_key_values is None:
             logger.warning_once("past_key_values should not be None in from_legacy_cache()")
-        cache = cls(
-            self_attention_cache=DynamicCache(),
-            cross_attention_cache=DynamicCache(),
-        )
-        if past_key_values is not None:
-            for layer_idx in range(len(past_key_values)):
-                key_states, value_states = past_key_values[layer_idx][:2]
-                cache.self_attention_cache.update(key_states, value_states, layer_idx)
-                if len(past_key_values[layer_idx]) > 2:
-                    key_states, value_states = past_key_values[layer_idx][2:]
-                    cache.cross_attention_cache.update(key_states, value_states, layer_idx)
-                    cache.is_updated[layer_idx] = True
-        return cache
+            self_attention_cache, cross_attention_cache = DynamicCache(), DynamicCache()
+        else:
+            self_attention_cache, cross_attention_cache = cls.create_dynamic_caches_from_legacy_cache(past_key_values)
+        return cls(self_attention_cache, cross_attention_cache)
 
     def get_seq_length(self, layer_idx: Optional[int] = 0) -> int:
         """Returns the sequence length of the cached states. A layer index can be optionally passed."""

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1564,7 +1564,7 @@ class EncoderDecoderCache(Cache):
 
     @classmethod
     def from_legacy_cache(
-        cls, past_key_values: Optional[Iterable[tuple[torch.FloatTensor, ...]]],
+        cls, past_key_values: Optional[Iterable[tuple[torch.FloatTensor, ...]]]
     ) -> "EncoderDecoderCache":
         """Converts a cache in the legacy cache format into an equivalent `EncoderDecoderCache`."""
         if past_key_values is None:

--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -1154,6 +1154,7 @@ class AutoformerDecoder(AutoformerPreTrainedModel):
             )
             use_cache = False
 
+        # TODO: change the type hint of past_key_values (here and in other models)
         if use_cache and past_key_values is None:
             past_key_values = EncoderDecoderCache(DynamicCache(), DynamicCache())
         if use_cache and isinstance(past_key_values, tuple):

--- a/src/transformers/models/autoformer/modeling_autoformer.py
+++ b/src/transformers/models/autoformer/modeling_autoformer.py
@@ -1154,7 +1154,6 @@ class AutoformerDecoder(AutoformerPreTrainedModel):
             )
             use_cache = False
 
-        # TODO: change the type hint of past_key_values (here and in other models)
         if use_cache and past_key_values is None:
             past_key_values = EncoderDecoderCache(DynamicCache(), DynamicCache())
         if use_cache and isinstance(past_key_values, tuple):

--- a/src/transformers/models/blip/modeling_blip_text.py
+++ b/src/transformers/models/blip/modeling_blip_text.py
@@ -446,9 +446,7 @@ class BlipTextEncoder(nn.Module):
             elif isinstance(past_key_values, DynamicCache):
                 past_key_values = EncoderDecoderCache(past_key_values, DynamicCache())
             elif past_key_values is None:
-                past_key_values = EncoderDecoderCache(
-                    self_attention_cache=DynamicCache(), cross_attention_cache=DynamicCache()
-                )
+                past_key_values = EncoderDecoderCache(DynamicCache(), DynamicCache())
 
         all_hidden_states = () if output_hidden_states else None
         all_self_attentions = () if output_attentions else None

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -25,6 +25,7 @@ from transformers import T5Config, is_torch_available
 from transformers.models.auto.modeling_auto import MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES
 from transformers.pytorch_utils import is_torch_greater_or_equal_than_2_4
 from transformers.testing_utils import (
+    Expectations,
     cleanup,
     require_accelerate,
     require_sentencepiece,
@@ -1200,7 +1201,12 @@ class T5ModelIntegrationTests(unittest.TestCase):
         loss = model(input_ids.to(torch_device), labels=labels.to(torch_device)).loss
         mtf_score = -(labels.shape[-1] * loss.item())
 
-        EXPECTED_SCORE = -19.0845
+        EXPECTED_SCORE = Expectations(
+            {
+                (None, None): -19.0845,
+                ("rocm", (9, 4)): -19.0846,
+            }
+        ).get_expectation()
         self.assertTrue(abs(mtf_score - EXPECTED_SCORE) < 1e-4)
 
     @slow

--- a/tests/models/t5gemma/test_modeling_t5gemma.py
+++ b/tests/models/t5gemma/test_modeling_t5gemma.py
@@ -1386,10 +1386,6 @@ class T5GemmaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
             # If this does not raise an error, the test passes (see https://github.com/huggingface/transformers/pull/35605)
             _ = model(**dummy_inputs)
 
-    @unittest.skip("EncoderDecoderCache can't be gathered because it is not iterable.")
-    def test_multi_gpu_data_parallel_forward(self):
-        pass
-
 
 class T5GemmaEncoderOnlyModelTester:
     config_class = T5GemmaConfig


### PR DESCRIPTION
The `EncoderDecoderCache` object is not compatible with `nn.DataParallel` because it expects to be instantiated with 2 arguments. This probably was not an issue before because the legacy cache was a tuple of tuples (thus compatible with `nn.DataParallel.gather`) but it is now. 

This PR proposes a fix by changing the `EncoderDecoderCache.__init__` to make it more flexible: it retrieves all passed arguments using `*caches` and expects either:
- 2 arguments, which are 2 `Cache` objects, as is the case today;
- 1 argument, which is an iterable of `tuple[Tensor.floatTensor, ...]` compatible with the legacy cache but also `nn.DataParallel`, which gathers object using `EncoderDecoderCache(map(gathered_past_key_value))` -> hence the `create_dynamic_caches_from_legacy_cache` was slightly changed to support non-indexable iterables 
For other numbers of arguments, it fails. 

There was also a line `cross_attention_cache.is_updated[layer_idx] = True` which was removed because if `cross_attention_cache` has no `is_updated` attribute it fails, eg. a `DynamicCache` object.

The drawback of this is these changes is that initialization of `EncoderDecoderCache` is no longer possible (it was done once in the codebase and has been fixed) and the inside mechanism is a bit more convoluted than before. 

This also has the benefit of fixing one `t5` test that was failing (`test_multi_gpu_data_parallel_forward`) and not skipping the same test in `t5gemma`