### PR TITLE
🚨🚨  [generate] ignore `cache_implementation="hybrid"` hub defaults

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1744,10 +1744,10 @@ class GenerationMixin(ContinuousMixin):
 
             # Related to #40039: prior to this PR, models with sliding window attention were forced to have
             # `cache_implementation="hybrid"` (the static sliding window cache). For these models, we now want to use
-            # the dynamic sliding window cache, so we change `cache_implementation` if it is a default value.
-            # (if we're inside this branch, then it is because we're using default values)
+            # the dynamic sliding window cache by default, so we UNSET `cache_implementation` if it is a default value.
+            # (if we're inside this branch, then it is because we're using default values from the Hub)
             if generation_config.cache_implementation == "hybrid":
-                generation_config.cache_implementation = "dynamic"
+                generation_config.cache_implementation = None
 
         # `torch.export.export` usually raises an exception if it is called
         # with ``strict=True``. deepcopy can only be processed if ``strict=False``.

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1742,6 +1742,13 @@ class GenerationMixin(ContinuousMixin):
             generation_config = self.generation_config
             using_model_generation_config = True
 
+            # Related to #40039: prior to this PR, models with sliding window attention were forced to have
+            # `cache_implementation="hybrid"` (the static sliding window cache). For these models, we now want to use
+            # the dynamic sliding window cache, so we change `cache_implementation` if it is a default value.
+            # (if we're inside this branch, then it is because we're using default values)
+            if generation_config.cache_implementation == "hybrid":
+                generation_config.cache_implementation = "dynamic"
+
         # `torch.export.export` usually raises an exception if it is called
         # with ``strict=True``. deepcopy can only be processed if ``strict=False``.
         generation_config = copy.deepcopy(generation_config)
@@ -1953,10 +1960,6 @@ class GenerationMixin(ContinuousMixin):
                 f"'{generation_config.cache_implementation}'."
             )
             generation_config.cache_implementation = None
-
-        generation_config.cache_implementation = generation_config.cache_implementation or getattr(
-            self.config.get_text_config(decoder=True), "cache_implementation", None
-        )
 
         # assisted decoding and contrastive search need to roll-back the Cache, which is not supported if
         # it has sliding layers - so if we use any of those 2, do not pass the config to DynamicCache, which

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -500,7 +500,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
             add_generation_prompt=True,
         ).to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = self.processor.batch_decode(output, skip_special_tokens=True)
 
         EXPECTED_TEXTS = Expectations(
@@ -545,7 +546,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
             add_generation_prompt=True,
         ).to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = self.processor.batch_decode(output, skip_special_tokens=True)
 
         EXPECTED_TEXTS = Expectations(
@@ -599,7 +601,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
             **crop_config,
         ).to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = self.processor.batch_decode(output, skip_special_tokens=True)
 
         EXPECTED_NUM_IMAGES = 3  # one for the origin image and two crops of images
