### PR TITLE
Revert "fix `notification_service.py` about `time_spent`"

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1225,7 +1225,7 @@ if __name__ == "__main__":
                 matrix_job_results[matrix_name]["success"] += success
                 matrix_job_results[matrix_name]["errors"] += errors
                 matrix_job_results[matrix_name]["skipped"] += skipped
-                matrix_job_results[matrix_name]["time_spent"] += time_spent[:-1] + ", "
+                matrix_job_results[matrix_name]["time_spent"] += time_spent[1:-1] + ", "
 
                 stacktraces = handle_stacktraces(artifact["failures_line"])
 
@@ -1360,7 +1360,7 @@ if __name__ == "__main__":
             additional_results[key]["success"] += success
             additional_results[key]["errors"] += errors
             additional_results[key]["skipped"] += skipped
-            additional_results[key]["time_spent"] += time_spent[:-1] + ", "
+            additional_results[key]["time_spent"] += time_spent[1:-1] + ", "
 
             if len(artifact["errors"]):
                 additional_results[key]["error"] = True


### PR DESCRIPTION
Reverts huggingface/transformers#40037

There were some edge case errors not detected until a full run was triggered

https://github.com/huggingface/transformers/actions/runs/16833364235/job/47693598035

```
  File "/home/runner/work/transformers/transformers/utils/notification_service.py", line 206, in time
    hours, minutes, seconds = int(time_parts[0]), int(time_parts[1]), float(time_parts[2])
ValueError: invalid literal for int() with base 10: '(0'
```

revert for now to avoid next daily CI failing to produce reports.

Will check and fix later.