### PR TITLE
Add support for SDPA for OWLViT and OWLv2

### DIFF
--- a/docs/source/en/model_doc/owlv2.md
+++ b/docs/source/en/model_doc/owlv2.md
@@ -50,7 +50,7 @@ OWLv2 is, just like its predecessor [OWL-ViT](owlvit), a zero-shot text-conditio
 >>> from transformers import Owlv2Processor, Owlv2ForObjectDetection
 
 >>> processor = Owlv2Processor.from_pretrained("google/owlv2-base-patch16-ensemble")
->>> model = Owlv2ForObjectDetection.from_pretrained("google/owlv2-base-patch16-ensemble")
+>>> model = Owlv2ForObjectDetection.from_pretrained("google/owlv2-base-patch16-ensemble", torch_dtype=torch.float16, device_map="auto", attn_implementation="sdpa")
 
 >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
 >>> image = Image.open(requests.get(url, stream=True).raw)

--- a/docs/source/en/model_doc/owlvit.md
+++ b/docs/source/en/model_doc/owlvit.md
@@ -49,7 +49,7 @@ OWL-ViT is a zero-shot text-conditioned object detection model. OWL-ViT uses [CL
 >>> from transformers import OwlViTProcessor, OwlViTForObjectDetection
 
 >>> processor = OwlViTProcessor.from_pretrained("google/owlvit-base-patch32")
->>> model = OwlViTForObjectDetection.from_pretrained("google/owlvit-base-patch32")
+>>> model = OwlViTForObjectDetection.from_pretrained("google/owlvit-base-patch32", torch_dtype=torch.float16, device_map="auto", attn_implementation="sdpa")
 
 >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
 >>> image = Image.open(requests.get(url, stream=True).raw)

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -503,9 +503,6 @@ class Owlv2Attention(nn.Module):
         attn_output = attn_output.reshape(bsz, seq_len, -1).contiguous()
         attn_output = self.out_proj(attn_output)
 
-        if not output_attentions:
-            attn_weights = None
-
         return attn_output, attn_weights
 
 

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -432,7 +432,8 @@ def eager_attention_forward(
 
     attn_output = attn_output.view(bsz, num_heads, seq_len, head_dim)
     attn_output = attn_output.transpose(1, 2)
-    return attn_output, attn_weights
+
+    return attn_output, attn_weights_reshaped
 
 
 # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTAttention with OwlViT->Owlv2

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -377,7 +377,7 @@ class Owlv2TextEmbeddings(nn.Module):
         return embeddings
 
 
-# Copied from transformers.models.owlvit.modeling_owlvit.eager_attention_forward
+# Copied from transformers.models.blip_2.modeling_blip_2.eager_attention_forward
 def eager_attention_forward(
     module: nn.Module,
     query: torch.Tensor,
@@ -388,52 +388,17 @@ def eager_attention_forward(
     dropout: float = 0.0,
     **kwargs,
 ):
-    bsz, num_heads, seq_len, head_dim = query.shape
-    proj_shape = (bsz * num_heads, -1, head_dim)
-    query = query.reshape(proj_shape)
-    key = key.reshape(proj_shape)
-    value = value.reshape(proj_shape)
-
-    attn_weights = torch.bmm(query, key.transpose(1, 2)) * scaling
-
-    if attn_weights.size() != (bsz * num_heads, seq_len, seq_len):
-        raise ValueError(
-            f"Attention weights should be of size {(bsz * num_heads, seq_len, seq_len)}, but is {attn_weights.size()}"
-        )
-
+    attn_weights = torch.matmul(query, key.transpose(-1, -2)) * scaling
     if attention_mask is not None:
-        if attention_mask.size() != (bsz, 1, seq_len, seq_len):
-            raise ValueError(
-                f"Attention mask should be of size {(bsz, 1, seq_len, seq_len)}, but is {attention_mask.size()}"
-            )
-        attn_weights = attn_weights.view(bsz, num_heads, seq_len, seq_len) + attention_mask
-        attn_weights = attn_weights.view(bsz * num_heads, seq_len, seq_len)
+        attn_weights = attn_weights + attention_mask
 
     attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
 
-    # this operation is a bit akward, but it's required to
-    # make sure that attn_weights keeps its gradient.
-    # In order to do so, attn_weights have to reshaped
-    # twice and have to be reused in the following
-    attn_weights_reshaped = attn_weights.view(bsz, num_heads, seq_len, seq_len)
-    attn_weights = attn_weights_reshaped.view(bsz * num_heads, seq_len, seq_len)
+    attn_output = torch.matmul(attn_weights, value)
+    attn_output = attn_output.transpose(1, 2).contiguous()
 
-    attn_probs = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
-
-    # For int8 compatibility, sometimes the `attn_probs` are in `fp32`
-    attn_probs = attn_probs.to(value.dtype)
-
-    attn_output = torch.bmm(attn_probs, value)
-
-    if attn_output.size() != (bsz * num_heads, seq_len, head_dim):
-        raise ValueError(
-            f"`attn_output` should be of size {(bsz, num_heads, seq_len, head_dim)}, but is {attn_output.size()}"
-        )
-
-    attn_output = attn_output.view(bsz, num_heads, seq_len, head_dim)
-    attn_output = attn_output.transpose(1, 2)
-
-    return attn_output, attn_weights_reshaped
+    return attn_output, attn_weights
 
 
 # Copied from transformers.models.owlvit.modeling_owlvit.OwlViTAttention with OwlViT->Owlv2

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -971,8 +971,13 @@ class Owlv2Model(Owlv2PreTrainedModel):
         self.text_embed_dim = text_config.hidden_size
         self.vision_embed_dim = vision_config.hidden_size
 
-        self.text_model = Owlv2TextTransformer(text_config)
-        self.vision_model = Owlv2VisionTransformer(vision_config)
+        # First, initialize the text and vision models with proper attention implementation
+        text_model = Owlv2TextModel._from_config(text_config)
+        vision_model = Owlv2VisionModel._from_config(vision_config)
+
+        # Second, get the text and vision submodules (for backward compatibility)
+        self.text_model = text_model.text_model
+        self.vision_model = vision_model.vision_model
 
         self.visual_projection = nn.Linear(self.vision_embed_dim, self.projection_dim, bias=False)
         self.text_projection = nn.Linear(self.text_embed_dim, self.projection_dim, bias=False)

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -420,7 +420,8 @@ def eager_attention_forward(
 
     attn_output = attn_output.view(bsz, num_heads, seq_len, head_dim)
     attn_output = attn_output.transpose(1, 2)
-    return attn_output, attn_weights
+
+    return attn_output, attn_weights_reshaped
 
 
 class OwlViTAttention(nn.Module):

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -490,9 +490,6 @@ class OwlViTAttention(nn.Module):
         attn_output = attn_output.reshape(bsz, seq_len, -1).contiguous()
         attn_output = self.out_proj(attn_output)
 
-        if not output_attentions:
-            attn_weights = None
-
         return attn_output, attn_weights
 
 

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -16,7 +16,7 @@
 
 from dataclasses import dataclass
 from functools import lru_cache
-from typing import Any, Optional, Union
+from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.utils.checkpoint
@@ -26,7 +26,7 @@ from ...activations import ACT2FN
 from ...modeling_attn_mask_utils import _create_4d_causal_attention_mask, _prepare_4d_attention_mask
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
-from ...modeling_utils import PreTrainedModel
+from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...utils import ModelOutput, auto_docstring, is_vision_available, logging, torch_int
 from .configuration_owlvit import OwlViTConfig, OwlViTTextConfig, OwlViTVisionConfig
 
@@ -366,6 +366,63 @@ class OwlViTTextEmbeddings(nn.Module):
         return embeddings
 
 
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: Optional[torch.Tensor],
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs,
+):
+    bsz, num_heads, seq_len, head_dim = query.shape
+    proj_shape = (bsz * num_heads, -1, head_dim)
+    query = query.reshape(proj_shape)
+    key = key.reshape(proj_shape)
+    value = value.reshape(proj_shape)
+
+    attn_weights = torch.bmm(query, key.transpose(1, 2)) * scaling
+
+    if attn_weights.size() != (bsz * num_heads, seq_len, seq_len):
+        raise ValueError(
+            f"Attention weights should be of size {(bsz * num_heads, seq_len, seq_len)}, but is {attn_weights.size()}"
+        )
+
+    if attention_mask is not None:
+        if attention_mask.size() != (bsz, 1, seq_len, seq_len):
+            raise ValueError(
+                f"Attention mask should be of size {(bsz, 1, seq_len, seq_len)}, but is {attention_mask.size()}"
+            )
+        attn_weights = attn_weights.view(bsz, num_heads, seq_len, seq_len) + attention_mask
+        attn_weights = attn_weights.view(bsz * num_heads, seq_len, seq_len)
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+
+    # this operation is a bit akward, but it's required to
+    # make sure that attn_weights keeps its gradient.
+    # In order to do so, attn_weights have to reshaped
+    # twice and have to be reused in the following
+    attn_weights_reshaped = attn_weights.view(bsz, num_heads, seq_len, seq_len)
+    attn_weights = attn_weights_reshaped.view(bsz * num_heads, seq_len, seq_len)
+
+    attn_probs = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+
+    # For int8 compatibility, sometimes the `attn_probs` are in `fp32`
+    attn_probs = attn_probs.to(value.dtype)
+
+    attn_output = torch.bmm(attn_probs, value)
+
+    if attn_output.size() != (bsz * num_heads, seq_len, head_dim):
+        raise ValueError(
+            f"`attn_output` should be of size {(bsz, num_heads, seq_len, head_dim)}, but is {attn_output.size()}"
+        )
+
+    attn_output = attn_output.view(bsz, num_heads, seq_len, head_dim)
+    attn_output = attn_output.transpose(1, 2)
+    return attn_output, attn_weights
+
+
 class OwlViTAttention(nn.Module):
     """Multi-headed attention from 'Attention Is All You Need' paper"""
 
@@ -400,77 +457,43 @@ class OwlViTAttention(nn.Module):
     ) -> tuple[torch.Tensor, Optional[torch.Tensor], Optional[tuple[torch.Tensor]]]:
         """Input shape: Batch x Time x Channel"""
 
-        bsz, tgt_len, embed_dim = hidden_states.size()
+        bsz, seq_len, _ = hidden_states.size()
 
-        # get query proj
-        query_states = self.q_proj(hidden_states) * self.scale
-        key_states = self._shape(self.k_proj(hidden_states), -1, bsz)
-        value_states = self._shape(self.v_proj(hidden_states), -1, bsz)
+        queries = self._shape(self.q_proj(hidden_states), -1, bsz)
+        keys = self._shape(self.k_proj(hidden_states), -1, bsz)
+        values = self._shape(self.v_proj(hidden_states), -1, bsz)
 
-        proj_shape = (bsz * self.num_heads, -1, self.head_dim)
-        query_states = self._shape(query_states, tgt_len, bsz).view(*proj_shape)
-        key_states = key_states.view(*proj_shape)
-        value_states = value_states.view(*proj_shape)
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
 
-        src_len = key_states.size(1)
-        attn_weights = torch.bmm(query_states, key_states.transpose(1, 2))
+        full_attention_mask = None
+        if attention_mask is not None and causal_attention_mask is not None:
+            full_attention_mask = attention_mask + causal_attention_mask
+        elif attention_mask is not None:
+            full_attention_mask = attention_mask
+        elif causal_attention_mask is not None:
+            full_attention_mask = causal_attention_mask
 
-        if attn_weights.size() != (bsz * self.num_heads, tgt_len, src_len):
-            raise ValueError(
-                f"Attention weights should be of size {(bsz * self.num_heads, tgt_len, src_len)}, but is"
-                f" {attn_weights.size()}"
-            )
+        attn_output, attn_weights = attention_interface(
+            self,
+            queries,
+            keys,
+            values,
+            full_attention_mask,
+            dropout=self.dropout if self.training else 0.0,
+            scaling=self.scale,
+            is_causal=False,  # This model uses causal attention masks.
+        )
 
-        # apply the causal_attention_mask first
-        if causal_attention_mask is not None:
-            if causal_attention_mask.size() != (bsz, 1, tgt_len, src_len):
-                raise ValueError(
-                    f"Attention mask should be of size {(bsz, 1, tgt_len, src_len)}, but is"
-                    f" {causal_attention_mask.size()}"
-                )
-            attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len) + causal_attention_mask
-            attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
-
-        if attention_mask is not None:
-            if attention_mask.size() != (bsz, 1, tgt_len, src_len):
-                raise ValueError(
-                    f"Attention mask should be of size {(bsz, 1, tgt_len, src_len)}, but is {attention_mask.size()}"
-                )
-            attn_weights = attn_weights.view(bsz, self.num_heads, tgt_len, src_len) + attention_mask
-            attn_weights = attn_weights.view(bsz * self.num_heads, tgt_len, src_len)
-
-        attn_weights = nn.functional.softmax(attn_weights, dim=-1)
-
-        if output_attentions:
-            # this operation is a bit akward, but it's required to
-            # make sure that attn_weights keeps its gradient.
-            # In order to do so, attn_weights have to reshaped
-            # twice and have to be reused in the following
-            attn_weights_reshaped = attn_weights.view(bsz, self.num_heads, tgt_len, src_len)
-            attn_weights = attn_weights_reshaped.view(bsz * self.num_heads, tgt_len, src_len)
-        else:
-            attn_weights_reshaped = None
-
-        attn_probs = nn.functional.dropout(attn_weights, p=self.dropout, training=self.training)
-
-        # For int8 compatibility, sometimes the `attn_probs` are in `fp32`
-        attn_probs = attn_probs.to(value_states.dtype)
-
-        attn_output = torch.bmm(attn_probs, value_states)
-
-        if attn_output.size() != (bsz * self.num_heads, tgt_len, self.head_dim):
-            raise ValueError(
-                f"`attn_output` should be of size {(bsz, self.num_heads, tgt_len, self.head_dim)}, but is"
-                f" {attn_output.size()}"
-            )
-
-        attn_output = attn_output.view(bsz, self.num_heads, tgt_len, self.head_dim)
-        attn_output = attn_output.transpose(1, 2)
-        attn_output = attn_output.reshape(bsz, tgt_len, embed_dim)
-
+        # The transpose(1, 2) happens in the attention interface.
+        attn_output = attn_output.reshape(bsz, seq_len, -1).contiguous()
         attn_output = self.out_proj(attn_output)
 
-        return attn_output, attn_weights_reshaped
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights
 
 
 # Copied from transformers.models.clip.modeling_clip.CLIPMLP with CLIP->OwlViT
@@ -546,6 +569,8 @@ class OwlViTPreTrainedModel(PreTrainedModel):
     base_model_prefix = "owlvit"
     supports_gradient_checkpointing = True
     _no_split_modules = ["OwlViTEncoderLayer"]
+
+    _supports_sdpa = True
 
     def _init_weights(self, module: nn.Module):
         """Initialize the weights"""

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -951,8 +951,13 @@ class OwlViTModel(OwlViTPreTrainedModel):
         self.text_embed_dim = text_config.hidden_size
         self.vision_embed_dim = vision_config.hidden_size
 
-        self.text_model = OwlViTTextTransformer(text_config)
-        self.vision_model = OwlViTVisionTransformer(vision_config)
+        # First, initialize the text and vision models with proper attention implementation
+        text_model = OwlViTTextModel._from_config(text_config)
+        vision_model = OwlViTVisionModel._from_config(vision_config)
+
+        # Second, get the text and vision submodules (for backward compatibility)
+        self.text_model = text_model.text_model
+        self.vision_model = vision_model.vision_model
 
         self.visual_projection = nn.Linear(self.vision_embed_dim, self.projection_dim, bias=False)
         self.text_projection = nn.Linear(self.text_embed_dim, self.projection_dim, bias=False)

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -1072,8 +1072,8 @@ class Owlv2ModelIntegrationTest(unittest.TestCase):
             model_name, attn_implementation="sdpa", torch_dtype=torch.float16
         ).to(torch_device)
         self.assertTrue(model.config._attn_implementation == "sdpa")
