### PR TITLE
docs(layoutlm): add missing `id=usage` to `<hfoptions>` tag in LayoutLM model card

### DIFF
--- a/docs/source/en/model_doc/layoutlm.md
+++ b/docs/source/en/model_doc/layoutlm.md
@@ -33,7 +33,7 @@ You can find all the original LayoutLM checkpoints under the [LayoutLM](https://
 
 The example below demonstrates question answering with the [`AutoModel`] class. 
 
-<hfoptions>
+<hfoptions id="usage">
 <hfoption id="AutoModel">
 
 ```py


### PR DESCRIPTION
LayoutLM model card

# Add missing `id=usage` to `<hfoptions>` tag

This PR fixes a documentation issue in the LayoutLM model card by adding the missing `id=usage` option to the `<hfoptions>` tag.  
This ensures correct rendering via Hugging Face doc-builder.

No code changes.  
No dependencies.

Related to #36979 and discussed in https://github.com/huggingface/transformers/pull/40129#issuecomment-3197541436

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? (not applicable)

## Who can review?

Anyone in the community is free to review the PR once the tests have passed.  
For documentation fixes: @stevhliu
