### PR TITLE
One cache class to rule them all

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -717,13 +717,6 @@ class HQQQuantizedLayer(QuantizedLayer):
         return tensor
 
 
-STATIC_LAYER_CLASS_MAPPING: dict[str, type[CacheLayerMixin]] = {
-    "full_attention": StaticLayer,
-    "sliding_attention": SlidingWindowLayer,
-    "chunked_attention": ChunkedSlidingLayer,
-}
-
-
 class Cache:
     """
     A `Cache` is mostly a list of `CacheLayerMixin` objects, one per model layer. It serves as a container for
@@ -995,6 +988,8 @@ class DynamicCache(Cache):
         self,
         ddp_cache_data: Optional[Iterable[tuple[torch.Tensor, torch.Tensor]]] = None,
         config: Optional[PretrainedConfig] = None,
+        offloading: bool = False,
+        offload_only_non_sliding: bool = False,
     ):
         """
         Create a `DynamicCache`. Specialized constructor for DDP cache data, needed for BC.
@@ -1009,6 +1004,11 @@ class DynamicCache(Cache):
                 The config of the model for which this Cache will be used. If passed, it will be used to check for sliding
                 or hybrid layer structure, greatly reducing the memory requirement of the cached tensors to
                 `[batch_size, num_heads, min(seq_len, sliding_window), head_dim]`.
+            offloading (`bool`, *optional*, defaults to `False`):
+                Whether to perform offloading of the layers to `cpu`, to save GPU memory.
+            offload_only_non_sliding (`bool`, *optional*, defaults to `False`):
+                If `offloading` is `True`, this further decides if only the non-sliding layers will be offloaded (because
+                usually the sliding layers are small in size, so there is no need to offload them, and skipping it is faster).
         """
         layers = []
         # If a config is passed, use it to infer the layer types and initialize accordingly
@@ -1040,9 +1040,13 @@ class DynamicCache(Cache):
 
         # If neither of config nor ddp_data was passed, then simply lazy init a full cache of DynamicLayer
         if len(layers) == 0:
-            super().__init__(layer_class_to_replicate=DynamicLayer)
+            super().__init__(
+                layer_class_to_replicate=DynamicLayer,
+                offloading=offloading,
+                offload_only_non_sliding=offload_only_non_sliding,
+            )
         else:
-            super().__init__(layers=layers)
+            super().__init__(layers=layers, offloading=offloading, offload_only_non_sliding=offload_only_non_sliding)
 
     def to_legacy_cache(self) -> tuple[tuple[torch.Tensor, torch.Tensor]]:
         """
@@ -1070,21 +1074,10 @@ class DynamicCache(Cache):
         return cache
 
 
-class OffloadedCache(Cache):
-    """
-    A drop-in replacement for DynamicCache that conserves accelerator (GPU, XPU) memory at the expense of more CPU memory.
-    Useful for generating from models with very long context.
-
-    See `Cache` for details on common methods that are implemented by all cache classes.
-    """
-
-    def __init__(self) -> None:
-        super().__init__(layer_class_to_replicate=DynamicLayer, offloading=True)
-
-
 class StaticCache(Cache):
     """
-    Static Cache class to be used with `torch.compile(model)` and `torch.export()`.
+    Static Cache class to be used with `torch.compile(model)` and `torch.export()`. It will check the `config`
+    for potential hybrid cache structure, and initialize each layer accordingly.
 
     See `Cache` for details on common methods that are implemented by all cache classes.
 
@@ -1108,154 +1101,52 @@ class StaticCache(Cache):
     ```
     """
 
-    # Pass-in args and kwargs as well to avoid crashing for BC (it used more arguments before)
-    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
-        layers = [StaticLayer(max_cache_len) for _ in range(config.num_hidden_layers)]
-        super().__init__(layers=layers)
+    # Pass-in kwargs as well to avoid crashing for BC (it used more arguments before)
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        max_cache_len: int,
+        offloading: bool = False,
+        offload_only_non_sliding: bool = True,
+        **kwargs,
+    ):
+        """
+        Create a `Static`. Specialized constructor for DDP cache data, needed for BC.
 
+        Args:
+            config (`PretrainedConfig`):
+                The config of the model for which this Cache will be used. It will be used to check for sliding
+                or hybrid layer structure, and initialize each layer accordingly.
+            max_cache_len (`int`):
+                The maximum number of tokens that this Cache should hold.
+            offloading (`bool`, *optional*, defaults to `False`):
+                Whether to perform offloading of the layers to `cpu`, to save GPU memory.
+            offload_only_non_sliding (`bool`, *optional*, defaults to `True`):
+                If `offloading` is `True`, this further decides if only the non-sliding layers will be offloaded (because
+                usually the sliding layers are small in size, so there is no need to offload them, and skipping it is faster).
+        """
+        config = config.get_text_config()
+        layer_types = getattr(config, "layer_types", None)
+        # If `layer_types` is not explicitly provided, infer if the model is fully sliding
+        if layer_types is None:
+            if getattr(config, "sliding_window", None) is not None:
+                layer_types = ["sliding_attention" for _ in range(config.num_hidden_layers)]
+            elif getattr(config, "attention_chunk_size", None) is not None:
+                layer_types = ["chunked_attention" for _ in range(config.num_hidden_layers)]
+            else:
+                layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
 
-class OffloadedStaticCache(Cache):
-    """
-    A drop-in replacement for StaticCache that conserves accelerator memory by offloading
-    cache tensors to CPU when not actively being used.
+        layers = []
+        for layer_type in config.layer_types:
+            if layer_type == "sliding_attention":
+                layer = SlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.sliding_window)
+            elif layer_type == "chunked_attention":
+                layer = ChunkedSlidingLayer(max_cache_len=max_cache_len, sliding_window=config.attention_chunk_size)
+            else:
+                layer = StaticLayer(max_cache_len=max_cache_len)
+            layers.append(layer)
 
-    This cache maintains the compilation-friendly properties of StaticCache while enabling
-    much longer sequences by offloading inactive layers to CPU memory.
-
-    See `Cache` for details on common methods that are implemented by all cache classes.
-
-    Example:
-
-    ```python
-    >>> from transformers import AutoTokenizer, AutoModelForCausalLM, OffloadedStaticCache
-
-    >>> model = AutoModelForCausalLM.from_pretrained("openai-community/gpt2")
-    >>> tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
-
-    >>> inputs = tokenizer(text="My name is GPT2", return_tensors="pt")
-
-    >>> # Prepare a cache class with offloading
-    >>> max_generated_length = inputs.input_ids.shape[1] + 10
-    >>> past_key_values = OffloadedStaticCache(config=model.config, max_cache_len=max_generated_length)
-    >>> outputs = model(**inputs, past_key_values=past_key_values, use_cache=True)
-    >>> outputs.past_key_values # access cache with offloaded layers
-    OffloadedStaticCache()
-    ```
-    """
-
-    # Pass-in args and kwargs as well to avoid crashing for BC (it used more arguments before)
-    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
-        layers = [StaticLayer(max_cache_len) for _ in range(config.num_hidden_layers)]
-        super().__init__(layers=layers, offloading=True)
-
-
-class SlidingWindowCache(Cache):
-    """
-    Sliding Window Cache class to be used with `torch.compile` for models like Mistral that support sliding window attention.
-    See `Cache` for details on common methods that are implemented by all cache classes.
-
-    Example:
-
-    ```python
-    >>> from transformers import AutoTokenizer, AutoModelForCausalLM, SlidingWindowCache
-
-    >>> model = AutoModelForCausalLM.from_pretrained("mistralai/Mistral-7B-Instruct-v0.3")
-    >>> tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.3")
-
-    >>> inputs = tokenizer(text="My name is Mistral", return_tensors="pt")
-
-    >>> # Prepare a cache class and pass it to model's forward
-    >>> # Leave empty space for 10 new tokens, which can be used when calling forward iteratively 10 times to generate
-    >>> max_generated_length = inputs.input_ids.shape[1] + 10
-    >>> past_key_values = SlidingWindowCache(config=model.config, max_cache_len=max_generated_length)
-    >>> outputs = model(**inputs, past_key_values=past_key_values, use_cache=True)
-    >>> outputs.past_key_values # access cache filled with key/values from generation
-    SlidingWindowCache()
-    ```
-    """
-
-    # Pass-in args and kwargs as well to avoid crashing for BC (it used more arguments before)
-    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
-        layers = [SlidingWindowLayer(max_cache_len, config.sliding_window) for _ in range(config.num_hidden_layers)]
-        super().__init__(layers=layers)
-
-
-class HybridCache(Cache):
-    """
-    Hybrid Cache class to be used with `torch.compile` for models that alternate between a local sliding window
-    attention and global attention in every other layer (originally implemented for Gemma2).
-    Under the hood, Hybrid Cache leverages ["SlidingWindowLayer"] for sliding window attention and ["StaticLayer"]
-    for global attention. For more information, see the documentation of those layer types.
-
-    See `Cache` for details on common methods that are implemented by all cache classes.
-
-    Example:
-
-    ```python
-    >>> from transformers import AutoTokenizer, AutoModelForCausalLM, HybridCache
-
-    >>> model = AutoModelForCausalLM.from_pretrained("google/gemma-2-2b")
-    >>> tokenizer = AutoTokenizer.from_pretrained("google/gemma-2-2b")
-
-    >>> inputs = tokenizer(text="My name is Gemma", return_tensors="pt")
-
-    >>> # Prepare a cache class and pass it to model's forward
-    >>> # Leave empty space for 10 new tokens, which can be used when calling forward iteratively 10 times to generate
-    >>> max_generated_length = inputs.input_ids.shape[1] + 10
-    >>> past_key_values = HybridCache(config=model.config, max_cache_len=max_generated_length)
-    >>> outputs = model(**inputs, past_key_values=past_key_values, use_cache=True)
-    >>> outputs.past_key_values # access cache filled with key/values from generation
-    HybridCache()
-    ```
-    """
-
-    # Pass-in args and kwargs as well to avoid crashing for BC (it used more arguments before)
-    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
-        if hasattr(config, "layer_types"):
-            layers = []
-            for layer_type in config.layer_types:
-                init_kwargs = {"max_cache_len": max_cache_len}
-                if layer_type == "sliding_attention":
-                    init_kwargs["sliding_window"] = config.sliding_window
-                elif layer_type == "chunked_attention":
-                    init_kwargs["sliding_window"] = config.attention_chunk_size
-                layers.append(STATIC_LAYER_CLASS_MAPPING[layer_type](**init_kwargs))
-        else:
-            # In this case, fall back to StaticCache
-            layers = [StaticLayer(max_cache_len) for _ in range(config.num_hidden_layers)]
-        super().__init__(layers=layers)
-
-
-# The mapping already handles dispatching the correct layers in Hybrid, this is only used for BC
-class HybridChunkedCache(HybridCache): ...
-
-
-class OffloadedHybridCache(Cache):
-    """
-    A drop-in replacement for HybridChunkedCache that conserves accelerator memory by offloading
-    cache tensors to CPU when not actively being used.
-
-    This cache maintains the compilation-friendly properties of HybridChunkedCache while enabling
-    much longer sequences by offloading inactive layers to CPU memory.
-
-    See `Cache` for details on common methods that are implemented by all cache classes.
-    """
-
-    # Pass-in args and kwargs as well to avoid crashing for BC (it used more arguments before)
-    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
-        if hasattr(config, "layer_types"):
-            layers = []
-            for layer_type in config.layer_types:
-                init_kwargs = {"max_cache_len": max_cache_len}
-                if layer_type == "sliding_attention":
-                    init_kwargs["sliding_window"] = config.sliding_window
-                elif layer_type == "chunked_attention":
-                    init_kwargs["sliding_window"] = config.attention_chunk_size
-                layers.append(STATIC_LAYER_CLASS_MAPPING[layer_type](**init_kwargs))
-        else:
-            # In this case, fall back to StaticCache
-            layers = [StaticLayer(max_cache_len) for _ in range(config.num_hidden_layers)]
-        super().__init__(layers=layers, offloading=True)
+        super().__init__(layers=layers, offloading=offloading, offload_only_non_sliding=offload_only_non_sliding)
 
 
 class QuantizedCache(Cache):
