### PR TITLE
Enable PLW and PLE rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,10 +29,15 @@ line-length = 119
 # UP028: Checks for for loops that can be replaced with yield from expressions
 # UP045: Use `X | None` for type annotations
 # UP007: Use `X | Y` for type annotations
-ignore = ["C901", "E501", "E741", "F402", "F823", "SIM1", "SIM300", "SIM212", "SIM905", "UP009", "UP015", "UP031", "UP028", "UP004", "UP045", "UP007"]
+# PLW2901: `for` loop variable overwritten by assignment target
+# PLW0603: Using the global statement to update variable
+# PLW1641: Checks for classes that implement __eq__ but not __hash__
+# PLE0643: Expression is likely to raise `IndexError`
+# PLW1510: `subprocess.run` without explicit `check` argument
+ignore = ["C901", "E501", "E741", "F402", "F823", "SIM1", "SIM300", "SIM212", "SIM905", "UP009", "UP015", "UP031", "UP028", "UP004", "UP045", "UP007", "PLW2901", "PLW0603", "PLW1641", "PLE0643","PLW1510"]
 # RUF013: Checks for the use of implicit Optional
 #  in type annotations when the default parameter value is None.
-select = ["C", "E", "F", "I", "W", "RUF013", "PERF102", "PLC1802", "PLC0208", "SIM", "UP", "PIE794", "FURB"]
+select = ["C", "E", "F", "I", "W", "RUF013", "PERF102", "PLC1802", "PLC0208", "SIM", "UP", "PIE794", "FURB", "PLW", "PLE"]
 extend-safe-fixes = ["UP006"]
 
 # Ignore import violations in all `__init__.py` files.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2713,7 +2713,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         if getattr(self.config, "is_encoder_decoder", False) and getattr(self.config, "tie_encoder_decoder", False):
             if hasattr(self, self.base_model_prefix):
-                self = getattr(self, self.base_model_prefix)
+                self = getattr(self, self.base_model_prefix)  # noqa: PLW0642
             tied_weights = self._tie_encoder_decoder_weights(
                 self.encoder, self.decoder, self.base_model_prefix, "encoder"
             )

--- a/src/transformers/models/depth_pro/modeling_depth_pro.py
+++ b/src/transformers/models/depth_pro/modeling_depth_pro.py
@@ -103,7 +103,7 @@ def reshape_features(hidden_states: torch.Tensor) -> torch.Tensor:
 
 def merge_patches(patches: torch.Tensor, batch_size: int, padding: int) -> torch.Tensor:
     """Merges smaller patches into image-like feature map."""
-    n_patches, hidden_size, out_size, out_size = patches.shape
+    n_patches, hidden_size, out_size, _ = patches.shape
     n_patches_per_batch = n_patches // batch_size
     sqrt_n_patches_per_batch = torch_int(n_patches_per_batch**0.5)
     new_out_size = sqrt_n_patches_per_batch * out_size

--- a/src/transformers/models/marian/modeling_marian.py
+++ b/src/transformers/models/marian/modeling_marian.py
@@ -1152,7 +1152,7 @@ class MarianMTModel(MarianPreTrainedModel, GenerationMixin):
 
         if getattr(self.config, "is_encoder_decoder", False) and getattr(self.config, "tie_encoder_decoder", False):
             if hasattr(self, self.base_model_prefix):
-                self = getattr(self, self.base_model_prefix)
+                self = getattr(self, self.base_model_prefix)  # noqa: PLW0642
             tied_weights = self._tie_encoder_decoder_weights(
                 self.encoder, self.decoder, self.base_model_prefix, "encoder"
             )


### PR DESCRIPTION
# What does this PR do?

Enable ruff `PLW` and `PLE` rules, which implement warnings and errors of Pylint. 