### PR TITLE
Fix CI: Use correct import for torchvision InterpolationMode

### DIFF
--- a/src/transformers/models/sam/image_processing_sam_fast.py
+++ b/src/transformers/models/sam/image_processing_sam_fast.py
@@ -243,9 +243,9 @@ class SamImageProcessorFast(BaseImageProcessorFast):
                 {
                     "do_normalize": False,
                     "do_rescale": False,
-                    "interpolation": F.InterpolationMode.NEAREST_EXACT
+                    "interpolation": F_t.InterpolationMode.NEAREST_EXACT
                     if is_torchvision_v2_available()
-                    else F.InterpolationMode.NEAREST,
+                    else F_t.InterpolationMode.NEAREST,
                     "size": segmentation_maps_kwargs.pop("mask_size"),
                     "pad_size": segmentation_maps_kwargs.pop("mask_pad_size"),
                 }


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/32317 renamed `from torchvision.transforms.v2 import functional as F_t` leaving `F` for `torch.functional`

but some usages of `F` remained unchanged, breaking CI ([example](https://app.circleci.com/pipelines/github/huggingface/transformers/142032/workflows/d0770631-92de-4f3c-96df-5832a7322bc2/jobs/1879488)):

```
FAILED tests/models/sam/test_image_processing_sam.py::SamImageProcessingTest::test_slow_fast_equivalence
...
E           AttributeError: module 'torch.nn.functional' has no attribute 'InterpolationMode'

/usr/local/lib/python3.9/site-packages/transformers/models/sam/image_processing_sam_fast.py:246: AttributeError
```