@@ -1290,101 +1181,12 @@ class QuantizedCache(Cache):
         else:
             raise ValueError(f"Unknown quantization backend `{backend}`")
 
+        config = config.get_text_config()
         layers = [
             layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
             for _ in range(config.num_hidden_layers)
         ]
         super().__init__(layers=layers)
-
-
-class QuantoQuantizedCache(QuantizedCache):
-    """
-    A quantizer cache similar to what is described in the
-    [KIVI: A Tuning-Free Asymmetric 2bit Quantization for KV Cache paper](https://arxiv.org/abs/2402.02750).
-    It allows the model to generate longer sequence length without allocating too much memory for keys and values
-    by applying quantization.
-    The cache has two types of storage, one for original precision and one for the
-    quantized cache. A `residual length` is set as a maximum capacity for the original precision cache. When the
-    length goes beyond maximum capacity, the original precision cache is discarded and moved into the quantized cache.
-    The quantization is done per-channel with a set `q_group_size` for both keys and values, in contrast to what was
-    described in the paper.
-
-    See `Cache` for details on common methods that are implemented by all cache classes.
-
-    Example:
-
-    ```python
-    >>> # Run pip install quanto first if you don't have it yet
-    >>> from transformers import AutoTokenizer, AutoModelForCausalLM, QuantoQuantizedCache
-
-    >>> model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2-0.5B-Instruct")
-    >>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-0.5B-Instruct")
-
-    >>> inputs = tokenizer(text="My name is Qwen2", return_tensors="pt")
-
-    >>> # Prepare a cache class and pass it to model's forward
-    >>> past_key_values = QuantoQuantizedCache(config=model.config, nbits=4)
-    >>> outputs = model(**inputs, past_key_values=past_key_values, use_cache=True)
-    >>> outputs.past_key_values # access cache filled with key/values from generation
-    QuantoQuantizedCache()
-    ```
-    """
-
-    def __init__(
-        self,
-        config: PretrainedConfig,
-        nbits: int = 4,
-        axis_key: int = 0,
-        axis_value: int = 0,
-        q_group_size: int = 64,
-        residual_length: int = 128,
-    ):
-        super().__init__("quanto", config, nbits, axis_key, axis_value, q_group_size, residual_length)
-
-
-class HQQQuantizedCache(QuantizedCache):
-    """
-    A quantizer cache similar to what is described in the
-    [KIVI: A Tuning-Free Asymmetric 2bit Quantization for KV Cache paper](https://arxiv.org/abs/2402.02750).
-    It allows the model to generate longer sequence length without allocating too much memory for keys and values
-    by applying quantization.
-    The cache has two types of storage, one for original precision and one for the
-    quantized cache. A `residual length` is set as a maximum capacity for the original precision cache. When the
-    length goes beyond maximum capacity, the original precision cache is discarded and moved into the quantized cache.
-    The quantization is done per-channel with a set `q_group_size` for both keys and values, in contrast to what was
-    described in the paper.
-
-    See `Cache` for details on common methods that are implemented by all cache classes.
-
-    Example:
-
-    ```python
-    >>> # Run pip install hqq first if you don't have it yet
-    >>> from transformers import AutoTokenizer, AutoModelForCausalLM, HQQQuantizedCache
-
-    >>> model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen2-0.5B-Instruct")
-    >>> tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-0.5B-Instruct")
-
-    >>> inputs = tokenizer(text="My name is Qwen2", return_tensors="pt")
-
-    >>> # Prepare a cache class and pass it to model's forward
-    >>> past_key_values = HQQQuantizedCache(config=model.config, nbits=4, axis_key=1, axis_value=1)
-    >>> outputs = model(**inputs, past_key_values=past_key_values, use_cache=True)
-    >>> outputs.past_key_values # access cache filled with key/values from generation
-    HQQQuantizedCache()
-    ```
-    """
-
-    def __init__(
-        self,
-        config: PretrainedConfig,
-        nbits: int = 4,
-        axis_key: int = 0,
-        axis_value: int = 0,
-        q_group_size: int = 64,
-        residual_length: int = 128,
-    ):
-        super().__init__("hqq", config, nbits, axis_key, axis_value, q_group_size, residual_length)
 
 
 class EncoderDecoderCache(Cache):
@@ -1588,6 +1390,94 @@ class EncoderDecoderCache(Cache):
 
 
 ### Deprecated classes
