### PR TITLE
Add model card for BERT Base Uncased

### DIFF
--- a/docs/source/model_cards/bert-base-uncased/README.md
+++ b/docs/source/model_cards/bert-base-uncased/README.md
@@ -1,0 +1,44 @@
+\# BERT Base Uncased
+
+
+
+This is the BERT base model (uncased) as described in the paper:
+
+\*\*BERT: Pre-training of Deep Bidirectional Transformers for Language Understanding\*\*.
+
+
+
+\- \*\*Layers\*\*: 12  
+
+\- \*\*Hidden Size\*\*: 768  
+
+\- \*\*Heads\*\*: 12  
+
+\- \*\*Parameters\*\*: 110M  
+
+\- \*\*Case\*\*: Uncased (lowercased input text)  
+
+
+
+\## Usage
+
+Example:
+
+```python
+
+from transformers import BertTokenizer, BertModel
+
+
+
+tokenizer = BertTokenizer.from\_pretrained("bert-base-uncased")
+
+model = BertModel.from\_pretrained("bert-base-uncased")
+
+
+
+inputs = tokenizer("Hello, how are you?", return\_tensors="pt")
+
+outputs = model(\*\*inputs)
+
+
+


### PR DESCRIPTION
This PR adds a beginner-friendly model card for `bert-base-uncased` under `docs/source/model_cards/`.

Includes:
- Model description (plain language)
- Usage example
- Intended use & limitations
- Resources and references

