### PR TITLE
Fix: Only call Trainer.align_special_tokens if model has "config" attribute

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2237,7 +2237,9 @@ class Trainer:
         self.is_in_train = True
 
         # If the model uses a tokenizer, it may have a new tokens for fine-tuning purposes.
-        if isinstance(self.processing_class, (PreTrainedTokenizerBase, ProcessorMixin)):
+        if isinstance(self.processing_class, (PreTrainedTokenizerBase, ProcessorMixin)) and hasattr(
+            self.model, "config"
+        ):
             self._align_special_tokens()
 
         # Attach NEFTune hooks if necessary

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -516,11 +516,15 @@ if is_torch_available():
             self.lstm = nn.LSTM(hidden_size, hidden_size, batch_first=True)
             self.fc = nn.Linear(hidden_size, vocab_size)
 
-        def forward(self, input_ids, **kwargs):
+        def forward(self, input_ids, labels=None, **kwargs):
             embedded = self.embedding(input_ids)
             lstm_out, _ = self.lstm(embedded)
             logits = self.fc(lstm_out)
-            return logits
+            if labels is None:
+                return logits
+
+            loss = nn.functional.cross_entropy(logits.view(-1, logits.size(-1)), labels.view(-1))
+            return loss, logits
 
     def create_dummy_dataset_for_text_generation(vocab_size, seq_length, num_samples):
         import numpy as np
@@ -5021,6 +5025,39 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
             self.assertEqual(trainer.model.config.pad_token_id, tokenizer.pad_token_id)
             self.assertEqual(trainer.model.config.bos_token_id, tokenizer.bos_token_id)
 
+    def test_trainer_works_without_model_config(self):
+        """
+        Tests that models without a `config` parameter can still be trained.
+        This is useful for preserving compatibility with third parties that train different models using the
+        transformers Trainer.
+
+        If this test fails, it doesn't imply that there's issues with transformers, but perhaps with third
+        parties.
+        """
+
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
+        model = BasicTextGenerationModel(vocab_size=tokenizer.vocab_size, hidden_size=32)
+        # Note that this class does not have a config attribute
+
+        train_dataset = LineByLineTextDataset(
+            tokenizer=tokenizer,
+            file_path=PATH_SAMPLE_TEXT,
+            block_size=tokenizer.max_len_single_sentence,
+        )
+        for example in train_dataset.examples:
+            example["labels"] = example["input_ids"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            training_args = TrainingArguments(
+                output_dir=tmpdir, report_to="none", max_steps=5, per_device_train_batch_size=1, remove_unused_columns=False
+            )
+            trainer = Trainer(
+                model=model,
+                args=training_args,
+                processing_class=tokenizer,
+                train_dataset=train_dataset,
+            )
+            trainer.train()
 
 @require_torch
 @is_staging_test

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -5049,7 +5049,11 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             training_args = TrainingArguments(
-                output_dir=tmpdir, report_to="none", max_steps=5, per_device_train_batch_size=1, remove_unused_columns=False
+                output_dir=tmpdir,
+                report_to="none",
+                max_steps=5,
+                per_device_train_batch_size=1,
+                remove_unused_columns=False,
             )
             trainer = Trainer(
                 model=model,
@@ -5058,6 +5062,7 @@ class TrainerIntegrationTest(TestCasePlus, TrainerIntegrationCommon):
                 train_dataset=train_dataset,
             )
             trainer.train()
+
 
 @require_torch
 @is_staging_test


### PR DESCRIPTION
Resolves https://github.com/huggingface/transformers/pull/38441#issuecomment-3206817330

# What does this PR do?

#38441 introduced a function on the `Trainer` that calls `self.model.config`, but this only works if the trained model has a `config` parameter. This isn't always the case, especially for third parties like Sentence Transformers and SetFit.

We've encountered this before in the Trainer, and we explicitly check whether the `self.model` has this `config` attribute:
https://github.com/huggingface/transformers/blob/4977ec2ae81d868fcd96ad4c7b1bffdc8c57f52c/src/transformers/trainer.py#L4708-L4711

The very straight-forward fix is simply to only call this function if `config` exists on `self.model`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@SunMarc @gante

## TODO

@gante I'm open to advice re. tests to prevent future regressions here. I've not worked with the trainer tests before.

- Tom Aarsen