+
+
+class OffloadedCache(DynamicCache):
+    def __init__(self) -> None:
+        logger.warning_once(
+            "`OffloadedCache` is deprecated and will be removed in version v4.58 "
+            "Use `DynamicCache(offloading=True)` instead"
+        )
+        super().__init__(offloading=True)
+
+
+class OffloadedStaticCache(StaticCache):
+    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
+        logger.warning_once(
+            "`OffloadedStaticCache` is deprecated and will be removed in version v4.58 "
+            "Use `StaticCache(..., offloading=True)` instead"
+        )
+        super().__init__(config=config, max_cache_len=max_cache_len, offloading=True)
+
+
+class SlidingWindowCache(StaticCache):
+    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
+        logger.warning_once(
+            "`SlidingWindowCache` is deprecated and will be removed in version v4.58 "
+            "Use `StaticCache` instead which will correctly infer the type of each layer."
+        )
+        super().__init__(config=config, max_cache_len=max_cache_len)
+
+
+class HybridCache(StaticCache):
+    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
+        logger.warning_once(
+            "`HybridCache` is deprecated and will be removed in version v4.58 "
+            "Use `StaticCache` instead which will correctly infer the type of each layer."
+        )
+        super().__init__(config=config, max_cache_len=max_cache_len)
+
+
+class HybridChunkedCache(StaticCache):
+    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
+        logger.warning_once(
+            "`HybridChunkedCache` is deprecated and will be removed in version v4.58 "
+            "Use `StaticCache` instead which will correctly infer the type of each layer."
+        )
+        super().__init__(config=config, max_cache_len=max_cache_len)
+
+
+class OffloadedHybridCache(StaticCache):
+    def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
+        logger.warning_once(
+            "`OffloadedHybridCache` is deprecated and will be removed in version v4.58 "
+            "Use `StaticCache(..., offload=True)` instead which will correctly infer the type of each layer."
+        )
+        super().__init__(config=config, max_cache_len=max_cache_len, offloading=True)
+
+
+class QuantoQuantizedCache(QuantizedCache):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        nbits: int = 4,
+        axis_key: int = 0,
+        axis_value: int = 0,
+        q_group_size: int = 64,
+        residual_length: int = 128,
+    ):
+        logger.warning_once(
+            "`QuantoQuantizedCache` is deprecated and will be removed in version v4.58 "
+            "Use `QuantizedCache(backend='quanto', ...)` instead."
+        )
+        super().__init__("quanto", config, nbits, axis_key, axis_value, q_group_size, residual_length)
+
+
+class HQQQuantizedCache(QuantizedCache):
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        nbits: int = 4,
+        axis_key: int = 0,
+        axis_value: int = 0,
+        q_group_size: int = 64,
+        residual_length: int = 128,
+    ):
+        logger.warning_once(
+            "`HQQQuantizedCache` is deprecated and will be removed in version v4.58 "
+            "Use `QuantizedCache(backend='hqq', ...)` instead."
+        )
+        super().__init__("hqq", config, nbits, axis_key, axis_value, q_group_size, residual_length)
 
 
 class SinkCache(Cache):

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1137,7 +1137,7 @@ class StaticCache(Cache):
                 layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
 
         layers = []
