### PR TITLE
Fix image_grid_thw to be in CPU

### DIFF
--- a/src/transformers/models/glm4v/image_processing_glm4v_fast.py
+++ b/src/transformers/models/glm4v/image_processing_glm4v_fast.py
@@ -187,7 +187,7 @@ class Glm4vImageProcessorFast(BaseImageProcessorFast):
             processed_grids.append([grid_t, grid_h, grid_w])
 
         pixel_values = torch.stack(processed_images, dim=0)
-        image_grid_thw = torch.tensor(processed_grids)
+        image_grid_thw = torch.tensor(processed_grids, device="cpu")
 
         return BatchFeature(
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
@@ -276,7 +276,7 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)
         pixel_values = torch.cat(processed_images, dim=0)
-        image_grid_thw = torch.tensor(processed_grids)
+        image_grid_thw = torch.tensor(processed_grids, device="cpu")
 
         return BatchFeature(
             data={"pixel_values": pixel_values, "image_grid_thw": image_grid_thw}, tensor_type=return_tensors


### PR DESCRIPTION
# What does this PR do?

In vLLm inference and SFT training, there are lots of blocking operations of image_grid_thw such as `torch.prod` and `torch.tolist`, so let's always fix image_grid_thw to CPU to avoid them.
A simple grep gives the following examples:
```
src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py:        split_sizes = (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
src/transformers/models/qwen2_vl/modeling_qwen2_vl.py:        split_sizes = (image_grid_thw.prod(-1) // self.visual.spatial_merge_size**2).tolist()
src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py:                    samples = torch.split(image_grid_thw, list(image_nums))
src/transformers/models/qwen2_vl/modeling_qwen2_vl.py:                    samples = torch.split(image_grid_thw, list(image_nums))
src/transformers/models/glm4v/modeling_glm4v.py:                    samples = torch.split(image_grid_thw, list(image_nums))
```
