### PR TITLE
fix to accept cumulative_seqlens from TransformersKwargs in FA

### DIFF
--- a/src/transformers/generation/continuous_batching.py
+++ b/src/transformers/generation/continuous_batching.py
@@ -664,8 +664,8 @@ class PagedAttentionArgs:
     input_ids: torch.Tensor
     attention_mask: torch.Tensor
     position_ids: torch.Tensor
-    cu_seq_lens_q: torch.Tensor
-    cu_seq_lens_k: torch.Tensor
+    cumulative_seqlens_q: torch.Tensor
+    cumulative_seqlens_k: torch.Tensor
     max_seqlen_q: int
     max_seqlen_k: int
     write_index: torch.Tensor
@@ -677,28 +677,28 @@ class PagedAttentionArgs:
 
 
 @traced
-def create_document_mask(cu_seq_lens_q, cu_seq_lens_k):
+def create_document_mask(cumulative_seqlens_q, cumulative_seqlens_k):
     # Number of documents
-    valid_docs_q = cu_seq_lens_q[1:] > cu_seq_lens_q[:-1]
-    valid_docs_k = cu_seq_lens_k[1:] > cu_seq_lens_k[:-1]
+    valid_docs_q = cumulative_seqlens_q[1:] > cumulative_seqlens_q[:-1]
+    valid_docs_k = cumulative_seqlens_k[1:] > cumulative_seqlens_k[:-1]
     num_valid_docs = min(valid_docs_q.sum(), valid_docs_k.sum())
 
     # Trim to valid docs
-    cu_seq_lens_q = cu_seq_lens_q[: num_valid_docs + 1]
-    cu_seq_lens_k = cu_seq_lens_k[: num_valid_docs + 1]
+    cumulative_seqlens_q = cumulative_seqlens_q[: num_valid_docs + 1]
+    cumulative_seqlens_k = cumulative_seqlens_k[: num_valid_docs + 1]
 
-    total_q = cu_seq_lens_q[-1]
-    total_k = cu_seq_lens_k[-1]
+    total_q = cumulative_seqlens_q[-1]
+    total_k = cumulative_seqlens_k[-1]
 
-    q_indices = torch.arange(total_q, device=cu_seq_lens_q.device)
-    k_indices = torch.arange(total_k, device=cu_seq_lens_k.device)
+    q_indices = torch.arange(total_q, device=cumulative_seqlens_q.device)
+    k_indices = torch.arange(total_k, device=cumulative_seqlens_k.device)
 
-    q_doc_ids = torch.bucketize(q_indices, cu_seq_lens_q[1:], right=True)
-    k_doc_ids = torch.bucketize(k_indices, cu_seq_lens_k[1:], right=False)
+    q_doc_ids = torch.bucketize(q_indices, cumulative_seqlens_q[1:], right=True)
+    k_doc_ids = torch.bucketize(k_indices, cumulative_seqlens_k[1:], right=False)
     doc_mask = q_doc_ids[:, None] == k_doc_ids[None, :]
     # apply causal mask where no decoding (same nb of q than k)
 
-    is_causal = ~(cu_seq_lens_q[1:] - cu_seq_lens_q[:-1] == 1) * cu_seq_lens_q[1:]
+    is_causal = ~(cumulative_seqlens_q[1:] - cumulative_seqlens_q[:-1] == 1) * cumulative_seqlens_q[1:]
     apply_causal = torch.bucketize(q_indices, is_causal, right=True)[:, None] == k_doc_ids
     # TODO don't apply on prefill splitting
     causal_mask = torch.triu(torch.ones(total_q, total_k, device=q_doc_ids.device), diagonal=1).bool()
@@ -769,8 +769,8 @@ class ContinuousBatchProcessor:
         self.attention_mask = torch.zeros(
             (1, 1, T, max_token_budget), dtype=self.model_dtype, device=self.model_device
         )
-        self.cu_seq_lens_q = torch.zeros((T + 1,), **tensor_metadata)
-        self.cu_seq_lens_k = torch.zeros((T + 1,), **tensor_metadata)
+        self.cumulative_seqlens_q = torch.zeros((T + 1,), **tensor_metadata)
+        self.cumulative_seqlens_k = torch.zeros((T + 1,), **tensor_metadata)
         self.write_index = torch.zeros((T,), **tensor_metadata)
         self.read_index = torch.zeros((max_token_budget,), **tensor_metadata)
         self.logits_indices = torch.full((T,), -1, **tensor_metadata)
@@ -785,8 +785,8 @@ class ContinuousBatchProcessor:
         self.input_ids.zero_()
         self.position_ids.zero_()
         self.attention_mask.fill_(torch.finfo(self.model_dtype).min)