-        for layer_type in config.layer_types:
+        for layer_type in layer_types:
             if layer_type == "sliding_attention":
                 layer = SlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.sliding_window)
             elif layer_type == "chunked_attention":

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1160,15 +1160,15 @@ class QuantizedCache(Cache):
             The quantization backend to use. One of `("quanto", "hqq").
         config (`PretrainedConfig`):
             The config of the model for which this Cache will be used.
-        nbits (`int`, *optional*, defaults to `4`):
+        nbits (`int`, *optional*, defaults to 4):
             The number of bits for quantization.
-        axis_key (`int`, *optional*, defaults to `0`):
+        axis_key (`int`, *optional*, defaults to 0):
             The axis on which to quantize the keys.
-        axis_value (`int`, *optional*, defaults to `0`):
+        axis_value (`int`, *optional*, defaults to 0):
             The axis on which to quantize the values.
-        q_group_size (`int`, *optional*, defaults to `64`):
+        q_group_size (`int`, *optional*, defaults to 64):
             Quantization is done per-channel according to a set `q_group_size` for both keys and values.
-        residual_length (`int`, *optional*, defaults to `128`):
+        residual_length (`int`, *optional*, defaults to 128):
             Maximum capacity for the original precision cache
     """
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1189,7 +1189,7 @@ class QuantizedCache(Cache):
         else:
             raise ValueError(f"Unknown quantization backend `{backend}`")
 
-        config = config.get_text_config()
+        config = config.get_text_config(decoder=True)
         layers = [
             layer_class(nbits, axis_key, axis_value, q_group_size, residual_length)
             for _ in range(config.num_hidden_layers)
@@ -1409,7 +1409,7 @@ class EncoderDecoderCache(Cache):
 class OffloadedCache(DynamicCache):
     def __init__(self) -> None:
         logger.warning_once(
-            "`OffloadedCache` is deprecated and will be removed in version v4.58 "
+            "`OffloadedCache` is deprecated and will be removed in version v4.60 "
             "Use `DynamicCache(offloading=True)` instead"
         )
         super().__init__(offloading=True)
@@ -1418,7 +1418,7 @@ class OffloadedCache(DynamicCache):
 class OffloadedStaticCache(StaticCache):
     def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
         logger.warning_once(
-            "`OffloadedStaticCache` is deprecated and will be removed in version v4.58 "
+            "`OffloadedStaticCache` is deprecated and will be removed in version v4.59 "
             "Use `StaticCache(..., offloading=True)` instead"
         )
         super().__init__(config=config, max_cache_len=max_cache_len, offloading=True)
@@ -1427,8 +1427,8 @@ class OffloadedStaticCache(StaticCache):
 class SlidingWindowCache(StaticCache):
     def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
         logger.warning_once(
-            "`SlidingWindowCache` is deprecated and will be removed in version v4.58 "
-            "Use `StaticCache` instead which will correctly infer the type of each layer."
+            "`SlidingWindowCache` is deprecated and will be removed in version v4.59 "
+            "Use `StaticCache(...)` instead which will correctly infer the type of each layer."
         )
         super().__init__(config=config, max_cache_len=max_cache_len)
 
@@ -1436,8 +1436,8 @@ class SlidingWindowCache(StaticCache):
 class HybridCache(StaticCache):
     def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
         logger.warning_once(
-            "`HybridCache` is deprecated and will be removed in version v4.58 "
-            "Use `StaticCache` instead which will correctly infer the type of each layer."
+            "`HybridCache` is deprecated and will be removed in version v4.59 "
+            "Use `StaticCache(...)` instead which will correctly infer the type of each layer."
         )
         super().__init__(config=config, max_cache_len=max_cache_len)
 
@@ -1445,8 +1445,8 @@ class HybridCache(StaticCache):
 class HybridChunkedCache(StaticCache):
     def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
         logger.warning_once(
-            "`HybridChunkedCache` is deprecated and will be removed in version v4.58 "
-            "Use `StaticCache` instead which will correctly infer the type of each layer."
+            "`HybridChunkedCache` is deprecated and will be removed in version v4.59 "
+            "Use `StaticCache(...)` instead which will correctly infer the type of each layer."
         )
         super().__init__(config=config, max_cache_len=max_cache_len)
 
@@ -1454,7 +1454,7 @@ class HybridChunkedCache(StaticCache):
 class OffloadedHybridCache(StaticCache):
     def __init__(self, config: PretrainedConfig, max_cache_len: int, *args, **kwargs):
         logger.warning_once(
-            "`OffloadedHybridCache` is deprecated and will be removed in version v4.58 "
+            "`OffloadedHybridCache` is deprecated and will be removed in version v4.59 "
             "Use `StaticCache(..., offload=True)` instead which will correctly infer the type of each layer."
         )
         super().__init__(config=config, max_cache_len=max_cache_len, offloading=True)
@@ -1471,7 +1471,7 @@ class QuantoQuantizedCache(QuantizedCache):
         residual_length: int = 128,
     ):
         logger.warning_once(
-            "`QuantoQuantizedCache` is deprecated and will be removed in version v4.58 "
+            "`QuantoQuantizedCache` is deprecated and will be removed in version v4.59 "
             "Use `QuantizedCache(backend='quanto', ...)` instead."
         )
         super().__init__("quanto", config, nbits, axis_key, axis_value, q_group_size, residual_length)
@@ -1488,7 +1488,7 @@ class HQQQuantizedCache(QuantizedCache):
         residual_length: int = 128,
     ):
         logger.warning_once(
-            "`HQQQuantizedCache` is deprecated and will be removed in version v4.58 "
+            "`HQQQuantizedCache` is deprecated and will be removed in version v4.59 "
             "Use `QuantizedCache(backend='hqq', ...)` instead."
         )
         super().__init__("hqq", config, nbits, axis_key, axis_value, q_group_size, residual_length)

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -161,9 +161,8 @@ class GenerationConfig(PushToHubMixin):
 
             - `"dynamic"`: [`DynamicCache`]
             - `"static"`: [`StaticCache`]
-            - `"offloaded_static"`: [`OffloadedStaticCache`]
-            - `"sliding_window"`: [`SlidingWindowCache`]
-            - `"hybrid"`: [`HybridCache`]
+            - `"offloaded"`: [`DynamicCache`]
+            - `"offloaded_static"`: [`StaticCache`]
             - `"quantized"`: [`QuantizedCache`]
 
             If none is specified, we will use the default cache for the model (which is often [`DynamicCache`]). See

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -43,34 +43,22 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 METADATA_FIELDS = ("_from_model_config", "_commit_hash", "_original_object_hash", "transformers_version")
-STATIC_CACHE_CLASSES_MAPPING = {}
-QUANT_BACKEND_CLASSES_MAPPING = {}
-ALL_CACHE_IMPLEMENTATIONS = []
+STATIC_CACHE_IMPLEMENTATIONS = ("static", "offloaded_static")
+DYNAMIC_CACHE_IMPLEMENTATIONS = ("dynamic", "offloaded", "quantized")
+# All the following are redundant and deprecated, but kept for BC
+DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS = (
+    "sliding_window",
+    "hybrid",
+    "hybrid_chunked",
+    "offloaded_hybrid",
+    "offloaded_hybrid_chunked",
+)
+ALL_STATIC_CACHE_IMPLEMENTATIONS = STATIC_CACHE_IMPLEMENTATIONS + DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS
+ALL_CACHE_IMPLEMENTATIONS = ALL_STATIC_CACHE_IMPLEMENTATIONS + DYNAMIC_CACHE_IMPLEMENTATIONS
+
 
 if is_torch_available():
-    from ..cache_utils import (
-        HQQQuantizedCache,
-        HybridCache,
-        HybridChunkedCache,
-        OffloadedHybridCache,
-        OffloadedStaticCache,
-        QuantoQuantizedCache,
-        SlidingWindowCache,
-        StaticCache,
-    )
     from .logits_process import SynthIDTextWatermarkLogitsProcessor, WatermarkLogitsProcessor
-
-    STATIC_CACHE_CLASSES_MAPPING = {
-        "static": StaticCache,
-        "offloaded_static": OffloadedStaticCache,
-        "sliding_window": SlidingWindowCache,
-        "hybrid": HybridCache,
-        "hybrid_chunked": HybridChunkedCache,
-        "offloaded_hybrid": OffloadedHybridCache,
-        "offloaded_hybrid_chunked": OffloadedHybridCache,
-    }
-    QUANT_BACKEND_CLASSES_MAPPING = {"quanto": QuantoQuantizedCache, "HQQ": HQQQuantizedCache}
-    ALL_CACHE_IMPLEMENTATIONS = list(STATIC_CACHE_CLASSES_MAPPING.keys()) + ["offloaded", "dynamic", "quantized"]
 
 
 class GenerationMode(ExplicitEnum):

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -161,8 +161,8 @@ class GenerationConfig(PushToHubMixin):
 
             - `"dynamic"`: [`DynamicCache`]
             - `"static"`: [`StaticCache`]
-            - `"offloaded"`: [`DynamicCache`]
-            - `"offloaded_static"`: [`StaticCache`]
+            - `"offloaded"`: [`DynamicCache(offloaded=True)`]
+            - `"offloaded_static"`: [`StaticCache(offloaded=True)`]
             - `"quantized"`: [`QuantizedCache`]
 
             If none is specified, we will use the default cache for the model (which is often [`DynamicCache`]). See

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -32,9 +32,8 @@ from ..cache_utils import (
     Cache,
     DynamicCache,
     EncoderDecoderCache,
-    HybridChunkedCache,
-    OffloadedCache,
-    OffloadedHybridCache,
+    QuantizedCache,
+    StaticCache,
 )
 from ..configuration_utils import PretrainedConfig
 from ..dynamic_module_utils import (
@@ -71,8 +70,9 @@ from .candidate_generator import (
     _prepare_token_type_ids,
 )
 from .configuration_utils import (
-    QUANT_BACKEND_CLASSES_MAPPING,
-    STATIC_CACHE_CLASSES_MAPPING,
+    ALL_STATIC_CACHE_IMPLEMENTATIONS,
+    DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS,
+    STATIC_CACHE_IMPLEMENTATIONS,
     GenerationConfig,
     GenerationMode,
 )
@@ -1822,27 +1822,18 @@ class GenerationMixin(ContinuousMixin):
 
         Returns the resulting cache object.
         """
-        if cache_implementation == "hybrid" and "llama4" in getattr(self.config, "model_type", ""):
-            cache_implementation = "hybrid_chunked"
-
-        cache_cls: Cache = STATIC_CACHE_CLASSES_MAPPING[cache_implementation]
         requires_cross_attention_cache = (
             self.config.is_encoder_decoder or model_kwargs.get("encoder_outputs") is not None
         )
+        offload_cache = "offloaded" in cache_implementation
 
         if hasattr(self, "_cache"):
             cache_to_check = self._cache.self_attention_cache if requires_cross_attention_cache else self._cache
 
-        if cache_implementation == "sliding_window":
-            max_cache_len = min(self.config.sliding_window, max_cache_len)
-
         need_new_cache = (
             not hasattr(self, "_cache")
-            or (not isinstance(cache_to_check, cache_cls))
+            or cache_to_check.offloading != offload_cache
             or cache_to_check.max_batch_size != batch_size
-            or isinstance(
-                cache_to_check, (HybridChunkedCache, OffloadedHybridCache)
-            )  # due to internal slicing, we always re-init
             or cache_to_check.max_cache_len < max_cache_len
         )
 
@@ -1853,12 +1844,12 @@ class GenerationMixin(ContinuousMixin):
             )
 
         if need_new_cache:
-            cache_kwargs = {"config": self.config.get_text_config(), "max_cache_len": max_cache_len}
-            self._cache = cache_cls(**cache_kwargs)
+            cache_kwargs = {"config": self.config, "max_cache_len": max_cache_len, "offloading": offload_cache}
+            self._cache = StaticCache(**cache_kwargs)
             if requires_cross_attention_cache:
                 encoder_kwargs = cache_kwargs.copy()
                 encoder_kwargs["max_cache_len"] = model_kwargs["encoder_outputs"][0].shape[1]
-                self._cache = EncoderDecoderCache(self._cache, cache_cls(**encoder_kwargs))
+                self._cache = EncoderDecoderCache(self._cache, StaticCache(**encoder_kwargs))
         else:
             self._cache.reset()
         return self._cache
@@ -1957,7 +1948,12 @@ class GenerationMixin(ContinuousMixin):
             else {}
         )
         if generation_config.cache_implementation is not None:
-            if generation_config.cache_implementation in STATIC_CACHE_CLASSES_MAPPING:
+            if generation_config.cache_implementation in ALL_STATIC_CACHE_IMPLEMENTATIONS:
+                if generation_config.cache_implementation in DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS:
+                    logger.waring_once(
+                        f"Using `cache_implementation='{generation_config.cache_implementation}' is deprecated. Please only "
+                        f"use one of {STATIC_CACHE_IMPLEMENTATIONS}, and the layer structure will be inferred automatically."
+                    )
                 model_kwargs[cache_name] = self._get_cache(
                     cache_implementation=generation_config.cache_implementation,
                     batch_size=max(generation_config.num_beams, generation_config.num_return_sequences) * batch_size,
@@ -1977,7 +1973,6 @@ class GenerationMixin(ContinuousMixin):
                     cache_config["config"] = self.config.get_text_config()
                 # Pop the backend from the config (defaults to quanto if not defined)
                 backend = cache_config.pop("backend", "quanto")
-                cache_class = QUANT_BACKEND_CLASSES_MAPPING[backend]
 
                 if backend == "quanto" and not is_optimum_quanto_available():
                     raise ImportError(
@@ -1989,10 +1984,9 @@ class GenerationMixin(ContinuousMixin):
                         "You need to install `HQQ` in order to use KV cache quantization with HQQ backend. "
                         "Please install it via  with `pip install hqq`"
                     )
-
-                model_kwargs[cache_name] = cache_class(**cache_config)
+                model_kwargs[cache_name] = QuantizedCache(backend=backend, **cache_config)
             elif generation_config.cache_implementation == "offloaded":
-                model_kwargs[cache_name] = OffloadedCache()
+                model_kwargs[cache_name] = DynamicCache(**dynamic_cache_kwargs, offloading=True)
             elif generation_config.cache_implementation == "dynamic":
                 model_kwargs[cache_name] = DynamicCache(**dynamic_cache_kwargs)
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1950,7 +1950,7 @@ class GenerationMixin(ContinuousMixin):
         if generation_config.cache_implementation is not None:
             if generation_config.cache_implementation in ALL_STATIC_CACHE_IMPLEMENTATIONS:
                 if generation_config.cache_implementation in DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS:
-                    logger.waring_once(
+                    logger.warning_once(
                         f"Using `cache_implementation='{generation_config.cache_implementation}' is deprecated. Please only "
                         f"use one of {STATIC_CACHE_IMPLEMENTATIONS}, and the layer structure will be inferred automatically."
                     )

--- a/src/transformers/integrations/executorch.py
+++ b/src/transformers/integrations/executorch.py
@@ -20,7 +20,6 @@ from ..cache_utils import (
     DynamicLayer,
     DynamicSlidingWindowLayer,
     EncoderDecoderCache,
-    HybridCache,
     StaticCache,
 )
 from ..generation.configuration_utils import GenerationConfig
@@ -36,9 +35,6 @@ from ..pytorch_utils import (
     is_torch_greater_or_equal_than_2_3,
     is_torch_greater_or_equal_than_2_6,
 )
-
-
-# Add this to src/transformers/integrations/executorch.py
 
 
 class TorchExportableModuleForVLM:
@@ -211,7 +207,7 @@ class TorchExportableModuleForDecoderOnlyLM(torch.nn.Module):
         model: PreTrainedModel,
     ):
         """
-        Initializes the exportable module with `HybridCache`.
+        Initializes the exportable module.
 
         Args:
             model (`PreTrainedModel`): The pretrained model to wrap.
@@ -640,7 +636,7 @@ class TorchExportableModuleWithStaticCache(torch.nn.Module):
 class TorchExportableModuleWithHybridCache(torch.nn.Module):
     """
     A recipe module designed to make a `PreTrainedModel` exportable with `torch.export`,
-    specifically for decoder-only LM to `HybridCache`. This module ensures that the
+    specifically for decoder-only LM to hybrid `StaticCache`. This module ensures that the
     exported model is compatible with further lowering and execution in `ExecuTorch`.
     """
 
@@ -649,13 +645,13 @@ class TorchExportableModuleWithHybridCache(torch.nn.Module):
         model: PreTrainedModel,
     ):
         """
-        Initializes the exportable module with `HybridCache`.
+        Initializes the exportable module.
 
         Args:
             model (`PreTrainedModel`): The pretrained model to wrap.
 
         Raises:
-            AssertionError: If the model doesn't have the expected configuration for HybridCache.
+            AssertionError: If the model doesn't have the expected configuration for an hybrid StaticCache.
         """
         super().__init__()
         self.model = model
@@ -680,8 +676,8 @@ class TorchExportableModuleWithHybridCache(torch.nn.Module):
         if not config.use_cache:
             raise AssertionError("Model must have caching enabled.")
 
-        # Initialize the HybridCache
-        self.cache = HybridCache(config=config, max_cache_len=generation_config.cache_config.get("max_cache_len"))
+        # Initialize the cache
+        self.cache = StaticCache(config=config, max_cache_len=generation_config.cache_config.get("max_cache_len"))
         head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
         num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
         max_batch_size = generation_config.cache_config.get("batch_size")

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -736,7 +736,7 @@ def create_causal_mask(
 ) -> Optional[Union[torch.Tensor, BlockMask]]:
     """
     Create a standard causal mask based on the attention implementation used (stored in the config). If `past_key_values`
-    has an HybridCache structure, this function will return the mask corresponding to one of the "full_attention" layers (to align
+    has an hybrid cache structure, this function will return the mask corresponding to one of the "full_attention" layers (to align
     to what is needed in the `modeling_xxx.py` files).
 
     Args:
@@ -761,7 +761,7 @@ def create_causal_mask(
             An optional mask function to combine with the causal mask function (by doing the intersection of both). This is
             useful to easily overlay another mask on top of the causal one, for example for image tokens handling.
     """
-    # If we have an HybridCache structure, here we want to create the mask for the full layers
+    # If we have an hybrid cache structure, here we want to create the mask for the full layers
     if hasattr(past_key_values, "is_sliding") and False in past_key_values.is_sliding:
         layer_idx = past_key_values.is_sliding.index(False)
     else:
@@ -828,7 +828,7 @@ def create_sliding_window_causal_mask(
 ) -> Optional[Union[torch.Tensor, BlockMask]]:
     """
     Create a sliding window causal mask based on the attention implementation used (stored in the config). This type
-    of attention pattern was mostly democratized by Mistral. If `past_key_values` has an HybridCache structure, this
+    of attention pattern was mostly democratized by Mistral. If `past_key_values` has an hybrid cache structure, this
     function will return the mask corresponding to one of the "sliding_attention" layers (to align to what is needed in the
     `modeling_xxx.py` files).
 
@@ -854,7 +854,7 @@ def create_sliding_window_causal_mask(
             An optional mask function to combine with the sliding causal mask function (by doing the intersection of both). This is
             useful to easily overlay another mask on top of the sliding causal one, for example for image tokens handling.
     """
-    # If we have an HybridCache structure, here we want to create the mask for the sliding layers
+    # If we have an hybrid cache structure, here we want to create the mask for the sliding layers
     if hasattr(past_key_values, "is_sliding") and True in past_key_values.is_sliding:
         layer_idx = past_key_values.is_sliding.index(True)
     else:
@@ -923,7 +923,7 @@ def create_chunked_causal_mask(
 ) -> Optional[Union[torch.Tensor, BlockMask]]:
     """
     Create a chunked attention causal mask based on the attention implementation used (stored in the config). This type
-    of attention pattern was mostly democratized by Llama4. If `past_key_values` has an HybridCache structure, this
+    of attention pattern was mostly democratized by Llama4. If `past_key_values` has an hybrid cache structure, this
     function will return the mask corresponding to one of the "chunked_attention" layers (to align to what is needed in the
     `modeling_xxx.py` files).
 
@@ -949,7 +949,7 @@ def create_chunked_causal_mask(
             An optional mask function to combine with the chunked causal mask function (by doing the intersection of both). This is
             useful to easily overlay another mask on top of the chunked causal one, for example for image tokens handling.
     """
-    # If we have an HybridCache structure, here we want to create the mask for the sliding layers
+    # If we have an hybrid cache structure, here we want to create the mask for the sliding layers
     if hasattr(past_key_values, "is_sliding") and True in past_key_values.is_sliding:
         layer_idx = past_key_values.is_sliding.index(True)
     else:

--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -467,7 +467,7 @@ class BambaMixer(nn.Module):
     and is why Mamba is called **selective** state spaces)
 
     The are a few differences between this and Mamba2Mixer:
-    - The variable use_precomputed_states is slightly different due to the HybridCache structure
+    - The variable use_precomputed_states is slightly different due to the hybrid cache structure
     - There's a few non-obvious bugs fixed with batching in the slow path that exist in main
     - Some extra variables that our layer doesn't need have been removed
     - We ported most of the refactors in https://github.com/huggingface/transformers/pull/35154, which is (as of Dec 18, 2024) unmerged

--- a/src/transformers/models/bamba/modular_bamba.py
+++ b/src/transformers/models/bamba/modular_bamba.py
@@ -225,7 +225,7 @@ class BambaMixer(nn.Module):
     and is why Mamba is called **selective** state spaces)
 
     The are a few differences between this and Mamba2Mixer:
-    - The variable use_precomputed_states is slightly different due to the HybridCache structure
+    - The variable use_precomputed_states is slightly different due to the hybrid cache structure
     - There's a few non-obvious bugs fixed with batching in the slow path that exist in main
     - Some extra variables that our layer doesn't need have been removed
     - We ported most of the refactors in https://github.com/huggingface/transformers/pull/35154, which is (as of Dec 18, 2024) unmerged

--- a/src/transformers/models/gpt_neo/modeling_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/modeling_gpt_neo.py
@@ -477,7 +477,7 @@ class GPTNeoPreTrainedModel(PreTrainedModel):
     _no_split_modules = ["GPTNeoBlock"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn = True
-    _can_compile_fullgraph = False  # TODO: needs a HybridCache
+    _can_compile_fullgraph = False  # TODO: needs a hybrid cache
 
     def __init__(self, *inputs, **kwargs):
         super().__init__(*inputs, **kwargs)

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -394,7 +394,7 @@ class GraniteMoeHybridMambaLayer(nn.Module):
     and is why Mamba is called **selective** state spaces)
 
     The are a few differences between this and Mamba2Mixer:
-    - The variable use_precomputed_states is slightly different due to the HybridCache structure
+    - The variable use_precomputed_states is slightly different due to the hybrid cache structure
     - There's a few non-obvious bugs fixed with batching in the slow path that exist in main
     - Some extra variables that our layer doesn't need have been removed
     - We ported most of the refactors in https://github.com/huggingface/transformers/pull/35154, which is (as of Dec 18, 2024) unmerged

--- a/src/transformers/models/kyutai_speech_to_text/modeling_kyutai_speech_to_text.py
+++ b/src/transformers/models/kyutai_speech_to_text/modeling_kyutai_speech_to_text.py
@@ -27,7 +27,7 @@ import torch
 import torch.nn as nn
 
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from ...cache_utils import Cache, DynamicCache, StaticCache
 from ...generation import GenerationConfig, GenerationMixin
 from ...modeling_attn_mask_utils import AttentionMaskConverter
 from ...modeling_flash_attention_utils import flash_attn_supports_top_left_mask, is_flash_attn_available
@@ -945,14 +945,9 @@ class KyutaiSpeechToTextModel(KyutaiSpeechToTextPreTrainedModel):
         # to infer the attention mask.
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         using_static_cache = isinstance(past_key_values, StaticCache)
-        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
 
         # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
-        if (
-            self.config._attn_implementation == "sdpa"
-            and not (using_static_cache or using_sliding_window_cache)
-            and not output_attentions
-        ):
+        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
             if AttentionMaskConverter._ignore_causal_mask_sdpa(
                 attention_mask,
                 inputs_embeds=input_tensor,
@@ -965,8 +960,8 @@ class KyutaiSpeechToTextModel(KyutaiSpeechToTextPreTrainedModel):
         dtype = input_tensor.dtype
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
-        # SlidingWindowCache or StaticCache
-        if using_sliding_window_cache or using_static_cache:
+        # StaticCache
+        if using_static_cache:
             target_length = past_key_values.get_max_cache_shape()
         # DynamicCache or no cache
         else:
@@ -1049,7 +1044,8 @@ class KyutaiSpeechToTextModel(KyutaiSpeechToTextPreTrainedModel):
             if getattr(text_config, "use_sliding_window", True) and text_config.sliding_window is not None:
                 # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
                 # the check is needed to verify is current checkpoint was trained with sliding window or not
-                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                is_static_sliding_cache = isinstance(past_key_values, StaticCache) and all(past_key_values.is_sliding)
+                if not is_static_sliding_cache or sequence_length > target_length:
                     sliding_attend_mask = torch.arange(target_length, device=cache_position.device) <= (
                         cache_position.reshape(-1, 1) - text_config.sliding_window
                     )

--- a/src/transformers/models/moshi/modeling_moshi.py
+++ b/src/transformers/models/moshi/modeling_moshi.py
@@ -24,7 +24,7 @@ import torch.utils.checkpoint
 from torch.nn import CrossEntropyLoss
 
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from ...cache_utils import Cache, DynamicCache, StaticCache
 from ...generation import GenerationConfig, GenerationMixin
 from ...modeling_attn_mask_utils import AttentionMaskConverter
 from ...modeling_flash_attention_utils import flash_attn_supports_top_left_mask, is_flash_attn_available
@@ -1084,14 +1084,9 @@ class MoshiDepthDecoder(MoshiPreTrainedModel, GenerationMixin):
         # to infer the attention mask.
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         using_static_cache = isinstance(past_key_values, StaticCache)
-        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
 
         # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
-        if (
-            self.config._attn_implementation == "sdpa"
-            and not (using_static_cache or using_sliding_window_cache)
-            and not output_attentions
-        ):
+        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
             if AttentionMaskConverter._ignore_causal_mask_sdpa(
                 attention_mask,
                 inputs_embeds=input_tensor,
@@ -1104,8 +1099,8 @@ class MoshiDepthDecoder(MoshiPreTrainedModel, GenerationMixin):
         dtype = input_tensor.dtype
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
-        # SlidingWindowCache or StaticCache
-        if using_sliding_window_cache or using_static_cache:
+        # StaticCache
+        if using_static_cache:
             target_length = past_key_values.get_max_cache_shape()
         # DynamicCache or no cache
         else:
@@ -1189,7 +1184,8 @@ class MoshiDepthDecoder(MoshiPreTrainedModel, GenerationMixin):
             if getattr(text_config, "use_sliding_window", True) and text_config.sliding_window is not None:
                 # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
                 # the check is needed to verify is current checkpoint was trained with sliding window or not
-                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                is_static_sliding_cache = isinstance(past_key_values, StaticCache) and all(past_key_values.is_sliding)
+                if not is_static_sliding_cache or sequence_length > target_length:
                     sliding_attend_mask = torch.arange(target_length, device=cache_position.device) <= (
                         cache_position.reshape(-1, 1) - text_config.sliding_window
                     )
@@ -1357,14 +1353,9 @@ class MoshiModel(MoshiPreTrainedModel):
         # to infer the attention mask.
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         using_static_cache = isinstance(past_key_values, StaticCache)
-        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
 
         # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
-        if (
-            self.config._attn_implementation == "sdpa"
-            and not (using_static_cache or using_sliding_window_cache)
-            and not output_attentions
-        ):
+        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
             if AttentionMaskConverter._ignore_causal_mask_sdpa(
                 attention_mask,
                 inputs_embeds=input_tensor,
@@ -1377,8 +1368,8 @@ class MoshiModel(MoshiPreTrainedModel):
         dtype = input_tensor.dtype
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
-        # SlidingWindowCache or StaticCache
-        if using_sliding_window_cache or using_static_cache:
+        # StaticCache
+        if using_static_cache:
             target_length = past_key_values.get_max_cache_shape()
         # DynamicCache or no cache
         else:
@@ -1462,7 +1453,8 @@ class MoshiModel(MoshiPreTrainedModel):
             if getattr(text_config, "use_sliding_window", True) and text_config.sliding_window is not None:
                 # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
                 # the check is needed to verify is current checkpoint was trained with sliding window or not
-                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                is_static_sliding_cache = isinstance(past_key_values, StaticCache) and all(past_key_values.is_sliding)
+                if not is_static_sliding_cache or sequence_length > target_length:
                     sliding_attend_mask = torch.arange(target_length, device=cache_position.device) <= (
                         cache_position.reshape(-1, 1) - text_config.sliding_window
                     )
@@ -2055,7 +2047,7 @@ class MoshiForConditionalGeneration(MoshiPreTrainedModel, GenerationMixin):
             depth_decoder_generation_config = {
                 "min_length": self.num_codebooks + 1,
                 "max_length": self.num_codebooks + 1,
-                "cache_implementation": "sliding_window",
+                "cache_implementation": "static",
             }
         # update kwargs_depth_decoder: kwargs_depth_decoder have priority over depth_decoder_generation_config
         depth_decoder_generation_config.update(kwargs_depth_decoder)

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -23,7 +23,7 @@ import torch.utils.checkpoint
 from torch import nn
 
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from ...cache_utils import Cache, DynamicCache, StaticCache
 from ...generation import GenerationMixin
 from ...modeling_attn_mask_utils import AttentionMaskConverter, _prepare_4d_causal_attention_mask
 from ...modeling_flash_attention_utils import is_flash_attn_available
@@ -1073,14 +1073,9 @@ class PhimoeModel(PhimoePreTrainedModel):
         # to infer the attention mask.
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         using_static_cache = isinstance(past_key_values, StaticCache)
-        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
 
         # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
-        if (
-            self.config._attn_implementation == "sdpa"
-            and not (using_static_cache or using_sliding_window_cache)
-            and not output_attentions
-        ):
+        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
             if AttentionMaskConverter._ignore_causal_mask_sdpa(
                 attention_mask,
                 inputs_embeds=input_tensor,
@@ -1093,8 +1088,8 @@ class PhimoeModel(PhimoePreTrainedModel):
         dtype = input_tensor.dtype
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
-        # SlidingWindowCache or StaticCache
-        if using_sliding_window_cache or using_static_cache:
+        # StaticCache
+        if using_static_cache:
             target_length = past_key_values.get_max_cache_shape()
         # DynamicCache or no cache
         else:
@@ -1177,7 +1172,8 @@ class PhimoeModel(PhimoePreTrainedModel):
             if getattr(text_config, "use_sliding_window", True) and text_config.sliding_window is not None:
                 # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
                 # the check is needed to verify is current checkpoint was trained with sliding window or not
-                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                is_static_sliding_cache = isinstance(past_key_values, StaticCache) and all(past_key_values.is_sliding)
+                if not is_static_sliding_cache or sequence_length > target_length:
                     sliding_attend_mask = torch.arange(target_length, device=cache_position.device) <= (
                         cache_position.reshape(-1, 1) - text_config.sliding_window
                     )

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -28,7 +28,7 @@ import torch.utils.checkpoint
 from torch import nn
 
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from ...cache_utils import Cache, DynamicCache, StaticCache
 from ...generation import GenerationMixin
 from ...modeling_attn_mask_utils import AttentionMaskConverter
 from ...modeling_flash_attention_utils import flash_attn_supports_top_left_mask, is_flash_attn_available
@@ -924,14 +924,9 @@ class Qwen2MoeModel(Qwen2MoePreTrainedModel):
         # to infer the attention mask.
         past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
         using_static_cache = isinstance(past_key_values, StaticCache)
-        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
 
         # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
-        if (
-            self.config._attn_implementation == "sdpa"
-            and not (using_static_cache or using_sliding_window_cache)
-            and not output_attentions
-        ):
+        if self.config._attn_implementation == "sdpa" and not using_static_cache and not output_attentions:
             if AttentionMaskConverter._ignore_causal_mask_sdpa(
                 attention_mask,
                 inputs_embeds=input_tensor,
@@ -944,8 +939,8 @@ class Qwen2MoeModel(Qwen2MoePreTrainedModel):
         dtype = input_tensor.dtype
         min_dtype = torch.finfo(dtype).min
         sequence_length = input_tensor.shape[1]
-        # SlidingWindowCache or StaticCache
-        if using_sliding_window_cache or using_static_cache:
+        # StaticCache
+        if using_static_cache:
             target_length = past_key_values.get_max_cache_shape()
         # DynamicCache or no cache
         else:
@@ -1029,7 +1024,8 @@ class Qwen2MoeModel(Qwen2MoePreTrainedModel):
             if getattr(text_config, "use_sliding_window", True) and text_config.sliding_window is not None:
                 # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
                 # the check is needed to verify is current checkpoint was trained with sliding window or not
-                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                is_static_sliding_cache = isinstance(past_key_values, StaticCache) and all(past_key_values.is_sliding)
+                if not is_static_sliding_cache or sequence_length > target_length:
                     sliding_attend_mask = torch.arange(target_length, device=cache_position.device) <= (
                         cache_position.reshape(-1, 1) - text_config.sliding_window
                     )

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -83,7 +83,7 @@ if is_torch_available():
         Cache,
         DynamicCache,
         EncoderDecoderCache,
-        QuantoQuantizedCache,
+        QuantoQuantizedLayer,
         StaticCache,
     )
     from transformers.generation import (
@@ -2041,7 +2041,7 @@ class GenerationTesterMixin:
             }
 
             results = model.generate(**generation_kwargs, **inputs_dict)
-            self.assertTrue(isinstance(results.past_key_values, QuantoQuantizedCache))
+            self.assertTrue(all(isinstance(layer, QuantoQuantizedLayer) for layer in results.past_key_values.layers))
 
             # passing past key values of different type should raise Error
             with self.assertRaises(ValueError):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -83,7 +83,6 @@ if is_torch_available():
         Cache,
         DynamicCache,
         EncoderDecoderCache,
-        HybridCache,
         QuantoQuantizedCache,
         StaticCache,
     )
@@ -2532,11 +2531,11 @@ class GenerationTesterMixin:
         self.assertEqual(len(attentions), (output_length - prompt_length))
 
         use_cache = decoder_past_key_values is not None
-        has_static_cache = isinstance(decoder_past_key_values, (StaticCache, HybridCache))
+        has_static_cache = isinstance(decoder_past_key_values, StaticCache)
 
         # When `output_attentions=True`, each iteration of generate appends the attentions corresponding to the new
         # token(s)
-        # NOTE: `HybridCache` may have different lengths on different layers, if this test starts failing add more
+        # NOTE: `StaticCache` may have different lengths on different layers, if this test starts failing add more
         # elaborate checks
         for generated_length, iter_attentions in enumerate(attentions):
             # regardless of using cache, the first forward pass will have the full prompt as input
@@ -2581,7 +2580,7 @@ class GenerationTesterMixin:
 
         # When `output_hidden_states=True`, each iteration of generate appends the hidden states corresponding to the
         # new token(s)
-        # NOTE: `HybridCache` may have different lengths on different layers, if this test starts failing add more
+        # NOTE: `StaticCache` may have different lengths on different layers, if this test starts failing add more
         # elaborate checks
         for generated_length, iter_hidden_states in enumerate(hidden_states):
             # regardless of using cache, the first forward pass will have the full prompt as input

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2164,10 +2164,11 @@ class GenerationTesterMixin:
                 torch._logging.set_logs()
 
             # Compilation of slidind layers necesarily has recompiles with `dynamic=False` - however this test
-            # still checks that `fullgraph=True` is supported, as compilation with `dynamic=None` is the default
-            # and does not actually lead to too many recompiles
+            # still checks that `fullgraph=True` is supported in this case, as compilation with `dynamic=None`
+            # is the default and does not actually lead to too many recompiles
             has_sliding_layers = any(decoder_cache.is_sliding)
-            if not has_sliding_layers and "Recompiling" in cl.out or ("guard" in cl.out and "failure" in cl.out):
+            has_recompilation = "Recompiling" in cl.out or ("guard" in cl.out and "failure" in cl.out)
+            if not has_sliding_layers and has_recompilation:
                 raise RuntimeError(
                     f"`torch.compile` recompiled part of the forward pass in {model.__class__.__name__}. "
                     "See the test logs for more details."

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2163,7 +2163,11 @@ class GenerationTesterMixin:
             finally:
                 torch._logging.set_logs()
 
-            if "Recompiling" in cl.out or ("guard" in cl.out and "failure" in cl.out):
+            # Compilation of slidind layers necesarily has recompiles with `dynamic=False` - however this test
+            # still checks that `fullgraph=True` is supported, as compilation with `dynamic=None` is the default
+            # and does not actually lead to too many recompiles
+            has_sliding_layers = any(decoder_cache.is_sliding)
+            if not has_sliding_layers and "Recompiling" in cl.out or ("guard" in cl.out and "failure" in cl.out):
                 raise RuntimeError(
                     f"`torch.compile` recompiled part of the forward pass in {model.__class__.__name__}. "
                     "See the test logs for more details."

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2161,7 +2161,7 @@ class GenerationTesterMixin:
             finally:
                 torch._logging.set_logs()
 
-            # Compilation of slidind layers necesarily has recompiles with `dynamic=False` - however this test
+            # Compilation of sliding layers necessarily has recompiles with `dynamic=False` - however this test
             # still checks that `fullgraph=True` is supported in this case, as compilation with `dynamic=None`
             # is the default and does not actually lead to too many recompiles
             has_sliding_layers = any(decoder_cache.is_sliding)

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1956,7 +1956,6 @@ class GenerationTesterMixin:
         Tests that generating with static cache give almost same results as with dynamic cache, and the output cache
         has the expected shapes
         """
-        set_model_tester_for_less_flaky_test(self)
         for model_class in self.all_generative_model_classes:
             # Here, we should ideally not skip any model, and test them all. However, some old models cannot correctly
             # use a static cache because they don't create the causal masks correctly.
@@ -2062,7 +2061,6 @@ class GenerationTesterMixin:
 
         ⚠️ Runs two sequential generations to ensure the cache doesn't get stuck after the first compiled run! ⚠️
         """
-        set_model_tester_for_less_flaky_test(self)
         for model_class in self.all_generative_model_classes:
             # 1. Test exclusion criteria
             if not model_class._can_compile_fullgraph:

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -50,11 +50,9 @@ if is_torch_available():
         DynamicCache,
         Gemma2Config,
         GenerationConfig,
-        HybridCache,
         HybridChunkedCache,
         LlamaConfig,
         QuantizedCache,
-        SlidingWindowCache,
         StaticCache,
         convert_and_export_with_cache,
         pipeline,
@@ -424,7 +422,7 @@ class CacheHardIntegrationTest(unittest.TestCase):
     @require_torch_accelerator
     @slow
     def test_offloaded_cache_uses_less_memory_than_dynamic_cache(self):
-        """Tests that OffloadedCache uses less memory than the default DynamicCache"""
+        """Tests that offloading uses less memory than the default DynamicCache"""
         model_name = "microsoft/Phi-3-mini-4k-instruct"
         tokenizer = AutoTokenizer.from_pretrained(model_name)
         model = AutoModelForCausalLM.from_pretrained(model_name, device_map="auto", torch_dtype=torch.float16)
@@ -827,9 +825,8 @@ class CacheExportIntegrationTest(unittest.TestCase):
         model = AutoModelForCausalLM.from_pretrained(model_id)
         model.eval()
         self.assertEqual(model.config.use_cache, True)
-        self.assertEqual(model.config.cache_implementation, "hybrid")
 
-        # Export + HybridCache
+        # Export + hybrid StaticCache
         model.eval()
         max_batch_size = 1
         max_cache_len = 23
@@ -838,7 +835,7 @@ class CacheExportIntegrationTest(unittest.TestCase):
 
         model.generation_config = GenerationConfig(
             use_cache=True,
-            cache_implementation="hybrid",
+            cache_implementation="static",
             max_length=max_cache_len,
             cache_config={
                 "batch_size": max_batch_size,
@@ -944,7 +941,7 @@ class SyntheticCacheTest(unittest.TestCase):
         )
 
     def test_sliding_window_cache(self):
-        """Test SlidingWindowCache with manually prefilled states and hardcoded assertions.
+        """Test fully sliding StaticCache with manually prefilled states and hardcoded assertions.
 
         Scenario 1: Update within window, no slide yet
         prefill:       [1.0, 2.0, 0.0, 0.0]
@@ -961,7 +958,7 @@ class SyntheticCacheTest(unittest.TestCase):
         # Scenario 1: Update within window, no slide yet
         config = copy.deepcopy(self.config)
         config.layer_types = ["sliding_attention"] * config.num_hidden_layers
-        sliding_cache = SlidingWindowCache(config=config, max_cache_len=self.max_cache_len)
+        sliding_cache = StaticCache(config=config, max_cache_len=self.max_cache_len)
         prefill = torch.tensor([1.0, 2.0])[None, None, :, None]
         sliding_cache.update(
             key_states=prefill,
@@ -978,11 +975,11 @@ class SyntheticCacheTest(unittest.TestCase):
         self.assertEqual(
             sliding_cache.layers[0].keys[0, 0, :, 0].tolist(),
             [1.0, 2.0, 3.0, 0.0],
-            "SlidingWindowCache Scenario 1 failed",
+            "Fully sliding StaticCache Scenario 1 failed",
         )
 
         # Scenario 2: Update causing slide
-        sliding_cache = SlidingWindowCache(config=config, max_cache_len=self.max_cache_len)
+        sliding_cache = StaticCache(config=config, max_cache_len=self.max_cache_len)
         prefill = torch.tensor([1.0, 2.0, 3.0, 4.0])[None, None, :, None]
         sliding_cache.update(
             key_states=prefill,
@@ -999,11 +996,11 @@ class SyntheticCacheTest(unittest.TestCase):
         self.assertEqual(
             sliding_cache.layers[0].keys[0, 0, :, 0].tolist(),
             [2.0, 3.0, 4.0, 5.0],
-            "SlidingWindowCache Scenario 2 failed",
+            "Fully sliding StaticCache Scenario 2 failed",
         )
 
         # Scenario 3: Long prompt handling
-        sliding_cache = SlidingWindowCache(config=config, max_cache_len=self.max_cache_len)
+        sliding_cache = StaticCache(config=config, max_cache_len=self.max_cache_len)
         long_prefill = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])[None, None, :, None]
         sliding_cache.update(
             key_states=long_prefill,
@@ -1014,144 +1011,7 @@ class SyntheticCacheTest(unittest.TestCase):
         self.assertEqual(
             sliding_cache.layers[0].keys[0, 0, :, 0].tolist(),
             [3.0, 4.0, 5.0, 6.0],
-            "SlidingWindowCache Scenario 3 failed",
-        )
-
-    def test_hybrid_cache_static_mode(self):
-        """Test HybridCache with only 1 static layer.
-
-        Scenario 1: Static layer behavior
-        prefill:       [1.0, 2.0, 0.0, 0.0]
-        update pos 2:  [1.0, 2.0, 3.0, 0.0]
-
-        Scenario 2: Fill to capacity
-        update pos 3:  [1.0, 2.0, 3.0, 4.0]
-        """
-        config = copy.deepcopy(self.config)
-        config.layer_types = ["full_attention"] * config.num_hidden_layers
-
-        # Scenario 1
-        hybrid_cache_static_mode = HybridCache(config=config, max_cache_len=self.max_cache_len)
-        prefill = torch.tensor([1.0, 2.0])[None, None, :, None]
-        hybrid_cache_static_mode.update(
-            key_states=prefill,
-            value_states=prefill,
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.arange(2)},
-        )
-        hybrid_cache_static_mode.update(
-            key_states=torch.tensor(3.0)[None, None, None, None],
-            value_states=torch.tensor(3.0)[None, None, None, None],
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.tensor([2])},
-        )
-        self.assertEqual(
-            hybrid_cache_static_mode.layers[0].keys[0, 0, :, 0].tolist(),
-            [1.0, 2.0, 3.0, 0.0],
-            "HybridCache Static Scenario 1 failed",
-        )
-
-        # Scenario 2
-        hybrid_cache_static_mode.update(
-            key_states=torch.tensor(4.0)[None, None, None, None],
-            value_states=torch.tensor(4.0)[None, None, None, None],
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.tensor([3])},
-        )
-        self.assertEqual(
-            hybrid_cache_static_mode.layers[0].keys[0, 0, :, 0].tolist(),
-            [1.0, 2.0, 3.0, 4.0],
-            "HybridCache Static Scenario 2 failed",
-        )
-
-    def test_hybrid_cache_sliding_mode(self):
-        """Test HybridCache in sliding mode with hardcoded assertions.
-
-        Scenario 1: Update within window, no slide yet
-        prefill:       [1.0, 2.0, 0.0, 0.0]
-        update pos 2:  [1.0, 2.0, 3.0, 0.0]
-
-        Scenario 2: Update causing first slide
-        prefill:       [1.0, 2.0, 3.0, 4.0]
-        update pos 4:  [2.0, 3.0, 4.0, 5.0] (shift happens as pos > window_size-1)
-
-        Scenario 3: Update causing subsequent slide
-        update pos 5:  [3.0, 4.0, 5.0, 6.0] (shift continues)
-
-        Scenario 4: Long prompt handling (prompt_len > window_size)
-        input:         [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
-        result:        [3.0, 4.0, 5.0, 6.0] (keeps last window_size tokens)
-        """
-        config = copy.deepcopy(self.config)
-        config.layer_types = ["sliding_attention"] * config.num_hidden_layers
-        # Scenario 1: Update within window, no slide yet
-        hybrid_cache = HybridCache(config=config, max_cache_len=self.max_cache_len)
-        prefill = torch.tensor([1.0, 2.0])[None, None, :, None]
-        hybrid_cache.update(
-            key_states=prefill,
-            value_states=prefill,
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.arange(2)},
-        )
-        hybrid_cache.update(
-            key_states=torch.tensor(3.0)[None, None, None, None],
-            value_states=torch.tensor(3.0)[None, None, None, None],
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.tensor([2])},
-        )
-        self.assertEqual(
-            hybrid_cache.layers[0].keys[0, 0, :, 0].tolist(),
-            [1.0, 2.0, 3.0, 0.0],
-            "HybridCache Sliding Scenario 1 failed",
-        )
-
-        # Scenario 2: Update causing first slide
-        hybrid_cache = HybridCache(config=config, max_cache_len=self.max_cache_len)
-        prefill = torch.tensor([1.0, 2.0, 3.0, 4.0])[None, None, :, None]
-        hybrid_cache.update(
-            key_states=prefill,
-            value_states=prefill,
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.arange(4)},
-        )
-        hybrid_cache.update(
-            key_states=torch.tensor(5.0)[None, None, None, None],
-            value_states=torch.tensor(5.0)[None, None, None, None],
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.tensor([4])},
-        )
-        self.assertEqual(
-            hybrid_cache.layers[0].keys[0, 0, :, 0].tolist(),
-            [2.0, 3.0, 4.0, 5.0],
-            "HybridCache Sliding Scenario 2 failed",
-        )
-
-        # Scenario 3: Update causing subsequent slide
-        hybrid_cache.update(
-            key_states=torch.tensor(6.0)[None, None, None, None],
-            value_states=torch.tensor(6.0)[None, None, None, None],
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.tensor([5])},
-        )
-        self.assertEqual(
-            hybrid_cache.layers[0].keys[0, 0, :, 0].tolist(),
-            [3.0, 4.0, 5.0, 6.0],
-            "HybridCache Sliding Scenario 3 failed",
-        )
-
-        # Scenario 4: Long prompt handling
-        hybrid_cache = HybridCache(config=config, max_cache_len=self.max_cache_len)
-        long_prefill = torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])[None, None, :, None]
-        hybrid_cache.update(
-            key_states=long_prefill,
-            value_states=long_prefill,
-            layer_idx=0,
-            cache_kwargs={"cache_position": torch.arange(6)},
-        )
-        self.assertEqual(
-            hybrid_cache.layers[0].keys[0, 0, :, 0].tolist(),
-            [3.0, 4.0, 5.0, 6.0],
-            "HybridCache Sliding Scenario 4 failed",
+            "Fully sliding StaticCache Scenario 3 failed",
         )
 
     def test_dynamic_cache(self):
@@ -1221,7 +1081,7 @@ class SyntheticCacheTest(unittest.TestCase):
 
     def test_hybrid_cache(self):
         """
-        Test HybridCache with a mix of static and sliding layers,
+        Test hybrid StaticCache with a mix of static and sliding layers,
         with prefill size bigger than sliding window.
 
         prefill:
@@ -1237,7 +1097,7 @@ class SyntheticCacheTest(unittest.TestCase):
         config.num_hidden_layers = 2
         config.layer_types = ["full_attention", "sliding_attention"]
         config.sliding_window = 2
-        hybrid_cache = HybridCache(config=config, max_cache_len=self.max_cache_len)
+        hybrid_cache = StaticCache(config=config, max_cache_len=self.max_cache_len)
 
         # Prefill both layers up to cache capacity
         prefill_static = torch.tensor([1.0, 2.0, 3.0])[None, None, :, None]


### PR DESCRIPTION
# What does this PR do?

Now that we moved the cache logic to a per-layer approach and added DynamicSliding layer, duplicating the number of Cache classes is kind of useless, and brings a lot of unnecessary complexity.

This PR deprecates all Cache classes to keep only 3:

- DynamicCache -> each layer type is inferred from config and correctly dispatched
- StaticCache -> each layer type is inferred from config and correctly dispatched
- QuantizedCache -> only has 1 layer type anyway

This simplifies quite a lot as we had created a lot of classes before, which are always the same up to the layer type.
Also, offloading is now ALWAYS possible, independently of the layer combination, which was not the case before: `OffloadedCache` would work with only full layers, and we had 2 different classes for `StaticOffloaded`, depending on hybrid structure or only full layer, but fully sliding models such as Mistral could not be offloaded with static implementation.
Finally, `cache_implementation="static"` will correctly instantiate the correct layer types, independently of the model, which is not the case currently (it would use only full layers all the time, even if model uses sliding layers, wasting memory)