### PR TITLE
changed xLSTMRMSNorm to RMSNorm

### DIFF
--- a/src/transformers/models/xlstm/modeling_xlstm.py
+++ b/src/transformers/models/xlstm/modeling_xlstm.py
@@ -31,7 +31,7 @@ from .configuration_xlstm import xLSTMConfig
 if is_xlstm_available():
     from xlstm.xlstm_large.model import mLSTMBlock as xLSTMBlock
     from xlstm.xlstm_large.model import mLSTMStateType, soft_cap
-    from xlstm.xlstm_large.model import xLSTMRMSNorm as xLSTMRMSNorm
+    from xlstm.xlstm_large.model import RMSNorm as xLSTMRMSNorm
 
     external_xlstm = True
 else:

--- a/src/transformers/models/xlstm/modeling_xlstm.py
+++ b/src/transformers/models/xlstm/modeling_xlstm.py
@@ -29,9 +29,9 @@ from .configuration_xlstm import xLSTMConfig
 
 
 if is_xlstm_available():
+    from xlstm.xlstm_large.model import RMSNorm as xLSTMRMSNorm
     from xlstm.xlstm_large.model import mLSTMBlock as xLSTMBlock
     from xlstm.xlstm_large.model import mLSTMStateType, soft_cap
-    from xlstm.xlstm_large.model import RMSNorm as xLSTMRMSNorm
 
     external_xlstm = True
 else:


### PR DESCRIPTION
xLSTMRMSNorm doesn't exist and hence gives an ImportError, without it users can't test NX-AI/xLSTM-7b.

cc @Cyrilvallez