### PR TITLE
Fix GPT-OSS `swiglu_limit` not passed in for MXFP4

### DIFF
--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -172,7 +172,7 @@ class Mxfp4GptOssExperts(nn.Module):
             torch.zeros(self.num_experts, self.hidden_size, dtype=torch.float32), requires_grad=False
         )
         self.alpha = 1.702
-
+        self.limit = getattr(config, "swiglu_limit", 7.0)
         self.gate_up_proj_precision_config = None
         self.down_proj_precision_config = None
 
@@ -185,7 +185,7 @@ class Mxfp4GptOssExperts(nn.Module):
         swiglu_fn = triton_kernels_hub.swiglu.swiglu_fn
 
         with torch.cuda.device(hidden_states.device):
-            act = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")), (self.alpha, None), 2)
+            act = FusedActivation(FnSpecs("swiglu", swiglu_fn, ("alpha", "limit")), (self.alpha, self.limit), 2)
 
             intermediate_cache1 = matmul_ogs(
                 hidden_states,


### PR DESCRIPTION
`swiglu_limit = 7.0` was not passed in when doing MXFP4 inference when using OpenAI's triton_kernels library.