### PR TITLE
DOCS: Clarification on the use of `label_names` as an argument to TrainingArguments

### DIFF
--- a/docs/source/en/main_classes/trainer.md
+++ b/docs/source/en/main_classes/trainer.md
@@ -29,7 +29,6 @@ when used with other models. When using it with your own model, make sure:
 - your model can compute the loss if a `labels` argument is provided and that loss is returned as the first
   element of the tuple (if your model returns tuples)
 - your model can accept multiple label arguments (use `label_names` in [`TrainingArguments`] to indicate their name to the [`Trainer`]) but none of them should be named `"label"`
-- For classification models, you should not set `label_names`; such models expect a single `labels` tensor. `label_names` is only required when your model’s `forward()` method genuinely accepts multiple label arguments (e.g., extractive QA).
 </Tip>
 
 ## Trainer[[api-reference]]

--- a/docs/source/en/main_classes/trainer.md
+++ b/docs/source/en/main_classes/trainer.md
@@ -29,7 +29,7 @@ when used with other models. When using it with your own model, make sure:
 - your model can compute the loss if a `labels` argument is provided and that loss is returned as the first
   element of the tuple (if your model returns tuples)
 - your model can accept multiple label arguments (use `label_names` in [`TrainingArguments`] to indicate their name to the [`Trainer`]) but none of them should be named `"label"`
-
+- For classification models, you should not set `label_names`; such models expect a single `labels` tensor. `label_names` is only required when your model’s `forward()` method genuinely accepts multiple label arguments (e.g., extractive QA).
 </Tip>
 
 ## Trainer[[api-reference]]

--- a/docs/source/en/main_classes/trainer.md
+++ b/docs/source/en/main_classes/trainer.md
@@ -29,6 +29,7 @@ when used with other models. When using it with your own model, make sure:
 - your model can compute the loss if a `labels` argument is provided and that loss is returned as the first
   element of the tuple (if your model returns tuples)
 - your model can accept multiple label arguments (use `label_names` in [`TrainingArguments`] to indicate their name to the [`Trainer`]) but none of them should be named `"label"`
+
 </Tip>
 
 ## Trainer[[api-reference]]

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -453,6 +453,8 @@ class TrainingArguments:
             Will eventually default to the list of argument names accepted by the model that contain the word "label",
             except if the model used is one of the `XxxForQuestionAnswering` in which case it will also include the
             `["start_positions", "end_positions"]` keys.
+
+            You should only specify `label_names` if you're using custom label names or if your model's `forward` consumes multiple label tensors (e.g., extractive QA).
         load_best_model_at_end (`bool`, *optional*, defaults to `False`):
             Whether or not to load the best model found during training at the end of training. When this option is
             enabled, the best checkpoint will always be saved. See


### PR DESCRIPTION
# What does this PR do?

This PR clarifies the documentation for the label_names argument in TrainingArguments. Currently, it may be unclear when label_names should be used. For classification tasks (binary, multi-class), labels are expected as a single tensor (labels), so label_names is not required and can cause errors if set. label_names is only relevant for tasks where models accept multiple label arguments (e.g., QA).


Fixes #40217

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (Fixes #40217)
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? (Not applicable, doc-only PR)


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@zach-huggingface @stevhliu
