### PR TITLE
Fix an infinite loop bug in recursive search of relative imports

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -130,11 +130,10 @@ def get_relative_import_files(module_file: Union[str, os.PathLike]) -> list[str]
             new_imports.extend(get_relative_imports(f))
 
         module_path = Path(module_file).parent
-        new_import_files = [str(module_path / m) for m in new_imports]
-        new_import_files = [f for f in new_import_files if f not in all_relative_imports]
-        files_to_check = [f"{f}.py" for f in new_import_files]
+        new_import_files = [f"{str(module_path / m)}.py" for m in new_imports]
+        files_to_check = [f for f in new_import_files if f not in all_relative_imports]
 
-        no_change = len(new_import_files) == 0
+        no_change = len(files_to_check) == 0
         all_relative_imports.extend(files_to_check)
 
     return all_relative_imports


### PR DESCRIPTION
# What does this PR do?

This PR fixes a bug in `get_relative_import_files` in `dynamic_module_utils`.
The mechanism to exclude already-found imports from the next iteration had a wrong inclusion check, as it was missing a ".py" suffix.
This means that even if an import was in `all_relative_imports`, it wasn't excluded from `files_to_check`.
In most cases it was a silent bug, but for files with circular imports it resulted in an infinite loop.

## Who can review?

Maybe @Rocketknight1, @Cyrilvallez  ?
