### PR TITLE
add-loftr-keypoints-to-map

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -130,7 +130,7 @@ MODEL_MAPPING_NAMES = OrderedDict(
         ("dpr", "DPRQuestionEncoder"),
         ("dpt", "DPTModel"),
         ("efficientformer", "EfficientFormerModel"),
-        ("efficientloftr", "EfficientLoFTRModel"),
+        ("efficientloftr", ("EfficientLoFTRModel", "EfficientLoFTRForKeypointMatching")),
         ("efficientnet", "EfficientNetModel"),
         ("electra", "ElectraModel"),
         ("emu3", "Emu3Model"),


### PR DESCRIPTION
# What does this PR do?
The[ official demo for eloftr](https://huggingface.co/zju-community/matchanything_eloftr) does not work with the current transformers because `EfficientLoFTRForKeypointMatching` is not instantiated when the model is called. This fixes the problem by adding it to the model mapping.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@qubvel tagging you as you reviewed the pr that added this model

