### PR TITLE
[pipelines] add support to `skip_special_tokens` in the main text generation pipelines

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1754,6 +1754,9 @@ class GenerationMixin(ContinuousMixin):
                 for key, model_gen_config_value in model_generation_config.__dict__.items():
                     if key.startswith("_") or key == "transformers_version":  # metadata
                         continue
+                    # Don't set `cache_implementation = 'hybrid'` from the model defaults, see #40135
+                    if key == "cache_implementation" and model_generation_config.cache_implementation == "hybrid":
+                        continue
                     global_default_value = getattr(global_default_generation_config, key, None)
                     custom_gen_config_value = getattr(generation_config, key, None)
                     if (

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1075,9 +1075,6 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                     and self.generation_config.max_length != 20  # global default
                 ):
                     self.generation_config.max_new_tokens = None
-                # Use dynamic cache shapes by default -- See #40135
-                if self.generation_config.cache_implementation == "hybrid":
-                    self.generation_config.cache_implementation = None
             else:
                 # TODO (joao): no PT model should reach this line. However, some audio models with complex
                 # inheritance patterns do. Streamline those models such that this line is no longer needed.

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1075,6 +1075,9 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                     and self.generation_config.max_length != 20  # global default
                 ):
                     self.generation_config.max_new_tokens = None
+                # Use dynamic cache shapes by default -- See #40135
+                if self.generation_config.cache_implementation == "hybrid":
+                    self.generation_config.cache_implementation = None
             else:
                 # TODO (joao): no PT model should reach this line. However, some audio models with complex
                 # inheritance patterns do. Streamline those models such that this line is no longer needed.

--- a/src/transformers/pipelines/image_text_to_text.py
+++ b/src/transformers/pipelines/image_text_to_text.py
@@ -203,22 +203,33 @@ class ImageTextToTextPipeline(Pipeline):
         clean_up_tokenization_spaces=None,
         stop_sequence=None,
         continue_final_message=None,
+        skip_special_tokens=None,
         **kwargs: Unpack[ProcessingKwargs],
     ):
         forward_kwargs = {}
         preprocess_params = {}
         postprocess_params = {}
-        preprocess_params.update(kwargs)
 
+        # Preprocess params
+        preprocess_params.update(kwargs)
         if timeout is not None:
             preprocess_params["timeout"] = timeout
-
         if continue_final_message is not None:
             preprocess_params["continue_final_message"] = continue_final_message
 
+        # Forward kwargs
         if generate_kwargs is not None:
             forward_kwargs["generate_kwargs"] = generate_kwargs
-
+        if stop_sequence is not None:
+            stop_sequence_ids = self.processor.tokenizer.encode(stop_sequence, add_special_tokens=False)
+            if len(stop_sequence_ids) > 1:
+                logger.warning_once(
+                    "Stopping on a multiple token sequence is not yet supported on transformers. The first token of"
+                    " the stop sequence will be used as the stop sequence string in the interim."
+                )
+            generate_kwargs["eos_token_id"] = stop_sequence_ids[0]
+        if generate_kwargs is not None:
+            forward_kwargs["generate_kwargs"] = generate_kwargs
         if max_new_tokens is not None:
             if "generate_kwargs" not in forward_kwargs:
                 forward_kwargs["generate_kwargs"] = {}
@@ -229,6 +240,7 @@ class ImageTextToTextPipeline(Pipeline):
                 )
             forward_kwargs["generate_kwargs"]["max_new_tokens"] = max_new_tokens
 
+        # Postprocess params
         if return_full_text is not None and return_type is None:
             if return_tensors is not None:
                 raise ValueError("`return_full_text` is mutually exclusive with `return_tensors`")
@@ -241,14 +253,9 @@ class ImageTextToTextPipeline(Pipeline):
             postprocess_params["continue_final_message"] = continue_final_message
         if clean_up_tokenization_spaces is not None:
             postprocess_params["clean_up_tokenization_spaces"] = clean_up_tokenization_spaces