-        self.assertTrue(model.vision_model.config._attn_implementation == "sdpa")
-        self.assertTrue(model.text_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.owlv2.vision_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.owlv2.text_model.config._attn_implementation == "sdpa")
 
         processor = OwlViTProcessor.from_pretrained(model_name)
 

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -39,6 +39,7 @@ from ...test_modeling_common import (
     floats_tensor,
     ids_tensor,
     random_attention_mask,
+    require_torch_sdpa,
 )
 from ...test_pipeline_mixin import PipelineTesterMixin
 
@@ -1037,6 +1038,38 @@ class Owlv2ModelIntegrationTest(unittest.TestCase):
     def test_inference_one_shot_object_detection_fp16(self):
         model_name = "google/owlv2-base-patch16"
         model = Owlv2ForObjectDetection.from_pretrained(model_name, torch_dtype=torch.float16).to(torch_device)
+
+        processor = OwlViTProcessor.from_pretrained(model_name)
+
+        image = prepare_img()
+        query_image = prepare_img()
+        inputs = processor(
+            images=image,
+            query_images=query_image,
+            max_length=16,
+            padding="max_length",
+            return_tensors="pt",
+        ).to(torch_device)
+
+        with torch.no_grad():
+            outputs = model.image_guided_detection(**inputs)
+
+        # No need to check the logits, we just check inference runs fine.
+        num_queries = int((model.config.vision_config.image_size / model.config.vision_config.patch_size) ** 2)
+        self.assertEqual(outputs.target_pred_boxes.shape, torch.Size((1, num_queries, 4)))
+
+    @slow
+    @require_torch_accelerator
+    @require_torch_sdpa
+    @require_torch_fp16
+    def test_inference_one_shot_object_detection_fp16_sdpa(self):
+        model_name = "google/owlv2-base-patch16"
+        model = Owlv2ForObjectDetection.from_pretrained(
+            model_name, attention_type="sdpa", torch_dtype=torch.float16
+        ).to(torch_device)
+        self.assertTrue(model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.vision_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.text_model.config._attn_implementation == "sdpa")
 
         processor = OwlViTProcessor.from_pretrained(model_name)
 

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -432,10 +432,6 @@ class Owlv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
-    # Disable this since failing following SigLIP2
-    test_cpu_offload = False
-    test_disk_offload_safetensors = False
-    test_disk_offload_bin = False
     # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
     additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 
