### PR TITLE
fix: resolve dropout type error in DogeDecoder

### DIFF
--- a/src/transformers/models/doge/modeling_doge.py
+++ b/src/transformers/models/doge/modeling_doge.py
@@ -70,6 +70,8 @@ class DogeRMSNorm(nn.Module):
 
 
 class DogeRotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor  # fix linting for `register_buffer`
+
     def __init__(self, config: DogeConfig, device=None):
         super().__init__()
         # BC: "rope_type" was originally "type"

--- a/src/transformers/models/doge/modular_doge.py
+++ b/src/transformers/models/doge/modular_doge.py
@@ -576,7 +576,7 @@ class DogePreTrainedModel(LlamaPreTrainedModel):
 
     def _init_weights(self, module):
         """Initialize the weights"""
-        super()._init_weights(module)
+        LlamaPreTrainedModel._init_weights(module)
         if isinstance(module, DogeAttention):
             if hasattr(module, "A"):
                 module.A.data.zero_()

--- a/src/transformers/models/doge/modular_doge.py
+++ b/src/transformers/models/doge/modular_doge.py
@@ -336,6 +336,7 @@ class DogeAttention(nn.Module):
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.keep_window_size = config.keep_window_size
+        self.is_causal = True
 
         self.q_proj = nn.Linear(
             config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
@@ -539,7 +540,7 @@ class DogeDecoderLayer(GradientCheckpointingLayer):
         # sequence transformation
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
-        hidden_states, self_attn_weights = self.self_attn(
+        hidden_states, _ = self.self_attn(
             hidden_states=hidden_states,
             position_embeddings=position_embeddings,
             attention_mask=attention_mask,
@@ -556,6 +557,8 @@ class DogeDecoderLayer(GradientCheckpointingLayer):
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
         hidden_states = self.mlp(hidden_states)
+        if isinstance(hidden_states, tuple):
+            hidden_states, _ = hidden_states
         hidden_states = F.dropout(hidden_states, p=self.hidden_dropout, training=self.training)
         hidden_states = self.post_attention_residual * residual + hidden_states
 
@@ -573,10 +576,13 @@ class DogePreTrainedModel(LlamaPreTrainedModel):
 
     def _init_weights(self, module):
         """Initialize the weights"""
-        LlamaPreTrainedModel._init_weights(module)
+        super()._init_weights(module)
         if isinstance(module, DogeAttention):
             if hasattr(module, "A"):
                 module.A.data.zero_()
+        elif isinstance(module, DogeCDMoE):
+            if hasattr(module, "router_gate"):
+                module.router_gate.weight.data.zero_()
         elif isinstance(module, DogeDecoderLayer):
             if hasattr(module, "input_residual"):
                 module.input_residual.data.fill_(1.0)


### PR DESCRIPTION
Fix: #40079
Fixed TypeError where dropout() received tuple instead of Tensor in DogeDecoderLayer when using MoE configuration. The MLP forward method returns a tuple (hidden_states, router_logits) for MoE layers, but the subsequent dropout operation expected only a Tensor.

- Extract hidden_states from tuple before dropout when using MoE
- Ensure consistent tensor handling in both MLP and MoE configurations

Fixes issue where model.generate() failed with:
TypeError: dropout(): argument 'input' (position 1) must be Tensor, not tuple
@ArthurZucker  @gante @LoserCheems 