### PR TITLE
[WIP] ESM-2 Attention interface refactor

### DIFF
--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -32,7 +32,12 @@ from ...modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
 )
-from ...modeling_utils import ALL_ATTENTION_FUNCTIONS,PreTrainedModel, find_pruneable_heads_and_indices, prune_linear_layer
+from ...modeling_utils import (
+    ALL_ATTENTION_FUNCTIONS,
+    PreTrainedModel,
+    find_pruneable_heads_and_indices,
+    prune_linear_layer,
+)
 from ...utils import auto_docstring, can_return_tuple, logging
 from .configuration_esm import EsmConfig
 
@@ -327,7 +332,9 @@ class EsmSelfAttention(nn.Module):
         if self.config._attn_implementation != "eager":
             attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
             assert head_mask is None, "head_mask is only supported for eager attention"
-            assert "relative" not in self.position_embedding_type, "relative position embeddings are only supported for eager attention"
+            assert "relative" not in self.position_embedding_type, (
+                "relative position embeddings are only supported for eager attention"
+            )
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -854,22 +861,22 @@ class EsmModel(EsmPreTrainedModel):
         return_dict: Optional[bool] = None,
     ) -> Union[tuple[torch.Tensor], BaseModelOutputWithPoolingAndCrossAttentions]:
         r"""
-        input_ids (`torch.LongTensor` of shape `((batch_size, sequence_length))`):
-            Indices of input sequence tokens in the vocabulary.
+                input_ids (`torch.LongTensor` of shape `((batch_size, sequence_length))`):
+                    Indices of input sequence tokens in the vocabulary.
 
-            Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
-            [`PreTrainedTokenizer.__call__`] for details.
-f
-            [What are input IDs?](../glossary#input-ids)
-        position_ids (`torch.LongTensor` of shape `((batch_size, sequence_length))`, *optional*):
-            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
-            config.max_position_embeddings - 1]`.
+                    Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
+                    [`PreTrainedTokenizer.__call__`] for details.
+        f
+                    [What are input IDs?](../glossary#input-ids)
+                position_ids (`torch.LongTensor` of shape `((batch_size, sequence_length))`, *optional*):
+                    Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
+                    config.max_position_embeddings - 1]`.
 
-            [What are position IDs?](../glossary#position-ids)
-        inputs_embeds (`torch.FloatTensor` of shape `((batch_size, sequence_length), hidden_size)`, *optional*):
-            Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
-            is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
-            model's internal embedding lookup matrix.
+                    [What are position IDs?](../glossary#position-ids)
+                inputs_embeds (`torch.FloatTensor` of shape `((batch_size, sequence_length), hidden_size)`, *optional*):
+                    Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
+                    is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
+                    model's internal embedding lookup matrix.
         """
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (

--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -331,7 +331,9 @@ class EsmModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
                 )
                 model_fa.to(torch_device)
 
-                model = model_class.from_pretrained(tmpdirname, torch_dtype=torch.bfloat16, attn_implementation="eager")
+                model = model_class.from_pretrained(
+                    tmpdirname, torch_dtype=torch.bfloat16, attn_implementation="eager"
+                )
                 model.to(torch_device)
 
                 dummy_input = inputs_dict[model_class.main_input_name]

--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -327,11 +327,11 @@ class EsmModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             with tempfile.TemporaryDirectory() as tmpdirname:
                 model.save_pretrained(tmpdirname)
                 model_fa = model_class.from_pretrained(
-                    tmpdirname, torch_dtype=torch.float16, attn_implementation="flash_attention_2"
+                    tmpdirname, torch_dtype=torch.bfloat16, attn_implementation="flash_attention_2"
                 )
                 model_fa.to(torch_device)
 
-                model = model_class.from_pretrained(tmpdirname, torch_dtype=torch.float16, attn_implementation="eager")
+                model = model_class.from_pretrained(tmpdirname, torch_dtype=torch.bfloat16, attn_implementation="eager")
                 model.to(torch_device)
 
                 dummy_input = inputs_dict[model_class.main_input_name]


### PR DESCRIPTION
Refectors the ESM-2 model to use the new ATTENTION_INTERFACE api.

Some of the unit tests are still failing, need to debug.