@@ -655,10 +651,6 @@ class Owlv2ForObjectDetectionTest(ModelTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
-    # Disable this since failing following SigLIP2
-    test_cpu_offload = False
-    test_disk_offload_safetensors = False
-    test_disk_offload_bin = False
     # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
     additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -380,7 +380,6 @@ class Owlv2ModelTester:
             text_config=self.text_config,
             vision_config=self.vision_config,
             projection_dim=64,
-            attn_implementation="eager",
         )
 
     def create_and_check_model(self, config, input_ids, attention_mask, pixel_values):
@@ -1073,12 +1072,12 @@ class Owlv2ModelIntegrationTest(unittest.TestCase):
 
     @slow
     @require_torch_accelerator
-    @require_torch_sdpa
     @require_torch_fp16
+    @require_torch_sdpa
     def test_inference_one_shot_object_detection_fp16_sdpa(self):
         model_name = "google/owlv2-base-patch16"
         model = Owlv2ForObjectDetection.from_pretrained(
-            model_name, attention_type="sdpa", torch_dtype=torch.float16
+            model_name, attn_implementation="sdpa", torch_dtype=torch.float16
         ).to(torch_device)
         self.assertTrue(model.config._attn_implementation == "sdpa")
         self.assertTrue(model.vision_model.config._attn_implementation == "sdpa")

