### PR TITLE
fix: fix keras compat with TF_USE_LEGACY_KERAS in tensorflow <2.15

### DIFF
--- a/src/transformers/modeling_tf_utils.py
+++ b/src/transformers/modeling_tf_utils.py
@@ -80,17 +80,18 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 
-if "TF_USE_LEGACY_KERAS" not in os.environ:
-    os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
-elif os.environ["TF_USE_LEGACY_KERAS"] != "1":
-    logger.warning(
-        "Transformers is only compatible with Keras 2, but you have explicitly set `TF_USE_LEGACY_KERAS` to `0`. "
-        "This may result in unexpected behaviour or errors if Keras 3 objects are passed to Transformers models."
-    )
-
 try:
     import tf_keras as keras
     from tf_keras import backend as K
+
+    if "TF_USE_LEGACY_KERAS" not in os.environ:
+        os.environ["TF_USE_LEGACY_KERAS"] = "1"  # Compatibility fix to make sure tf.keras stays at Keras 2
+    elif os.environ.get("TF_USE_LEGACY_KERAS", None) not in ("true", "True", "1"):
+        logger.warning(
+            "Transformers is only compatible with Keras 2, but you have explicitly unset `TF_USE_LEGACY_KERAS`. "
+            "This may result in unexpected behaviour or errors if Keras 3 objects are passed to Transformers models."
+        )
+
 except (ModuleNotFoundError, ImportError):
     import keras
     from keras import backend as K


### PR DESCRIPTION
# What does this PR do?

Tensorflow 2.16 made keras 3 the default https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1

Since huggingface does not support keras 3 yet, this compat logic was introduced in https://github.com/huggingface/transformers/commit/df1542581ee89107eea0569ee044fa8797b66ab0

However, in tensorflow 2.15, keras is still keras 2, meaning we don't need `tf-keras` at this point. However, since this `TF_USE_LEGACY_KERAS` is set unconditionally (even in 2.15):

1. import of this file sets TF_USE_LEGACY_KERAS -> 1
2. import tensorflow attempts to `import tf_keras`
3. we dont have that package because we dont need it
4. import fails and process bails

This change slightly modifies the environment modification to only happen if tf_keras is available. If it is available, we ensure tensorflow also uses it internally. If its not available, we go into the `except` block and use raw `keras`

## Repro
With tensorflow 2.15 installed

```python
from transformers.models.distilbert import TFDistilBertMainLayer # causes TF_USE_LEGACY_KERAS to be set
import tensorflow as tf                
tf.keras.models.load_model # simply getting this will cause error
WARNING:tensorflow:Your environment has TF_USE_LEGACY_KERAS set to True, but you do not have the tf_keras package installed. You must install it in order to use the legacy tf.keras. Install it via: `pip install tf_keras`
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/...lib/python3.11/site-packages/tensorflow/python/util/lazy_loader.py", line 146, in __getattr__
    self._initialize()
  File "/home/.../lib/python3.11/site-packages/tensorflow/python/util/lazy_loader.py", line 138, in _initialize
    raise ImportError(  # pylint: disable=raise-missing-from
ImportError: Keras cannot be imported. Check that it is installed.
```

after this change

```python
from transformers.models.distilbert import TFDistilBertMainLayer
import tensorflow as tf                
tf.keras.models.load_model # happy
```


Note: there is no current associated issue but i can make one if necessary

## Who can review?

@Rocketknight1 based on linked commit

