### PR TITLE
Set `_can_compile_fullgraph=False` for `HunYuanMoEV1`

### DIFF
--- a/src/transformers/models/hunyuan_v1_moe/modeling_hunyuan_v1_moe.py
+++ b/src/transformers/models/hunyuan_v1_moe/modeling_hunyuan_v1_moe.py
@@ -362,6 +362,8 @@ class HunYuanMoEV1PreTrainedModel(PreTrainedModel):
         "attentions": HunYuanMoEV1Attention,
     }
 
+    _can_compile_fullgraph = False  # MoE models don't work with torch.compile (`torch.where(condition)` not supported)
+
     def _init_weights(self, module):
         std = self.config.initializer_range
         if isinstance(module, nn.Linear):

--- a/src/transformers/models/hunyuan_v1_moe/modeling_hunyuan_v1_moe.py
+++ b/src/transformers/models/hunyuan_v1_moe/modeling_hunyuan_v1_moe.py
@@ -356,7 +356,6 @@ class HunYuanMoEV1PreTrainedModel(PreTrainedModel):
     _supports_sdpa = True
     _supports_flex_attn = True
 
-    _can_compile_fullgraph = True
     _supports_attention_backend = True
     _can_record_outputs = {
         "hidden_states": HunYuanMoEV1DecoderLayer,

--- a/src/transformers/models/hunyuan_v1_moe/modular_hunyuan_v1_moe.py
+++ b/src/transformers/models/hunyuan_v1_moe/modular_hunyuan_v1_moe.py
@@ -197,6 +197,8 @@ class HunYuanMoEV1DecoderLayer(LlamaDecoderLayer):
 
 
 class HunYuanMoEV1PreTrainedModel(LlamaPreTrainedModel):
+    _can_compile_fullgraph = False  # MoE models don't work with torch.compile (`torch.where(condition)` not supported)
+
     def _init_weights(self, module):
         std = self.config.initializer_range
         if isinstance(module, nn.Linear):


### PR DESCRIPTION
# What does this PR do?

The test `test_generate_compile_model_forward_fullgraph` for this model fails, see [here](https://app.circleci.com/pipelines/github/huggingface/transformers/143418/workflows/c4499a68-ac31-40f7-91a8-65d81c7b9e4e/jobs/1896331/parallel-runs/7)

with 

```bash
FAILED tests/models/hunyuan_v1_moe/test_modeling_hunyuan_v1_moe.py::HunYuanMoEV1ModelTest::test_generate_compile_model_forward_fullgraph - torch._dynamo.exc.Unsupported: Dynamic shape operator
  Explanation: Operator `aten.nonzero.default`'s output shape depends on input Tensor data.
  Hint: Enable tracing of dynamic shape operators with `torch._dynamo.config.capture_dynamic_output_shape_ops = True`

...

  File "/usr/local/lib/python3.9/site-packages/transformers/models/hunyuan_v1_moe/modeling_hunyuan_v1_moe.py", line 285, in forward
    expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
```

This line also appear in a few Moe models, and we have

```bash
tests/models/mixtral/test_modeling_mixtral.py::MistralModelTest::test_generate_compile_model_forward_fullgraph SKIPPED (This model doesn't support compilation without graph breaks)

tests/models/qwen2_moe/test_modeling_qwen2_moe.py::Qwen2MoeModelTest::test_generate_compile_model_forward_fullgraph SKIPPED (This model doesn't support compilation without graph breaks)
```

So this PR does the same things as done for the above 2 models: Set `_can_compile_fullgraph=False` for `HunYuanMoEV1`