-        self.cu_seq_lens_q.zero_()
-        self.cu_seq_lens_k.zero_()
+        self.cumulative_seqlens_q.zero_()
+        self.cumulative_seqlens_k.zero_()
         self.write_index.fill_(-1)
         self.read_index.fill_(-1)
         self.logits_indices.fill_(-1)
@@ -801,8 +801,8 @@ class ContinuousBatchProcessor:
             "input_ids": self.input_ids,
             "position_ids": self.position_ids,
             "attention_mask": self.attention_mask,
-            "cu_seq_lens_q": self.cu_seq_lens_q,
-            "cu_seq_lens_k": self.cu_seq_lens_k,
+            "cu_seq_lens_q": self.cumulative_seqlens_q,
+            "cu_seq_lens_k": self.cumulative_seqlens_k,
             "write_index": self.write_index,
             "read_index": self.read_index,
             "logits_indices": self.logits_indices,
@@ -872,8 +872,8 @@ class ContinuousBatchProcessor:
         input_ids = []
         read_index = []
         write_index = []
-        cu_seq_lens_q = [0]
-        cu_seq_lens_k = [0]
+        cumulative_seqlens_q = [0]
+        cumulative_seqlens_k = [0]
         logits_indices = []
         self.metrics.record_batch_metrics(self.requests_in_batch)
 
@@ -892,24 +892,24 @@ class ContinuousBatchProcessor:
             position_ids.extend(positions_to_add)
             read_index.extend(read_indices)
             write_index.extend(write_indices)
-            cu_seq_lens_q.append(cu_seq_lens_q[-1] + query_length)
-            cu_seq_lens_k.append(cu_seq_lens_k[-1] + key_length)
+            cumulative_seqlens_q.append(cumulative_seqlens_q[-1] + query_length)
+            cumulative_seqlens_k.append(cumulative_seqlens_k[-1] + key_length)
             if len(state.remaining_prompt_ids) == 0:
-                logits_indices.append(cu_seq_lens_q[-1] - 1)
+                logits_indices.append(cumulative_seqlens_q[-1] - 1)
             self.max_seqlen_q = max(self.max_seqlen_q, query_length)
             self.max_seqlen_k = max(self.max_seqlen_k, key_length)
             state.position_offset += query_length
 
         logger.info(
-            f"Scheduled: {len(self.requests_in_batch)}, Waiting: {len(self.scheduler.waiting_requests)}, Active: {len(self.scheduler.active_requests)}. cum Q: {cu_seq_lens_q[-1]}. cum KV: {cu_seq_lens_k[-1]}, free blocks: {self.cache.get_num_free_blocks()}"
+            f"Scheduled: {len(self.requests_in_batch)}, Waiting: {len(self.scheduler.waiting_requests)}, Active: {len(self.scheduler.active_requests)}. cum Q: {cumulative_seqlens_q[-1]}. cum KV: {cumulative_seqlens_k[-1]}, free blocks: {self.cache.get_num_free_blocks()}"
         )
         self._build_tensors(
             input_ids,
             position_ids,
             read_index,
             write_index,
-            cu_seq_lens_q,
-            cu_seq_lens_k,
+            cumulative_seqlens_q,
+            cumulative_seqlens_k,
             logits_indices,
         )
 
@@ -922,8 +922,8 @@ class ContinuousBatchProcessor:
         position_ids,
         read_index,
         write_index,
-        cu_seq_lens_q,
-        cu_seq_lens_k,
+        cumulative_seqlens_q,
+        cumulative_seqlens_k,
         logits_indices,
     ):
         to_tensor = partial(torch.tensor, **self.tensor_metadata)
@@ -931,22 +931,25 @@ class ContinuousBatchProcessor:
         self.position_ids[:, : len(position_ids)] = to_tensor(position_ids)
         self.write_index[: len(write_index)] = to_tensor(write_index)
         self.read_index[: len(read_index)] = to_tensor(read_index)
-        self.cu_seq_lens_q[: len(cu_seq_lens_q)] = to_tensor(cu_seq_lens_q)
-        self.cu_seq_lens_k[: len(cu_seq_lens_k)] = to_tensor(cu_seq_lens_k)
+        self.cumulative_seqlens_q[: len(cumulative_seqlens_q)] = to_tensor(cumulative_seqlens_q)
+        self.cumulative_seqlens_k[: len(cumulative_seqlens_k)] = to_tensor(cumulative_seqlens_k)
         self.logits_indices[: len(logits_indices)] = to_tensor(logits_indices)
         min_value = torch.finfo(self.model_dtype).min
         if self.config._attn_implementation != "paged_attention":  # we set `is_causal` to True in paged call`
