### PR TITLE
FIX EncoderDecoderCache broken repr

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1611,6 +1611,9 @@ class EncoderDecoderCache(Cache):
     def is_compileable(self) -> bool:
         return self.self_attention_cache.is_compileable
 
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.self_attention_cache}, {self.cross_attention_cache})"
+
 
 ### Deprecated classes
 

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -48,6 +48,7 @@ if is_torch_available():
         AutoTokenizer,
         Cache,
         DynamicCache,
+        EncoderDecoderCache,
         Gemma2Config,
         GenerationConfig,
         HybridCache,
@@ -163,6 +164,20 @@ class CacheTest(unittest.TestCase):
         )
         self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
         self.assertTrue(cached_values.shape == (1, 1, 10, 128))
+
+    @parameterized.expand(
+        [
+            # wrap the test cases into tuples, otherwise parametrized is confused and tries to unpack the cache
+            (DynamicCache(),),
+            (EncoderDecoderCache(DynamicCache(), DynamicCache()),),
+            (HybridCache(config=Gemma2Config(), max_cache_len=4),),
+            (SlidingWindowCache(config=Gemma2Config(), max_cache_len=4),),
+            (StaticCache(config=Gemma2Config(), max_cache_len=4),),
+        ]
+    )
+    def test_cache_repr_does_not_raise(self, cache):
+        # check that reprs of the cache does not raise an error
+        repr(cache)
 
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):


### PR DESCRIPTION
# What does this PR do?

Currently, trying to print `EncoderDecoderCache` instances results in an error:

> AttributeError: 'EncoderDecoderCache' object has no attribute 'layers'

This PR fixes the error. It adds a couple of tests for `repr`s of cache instances. The tests are not exhaustive but focus on the cache classes already being tested in `test_cache_utils.py`.

Reproducer:

```python
from transformers import DynamicCache, EncoderDecoderCache
print(EncoderDecoderCache(DynamicCache(), DynamicCache()))
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?