### PR TITLE
No more `natten`

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -55,11 +55,6 @@ RUN python3 -m pip install --no-cache-dir quanto
 # (`deformable_detr`, `rwkv`, `mra`)
 RUN python3 -m pip uninstall -y ninja
 
-# For `dinat` model
-# The `XXX` part in `torchXXX` needs to match `PYTORCH` (to some extent)
-# pin `0.17.4` otherwise `cannot import name 'natten2dav' from 'natten.functional'`
-RUN python3 -m pip install --no-cache-dir natten==0.17.4+torch250cu121 -f https://shi-labs.com/natten/wheels
-
 # For `nougat` tokenizer
 RUN python3 -m pip install --no-cache-dir python-Levenshtein
 


### PR DESCRIPTION
# What does this PR do?

This is required by `nat` (already depreciated) and `dinat`.

We have to pin it to a very old version to avoid `natten2dav` issue, but now we get 

> ImportError: cannot import name '_device_t' from 'torch.cuda' (/usr/local/lib/python3.10/dist-packages/torch/cuda/__init__.py)

with torch 2.8, which fails the job of `tests/utils` where `from transformers import *` is used.

Let's simply remove this natten from docker CI image (and no tests for `dinat` for which I think reasonable).