### PR TITLE
Add fromjson filter to Jinja2 chat templates

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -450,6 +450,17 @@ def _compile_jinja_template(chat_template):
         # We also expose some options like custom indents and separators
         return json.dumps(x, ensure_ascii=ensure_ascii, indent=indent, separators=separators, sort_keys=sort_keys)
 
+    def fromjson(x):
+        # Parse a JSON string into a Python object
+        # This is useful for parsing tool call arguments from JSON strings
+        if isinstance(x, str):
+            try:
+                return json.loads(x)
+            except (json.JSONDecodeError, TypeError):
+                # If parsing fails, return the original string
+                return x
+        return x
+
     def strftime_now(format):
         return datetime.now().strftime(format)
 
@@ -457,6 +468,7 @@ def _compile_jinja_template(chat_template):
         trim_blocks=True, lstrip_blocks=True, extensions=[AssistantTracker, jinja2.ext.loopcontrols]
     )
     jinja_env.filters["tojson"] = tojson
+    jinja_env.filters["fromjson"] = fromjson
     jinja_env.globals["raise_exception"] = raise_exception
     jinja_env.globals["strftime_now"] = strftime_now
     return jinja_env.from_string(chat_template)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -1303,6 +1303,48 @@ class TokenizerTesterMixin:
                 self.assertEqual(len(strftime_output), 10)
                 self.assertEqual(len(strftime_output.split("-")), 3)
 
+    @require_jinja
+    def test_jinja_fromjson(self):
+        # Test fromjson filter for parsing JSON strings in chat templates
+        fromjson_template = (
+            """{% set args = '{"name": "test_func", "value": 42}' | fromjson %}{{ args.name }}: {{ args.value }}"""
+        )
+
+        # Test with tool calls that have JSON string arguments
+        tool_call_template = """{% for message in messages %}{% if message.tool_calls %}{% for tc in message.tool_calls %}{% set args = tc.function.arguments | fromjson %}Function: {{ tc.function.name }}, Args: {% for k, v in args.items() %}{{ k }}={{ v }}{% if not loop.last %}, {% endif %}{% endfor %}{% endfor %}{% endif %}{% endfor %}"""
+
+        dummy_conversation = [{"role": "user", "content": "test"}]
+
+        tool_conversation = [
+            {
+                "role": "assistant",
+                "content": "I'll help with that.",
+                "tool_calls": [{"function": {"name": "search", "arguments": '{"query": "hello world", "limit": 10}'}}],
+            }
+        ]
+
+        tokenizers = self.get_tokenizers()
+        for tokenizer in tokenizers:
+            with self.subTest(f"{tokenizer.__class__.__name__}"):
+                # Test basic fromjson usage
+                fromjson_output = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template=fromjson_template, tokenize=False
+                )
+                self.assertEqual(fromjson_output, "test_func: 42")
+
+                # Test fromjson with tool calls
+                tool_output = tokenizer.apply_chat_template(
+                    tool_conversation, chat_template=tool_call_template, tokenize=False
+                )
+                self.assertEqual(tool_output, "Function: search, Args: query=hello world, limit=10")
+
+                # Test that fromjson handles non-string inputs gracefully
+                graceful_template = """{{ 123 | fromjson }}"""
+                graceful_output = tokenizer.apply_chat_template(
+                    dummy_conversation, chat_template=graceful_template, tokenize=False
+                )
+                self.assertEqual(graceful_output, "123")
+
     @require_torch
     @require_jinja
     def test_chat_template_return_assistant_tokens_mask(self):


### PR DESCRIPTION
- Added fromjson filter to parse JSON strings in chat templates
- Enables deserializing tool_calls.function.arguments from JSON strings to dictionaries
- Allows iterating over argument key-value pairs in templates
- Added comprehensive tests for the new filter functionality
- Handles graceful fallback when JSON parsing fails

This feature is particularly useful for models like GLM-4.5 that need to parse JSON-formatted argument strings in tool calls within chat templates.

Fixes #40366

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