--- a/tests/models/owlv2/test_modeling_owlv2.py
+++ b/tests/models/owlv2/test_modeling_owlv2.py
@@ -380,6 +380,7 @@ class Owlv2ModelTester:
             text_config=self.text_config,
             vision_config=self.vision_config,
             projection_dim=64,
+            attn_implementation="eager",
         )
 
     def create_and_check_model(self, config, input_ids, attention_mask, pixel_values):
@@ -432,6 +433,12 @@ class Owlv2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
+    # Disable this since failing following SigLIP2
+    test_cpu_offload = False
+    test_disk_offload_safetensors = False
+    test_disk_offload_bin = False
+    # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
+    additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 
     def setUp(self):
         self.model_tester = Owlv2ModelTester(self)
@@ -649,6 +656,12 @@ class Owlv2ForObjectDetectionTest(ModelTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
+    # Disable this since failing following SigLIP2
+    test_cpu_offload = False
+    test_disk_offload_safetensors = False
+    test_disk_offload_bin = False
+    # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
+    additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 
     def setUp(self):
         self.model_tester = Owlv2ForObjectDetectionTester(self)

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -376,7 +376,6 @@ class OwlViTModelTester:
             text_config=self.text_config,
             vision_config=self.vision_config,
             projection_dim=64,
-            attn_implementation="eager",
         )
 
     def create_and_check_model(self, config, input_ids, attention_mask, pixel_values):
