### PR TITLE
Remove unnecessary contiguous calls for modern torch

### DIFF
--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -67,12 +67,6 @@ def sdpa_attention_forward(
     if attention_mask is not None and attention_mask.ndim == 4:
         attention_mask = attention_mask[:, :, :, : key.shape[-2]]
 
-    # SDPA with memory-efficient backend is bugged with non-contiguous inputs and custom attn_mask for some torch versions
-    # Reference: https://github.com/pytorch/pytorch/issues/112577.
-    query = query.contiguous()
-    key = key.contiguous()
-    value = value.contiguous()
-
     # We dispatch to SDPA's Flash Attention or Efficient kernels via this `is_causal` if statement instead of an inline conditional assignment
     # in SDPA to support both torch.compile's dynamic shapes and full graph options. An inline conditional prevents dynamic shapes from compiling.
     # Note that it is important to check first for the shape, otherwise compile will fail with `argument 'is_causal' must be bool, not SymBool`


### PR DESCRIPTION
`sdpa_integration.py` calls `contiguous()` on the three attention tensors to work around a bug that was present before `torch 2.2`. However, our minimum version is now >= 2.2 anyway, so this bug should not longer be relevant, and we can remove the workaround to boost performance.

Pytorch issue link: https://github.com/pytorch/pytorch/issues/112577