@@ -654,7 +657,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
             **crop_config,
         ).to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = self.processor.batch_decode(output, skip_special_tokens=True)
         EXPECTED_NUM_IMAGES = 9  # 3 * (one for the origin image and two crops of images) = 9
         EXPECTED_TEXTS = Expectations(
@@ -708,7 +712,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
             add_generation_prompt=True,
         ).to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = self.processor.batch_decode(output, skip_special_tokens=True)
         EXPECTED_TEXTS = Expectations(
             {
@@ -729,7 +734,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
         inputs = tokenizer("Write a poem about Machine Learning.", return_tensors="pt").to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
 
         EXPECTED_TEXTS = Expectations(
@@ -763,7 +769,8 @@ class Gemma3IntegrationTest(unittest.TestCase):
             add_generation_prompt=True,
         ).to(torch_device)
 
-        output = model.generate(**inputs, max_new_tokens=30, do_sample=False)
+        # cache_implementation="hybrid" an in the original transformers implementation
+        output = model.generate(**inputs, max_new_tokens=30, do_sample=False, cache_implementation="hybrid")
         output_text = self.processor.batch_decode(output, skip_special_tokens=True)
 
         EXPECTED_TEXTS = Expectations(
@@ -803,7 +810,10 @@ class Gemma3IntegrationTest(unittest.TestCase):
         input_size = inputs.input_ids.shape[-1]
         self.assertTrue(input_size > model.config.sliding_window)
 
-        out = model.generate(**inputs, max_new_tokens=20, do_sample=False)[:, input_size:]
+        # cache_implementation="hybrid" an in the original transformers implementation
+        out = model.generate(**inputs, max_new_tokens=20, do_sample=False, cache_implementation="hybrid")[
+            :, input_size:
+        ]
         output_text = tokenizer.batch_decode(out)
 
         EXPECTED_COMPLETIONS = [" and I'm going to take a walk.\n\nI really enjoy the scenery, and I'", ", green, yellow, orange, purple, brown, black, white, gray.\n\nI'"]  # fmt: skip
@@ -844,6 +854,7 @@ class Gemma3IntegrationTest(unittest.TestCase):
                 **input_text,
                 max_new_tokens=max_new_tokens_to_generate,
                 do_sample=False,  # Use greedy decoding to match the exported model
+                cache_implementation="hybrid",
             )
 
         eager_generated_text = tokenizer.decode(eager_outputs[0], skip_special_tokens=True)
@@ -875,7 +886,7 @@ class Gemma3IntegrationTest(unittest.TestCase):
         )
         self.assertIn("DynamicSlidingWindowLayer", str(generate_outputs.past_key_values))
 
-        # If we manually specify the cache implementation, it will work
+        # If we manually specify the cache implementation = "hybrid", it will use the static sliding window cache
         generate_outputs = model.generate(
             **model_inputs,
             max_new_tokens=2,


### PR DESCRIPTION
# What does this PR do?

Follow-up to #40039 -- on models where the hub checkpoint specifies `cache_implementation="hybrid"` (static sliding window hybrid cache), UNSETS this value. This will make the model use the dynamic sliding window layers by default.

Any user-defined `cache_implementation="hybrid"` will apply the static sliding window hybrid cache.

✅ with this PR, we no longer suffer from super slow 1st `generate` calls on models with hybrid caches. See snippet below.

🚨🚨  
- BC breaking: the cache returned by `generate` calls now will have `DynamicSlidingWindowLayer` layers by default (as opposed to `SlidingWindowLayer`, its static-shaped counterpart).
- Tests: we might have failing slow tests after merging this PR. Tests using checkpoints with `cache_implementation="hybrid"` may have small differences in their `generate` calls.

___________________________________

Time of 1st `generate` call test snippet:
```py
from transformers import AutoModelForCausalLM, AutoTokenizer
import torch
from time import time


model_id = "google/gemma-3-1b-it"
model = AutoModelForCausalLM.from_pretrained(model_id, device_map="auto", torch_dtype=torch.bfloat16)

tokenizer = AutoTokenizer.from_pretrained(model_id)
prompt = "What is the capital of France?"
model_inputs = tokenizer(prompt, return_tensors="pt").to(model.device)

torch.cuda.synchronize()
start = time()
generate_outputs = model.generate(
    **model_inputs, max_new_tokens=100, do_sample=False, return_dict_in_generate=True
)
torch.cuda.synchronize()
end = time()
print(f"Time taken: {end - start} seconds (new)")
# time on RTX 4090: 0.79s

torch.cuda.synchronize()
start = time()
generate_outputs = model.generate(
    **model_inputs, max_new_tokens=100, do_sample=False, return_dict_in_generate=True, cache_implementation="hybrid"
)
torch.cuda.synchronize()
end = time()
print(f"Time taken: {end - start} seconds (old)")
# time on RTX 4090: 21.62s

```