@@ -1059,12 +1058,12 @@ class OwlViTModelIntegrationTest(unittest.TestCase):
 
     @slow
     @require_torch_accelerator
-    @require_torch_sdpa
     @require_torch_fp16
+    @require_torch_sdpa
     def test_inference_one_shot_object_detection_fp16_sdpa(self):
         model_name = "google/owlvit-base-patch32"
         model = OwlViTForObjectDetection.from_pretrained(
-            model_name, attention_type="sdpa", torch_dtype=torch.float16
+            model_name, attn_implementation="sdpa", torch_dtype=torch.float16
         ).to(torch_device)
         self.assertTrue(model.config._attn_implementation == "sdpa")
         self.assertTrue(model.vision_model.config._attn_implementation == "sdpa")

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -427,10 +427,6 @@ class OwlViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
-    # Disable this since failing following SigLIP2
-    test_cpu_offload = False
-    test_disk_offload_safetensors = False
-    test_disk_offload_bin = False
     # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
     additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 
@@ -648,10 +644,6 @@ class OwlViTForObjectDetectionTest(ModelTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
-    # Disable this since failing following SigLIP2
-    test_cpu_offload = False
-    test_disk_offload_safetensors = False
-    test_disk_offload_bin = False
     # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
     additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -1058,8 +1058,8 @@ class OwlViTModelIntegrationTest(unittest.TestCase):
             model_name, attn_implementation="sdpa", torch_dtype=torch.float16
         ).to(torch_device)
         self.assertTrue(model.config._attn_implementation == "sdpa")
