### PR TITLE
Fix qwen-omni processor text only mode

### DIFF
--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -238,45 +238,54 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
 
             for _, special_token in positions:
                 if special_token == self.audio_token:
-                    sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
+                    try:
+                        sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
+                    except StopIteration:
+                        logging.warning(f"Audio token `{self.audio_token}` found in text but no audio is provided.")
                 elif special_token == self.image_token:
-                    image_seq_length = next(image_grid_thw).prod() // merge_length_image
-                    sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
+                    try:
+                        image_seq_length = next(image_grid_thw).prod() // merge_length_image
+                        sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
+                    except StopIteration:
+                        logging.warning(f"Image token `{self.image_token}` found in text but no image is provided.")
                 elif special_token == self.video_token:
-                    if not use_audio_in_video:
-                        video_seq_length = next(video_grid_thw).prod() // merge_length_video
-                        sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
-                    else:
-                        audio_token_indices = np.arange(next(audio_lengths))
-                        curr_video_grid_thw = next(video_grid_thw)
-                        height = curr_video_grid_thw[1] // self.video_processor.merge_size
-                        width = curr_video_grid_thw[2] // self.video_processor.merge_size
-                        video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
-                        video_token_indices = np.broadcast_to(
-                            video_token_indices, (video_token_indices.shape[0], height, width)
-                        ).reshape(-1)
-                        video_token_indices = (
-                            video_token_indices * next(video_second_per_grid) * position_id_per_seconds
-                        )
+                    try:
+                        if not use_audio_in_video:
+                            video_seq_length = next(video_grid_thw).prod() // merge_length_video
+                            sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
+                        else:
+                            audio_token_indices = np.arange(next(audio_lengths))
+                            curr_video_grid_thw = next(video_grid_thw)
+                            height = curr_video_grid_thw[1] // self.video_processor.merge_size
+                            width = curr_video_grid_thw[2] // self.video_processor.merge_size
+                            video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
+                            video_token_indices = np.broadcast_to(
+                                video_token_indices, (video_token_indices.shape[0], height, width)
+                            ).reshape(-1)
+                            video_token_indices = (
+                                video_token_indices * next(video_second_per_grid) * position_id_per_seconds
+                            )
 
-                        tokens_per_chunk = int(position_id_per_seconds * seconds_per_chunk)
-                        video_chunk_indexes = self.get_chunked_index(video_token_indices, tokens_per_chunk)
-                        audio_chunk_indexes = self.get_chunked_index(audio_token_indices, tokens_per_chunk)
+                            tokens_per_chunk = int(position_id_per_seconds * seconds_per_chunk)
+                            video_chunk_indexes = self.get_chunked_index(video_token_indices, tokens_per_chunk)
+                            audio_chunk_indexes = self.get_chunked_index(audio_token_indices, tokens_per_chunk)
 
-                        placeholder_string = self.vision_bos_token + self.audio_bos_token
-                        for j in range(max(len(video_chunk_indexes), len(audio_chunk_indexes))):
-                            if j < len(video_chunk_indexes):
-                                video_seq_length = video_chunk_indexes[j][1] - video_chunk_indexes[j][0]
-                                placeholder_string += "<|video_placeholder|>" * video_seq_length
-                            if j < len(audio_chunk_indexes):
-                                audio_seq_length = audio_chunk_indexes[j][1] - audio_chunk_indexes[j][0]
-                                placeholder_string += "<|audio_placeholder|>" * audio_seq_length
-                        placeholder_string += self.audio_eos_token + self.vision_eos_token
-                        sample = sample.replace(
-                            self.vision_bos_token + self.video_token + self.vision_eos_token,
-                            placeholder_string,
-                            1,
-                        )
+                            placeholder_string = self.vision_bos_token + self.audio_bos_token
+                            for j in range(max(len(video_chunk_indexes), len(audio_chunk_indexes))):
+                                if j < len(video_chunk_indexes):
+                                    video_seq_length = video_chunk_indexes[j][1] - video_chunk_indexes[j][0]
+                                    placeholder_string += "<|video_placeholder|>" * video_seq_length
+                                if j < len(audio_chunk_indexes):
+                                    audio_seq_length = audio_chunk_indexes[j][1] - audio_chunk_indexes[j][0]
+                                    placeholder_string += "<|audio_placeholder|>" * audio_seq_length
+                            placeholder_string += self.audio_eos_token + self.vision_eos_token
+                            sample = sample.replace(
+                                self.vision_bos_token + self.video_token + self.vision_eos_token,
+                                placeholder_string,
+                                1,
+                            )
+                    except StopIteration:
+                        logging.warning(f"Video token `{self.video_token}` found in text but no video is provided.")
 
             sample = sample.replace("<|audio_placeholder|>", self.audio_token)
             sample = sample.replace("<|image_placeholder|>", self.image_token)

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -195,16 +195,17 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         if not isinstance(text, list):
             text = [text]
 
