### PR TITLE
try `PYTHONUNBUFFERED` to avoid no output for too long

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -30,6 +30,7 @@ COMMON_ENV_VARIABLES = {
     "RUN_PIPELINE_TESTS": False,
     # will be adjust in `CircleCIJob.to_dict`.
     "RUN_FLAKY": True,
+    "PYTHONUNBUFFERED": 1,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
 COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "vvv": None, "rsfE":None}


### PR DESCRIPTION
# What does this PR do?

to see if this could reduce

https://app.circleci.com/pipelines/github/huggingface/transformers/141243/workflows/d61ac0c2-3205-433f-a744-a045664e6a05/jobs/1869761 