-        self.assertTrue(model.vision_model.config._attn_implementation == "sdpa")
-        self.assertTrue(model.text_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.owlv2.vision_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.owlv2.text_model.config._attn_implementation == "sdpa")
 
         processor = OwlViTProcessor.from_pretrained(model_name)
 

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -1058,8 +1058,8 @@ class OwlViTModelIntegrationTest(unittest.TestCase):
             model_name, attn_implementation="sdpa", torch_dtype=torch.float16
         ).to(torch_device)
         self.assertTrue(model.config._attn_implementation == "sdpa")
-        self.assertTrue(model.owlv2.vision_model.config._attn_implementation == "sdpa")
-        self.assertTrue(model.owlv2.text_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.owlvit.vision_model.config._attn_implementation == "sdpa")
+        self.assertTrue(model.owlvit.text_model.config._attn_implementation == "sdpa")
 
         processor = OwlViTProcessor.from_pretrained(model_name)
 

--- a/tests/models/owlvit/test_modeling_owlvit.py
+++ b/tests/models/owlvit/test_modeling_owlvit.py
@@ -376,6 +376,7 @@ class OwlViTModelTester:
             text_config=self.text_config,
             vision_config=self.vision_config,
             projection_dim=64,
+            attn_implementation="eager",
         )
 
     def create_and_check_model(self, config, input_ids, attention_mask, pixel_values):
