### PR TITLE
fix `notification_service.py` about `time_spent`

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1225,7 +1225,7 @@ if __name__ == "__main__":
                 matrix_job_results[matrix_name]["success"] += success
                 matrix_job_results[matrix_name]["errors"] += errors
                 matrix_job_results[matrix_name]["skipped"] += skipped
-                matrix_job_results[matrix_name]["time_spent"] += time_spent[1:-1] + ", "
+                matrix_job_results[matrix_name]["time_spent"] += time_spent[:-1] + ", "
 
                 stacktraces = handle_stacktraces(artifact["failures_line"])
 
@@ -1360,7 +1360,7 @@ if __name__ == "__main__":
             additional_results[key]["success"] += success
             additional_results[key]["errors"] += errors
             additional_results[key]["skipped"] += skipped
-            additional_results[key]["time_spent"] += time_spent[1:-1] + ", "
+            additional_results[key]["time_spent"] += time_spent[:-1] + ", "
 
             if len(artifact["errors"]):
                 additional_results[key]["error"] = True


### PR DESCRIPTION
# What does this PR do?

We extract the information from test report file like in `1 passed in 7.89s`, but at some point, we do

> ... ["time_spent"] += time_spent[1:-1]

which remove the first digit. I am not guility!