### PR TITLE
Fix MXFP4 mlp_forward to handle 2D and 3D hidden_states shapes for multi-turn chat

### DIFF
--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -32,9 +32,7 @@ from transformers.utils import (
 
 if is_torch_available():
     from types import SimpleNamespace
-
     import torch
-
     from transformers.integrations.mxfp4 import mlp_forward
     from transformers.testing_utils import torch_device
 

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -32,7 +32,9 @@ from transformers.utils import (
 
 if is_torch_available():
     from types import SimpleNamespace
+
     import torch
+
     from transformers.integrations.mxfp4 import mlp_forward
     from transformers.testing_utils import torch_device
 

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -15,6 +15,7 @@
 import gc
 import unittest
 from unittest.mock import patch
+from types import SimpleNamespace
 
 from transformers import AutoTokenizer, GptOssForCausalLM, Mxfp4Config
 from transformers.testing_utils import (
@@ -32,7 +33,6 @@ from transformers.utils import (
 
 if is_torch_available():
     import torch
-    from types import SimpleNamespace
     from transformers.integrations.mxfp4 import mlp_forward
     from transformers.testing_utils import torch_device
 

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -14,8 +14,8 @@
 
 import gc
 import unittest
-from unittest.mock import patch
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from transformers import AutoTokenizer, GptOssForCausalLM, Mxfp4Config
 from transformers.testing_utils import (
@@ -33,6 +33,7 @@ from transformers.utils import (
 
 if is_torch_available():
     import torch
+
     from transformers.integrations.mxfp4 import mlp_forward
     from transformers.testing_utils import torch_device
 
@@ -72,7 +73,11 @@ class Mxfp4ConfigTest(unittest.TestCase):
 
     def test_from_dict(self):
         """Test configuration creation from dict"""
-        config_dict = {"quant_method": "mxfp4", "modules_to_not_convert": ["lm_head"], "dequantize": True}
+        config_dict = {
+            "quant_method": "mxfp4",
+            "modules_to_not_convert": ["lm_head"],
+            "dequantize": True,
+        }
         config = Mxfp4Config.from_dict(config_dict)
         self.assertEqual(config.modules_to_not_convert, ["lm_head"])
         self.assertTrue(config.dequantize)
@@ -88,7 +93,10 @@ class Mxfp4QuantizerTest(unittest.TestCase):
 
     def test_quantizer_validation_no_torch(self):
         """Test quantizer validation when torch is not available"""
-        with patch("transformers.quantizers.quantizer_mxfp4.is_torch_available", return_value=False):
+        with patch(
+            "transformers.quantizers.quantizer_mxfp4.is_torch_available",
+            return_value=False,
+        ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
             config = Mxfp4Config()
@@ -145,7 +153,9 @@ class Mxfp4QuantizerTest(unittest.TestCase):
                 quantizer.validate_environment()
             except ValueError as e:
                 if "compute capability" in str(e):
-                    self.fail("Should not raise compute capability error when dequantize=True")
+                    self.fail(
+                        "Should not raise compute capability error when dequantize=True"
+                    )
 
     def test_quantizer_validation_dequantize_on_cpu(self):
         """Test quantizer validation with dequantize enabled on CPU-only environment"""
@@ -160,7 +170,9 @@ class Mxfp4QuantizerTest(unittest.TestCase):
                 quantizer.validate_environment()
             except RuntimeError as e:
                 if "requires a GPU" in str(e):
-                    self.fail("Should not raise GPU requirement error when dequantize=True on CPU")
+                    self.fail(
+                        "Should not raise GPU requirement error when dequantize=True on CPU"
+                    )
 
     def test_quantizer_validation_order_dequantize_before_cuda_check(self):
         """Test that dequantize check happens before CUDA availability check"""
@@ -196,8 +208,14 @@ class Mxfp4QuantizerTest(unittest.TestCase):
     def test_quantizer_validation_missing_triton(self):
         """Test quantizer validation when triton is not available"""
         with (
-            patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=False),
-            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_available", return_value=False),
+            patch(
+                "transformers.quantizers.quantizer_mxfp4.is_triton_available",
+                return_value=False,
+            ),
+            patch(
+                "transformers.quantizers.quantizer_mxfp4.is_kernels_available",
+                return_value=False,
+            ),
         ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
@@ -210,8 +228,14 @@ class Mxfp4QuantizerTest(unittest.TestCase):
     def test_quantizer_validation_missing_triton_pre_quantized_no_dequantize(self):
         """Test quantizer validation when triton is not available but model is pre-quantized and dequantize is False"""
         with (
-            patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=False),
-            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_available", return_value=False),
+            patch(
+                "transformers.quantizers.quantizer_mxfp4.is_triton_available",
+                return_value=False,
+            ),
+            patch(
+                "transformers.quantizers.quantizer_mxfp4.is_kernels_available",
+                return_value=False,
+            ),
         ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
@@ -329,11 +353,15 @@ class Mxfp4IntegrationTest(unittest.TestCase):
 
         # Should not convert if in exclusion list
         patterns = ["model.layers.*.self_attn", "lm_head"]
-        self.assertFalse(should_convert_module(["model", "layers", "0", "self_attn"], patterns))
+        self.assertFalse(
+            should_convert_module(["model", "layers", "0", "self_attn"], patterns)
+        )
         self.assertFalse(should_convert_module(["lm_head"], patterns))
 
         # Should convert if not in exclusion list
-        self.assertTrue(should_convert_module(["model", "layers", "0", "mlp", "experts"], patterns))
+        self.assertTrue(
+            should_convert_module(["model", "layers", "0", "mlp", "experts"], patterns)
+        )
 
     @require_torch
     def test_convert_moe_packed_tensors(self):
@@ -386,7 +414,11 @@ class Mxfp4IntegrationTest(unittest.TestCase):
         mock_routing_data = SimpleNamespace()  # Dummy object
         mock_gather_idx = torch.zeros(10, dtype=torch.int32, device=torch_device)
         mock_scatter_idx = torch.zeros(10, dtype=torch.int32, device=torch_device)
-        mock_triton_hub.routing.routing.return_value = (mock_routing_data, mock_gather_idx, mock_scatter_idx)
+        mock_triton_hub.routing.routing.return_value = (
+            mock_routing_data,
+            mock_gather_idx,
+            mock_scatter_idx,
+        )
 
         # Mock the 'self' object that mlp_forward is bound to
         mock_self = SimpleNamespace()
@@ -408,7 +440,11 @@ class Mxfp4IntegrationTest(unittest.TestCase):
         output_2d, _ = mlp_forward(mock_self, hidden_states_2d)
 
         self.assertEqual(len(output_2d.shape), 2, "Output should be 2D for 2D input")
-        self.assertEqual(hidden_states_2d.shape, output_2d.shape, "Shape should be preserved for 2D input")
+        self.assertEqual(
+            hidden_states_2d.shape,
+            output_2d.shape,
+            "Shape should be preserved for 2D input",
+        )
 
         # 3. Test with 3D input
         hidden_states_3d = torch.randn(2, 5, hidden_dim, device=torch_device)
@@ -423,7 +459,11 @@ class Mxfp4IntegrationTest(unittest.TestCase):
         output_3d, _ = mlp_forward(mock_self, hidden_states_3d)
 
         self.assertEqual(len(output_3d.shape), 3, "Output should be 3D for 3D input")
-        self.assertEqual(hidden_states_3d.shape, output_3d.shape, "Shape should be preserved for 3D input")
+        self.assertEqual(
+            hidden_states_3d.shape,
+            output_3d.shape,
+            "Shape should be preserved for 3D input",
+        )
 
 
 @require_torch

--- a/tests/quantization/mxfp4/test_mxfp4.py
+++ b/tests/quantization/mxfp4/test_mxfp4.py
@@ -32,6 +32,9 @@ from transformers.utils import (
 
 if is_torch_available():
     import torch
+    from types import SimpleNamespace
+    from transformers.integrations.mxfp4 import mlp_forward
+    from transformers.testing_utils import torch_device
 
 
 class Mxfp4ConfigTest(unittest.TestCase):
@@ -194,7 +197,7 @@ class Mxfp4QuantizerTest(unittest.TestCase):
         """Test quantizer validation when triton is not available"""
         with (
             patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=False),
-            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_availalble", return_value=False),
+            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_available", return_value=False),
         ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
@@ -208,7 +211,7 @@ class Mxfp4QuantizerTest(unittest.TestCase):
         """Test quantizer validation when triton is not available but model is pre-quantized and dequantize is False"""
         with (
             patch("transformers.quantizers.quantizer_mxfp4.is_triton_available", return_value=False),
-            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_availalble", return_value=False),
+            patch("transformers.quantizers.quantizer_mxfp4.is_kernels_available", return_value=False),
         ):
             from transformers.quantizers.quantizer_mxfp4 import Mxfp4HfQuantizer
 
@@ -364,6 +367,63 @@ class Mxfp4IntegrationTest(unittest.TestCase):
         self.assertEqual(quantized_w.dtype, torch.uint8)
         self.assertIsNotNone(flex_data)
         self.assertIsNotNone(mx_ctx)
+
+    @require_torch
+    @patch("torch.cuda.device")
+    @patch("transformers.integrations.mxfp4.triton_kernels_hub", create=True)
+    def test_mlp_forward_dimensionality(self, mock_triton_hub, mock_cuda_device):
+        """
+        Tests that the `mlp_forward` function correctly handles 2D and 3D tensors,
+        preserving the input dimensionality in the output. This is a regression
+        test for an issue seen in multi-turn chat scenarios.
+        """
+        # 1. Setup
+        hidden_dim = 32
+        num_experts = 4
+        top_k = 1
+
+        # Mock the routing function from the triton kernel
+        mock_routing_data = SimpleNamespace()  # Dummy object
+        mock_gather_idx = torch.zeros(10, dtype=torch.int32, device=torch_device)
+        mock_scatter_idx = torch.zeros(10, dtype=torch.int32, device=torch_device)
+        mock_triton_hub.routing.routing.return_value = (mock_routing_data, mock_gather_idx, mock_scatter_idx)
+
+        # Mock the 'self' object that mlp_forward is bound to
+        mock_self = SimpleNamespace()
+        mock_self.router = SimpleNamespace(
+            hidden_dim=hidden_dim,
+            weight=torch.randn((num_experts * top_k, hidden_dim), device=torch_device),
+            bias=torch.randn(num_experts * top_k, device=torch_device),
+            top_k=top_k,
+        )
+
+        # The experts function should return a tensor of the same shape as its input
+        def mock_experts_forward(hidden_states, *args, **kwargs):
+            return hidden_states
+
+        mock_self.experts = mock_experts_forward
+
+        # 2. Test with 2D input
+        hidden_states_2d = torch.randn(10, hidden_dim, device=torch_device)
+        output_2d, _ = mlp_forward(mock_self, hidden_states_2d)
+
+        self.assertEqual(len(output_2d.shape), 2, "Output should be 2D for 2D input")
+        self.assertEqual(hidden_states_2d.shape, output_2d.shape, "Shape should be preserved for 2D input")
+
+        # 3. Test with 3D input
+        hidden_states_3d = torch.randn(2, 5, hidden_dim, device=torch_device)
+        # The mock routing indices need to match the flattened input size
+        num_tokens = hidden_states_3d.shape[0] * hidden_states_3d.shape[1]
+        mock_triton_hub.routing.routing.return_value = (
+            mock_routing_data,
+            torch.zeros(num_tokens, dtype=torch.int32, device=torch_device),
+            torch.zeros(num_tokens, dtype=torch.int32, device=torch_device),
+        )
+
+        output_3d, _ = mlp_forward(mock_self, hidden_states_3d)
+
+        self.assertEqual(len(output_3d.shape), 3, "Output should be 3D for 3D input")
+        self.assertEqual(hidden_states_3d.shape, output_3d.shape, "Shape should be preserved for 3D input")
 
 
 @require_torch


### PR DESCRIPTION
Fixes #40202

This pull request fixes the AssertionError: assert num_stages >= 1 error that happens during multi-turn chat generation in GPT-OSS models using MXFP4 quantization. The issue arises because the input tensor shape to the MXFP4 Triton kernel is different between the first chat turn, which uses a 3D tensor with the full sequence, and later turns, which use a 2D tensor or a single token due to key-value caching. This discrepancy causes the Triton kernel’s internal autotuning to choose invalid optimization flags, leading to a crash.

The solution changes the mlp_forward function in mxfp4.py to clearly check if the hidden_states tensor is 3D or 2D. If it is 3D, the tensor is reshaped to 2D before routing and expert dispatch, and then it is reshaped back to 3D afterward. If it is already 2D, it is passed through unchanged. This guarantees that consistent and valid tensor shapes are sent to the Triton kernel for all generation turns.

Note- This PR solves the root cause and by this way can support all GPU's for multi-turn

--------------------------------------------------------------------------------------------------------------------------------------------

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Models:
- text models: @ArthurZucker

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker
- chat templates: @Rocketknight1

Maintained examples (not research project or legacy):

- PyTorch: See Models above and tag the person corresponding to the modality of the example.

 