@@ -427,6 +428,12 @@ class OwlViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
+    # Disable this since failing following SigLIP2
+    test_cpu_offload = False
+    test_disk_offload_safetensors = False
+    test_disk_offload_bin = False
+    # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
+    additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 
     def setUp(self):
         self.model_tester = OwlViTModelTester(self)
@@ -642,6 +649,12 @@ class OwlViTForObjectDetectionTest(ModelTesterMixin, unittest.TestCase):
     test_pruning = False
     test_resize_embeddings = False
     test_attention_outputs = False
+    # Disable this since failing following SigLIP2
+    test_cpu_offload = False
+    test_disk_offload_safetensors = False
+    test_disk_offload_bin = False
+    # For multi-modal models like OwlV2, we need to include all required inputs for SDPA tests
+    additional_model_inputs = ["input_ids", "attention_mask", "pixel_values"]
 
     def setUp(self):
         self.model_tester = OwlViTForObjectDetectionTester(self)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3822,6 +3822,10 @@ class ModelTesterMixin:
                 self.skipTest(reason="Idefics currently (transformers==4.39.1) requires an image_attention_mask input")
             if config.model_type in ["sam"]:
                 self.skipTest(reason="SAM requires an attention_mask input for relative positional embeddings")
+            if config.model_type in ["owlvit", "owlv2"]:
+                self.skipTest(
+                    reason="OwlViT/V2 models currently (transformers==4.55.0) use attention_mask inputs in attention"
+                )
 
             model = model_class(config)
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3822,7 +3822,7 @@ class ModelTesterMixin:
                 self.skipTest(reason="Idefics currently (transformers==4.39.1) requires an image_attention_mask input")
             if config.model_type in ["sam"]:
                 self.skipTest(reason="SAM requires an attention_mask input for relative positional embeddings")
-            if config.model_type in ["owlvit", "owlv2"]:
+            if config.model_type in ["owlvit", "owlvit_text_model", "owlv2", "owlv2_text_model"]:
                 self.skipTest(
                     reason="OwlViT/V2 models currently (transformers==4.55.0) use attention_mask inputs in attention"
                 )

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -423,6 +423,10 @@ def _test_eager_matches_sdpa_inference(
                 outputs_eager = outputs_eager["language_model_outputs"]
                 outputs_sdpa = outputs_sdpa["language_model_outputs"]
                 key = "hidden_states" if "hidden_states" in outputs_eager else "decoder_hidden_states"
+            elif "text_model_output" in outputs_eager and "owl" in model_class.__name__.lower():
+                outputs_eager = outputs_eager["text_model_output"]
+                outputs_sdpa = outputs_sdpa["text_model_output"]
+                key = "hidden_states"
             else:
                 key = "hidden_states"
 


### PR DESCRIPTION
# What does this PR do?

Add support for SDPA (scaled_dot_product_attention) for efficient attention to OWLViT and OWLv2 models.
The previous code is used in the eager attention implementation. I roughly followed the SigLIP code for inspiration.
Note that we could do a larger refactory to use the is_causal flag, but I tried to stick as close as possible to the original implementation in this first version.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? > I added an e2e sdpa inference test based on the fp16 one, but let me know if anything else is needed.

## Who can review?

Maybe @amyeroberts @qubvel @ArthurZucker 