### PR TITLE
Auto-log parallelism info to wandb.config using HF Accelerate

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -963,6 +963,17 @@ class WandbCallback(TrainerCallback):
             args.run_name = None
         if not self._initialized:
             self.setup(args, state, model, **kwargs)
+        
+        # Auto log Accelerate parallelism info to wandb.config
+        if self._initialized and state.is_world_process_zero and getattr(self._wandb, "run", None) is not None:
+            acc = getattr(model, "accelerator", None)
+            pc = getattr(acc, "parallelism_config", None) if acc is not None else None
+            sizes = getattr(pc, "_sizes", None) if pc is not None else None
+            if isinstance(sizes, dict) and sizes:
+                try:
+                    self._wandb.config.update({"parallelism": sizes}, allow_val_change=True)
+                except Exception:
+                    pass
 
     def on_train_end(self, args: TrainingArguments, state, control, model=None, processing_class=None, **kwargs):
         if self._wandb is None:


### PR DESCRIPTION
### What
This PR adds parallelism info non intrusively to `WandbCallback` so that, **when Hugging Face Accelerate is in use**, the callback automatically logs the parallelism sizes to `wandb.config` at train start.

### Why
Users frequently want their distributed setup (e.g., `tp_size`, `dp_replicate_size`) with Weights & Biases for reproducibility and experiment analysis. Today, this is typically done manually on the user side. This change standardizes and automates that step.

This PR is from Issue #39882 
@Rocketknight1 @MekkCyber 

Thanks for you precious time for reviewing this PR.
