### PR TITLE
add attribute map for MoE standardization

### DIFF
--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -137,7 +137,7 @@ class AriaTextConfig(PretrainedConfig):
     attribute_map = {
         "num_experts": "moe_num_experts",
         "num_experts_per_tok": "moe_topk",
-        "num_shared_experts": "moe_num_shared_experts",
+        "num_experts_shared": "moe_num_shared_experts",
     }
     # Default tensor parallel plan for base model `AriaTextModel`
     base_model_tp_plan = {

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -134,6 +134,10 @@ class AriaTextConfig(PretrainedConfig):
 
     model_type = "aria_text"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts": "moe_num_experts",
+        "num_experts_per_tok": "moe_topk",
+    }
     # Default tensor parallel plan for base model `AriaTextModel`
     base_model_tp_plan = {
         "layers.*.self_attn.q_proj": "colwise",

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -137,6 +137,7 @@ class AriaTextConfig(PretrainedConfig):
     attribute_map = {
         "num_experts": "moe_num_experts",
         "num_experts_per_tok": "moe_topk",
+        "num_shared_experts": "moe_num_shared_experts",
     }
     # Default tensor parallel plan for base model `AriaTextModel`
     base_model_tp_plan = {

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -137,7 +137,7 @@ class AriaTextConfig(PretrainedConfig):
     attribute_map = {
         "num_experts": "moe_num_experts",
         "num_experts_per_tok": "moe_topk",
-        "num_experts_shared": "moe_num_shared_experts",
+        "num_shared_experts": "moe_num_shared_experts",
     }
     # Default tensor parallel plan for base model `AriaTextModel`
     base_model_tp_plan = {

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -178,8 +178,6 @@ class DbrxConfig(PretrainedConfig):
         "hidden_size": "d_model",
         "num_hidden_layers": "n_layers",
         "max_position_embeddings": "max_seq_len",
-        "num_experts": "moe_num_experts",
-        "num_experts_per_tok": "moe_top_k",
     }
 
     def __init__(
@@ -212,6 +210,9 @@ class DbrxConfig(PretrainedConfig):
         else:
             self.ffn_config = ffn_config
 
+        self.num_experts = self.ffn_config.moe_num_experts
+        self.num_experts_per_tok = self.ffn_config.moe_top_k
+        self.norm_topk_prob = self.ffn_config.moe_norm_topk_prob
         self.d_model = d_model
         self.n_heads = n_heads
         self.n_layers = n_layers

--- a/src/transformers/models/dbrx/configuration_dbrx.py
+++ b/src/transformers/models/dbrx/configuration_dbrx.py
@@ -178,6 +178,8 @@ class DbrxConfig(PretrainedConfig):
         "hidden_size": "d_model",
         "num_hidden_layers": "n_layers",
         "max_position_embeddings": "max_seq_len",
+        "num_experts": "moe_num_experts",
+        "num_experts_per_tok": "moe_top_k",
     }
 
     def __init__(

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -127,7 +127,7 @@ class DeepseekV2Config(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts_per_tok": "top_k",
-        "num_experts_shared": "n_shared_experts",
+        "num_shared_experts": "n_shared_experts",
         "num_experts": "n_routed_experts",
     }
 

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -127,7 +127,7 @@ class DeepseekV2Config(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts_per_tok": "top_k",
-        "num_shared_experts": "n_shared_experts",
+        "num_experts_shared": "n_shared_experts",
         "num_experts": "n_routed_experts",
     }
 

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -127,6 +127,8 @@ class DeepseekV2Config(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts_per_tok": "top_k",
+        "num_shared_experts": "n_shared_experts",
+        "num_experts": "n_routed_experts",
     }
 
     base_model_tp_plan = {

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -125,6 +125,9 @@ class DeepseekV2Config(PretrainedConfig):
 
     model_type = "deepseek_v2"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     base_model_tp_plan = {
         "layers.*.self_attn.q_proj": "colwise",

--- a/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
@@ -132,6 +132,9 @@ class DeepseekV3Config(PretrainedConfig):
 
     model_type = "deepseek_v3"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
     base_model_tp_plan = {  # TODO: only replicate attention layers when > first_k_dense_replace
         "layers.*.mlp.experts.*.gate_proj": "local_colwise",
         "layers.*.mlp.experts.*.up_proj": "local_colwise",

--- a/src/transformers/models/doge/configuration_doge.py
+++ b/src/transformers/models/doge/configuration_doge.py
@@ -139,6 +139,9 @@ class DogeConfig(PretrainedConfig):
 
     model_type = "doge"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
     # Default tensor parallel plan for base model `DogeModel`
     base_model_tp_plan = {
         "layers.*.self_attn.q_proj": "colwise",

--- a/src/transformers/models/dots1/configuration_dots1.py
+++ b/src/transformers/models/dots1/configuration_dots1.py
@@ -105,6 +105,9 @@ class Dots1Config(PretrainedConfig):
 
     model_type = "dots1"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     base_model_tp_plan = {  # TODO: only replicate attention layers when > first_k_dense_replace
         "layers.*.self_attn.q_proj": "colwise",

--- a/src/transformers/models/glm4_moe/configuration_glm4_moe.py
+++ b/src/transformers/models/glm4_moe/configuration_glm4_moe.py
@@ -147,6 +147,9 @@ class Glm4MoeConfig(PretrainedConfig):
 
     model_type = "glm4_moe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     # Default tensor parallel plan for base model `Glm4Moe`
     base_model_tp_plan = {

--- a/src/transformers/models/glm4v_moe/configuration_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/configuration_glm4v_moe.py
@@ -222,6 +222,9 @@ class Glm4vMoeTextConfig(PretrainedConfig):
 
     model_type = "Glm4vMoe_text"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
     # Default tensor parallel plan for base model `Glm4vMoe`
     base_model_tp_plan = {
         "layers.*.self_attn.q_proj": "colwise",

--- a/src/transformers/models/gpt_oss/configuration_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/configuration_gpt_oss.py
@@ -44,6 +44,10 @@ class GptOssConfig(PretrainedConfig):
         "layers.*.mlp.experts.down_proj": "grouped_gemm",
         "layers.*.mlp.experts.down_proj_bias": "grouped_gemm",
     }
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/gpt_oss/configuration_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/configuration_gpt_oss.py
@@ -46,7 +46,7 @@ class GptOssConfig(PretrainedConfig):
     }
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/granitemoe/configuration_granitemoe.py
+++ b/src/transformers/models/granitemoe/configuration_granitemoe.py
@@ -116,6 +116,10 @@ class GraniteMoeConfig(PretrainedConfig):
 
     model_type = "granitemoe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/granitemoe/configuration_granitemoe.py
+++ b/src/transformers/models/granitemoe/configuration_granitemoe.py
@@ -118,7 +118,7 @@ class GraniteMoeConfig(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py
@@ -133,12 +133,10 @@ class GraniteMoeHybridConfig(PretrainedConfig):
     model_type = "granitemoehybrid"
     attribute_map = {
         "layers_block_type": "layer_types",
+        "num_experts": "num_local_experts",
+        "num_experts_per_tok": "top_k",
     }
     keys_to_ignore_at_inference = ["past_key_values"]
-    attribute_map = {
-        "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
-    }
 
     def __init__(
         self,

--- a/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py
@@ -135,6 +135,10 @@ class GraniteMoeHybridConfig(PretrainedConfig):
         "layers_block_type": "layer_types",
     }
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/granitemoeshared/configuration_granitemoeshared.py
+++ b/src/transformers/models/granitemoeshared/configuration_granitemoeshared.py
@@ -118,6 +118,10 @@ class GraniteMoeSharedConfig(PretrainedConfig):
 
     model_type = "granitemoeshared"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/granitemoeshared/configuration_granitemoeshared.py
+++ b/src/transformers/models/granitemoeshared/configuration_granitemoeshared.py
@@ -120,7 +120,7 @@ class GraniteMoeSharedConfig(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/jamba/configuration_jamba.py
+++ b/src/transformers/models/jamba/configuration_jamba.py
@@ -124,6 +124,9 @@ class JambaConfig(PretrainedConfig):
 
     model_type = "jamba"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/jetmoe/configuration_jetmoe.py
+++ b/src/transformers/models/jetmoe/configuration_jetmoe.py
@@ -96,7 +96,7 @@ class JetMoeConfig(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/jetmoe/configuration_jetmoe.py
+++ b/src/transformers/models/jetmoe/configuration_jetmoe.py
@@ -94,6 +94,10 @@ class JetMoeConfig(PretrainedConfig):
 
     model_type = "jetmoe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/llama4/configuration_llama4.py
+++ b/src/transformers/models/llama4/configuration_llama4.py
@@ -277,7 +277,7 @@ class Llama4TextConfig(PretrainedConfig):
     }
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/llama4/configuration_llama4.py
+++ b/src/transformers/models/llama4/configuration_llama4.py
@@ -275,6 +275,10 @@ class Llama4TextConfig(PretrainedConfig):
         "layers.*.feed_forward.down_proj": "local_rowwise",
         "layers.*.feed_forward.router": "ep_router",
     }
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/minimax/configuration_minimax.py
+++ b/src/transformers/models/minimax/configuration_minimax.py
@@ -141,6 +141,10 @@ class MiniMaxConfig(PretrainedConfig):
         "layers": (["hidden_states", "attention_mask"], ["hidden_states"]),
         "norm": (["hidden_states"], ["hidden_states"]),
     }
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/minimax/configuration_minimax.py
+++ b/src/transformers/models/minimax/configuration_minimax.py
@@ -143,7 +143,7 @@ class MiniMaxConfig(PretrainedConfig):
     }
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/mixtral/configuration_mixtral.py
+++ b/src/transformers/models/mixtral/configuration_mixtral.py
@@ -124,6 +124,10 @@ class MixtralConfig(PretrainedConfig):
         "layers": (["hidden_states", "attention_mask"], ["hidden_states"]),
         "norm": (["hidden_states"], ["hidden_states"]),
     }
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/mixtral/configuration_mixtral.py
+++ b/src/transformers/models/mixtral/configuration_mixtral.py
@@ -126,7 +126,7 @@ class MixtralConfig(PretrainedConfig):
     }
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
+        "num_experts_per_tok": "top_k",
     }
 
     def __init__(

--- a/src/transformers/models/olmoe/configuration_olmoe.py
+++ b/src/transformers/models/olmoe/configuration_olmoe.py
@@ -108,6 +108,9 @@ class OlmoeConfig(PretrainedConfig):
 
     model_type = "olmoe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/phimoe/configuration_phimoe.py
+++ b/src/transformers/models/phimoe/configuration_phimoe.py
@@ -114,7 +114,6 @@ class PhimoeConfig(PretrainedConfig):
     keys_to_ignore_at_inference = ["past_key_values"]
     attribute_map = {
         "num_experts": "num_local_experts",
-        "top_k": "num_experts_per_tok",
     }
 
     def __init__(

--- a/src/transformers/models/phimoe/configuration_phimoe.py
+++ b/src/transformers/models/phimoe/configuration_phimoe.py
@@ -112,6 +112,10 @@ class PhimoeConfig(PretrainedConfig):
 
     model_type = "phimoe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts": "num_local_experts",
+        "top_k": "num_experts_per_tok",
+    }
 
     def __init__(
         self,

--- a/src/transformers/models/qwen2_moe/configuration_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/configuration_qwen2_moe.py
@@ -150,6 +150,9 @@ class Qwen2MoeConfig(PretrainedConfig):
 
     model_type = "qwen2_moe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     # Default tensor parallel plan for base model `Qwen2Moe`
     base_model_tp_plan = {

--- a/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py
@@ -147,6 +147,9 @@ class Qwen3MoeConfig(PretrainedConfig):
 
     model_type = "qwen3_moe"
     keys_to_ignore_at_inference = ["past_key_values"]
+    attribute_map = {
+        "num_experts_per_tok": "top_k",
+    }
 
     # Default tensor parallel plan for base model `Qwen3Moe`
     base_model_tp_plan = {


### PR DESCRIPTION
# What does this PR do?
This ensures that the naming is always the same across MoEs