### PR TITLE
[Continous Batching] set head_dim when config.head_dim is None

### DIFF
--- a/src/transformers/generation/continuous_batching.py
+++ b/src/transformers/generation/continuous_batching.py
@@ -185,7 +185,9 @@ class PagedAttentionCache:
             # self.num_key_value_heads //= tp_size
 
         self.head_dim = (
-            config.head_dim if hasattr(config, "head_dim") else config.hidden_size // config.num_attention_heads
+            config.head_dim
+            if hasattr(config, "head_dim") and config.head_dim is not None
+            else config.hidden_size // config.num_attention_heads
         )
         self.num_hidden_layers = config.num_hidden_layers
 

--- a/src/transformers/generation/continuous_batching.py
+++ b/src/transformers/generation/continuous_batching.py
@@ -1261,7 +1261,7 @@ class ContinuousBatchingManager:
                 self.model.device,
                 self.model.dtype,
                 num_requests=len(self.input_queue.queue),
-                tp_size=getattr(self.model, "_tp_size", 8),  # TODO quantized converted don't set this
+                tp_size=getattr(self.model, "_tp_size", None),  # Use model's actual TP setting
             )
 
             scheduler = None


### PR DESCRIPTION
# What does this PR do?

Some models have empty `config.head_dim` so we now check if the value is not None instead of setting it to `None`