-            for i in range(len(cu_seq_lens_q) - 1):
+            for i in range(len(cumulative_seqlens_q) - 1):
                 if (
-                    cu_seq_lens_q[i + 1] - cu_seq_lens_q[i] < cu_seq_lens_k[i + 1] - cu_seq_lens_k[i]
-                    and cu_seq_lens_q[i + 1] - cu_seq_lens_q[i] >= 1
+                    cumulative_seqlens_q[i + 1] - cumulative_seqlens_q[i]
+                    < cumulative_seqlens_k[i + 1] - cumulative_seqlens_k[i]
+                    and cumulative_seqlens_q[i + 1] - cumulative_seqlens_q[i] >= 1
                 ):
-                    diagonal = cu_seq_lens_k[i + 1] - (cu_seq_lens_q[i + 1] - cu_seq_lens_q[i]) + 1
-                    diagonal = diagonal - cu_seq_lens_k[i]
+                    diagonal = (
+                        cumulative_seqlens_k[i + 1] - (cumulative_seqlens_q[i + 1] - cumulative_seqlens_q[i]) + 1
+                    )
+                    diagonal = diagonal - cumulative_seqlens_k[i]
                 else:
                     diagonal = 1
-                query_range = slice(cu_seq_lens_q[i], cu_seq_lens_q[i + 1])
-                key_range = slice(cu_seq_lens_k[i], cu_seq_lens_k[i + 1])
+                query_range = slice(cumulative_seqlens_q[i], cumulative_seqlens_q[i + 1])
+                key_range = slice(cumulative_seqlens_k[i], cumulative_seqlens_k[i + 1])
 
                 mask = torch.triu(
                     torch.full(

--- a/src/transformers/generation/continuous_batching.py
+++ b/src/transformers/generation/continuous_batching.py
@@ -938,13 +938,10 @@ class ContinuousBatchProcessor:
         if self.config._attn_implementation != "paged_attention":  # we set `is_causal` to True in paged call`
             for i in range(len(cu_seq_lens_q) - 1):
                 if (
-                    cu_seq_lens_q[i + 1] - cu_seq_lens_q[i]
-                    < cu_seq_lens_k[i + 1] - cu_seq_lens_k[i]
+                    cu_seq_lens_q[i + 1] - cu_seq_lens_q[i] < cu_seq_lens_k[i + 1] - cu_seq_lens_k[i]
                     and cu_seq_lens_q[i + 1] - cu_seq_lens_q[i] >= 1
                 ):
-                    diagonal = (
-                        cu_seq_lens_k[i + 1] - (cu_seq_lens_q[i + 1] - cu_seq_lens_q[i]) + 1
-                    )
+                    diagonal = cu_seq_lens_k[i + 1] - (cu_seq_lens_q[i + 1] - cu_seq_lens_q[i]) + 1
                     diagonal = diagonal - cu_seq_lens_k[i]
                 else:
                     diagonal = 1

--- a/src/transformers/integrations/flash_paged.py
+++ b/src/transformers/integrations/flash_paged.py
@@ -48,7 +48,7 @@ def paged_attention_forward(
         window_size: (left, right). If not (-1, -1), implements sliding window local attention.
         softcap: float. Anything > 0 activates softcapping attention.
     """
-    k, v = cache.update(k, v, module.layer_idx, cu_seq_lens_k=cu_seq_lens_k, **kwargs)
+    k, v = cache.update(k, v, module.layer_idx, **kwargs)
 
     sliding_window = (-1, -1) if not getattr(module, "sliding_window", False) else (module.sliding_window, 0)
     if implementation is not None:

--- a/src/transformers/integrations/flash_paged.py
+++ b/src/transformers/integrations/flash_paged.py
@@ -18,8 +18,8 @@ def paged_attention_forward(
     v: torch.Tensor,
     attention_mask: torch.Tensor = None,
     cache: PagedAttentionCache = None,
-    cumulative_seqlens_q=None,
-    cumulative_seqlens_k=None,
+    cu_seq_lens_q=None,
+    cu_seq_lens_k=None,
     max_seqlen_q=None,
     max_seqlen_k=None,
     block_tables=None,
@@ -35,9 +35,9 @@ def paged_attention_forward(
         q: (total_q, nheads, headdim), where total_q = total number of query tokens in the batch.
         k: (total_k, nheads_k, headdim), where total_k = total number of key tokens in the batch.  but if there is a block table it can be the full k
         v: (total_k, nheads_k, headdim), where total_k = total number of key tokens in the batch.  but if there is a block table it can be the full v
-        cumulative_seqlens_q: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
+        cu_seq_lens_q: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
            of the sequences in the batch, used to index into q.
-        cumulative_seqlens_k: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
+        cu_seq_lens_k: (batch_size + 1,), dtype torch.int32. The cumulative sequence lengths
            of the sequences in the batch, used to index into kv.
         max_seqlen_q: int. Maximum query sequence length in the batch.
         max_seqlen_k: int. Maximum key sequence length in the batch.
@@ -48,7 +48,7 @@ def paged_attention_forward(
         window_size: (left, right). If not (-1, -1), implements sliding window local attention.
         softcap: float. Anything > 0 activates softcapping attention.
     """
-    k, v = cache.update(k, v, module.layer_idx, cumulative_seqlens_k=cumulative_seqlens_k, **kwargs)
+    k, v = cache.update(k, v, module.layer_idx, cu_seq_lens_k=cu_seq_lens_k, **kwargs)
 
     sliding_window = (-1, -1) if not getattr(module, "sliding_window", False) else (module.sliding_window, 0)
     if implementation is not None:
@@ -58,8 +58,8 @@ def paged_attention_forward(
         q.transpose(1, 2).squeeze(0).contiguous(),
         k.transpose(1, 2).squeeze(0).contiguous(),
         v.transpose(1, 2).squeeze(0).contiguous(),
-        cumulative_seqlens_q.to(torch.int32),
-        cumulative_seqlens_k.to(torch.int32).clone(),
+        cu_seq_lens_q.to(torch.int32),
+        cu_seq_lens_k.to(torch.int32).clone(),
         max_seqlen_q,
         max_seqlen_k,
         softmax_scale=module.scaling,

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -462,9 +462,9 @@ class FlashAttentionKwargs(TypedDict, total=False):
     Keyword arguments for Flash Attention with Compile.
 
     Attributes:
-        cumulative_seqlens_q (`torch.LongTensor`, *optional*)
+        cu_seq_lens_q (`torch.LongTensor`, *optional*)
             Gets cumulative sequence length for query state.
-        cumulative_seqlens_k (`torch.LongTensor`, *optional*)
+        cu_seq_lens_k (`torch.LongTensor`, *optional*)
             Gets cumulative sequence length for key state.
         max_length_q (`int`, *optional*):
             Maximum sequence length for query state.
@@ -472,8 +472,8 @@ class FlashAttentionKwargs(TypedDict, total=False):
             Maximum sequence length for key state.
     """
 
-    cumulative_seqlens_q: Optional[torch.LongTensor]
-    cumulative_seqlens_k: Optional[torch.LongTensor]
+    cu_seq_lens_q: Optional[torch.LongTensor]
+    cu_seq_lens_k: Optional[torch.LongTensor]
     max_length_q: Optional[int]
     max_length_k: Optional[int]
 

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -866,9 +866,9 @@ class TransformersKwargs(TypedDict, total=False):
             Turn this on to return the intermediary attention scores.
         output_router_logits (`Optional[bool]`, *optional*):
             For MoE models, this allows returning the router logits to compute the loss.
-        cumulative_seqlens_q (`torch.LongTensor`, *optional*)
+        cu_seq_lens_q (`torch.LongTensor`, *optional*)
             Gets cumulative sequence length for query state.
-        cumulative_seqlens_k (`torch.LongTensor`, *optional*)
+        cu_seq_lens_k (`torch.LongTensor`, *optional*)
             Gets cumulative sequence length for key state.
         max_length_q (`int`, *optional*):
             Maximum sequence length for query state.
@@ -880,8 +880,8 @@ class TransformersKwargs(TypedDict, total=False):
     output_hidden_states: Optional[bool]
     output_attentions: Optional[bool]
     output_router_logits: Optional[bool]
-    cumulative_seqlens_q: Optional["torch.LongTensor"]
-    cumulative_seqlens_k: Optional["torch.LongTensor"]
+    cu_seq_lens_q: Optional["torch.LongTensor"]
+    cu_seq_lens_k: Optional["torch.LongTensor"]
     max_length_q: Optional[int]
     max_length_k: Optional[int]
 


### PR DESCRIPTION
The helper _flash_attention_forward now falls back to the keys cumulative_seqlens_q/k that may arrive inside TransformersKwargs when the explicit cu_seq_lens_q/k arguments are absent

A warning is raised on conflict, ensuring users notice any override

# What does this PR do?

I note that current transformer use [TransformersKwargs](https://github.com/huggingface/transformers/blob/4912d5b490a39d621b9d6f1b80df446d99e6239a/src/transformers/utils/generic.py#L856) as extra, but it will refuse the cumulative_seqlens_q and cumulative_seqlens_k args in [flash_attention func](https://github.com/huggingface/transformers/blob/4912d5b490a39d621b9d6f1b80df446d99e6239a/src/transformers/modeling_flash_attention_utils.py#L563), as unmatched argument name.

So I updated `_flash_attention_forward` to ensure compatibility with TransformersKwargs.

Fixes #40193 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?