### PR TITLE
Standardize BertGeneration model card

### DIFF
--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -25,7 +25,7 @@ rendered properly in your Markdown viewer.
 [BertGeneration](https://huggingface.co/papers/1907.12461) leverages pretrained BERT checkpoints for sequence-to-sequence tasks with the [`EncoderDecoderModel`] architecture. BertGeneration adapts the [`BERT`] for generative tasks.
 
 
-You can find all the original BertGeneration checkpoints under the [BERT Generation](https://huggingface.co/models?search=bert-generation) collection.
+You can find all the original BERT checkpoints under the [BERT](https://huggingface.co/collections/google/bert-release-64ff5e7a4be99045d1896dbc) collection.
 
 > [!TIP]
 > This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -75,8 +75,7 @@ print(summary)
 <hfoption id="transformers-cli">
 
 ```bash
-# Using transformers-cli for quick inference
-python -m transformers.models.bert_generation --model google/roberta2roberta_L-24_discofuse --input "This is the first sentence. This is the second sentence."
+echo -e "Plants create energy through " | transformers run --task text2text-generation --model "google/roberta2roberta_L-24_discofuse" --device 0
 ```
 
 </hfoption>

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -22,7 +22,7 @@ rendered properly in your Markdown viewer.
 
 # BertGeneration
 
-[BertGeneration](https://huggingface.co/papers/1907.12461) leverages pre-trained BERT checkpoints for sequence-to-sequence tasks using EncoderDecoderModel architecture.
+[BertGeneration](https://huggingface.co/papers/1907.12461) leverages pretrained BERT checkpoints for sequence-to-sequence tasks with the [`EncoderDecoderModel`] architecture. BertGeneration adapts the [`BERT`] for generative tasks.
 
 BertGeneration adapts the powerful BERT encoder for generative tasks by using it in encoder-decoder architectures for tasks like summarization, translation, and text fusion. Think of it as taking BERT's deep understanding of language and teaching it to generate new text based on input context.
 

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -107,7 +107,9 @@ tokenizer = BertTokenizer.from_pretrained("google-bert/bert-large-uncased")
 
 ## Notes
 
-- BertGenerationEncoder and BertGenerationDecoder should be used in combination with EncoderDecoderModel for sequence-to-sequence tasks.
+- [`BertGenerationEncoder`] and [`BertGenerationDecoder`] should be used in combination with [`EncoderDecoderModel`] for sequence-to-sequence tasks.
+   
+   <add code example here from https://huggingface.co/docs/transformers/model_doc/bert-generation#usage-examples-and-tips>
 - For summarization, sentence splitting, sentence fusion and translation, no special tokens are required for the input.
 - No EOS token should be added to the end of the input for most generation tasks.
 

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -24,7 +24,6 @@ rendered properly in your Markdown viewer.
 
 [BertGeneration](https://huggingface.co/papers/1907.12461) leverages pretrained BERT checkpoints for sequence-to-sequence tasks with the [`EncoderDecoderModel`] architecture. BertGeneration adapts the [`BERT`] for generative tasks.
 
-BertGeneration adapts the powerful BERT encoder for generative tasks by using it in encoder-decoder architectures for tasks like summarization, translation, and text fusion. Think of it as taking BERT's deep understanding of language and teaching it to generate new text based on input context.
 
 You can find all the original BertGeneration checkpoints under the [BERT Generation](https://huggingface.co/models?search=bert-generation) collection.
 

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -13,84 +13,125 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on 2019-07-29 and added to Hugging Face Transformers on 2020-11-16.*
+
+<div style="float: right;">
+    <div class="flex flex-wrap space-x-1">
+        <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
+    </div>
+</div>
 
 # BertGeneration
 
-<div class="flex flex-wrap space-x-1">
-<img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-</div>
+[BertGeneration](https://huggingface.co/papers/1907.12461) leverages pre-trained BERT checkpoints for sequence-to-sequence tasks using EncoderDecoderModel architecture.
 
-## Overview
+BertGeneration adapts the powerful BERT encoder for generative tasks by using it in encoder-decoder architectures for tasks like summarization, translation, and text fusion. Think of it as taking BERT's deep understanding of language and teaching it to generate new text based on input context.
 
-The BertGeneration model is a BERT model that can be leveraged for sequence-to-sequence tasks using
-[`EncoderDecoderModel`] as proposed in [Leveraging Pre-trained Checkpoints for Sequence Generation
-Tasks](https://huggingface.co/papers/1907.12461) by Sascha Rothe, Shashi Narayan, Aliaksei Severyn.
+You can find all the original BertGeneration checkpoints under the [BERT Generation](https://huggingface.co/models?search=bert-generation) collection.
 
-The abstract from the paper is the following:
+> [!TIP]
+> This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten).
+>
+> Click on the BertGeneration models in the right sidebar for more examples of how to apply BertGeneration to different sequence generation tasks.
 
-*Unsupervised pretraining of large neural models has recently revolutionized Natural Language Processing. By
-warm-starting from the publicly released checkpoints, NLP practitioners have pushed the state-of-the-art on multiple
-benchmarks while saving significant amounts of compute time. So far the focus has been mainly on the Natural Language
-Understanding tasks. In this paper, we demonstrate the efficacy of pre-trained checkpoints for Sequence Generation. We
-developed a Transformer-based sequence-to-sequence model that is compatible with publicly available pre-trained BERT,
-GPT-2 and RoBERTa checkpoints and conducted an extensive empirical study on the utility of initializing our model, both
-encoder and decoder, with these checkpoints. Our models result in new state-of-the-art results on Machine Translation,
-Text Summarization, Sentence Splitting, and Sentence Fusion.*
+The example below demonstrates how to use BertGeneration with [`EncoderDecoderModel`] for sequence-to-sequence tasks.
 
-This model was contributed by [patrickvonplaten](https://huggingface.co/patrickvonplaten). The original code can be
-found [here](https://tfhub.dev/s?module-type=text-generation&subtype=module,placeholder).
-
-## Usage examples and tips
-
-The model can be used in combination with the [`EncoderDecoderModel`] to leverage two pretrained BERT checkpoints for 
-subsequent fine-tuning:
+<hfoptions id="usage">
+<hfoption id="Pipeline">
 
 ```python
->>> # leverage checkpoints for Bert2Bert model...
->>> # use BERT's cls token as BOS token and sep token as EOS token
->>> encoder = BertGenerationEncoder.from_pretrained("google-bert/bert-large-uncased", bos_token_id=101, eos_token_id=102)
->>> # add cross attention layers and use BERT's cls token as BOS token and sep token as EOS token
->>> decoder = BertGenerationDecoder.from_pretrained(
-...     "google-bert/bert-large-uncased", add_cross_attention=True, is_decoder=True, bos_token_id=101, eos_token_id=102
-... )
->>> bert2bert = EncoderDecoderModel(encoder=encoder, decoder=decoder)
+from transformers import pipeline
 
->>> # create tokenizer...
->>> tokenizer = BertTokenizer.from_pretrained("google-bert/bert-large-uncased")
-
->>> input_ids = tokenizer(
-...     "This is a long article to summarize", add_special_tokens=False, return_tensors="pt"
-... ).input_ids
->>> labels = tokenizer("This is a short summary", return_tensors="pt").input_ids
-
->>> # train...
->>> loss = bert2bert(input_ids=input_ids, decoder_input_ids=labels, labels=labels).loss
->>> loss.backward()
+# Use pipeline for text generation with BERT-based models
+generator = pipeline("text2text-generation", model="google/roberta2roberta_L-24_discofuse")
+result = generator("This is the first sentence. This is the second sentence.")
+print(result[0]['generated_text'])
 ```
 
-Pretrained [`EncoderDecoderModel`] are also directly available in the model hub, e.g.:
+</hfoption>
+<hfoption id="AutoModel">
 
 ```python
->>> # instantiate sentence fusion model
->>> sentence_fuser = EncoderDecoderModel.from_pretrained("google/roberta2roberta_L-24_discofuse")
->>> tokenizer = AutoTokenizer.from_pretrained("google/roberta2roberta_L-24_discofuse")
+from transformers import BertGenerationEncoder, BertGenerationDecoder, BertTokenizer, EncoderDecoderModel
 
->>> input_ids = tokenizer(
-...     "This is the first sentence. This is the second sentence.", add_special_tokens=False, return_tensors="pt"
-... ).input_ids
+# Create encoder-decoder model from BERT checkpoints
+encoder = BertGenerationEncoder.from_pretrained("google-bert/bert-large-uncased", bos_token_id=101, eos_token_id=102)
+decoder = BertGenerationDecoder.from_pretrained(
+    "google-bert/bert-large-uncased", add_cross_attention=True, is_decoder=True, bos_token_id=101, eos_token_id=102
+)
+model = EncoderDecoderModel(encoder=encoder, decoder=decoder)
 
->>> outputs = sentence_fuser.generate(input_ids)
+# Create tokenizer
+tokenizer = BertTokenizer.from_pretrained("google-bert/bert-large-uncased")
 
->>> print(tokenizer.decode(outputs[0]))
+# Prepare input
+input_ids = tokenizer("This is a long article to summarize", add_special_tokens=False, return_tensors="pt").input_ids
+
+# Generate summary
+outputs = model.generate(input_ids, max_length=50)
+summary = tokenizer.decode(outputs[0], skip_special_tokens=True)
+print(summary)
 ```
 
-Tips:
+</hfoption>
+<hfoption id="transformers-cli">
 
-- [`BertGenerationEncoder`] and [`BertGenerationDecoder`] should be used in
-  combination with [`EncoderDecoder`].
+```bash
+# Using transformers-cli for quick inference
+python -m transformers.models.bert_generation --model google/roberta2roberta_L-24_discofuse --input "This is the first sentence. This is the second sentence."
+```
+
+</hfoption>
+</hfoptions>
+
+Quantization reduces the memory burden of large models by representing the weights in a lower precision. Refer to the [Quantization](../quantization/overview) overview for more available quantization backends.
+
+The example below uses [BitsAndBytesConfig](../main_classes/quantization#transformers.BitsAndBytesConfig) to quantize the weights to 4-bit.
+
+```python
+from transformers import BertGenerationEncoder, BertTokenizer, BitsAndBytesConfig
+import torch
+
+# Configure 4-bit quantization
+quantization_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_compute_dtype=torch.float16
+)
+
+# Load quantized model
+encoder = BertGenerationEncoder.from_pretrained(
+    "google-bert/bert-large-uncased",
+    quantization_config=quantization_config,
+    bos_token_id=101,
+    eos_token_id=102
+)
+tokenizer = BertTokenizer.from_pretrained("google-bert/bert-large-uncased")
+```
+
+## Notes
+
+- BertGenerationEncoder and BertGenerationDecoder should be used in combination with EncoderDecoderModel for sequence-to-sequence tasks.
 - For summarization, sentence splitting, sentence fusion and translation, no special tokens are required for the input.
-  Therefore, no EOS token should be added to the end of the input.
+- No EOS token should be added to the end of the input for most generation tasks.
+
+   ```python
+   # Example of creating a complete encoder-decoder setup
+   from transformers import EncoderDecoderModel, AutoTokenizer
+   
+   # Load pre-trained encoder-decoder model
+   model = EncoderDecoderModel.from_pretrained("google/roberta2roberta_L-24_discofuse")
+   tokenizer = AutoTokenizer.from_pretrained("google/roberta2roberta_L-24_discofuse")
+   
+   # Generate text
+   input_text = "This is the first sentence. This is the second sentence."
+   input_ids = tokenizer(input_text, add_special_tokens=False, return_tensors="pt").input_ids
+   outputs = model.generate(input_ids)
+   result = tokenizer.decode(outputs[0])
+   ```
+
+## Resources
+
+- [Original Paper: Leveraging Pre-trained Checkpoints for Sequence Generation Tasks](https://arxiv.org/abs/1907.12461)
+- [Google Research Blog Post](https://ai.googleblog.com/2020/01/leveraging-bert-for-sequence-generation.html)
 
 ## BertGenerationConfig
 

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -109,6 +109,32 @@ print(tokenizer.decode(outputs[0]))
 ## Notes
 
 - [`BertGenerationEncoder`] and [`BertGenerationDecoder`] should be used in combination with [`EncoderDecoderModel`] for sequence-to-sequence tasks.
+
+   ```python
+   from transformers import BertGenerationEncoder, BertGenerationDecoder, BertTokenizer, EncoderDecoderModel
+   
+   # leverage checkpoints for Bert2Bert model
+   # use BERT's cls token as BOS token and sep token as EOS token
+   encoder = BertGenerationEncoder.from_pretrained("google-bert/bert-large-uncased", bos_token_id=101, eos_token_id=102)
+   # add cross attention layers and use BERT's cls token as BOS token and sep token as EOS token
+   decoder = BertGenerationDecoder.from_pretrained(
+       "google-bert/bert-large-uncased", add_cross_attention=True, is_decoder=True, bos_token_id=101, eos_token_id=102
+   )
+   bert2bert = EncoderDecoderModel(encoder=encoder, decoder=decoder)
+
+   # create tokenizer
+   tokenizer = BertTokenizer.from_pretrained("google-bert/bert-large-uncased")
+
+   input_ids = tokenizer(
+       "This is a long article to summarize", add_special_tokens=False, return_tensors="pt"
+   ).input_ids
+   labels = tokenizer("This is a short summary", return_tensors="pt").input_ids
+
+   # train
+   loss = bert2bert(input_ids=input_ids, decoder_input_ids=labels, labels=labels).loss
+   loss.backward()
+   ```
+
 - For summarization, sentence splitting, sentence fusion and translation, no special tokens are required for the input.
 - No EOS token should be added to the end of the input for most generation tasks.
 

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -83,7 +83,7 @@ echo -e "Plants create energy through " | transformers run --task text2text-gene
 
 Quantization reduces the memory burden of large models by representing the weights in a lower precision. Refer to the [Quantization](../quantization/overview) overview for more available quantization backends.
 
-The example below uses [BitsAndBytesConfig](../main_classes/quantization#transformers.BitsAndBytesConfig) to quantize the weights to 4-bit.
+The example below uses [BitsAndBytesConfig](../quantizationbitsandbytes) to quantize the weights to 4-bit.
 
 ```python
 from transformers import BertGenerationEncoder, BertTokenizer, BitsAndBytesConfig

--- a/docs/source/en/model_doc/bert-generation.md
+++ b/docs/source/en/model_doc/bert-generation.md
@@ -72,7 +72,7 @@ print(summary)
 ```
 
 </hfoption>
-<hfoption id="transformers-cli">
+<hfoption id="transformers CLI">
 
 ```bash
 echo -e "Plants create energy through " | transformers run --task text2text-generation --model "google/roberta2roberta_L-24_discofuse" --device 0


### PR DESCRIPTION
# What does this PR do?

#36979

Updated the BertGeneration model card to follow the new standardized format including:
- New consistent layout with badges  
- Friendly description written for accessibility
- Usage examples with Pipeline, AutoModel, and transformers-cli
- Quantization example with BitsAndBytesConfig
- Updated resources section with proper links

This standardizes the BertGeneration documentation to match the new template format requested in issue #36979.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [[forum](https://discuss.huggingface.co/)](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [[documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs)](https://github.com/huggingface/transformers/tree/main/docs), and
      [[here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation)](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@stevhliu - Documentation lead who is managing the model card standardization project.

Anyone in the community is free to review the PR once the tests have passed.