-        text = self.replace_multimodal_special_tokens(
-            text,
-            audio_lengths,
-            image_grid_thw,
-            video_grid_thw,
-            video_second_per_grid=video_second_per_grid,
-            use_audio_in_video=use_audio_in_video,
-            position_id_per_seconds=position_id_per_seconds,
-            seconds_per_chunk=seconds_per_chunk,
-        )
+        if images is not None or videos is not None or audio is not None:
+            text = self.replace_multimodal_special_tokens(
+                text,
+                audio_lengths,
+                image_grid_thw,
+                video_grid_thw,
+                video_second_per_grid=video_second_per_grid,
+                use_audio_in_video=use_audio_in_video,
+                position_id_per_seconds=position_id_per_seconds,
+                seconds_per_chunk=seconds_per_chunk,
+            )
 
         texts_inputs = self.tokenizer(text, **output_kwargs["text_kwargs"])
 
@@ -238,54 +239,45 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
 
             for _, special_token in positions:
                 if special_token == self.audio_token:
-                    try:
-                        sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
-                    except StopIteration:
-                        logging.warning(f"Audio token `{self.audio_token}` found in text but no audio is provided.")
+                    sample = sample.replace(self.audio_token, "<|audio_placeholder|>" * next(audio_lengths), 1)
                 elif special_token == self.image_token:
-                    try:
-                        image_seq_length = next(image_grid_thw).prod() // merge_length_image
-                        sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
-                    except StopIteration:
-                        logging.warning(f"Image token `{self.image_token}` found in text but no image is provided.")
+                    image_seq_length = next(image_grid_thw).prod() // merge_length_image
+                    sample = sample.replace(self.image_token, "<|image_placeholder|>" * image_seq_length, 1)
                 elif special_token == self.video_token:
-                    try:
-                        if not use_audio_in_video:
-                            video_seq_length = next(video_grid_thw).prod() // merge_length_video
-                            sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
-                        else:
-                            audio_token_indices = np.arange(next(audio_lengths))
-                            curr_video_grid_thw = next(video_grid_thw)
-                            height = curr_video_grid_thw[1] // self.video_processor.merge_size
-                            width = curr_video_grid_thw[2] // self.video_processor.merge_size
-                            video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
-                            video_token_indices = np.broadcast_to(
-                                video_token_indices, (video_token_indices.shape[0], height, width)
-                            ).reshape(-1)
-                            video_token_indices = (
-                                video_token_indices * next(video_second_per_grid) * position_id_per_seconds
-                            )
+                    if not use_audio_in_video:
+                        video_seq_length = next(video_grid_thw).prod() // merge_length_video
+                        sample = sample.replace(self.video_token, "<|video_placeholder|>" * video_seq_length, 1)
+                    else:
+                        audio_token_indices = np.arange(next(audio_lengths))
+                        curr_video_grid_thw = next(video_grid_thw)
+                        height = curr_video_grid_thw[1] // self.video_processor.merge_size
+                        width = curr_video_grid_thw[2] // self.video_processor.merge_size
+                        video_token_indices = np.arange(curr_video_grid_thw[0]).reshape(-1, 1, 1)
+                        video_token_indices = np.broadcast_to(
+                            video_token_indices, (video_token_indices.shape[0], height, width)
+                        ).reshape(-1)
+                        video_token_indices = (
+                            video_token_indices * next(video_second_per_grid) * position_id_per_seconds
+                        )
 
