### PR TITLE
[docs] remove TF references from `/en/model_doc`

### DIFF
--- a/docs/source/en/model_doc/blip.md
+++ b/docs/source/en/model_doc/blip.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -31,7 +30,7 @@ You can find all the original BLIP checkpoints under the [BLIP](https://huggingf
 
 > [!TIP]
 > This model was contributed by [ybelkada](https://huggingface.co/ybelkada).
-> 
+>
 > Click on the BLIP models in the right sidebar for more examples of how to apply BLIP to different vision language tasks.
 
 The example below demonstrates how to visual question answering with [`Pipeline`] or the [`AutoModel`] class.
@@ -64,7 +63,7 @@ from transformers import AutoProcessor, AutoModelForVisualQuestionAnswering
 
 processor = AutoProcessor.from_pretrained("Salesforce/blip-vqa-base")
 model = AutoModelForVisualQuestionAnswering.from_pretrained(
-    "Salesforce/blip-vqa-base", 
+    "Salesforce/blip-vqa-base",
     torch_dtype=torch.float16,
     device_map="auto"
 )
@@ -113,9 +112,6 @@ Refer to this [notebook](https://github.com/huggingface/notebooks/blob/main/exam
 [[autodoc]] BlipImageProcessorFast
     - preprocess
 
-<frameworkcontent>
-<pt>
-
 ## BlipModel
 
 `BlipModel` is going to be deprecated in future versions, please use `BlipForConditionalGeneration`, `BlipForImageTextRetrieval` or `BlipForQuestionAnswering` depending on your usecase.
@@ -154,45 +150,3 @@ Refer to this [notebook](https://github.com/huggingface/notebooks/blob/main/exam
 
 [[autodoc]] BlipForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFBlipModel
-
-[[autodoc]] TFBlipModel
-    - call
-    - get_text_features
-    - get_image_features
-
-## TFBlipTextModel
-
-[[autodoc]] TFBlipTextModel
-    - call
-
-## TFBlipTextLMHeadModel
-
-[[autodoc]] TFBlipTextLMHeadModel
-- forward
-
-## TFBlipVisionModel
-
-[[autodoc]] TFBlipVisionModel
-    - call
-
-## TFBlipForConditionalGeneration
-
-[[autodoc]] TFBlipForConditionalGeneration
-    - call
-
-## TFBlipForImageTextRetrieval
-
-[[autodoc]] TFBlipForImageTextRetrieval
-    - call
-
-## TFBlipForQuestionAnswering
-
-[[autodoc]] TFBlipForQuestionAnswering
-    - call
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/camembert.md
+++ b/docs/source/en/model_doc/camembert.md
@@ -18,8 +18,7 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
 	<div class="flex flex-wrap space-x-1">
 		<img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-		<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
-    <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
+        <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
 	</div>
 </div>
 
@@ -51,7 +50,7 @@ from transformers import pipeline
 pipeline = pipeline("fill-mask", model="camembert-base", torch_dtype=torch.float16, device=0)
 pipeline("Le camembert est un délicieux fromage <mask>.")
 ```
-</hfoption> 
+</hfoption>
 
 <hfoption id="AutoModel">
 
@@ -73,7 +72,7 @@ predicted_token = tokenizer.decode(predicted_token_id)
 
 print(f"The predicted token is: {predicted_token}")
 ```
-</hfoption> 
+</hfoption>
 
 <hfoption id="transformers CLI">
 
@@ -81,15 +80,15 @@ print(f"The predicted token is: {predicted_token}")
 echo -e "Le camembert est un délicieux fromage <mask>." | transformers run --task fill-mask --model camembert-base --device 0
 ```
 
-</hfoption> 
+</hfoption>
 
-</hfoptions> 
+</hfoptions>
 
 
 Quantization reduces the memory burden of large models by representing weights in lower precision. Refer to the [Quantization](../quantization/overview) overview for available options.
 
 The example below uses [bitsandbytes](../quantization/bitsandbytes) quantization to quantize the weights to 8-bits.
-  
+
 ```python
 from transformers import AutoTokenizer, AutoModelForMaskedLM, BitsAndBytesConfig
 import torch
@@ -131,9 +130,6 @@ print(f"The predicted token is: {predicted_token}")
 
 [[autodoc]] CamembertTokenizerFast
 
-<frameworkcontent>
-<pt>
-
 ## CamembertModel
 
 [[autodoc]] CamembertModel
@@ -161,37 +157,3 @@ print(f"The predicted token is: {predicted_token}")
 ## CamembertForQuestionAnswering
 
 [[autodoc]] CamembertForQuestionAnswering
-
-</pt>
-<tf>
-
-## TFCamembertModel
-
-[[autodoc]] TFCamembertModel
-
-## TFCamembertForCausalLM
-
-[[autodoc]] TFCamembertForCausalLM
-
-## TFCamembertForMaskedLM
-
-[[autodoc]] TFCamembertForMaskedLM
-
-## TFCamembertForSequenceClassification
-
-[[autodoc]] TFCamembertForSequenceClassification
-
-## TFCamembertForMultipleChoice
-
-[[autodoc]] TFCamembertForMultipleChoice
-
-## TFCamembertForTokenClassification
-
-[[autodoc]] TFCamembertForTokenClassification
-
-## TFCamembertForQuestionAnswering
-
-[[autodoc]] TFCamembertForQuestionAnswering
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/convbert.md
+++ b/docs/source/en/model_doc/convbert.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -72,9 +71,6 @@ ConvBERT training tips are similar to those of BERT. For usage tips refer to [BE
 
 [[autodoc]] ConvBertTokenizerFast
 
-<frameworkcontent>
-<pt>
-
 ## ConvBertModel
 
 [[autodoc]] ConvBertModel
@@ -104,39 +100,3 @@ ConvBERT training tips are similar to those of BERT. For usage tips refer to [BE
 
 [[autodoc]] ConvBertForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFConvBertModel
-
-[[autodoc]] TFConvBertModel
-    - call
-
-## TFConvBertForMaskedLM
-
-[[autodoc]] TFConvBertForMaskedLM
-    - call
-
-## TFConvBertForSequenceClassification
-
-[[autodoc]] TFConvBertForSequenceClassification
-    - call
-
-## TFConvBertForMultipleChoice
-
-[[autodoc]] TFConvBertForMultipleChoice
-    - call
-
-## TFConvBertForTokenClassification
-
-[[autodoc]] TFConvBertForTokenClassification
-    - call
-
-## TFConvBertForQuestionAnswering
-
-[[autodoc]] TFConvBertForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/convnext.md
+++ b/docs/source/en/model_doc/convnext.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -43,8 +42,7 @@ alt="drawing" width="600"/>
 
 <small> ConvNeXT architecture. Taken from the <a href="https://huggingface.co/papers/2201.03545">original paper</a>.</small>
 
-This model was contributed by [nielsr](https://huggingface.co/nielsr). TensorFlow version of the model was contributed by [ariG23498](https://github.com/ariG23498),
-[gante](https://github.com/gante), and [sayakpaul](https://github.com/sayakpaul) (equal contribution). The original code can be found [here](https://github.com/facebookresearch/ConvNeXt).
+This model was contributed by [nielsr](https://huggingface.co/nielsr). The original code can be found [here](https://github.com/facebookresearch/ConvNeXt).
 
 ## Resources
 
@@ -75,9 +73,6 @@ If you're interested in submitting a resource to be included here, please feel f
 [[autodoc]] ConvNextImageProcessorFast
     - preprocess
 
-<frameworkcontent>
-<pt>
-
 ## ConvNextModel
 
 [[autodoc]] ConvNextModel
@@ -87,19 +82,3 @@ If you're interested in submitting a resource to be included here, please feel f
 
 [[autodoc]] ConvNextForImageClassification
     - forward
-
-</pt>
-<tf>
-
-## TFConvNextModel
-
-[[autodoc]] TFConvNextModel
-    - call
-
-## TFConvNextForImageClassification
-
-[[autodoc]] TFConvNextForImageClassification
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/convnextv2.md
+++ b/docs/source/en/model_doc/convnextv2.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -61,14 +60,3 @@ If you're interested in submitting a resource to be included here, please feel f
 
 [[autodoc]] ConvNextV2ForImageClassification
     - forward
-
-## TFConvNextV2Model
-
-[[autodoc]] TFConvNextV2Model
-    - call
-
-
-## TFConvNextV2ForImageClassification
-
-[[autodoc]] TFConvNextV2ForImageClassification
-    - call

--- a/docs/source/en/model_doc/ctrl.md
+++ b/docs/source/en/model_doc/ctrl.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -52,7 +51,7 @@ This model was contributed by [keskarnitishr](https://huggingface.co/keskarnitis
   token in a sequence. Leveraging this feature allows CTRL to generate syntactically coherent text as it can be
   observed in the *run_generation.py* example script.
 - The PyTorch models can take the `past_key_values` as input, which is the previously computed key/value attention pairs.
-  TensorFlow models accepts `past` as input. Using the `past_key_values` value prevents the model from re-computing
+  Using the `past_key_values` value prevents the model from re-computing
   pre-computed values in the context of text generation. See the [`forward`](model_doc/ctrl#transformers.CTRLModel.forward)
   method for more information on the usage of this argument.
 
@@ -71,9 +70,6 @@ This model was contributed by [keskarnitishr](https://huggingface.co/keskarnitis
 [[autodoc]] CTRLTokenizer
     - save_vocabulary
 
-<frameworkcontent>
-<pt>
-
 ## CTRLModel
 
 [[autodoc]] CTRLModel
@@ -88,24 +84,3 @@ This model was contributed by [keskarnitishr](https://huggingface.co/keskarnitis
 
 [[autodoc]] CTRLForSequenceClassification
     - forward
-
-</pt>
-<tf>
-
-## TFCTRLModel
-
-[[autodoc]] TFCTRLModel
-    - call
-
-## TFCTRLLMHeadModel
-
-[[autodoc]] TFCTRLLMHeadModel
-    - call
-
-## TFCTRLForSequenceClassification
-
-[[autodoc]] TFCTRLForSequenceClassification
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/cvt.md
+++ b/docs/source/en/model_doc/cvt.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -30,7 +29,7 @@ You can find all the CvT checkpoints under the [Microsoft](https://huggingface.c
 
 > [!TIP]
 > This model was contributed by [anujunj](https://huggingface.co/anugunj).
-> 
+>
 > Click on the CvT models in the right sidebar for more examples of how to apply CvT to different computer vision tasks.
 
 The example below demonstrates how to classify an image with [`Pipeline`] or the [`AutoModel`] class.
@@ -46,7 +45,7 @@ pipeline = pipeline(
     task="image-classification",
     model="microsoft/cvt-13",
     torch_dtype=torch.float16,
-    device=0 
+    device=0
 )
 pipeline("https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg")
 ```
@@ -91,9 +90,6 @@ Refer to this set of ViT [notebooks](https://github.com/NielsRogge/Transformers-
 
 [[autodoc]] CvtConfig
 
-<frameworkcontent>
-<pt>
-
 ## CvtModel
 
 [[autodoc]] CvtModel
@@ -103,19 +99,3 @@ Refer to this set of ViT [notebooks](https://github.com/NielsRogge/Transformers-
 
 [[autodoc]] CvtForImageClassification
     - forward
-
-</pt>
-<tf>
-
-## TFCvtModel
-
-[[autodoc]] TFCvtModel
-    - call
-
-## TFCvtForImageClassification
-
-[[autodoc]] TFCvtForImageClassification
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/data2vec.md
+++ b/docs/source/en/model_doc/data2vec.md
@@ -43,7 +43,6 @@ natural language understanding demonstrate a new state of the art or competitive
 Models and code are available at www.github.com/pytorch/fairseq/tree/master/examples/data2vec.*
 
 This model was contributed by [edugp](https://huggingface.co/edugp) and [patrickvonplaten](https://huggingface.co/patrickvonplaten).
-[sayakpaul](https://github.com/sayakpaul) and [Rocketknight1](https://github.com/Rocketknight1) contributed Data2Vec for vision in TensorFlow.
 
 The original code (for NLP and Speech) can be found [here](https://github.com/pytorch/fairseq/tree/main/examples/data2vec).
 The original code for vision can be found [here](https://github.com/facebookresearch/data2vec_vision/tree/main/beit).
@@ -54,17 +53,17 @@ The original code for vision can be found [here](https://github.com/facebookrese
 - For Data2VecAudio, preprocessing is identical to [`Wav2Vec2Model`], including feature extraction
 - For Data2VecText, preprocessing is identical to [`RobertaModel`], including tokenization.
 - For Data2VecVision, preprocessing is identical to [`BeitModel`], including feature extraction.
-- The `head_mask` argument is ignored when using all attention implementation other than "eager". If you have a `head_mask` and want it to have effect, load the model with `XXXModel.from_pretrained(model_id, attn_implementation="eager")`  
+- The `head_mask` argument is ignored when using all attention implementation other than "eager". If you have a `head_mask` and want it to have effect, load the model with `XXXModel.from_pretrained(model_id, attn_implementation="eager")`
 
 ### Using Scaled Dot Product Attention (SDPA)
 
-PyTorch includes a native scaled dot-product attention (SDPA) operator as part of `torch.nn.functional`. This function 
-encompasses several implementations that can be applied depending on the inputs and the hardware in use. See the 
-[official documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) 
+PyTorch includes a native scaled dot-product attention (SDPA) operator as part of `torch.nn.functional`. This function
+encompasses several implementations that can be applied depending on the inputs and the hardware in use. See the
+[official documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html)
 or the [GPU Inference](https://huggingface.co/docs/transformers/main/en/perf_infer_gpu_one#pytorch-scaled-dot-product-attention)
 page for more information.
 
-SDPA is used by default for `torch>=2.1.1` when an implementation is available, but you may also set 
+SDPA is used by default for `torch>=2.1.1` when an implementation is available, but you may also set
 `attn_implementation="sdpa"` in `from_pretrained()` to explicitly request SDPA to be used.
 
 The SDPA implementation is currently available for the Data2VecAudio and Data2VecVision models.
@@ -103,7 +102,6 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 <PipelineTag pipeline="image-classification"/>
 
 - [`Data2VecVisionForImageClassification`] is supported by this [example script](https://github.com/huggingface/transformers/tree/main/examples/pytorch/image-classification) and [notebook](https://colab.research.google.com/github/huggingface/notebooks/blob/main/examples/image_classification.ipynb).
-- To fine-tune [`TFData2VecVisionForImageClassification`] on a custom dataset, see [this notebook](https://colab.research.google.com/github/sayakpaul/TF-2.0-Hacks/blob/master/data2vec_vision_image_classification.ipynb).
 
 **Data2VecText documentation resources**
 - [Text classification task guide](../tasks/sequence_classification)
@@ -134,9 +132,6 @@ If you're interested in submitting a resource to be included here, please feel f
 ## Data2VecVisionConfig
 
 [[autodoc]] Data2VecVisionConfig
-
-<frameworkcontent>
-<pt>
 
 ## Data2VecAudioModel
 
@@ -212,24 +207,3 @@ If you're interested in submitting a resource to be included here, please feel f
 
 [[autodoc]] Data2VecVisionForSemanticSegmentation
     - forward
-
-</pt>
-<tf>
-
-## TFData2VecVisionModel
-
-[[autodoc]] TFData2VecVisionModel
-    - call
-
-## TFData2VecVisionForImageClassification
-
-[[autodoc]] TFData2VecVisionForImageClassification
-    - call
-
-## TFData2VecVisionForSemanticSegmentation
-
-[[autodoc]] TFData2VecVisionForSemanticSegmentation
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/deberta-v2.md
+++ b/docs/source/en/model_doc/deberta-v2.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
            <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white" >
-           <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -139,9 +138,6 @@ print(f"Predicted label: {predicted_label}")
     - build_inputs_with_special_tokens
     - create_token_type_ids_from_sequences
 
-<frameworkcontent>
-<pt>
-
 ## DebertaV2Model
 
 [[autodoc]] DebertaV2Model
@@ -176,44 +172,3 @@ print(f"Predicted label: {predicted_label}")
 
 [[autodoc]] DebertaV2ForMultipleChoice
     - forward
-
-</pt>
-<tf>
-
-## TFDebertaV2Model
-
-[[autodoc]] TFDebertaV2Model
-    - call
-
-## TFDebertaV2PreTrainedModel
-
-[[autodoc]] TFDebertaV2PreTrainedModel
-    - call
-
-## TFDebertaV2ForMaskedLM
-
-[[autodoc]] TFDebertaV2ForMaskedLM
-    - call
-
-## TFDebertaV2ForSequenceClassification
-
-[[autodoc]] TFDebertaV2ForSequenceClassification
-    - call
-
-## TFDebertaV2ForTokenClassification
-
-[[autodoc]] TFDebertaV2ForTokenClassification
-    - call
-
-## TFDebertaV2ForQuestionAnswering
-
-[[autodoc]] TFDebertaV2ForQuestionAnswering
-    - call
-
-## TFDebertaV2ForMultipleChoice
-
-[[autodoc]] TFDebertaV2ForMultipleChoice
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/deberta.md
+++ b/docs/source/en/model_doc/deberta.md
@@ -18,8 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
-</div>
     </div>
 </div>
 
@@ -117,9 +115,6 @@ echo -e '{"text": "A soccer game with multiple people playing.", "text_pair": "S
     - build_inputs_with_special_tokens
     - create_token_type_ids_from_sequences
 
-<frameworkcontent>
-<pt>
-
 ## DebertaModel
 
 [[autodoc]] DebertaModel
@@ -148,40 +143,3 @@ echo -e '{"text": "A soccer game with multiple people playing.", "text_pair": "S
 
 [[autodoc]] DebertaForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFDebertaModel
-
-[[autodoc]] TFDebertaModel
-    - call
-
-## TFDebertaPreTrainedModel
-
-[[autodoc]] TFDebertaPreTrainedModel
-    - call
-
-## TFDebertaForMaskedLM
-
-[[autodoc]] TFDebertaForMaskedLM
-    - call
-
-## TFDebertaForSequenceClassification
-
-[[autodoc]] TFDebertaForSequenceClassification
-    - call
-
-## TFDebertaForTokenClassification
-
-[[autodoc]] TFDebertaForTokenClassification
-    - call
-
-## TFDebertaForQuestionAnswering
-
-[[autodoc]] TFDebertaForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>
-

--- a/docs/source/en/model_doc/deit.md
+++ b/docs/source/en/model_doc/deit.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 <img alt="FlashAttention" src="https://img.shields.io/badge/%E2%9A%A1%EF%B8%8E%20FlashAttention-eae0c8?style=flat">
 <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
 </div>
@@ -46,7 +45,7 @@ distillation, especially when using a convnet as a teacher. This leads us to rep
 for both Imagenet (where we obtain up to 85.2% accuracy) and when transferring to other tasks. We share our code and
 models.*
 
-This model was contributed by [nielsr](https://huggingface.co/nielsr). The TensorFlow version of this model was added by [amyeroberts](https://huggingface.co/amyeroberts).
+This model was contributed by [nielsr](https://huggingface.co/nielsr).
 
 ## Usage tips
 
@@ -78,13 +77,13 @@ This model was contributed by [nielsr](https://huggingface.co/nielsr). The Tenso
 
 ### Using Scaled Dot Product Attention (SDPA)
 
-PyTorch includes a native scaled dot-product attention (SDPA) operator as part of `torch.nn.functional`. This function 
-encompasses several implementations that can be applied depending on the inputs and the hardware in use. See the 
-[official documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) 
+PyTorch includes a native scaled dot-product attention (SDPA) operator as part of `torch.nn.functional`. This function
+encompasses several implementations that can be applied depending on the inputs and the hardware in use. See the
+[official documentation](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html)
 or the [GPU Inference](https://huggingface.co/docs/transformers/main/en/perf_infer_gpu_one#pytorch-scaled-dot-product-attention)
 page for more information.
 
-SDPA is used by default for `torch>=2.1.1` when an implementation is available, but you may also set 
+SDPA is used by default for `torch>=2.1.1` when an implementation is available, but you may also set
 `attn_implementation="sdpa"` in `from_pretrained()` to explicitly request SDPA to be used.
 
 ```
@@ -138,9 +137,6 @@ If you're interested in submitting a resource to be included here, please feel f
 [[autodoc]] DeiTImageProcessorFast
     - preprocess
 
-<frameworkcontent>
-<pt>
-
 ## DeiTModel
 
 [[autodoc]] DeiTModel
@@ -160,29 +156,3 @@ If you're interested in submitting a resource to be included here, please feel f
 
 [[autodoc]] DeiTForImageClassificationWithTeacher
     - forward
-
-</pt>
-<tf>
-
-## TFDeiTModel
-
-[[autodoc]] TFDeiTModel
-    - call
-
-## TFDeiTForMaskedImageModeling
-
-[[autodoc]] TFDeiTForMaskedImageModeling
-    - call
-
-## TFDeiTForImageClassification
-
-[[autodoc]] TFDeiTForImageClassification
-    - call
-
-## TFDeiTForImageClassificationWithTeacher
-
-[[autodoc]] TFDeiTForImageClassificationWithTeacher
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/dpr.md
+++ b/docs/source/en/model_doc/dpr.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
 </div>
 
@@ -85,9 +84,6 @@ This model was contributed by [lhoestq](https://huggingface.co/lhoestq). The ori
 
 [[autodoc]] models.dpr.modeling_dpr.DPRReaderOutput
 
-<frameworkcontent>
-<pt>
-
 ## DPRContextEncoder
 
 [[autodoc]] DPRContextEncoder
@@ -102,25 +98,3 @@ This model was contributed by [lhoestq](https://huggingface.co/lhoestq). The ori
 
 [[autodoc]] DPRReader
     - forward
-
-</pt>
-<tf>
-
-## TFDPRContextEncoder
-
-[[autodoc]] TFDPRContextEncoder
-    - call
-
-## TFDPRQuestionEncoder
-
-[[autodoc]] TFDPRQuestionEncoder
-    - call
-
-## TFDPRReader
-
-[[autodoc]] TFDPRReader
-    - call
-
-</tf>
-</frameworkcontent>
-

--- a/docs/source/en/model_doc/efficientformer.md
+++ b/docs/source/en/model_doc/efficientformer.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 <Tip warning={true}>
@@ -55,7 +54,7 @@ EfficientFormer-L7, obtains 83.3% accuracy with only 7.0 ms latency. Our work pr
 reach extremely low latency on mobile devices while maintaining high performance.*
 
 This model was contributed by [novice03](https://huggingface.co/novice03) and [Bearnardd](https://huggingface.co/Bearnardd).
-The original code can be found [here](https://github.com/snap-research/EfficientFormer). The TensorFlow version of this model was added by [D-Roberts](https://huggingface.co/D-Roberts).
+The original code can be found [here](https://github.com/snap-research/EfficientFormer).
 
 ## Documentation resources
 
@@ -69,9 +68,6 @@ The original code can be found [here](https://github.com/snap-research/Efficient
 
 [[autodoc]] EfficientFormerImageProcessor
     - preprocess
-
-<frameworkcontent>
-<pt>
 
 ## EfficientFormerModel
 
@@ -87,24 +83,3 @@ The original code can be found [here](https://github.com/snap-research/Efficient
 
 [[autodoc]] EfficientFormerForImageClassificationWithTeacher
     - forward
-
-</pt>
-<tf>
-
-## TFEfficientFormerModel
-
-[[autodoc]] TFEfficientFormerModel
-    - call
-
-## TFEfficientFormerForImageClassification
-
-[[autodoc]] TFEfficientFormerForImageClassification
-    - call
-
-## TFEfficientFormerForImageClassificationWithTeacher
-
-[[autodoc]] TFEfficientFormerForImageClassificationWithTeacher
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/esm.md
+++ b/docs/source/en/model_doc/esm.md
@@ -19,16 +19,15 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
 
-This page provides code and pre-trained weights for Transformer protein language models from Meta AI's Fundamental 
+This page provides code and pre-trained weights for Transformer protein language models from Meta AI's Fundamental
 AI Research Team, providing the state-of-the-art ESMFold and ESM-2, and the previously released ESM-1b and ESM-1v.
 Transformer protein language models were introduced in the paper [Biological structure and function emerge from scaling
-unsupervised learning to 250 million protein sequences](https://www.pnas.org/content/118/15/e2016239118) by 
-Alexander Rives, Joshua Meier, Tom Sercu, Siddharth Goyal, Zeming Lin, Jason Liu, Demi Guo, Myle Ott, 
+unsupervised learning to 250 million protein sequences](https://www.pnas.org/content/118/15/e2016239118) by
+Alexander Rives, Joshua Meier, Tom Sercu, Siddharth Goyal, Zeming Lin, Jason Liu, Demi Guo, Myle Ott,
 C. Lawrence Zitnick, Jerry Ma, and Rob Fergus.
 The first version of this paper was [preprinted in 2019](https://www.biorxiv.org/content/10.1101/622803v1?versioned=true).
 
@@ -46,8 +45,8 @@ they do not require a database of known protein sequences and structures with as
 to make predictions, and are much faster as a result.
 
 
-The abstract from 
-"Biological structure and function emerge from scaling unsupervised learning to 250 
+The abstract from
+"Biological structure and function emerge from scaling unsupervised learning to 250
 million protein sequences" is
 
 
@@ -113,9 +112,6 @@ help throughout the process!
     - create_token_type_ids_from_sequences
     - save_vocabulary
 
-<frameworkcontent>
-<pt>
-
 ## EsmModel
 
 [[autodoc]] EsmModel
@@ -140,29 +136,3 @@ help throughout the process!
 
 [[autodoc]] EsmForProteinFolding
     - forward
-
-</pt>
-<tf>
-
-## TFEsmModel
-
-[[autodoc]] TFEsmModel
-    - call
-
-## TFEsmForMaskedLM
-
-[[autodoc]] TFEsmForMaskedLM
-    - call
-
-## TFEsmForSequenceClassification
-
-[[autodoc]] TFEsmForSequenceClassification
-    - call
-
-## TFEsmForTokenClassification
-
-[[autodoc]] TFEsmForTokenClassification
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/flaubert.md
+++ b/docs/source/en/model_doc/flaubert.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -63,9 +62,6 @@ Tips:
 
 [[autodoc]] FlaubertTokenizer
 
-<frameworkcontent>
-<pt>
-
 ## FlaubertModel
 
 [[autodoc]] FlaubertModel
@@ -100,42 +96,3 @@ Tips:
 
 [[autodoc]] FlaubertForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFFlaubertModel
-
-[[autodoc]] TFFlaubertModel
-    - call
-
-## TFFlaubertWithLMHeadModel
-
-[[autodoc]] TFFlaubertWithLMHeadModel
-    - call
-
-## TFFlaubertForSequenceClassification
-
-[[autodoc]] TFFlaubertForSequenceClassification
-    - call
-
-## TFFlaubertForMultipleChoice
-
-[[autodoc]] TFFlaubertForMultipleChoice
-    - call
-
-## TFFlaubertForTokenClassification
-
-[[autodoc]] TFFlaubertForTokenClassification
-    - call
-
-## TFFlaubertForQuestionAnsweringSimple
-
-[[autodoc]] TFFlaubertForQuestionAnsweringSimple
-    - call
-
-</tf>
-</frameworkcontent>
-
-
-

--- a/docs/source/en/model_doc/funnel.md
+++ b/docs/source/en/model_doc/funnel.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -89,11 +88,6 @@ This model was contributed by [sgugger](https://huggingface.co/sgugger). The ori
 
 [[autodoc]] models.funnel.modeling_funnel.FunnelForPreTrainingOutput
 
-[[autodoc]] models.funnel.modeling_tf_funnel.TFFunnelForPreTrainingOutput
-
-<frameworkcontent>
-<pt>
-
 ## FunnelBaseModel
 
 [[autodoc]] FunnelBaseModel
@@ -133,49 +127,3 @@ This model was contributed by [sgugger](https://huggingface.co/sgugger). The ori
 
 [[autodoc]] FunnelForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFFunnelBaseModel
-
-[[autodoc]] TFFunnelBaseModel
-    - call
-
-## TFFunnelModel
-
-[[autodoc]] TFFunnelModel
-    - call
-
-## TFFunnelModelForPreTraining
-
-[[autodoc]] TFFunnelForPreTraining
-    - call
-
-## TFFunnelForMaskedLM
-
-[[autodoc]] TFFunnelForMaskedLM
-    - call
-
-## TFFunnelForSequenceClassification
-
-[[autodoc]] TFFunnelForSequenceClassification
-    - call
-
-## TFFunnelForMultipleChoice
-
-[[autodoc]] TFFunnelForMultipleChoice
-    - call
-
-## TFFunnelForTokenClassification
-
-[[autodoc]] TFFunnelForTokenClassification
-    - call
-
-## TFFunnelForQuestionAnswering
-
-[[autodoc]] TFFunnelForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/groupvit.md
+++ b/docs/source/en/model_doc/groupvit.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -31,19 +30,18 @@ The abstract from the paper is the following:
 
 *Grouping and recognition are important components of visual scene understanding, e.g., for object detection and semantic segmentation. With end-to-end deep learning systems, grouping of image regions usually happens implicitly via top-down supervision from pixel-level recognition labels. Instead, in this paper, we propose to bring back the grouping mechanism into deep networks, which allows semantic segments to emerge automatically with only text supervision. We propose a hierarchical Grouping Vision Transformer (GroupViT), which goes beyond the regular grid structure representation and learns to group image regions into progressively larger arbitrary-shaped segments. We train GroupViT jointly with a text encoder on a large-scale image-text dataset via contrastive losses. With only text supervision and without any pixel-level annotations, GroupViT learns to group together semantic regions and successfully transfers to the task of semantic segmentation in a zero-shot manner, i.e., without any further fine-tuning. It achieves a zero-shot accuracy of 52.3% mIoU on the PASCAL VOC 2012 and 22.4% mIoU on PASCAL Context datasets, and performs competitively to state-of-the-art transfer-learning methods requiring greater levels of supervision.*
 
-This model was contributed by [xvjiarui](https://huggingface.co/xvjiarui). The TensorFlow version was contributed by [ariG23498](https://huggingface.co/ariG23498) with the help of [Yih-Dar SHIEH](https://huggingface.co/ydshieh), [Amy Roberts](https://huggingface.co/amyeroberts), and [Joao Gante](https://huggingface.co/joaogante).
-The original code can be found [here](https://github.com/NVlabs/GroupViT).
+This model was contributed by [xvjiarui](https://huggingface.co/xvjiarui). The original code can be found [here](https://github.com/NVlabs/GroupViT).
 
 ## Usage tips
- 
-- You may specify `output_segmentation=True` in the forward of `GroupViTModel` to get the segmentation logits of input texts. 
+
+- You may specify `output_segmentation=True` in the forward of `GroupViTModel` to get the segmentation logits of input texts.
 
 ## Resources
 
 A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with GroupViT.
 
 - The quickest way to get started with GroupViT is by checking the [example notebooks](https://github.com/xvjiarui/GroupViT/blob/main/demo/GroupViT_hf_inference_notebook.ipynb) (which showcase zero-shot segmentation inference).
-- One can also check out the [HuggingFace Spaces demo](https://huggingface.co/spaces/xvjiarui/GroupViT) to play with GroupViT. 
+- One can also check out the [HuggingFace Spaces demo](https://huggingface.co/spaces/xvjiarui/GroupViT) to play with GroupViT.
 
 ## GroupViTConfig
 
@@ -57,9 +55,6 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 ## GroupViTVisionConfig
 
 [[autodoc]] GroupViTVisionConfig
-
-<frameworkcontent>
-<pt>
 
 ## GroupViTModel
 
@@ -77,26 +72,3 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 
 [[autodoc]] GroupViTVisionModel
     - forward
-
-</pt>
-<tf>
-
-## TFGroupViTModel
-
-[[autodoc]] TFGroupViTModel
-    - call
-    - get_text_features
-    - get_image_features
-
-## TFGroupViTTextModel
-
-[[autodoc]] TFGroupViTTextModel
-    - call
-
-## TFGroupViTVisionModel
-
-[[autodoc]] TFGroupViTVisionModel
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/hubert.md
+++ b/docs/source/en/model_doc/hubert.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
         <img alt="FlashAttention" src="https://img.shields.io/badge/%E2%9A%A1%EF%B8%8E%20FlashAttention-eae0c8?style=flat">
         <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
     </div>
@@ -125,9 +124,6 @@ print(transcription[0])
 [[autodoc]] HubertConfig
     - all
 
-<frameworkcontent>
-<pt>
-
 ## HubertModel
 
 [[autodoc]] HubertModel
@@ -142,19 +138,3 @@ print(transcription[0])
 
 [[autodoc]] HubertForSequenceClassification
     - forward
-
-</pt>
-<tf>
-
-## TFHubertModel
-
-[[autodoc]] TFHubertModel
-    - call
-
-## TFHubertForCTC
-
-[[autodoc]] TFHubertForCTC
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/idefics.md
+++ b/docs/source/en/model_doc/idefics.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
 </div>
 
@@ -58,16 +57,6 @@ To train a new IDEFICS model from scratch use the m4 codebase (a link will be pr
 
 [[autodoc]] IdeficsForVisionText2Text
     - forward
-
-## TFIdeficsModel
-
-[[autodoc]] TFIdeficsModel
-    - call
-
-## TFIdeficsForVisionText2Text
-
-[[autodoc]] TFIdeficsForVisionText2Text
-    - call
 
 ## IdeficsImageProcessor
 

--- a/docs/source/en/model_doc/layoutlm.md
+++ b/docs/source/en/model_doc/layoutlm.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -31,49 +30,49 @@ You can find all the original LayoutLM checkpoints under the [LayoutLM](https://
 > [!TIP]
 > Click on the LayoutLM models in the right sidebar for more examples of how to apply LayoutLM to different vision and language tasks.
 
-The example below demonstrates question answering with the [`AutoModel`] class. 
+The example below demonstrates question answering with the [`AutoModel`] class.
 
 <hfoptions id="usage">
 <hfoption id="AutoModel">
 
 ```py
-import torch  
-from datasets import load_dataset  
-from transformers import AutoTokenizer, LayoutLMForQuestionAnswering  
+import torch
+from datasets import load_dataset
+from transformers import AutoTokenizer, LayoutLMForQuestionAnswering
 
-tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)  
-model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", torch_dtype=torch.float16)  
+tokenizer = AutoTokenizer.from_pretrained("impira/layoutlm-document-qa", add_prefix_space=True)
+model = LayoutLMForQuestionAnswering.from_pretrained("impira/layoutlm-document-qa", torch_dtype=torch.float16)
 
-dataset = load_dataset("nielsr/funsd", split="train")  
-example = dataset[0]  
-question = "what's his name?"  
-words = example["words"]  
-boxes = example["bboxes"]  
+dataset = load_dataset("nielsr/funsd", split="train")
+example = dataset[0]
+question = "what's his name?"
+words = example["words"]
+boxes = example["bboxes"]
 
-encoding = tokenizer(  
-    question.split(), 
-    words, 
-    is_split_into_words=True, 
-    return_token_type_ids=True, 
-    return_tensors="pt"  
-)  
-bbox = []  
-for i, s, w in zip(encoding.input_ids[0], encoding.sequence_ids(0), encoding.word_ids(0)):  
-    if s == 1:  
-        bbox.append(boxes[w])  
-    elif i == tokenizer.sep_token_id:  
-        bbox.append([1000] * 4)  
-    else:  
-        bbox.append([0] * 4)  
-encoding["bbox"] = torch.tensor([bbox])  
+encoding = tokenizer(
+    question.split(),
+    words,
+    is_split_into_words=True,
+    return_token_type_ids=True,
+    return_tensors="pt"
+)
+bbox = []
+for i, s, w in zip(encoding.input_ids[0], encoding.sequence_ids(0), encoding.word_ids(0)):
+    if s == 1:
+        bbox.append(boxes[w])
+    elif i == tokenizer.sep_token_id:
+        bbox.append([1000] * 4)
+    else:
+        bbox.append([0] * 4)
+encoding["bbox"] = torch.tensor([bbox])
 
-word_ids = encoding.word_ids(0)  
-outputs = model(**encoding)  
-loss = outputs.loss  
-start_scores = outputs.start_logits  
-end_scores = outputs.end_logits  
-start, end = word_ids[start_scores.argmax(-1)], word_ids[end_scores.argmax(-1)]  
-print(" ".join(words[start : end + 1]))  
+word_ids = encoding.word_ids(0)
+outputs = model(**encoding)
+loss = outputs.loss
+start_scores = outputs.start_logits
+end_scores = outputs.end_logits
+start, end = word_ids[start_scores.argmax(-1)], word_ids[end_scores.argmax(-1)]
+print(" ".join(words[start : end + 1]))
 ```
 
 </hfoption>
@@ -81,7 +80,7 @@ print(" ".join(words[start : end + 1]))
 
 ## Notes
 
-- The original LayoutLM was not designed with a unified processing workflow. Instead, it expects preprocessed text (`words`) and bounding boxes (`boxes`) from an external OCR engine (like [Pytesseract](https://pypi.org/project/pytesseract/)) and provide them as additional inputs to the tokenizer. 
+- The original LayoutLM was not designed with a unified processing workflow. Instead, it expects preprocessed text (`words`) and bounding boxes (`boxes`) from an external OCR engine (like [Pytesseract](https://pypi.org/project/pytesseract/)) and provide them as additional inputs to the tokenizer.
 
 - The [`~LayoutLMModel.forward`] method expects the input `bbox` (bounding boxes of the input tokens). Each bounding box should be in the format `(x0, y0, x1, y1)`.  `(x0, y0)` corresponds to the upper left corner of the bounding box and `{x1, y1)` corresponds to the lower right corner. The bounding boxes need to be normalized on a 0-1000 scale as shown below.
 
@@ -110,12 +109,12 @@ width, height = image.size
 
 A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with LayoutLM. If you're interested in submitting a resource to be included here, please feel free to open a Pull Request and we'll review it! The resource should ideally demonstrate something new instead of duplicating an existing resource.
 
-- Read [fine-tuning LayoutLM for document-understanding using Keras & Hugging Face Transformers](https://www.philschmid.de/fine-tuning-layoutlm-keras) to learn more.  
-- Read [fine-tune LayoutLM for document-understanding using only Hugging Face Transformers](https://www.philschmid.de/fine-tuning-layoutlm) for more information.  
-- Refer to this [notebook](https://colab.research.google.com/github/NielsRogge/Transformers-Tutorials/blob/master/LayoutLM/Add_image_embeddings_to_LayoutLM.ipynb) for a practical example of how to fine-tune LayoutLM.  
-- Refer to this [notebook](https://colab.research.google.com/github/NielsRogge/Transformers-Tutorials/blob/master/LayoutLM/Fine_tuning_LayoutLMForSequenceClassification_on_RVL_CDIP.ipynb) for an example of how to fine-tune LayoutLM for sequence classification.  
-- Refer to this [notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/LayoutLM/Fine_tuning_LayoutLMForTokenClassification_on_FUNSD.ipynb) for an example of how to fine-tune LayoutLM for token classification.  
-- Read [Deploy LayoutLM with Hugging Face Inference Endpoints](https://www.philschmid.de/inference-endpoints-layoutlm) to learn how to deploy LayoutLM.  
+- Read [fine-tuning LayoutLM for document-understanding using Keras & Hugging Face Transformers](https://www.philschmid.de/fine-tuning-layoutlm-keras) to learn more.
+- Read [fine-tune LayoutLM for document-understanding using only Hugging Face Transformers](https://www.philschmid.de/fine-tuning-layoutlm) for more information.
+- Refer to this [notebook](https://colab.research.google.com/github/NielsRogge/Transformers-Tutorials/blob/master/LayoutLM/Add_image_embeddings_to_LayoutLM.ipynb) for a practical example of how to fine-tune LayoutLM.
+- Refer to this [notebook](https://colab.research.google.com/github/NielsRogge/Transformers-Tutorials/blob/master/LayoutLM/Fine_tuning_LayoutLMForSequenceClassification_on_RVL_CDIP.ipynb) for an example of how to fine-tune LayoutLM for sequence classification.
+- Refer to this [notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/LayoutLM/Fine_tuning_LayoutLMForTokenClassification_on_FUNSD.ipynb) for an example of how to fine-tune LayoutLM for token classification.
+- Read [Deploy LayoutLM with Hugging Face Inference Endpoints](https://www.philschmid.de/inference-endpoints-layoutlm) to learn how to deploy LayoutLM.
 
 
 ## LayoutLMConfig
@@ -131,9 +130,6 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 
 [[autodoc]] LayoutLMTokenizerFast
     - __call__
-
-<frameworkcontent>
-<pt>
 
 ## LayoutLMModel
 
@@ -154,29 +150,3 @@ A list of official Hugging Face and community (indicated by 🌎) resources to h
 ## LayoutLMForQuestionAnswering
 
 [[autodoc]] LayoutLMForQuestionAnswering
-
-</pt>
-<tf>
-
-## TFLayoutLMModel
-
-[[autodoc]] TFLayoutLMModel
-
-## TFLayoutLMForMaskedLM
-
-[[autodoc]] TFLayoutLMForMaskedLM
-
-## TFLayoutLMForSequenceClassification
-
-[[autodoc]] TFLayoutLMForSequenceClassification
-
-## TFLayoutLMForTokenClassification
-
-[[autodoc]] TFLayoutLMForTokenClassification
-
-## TFLayoutLMForQuestionAnswering
-
-[[autodoc]] TFLayoutLMForQuestionAnswering
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/layoutlmv3.md
+++ b/docs/source/en/model_doc/layoutlmv3.md
@@ -32,7 +32,7 @@ alt="drawing" width="600"/>
 
 <small> LayoutLMv3 architecture. Taken from the <a href="https://huggingface.co/papers/2204.08387">original paper</a>. </small>
 
-This model was contributed by [nielsr](https://huggingface.co/nielsr). The TensorFlow version of this model was added by [chriskoo](https://huggingface.co/chriskoo), [tokec](https://huggingface.co/tokec), and [lre](https://huggingface.co/lre). The original code can be found [here](https://github.com/microsoft/unilm/tree/master/layoutlmv3).
+This model was contributed by [nielsr](https://huggingface.co/nielsr). The original code can be found [here](https://github.com/microsoft/unilm/tree/master/layoutlmv3).
 
 ## Usage tips
 
@@ -110,9 +110,6 @@ LayoutLMv3 is nearly identical to LayoutLMv2, so we've also included LayoutLMv2 
 [[autodoc]] LayoutLMv3Processor
     - __call__
 
-<frameworkcontent>
-<pt>
-
 ## LayoutLMv3Model
 
 [[autodoc]] LayoutLMv3Model
@@ -132,29 +129,3 @@ LayoutLMv3 is nearly identical to LayoutLMv2, so we've also included LayoutLMv2 
 
 [[autodoc]] LayoutLMv3ForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFLayoutLMv3Model
-
-[[autodoc]] TFLayoutLMv3Model
-    - call
-
-## TFLayoutLMv3ForSequenceClassification
-
-[[autodoc]] TFLayoutLMv3ForSequenceClassification
-    - call
-
-## TFLayoutLMv3ForTokenClassification
-
-[[autodoc]] TFLayoutLMv3ForTokenClassification
-    - call
-
-## TFLayoutLMv3ForQuestionAnswering
-
-[[autodoc]] TFLayoutLMv3ForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/led.md
+++ b/docs/source/en/model_doc/led.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
            <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-            <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -173,15 +172,6 @@ print(tokenizer.decode(output[0], skip_special_tokens=True))
 
 [[autodoc]] models.led.modeling_led.LEDSeq2SeqQuestionAnsweringModelOutput
 
-[[autodoc]] models.led.modeling_tf_led.TFLEDEncoderBaseModelOutput
-
-[[autodoc]] models.led.modeling_tf_led.TFLEDSeq2SeqModelOutput
-
-[[autodoc]] models.led.modeling_tf_led.TFLEDSeq2SeqLMOutput
-
-<frameworkcontent>
-<pt>
-
 ## LEDModel
 
 [[autodoc]] LEDModel
@@ -201,22 +191,3 @@ print(tokenizer.decode(output[0], skip_special_tokens=True))
 
 [[autodoc]] LEDForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFLEDModel
-
-[[autodoc]] TFLEDModel
-    - call
-
-## TFLEDForConditionalGeneration
-
-[[autodoc]] TFLEDForConditionalGeneration
-    - call
-
-</tf>
-</frameworkcontent>
-
-
-

--- a/docs/source/en/model_doc/longformer.md
+++ b/docs/source/en/model_doc/longformer.md
@@ -16,7 +16,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -127,20 +126,6 @@ echo -e "San Francisco 49ers cornerback Shawntae Spencer will miss the rest of t
 
 [[autodoc]] models.longformer.modeling_longformer.LongformerTokenClassifierOutput
 
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerBaseModelOutput
-
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerBaseModelOutputWithPooling
-
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerMaskedLMOutput
-
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerQuestionAnsweringModelOutput
-
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerSequenceClassifierOutput
-
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerMultipleChoiceModelOutput
-
-[[autodoc]] models.longformer.modeling_tf_longformer.TFLongformerTokenClassifierOutput
-
 ## LongformerModel
 
 [[autodoc]] LongformerModel
@@ -170,33 +155,3 @@ echo -e "San Francisco 49ers cornerback Shawntae Spencer will miss the rest of t
 
 [[autodoc]] LongformerForQuestionAnswering
     - forward
-
-## TFLongformerModel
-
-[[autodoc]] TFLongformerModel
-    - call
-
-## TFLongformerForMaskedLM
-
-[[autodoc]] TFLongformerForMaskedLM
-    - call
-
-## TFLongformerForQuestionAnswering
-
-[[autodoc]] TFLongformerForQuestionAnswering
-    - call
-
-## TFLongformerForSequenceClassification
-
-[[autodoc]] TFLongformerForSequenceClassification
-    - call
-
-## TFLongformerForTokenClassification
-
-[[autodoc]] TFLongformerForTokenClassification
-    - call
-
-## TFLongformerForMultipleChoice
-
-[[autodoc]] TFLongformerForMultipleChoice
-    - call

--- a/docs/source/en/model_doc/lxmert.md
+++ b/docs/source/en/model_doc/lxmert.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -85,13 +84,6 @@ This model was contributed by [eltoto1219](https://huggingface.co/eltoto1219). T
 
 [[autodoc]] models.lxmert.modeling_lxmert.LxmertForQuestionAnsweringOutput
 
-[[autodoc]] models.lxmert.modeling_tf_lxmert.TFLxmertModelOutput
-
-[[autodoc]] models.lxmert.modeling_tf_lxmert.TFLxmertForPreTrainingOutput
-
-<frameworkcontent>
-<pt>
-
 ## LxmertModel
 
 [[autodoc]] LxmertModel
@@ -106,19 +98,3 @@ This model was contributed by [eltoto1219](https://huggingface.co/eltoto1219). T
 
 [[autodoc]] LxmertForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFLxmertModel
-
-[[autodoc]] TFLxmertModel
-    - call
-
-## TFLxmertForPreTraining
-
-[[autodoc]] TFLxmertForPreTraining
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/metaclip_2.md
+++ b/docs/source/en/model_doc/metaclip_2.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on {release_date} and added to Hugging Face Transformers on 2025-07-31.*
+*This model was released on {release_date} and added to Hugging Face Transformers on 2025-08-20.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
@@ -129,6 +129,3 @@ print(f"Most likely label: {most_likely_label} with probability: {probs[0][most_
 
 [[autodoc]] MetaClip2ForImageClassification
     - forward
-
-</pt>
-<tf>

--- a/docs/source/en/model_doc/mobilebert.md
+++ b/docs/source/en/model_doc/mobilebert.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -107,11 +106,6 @@ echo -e "The capital of France is [MASK]." | transformers run --task fill-mask -
 
 [[autodoc]] models.mobilebert.modeling_mobilebert.MobileBertForPreTrainingOutput
 
-[[autodoc]] models.mobilebert.modeling_tf_mobilebert.TFMobileBertForPreTrainingOutput
-
-<frameworkcontent>
-<pt>
-
 ## MobileBertModel
 
 [[autodoc]] MobileBertModel
@@ -151,49 +145,3 @@ echo -e "The capital of France is [MASK]." | transformers run --task fill-mask -
 
 [[autodoc]] MobileBertForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFMobileBertModel
-
-[[autodoc]] TFMobileBertModel
-    - call
-
-## TFMobileBertForPreTraining
-
-[[autodoc]] TFMobileBertForPreTraining
-    - call
-
-## TFMobileBertForMaskedLM
-
-[[autodoc]] TFMobileBertForMaskedLM
-    - call
-
-## TFMobileBertForNextSentencePrediction
-
-[[autodoc]] TFMobileBertForNextSentencePrediction
-    - call
-
-## TFMobileBertForSequenceClassification
-
-[[autodoc]] TFMobileBertForSequenceClassification
-    - call
-
-## TFMobileBertForMultipleChoice
-
-[[autodoc]] TFMobileBertForMultipleChoice
-    - call
-
-## TFMobileBertForTokenClassification
-
-[[autodoc]] TFMobileBertForTokenClassification
-    - call
-
-## TFMobileBertForQuestionAnswering
-
-[[autodoc]] TFMobileBertForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/mobilevit.md
+++ b/docs/source/en/model_doc/mobilevit.md
@@ -19,7 +19,6 @@ Unless required by applicable law or agreed to in writing, software distributed 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-2">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -35,7 +34,7 @@ You can find all the original MobileViT checkpoints under the [Apple](https://hu
 
 
 > [!TIP]
-> - This model was contributed by [matthijs](https://huggingface.co/Matthijs) and the TensorFlow version was contributed by [sayakpaul](https://huggingface.co/sayakpaul).
+> - This model was contributed by [matthijs](https://huggingface.co/Matthijs).
 >
 > Click on the MobileViT models in the right sidebar for more examples of how to apply MobileViT to different vision tasks.
 
@@ -94,8 +93,6 @@ print(f"The predicted class label is:{predicted_class_label}")
 </hfoptions>
 
 
-
-
 ## Notes
 
 - Does **not** operate on sequential data, it's purely designed for image tasks.
@@ -104,12 +101,9 @@ print(f"The predicted class label is:{predicted_class_label}")
 - If using custom preprocessing, ensure that images are in **BGR** format (not RGB), as expected by the pretrained weights.
 - The classification models are pretrained on [ImageNet-1k](https://huggingface.co/datasets/imagenet-1k).
 - The segmentation models use a [DeepLabV3](https://huggingface.co/papers/1706.05587) head and are pretrained on [PASCAL VOC](http://host.robots.ox.ac.uk/pascal/VOC/).
-- TensorFlow versions are compatible with TensorFlow Lite, making them ideal for edge/mobile deployment.
 
 
 
-
-  
 ## MobileViTConfig
 
 [[autodoc]] MobileViTConfig
@@ -132,9 +126,6 @@ print(f"The predicted class label is:{predicted_class_label}")
     - preprocess
     - post_process_semantic_segmentation
 
-<frameworkcontent>
-<pt>
-
 ## MobileViTModel
 
 [[autodoc]] MobileViTModel
@@ -149,24 +140,3 @@ print(f"The predicted class label is:{predicted_class_label}")
 
 [[autodoc]] MobileViTForSemanticSegmentation
     - forward
-
-</pt>
-<tf>
-
-## TFMobileViTModel
-
-[[autodoc]] TFMobileViTModel
-    - call
-
-## TFMobileViTForImageClassification
-
-[[autodoc]] TFMobileViTForImageClassification
-    - call
-
-## TFMobileViTForSemanticSegmentation
-
-[[autodoc]] TFMobileViTForSemanticSegmentation
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/mpnet.md
+++ b/docs/source/en/model_doc/mpnet.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -47,7 +46,7 @@ The original code can be found [here](https://github.com/microsoft/MPNet).
 
 ## Usage tips
 
-MPNet doesn't have `token_type_ids`, you don't need to indicate which token belongs to which segment. Just 
+MPNet doesn't have `token_type_ids`, you don't need to indicate which token belongs to which segment. Just
 separate your segments with the separation token `tokenizer.sep_token` (or `[sep]`).
 
 ## Resources
@@ -73,9 +72,6 @@ separate your segments with the separation token `tokenizer.sep_token` (or `[sep
 ## MPNetTokenizerFast
 
 [[autodoc]] MPNetTokenizerFast
-
-<frameworkcontent>
-<pt>
 
 ## MPNetModel
 
@@ -106,39 +102,3 @@ separate your segments with the separation token `tokenizer.sep_token` (or `[sep
 
 [[autodoc]] MPNetForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFMPNetModel
-
-[[autodoc]] TFMPNetModel
-    - call
-
-## TFMPNetForMaskedLM
-
-[[autodoc]] TFMPNetForMaskedLM
-    - call
-
-## TFMPNetForSequenceClassification
-
-[[autodoc]] TFMPNetForSequenceClassification
-    - call
-
-## TFMPNetForMultipleChoice
-
-[[autodoc]] TFMPNetForMultipleChoice
-    - call
-
-## TFMPNetForTokenClassification
-
-[[autodoc]] TFMPNetForTokenClassification
-    - call
-
-## TFMPNetForQuestionAnswering
-
-[[autodoc]] TFMPNetForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/rag.md
+++ b/docs/source/en/model_doc/rag.md
@@ -20,7 +20,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
   <div class="flex flex-wrap space-x-1">
     <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-    <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     <img alt="FlashAttention" src="https://img.shields.io/badge/%E2%9A%A1%EF%B8%8E%20FlashAttention-eae0c8?style=flat">
   </div>
 </div>
@@ -105,9 +104,6 @@ print(tokenizer.batch_decode(generated, skip_special_tokens=True)[0])
 
 [[autodoc]] RagRetriever
 
-<frameworkcontent>
-<pt>
-
 ## RagModel
 
 [[autodoc]] RagModel
@@ -124,26 +120,3 @@ print(tokenizer.batch_decode(generated, skip_special_tokens=True)[0])
 [[autodoc]] RagTokenForGeneration
     - forward
     - generate
-
-</pt>
-<tf>
-
-## TFRagModel
-
-[[autodoc]] TFRagModel
-    - call
-
-## TFRagSequenceForGeneration
-
-[[autodoc]] TFRagSequenceForGeneration
-    - call
-    - generate
-
-## TFRagTokenForGeneration
-
-[[autodoc]] TFRagTokenForGeneration
-    - call
-    - generate
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/regnet.md
+++ b/docs/source/en/model_doc/regnet.md
@@ -31,9 +31,7 @@ The abstract from the paper is the following:
 
 *In this work, we present a new network design paradigm. Our goal is to help advance the understanding of network design and discover design principles that generalize across settings. Instead of focusing on designing individual network instances, we design network design spaces that parametrize populations of networks. The overall process is analogous to classic manual design of networks, but elevated to the design space level. Using our methodology we explore the structure aspect of network design and arrive at a low-dimensional design space consisting of simple, regular networks that we call RegNet. The core insight of the RegNet parametrization is surprisingly simple: widths and depths of good networks can be explained by a quantized linear function. We analyze the RegNet design space and arrive at interesting findings that do not match the current practice of network design. The RegNet design space provides simple and fast networks that work well across a wide range of flop regimes. Under comparable training settings and flops, the RegNet models outperform the popular EfficientNet models while being up to 5x faster on GPUs.*
 
-This model was contributed by [Francesco](https://huggingface.co/Francesco). The TensorFlow version of the model
-was contributed by [sayakpaul](https://huggingface.co/sayakpaul) and [ariG23498](https://huggingface.co/ariG23498).
-The original code can be found [here](https://github.com/facebookresearch/pycls).
+This model was contributed by [Francesco](https://huggingface.co/Francesco). The original code can be found [here](https://github.com/facebookresearch/pycls).
 
 The huge 10B model from [Self-supervised Pretraining of Visual Features in the Wild](https://huggingface.co/papers/2103.01988),
 trained on  one billion Instagram images, is available on the [hub](https://huggingface.co/facebook/regnet-y-10b-seer)

--- a/docs/source/en/model_doc/rembert.md
+++ b/docs/source/en/model_doc/rembert.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -76,9 +75,6 @@ also similar to the Albert one rather than the BERT one.
     - create_token_type_ids_from_sequences
     - save_vocabulary
 
-<frameworkcontent>
-<pt>
-
 ## RemBertModel
 
 [[autodoc]] RemBertModel
@@ -113,44 +109,3 @@ also similar to the Albert one rather than the BERT one.
 
 [[autodoc]] RemBertForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFRemBertModel
-
-[[autodoc]] TFRemBertModel
-    - call
-
-## TFRemBertForMaskedLM
-
-[[autodoc]] TFRemBertForMaskedLM
-    - call
-
-## TFRemBertForCausalLM
-
-[[autodoc]] TFRemBertForCausalLM
-    - call
-
-## TFRemBertForSequenceClassification
-
-[[autodoc]] TFRemBertForSequenceClassification
-    - call
-
-## TFRemBertForMultipleChoice
-
-[[autodoc]] TFRemBertForMultipleChoice
-    - call
-
-## TFRemBertForTokenClassification
-
-[[autodoc]] TFRemBertForTokenClassification
-    - call
-
-## TFRemBertForQuestionAnswering
-
-[[autodoc]] TFRemBertForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/resnet.md
+++ b/docs/source/en/model_doc/resnet.md
@@ -36,7 +36,7 @@ The figure below illustrates the architecture of ResNet. Taken from the [origina
 
 <img width="600" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/resnet_architecture.png"/>
 
-This model was contributed by [Francesco](https://huggingface.co/Francesco). The TensorFlow version of this model was added by [amyeroberts](https://huggingface.co/amyeroberts). The original code can be found [here](https://github.com/KaimingHe/deep-residual-networks).
+This model was contributed by [Francesco](https://huggingface.co/Francesco). The original code can be found [here](https://github.com/KaimingHe/deep-residual-networks).
 
 ## Resources
 

--- a/docs/source/en/model_doc/sam.md
+++ b/docs/source/en/model_doc/sam.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -139,41 +138,24 @@ alt="drawing" width="900"/>
 
 [[autodoc]] SamPromptEncoderConfig
 
-
 ## SamProcessor
 
 [[autodoc]] SamProcessor
-
 
 ## SamImageProcessor
 
 [[autodoc]] SamImageProcessor
 
-
 ## SamImageProcessorFast
 
 [[autodoc]] SamImageProcessorFast
-
 
 ## SamVisionModel
 
 [[autodoc]] SamVisionModel
     - forward
 
-
 ## SamModel
 
 [[autodoc]] SamModel
     - forward
-
-
-## TFSamVisionModel
-
-[[autodoc]] TFSamVisionModel
-    - call
-
-
-## TFSamModel
-
-[[autodoc]] TFSamModel
-    - call

--- a/docs/source/en/model_doc/segformer.md
+++ b/docs/source/en/model_doc/segformer.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -46,8 +45,7 @@ The figure below illustrates the architecture of SegFormer. Taken from the [orig
 
 <img width="600" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/segformer_architecture.png"/>
 
-This model was contributed by [nielsr](https://huggingface.co/nielsr). The TensorFlow version
-of the model was contributed by [sayakpaul](https://huggingface.co/sayakpaul). The original code can be found [here](https://github.com/NVlabs/SegFormer).
+This model was contributed by [nielsr](https://huggingface.co/nielsr). The original code can be found [here](https://github.com/NVlabs/SegFormer).
 
 ## Usage tips
 
@@ -62,7 +60,6 @@ of the model was contributed by [sayakpaul](https://huggingface.co/sayakpaul). T
   found on the [hub](https://huggingface.co/models?other=segformer).
 - The quickest way to get started with SegFormer is by checking the [example notebooks](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/SegFormer) (which showcase both inference and
   fine-tuning on custom data). One can also check out the [blog post](https://huggingface.co/blog/fine-tune-segformer) introducing SegFormer and illustrating how it can be fine-tuned on custom data.
-- TensorFlow users should refer to [this repository](https://github.com/deep-diver/segformer-tf-transformers) that shows off-the-shelf inference and fine-tuning.
 - One can also check out [this interactive demo on Hugging Face Spaces](https://huggingface.co/spaces/chansung/segformer-tf-transformers)
   to try out a SegFormer model on custom images.
 - SegFormer works on any input size, as it pads the input to be divisible by `config.patch_sizes`.
@@ -108,7 +105,6 @@ Semantic segmentation:
 - [`SegformerForSemanticSegmentation`] is supported by this [example script](https://github.com/huggingface/transformers/tree/main/examples/pytorch/semantic-segmentation).
 - A blog on fine-tuning SegFormer on a custom dataset can be found [here](https://huggingface.co/blog/fine-tune-segformer).
 - More demo notebooks on SegFormer (both inference + fine-tuning on a custom dataset) can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/SegFormer).
-- [`TFSegformerForSemanticSegmentation`] is supported by this [example notebook](https://github.com/huggingface/notebooks/blob/main/examples/semantic_segmentation-tf.ipynb).
 - [Semantic segmentation task guide](../tasks/semantic_segmentation)
 
 If you're interested in submitting a resource to be included here, please feel free to open a Pull Request and we'll review it! The resource should ideally demonstrate something new instead of duplicating an existing resource.
@@ -135,9 +131,6 @@ If you're interested in submitting a resource to be included here, please feel f
     - preprocess
     - post_process_semantic_segmentation
 
-<frameworkcontent>
-<pt>
-
 ## SegformerModel
 
 [[autodoc]] SegformerModel
@@ -157,29 +150,3 @@ If you're interested in submitting a resource to be included here, please feel f
 
 [[autodoc]] SegformerForSemanticSegmentation
     - forward
-
-</pt>
-<tf>
-
-## TFSegformerDecodeHead
-
-[[autodoc]] TFSegformerDecodeHead
-    - call
-
-## TFSegformerModel
-
-[[autodoc]] TFSegformerModel
-    - call
-
-## TFSegformerForImageClassification
-
-[[autodoc]] TFSegformerForImageClassification
-    - call
-
-## TFSegformerForSemanticSegmentation
-
-[[autodoc]] TFSegformerForSemanticSegmentation
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/speech_to_text.md
+++ b/docs/source/en/model_doc/speech_to_text.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -128,9 +127,6 @@ See the [model hub](https://huggingface.co/models?filter=speech_to_text) to look
     - batch_decode
     - decode
 
-<frameworkcontent>
-<pt>
-
 ## Speech2TextModel
 
 [[autodoc]] Speech2TextModel
@@ -140,19 +136,3 @@ See the [model hub](https://huggingface.co/models?filter=speech_to_text) to look
 
 [[autodoc]] Speech2TextForConditionalGeneration
     - forward
-
-</pt>
-<tf>
-
-## TFSpeech2TextModel
-
-[[autodoc]] TFSpeech2TextModel
-    - call
-
-## TFSpeech2TextForConditionalGeneration
-
-[[autodoc]] TFSpeech2TextForConditionalGeneration
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/superpoint.md
+++ b/docs/source/en/model_doc/superpoint.md
@@ -139,12 +139,7 @@ processed_outputs = processor.post_process_keypoint_detection(outputs, [image_si
 - preprocess
 - post_process_keypoint_detection
 
-<frameworkcontent>
-<pt>
 ## SuperPointForKeypointDetection
 
 [[autodoc]] SuperPointForKeypointDetection
-
 - forward
-
-</pt>

--- a/docs/source/en/model_doc/swiftformer.md
+++ b/docs/source/en/model_doc/swiftformer.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -32,8 +31,7 @@ The abstract from the paper is the following:
 
 *Self-attention has become a defacto choice for capturing global context in various vision applications. However, its quadratic computational complexity with respect to image resolution limits its use in real-time applications, especially for deployment on resource-constrained mobile devices. Although hybrid approaches have been proposed to combine the advantages of convolutions and self-attention for a better speed-accuracy trade-off, the expensive matrix multiplication operations in self-attention remain a bottleneck. In this work, we introduce a novel efficient additive attention mechanism that effectively replaces the quadratic matrix multiplication operations with linear element-wise multiplications. Our design shows that the key-value interaction can be replaced with a linear layer without sacrificing any accuracy. Unlike previous state-of-the-art methods, our efficient formulation of self-attention enables its usage at all stages of the network. Using our proposed efficient additive attention, we build a series of models called "SwiftFormer" which achieves state-of-the-art performance in terms of both accuracy and mobile inference speed. Our small variant achieves 78.5% top-1 ImageNet-1K accuracy with only 0.8 ms latency on iPhone 14, which is more accurate and 2x faster compared to MobileViT-v2.*
 
-This model was contributed by [shehan97](https://huggingface.co/shehan97). The TensorFlow version was contributed by [joaocmd](https://huggingface.co/joaocmd).
-The original code can be found [here](https://github.com/Amshaker/SwiftFormer).
+This model was contributed by [shehan97](https://huggingface.co/shehan97). The original code can be found [here](https://github.com/Amshaker/SwiftFormer).
 
 ## SwiftFormerConfig
 
@@ -48,13 +46,3 @@ The original code can be found [here](https://github.com/Amshaker/SwiftFormer).
 
 [[autodoc]] SwiftFormerForImageClassification
     - forward
-
-## TFSwiftFormerModel
-
-[[autodoc]] TFSwiftFormerModel
-    - call
-
-## TFSwiftFormerForImageClassification
-
-[[autodoc]] TFSwiftFormerForImageClassification
-    - call

--- a/docs/source/en/model_doc/swin.md
+++ b/docs/source/en/model_doc/swin.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -92,9 +91,6 @@ print(f"The predicted class label is: {predicted_class_label}")
 
 [[autodoc]] SwinConfig
 
-<frameworkcontent>
-<pt>
-
 ## SwinModel
 
 [[autodoc]] SwinModel
@@ -109,24 +105,3 @@ print(f"The predicted class label is: {predicted_class_label}")
 
 [[autodoc]] transformers.SwinForImageClassification
     - forward
-
-</pt>
-<tf>
-
-## TFSwinModel
-
-[[autodoc]] TFSwinModel
-    - call
-
-## TFSwinForMaskedImageModeling
-
-[[autodoc]] TFSwinForMaskedImageModeling
-    - call
-
-## TFSwinForImageClassification
-
-[[autodoc]] transformers.TFSwinForImageClassification
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/tapas.md
+++ b/docs/source/en/model_doc/tapas.md
@@ -19,21 +19,20 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
 
 The TAPAS model was proposed in [TAPAS: Weakly Supervised Table Parsing via Pre-training](https://huggingface.co/papers/2004.02349)
-by Jonathan Herzig, Paweł Krzysztof Nowak, Thomas Müller, Francesco Piccinno and Julian Martin Eisenschlos. It's a BERT-based model specifically 
-designed (and pre-trained) for answering questions about tabular data. Compared to BERT, TAPAS uses relative position embeddings and has 7 
-token types that encode tabular structure. TAPAS is pre-trained on the masked language modeling (MLM) objective on a large dataset comprising 
-millions of tables from English Wikipedia and corresponding texts. 
+by Jonathan Herzig, Paweł Krzysztof Nowak, Thomas Müller, Francesco Piccinno and Julian Martin Eisenschlos. It's a BERT-based model specifically
+designed (and pre-trained) for answering questions about tabular data. Compared to BERT, TAPAS uses relative position embeddings and has 7
+token types that encode tabular structure. TAPAS is pre-trained on the masked language modeling (MLM) objective on a large dataset comprising
+millions of tables from English Wikipedia and corresponding texts.
 
-For question answering, TAPAS has 2 heads on top: a cell selection head and an aggregation head, for (optionally) performing aggregations (such as counting or summing) among selected cells. TAPAS has been fine-tuned on several datasets: 
+For question answering, TAPAS has 2 heads on top: a cell selection head and an aggregation head, for (optionally) performing aggregations (such as counting or summing) among selected cells. TAPAS has been fine-tuned on several datasets:
 - [SQA](https://www.microsoft.com/en-us/download/details.aspx?id=54253) (Sequential Question Answering by Microsoft)
 - [WTQ](https://github.com/ppasupat/WikiTableQuestions) (Wiki Table Questions by Stanford University)
-- [WikiSQL](https://github.com/salesforce/WikiSQL) (by Salesforce). 
+- [WikiSQL](https://github.com/salesforce/WikiSQL) (by Salesforce).
 
 It achieves state-of-the-art on both SQA and WTQ, while having comparable performance to SOTA on WikiSQL, with a much simpler architecture.
 
@@ -44,11 +43,11 @@ The abstract from the paper is the following:
 In addition, the authors have further pre-trained TAPAS to recognize **table entailment**, by creating a balanced dataset of millions of automatically created training examples which are learned in an intermediate step prior to fine-tuning. The authors of TAPAS call this further pre-training intermediate pre-training (since TAPAS is first pre-trained on MLM, and then on another dataset). They found that intermediate pre-training further improves performance on SQA, achieving a new state-of-the-art as well as state-of-the-art on [TabFact](https://github.com/wenhuchen/Table-Fact-Checking), a large-scale dataset with 16k Wikipedia tables for table entailment (a binary classification task). For more details, see their follow-up paper: [Understanding tables with intermediate pre-training](https://www.aclweb.org/anthology/2020.findings-emnlp.27/) by Julian Martin Eisenschlos, Syrine Krichene and Thomas Müller.
 
 <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/tapas_architecture.png"
-alt="drawing" width="600"/> 
+alt="drawing" width="600"/>
 
 <small> TAPAS architecture. Taken from the <a href="https://ai.googleblog.com/2020/04/using-neural-networks-to-find-answers.html">original blog post</a>.</small>
 
-This model was contributed by [nielsr](https://huggingface.co/nielsr). The Tensorflow version of this model was contributed by [kamalkraj](https://huggingface.co/kamalkraj). The original code can be found [here](https://github.com/google-research/tapas).
+This model was contributed by [nielsr](https://huggingface.co/nielsr). The original code can be found [here](https://github.com/google-research/tapas).
 
 ## Usage tips
 
@@ -77,8 +76,7 @@ To summarize:
 | Weak supervision for aggregation    | WTQ                 | Questions might involve aggregation, and the model must learn this given only the answer as supervision |
 | Strong supervision for aggregation  | WikiSQL-supervised  | Questions might involve aggregation, and the model must learn this given the gold aggregation operator  |
 
-<frameworkcontent>
-<pt>
+
 Initializing a model with a pre-trained base and randomly initialized classification heads from the hub can be done as shown below.
 
 ```py
@@ -106,37 +104,7 @@ Of course, you don't necessarily have to follow one of these three ways in which
 >>> # initializing the pre-trained base sized model with our custom classification heads
 >>> model = TapasForQuestionAnswering.from_pretrained("google/tapas-base", config=config)
 ```
-</pt>
-<tf>
-Initializing a model with a pre-trained base and randomly initialized classification heads from the hub can be done as shown below. Be sure to have installed the [tensorflow_probability](https://github.com/tensorflow/probability) dependency:
 
-```py
->>> from transformers import TapasConfig, TFTapasForQuestionAnswering
-
->>> # for example, the base sized model with default SQA configuration
->>> model = TFTapasForQuestionAnswering.from_pretrained("google/tapas-base")
-
->>> # or, the base sized model with WTQ configuration
->>> config = TapasConfig.from_pretrained("google/tapas-base-finetuned-wtq")
->>> model = TFTapasForQuestionAnswering.from_pretrained("google/tapas-base", config=config)
-
->>> # or, the base sized model with WikiSQL configuration
->>> config = TapasConfig("google-base-finetuned-wikisql-supervised")
->>> model = TFTapasForQuestionAnswering.from_pretrained("google/tapas-base", config=config)
-```
-
-Of course, you don't necessarily have to follow one of these three ways in which TAPAS was fine-tuned. You can also experiment by defining any hyperparameters you want when initializing [`TapasConfig`], and then create a [`TFTapasForQuestionAnswering`] based on that configuration. For example, if you have a dataset that has both conversational questions and questions that might involve aggregation, then you can do it this way. Here's an example:
-
-```py
->>> from transformers import TapasConfig, TFTapasForQuestionAnswering
-
->>> # you can initialize the classification heads any way you want (see docs of TapasConfig)
->>> config = TapasConfig(num_aggregation_labels=3, average_logits_per_cell=True)
->>> # initializing the pre-trained base sized model with our custom classification heads
->>> model = TFTapasForQuestionAnswering.from_pretrained("google/tapas-base", config=config)
-```
-</tf>
-</frameworkcontent>
 
 What you can also do is start from an already fine-tuned checkpoint. A note here is that the already fine-tuned checkpoint on WTQ has some issues due to the L2-loss which is somewhat brittle. See [here](https://github.com/google-research/tapas/issues/91#issuecomment-735719340) for more info.
 
@@ -160,8 +128,7 @@ The tables themselves should be present in a folder, each table being a separate
 
 **STEP 3: Convert your data into tensors using TapasTokenizer**
 
-<frameworkcontent>
-<pt>
+
 Third, given that you've prepared your data in this TSV/CSV format (and corresponding CSV files containing the tabular data), you can then use [`TapasTokenizer`] to convert table-question pairs into `input_ids`, `attention_mask`, `token_type_ids` and so on. Again, based on which of the three cases you picked above, [`TapasForQuestionAnswering`] requires different
 inputs to be fine-tuned:
 
@@ -246,114 +213,14 @@ Of course, this only shows how to encode a single training example. It is advise
 >>> train_dataset = TableDataset(data, tokenizer)
 >>> train_dataloader = torch.utils.data.DataLoader(train_dataset, batch_size=32)
 ```
-</pt>
-<tf>
-Third, given that you've prepared your data in this TSV/CSV format (and corresponding CSV files containing the tabular data), you can then use [`TapasTokenizer`] to convert table-question pairs into `input_ids`, `attention_mask`, `token_type_ids` and so on. Again, based on which of the three cases you picked above, [`TFTapasForQuestionAnswering`] requires different
-inputs to be fine-tuned:
 
-| **Task**                           | **Required inputs**                                                                                                 |
-|------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| Conversational                     | `input_ids`, `attention_mask`, `token_type_ids`, `labels`                                                           |
-|  Weak supervision for aggregation  | `input_ids`, `attention_mask`, `token_type_ids`, `labels`, `numeric_values`, `numeric_values_scale`, `float_answer` |
-| Strong supervision for aggregation | `input ids`, `attention mask`, `token type ids`, `labels`, `aggregation_labels`                                     |
-
-[`TapasTokenizer`] creates the `labels`, `numeric_values` and `numeric_values_scale` based on the `answer_coordinates` and `answer_text` columns of the TSV file. The `float_answer` and `aggregation_labels` are already in the TSV file of step 2. Here's an example:
-
-```py
->>> from transformers import TapasTokenizer
->>> import pandas as pd
-
->>> model_name = "google/tapas-base"
->>> tokenizer = TapasTokenizer.from_pretrained(model_name)
-
->>> data = {"Actors": ["Brad Pitt", "Leonardo Di Caprio", "George Clooney"], "Number of movies": ["87", "53", "69"]}
->>> queries = [
-...     "What is the name of the first actor?",
-...     "How many movies has George Clooney played in?",
-...     "What is the total number of movies?",
-... ]
->>> answer_coordinates = [[(0, 0)], [(2, 1)], [(0, 1), (1, 1), (2, 1)]]
->>> answer_text = [["Brad Pitt"], ["69"], ["209"]]
->>> table = pd.DataFrame.from_dict(data)
->>> inputs = tokenizer(
-...     table=table,
-...     queries=queries,
-...     answer_coordinates=answer_coordinates,
-...     answer_text=answer_text,
-...     padding="max_length",
-...     return_tensors="tf",
-... )
->>> inputs
-{'input_ids': tensor([[ ... ]]), 'attention_mask': tensor([[...]]), 'token_type_ids': tensor([[[...]]]),
-'numeric_values': tensor([[ ... ]]), 'numeric_values_scale: tensor([[ ... ]]), labels: tensor([[ ... ]])}
-```
-
-Note that [`TapasTokenizer`] expects the data of the table to be **text-only**. You can use `.astype(str)` on a dataframe to turn it into text-only data.
-Of course, this only shows how to encode a single training example. It is advised to create a dataloader to iterate over batches:
-
-```py
->>> import tensorflow as tf
->>> import pandas as pd
-
->>> tsv_path = "your_path_to_the_tsv_file"
->>> table_csv_path = "your_path_to_a_directory_containing_all_csv_files"
-
-
->>> class TableDataset:
-...     def __init__(self, data, tokenizer):
-...         self.data = data
-...         self.tokenizer = tokenizer
-
-...     def __iter__(self):
-...         for idx in range(self.__len__()):
-...             item = self.data.iloc[idx]
-...             table = pd.read_csv(table_csv_path + item.table_file).astype(
-...                 str
-...             )  # be sure to make your table data text only
-...             encoding = self.tokenizer(
-...                 table=table,
-...                 queries=item.question,
-...                 answer_coordinates=item.answer_coordinates,
-...                 answer_text=item.answer_text,
-...                 truncation=True,
-...                 padding="max_length",
-...                 return_tensors="tf",
-...             )
-...             # remove the batch dimension which the tokenizer adds by default
-...             encoding = {key: tf.squeeze(val, 0) for key, val in encoding.items()}
-...             # add the float_answer which is also required (weak supervision for aggregation case)
-...             encoding["float_answer"] = tf.convert_to_tensor(item.float_answer, dtype=tf.float32)
-...             yield encoding["input_ids"], encoding["attention_mask"], encoding["numeric_values"], encoding[
-...                 "numeric_values_scale"
-...             ], encoding["token_type_ids"], encoding["labels"], encoding["float_answer"]
-
-...     def __len__(self):
-...         return len(self.data)
-
-
->>> data = pd.read_csv(tsv_path, sep="\t")
->>> train_dataset = TableDataset(data, tokenizer)
->>> output_signature = (
-...     tf.TensorSpec(shape=(512,), dtype=tf.int32),
-...     tf.TensorSpec(shape=(512,), dtype=tf.int32),
-...     tf.TensorSpec(shape=(512,), dtype=tf.float32),
-...     tf.TensorSpec(shape=(512,), dtype=tf.float32),
-...     tf.TensorSpec(shape=(512, 7), dtype=tf.int32),
-...     tf.TensorSpec(shape=(512,), dtype=tf.int32),
-...     tf.TensorSpec(shape=(512,), dtype=tf.float32),
-... )
->>> train_dataloader = tf.data.Dataset.from_generator(train_dataset, output_signature=output_signature).batch(32)
-```
-</tf>
-</frameworkcontent>
 
 Note that here, we encode each table-question pair independently. This is fine as long as your dataset is **not conversational**. In case your dataset involves conversational questions (such as in SQA), then you should first group together the `queries`, `answer_coordinates` and `answer_text` per table (in the order of their `position`
-index) and batch encode each table with its questions. This will make sure that the `prev_labels` token types (see docs of [`TapasTokenizer`]) are set correctly. See [this notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/TAPAS/Fine_tuning_TapasForQuestionAnswering_on_SQA.ipynb) for more info. See [this notebook](https://github.com/kamalkraj/Tapas-Tutorial/blob/master/TAPAS/Fine_tuning_TapasForQuestionAnswering_on_SQA.ipynb) for more info regarding using the TensorFlow model.
+index) and batch encode each table with its questions. This will make sure that the `prev_labels` token types (see docs of [`TapasTokenizer`]) are set correctly. See [this notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/TAPAS/Fine_tuning_TapasForQuestionAnswering_on_SQA.ipynb) for more info.
 
 **STEP 4: Train (fine-tune) the model
 
-<frameworkcontent>
-<pt>
+
 You can then fine-tune [`TapasForQuestionAnswering`] as follows (shown here for the weak supervision for aggregation case):
 
 ```py
@@ -404,63 +271,12 @@ You can then fine-tune [`TapasForQuestionAnswering`] as follows (shown here for 
 ...         loss.backward()
 ...         optimizer.step()
 ```
-</pt>
-<tf>
-You can then fine-tune [`TFTapasForQuestionAnswering`] as follows (shown here for the weak supervision for aggregation case):
 
-```py
->>> import tensorflow as tf
->>> from transformers import TapasConfig, TFTapasForQuestionAnswering
-
->>> # this is the default WTQ configuration
->>> config = TapasConfig(
-...     num_aggregation_labels=4,
-...     use_answer_as_supervision=True,
-...     answer_loss_cutoff=0.664694,
-...     cell_selection_preference=0.207951,
-...     huber_loss_delta=0.121194,
-...     init_cell_selection_weights_to_zero=True,
-...     select_one_column=True,
-...     allow_empty_column_selection=False,
-...     temperature=0.0352513,
-... )
->>> model = TFTapasForQuestionAnswering.from_pretrained("google/tapas-base", config=config)
-
->>> optimizer = tf.keras.optimizers.Adam(learning_rate=5e-5)
-
->>> for epoch in range(2):  # loop over the dataset multiple times
-...     for batch in train_dataloader:
-...         # get the inputs;
-...         input_ids = batch[0]
-...         attention_mask = batch[1]
-...         token_type_ids = batch[4]
-...         labels = batch[-1]
-...         numeric_values = batch[2]
-...         numeric_values_scale = batch[3]
-...         float_answer = batch[6]
-
-...         # forward + backward + optimize
-...         with tf.GradientTape() as tape:
-...             outputs = model(
-...                 input_ids=input_ids,
-...                 attention_mask=attention_mask,
-...                 token_type_ids=token_type_ids,
-...                 labels=labels,
-...                 numeric_values=numeric_values,
-...                 numeric_values_scale=numeric_values_scale,
-...                 float_answer=float_answer,
-...             )
-...         grads = tape.gradient(outputs.loss, model.trainable_weights)
-...         optimizer.apply_gradients(zip(grads, model.trainable_weights))
-```
-</tf>
-</frameworkcontent>
 
 ## Usage: inference
 
-<frameworkcontent>
-<pt>
-Here we explain how you can use [`TapasForQuestionAnswering`] or [`TFTapasForQuestionAnswering`] for inference (i.e. making predictions on new data). For inference, only `input_ids`, `attention_mask` and `token_type_ids` (which you can obtain using [`TapasTokenizer`]) have to be provided to the model to obtain the logits. Next, you can use the handy [`~models.tapas.tokenization_tapas.convert_logits_to_predictions`] method to convert these into predicted coordinates and optional aggregation indices.
+
+Here we explain how you can use [`TapasForQuestionAnswering`] for inference (i.e. making predictions on new data). For inference, only `input_ids`, `attention_mask` and `token_type_ids` (which you can obtain using [`TapasTokenizer`]) have to be provided to the model to obtain the logits. Next, you can use the handy [`~models.tapas.tokenization_tapas.convert_logits_to_predictions`] method to convert these into predicted coordinates and optional aggregation indices.
 
 However, note that inference is **different** depending on whether or not the setup is conversational. In a non-conversational set-up, inference can be done in parallel on all table-question pairs of a batch. Here's an example of that:
 
@@ -516,68 +332,9 @@ Predicted answer: COUNT > 69
 What is the total number of movies?
 Predicted answer: SUM > 87, 53, 69
 ```
-</pt>
-<tf>
-Here we explain how you can use [`TFTapasForQuestionAnswering`] for inference (i.e. making predictions on new data). For inference, only `input_ids`, `attention_mask` and `token_type_ids` (which you can obtain using [`TapasTokenizer`]) have to be provided to the model to obtain the logits. Next, you can use the handy [`~models.tapas.tokenization_tapas.convert_logits_to_predictions`] method to convert these into predicted coordinates and optional aggregation indices.
 
-However, note that inference is **different** depending on whether or not the setup is conversational. In a non-conversational set-up, inference can be done in parallel on all table-question pairs of a batch. Here's an example of that:
 
-```py
->>> from transformers import TapasTokenizer, TFTapasForQuestionAnswering
->>> import pandas as pd
-
->>> model_name = "google/tapas-base-finetuned-wtq"
->>> model = TFTapasForQuestionAnswering.from_pretrained(model_name)
->>> tokenizer = TapasTokenizer.from_pretrained(model_name)
-
->>> data = {"Actors": ["Brad Pitt", "Leonardo Di Caprio", "George Clooney"], "Number of movies": ["87", "53", "69"]}
->>> queries = [
-...     "What is the name of the first actor?",
-...     "How many movies has George Clooney played in?",
-...     "What is the total number of movies?",
-... ]
->>> table = pd.DataFrame.from_dict(data)
->>> inputs = tokenizer(table=table, queries=queries, padding="max_length", return_tensors="tf")
->>> outputs = model(**inputs)
->>> predicted_answer_coordinates, predicted_aggregation_indices = tokenizer.convert_logits_to_predictions(
-...     inputs, outputs.logits, outputs.logits_aggregation
-... )
-
->>> # let's print out the results:
->>> id2aggregation = {0: "NONE", 1: "SUM", 2: "AVERAGE", 3: "COUNT"}
->>> aggregation_predictions_string = [id2aggregation[x] for x in predicted_aggregation_indices]
-
->>> answers = []
->>> for coordinates in predicted_answer_coordinates:
-...     if len(coordinates) == 1:
-...         # only a single cell:
-...         answers.append(table.iat[coordinates[0]])
-...     else:
-...         # multiple cells
-...         cell_values = []
-...         for coordinate in coordinates:
-...             cell_values.append(table.iat[coordinate])
-...         answers.append(", ".join(cell_values))
-
->>> display(table)
->>> print("")
->>> for query, answer, predicted_agg in zip(queries, answers, aggregation_predictions_string):
-...     print(query)
-...     if predicted_agg == "NONE":
-...         print("Predicted answer: " + answer)
-...     else:
-...         print("Predicted answer: " + predicted_agg + " > " + answer)
-What is the name of the first actor?
-Predicted answer: Brad Pitt
-How many movies has George Clooney played in?
-Predicted answer: COUNT > 69
-What is the total number of movies?
-Predicted answer: SUM > 87, 53, 69
-```
-</tf>
-</frameworkcontent>
-
-In case of a conversational set-up, then each table-question pair must be provided **sequentially** to the model, such that the `prev_labels` token types can be overwritten by the predicted `labels` of the previous table-question pair. Again, more info can be found in [this notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/TAPAS/Fine_tuning_TapasForQuestionAnswering_on_SQA.ipynb) (for PyTorch) and [this notebook](https://github.com/kamalkraj/Tapas-Tutorial/blob/master/TAPAS/Fine_tuning_TapasForQuestionAnswering_on_SQA.ipynb) (for TensorFlow).
+In case of a conversational set-up, then each table-question pair must be provided **sequentially** to the model, such that the `prev_labels` token types can be overwritten by the predicted `labels` of the previous table-question pair. Again, more info can be found in [this notebook](https://github.com/NielsRogge/Transformers-Tutorials/blob/master/TAPAS/Fine_tuning_TapasForQuestionAnswering_on_SQA.ipynb).
 
 ## Resources
 
@@ -596,13 +353,10 @@ In case of a conversational set-up, then each table-question pair must be provid
     - convert_logits_to_predictions
     - save_vocabulary
 
-<frameworkcontent>
-<pt>
-
 ## TapasModel
 [[autodoc]] TapasModel
     - forward
-    
+
 ## TapasForMaskedLM
 [[autodoc]] TapasForMaskedLM
     - forward
@@ -610,31 +364,7 @@ In case of a conversational set-up, then each table-question pair must be provid
 ## TapasForSequenceClassification
 [[autodoc]] TapasForSequenceClassification
     - forward
-    
+
 ## TapasForQuestionAnswering
 [[autodoc]] TapasForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFTapasModel
-[[autodoc]] TFTapasModel
-    - call
-    
-## TFTapasForMaskedLM
-[[autodoc]] TFTapasForMaskedLM
-    - call
-
-## TFTapasForSequenceClassification
-[[autodoc]] TFTapasForSequenceClassification
-    - call
-    
-## TFTapasForQuestionAnswering
-[[autodoc]] TFTapasForQuestionAnswering
-    - call
-
-</tf>
-</frameworkcontent>
-
-

--- a/docs/source/en/model_doc/transfo-xl.md
+++ b/docs/source/en/model_doc/transfo-xl.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 <Tip warning={true}>
@@ -118,13 +117,6 @@ TransformerXL does **not** work with *torch.nn.DataParallel* due to a bug in PyT
 
 [[autodoc]] models.deprecated.transfo_xl.modeling_transfo_xl.TransfoXLLMHeadModelOutput
 
-[[autodoc]] models.deprecated.transfo_xl.modeling_tf_transfo_xl.TFTransfoXLModelOutput
-
-[[autodoc]] models.deprecated.transfo_xl.modeling_tf_transfo_xl.TFTransfoXLLMHeadModelOutput
-
-<frameworkcontent>
-<pt>
-
 ## TransfoXLModel
 
 [[autodoc]] TransfoXLModel
@@ -140,29 +132,6 @@ TransformerXL does **not** work with *torch.nn.DataParallel* due to a bug in PyT
 [[autodoc]] TransfoXLForSequenceClassification
     - forward
 
-</pt>
-<tf>
-
-## TFTransfoXLModel
-
-[[autodoc]] TFTransfoXLModel
-    - call
-
-## TFTransfoXLLMHeadModel
-
-[[autodoc]] TFTransfoXLLMHeadModel
-    - call
-
-## TFTransfoXLForSequenceClassification
-
-[[autodoc]] TFTransfoXLForSequenceClassification
-    - call
-
-</tf>
-</frameworkcontent>
-
 ## Internal Layers
 
 [[autodoc]] AdaptiveEmbedding
-
-[[autodoc]] TFAdaptiveEmbedding

--- a/docs/source/en/model_doc/vit_mae.md
+++ b/docs/source/en/model_doc/vit_mae.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
         <img alt="FlashAttention" src="https://img.shields.io/badge/%E2%9A%A1%EF%B8%8E%20FlashAttention-eae0c8?style=flat">
         <img alt="SDPA" src="https://img.shields.io/badge/SDPA-DE3412?style=flat&logo=pytorch&logoColor=white">
     </div>
@@ -30,7 +29,7 @@ rendered properly in your Markdown viewer.
 [ViTMAE](https://huggingface.co/papers/2111.06377) is a self-supervised vision model that is pretrained by masking large portions of an image (~75%). An encoder processes the visible image patches and a decoder reconstructs the missing pixels from the encoded patches and mask tokens. After pretraining, the encoder can be reused for downstream tasks like image classification or object detection — often outperforming models trained with supervised learning.
 
 <img src="https://user-images.githubusercontent.com/11435359/146857310-f258c86c-fde6-48e8-9cee-badd2b21bd2c.png"
-alt="drawing" width="600"/> 
+alt="drawing" width="600"/>
 
 You can find all the original ViTMAE checkpoints under the [AI at Meta](https://huggingface.co/facebook?search_models=vit-mae) organization.
 
@@ -79,9 +78,6 @@ reconstruction = outputs.logits
 
 [[autodoc]] ViTMAEConfig
 
-<frameworkcontent>
-<pt>
-
 ## ViTMAEModel
 
 [[autodoc]] ViTMAEModel
@@ -91,19 +87,3 @@ reconstruction = outputs.logits
 
 [[autodoc]] transformers.ViTMAEForPreTraining
     - forward
-
-</pt>
-<tf>
-
-## TFViTMAEModel
-
-[[autodoc]] TFViTMAEModel
-    - call
-
-## TFViTMAEForPreTraining
-
-[[autodoc]] transformers.TFViTMAEForPreTraining
-    - call
-
-</tf>
-</frameworkcontent>

--- a/docs/source/en/model_doc/xlm.md
+++ b/docs/source/en/model_doc/xlm.md
@@ -18,7 +18,6 @@ rendered properly in your Markdown viewer.
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
         <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-        <img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
     </div>
 </div>
 
@@ -37,15 +36,15 @@ The example below demonstrates how to predict the `<mask>` token with [`Pipeline
 <hfoption id="Pipeline">
 
 ```python
-import torch  
-from transformers import pipeline  
+import torch
+from transformers import pipeline
 
-pipeline = pipeline(  
-    task="fill-mask",  
-    model="facebook/xlm-roberta-xl",  
-    torch_dtype=torch.float16,  
-    device=0  
-)  
+pipeline = pipeline(
+    task="fill-mask",
+    model="facebook/xlm-roberta-xl",
+    torch_dtype=torch.float16,
+    device=0
+)
 pipeline("Bonjour, je suis un modèle <mask>.")
 ```
 
@@ -53,17 +52,17 @@ pipeline("Bonjour, je suis un modèle <mask>.")
 <hfoption id="AutoModel">
 
 ```python
-import torch  
-from transformers import AutoModelForMaskedLM, AutoTokenizer  
+import torch
+from transformers import AutoModelForMaskedLM, AutoTokenizer
 
-tokenizer = AutoTokenizer.from_pretrained(  
-    "FacebookAI/xlm-mlm-en-2048",  
-)  
-model = AutoModelForMaskedLM.from_pretrained(  
-    "FacebookAI/xlm-mlm-en-2048",  
-    torch_dtype=torch.float16,  
-    device_map="auto",  
-)  
+tokenizer = AutoTokenizer.from_pretrained(
+    "FacebookAI/xlm-mlm-en-2048",
+)
+model = AutoModelForMaskedLM.from_pretrained(
+    "FacebookAI/xlm-mlm-en-2048",
+    torch_dtype=torch.float16,
+    device_map="auto",
+)
 inputs = tokenizer("Hello, I'm a <mask> model.", return_tensors="pt").to("cuda")
 
 with torch.no_grad():
@@ -99,9 +98,6 @@ echo -e "Plants create <mask> through a process known as photosynthesis." | tran
 
 [[autodoc]] models.xlm.modeling_xlm.XLMForQuestionAnsweringOutput
 
-<frameworkcontent>
-<pt>
-
 ## XLMModel
 
 [[autodoc]] XLMModel
@@ -136,41 +132,3 @@ echo -e "Plants create <mask> through a process known as photosynthesis." | tran
 
 [[autodoc]] XLMForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFXLMModel
-
-[[autodoc]] TFXLMModel
-    - call
-
-## TFXLMWithLMHeadModel
-
-[[autodoc]] TFXLMWithLMHeadModel
-    - call
-
-## TFXLMForSequenceClassification
-
-[[autodoc]] TFXLMForSequenceClassification
-    - call
-
-## TFXLMForMultipleChoice
-
-[[autodoc]] TFXLMForMultipleChoice
-    - call
-
-## TFXLMForTokenClassification
-
-[[autodoc]] TFXLMForTokenClassification
-    - call
-
-## TFXLMForQuestionAnsweringSimple
-
-[[autodoc]] TFXLMForQuestionAnsweringSimple
-    - call
-
-</tf>
-</frameworkcontent>
-
-

--- a/docs/source/en/model_doc/xlnet.md
+++ b/docs/source/en/model_doc/xlnet.md
@@ -19,7 +19,6 @@ rendered properly in your Markdown viewer.
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
-<img alt="TensorFlow" src="https://img.shields.io/badge/TensorFlow-FF6F00?style=flat&logo=tensorflow&logoColor=white">
 </div>
 
 ## Overview
@@ -95,21 +94,6 @@ This model was contributed by [thomwolf](https://huggingface.co/thomwolf). The o
 
 [[autodoc]] models.xlnet.modeling_xlnet.XLNetForQuestionAnsweringOutput
 
-[[autodoc]] models.xlnet.modeling_tf_xlnet.TFXLNetModelOutput
-
-[[autodoc]] models.xlnet.modeling_tf_xlnet.TFXLNetLMHeadModelOutput
-
-[[autodoc]] models.xlnet.modeling_tf_xlnet.TFXLNetForSequenceClassificationOutput
-
-[[autodoc]] models.xlnet.modeling_tf_xlnet.TFXLNetForMultipleChoiceOutput
-
-[[autodoc]] models.xlnet.modeling_tf_xlnet.TFXLNetForTokenClassificationOutput
-
-[[autodoc]] models.xlnet.modeling_tf_xlnet.TFXLNetForQuestionAnsweringSimpleOutput
-
-<frameworkcontent>
-<pt>
-
 ## XLNetModel
 
 [[autodoc]] XLNetModel
@@ -144,39 +128,3 @@ This model was contributed by [thomwolf](https://huggingface.co/thomwolf). The o
 
 [[autodoc]] XLNetForQuestionAnswering
     - forward
-
-</pt>
-<tf>
-
-## TFXLNetModel
-
-[[autodoc]] TFXLNetModel
-    - call
-
-## TFXLNetLMHeadModel
-
-[[autodoc]] TFXLNetLMHeadModel
-    - call
-
-## TFXLNetForSequenceClassification
-
-[[autodoc]] TFXLNetForSequenceClassification
-    - call
-
-## TFXLNetForMultipleChoice
-
-[[autodoc]] TFXLNetForMultipleChoice
-    - call
-
-## TFXLNetForTokenClassification
-
-[[autodoc]] TFXLNetForTokenClassification
-    - call
-
-## TFXLNetForQuestionAnsweringSimple
-
-[[autodoc]] TFXLNetForQuestionAnsweringSimple
-    - call
-
-</tf>
-</frameworkcontent>


### PR DESCRIPTION
# What does this PR do?

In all files in `/en/model_doc` (i.e. transformers model docs):
1. finds all files with "tf" and "tensorflow" references
2. deletes all tensorflow-related references in those files
3. (minor nits were also fixed in those files along the way)

(same as #40311, but now tracking all references to `tf` and `tensorflow`)