### PR TITLE
Fix: correct `k_proj` weight and bias slicing in D-FINE

### DIFF
--- a/src/transformers/models/d_fine/convert_d_fine_original_pytorch_checkpoint_to_hf.py
+++ b/src/transformers/models/d_fine/convert_d_fine_original_pytorch_checkpoint_to_hf.py
@@ -364,8 +364,8 @@ def read_in_q_k_v(state_dict, config, model_name):
         if model_name in ["dfine_n_coco", "dfine_n_obj2coco_e25", "dfine_n_obj365"]:
             state_dict[f"model.decoder.layers.{i}.self_attn.q_proj.weight"] = in_proj_weight[:128, :]
             state_dict[f"model.decoder.layers.{i}.self_attn.q_proj.bias"] = in_proj_bias[:128]
-            state_dict[f"model.decoder.layers.{i}.self_attn.k_proj.weight"] = in_proj_weight[256:384, :]
-            state_dict[f"model.decoder.layers.{i}.self_attn.k_proj.bias"] = in_proj_bias[256:384]
+            state_dict[f"model.decoder.layers.{i}.self_attn.k_proj.weight"] = in_proj_weight[128:256, :]
+            state_dict[f"model.decoder.layers.{i}.self_attn.k_proj.bias"] = in_proj_bias[128:256]
             state_dict[f"model.decoder.layers.{i}.self_attn.v_proj.weight"] = in_proj_weight[-128:, :]
             state_dict[f"model.decoder.layers.{i}.self_attn.v_proj.bias"] = in_proj_bias[-128:]
         else:


### PR DESCRIPTION
This PR fixes the slicing of the `k_proj` weight and bias during checkpoint conversion for D-FINE.

Fixes #40253 

**Changes:**

* Corrected `k_proj.weight` from `in_proj_weight[256:384, :]` → `in_proj_weight[128:256, :]`.
* Corrected `k_proj.bias` from `in_proj_bias[256:384]` → `in_proj_bias[128:256]`.

**Impact:**
Ensures the attention mechanism in D-FINE correctly loads the original PyTorch checkpoint without misaligned projections.