-                            tokens_per_chunk = int(position_id_per_seconds * seconds_per_chunk)
-                            video_chunk_indexes = self.get_chunked_index(video_token_indices, tokens_per_chunk)
-                            audio_chunk_indexes = self.get_chunked_index(audio_token_indices, tokens_per_chunk)
+                        tokens_per_chunk = int(position_id_per_seconds * seconds_per_chunk)
+                        video_chunk_indexes = self.get_chunked_index(video_token_indices, tokens_per_chunk)
+                        audio_chunk_indexes = self.get_chunked_index(audio_token_indices, tokens_per_chunk)
 
-                            placeholder_string = self.vision_bos_token + self.audio_bos_token
-                            for j in range(max(len(video_chunk_indexes), len(audio_chunk_indexes))):
-                                if j < len(video_chunk_indexes):
-                                    video_seq_length = video_chunk_indexes[j][1] - video_chunk_indexes[j][0]
-                                    placeholder_string += "<|video_placeholder|>" * video_seq_length
-                                if j < len(audio_chunk_indexes):
-                                    audio_seq_length = audio_chunk_indexes[j][1] - audio_chunk_indexes[j][0]
-                                    placeholder_string += "<|audio_placeholder|>" * audio_seq_length
-                            placeholder_string += self.audio_eos_token + self.vision_eos_token
-                            sample = sample.replace(
-                                self.vision_bos_token + self.video_token + self.vision_eos_token,
-                                placeholder_string,
-                                1,
-                            )
-                    except StopIteration:
-                        logging.warning(f"Video token `{self.video_token}` found in text but no video is provided.")
+                        placeholder_string = self.vision_bos_token + self.audio_bos_token
+                        for j in range(max(len(video_chunk_indexes), len(audio_chunk_indexes))):
+                            if j < len(video_chunk_indexes):
+                                video_seq_length = video_chunk_indexes[j][1] - video_chunk_indexes[j][0]
+                                placeholder_string += "<|video_placeholder|>" * video_seq_length
+                            if j < len(audio_chunk_indexes):
+                                audio_seq_length = audio_chunk_indexes[j][1] - audio_chunk_indexes[j][0]
+                                placeholder_string += "<|audio_placeholder|>" * audio_seq_length
+                        placeholder_string += self.audio_eos_token + self.vision_eos_token
+                        sample = sample.replace(
+                            self.vision_bos_token + self.video_token + self.vision_eos_token,
+                            placeholder_string,
+                            1,
+                        )
 
             sample = sample.replace("<|audio_placeholder|>", self.audio_token)
             sample = sample.replace("<|image_placeholder|>", self.image_token)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->
Hi @BakerBunker and @zucchini-nlp,
This PR enables the Qwen2.5-Omni-Processor to handle text-only inputs, without requiring corresponding audio, video, or image data.
This feature is a prerequisite for the VLLM implementation, when uses multimodal embeddings as input.

```
from transformers import Qwen2_5OmniProcessor
text = "<|im_start|>system\nYou are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.<|im_end|>\n<|im_start|>user\n<|vision_bos|><|IMAGE|><|vision_eos|><prompt><|im_end|>\n<|im_start|>assistant\n"
processor = Qwen2_5OmniProcessor.from_pretrained("Qwen/Qwen2.5-Omni-7B")
inputs = processor(text=text)
print(inputs)
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