-        if stop_sequence is not None:
-            stop_sequence_ids = self.processor.tokenizer.encode(stop_sequence, add_special_tokens=False)
-            if len(stop_sequence_ids) > 1:
-                logger.warning_once(
-                    "Stopping on a multiple token sequence is not yet supported on transformers. The first token of"
-                    " the stop sequence will be used as the stop sequence string in the interim."
-                )
-            generate_kwargs["eos_token_id"] = stop_sequence_ids[0]
+        if skip_special_tokens is not None:
+            postprocess_params["skip_special_tokens"] = skip_special_tokens
+
         return preprocess_params, forward_kwargs, postprocess_params
 
     @overload
@@ -432,7 +439,12 @@ class ImageTextToTextPipeline(Pipeline):
         return {"generated_sequence": generated_sequence, "prompt_text": prompt_text, "input_ids": input_ids}
 
     def postprocess(
-        self, model_outputs, return_type=ReturnType.FULL_TEXT, continue_final_message=None, **postprocess_kwargs
+        self,
+        model_outputs,
+        return_type=ReturnType.FULL_TEXT,
+        continue_final_message=None,
+        skip_special_tokens=None,
+        **postprocess_kwargs,
     ):
         input_texts = model_outputs["prompt_text"]
         input_texts = [input_texts] if isinstance(input_texts, (str, Chat)) else input_texts
@@ -445,8 +457,13 @@ class ImageTextToTextPipeline(Pipeline):
             ]
 
         # Decode inputs and outputs the same way to remove input text from generated text if present
-        generated_texts = self.processor.post_process_image_text_to_text(generated_sequence, **postprocess_kwargs)
-        decoded_inputs = self.processor.post_process_image_text_to_text(input_ids, **postprocess_kwargs)
+        skip_special_tokens = skip_special_tokens if skip_special_tokens is not None else True
+        generated_texts = self.processor.post_process_image_text_to_text(
+            generated_sequence, skip_special_tokens=skip_special_tokens, **postprocess_kwargs
+        )
+        decoded_inputs = self.processor.post_process_image_text_to_text(
+            input_ids, skip_special_tokens=skip_special_tokens, **postprocess_kwargs
+        )
 
         # Force consistent behavior for including the input text in the output
         if return_type in {ReturnType.NEW_TEXT, ReturnType.FULL_TEXT}:

--- a/tests/pipelines/test_pipelines_text_generation.py
+++ b/tests/pipelines/test_pipelines_text_generation.py
@@ -540,3 +540,18 @@ class TextGenerationPipelineTests(unittest.TestCase):
         # It is running assisted generation under the hood (e.g. flags incompatible with assisted gen will crash)
         with self.assertRaises(ValueError):
             _ = pipe(prompt, generate_kwargs={"num_beams": 2})
+
+    @require_torch
+    def test_pipeline_skip_special_tokens(self):
+        """Tests that we can use `skip_special_tokens=False` to get the special tokens in the output"""
+        model_id = "google/gemma-3-270m-it"
+        chat = [{"role": "user", "content": "What's your name?"}]
+        generator = pipeline("text-generation", model=model_id)
+
+        # normal pipeline use
+        output = generator(chat, max_new_tokens=20, do_sample=False)
+        self.assertNotIn("<end_of_turn>", str(output[0]["generated_text"]))
+
+        # forcing special tokens to be included in the output
+        output = generator(chat, max_new_tokens=1000, do_sample=False, skip_special_tokens=False)
+        self.assertIn("<end_of_turn>", str(output[0]["generated_text"]))


### PR DESCRIPTION
# What does this PR do?

Useful for thinking models, where we sometimes want to retrieve all generated tokens (including special tokens).

Test script:
```py
from transformers import pipeline

model_id = "Qwen/Qwen3-0.6B"
chat = [{"role": "user", "content": "What's your name?\n\n"}]
generator = pipeline("text-generation", model=model_id)

# normal pipeline use
output = generator(chat, max_new_tokens=1000, do_sample=False)
print(output)
# print ends in "How can I assist you today?'}]}]"

# forcing special tokens to be included in the output
output = generator(chat, max_new_tokens=1000, do_sample=False, skip_special_tokens=False)
print(output)
# print ends in "How can I assist you today?<|im_end|>'}]}]"
```