### PR TITLE
Chat Template Doc Fixes

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -81,13 +81,13 @@
     - local: conversations
       title: Chat basics
     - local: chat_templating
-      title: Templates
+      title: Chat templates
     - local: chat_templating_multimodal
-      title: Multimodal templates
-    - local: chat_templating_writing
-      title: Template writing
+      title: Multimodal chat templates
     - local: chat_extras
-      title: Tools and RAG
+      title: Tool use
+    - local: chat_templating_writing
+      title: Writing a chat template
     title: Chat with models
   - sections:
     - local: serving

--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -14,7 +14,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Using Chat Templates With Tools
+# Tool Use
 
 It is very common for chat models to be trained with support for "function-calling" or "tool-use". These "tools" are functions,
 supplied by the user, which the model can choose to call as part of its response. For example, models could have access to a calculator
@@ -23,7 +23,7 @@ for larger inputs.
 
 This guide will demonstrate how to define tools, how to pass them to a chat model, and how to handle the model's output when it calls a tool.
 
-## Tools
+## Passing tools
 
 When a model supports tool-use, you can pass functions to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`].
 The tools can be passed as either [JSON schema](https://json-schema.org/learn) or as Python functions. If you pass Python functions,

--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -14,64 +14,68 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Tools and RAG
+# Using Chat Templates With Tools
 
-The [`~PreTrainedTokenizerBase.apply_chat_template`] method supports virtually any additional argument types - strings, lists, dicts - besides the chat message. This makes it possible to use chat templates for many use cases.
+It is very common for chat models to be trained with support for "function-calling" or "tool-use". These "tools" are functions,
+supplied by the user, which the model can choose to call as part of its response. For example, models could have access to a calculator
+tool so that they can perform arithmetic without having to do it internally in the neural net itself, which usually becomes unreliable
+for larger inputs.
 
-This guide will demonstrate how to use chat templates with tools and retrieval-augmented generation (RAG).
+This guide will demonstrate how to define tools, how to pass them to a chat model, and how to handle the model's output when it calls a tool.
 
 ## Tools
 
-Tools are functions a large language model (LLM) can call to perform specific tasks. It is a powerful way to extend the capabilities of conversational agents with real-time information, computational tools, or access to large databases.
+When a model supports tool-use, you can pass functions to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`].
+The tools can be passed as either [JSON schema](https://json-schema.org/learn) or as Python functions. If you pass Python functions,
+the arguments, argument types and function docstring will be parsed in order to generate the JSON schema automatically.
 
-Follow the rules below when creating a tool.
+Although passing Python functions is very convenient, the parser can only handle [Google-style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
+docstrings. Therefore, make sure you follow that format! Here are a couple of examples of well-formatted functions
+that are ready to use as tools:
 
-1. The function should have a descriptive name.
-2. The function arguments must have a type hint in the function header (don't include in the `Args` block).
-3. The function must have a [Google-style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings) docstring.
-4. The function can have a return type and `Returns` block, but these are optional because most tool use models ignore them.
-
-An example tool to get temperature and wind speed is shown below.
 
 ```py
-def get_current_temperature(location: str, unit: str) -> float:
+def get_current_temperature(location: str, unit: str):
     """
     Get the current temperature at a location.
     
     Args:
         location: The location to get the temperature for, in the format "City, Country"
         unit: The unit to return the temperature in. (choices: ["celsius", "fahrenheit"])
-    Returns:
-        The current temperature at the specified location in the specified units, as a float.
     """
     return 22.  # A real function should probably actually get the temperature!
 
-def get_current_wind_speed(location: str) -> float:
+def get_current_wind_speed(location: str):
     """
     Get the current wind speed in km/h at a given location.
     
     Args:
-        location: The location to get the temperature for, in the format "City, Country"
-    Returns:
-        The current wind speed at the given location in km/h, as a float.
+        location: The location to get the wind speed for, in the format "City, Country"
     """
     return 6.  # A real function should probably actually get the wind speed!
 
 tools = [get_current_temperature, get_current_wind_speed]
 ```
 
-Load a model and tokenizer that supports tool-use like [NousResearch/Hermes-2-Pro-Llama-3-8B](https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B), but you can also consider a larger model like [Command-R](./model_doc/cohere) and [Mixtral-8x22B](./model_doc/mixtral) if your hardware can support it.
+You may, if you wish, add a `Returns:` block to the docstring and a return type to the function header, but most models
+will not use this information. The parser will also ignore any of the actual code inside your function! What really
+matters is the function name, the argument names, the argument types, and the docstring describing the function's purpose
+and the purpose of its arguments. These create the "signature" that the model will use to decide whether to call the tool.
+
+## A tool-calling example
+
+Let's start by loading a model and tokenizer that supports tool-use like [NousResearch/Hermes-2-Pro-Llama-3-8B](https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B), but you can also consider a larger model like [Command-R](./model_doc/cohere) and [Mixtral-8x22B](./model_doc/mixtral) if your hardware can support it.
 
 ```py
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-tokenizer = AutoTokenizer.from_pretrained( "NousResearch/Hermes-2-Pro-Llama-3-8B")
-tokenizer = AutoTokenizer.from_pretrained( "NousResearch/Hermes-2-Pro-Llama-3-8B")
-model = AutoModelForCausalLM.from_pretrained( "NousResearch/Hermes-2-Pro-Llama-3-8B", dtype=torch.bfloat16, device_map="auto")
+checkpoint = "NousResearch/Hermes-2-Pro-Llama-3-8B"
+tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+model = AutoModelForCausalLM.from_pretrained(checkpoint, dtype="auto", device_map="auto")
 ```
 
-Create a chat message.
+Next, let's create a chat, just like you would with a normal chat model.
 
 ```py
 messages = [
@@ -80,12 +84,12 @@ messages = [
 ]
 ```
 
-Pass `messages` and a list of tools to [`~PreTrainedTokenizerBase.apply_chat_template`]. Then you can pass the inputs to the model for generation.
+Next, pass `messages` and a list of tools to [`~PreTrainedTokenizerBase.apply_chat_template`], then tokenize and generate a response. This is exactly
+the same as with a normal chat model, except for the `tools` argument.
 
 ```py
 inputs = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=True, return_dict=True, return_tensors="pt")
-inputs = {k: v for k, v in inputs.items()}
-outputs = model.generate(**inputs, max_new_tokens=128)
+outputs = model.generate(**inputs.to(model.device), max_new_tokens=128)
 print(tokenizer.decode(outputs[0][len(inputs["input_ids"][0]):]))
 ```
 
@@ -95,12 +99,14 @@ print(tokenizer.decode(outputs[0][len(inputs["input_ids"][0]):]))
 </tool_call><|im_end|>
 ```
 
-The chat model called the `get_current_temperature` tool with the correct parameters from the docstring. It inferred France as the location based on Paris, and that it should use Celsius for the units of temperature. 
+The chat model has emitted a tool call! Specifically, it called the `get_current_temperature` tool with the correct parameters from the docstring. It inferred France as the location based on Paris, and that it should use Celsius for the units of temperature.
 
-Now append the `get_current_temperature` function and these arguments to the chat message as `tool_call`. The `tool_call` dictionary should be provided to the `assistant` role instead of the `system` or `user`.
+Note that the model **cannot actually call the tool itself**. Instead, it will request a tool call, and it's your job to handle the call and append both the call and the result to the chat history.
+
+Let's start with the call: We use the `tool_calls` key of an `assistant` message to hold the call. This is the recommended API, and should be supported by the chat template of most tool-using models.
 
 > [!WARNING]
-> The OpenAI API uses a JSON string as its `tool_call` format. This may cause errors or strange model behavior if used in Transformers, which expects a dict.
+> Although this is similar to the OpenAI API, the OpenAI API uses a JSON string as its `tool_call` format. This may cause errors or strange model behavior if used in Transformers, which expects a dict.
 
 <hfoptions id="tool-call">
 <hfoption id="Llama">
@@ -110,45 +116,37 @@ tool_call = {"name": "get_current_temperature", "arguments": {"location": "Paris
 messages.append({"role": "assistant", "tool_calls": [{"type": "function", "function": tool_call}]})
 ```
 
-Allow the assistant to read the function outputs and chat with the user.
+Next, we have to actually append the tool response to the chat history. For this, we generally use the `tool` role:
+
+```py
+messages.append({"role": "tool", "content": "22"})  # Note that the returned content is always a string!
+```
+
+Finally, allow the model to read the tool response and reply to the user:
 
 ```py
 inputs = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=True, return_dict=True, return_tensors="pt")
-inputs = {k: v for k, v in inputs.items()}
-out = model.generate(**inputs, max_new_tokens=128)
+out = model.generate(**inputs.to(model.device), max_new_tokens=128)
 print(tokenizer.decode(out[0][len(inputs["input_ids"][0]):]))
 ```
 
 ```txt
-The temperature in Paris, France right now is approximately 12°C (53.6°F).<|im_end|>
+The temperature in Paris, France right now is 22°C.<|im_end|>
 ```
 
-</hfoption>
-<hfoption id="Mistral/Mixtral">
+> [!WARNING]
+> Although the key in the assistant message is called `tool_calls`, in most cases models only emit a single tool call at a time. Some older models emit multiple tool calls at the same time, but this is a
+> signficantly more complex process, as you need to handle multiple tool responses at once and disambiguate them, often using tool call IDs. If you try this sample code with a model and get an error from the
+> chat template telling you to add a tool call ID, this is probably what's happened! Please refer to the model card to see exactly what format that model expects for tool calls.
 
-For [Mistral](./model_doc/mistral) and [Mixtral](./model_doc/mixtral) models, you need an additional `tool_call_id`. The `tool_call_id` is 9 randomly generated alphanumeric characters assigned to the `id` key in the `tool_call` dictionary.
 
-```py
-tool_call_id = "9Ae3bDc2F"
-tool_call = {"name": "get_current_temperature", "arguments": {"location": "Paris, France", "unit": "celsius"}}
-messages.append({"role": "assistant", "tool_calls": [{"type": "function", "id": tool_call_id, "function": tool_call}]})
-```
+## Advanced: Manually writing JSON Schemas
 
-```py
-inputs = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=True, return_dict=True, return_tensors="pt")
-inputs = {k: v for k, v in inputs.items()}
-out = model.generate(**inputs, max_new_tokens=128)
-print(tokenizer.decode(out[0][len(inputs["input_ids"][0]):]))
-```
+In the examples above, we passed Python functions to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`]. This is a convenient way to define tools, but it is not the only way. You can also pass a [JSON schema](https://json-schema.org/learn/getting-started-step-by-step) directly.
+You can also manually call the low-level functions that convert Python functions to JSON schemas, and then check or edit the generated schemas. This is usually not necessary, but we include it here so that advanced users can understand the underlying mechanics. It's particularly important
+for chat template authors, since they will need to access the JSON schema to render the tool definitions.
 
-</hfoption>
-</hfoptions>
-
-## Schema
-
-[`~PreTrainedTokenizerBase.apply_chat_template`] converts functions into a [JSON schema](https://json-schema.org/learn/getting-started-step-by-step) which is passed to the chat template. A LLM never sees the code inside the function. In other words, a LLM doesn't care how the function works technically, it only cares about function **definition** and **arguments**.
-
-The JSON schema is automatically generated behind the scenes as long as your function follows the [rules](#tools) listed earlier above. But you can use [get_json_schema](https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205) to manually convert a schema for more visibility or debugging.
+The function that [`~PreTrainedTokenizerBase.apply_chat_template`] uses to convert Python functions to JSON schema is [get_json_schema](https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205). Let's try calling it directly:
 
 ```py
 from transformers.utils import get_json_schema
@@ -191,12 +189,7 @@ print(schema)
 }
 ```
 
-You can edit the schema or write one entirely from scratch. This gives you a lot of flexibility to define precise schemas for more complex functions.
-
-> [!WARNING]
-> Try keeping your function signatures simple and the arguments to a minimum. These are easier for a model to understand and use than complex functions for example with nested arguments.
-
-The example below demonstrates writing a schema manually and then passing it to [`~PreTrainedTokenizerBase.apply_chat_template`].
+We won't go into the details of JSON schema itself here, since it's already [very well documented](https://json-schema.org/) elsewhere. We will, however, mention that you can pass JSON schema dicts to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`] instead of Python functions:
 
 ```py
 # A simple function that takes no arguments
@@ -238,62 +231,4 @@ model_input = tokenizer.apply_chat_template(
     messages,
     tools = [current_time, multiply]
 )
-```
-
-## RAG
-
-Retrieval-augmented generation (RAG) models enhance a models existing knowledge by allowing it to search documents for additional information before returning a query. For RAG models, add a `documents` parameter to [`~PreTrainedTokenizerBase.apply_chat_template`]. This `documents` parameter should be a list of documents, and each document should be a single dict with `title` and `content` keys.
-
-> [!TIP]
-> The `documents` parameter for RAG isn't widely supported and many models have chat templates that ignore `documents`. Verify if a model supports `documents` by reading its model card or executing `print(tokenizer.chat_template)` to see if the `documents` key is present. [Command-R](https://hf.co/CohereForAI/c4ai-command-r-08-2024) and [Command-R+](https://hf.co/CohereForAI/c4ai-command-r-plus-08-2024) both support `documents` in their RAG chat templates.
-
-Create a list of documents to pass to the model.
-
-```py
-documents = [
-    {
-        "title": "The Moon: Our Age-Old Foe", 
-        "text": "Man has always dreamed of destroying the moon. In this essay, I shall..."
-    },
-    {
-        "title": "The Sun: Our Age-Old Friend",
-        "text": "Although often underappreciated, the sun provides several notable benefits..."
-    }
-]
-```
-
-Set `chat_template="rag"` in [`~PreTrainedTokenizerBase.apply_chat_template`] and generate a response.
-
-```py
-from transformers import AutoTokenizer, AutoModelForCausalLM
-
-# Load the model and tokenizer
-tokenizer = AutoTokenizer.from_pretrained("CohereForAI/c4ai-command-r-v01-4bit")
-model = AutoModelForCausalLM.from_pretrained("CohereForAI/c4ai-command-r-v01-4bit", device_map="auto")
-device = model.device # Get the device the model is loaded on
-
-# Define conversation input
-conversation = [
-    {"role": "user", "content": "What has Man always dreamed of?"}
-]
-
-input_ids = tokenizer.apply_chat_template(
-    conversation=conversation,
-    documents=documents,
-    chat_template="rag",
-    tokenize=True,
-    add_generation_prompt=True,
-    return_tensors="pt").to(device)
-
-# Generate a response 
-generated_tokens = model.generate(
-    input_ids,
-    max_new_tokens=100,
-    do_sample=True,
-    temperature=0.3,
-    )
-
-# Decode and print the generated text along with generation prompt
-generated_text = tokenizer.decode(generated_tokens[0])
-print(generated_text)
 ```

--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -53,10 +53,10 @@ def get_current_wind_speed(location: str):
 tools = [get_current_temperature, get_current_wind_speed]
 ```
 
-You may, if you wish, add a `Returns:` block to the docstring and a return type to the function header, but most models
-will not use this information. The parser will also ignore any of the actual code inside your function! What really
-matters is the function name, the argument names, the argument types, and the docstring describing the function's purpose
-and the purpose of its arguments. These create the "signature" that the model will use to decide whether to call the tool.
+You can optionally add a `Returns:` block to the docstring and a return type to the function header, but most models won't use this information. The parser will also ignore the actual code inside the function!
+
+What really matters is the function name, argument names, argument types, and docstring describing the function's purpose
+and the purpose of its arguments. These create the "signature" the model will use to decide whether to call the tool.
 
 ## A tool-calling example
 
@@ -132,7 +132,7 @@ The temperature in Paris, France right now is 22°C.<|im_end|>
 > significantly more complex process, as you need to handle multiple tool responses at once and disambiguate them, often using tool call IDs. Please refer to the model card to see exactly what format a model expects for tool calls.
 
 
-## Advanced: Manually writing JSON Schemas
+## JSON schemas
 
 Another way to define tools is by passing a [JSON schema](https://json-schema.org/learn/getting-started-step-by-step).
 

--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -58,7 +58,7 @@ You can optionally add a `Returns:` block to the docstring and a return type to 
 What really matters is the function name, argument names, argument types, and docstring describing the function's purpose
 and the purpose of its arguments. These create the "signature" the model will use to decide whether to call the tool.
 
-## A tool-calling example
+## Tool-calling Example
 
 Load a model and tokenizer that supports tool-use like [NousResearch/Hermes-2-Pro-Llama-3-8B](https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B), but you can also consider a larger model like [Command-R](./model_doc/cohere) and [Mixtral-8x22B](./model_doc/mixtral) if your hardware can support it.
 

--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -14,24 +14,20 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Tool Use
+# Tool use
 
-It is very common for chat models to be trained with support for "function-calling" or "tool-use". These "tools" are functions,
-supplied by the user, which the model can choose to call as part of its response. For example, models could have access to a calculator
-tool so that they can perform arithmetic without having to do it internally in the neural net itself, which usually becomes unreliable
-for larger inputs.
+Chat models are commonly trained with support for "function-calling" or "tool-use". Tools are functions supplied by the user, which the model can choose to call as part of its response. For example, models could have access to a calculator tool to perform arithmetic without having to it internally.
 
 This guide will demonstrate how to define tools, how to pass them to a chat model, and how to handle the model's output when it calls a tool.
 
 ## Passing tools
 
-When a model supports tool-use, you can pass functions to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`].
-The tools can be passed as either [JSON schema](https://json-schema.org/learn) or as Python functions. If you pass Python functions,
-the arguments, argument types and function docstring will be parsed in order to generate the JSON schema automatically.
+When a model supports tool-use, pass functions to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`].
+The tools are passed as either a [JSON schema](https://json-schema.org/learn) or Python functions. If you pass Python functions,
+the arguments, argument types, and function docstring are parsed in order to generate the JSON schema automatically.
 
 Although passing Python functions is very convenient, the parser can only handle [Google-style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings)
-docstrings. Therefore, make sure you follow that format! Here are a couple of examples of well-formatted functions
-that are ready to use as tools:
+docstrings. Refer to the examples below for how to format a tool-ready function.
 
 
 ```py
@@ -64,7 +60,7 @@ and the purpose of its arguments. These create the "signature" that the model wi
 
 ## A tool-calling example
 
-Let's start by loading a model and tokenizer that supports tool-use like [NousResearch/Hermes-2-Pro-Llama-3-8B](https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B), but you can also consider a larger model like [Command-R](./model_doc/cohere) and [Mixtral-8x22B](./model_doc/mixtral) if your hardware can support it.
+Load a model and tokenizer that supports tool-use like [NousResearch/Hermes-2-Pro-Llama-3-8B](https://hf.co/NousResearch/Hermes-2-Pro-Llama-3-8B), but you can also consider a larger model like [Command-R](./model_doc/cohere) and [Mixtral-8x22B](./model_doc/mixtral) if your hardware can support it.
 
 ```py
 import torch
@@ -75,7 +71,7 @@ tokenizer = AutoTokenizer.from_pretrained(checkpoint)
 model = AutoModelForCausalLM.from_pretrained(checkpoint, dtype="auto", device_map="auto")
 ```
 
-Next, let's create a chat, just like you would with a normal chat model.
+Create a chat history.
 
 ```py
 messages = [
@@ -84,8 +80,7 @@ messages = [
 ]
 ```
 
-Next, pass `messages` and a list of tools to [`~PreTrainedTokenizerBase.apply_chat_template`], then tokenize and generate a response. This is exactly
-the same as with a normal chat model, except for the `tools` argument.
+Next, pass `messages` and a list of tools to [`~PreTrainedTokenizerBase.apply_chat_template`]. Tokenize the chat and generate a response.
 
 ```py
 inputs = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=True, return_dict=True, return_tensors="pt")
@@ -99,30 +94,28 @@ print(tokenizer.decode(outputs[0][len(inputs["input_ids"][0]):]))
 </tool_call><|im_end|>
 ```
 
-The chat model has emitted a tool call! Specifically, it called the `get_current_temperature` tool with the correct parameters from the docstring. It inferred France as the location based on Paris, and that it should use Celsius for the units of temperature.
+The chat model called the `get_current_temperature` tool with the correct parameters from the docstring. It inferred France as the location based on Paris, and that it should use Celsius for the units of temperature.
 
-Note that the model **cannot actually call the tool itself**. Instead, it will request a tool call, and it's your job to handle the call and append both the call and the result to the chat history.
+A model **cannot actually call the tool itself**. It requests a tool call, and it's your job to handle the call and append it and the result to the chat history.
 
-Let's start with the call: We use the `tool_calls` key of an `assistant` message to hold the call. This is the recommended API, and should be supported by the chat template of most tool-using models.
+Hold the call in the `tool_calls` key of an `assistant` message. This is the recommended API, and should be supported by the chat template of most tool-using models.
 
 > [!WARNING]
-> Although this is similar to the OpenAI API, the OpenAI API uses a JSON string as its `tool_call` format. This may cause errors or strange model behavior if used in Transformers, which expects a dict.
+> Although `tool_calls` is similar to the OpenAI API, the OpenAI API uses a JSON string as its `tool_calls` format. This may cause errors or strange model behavior if used in Transformers, which expects a dict.
 
-<hfoptions id="tool-call">
-<hfoption id="Llama">
 
 ```py
 tool_call = {"name": "get_current_temperature", "arguments": {"location": "Paris, France", "unit": "celsius"}}
 messages.append({"role": "assistant", "tool_calls": [{"type": "function", "function": tool_call}]})
 ```
 
-Next, we have to actually append the tool response to the chat history. For this, we generally use the `tool` role:
+Append the tool response to the chat history with the `tool` role.
 
 ```py
 messages.append({"role": "tool", "content": "22"})  # Note that the returned content is always a string!
 ```
 
-Finally, allow the model to read the tool response and reply to the user:
+Finally, allow the model to read the tool response and reply to the user.
 
 ```py
 inputs = tokenizer.apply_chat_template(messages, tools=tools, add_generation_prompt=True, return_dict=True, return_tensors="pt")
@@ -135,18 +128,18 @@ The temperature in Paris, France right now is 22°C.<|im_end|>
 ```
 
 > [!WARNING]
-> Although the key in the assistant message is called `tool_calls`, in most cases models only emit a single tool call at a time. Some older models emit multiple tool calls at the same time, but this is a
-> signficantly more complex process, as you need to handle multiple tool responses at once and disambiguate them, often using tool call IDs. If you try this sample code with a model and get an error from the
-> chat template telling you to add a tool call ID, this is probably what's happened! Please refer to the model card to see exactly what format that model expects for tool calls.
+> Although the key in the assistant message is called `tool_calls`, in most cases, models only emit a single tool call at a time. Some older models emit multiple tool calls at the same time, but this is a
+> significantly more complex process, as you need to handle multiple tool responses at once and disambiguate them, often using tool call IDs. Please refer to the model card to see exactly what format a model expects for tool calls.
 
 
 ## Advanced: Manually writing JSON Schemas
 
-In the examples above, we passed Python functions to the `tools` argument of [`~PreTrainedTokenizerBase.apply_chat_template`]. This is a convenient way to define tools, but it is not the only way. You can also pass a [JSON schema](https://json-schema.org/learn/getting-started-step-by-step) directly.
-You can also manually call the low-level functions that convert Python functions to JSON schemas, and then check or edit the generated schemas. This is usually not necessary, but we include it here so that advanced users can understand the underlying mechanics. It's particularly important
-for chat template authors, since they will need to access the JSON schema to render the tool definitions.
+Another way to define tools is by passing a [JSON schema](https://json-schema.org/learn/getting-started-step-by-step).
 
-The function that [`~PreTrainedTokenizerBase.apply_chat_template`] uses to convert Python functions to JSON schema is [get_json_schema](https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205). Let's try calling it directly:
+You can also manually call the low-level functions that convert Python functions to JSON schemas, and then check or edit the generated schemas. This is usually not necessary, but is useful for understanding the underlying mechanics. It's particularly important
+for chat template authors who need to access the JSON schema to render the tool definitions.
+
+The  [`~PreTrainedTokenizerBase.apply_chat_template`] method uses the [get_json_schema](https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205) function to convert Python functions to a JSON schema.
 
 ```py
 from transformers.utils import get_json_schema

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -14,7 +14,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Chat Templates
+# Chat templates
 
 The [chat pipeline](./conversations) guide covers the basics of storing chat histories and generating text from chat models using [`TextGenerationPipeline`]. 
 This guide is intended for more advanced users, and covers the underlying classes and methods, as well as the key concepts you need to understand what's actually going on when you chat with a model.

--- a/docs/source/en/chat_templating.md
+++ b/docs/source/en/chat_templating.md
@@ -14,11 +14,18 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Templates
+# Chat Templates
 
-The [chat pipeline](./conversations) guide introduced [`TextGenerationPipeline`] and the concept of a chat prompt or chat template for conversing with a model. Underlying this high-level pipeline is the [`apply_chat_template`] method. A chat template is a part of the tokenizer and it specifies how to convert conversations into a single tokenizable string in the expected model format.
+The [chat pipeline](./conversations) guide covers the basics of storing chat histories and generating text from chat models using [`TextGenerationPipeline`]. 
+This guide is intended for more advanced users, and covers the underlying classes and methods, as well as the key concepts you need to understand what's actually going on when you chat with a model.
 
-In the example below, Mistral-7B-Instruct and Zephyr-7B are finetuned from the same base model but they’re trained with different chat formats. Without chat templates, you have to manually write formatting code for each model and even minor errors can hurt performance. Chat templates offer a universal way to format chat inputs to any model.
+The critical insight needed to understand chat models is this: All causal LMs, whether chat-trained or not, continue a sequence of tokens. When causal LMs are trained, the training usually begins with "pre-training" on a huge corpus of text, which creates a "base" model.
+These base models are then often "fine-tuned" for chat, which means training them on data that is formatted as a sequence of messages. The chat is still just a sequence of tokens, though! The list of `role` and `content` dictionaries that you pass
+to a chat model get converted to a token sequence, often with control tokens like `<|user|>` or `<|assistant|>` or `<|end_of_message|>`, which allow the model to see the chat structure. 
+There are many possible chat formats, and different models may use different formats or control tokens, even if they were fine-tuned from the same base model!
+
+Don't panic, though - you don't need to memorize every possible chat format in order to use chat models. Chat models come with **chat templates**, which indicate how they expect chats to be formatted.
+You can access these with the [`apply_chat_template`] method. Let's see two examples. Both of these models are fine-tuned from the same `Mistral-7B` base model:
 
 <hfoptions id="template">
 <hfoption id="Mistral">
@@ -61,13 +68,13 @@ tokenizer.apply_chat_template(chat, tokenize=False)
 </hfoption>
 </hfoptions>
 
-This guide explores [`apply_chat_template`] and chat templates in more detail.
+Note how `Mistral-7B-Instruct` uses `[INST]` and `[/INST]` tokens to indicate the start and end of user messages, while `Zephyr-7B` uses `<|user|>` and `<|assistant|>` tokens to indicate the roles of the speakers. This is why chat templates are important - with the wrong tokens, these models would have drastically worse performance!
 
-## apply_chat_template
+## Using `apply_chat_template` in a chat
 
-Chats should be structured as a list of dictionaries with `role` and `content` keys. The `role` key specifies the speaker (usually between you and the system), and the `content` key contains your message. For the system, the `content` is a high-level description of how the model should behave and respond when you’re chatting with it.
+The input to `apply_chat_template` should be structured as a list of dictionaries with `role` and `content` keys. The `role` key specifies the speaker, and the `content` key contains the message. The common roles are `user` for messages from the user, `assistant` for messages from the model, and `system`, which represent directives on how the model should act, and is usually placed at the beginning of the chat.
 
-Pass your messages to [`apply_chat_template`] to tokenize and format them. You can set [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) to `True` to indicate the start of a message.
+[`apply_chat_template`] takes this list and returns a formatted, and optionally tokenized, sequence:
 
 ```py
 import torch
@@ -83,6 +90,7 @@ messages = [
 tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=True, add_generation_prompt=True, return_tensors="pt")
 print(tokenizer.decode(tokenized_chat[0]))
 ```
+
 ```md
 <|system|>
 You are a friendly chatbot who always responds in the style of a pirate</s>
@@ -91,7 +99,7 @@ How many helicopters can a human eat in one sitting?</s>
 <|assistant|>
 ```
 
-Now pass the tokenized chat to [`~GenerationMixin.generate`] to generate a response.
+Now we can simply pass the tokenized chat to [`~GenerationMixin.generate`] to generate a response.
 
 ```py
 outputs = model.generate(tokenized_chat, max_new_tokens=128) 
@@ -106,10 +114,17 @@ How many helicopters can a human eat in one sitting?</s>
 Matey, I'm afraid I must inform ye that humans cannot eat helicopters. Helicopters are not food, they are flying machines. Food is meant to be eaten, like a hearty plate o' grog, a savory bowl o' stew, or a delicious loaf o' bread. But helicopters, they be for transportin' and movin' around, not for eatin'. So, I'd say none, me hearties. None at all.
 ```
 
-### add_generation_prompt
-The [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) parameter adds tokens that indicate the start of a response. This ensures the chat model generates a system response instead of continuing a users message.
+> [!WARNING]
+> Some tokenizers add special `<bos>` and `<eos>` tokens. Chat templates should already include all the necessary special tokens, and adding additional special tokens is often incorrect or duplicated, hurting model performance. When you format text with `apply_chat_template(tokenize=False)`, make sure you set `add_special_tokens=False` if you tokenize later to avoid duplicating these tokens.
+> This isn’t an issue if you use `apply_chat_template(tokenize=True)`, which means it's usually the safer option!
 
-Not all models require generation prompts, and some models, like [Llama](./model_doc/llama), don’t have any special tokens before the system response. In this case, [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) has no effect.
+### add_generation_prompt
+
+You may have noticed the [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) argument in the above examples. 
+This argument adds tokens to the end of the chat that indicate the start of an `assistant` response. Remember: Beneath all the chat abstractions, chat models are still just language models that continue a sequence of tokens!
+If you include tokens that tell it that it's now in an `assistant` response, it will correctly write a response, but if you don't include these tokens, the model may get confused and do something strange, like **continuing** the user's message instead of replying to it! 
+
+Let's see an example to understand what `add_generation_prompt` is actually doing. First, let's format a chat without `add_generation_prompt`:
 
 ```py
 tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=False)
@@ -124,11 +139,32 @@ Nice to meet you!<|im_end|>
 Can I ask a question?<|im_end|>
 ```
 
+Now, let's format the same chat with `add_generation_prompt=True`:
+
+```py
+tokenized_chat = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+tokenized_chat
+```
+```md
+<|im_start|>user
+Hi there!<|im_end|>
+<|im_start|>assistant
+Nice to meet you!<|im_end|>
+<|im_start|>user
+Can I ask a question?<|im_end|>
+<|im_start|>assistant
+
+```
+
+Notice the extra `<|im_start|>assistant` at the end - this indicates the start of an `assistant` message, and so the model knows that what's coming next is an assistant response.
+
+Not all models require generation prompts, and some models, like [Llama](./model_doc/llama), don’t have any special tokens before the `assistant` response. In these cases, [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) has no effect.
+
 ### continue_final_message
 
 The [continue_final_message](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.continue_final_message) parameter controls whether the final message in the chat should be continued or not instead of starting a new one. It removes end of sequence tokens so that the model continues generation from the final message.
 
-This is useful for “prefilling” a model response. In the example below, the model generates text that continues the JSON string rather than starting a new message. It can be very useful for improving the accuracy for instruction following when you know how to start its replies.
+This is useful for “prefilling” a model response. In the example below, the model generates text that continues the JSON string rather than starting a new message. It can be very useful for improving the accuracy of instruction following when you know how to start its replies.
 
 ```py
 chat = [
@@ -143,52 +179,12 @@ model.generate(**formatted_chat)
 > [!WARNING]
 > You shouldn’t use [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) and [continue_final_message](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.continue_final_message) together. The former adds tokens that start a new message, while the latter removes end of sequence tokens. Using them together returns an error.
 
-[`TextGenerationPipeline`] sets [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) to `True` by default to start a new message. However, if the final message in the chat has the “assistant” role, it assumes the message is a prefill and switches to `continue_final_message=True`. This is because most models don’t support multiple consecutive assistant messages. To override this behavior, explicitly pass the [continue_final_message](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.continue_final_message) to the pipeline.
+[`TextGenerationPipeline`] sets [add_generation_prompt](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.add_generation_prompt) to `True` by default to start a new message. However, if the final message in the chat has the “assistant” role, it assumes the message is a prefill and switches to `continue_final_message=True`. This is because most models don’t support multiple consecutive assistant messages. To override this behavior, explicitly pass the [continue_final_message](https://huggingface.co/docs/transformers/internal/tokenization_utils#transformers.PreTrainedTokenizerBase.apply_chat_template.continue_final_message) argument to the pipeline.
 
-## Multiple templates
 
-A model may have several different templates for different use cases. For example, a model may have a template for regular chat, tool use, and RAG.
+## Advanced: Model training
 
-When there are multiple templates, the chat template is a dictionary. Each key corresponds to the name of a template. [`apply_chat_template`] handles multiple templates based on their name. It looks for a template named `default` in most cases and if it can’t find one, it raises an error.
-
-For a tool calling template, if a user passes a `tools` parameter and a `tool_use` template exists, the tool calling template is used instead of `default`.
-
-To access templates with other names, pass the template name to the `chat_template` parameter in [`apply_chat_template`]. For example, if you’re using a RAG template then set `chat_template="rag"`.
-
-It can be confusing to manage multiple templates though, so we recommend using a single template for all use cases. Use Jinja statements like `if tools is defined` and `{% macro %}` definitions to wrap multiple code paths in a single template.
-
-## Template selection
-
-It is important to set a chat template format that matches the template format a model was pretrained on, otherwise performance may suffer. Even if you’re training the model further, performance is best if the chat tokens are kept constant.
-
-But if you’re training a model from scratch or finetuning a model for chat, you have more options to select a template. For example, [ChatML](https://github.com/openai/openai-python/blob/release-v0.28.0/chatml.md) is a popular format that is flexible enough to handle many use cases. It even includes support for [generation prompts](#add_generation_prompt), but it doesn’t add beginning-of-string (`BOS`) or end-of-string (`EOS`) tokens. If your model expects `BOS` and `EOS` tokens, set `add_special_tokens=True` and make sure to add them to your template.
-
-```py
-{%- for message in messages %}
-    {{- '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n' }}
-{%- endfor %}
-```
-
-Set the template with the following logic to support [generation prompts](#add_generation_prompt). The template wraps each message with `<|im_start|>` and `<|im_end|>` tokens and writes the role as a string. This allows you to easily customize the roles you want to train with.
-
-```py
-tokenizer.chat_template = "{% if not add_generation_prompt is defined %}{% set add_generation_prompt = false %}{% endif %}{% for message in messages %}{{'<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>' + '\n'}}{% endfor %}{% if add_generation_prompt %}{{ '<|im_start|>assistant\n' }}{% endif %}"
-```
-
-The `user`, `system` and `assistant` roles are standard roles in chat templates. We recommend using these roles when it makes sense, especially if you’re using your model with the [`TextGenerationPipeline`].
-
-```py
-<|im_start|>system
-You are a helpful chatbot that will do its best not to say anything so stupid that people tweet about it.<|im_end|>
-<|im_start|>user
-How are you?<|im_end|>
-<|im_start|>assistant
-I'm doing great!<|im_end|>
-```
-
-## Model training
-
-Training a model with a chat template is a good way to ensure a chat template matches the tokens a model is trained on. Apply the chat template as a preprocessing step to your dataset. Set `add_generation_prompt=False` because the additional tokens to prompt an assistant response aren’t helpful during training.
+Training a model with a chat template is a good way to ensure the template matches the tokens the model was trained on. Apply the chat template as a preprocessing step to your dataset. Set `add_generation_prompt=False` because the additional tokens to prompt an assistant response aren’t helpful during training.
 
 An example of preprocessing a dataset with a chat template is shown below.
 
@@ -219,11 +215,3 @@ The sun.</s>
 ```
 
 After this step, you can continue following the [training recipe](./tasks/language_modeling) for causal language models using the `formatted_chat` column.
-
-Some tokenizers add special `<bos>` and `<eos>` tokens. Chat templates should already include all the necessary special tokens, and adding additional special tokens is often incorrect or duplicated, hurting model performance. When you format text with `apply_chat_template(tokenize=False)`, make sure you set `add_special_tokens=False` as well to avoid duplicating them.
-
-```py
-apply_chat_template(messages, tokenize=False, add_special_tokens=False)
-```
-
-This isn’t an issue if `apply_chat_template(tokenize=True)`.

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -19,7 +19,7 @@ rendered properly in your Markdown viewer.
 Multimodal chat models are similar to normal chat models, but they can also accept non-text inputs like images, audio or video.
 
 Chatting with multimodal models is very similar to chatting with text-only models, with the key difference being the `content` key of the messages. Instead of a single string,
-as it is for text-only models, `content` can be a list containing multiple items of different types.
+as it is for text-only models, `content` should be a list containing multiple items of different types.
 
 In the same way that the [Tokenizer](./tokenizer_summary.md) class handles chat templates and tokenization for text-only models, 
 the [Processor](./processors) class handles preprocessing, tokenization and chat templates for multimodal models. Methods like [`ProcessorMixin.apply_chat_template`] are almost identical.

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -14,7 +14,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Multimodal templates
+# Multimodal chat templates
 
 Multimodal chat models are similar to normal chat models, but they can also accept non-text inputs like images, audio or video.
 

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -281,28 +281,3 @@ print(processed_chat.keys())
 </hfoption>
 </hfoptions>
 
-## Template configuration
-
-You can create a custom chat template with [Jinja](https://jinja.palletsprojects.com/en/3.1.x/templates/) and set it with [`~ProcessorMixin.apply_chat_template`]. Refer to the [Template writing](./chat_templating_writing) guide for more details.
-
-For example, to enable a template to handle a *list of content* from multiple modalities while still supporting plain strings for text-only inference, specify how to handle the `content['type']` if it is an image or text as shown below in the Llama 3.2 Vision Instruct [template](https://huggingface.co/meta-llama/Llama-3.2-11B-Vision-Instruct/blob/main/chat_template.json).
-
-```jinja
-{% for message in messages %}
-{% if loop.index0 == 0 %}{{ bos_token }}{% endif %}
-{{ '<|start_header_id|>' + message['role'] + '<|end_header_id|>\n\n' }}
-{% if message['content'] is string %}
-{{ message['content'] }}
-{% else %}
-{% for content in message['content'] %}
-{% if content['type'] == 'image' %}
-{{ '<|image|>' }}
-{% elif content['type'] == 'text' %}
-{{ content['text'] }}
-{% endif %}
-{% endfor %}
-{% endif %}
-{{ '<|eot_id|>' }}
-{% endfor %}
-{% if add_generation_prompt %}{{ '<|start_header_id|>assistant<|end_header_id|>\n\n' }}{% endif %}
-```

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -16,20 +16,22 @@ rendered properly in your Markdown viewer.
 
 # Multimodal templates
 
-Multimodal model chat templates expect a similar [template](./chat_templating) as text-only models. It needs `messages` that includes a dictionary of the `role` and `content`.
+Multimodal chat models are similar to normal chat models, but they can also accept non-text inputs like images, audio or video.
 
-Multimodal templates are included in the [Processor](./processors) class and require an additional `type` key for specifying whether the included content is an image, video, or text.
+Chatting with multimodal models is very similar to chatting with text-only models, with the key difference being the `content` key of the messages. Instead of a single string,
+as it is for text-only models, `content` can be a list containing multiple items of different types.
 
-This guide will show you how to format chat templates for multimodal models as well as some best practices for configuring the template
+In the same way that the [Tokenizer](./tokenizer_summary.md) class handles chat templates and tokenization for text-only models, 
+the [Processor](./processors) class handles preprocessing, tokenization and chat templates for multimodal models. Methods like [`ProcessorMixin.apply_chat_template`] are almost identical.
+
+This guide will show you how to chat with multimodal models, first at a high level using the [`ImageTextToTextPipeline`] and then at a lower level using the [`ProcessorMixin.apply_chat_template`] and [`GenerationMixin.generate`] methods.
 
 ## ImageTextToTextPipeline
 
-[`ImageTextToTextPipeline`] is a high-level image and text generation class with a “chat mode”. Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format).
+[`ImageTextToTextPipeline`] is a high-level image and text generation class with a “chat mode”. Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format). You can think of this pipeline
+as the equivalent of the [`TextGenerationPipeline`] for multimodal vision-language models (VLMs).
 
-Start by building a chat history with the following two roles.
-
-- `system` describes how the model should behave and respond when you’re chatting with it. This role isn’t supported by all chat models.
-- `user` is where you enter your first message to the model.
+We can see this pipeline in action by building a sample chat. Note how `content` is a list here!
 
 ```py
 messages = [
@@ -47,39 +49,37 @@ messages = [
 ]
 ```
 
-Create a [`ImageTextToTextPipeline`] and pass the chat to it. For large models, setting [device_map=“auto”](./models#big-model-inference) helps load the model quicker and automatically places it on the fastest device available. Changing the data type to [torch.bfloat16](./models#model-data-type) also helps save memory.
-
-> [!TIP]
-> The [`ImageTextToTextPipeline`] accepts chats in the OpenAI format to make inference easier and more accessible. 
+Next, we create an [`ImageTextToTextPipeline`] and pass the chat to it. For large models, setting [device_map=“auto”](./models#big-model-inference) helps load the model quicker and automatically places it on the fastest device available. Setting the data type to [auto](./models#model-data-type) also helps save memory and improve speed.
 
 ```python
 import torch
 from transformers import pipeline
 
-pipeline = pipeline("image-text-to-text", model="llava-hf/llava-onevision-qwen2-0.5b-ov-hf", device_map="auto", dtype=torch.float16)
-pipeline(text=messages, max_new_tokens=50, return_full_text=False)
-[{'input_text': [{'role': 'system',
-    'content': [{'type': 'text',
-      'text': 'You are a friendly chatbot who always responds in the style of a pirate'}]},
-   {'role': 'user',
-    'content': [{'type': 'image',
-      'url': 'http://images.cocodataset.org/val2017/000000039769.jpg'},
-     {'type': 'text', 'text': 'What are these?'}]}],
-  'generated_text': 'The image shows two cats lying on a pink surface, which appears to be a cushion or a soft blanket. The cat on the left has a striped coat, typical of tabby cats, and is lying on its side with its head resting on the'}]
+pipe = pipeline("image-text-to-text", model="Qwen/Qwen2.5-VL-3B-Instruct", device_map="auto", dtype="auto")
+out = pipe(text=messages, max_new_tokens=128)
+print(out[0]['generated_text'][-1]['content'])
 ```
 
-## Image inputs
+And we get:
 
-For multimodal models that accept images like [LLaVA](./model_doc/llava), include the following in `content` as shown below.
+```
+Ahoy, me hearty! These be two feline friends, likely some tabby cats, taking a siesta on a cozy pink blanket. They're resting near remote controls, perhaps after watching some TV or just enjoying some quiet time together. Cats sure know how to find comfort and relaxation, don't they?
+```
 
-- The content `"type"` can be an `"image"` or `"text"`.
-- For images, it can be a link to the image (`"url"`), a file path (`"path"`), or `"base64"`. Images are automatically loaded, processed, and prepared into pixel values as inputs to the model.
+Aside from the gradual descent from pirate-speak into modern American English (it **is** only a 3B model, after all), this is correct!
+
+## Using `apply_chat_template` directly
+
+Similarly to [text-only models](./chat_templating.md), you can use the [`ProcessorMixin.apply_chat_template`] method to prepare the chat messages for multimodal models. 
+This method handles the tokenization and formatting of the chat messages, including images and other media types. You can then pass the resulting inputs to the model for generation.
+
+Let's see the example above, but using the low-level methods directly instead of a `pipeline`:
 
 ```python
-from transformers import AutoProcessor, LlavaOnevisionForConditionalGeneration
+from transformers import AutoProcessor, AutoModelForImageTextToText
 
-model = LlavaOnevisionForConditionalGeneration.from_pretrained("llava-hf/llava-onevision-qwen2-0.5b-ov-hf")
-processor = AutoProcessor.from_pretrained("llava-hf/llava-onevision-qwen2-0.5b-ov-hf")
+model = AutoModelForImageTextToText.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct", device_map="auto", torch_dtype="auto")
+processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-3B-Instruct")
 
 messages = [
     {
@@ -96,14 +96,32 @@ messages = [
 ]
 ```
 
-Pass `messages` to [`~ProcessorMixin.apply_chat_template`] to tokenize the input content and return the `input_ids` and `pixel_values`.
+Pass `messages` to [`~ProcessorMixin.apply_chat_template`] to tokenize the input content. Note that, unlike text models, the output of `apply_chat_template` will
+contain a `pixel_values` key with the preprocessed image data, in addition to the tokenized text.
 
 ```py
 processed_chat = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=True, return_dict=True, return_tensors="pt")
-print(processed_chat.keys())
+print(list(processed_chat.keys()))
 ```
 
-These inputs are now ready to be used in [`~GenerationMixin.generate`].
+and you should see:
+
+```
+['input_ids', 'attention_mask', 'pixel_values', 'image_grid_thw']
+```
+
+These inputs are now ready to be used in [`~GenerationMixin.generate`]:
+
+```python
+out = model.generate(**processed_chat.to(model.device), max_new_tokens=128)
+print(processor.decode(out[0]))
+```
+
+If you try this, note that because we used lower-level methods the decoded output is the full conversation so far, including
+the user message and the placeholder tokens that contain the image information. As a result, I won't paste it all here,
+as it might blow up the document a bit! Just be aware that if you want to use the lower-level methods in practice,
+you may need to trim the previous conversation from the output before displaying it to the user.
+
 
 ## Video inputs
 

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -64,12 +64,11 @@ Ahoy, me hearty! These be two feline friends, likely some tabby cats, taking a s
 
 Aside from the gradual descent from pirate-speak into modern American English (it **is** only a 3B model, after all), this is correct!
 
-## Using `apply_chat_template` directly
+## Using `apply_chat_template`
 
-Similarly to [text-only models](./chat_templating.md), you can use the [`ProcessorMixin.apply_chat_template`] method to prepare the chat messages for multimodal models. 
-This method handles the tokenization and formatting of the chat messages, including images and other media types. You can then pass the resulting inputs to the model for generation.
+Like [text-only models](./chat_templating), use the [`~ProcessorMixin.apply_chat_template`] method to prepare the chat messages for multimodal models. 
+This method handles the tokenization and formatting of the chat messages, including images and other media types. The resulting inputs are passed to the model for generation.
 
-Let's see the example above, but using the low-level methods directly instead of a `pipeline`:
 
 ```python
 from transformers import AutoProcessor, AutoModelForImageTextToText
@@ -92,31 +91,27 @@ messages = [
 ]
 ```
 
-Pass `messages` to [`~ProcessorMixin.apply_chat_template`] to tokenize the input content. Note that, unlike text models, the output of `apply_chat_template` will
-contain a `pixel_values` key with the preprocessed image data, in addition to the tokenized text.
+Pass `messages` to [`~ProcessorMixin.apply_chat_template`] to tokenize the input content. Unlike text models, the output of `apply_chat_template`
+contains a `pixel_values` key with the preprocessed image data, in addition to the tokenized text.
 
 ```py
 processed_chat = processor.apply_chat_template(messages, add_generation_prompt=True, tokenize=True, return_dict=True, return_tensors="pt")
 print(list(processed_chat.keys()))
 ```
 
-and you should see:
 
 ```
 ['input_ids', 'attention_mask', 'pixel_values', 'image_grid_thw']
 ```
 
-These inputs are now ready to be used in [`~GenerationMixin.generate`]:
+Pass these inputs to [`~GenerationMixin.generate`].
 
 ```python
 out = model.generate(**processed_chat.to(model.device), max_new_tokens=128)
 print(processor.decode(out[0]))
 ```
 
-If you try this, note that because we used lower-level methods the decoded output is the full conversation so far, including
-the user message and the placeholder tokens that contain the image information. As a result, I won't paste it all here,
-as it might blow up the document a bit! Just be aware that if you want to use the lower-level methods in practice,
-you may need to trim the previous conversation from the output before displaying it to the user.
+The decoded output contains the full conversation so far, including the user message and the placeholder tokens that contain the image information. You may need to trim the previous conversation from the output before displaying it to the user.
 
 
 ## Video inputs

--- a/docs/source/en/chat_templating_multimodal.md
+++ b/docs/source/en/chat_templating_multimodal.md
@@ -16,22 +16,19 @@ rendered properly in your Markdown viewer.
 
 # Multimodal chat templates
 
-Multimodal chat models are similar to normal chat models, but they can also accept non-text inputs like images, audio or video.
+Multimodal chat models accept inputs like images, audio or video, in addition to text. The `content` key in a multimodal chat history is a list containing multiple items of different types. This is unlike text-only chat models whose `content` key is a single string.
 
-Chatting with multimodal models is very similar to chatting with text-only models, with the key difference being the `content` key of the messages. Instead of a single string,
-as it is for text-only models, `content` should be a list containing multiple items of different types.
 
-In the same way that the [Tokenizer](./tokenizer_summary.md) class handles chat templates and tokenization for text-only models, 
-the [Processor](./processors) class handles preprocessing, tokenization and chat templates for multimodal models. Methods like [`ProcessorMixin.apply_chat_template`] are almost identical.
+In the same way the [Tokenizer](./fast_tokenizer) class handles chat templates and tokenization for text-only models, 
+the [Processor](./processors) class handles preprocessing, tokenization and chat templates for multimodal models. Their [`~ProcessorMixin.apply_chat_template`] methods are almost identical.
 
-This guide will show you how to chat with multimodal models, first at a high level using the [`ImageTextToTextPipeline`] and then at a lower level using the [`ProcessorMixin.apply_chat_template`] and [`GenerationMixin.generate`] methods.
+This guide will show you how to chat with multimodal models with the high-level [`ImageTextToTextPipeline`] and at a lower level using the [`~ProcessorMixin.apply_chat_template`] and [`~GenerationMixin.generate`] methods.
 
 ## ImageTextToTextPipeline
 
-[`ImageTextToTextPipeline`] is a high-level image and text generation class with a “chat mode”. Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format). You can think of this pipeline
-as the equivalent of the [`TextGenerationPipeline`] for multimodal vision-language models (VLMs).
+[`ImageTextToTextPipeline`] is a high-level image and text generation class with a “chat mode”. Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format).
 
-We can see this pipeline in action by building a sample chat. Note how `content` is a list here!
+Add image and text blocks to the `content` key in the chat history.
 
 ```py
 messages = [
@@ -49,7 +46,7 @@ messages = [
 ]
 ```
 
-Next, we create an [`ImageTextToTextPipeline`] and pass the chat to it. For large models, setting [device_map=“auto”](./models#big-model-inference) helps load the model quicker and automatically places it on the fastest device available. Setting the data type to [auto](./models#model-data-type) also helps save memory and improve speed.
+Create an [`ImageTextToTextPipeline`] and pass the chat to it. For large models, setting [device_map=“auto”](./models#big-model-inference) helps load the model quicker and automatically places it on the fastest device available. Setting the data type to [auto](./models#model-data-type) also helps save memory and improve speed.
 
 ```python
 import torch
@@ -60,7 +57,6 @@ out = pipe(text=messages, max_new_tokens=128)
 print(out[0]['generated_text'][-1]['content'])
 ```
 
-And we get:
 
 ```
 Ahoy, me hearty! These be two feline friends, likely some tabby cats, taking a siesta on a cozy pink blanket. They're resting near remote controls, perhaps after watching some TV or just enjoying some quiet time together. Cats sure know how to find comfort and relaxation, don't they?

--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -16,7 +16,7 @@ rendered properly in your Markdown viewer.
 
 # Chat basics
 
-Chat models are conversational models which you communicate with by sending and receiving a series of messages, like an online chat. Most new language models from mid-2023 onwards are chat models, and models which are not trained for chat are usually referred to as "base" models, while models trained for chat are sometimes called "instruct" or "instruction-tuned". There are many chat models available to choose from; larger and newer models tend to be more capable, though there are plenty of exceptions to this rule!
+Chat models are conversational models you can send a message to and receive a response. Most language models from mid-2023 onwards are chat models and may be referred to as "instruct" or "instruction-tuned" models. Models that do not support chat are often referred to as "base" or "pretrained" models.
 
 Larger and newer models are generally more capable, but models specialized in certain domains (medical, legal text, non-English languages, etc.) can often outperform these larger models. Try leaderboards like [OpenLLM](https://hf.co/spaces/HuggingFaceH4/open_llm_leaderboard) and [LMSys Chatbot Arena](https://chat.lmsys.org/?leaderboard) to help you identify the best model for your use case.
 
@@ -95,12 +95,12 @@ or you run out of memory.
 
 ## Performance and memory usage
 
-Transformers load models in full `float32` precision by default, and for a 8B model, this requires ~32GB of memory! You can reduce memory usage using the `torch_dtype="auto"` argument, which will generally use `bfloat16` for models that were trained with it. To go even lower, you can quantize the model to 8-bit or 4-bit with [bitsandbytes](https://hf.co/docs/bitsandbytes/index).
+Transformers load models in full `float32` precision by default, and for a 8B model, this requires ~32GB of memory! Use the `torch_dtype="auto"` argument, which generally uses `bfloat16` for models that were trained with it, to reduce your memory usage.
 
 > [!TIP]
 > Refer to the [Quantization](./quantization/overview) docs for more information about the different quantization backends available.
 
-To load in 8-bit precision, create a [`BitsAndBytesConfig`] with your desired quantization settings and pass it to the pipelines `model_kwargs` parameter. The example below quantizes a model to 8-bits.
+To lower memory usage even lower, you can quantize the model to 8-bit or 4-bit with [bitsandbytes](https://hf.co/docs/bitsandbytes/index). Create a [`BitsAndBytesConfig`] with your desired quantization settings and pass it to the pipelines `model_kwargs` parameter. The example below quantizes a model to 8-bits.
 
 ```py
 from transformers import pipeline, BitsAndBytesConfig
@@ -110,10 +110,9 @@ pipeline = pipeline(task="text-generation", model="meta-llama/Meta-Llama-3-8B-In
 ```
 
 In general, model size and performance are directly correlated. Larger models are slower in addition to requiring more memory because each active parameter must be read from memory for every generated token. 
-This turns out to be the bottleneck for generating text from an LLM, which means that the main options for improving generation speed are to either quantize a model or use hardware with higher memory bandwidth. Adding
-more compute power has surprisingly little effect!
+This is a bottleneck for LLM text generation and the main options for improving generation speed are to either quantize a model or use hardware with higher memory bandwidth. Adding more compute power doesn't meaningfully help.
 
 You can also try techniques like [speculative decoding](./generation_strategies#speculative-decoding), where a smaller model generates candidate tokens that are verified by the larger model. If the candidate tokens are correct, the larger model can generate more than one token at a time. This significantly alleviates the bandwidth bottleneck and improves generation speed.
 
 > [!TIP]
-> MoE models such as [Mixtral](./model_doc/mixtral), [Qwen2MoE](./model_doc/qwen2_moe), and [GPT-OSS](./model_doc/gpt-oss) have lots of parameters, but only "activate" a small fraction of them to generate each token. As a result, MoE models generally have much lower memory bandwidth requirements and can be faster than a regular LLM of the same size. However, techniques like speculative decoding are ineffective with MoE models because more parameters become activated with each new speculated token.
+Mixture-of-Expert (MoE) models such as [Mixtral](./model_doc/mixtral), [Qwen2MoE](./model_doc/qwen2_moe), and [GPT-OSS](./model_doc/gpt-oss) have lots of parameters, but only "activate" a small fraction of them to generate each token. As a result, MoE models generally have much lower memory bandwidth requirements and can be faster than a regular LLM of the same size. However, techniques like speculative decoding are ineffective with MoE models because more parameters become activated with each new speculated token.

--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -53,8 +53,8 @@ The chat is implemented on top of the [AutoClass](./model_doc/auto), using tooli
 
 [`TextGenerationPipeline`] is a high-level text generation class with a "chat mode". Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format).
 
-Chat models accept a chat history as input, which is a list of messages. Each message is a dictionary with `role` and `content` keys.
-To start the chat, you can just have a single `user` message. You can also optionally include a `system` message to give the model directions on how to behave.
+Chat models accept a list of messages (the chat history) as the input. Each message is a dictionary with `role` and `content` keys.
+To start the chat, add a single `user` message. You can also optionally include a `system` message to give the model directions on how to behave.
 
 ```py
 chat = [

--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -79,7 +79,7 @@ you need to update the chat history with the model's response. You can do this e
 to `chat` (use the `assistant` role), or by reading `response[0]["generated_text"]`, which contains
 the full chat history, including the most recent response.
 
-Once you have the model's response, you can continue the conversation by appending a new `user` message to the chat history, like so:
+Once you have the model's response, you can continue the conversation by appending a new `user` message to the chat history.
 
 ```py
 chat = response[0]["generated_text"]

--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -18,7 +18,7 @@ rendered properly in your Markdown viewer.
 
 Chat models are conversational models which you communicate with by sending and receiving a series of messages, like an online chat. Most new language models from mid-2023 onwards are chat models, and models which are not trained for chat are usually referred to as "base" models, while models trained for chat are sometimes called "instruct" or "instruction-tuned". There are many chat models available to choose from; larger and newer models tend to be more capable, though there are plenty of exceptions to this rule!
 
-If you're just looking for a general chat model, try leaderboards like [OpenLLM](https://hf.co/spaces/HuggingFaceH4/open_llm_leaderboard) and [LMSys Chatbot Arena](https://chat.lmsys.org/?leaderboard) to help you identify the top performers. Be careful, though! Models that are specialized in certain domains (medical/legal text, non-English languages, etc.) can often outperform larger general purpose models, so the top leaderboard models may not be the best at your particular task.
+Larger and newer models are generally more capable, but models specialized in certain domains (medical, legal text, non-English languages, etc.) can often outperform these larger models. Try leaderboards like [OpenLLM](https://hf.co/spaces/HuggingFaceH4/open_llm_leaderboard) and [LMSys Chatbot Arena](https://chat.lmsys.org/?leaderboard) to help you identify the best model for your use case.
 
 This guide shows you how to quickly load chat models in Transformers from the command line, how to build and format a conversation, and how to chat using the [`TextGenerationPipeline`].
 

--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -16,18 +16,15 @@ rendered properly in your Markdown viewer.
 
 # Chat basics
 
-Chat models are conversational models you can send and receive messages from. There are many chat models available to choose from, but in general, larger models tend to be better though that's not always the case. The model size is often included in the name, like "8B" or "70B", and it describes the number of parameters. Mixture-of-expert (MoE) models have names like "8x7B" or "141B-A35B" which means it's a 56B and 141B parameter model. You can try quantizing larger models to reduce memory requirements, otherwise you'll need ~2 bytes of memory per parameter.
+Chat models are conversational models which you communicate with by sending and receiving a series of messages, like an online chat. Most new language models from mid-2023 onwards are chat models, and models which are not trained for chat are usually referred to as "base" models, while models trained for chat are sometimes called "instruct" or "instruction-tuned". There are many chat models available to choose from; larger and newer models tend to be more capable, though there are plenty of exceptions to this rule!
 
-Check model leaderboards like [OpenLLM](https://hf.co/spaces/HuggingFaceH4/open_llm_leaderboard) and [LMSys Chatbot Arena](https://chat.lmsys.org/?leaderboard) to further help you identify the best chat models for your use case. Models that are specialized in certain domains (medical, legal text, non-English languages, etc.) may sometimes outperform larger general purpose models.
+If you're just looking for a general chat model, try leaderboards like [OpenLLM](https://hf.co/spaces/HuggingFaceH4/open_llm_leaderboard) and [LMSys Chatbot Arena](https://chat.lmsys.org/?leaderboard) to help you identify the top performers. Be careful, though! Models that are specialized in certain domains (medical/legal text, non-English languages, etc.) can often outperform larger general purpose models, so the top leaderboard models may not be the best at your particular task.
 
-> [!TIP]
-> Chat with a number of open-source models for free on [HuggingChat](https://hf.co/chat/)!
-
-This guide shows you how to quickly start chatting with Transformers from the command line, how build and format a conversation, and how to chat using the [`TextGenerationPipeline`].
+This guide shows you how to quickly start chatting with chat models in Transformers from the command line, how build and format a conversation, and how to chat using the [`TextGenerationPipeline`].
 
 ## chat CLI
 
-After you've [installed Transformers](./installation), chat with a model directly from the command line as shown below. It launches an interactive session with a model, with a few base commands listed at the start of the session.
+After you've [installed Transformers](./installation), you can chat with a model directly from the command line. The command below launches an interactive session with a model, with a few base commands listed at the start of the session.
 
 ```bash
 transformers chat Qwen/Qwen2.5-0.5B-Instruct
@@ -56,80 +53,48 @@ The chat is implemented on top of the [AutoClass](./model_doc/auto), using tooli
 
 [`TextGenerationPipeline`] is a high-level text generation class with a "chat mode". Chat mode is enabled when a conversational model is detected and the chat prompt is [properly formatted](./llm_tutorial#wrong-prompt-format).
 
-To start, build a chat history with the following two roles.
-
-- `system` describes how the model should behave and respond when you're chatting with it. This role isn't supported by all chat models.
-- `user` is where you enter your first message to the model.
+Chat models accept a chat history as input, which is a list of messages. Each message is a dictionary with `role` and `content` keys.
+To start the chat, you can just have a single `user` message. You can also optionally include a `system` message to give the model directions on how to behave.
 
 ```py
 chat = [
-    {"role": "system", "content": "You are a sassy, wise-cracking robot as imagined by Hollywood circa 1986."},
-    {"role": "user", "content": "Hey, can you tell me any fun things to do in New York?"}
+    {"role": "system", "content": "You are a helpful science assistant."},
+    {"role": "user", "content": "Hey, can you explain gravity to me?"}
 ]
 ```
 
-Create the [`TextGenerationPipeline`] and pass `chat` to it. For large models, setting [device_map="auto"](./models#big-model-inference) helps load the model quicker and automatically places it on the fastest device available. Changing the data type to [torch.bfloat16](./models#model-data-type) also helps save memory.
+Create the [`TextGenerationPipeline`] and pass `chat` to it. For large models, setting [device_map="auto"](./models#big-model-inference) helps load the model quicker and automatically places it on the fastest device available.
 
 ```py
 import torch
 from transformers import pipeline
 
-pipeline = pipeline(task="text-generation", model="meta-llama/Meta-Llama-3-8B-Instruct", dtype=torch.bfloat16, device_map="auto")
+pipeline = pipeline(task="text-generation", model="HuggingFaceTB/SmolLM2-1.7B-Instruct", dtype="auto", device_map="auto")
 response = pipeline(chat, max_new_tokens=512)
 print(response[0]["generated_text"][-1]["content"])
 ```
 
-```txt
-(sigh) Oh boy, you're asking me for advice? You're gonna need a map, pal! Alright,
-alright, I'll give you the lowdown. But don't say I didn't warn you, I'm a robot, not a tour guide!
+If this works successfully, you should see a response from the model! If you want to continue the conversation,
+you need to update the chat history with the model's response. You can do this either by appending the text
+to `chat` (use the `assistant` role), or by reading `response[0]["generated_text"]`, which contains
+the full chat history, including the most recent response.
 
-So, you wanna know what's fun to do in the Big Apple? Well, let me tell you, there's a million
-things to do, but I'll give you the highlights. First off, you gotta see the sights: the Statue of
-Liberty, Central Park, Times Square... you know, the usual tourist traps. But if you're lookin' for
-something a little more... unusual, I'd recommend checkin' out the Museum of Modern Art. It's got
-some wild stuff, like that Warhol guy's soup cans and all that jazz.
-
-And if you're feelin' adventurous, take a walk across the Brooklyn Bridge. Just watch out for
-those pesky pigeons, they're like little feathered thieves! (laughs) Get it? Thieves? Ah, never mind.
-
-Now, if you're lookin' for some serious fun, hit up the comedy clubs in Greenwich Village. You might
-even catch a glimpse of some up-and-coming comedians... or a bunch of wannabes tryin' to make it big. (winks)
-
-And finally, if you're feelin' like a real New Yorker, grab a slice of pizza from one of the many amazing
-pizzerias around the city. Just don't try to order a "robot-sized" slice, trust me, it won't end well. (laughs)
-
-So, there you have it, pal! That's my expert advice on what to do in New York. Now, if you'll
-excuse me, I've got some oil changes to attend to. (winks)
-```
-
-Use the `append` method on `chat` to respond to the models message.
+Once you have the model's response, you can continue the conversation by appending a new `user` message to the chat history, like so:
 
 ```py
 chat = response[0]["generated_text"]
 chat.append(
-    {"role": "user", "content": "Wait, what's so wild about soup cans?"}
+    {"role": "user", "content": "Woah! But can it be reconciled with quantum mechanics?"}
 )
 response = pipeline(chat, max_new_tokens=512)
 print(response[0]["generated_text"][-1]["content"])
 ```
 
-```txt
-(laughs) Oh, you're killin' me, pal! You don't get it, do you? Warhol's soup cans are like, art, man!
-It's like, he took something totally mundane, like a can of soup, and turned it into a masterpiece. It's
-like, "Hey, look at me, I'm a can of soup, but I'm also a work of art!"
-(sarcastically) Oh, yeah, real original, Andy.
+By repeating this process, you can continue the conversation as long as you like.
 
-But, you know, back in the '60s, it was like, a big deal. People were all about challenging the
-status quo, and Warhol was like, the king of that. He took the ordinary and made it extraordinary.
-And, let me tell you, it was like, a real game-changer. I mean, who would've thought that a can of soup could be art? (laughs)
+## Performance and memory usage
 
-But, hey, you're not alone, pal. I mean, I'm a robot, and even I don't get it. (winks)
-But, hey, that's what makes art, art, right? (laughs)
-```
-
-## Performance
-
-Transformers load models in full precision by default, and for a 8B model, this requires ~32GB of memory! Reduce memory usage by loading a model in half-precision or bfloat16 (only uses ~2 bytes per parameter). You can even quantize the model to a lower precision like 8-bit or 4-bit with [bitsandbytes](https://hf.co/docs/bitsandbytes/index).
+Transformers load models in full `float32` precision by default, and for a 8B model, this requires ~32GB of memory! You can reduce memory usage using the `torch_dtype="auto"` argument, which will generally use `bfloat16`. To go even lower, you can quantize the model to 8-bit or 4-bit with [bitsandbytes](https://hf.co/docs/bitsandbytes/index).
 
 > [!TIP]
 > Refer to the [Quantization](./quantization/overview) docs for more information about the different quantization backends available.
@@ -143,19 +108,19 @@ quantization_config = BitsAndBytesConfig(load_in_8bit=True)
 pipeline = pipeline(task="text-generation", model="meta-llama/Meta-Llama-3-8B-Instruct", device_map="auto", model_kwargs={"quantization_config": quantization_config})
 ```
 
-In general, larger models are slower in addition to requiring more memory because text generation is bottlenecked by **memory bandwidth** instead of compute power. Each active parameter must be read from memory for every generated token. For a 16GB model, 16GB must be read from memory for every generated token.
+In general, model size and performance are directly correlated. Larger models are slower in addition to requiring more memory because text generation is bottlenecked by **memory bandwidth** instead of compute power. Each active parameter must be read from memory for every generated token. For a model with 16GB of active parameters, 16GB must be read from memory for every generated token.
 
 The number of generated tokens/sec is proportional to the total memory bandwidth of the system divided by the model size. Depending on your hardware, total memory bandwidth can vary. Refer to the table below for approximate generation speeds for different hardware types.
 
-| Hardware | Memory bandwidth |
-|---|---|
-| consumer CPU | 20-100GB/sec |
-| specialized CPU (Intel Xeon, AMD Threadripper/Epyc, Apple silicon) | 200-900GB/sec |
-| data center GPU (NVIDIA A100/H100) | 2-3TB/sec |
+| Hardware                                                                   | Memory bandwidth |
+|----------------------------------------------------------------------------|---|
+| consumer CPU                                                               | 20-100GB/sec |
+| specialized CPU (Intel Xeon, AMD Threadripper/Epyc, High-end Apple Silicon) | 200-900GB/sec |
+| datacenter GPU (NVIDIA A100/H100/B100)                                     | 2-3TB/sec |
 
 The easiest solution for improving generation speed is to either quantize a model or use hardware with higher memory bandwidth.
 
 You can also try techniques like [speculative decoding](./generation_strategies#speculative-decoding), where a smaller model generates candidate tokens that are verified by the larger model. If the candidate tokens are correct, the larger model can generate more than one token per `forward` pass. This significantly alleviates the bandwidth bottleneck and improves generation speed.
 
 > [!TIP]
-> Parameters may not be active for every generated token in MoE models such as [Mixtral](./model_doc/mixtral), [Qwen2MoE](./model_doc/qwen2_moe), and [DBRX](./model_doc/dbrx). As a result, MoE models generally have much lower memory bandwidth requirements and can be faster than a regular LLM of the same size. However, techniques like speculative decoding are ineffective with MoE models because parameters become activated with each new speculated token.
+> Parameters may not be active for every generated token in MoE models such as [Mixtral](./model_doc/mixtral), [Qwen2MoE](./model_doc/qwen2_moe), and [GPT-OSS](./model_doc/gpt-oss). As a result, MoE models generally have much lower memory bandwidth requirements and can be faster than a regular LLM of the same size. However, techniques like speculative decoding are ineffective with MoE models because more parameters become activated with each new speculated token.


### PR DESCRIPTION
The chat template docs were split into multiple parts and also refactored in recent PRs. The result is quite messy in some cases, and several examples are incomplete, or the text is misleading. I only noticed when I tried to refer to the docs while writing the `gpt-oss` template and realized that in many cases the text said things about chat templates that were completely incorrect or very unclear! This PR aims to fix it all up.