### PR TITLE
Fix: catch requests.ConnectionError in list_repo_templates

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -176,7 +176,7 @@ def list_repo_templates(
             ]
         except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError):
             raise  # valid errors => do not catch
-        except (ConnectionError, HTTPError):
+        except (ConnectionError, HTTPError, requests.exceptions.ConnectionError):
             pass  # offline mode, internet down, etc. => try local files
 
     # check local files


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug in the `list_repo_templates` function where network connectivity issues would cause the entire function to crash instead of gracefully falling back to local files.

## Problem

When used without an internet connection, the function raised:
```
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: (MaxRetryError("HTTPSConnectionPool(host='huggingface.co', port=443): Max retries exceeded with url: /api/models/Qwen/Qwen2.5-VL-7B-Instruct/tree/main/additional_chat_templates?recursive=False&expand=False (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x14cdd4b28b60>: Failed to establish a new connection: [Errno 101] Network is unreachable'))"), '(Request ID: ---)')
```

The exception handler only caught Python’s built-in `ConnectionError`, not the `requests`-specific one, so the fallback logic never ran.

## Fix

Add `requests.exceptions.ConnectionError` to the exception handler.

Now, if the network is unavailable, the function correctly falls back to local cached templates as intended.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Rocketknight1 
