### PR TITLE
AMD scheduled CI ref env file

### DIFF
--- a/.github/workflows/self-scheduled-amd-mi300-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi300-caller.yml
@@ -5,10 +5,10 @@ name: Self-hosted runner scale set (AMD mi300 scheduled CI caller)
 #              2gpu scale set: amd-mi300-ci-2gpu
 
 on:
-  workflow_run:
-    workflows: ["Self-hosted runner (AMD scheduled CI caller)"]
-    branches: ["main"]
-    types: [completed]
+  #workflow_run:
+  #  workflows: ["Self-hosted runner (AMD scheduled CI caller)"]
+  #  branches: ["main"]
+  #  types: [completed]
   push:
     branches:
       - run_amd_scheduled_ci_caller*

--- a/.github/workflows/self-scheduled-amd-mi300-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi300-caller.yml
@@ -24,6 +24,7 @@ jobs:
       docker: huggingface/transformers-pytorch-amd-gpu
       ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
 
   torch-pipeline:
@@ -36,6 +37,7 @@ jobs:
       docker: huggingface/transformers-pytorch-amd-gpu
       ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
 
   example-ci:
@@ -48,6 +50,7 @@ jobs:
       docker: huggingface/transformers-pytorch-amd-gpu
       ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
 
   deepspeed-ci:
@@ -60,4 +63,5 @@ jobs:
       docker: huggingface/transformers-pytorch-deepspeed-amd-gpu
       ci_event: Scheduled CI (AMD) - mi300
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit

--- a/.github/workflows/self-scheduled-amd-mi325-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi325-caller.yml
@@ -24,6 +24,7 @@ jobs:
       docker: huggingface/transformers-pytorch-amd-gpu
       ci_event: Scheduled CI (AMD) - mi325
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
 
   torch-pipeline:
@@ -36,6 +37,7 @@ jobs:
       docker: huggingface/transformers-pytorch-amd-gpu
       ci_event: Scheduled CI (AMD) - mi325
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
 
   example-ci:
@@ -48,6 +50,7 @@ jobs:
       docker: huggingface/transformers-pytorch-amd-gpu
       ci_event: Scheduled CI (AMD) - mi325
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit
 
   deepspeed-ci:
@@ -60,4 +63,5 @@ jobs:
       docker: huggingface/transformers-pytorch-deepspeed-amd-gpu
       ci_event: Scheduled CI (AMD) - mi325
       report_repo_id: optimum-amd/transformers_daily_ci
+      env_file: /etc/podinfo/gha-gpu-isolation-settings
     secrets: inherit


### PR DESCRIPTION
Some of our AMD runners require us to reference an env-file, some do not.
Added new input to the workflow to enable this functionality [here](https://github.com/huggingface/hf-workflows/pull/43).