### PR TITLE
Fix check_quantized_param method when param_value is a safetensors slice

### DIFF
--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -179,7 +179,9 @@ class Bnb8BitHfQuantizer(HfQuantizer):
             if self.pre_quantized:
                 if param_name.replace("weight", "SCB") not in state_dict:
                     raise ValueError("Missing quantization component `SCB`")
-                if param_value.dtype != torch.int8:
+                if (hasattr(param_value, "dtype") and param_value.dtype != torch.int8) or (
+                    hasattr(param_value, "get_dtype") and param_value.get_dtype() != "I8"
+                ):
                     raise ValueError(
                         f"Incompatible dtype `{param_value.dtype}` when loading 8-bit prequantized weight. Expected `torch.int8`."
                     )

--- a/src/transformers/quantizers/quantizer_eetq.py
+++ b/src/transformers/quantizers/quantizer_eetq.py
@@ -120,7 +120,10 @@ class EetqHfQuantizer(HfQuantizer):
 
         if isinstance(module, EetqLinear):
             if self.pre_quantized or tensor_name == "bias":
-                if tensor_name == "weight" and param_value.dtype != torch.int8:
+                if tensor_name == "weight" and (
+                    (hasattr(param_value, "dtype") and param_value.dtype != torch.int8)
+                    or (hasattr(param_value, "get_dtype") and param_value.get_dtype() != "I8")
+                ):
                     raise ValueError("Expect quantized weights but got an unquantized weight")
                 return False
             else:

--- a/src/transformers/quantizers/quantizer_fbgemm_fp8.py
+++ b/src/transformers/quantizers/quantizer_fbgemm_fp8.py
@@ -119,7 +119,10 @@ class FbgemmFp8HfQuantizer(HfQuantizer):
 
         if isinstance(module, FbgemmFp8Linear):
             if self.pre_quantized or tensor_name == "bias":
-                if tensor_name == "weight" and param_value.dtype != torch.float8_e4m3fn:
+                if tensor_name == "weight" and (
+                    (hasattr(param_value, "dtype") and param_value.dtype != torch.float8_e4m3fn)
+                    or (hasattr(param_value, "get_dtype") and param_value.get_dtype != "F8_E4M3")
+                ):
                     raise ValueError("Expect quantized weights but got an unquantized weight")
                 return False
             else:

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -148,7 +148,10 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
 
         if isinstance(module, FP8Linear):
             if self.pre_quantized or tensor_name == "bias":
-                if tensor_name == "weight" and param_value.dtype != torch.float8_e4m3fn:
+                if tensor_name == "weight" and (
+                    (hasattr(param_value, "dtype") and param_value.dtype != torch.float8_e4m3fn)
+                    or (hasattr(param_value, "get_dtype") and param_value.get_dtype() != "F8_E4M3")
+                ):
                     raise ValueError("Expect quantized weights but got an unquantized weight")
                 return False
             else:

--- a/src/transformers/quantizers/quantizer_higgs.py
+++ b/src/transformers/quantizers/quantizer_higgs.py
@@ -195,7 +195,14 @@ class HiggsHfQuantizer(HfQuantizer):
         from ..integrations import HiggsLinear
 
         module, tensor_name = get_module_from_name(model, param_name)
-        if isinstance(module, HiggsLinear) and tensor_name == "weight" and param_value.dtype != torch.int16:
+        if (
+            isinstance(module, HiggsLinear)
+            and tensor_name == "weight"
+            and (
+                (hasattr(param_value, "dtype") and param_value.dtype != torch.int16)
+                or (hasattr(param_value, "get_dtype") and param_value.get_dtype() != "I16")
+            )
+        ):
             # Only quantize weights of HiggsLinear modules that are not already quantized
             return True
         else:

--- a/tests/quantization/eetq_integration/test_eetq.py
+++ b/tests/quantization/eetq_integration/test_eetq.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import os
 import tempfile
 import unittest
 
@@ -34,6 +35,14 @@ if is_torch_available():
 
 if is_accelerate_available():
     from accelerate import init_empty_weights
+
+try:
+    from safetensors import safe_open
+    from safetensors.torch import save_file as save_file_pt
+
+    _safetensors_available = True
+except ImportError:
+    _safetensors_available = False
 
 
 @require_torch_gpu
@@ -169,3 +178,110 @@ class EetqTest(unittest.TestCase):
 
         output = quantized_model.generate(**input_ids, max_new_tokens=self.max_new_tokens)
         self.assertEqual(self.tokenizer.decode(output[0], skip_special_tokens=True), self.EXPECTED_OUTPUT)
+
+    def test_check_quantized_param_as_tensor(self):
+        r"""
+        Test the `check_quantized_param` method with torch.Tensor objects.
+        This verifies that the method correctly handles regular torch tensors with dtype attribute.
+        """
+        from unittest.mock import Mock
+
+        from eetq import EetqLinear
+
+        from transformers.quantizers.quantizer_eetq import EetqHfQuantizer
+
+        # Create quantizer directly
+        config = EetqConfig()
+        quantizer = EetqHfQuantizer(config)
+        quantizer.pre_quantized = True
+
+        # Create a mock model with a mock module that has EetqLinear
+        mock_model = Mock()
+        mock_module = Mock(spec=EetqLinear)
+
+        # Mock the get_module_from_name function
+        def mock_get_module_from_name(model, param_name):
+            return mock_module, "weight"
+
+        # Patch the function
+        import transformers.quantizers.quantizer_eetq as quantizer_module
+
+        original_get_module_from_name = quantizer_module.get_module_from_name
+        quantizer_module.get_module_from_name = mock_get_module_from_name
+
+        try:
+            param_name = "test.weight"
+            state_dict = {}
+
+            # Test with correct int8 tensor (should return False for pre-quantized)
+            int8_tensor = torch.randint(-128, 127, (10, 5), dtype=torch.int8)
+            result = quantizer.check_quantized_param(mock_model, int8_tensor, param_name, state_dict)
+            self.assertFalse(result)  # Pre-quantized weights return False
+
+        finally:
+            # Restore original function
+            quantizer_module.get_module_from_name = original_get_module_from_name
+
+    @unittest.skipIf(not _safetensors_available, "safetensors not available")
+    def test_check_quantized_param_as_slice(self):
+        r"""
+        Test the `check_quantized_param` method with PySafeSlice objects.
+        This verifies that the method correctly handles safetensors slices with get_dtype() method.
+        """
+        from unittest.mock import Mock
+
+        from eetq import EetqLinear
+
+        from transformers.quantizers.quantizer_eetq import EetqHfQuantizer
+
+        # Create quantizer directly
+        config = EetqConfig()
+        quantizer = EetqHfQuantizer(config)
+        quantizer.pre_quantized = True
+
+        # Create a mock model with a mock module that has EetqLinear
+        mock_model = Mock()
+        mock_module = Mock(spec=EetqLinear)
+
+        # Mock the get_module_from_name function
+        def mock_get_module_from_name(model, param_name):
+            return mock_module, "weight"
+
+        # Patch the function
+        import transformers.quantizers.quantizer_eetq as quantizer_module
+
+        original_get_module_from_name = quantizer_module.get_module_from_name
+        quantizer_module.get_module_from_name = mock_get_module_from_name
+
+        try:
+            param_name = "test.weight"
+            state_dict = {}
+
+            # Create a safetensors file with int8 data
+            A = torch.randint(-128, 127, (10, 5), dtype=torch.int8)
+            tensors = {"test_tensor": A}
+            safetensors_path = "./slice.safetensors"
+
+            try:
+                save_file_pt(tensors, safetensors_path)
+
+                # Load and test with safetensors slice (should return False for pre-quantized)
+                with safe_open(safetensors_path, framework="pt", device="cpu") as f:
+                    slice_ = f.get_slice("test_tensor")
+
+                    # Verify the slice has get_dtype method and returns "I8" for int8
+                    self.assertTrue(hasattr(slice_, "get_dtype"))
+                    self.assertEqual(slice_.get_dtype(), "I8")
+
+                    # Test the check_quantized_param method with the slice
+                    result = quantizer.check_quantized_param(mock_model, slice_, param_name, state_dict)
+                    self.assertFalse(result)  # Pre-quantized weights return False
+
+            finally:
+                # Clean up safetensors file
+                if os.path.exists(safetensors_path):
+                    os.remove(safetensors_path)
+
+        finally:
+            # Restore original function
+            quantizer_module.get_module_from_name = original_get_module_from_name

--- a/tests/quantization/fbgemm_fp8/test_fbgemm_fp8.py
+++ b/tests/quantization/fbgemm_fp8/test_fbgemm_fp8.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import gc
+import os
 import tempfile
 import unittest
 
@@ -35,6 +36,14 @@ if is_torch_available():
 
 if is_accelerate_available():
     from accelerate import init_empty_weights
+
+try:
+    from safetensors import safe_open
+    from safetensors.torch import save_file as save_file_pt
+
+    _safetensors_available = True
+except ImportError:
+    _safetensors_available = False
 
 
 @require_torch_gpu
@@ -299,3 +308,108 @@ class FbgemmFp8LinearTest(unittest.TestCase):
 
         x_ = linear(x)
         self.assertEqual(x_.shape, (17, 23, 2048))
+
+    def test_check_quantized_param_as_tensor(self):
+        r"""
+        Test the `check_quantized_param` method with torch.Tensor objects.
+        This verifies that the method correctly handles regular torch tensors with dtype attribute.
+        """
+        from unittest.mock import Mock
+
+        from transformers.integrations.fbgemm_fp8 import FbgemmFp8Linear
+        from transformers.quantizers.quantizer_fbgemm_fp8 import FbgemmFp8HfQuantizer
+
+        # Create quantizer directly
+        config = FbgemmFp8Config()
+        quantizer = FbgemmFp8HfQuantizer(config)
+        quantizer.pre_quantized = True
+
+        # Create a mock model with a mock module that has FbgemmFp8Linear
+        mock_model = Mock()
+        mock_module = Mock(spec=FbgemmFp8Linear)
+
+        # Mock the get_module_from_name function
+        def mock_get_module_from_name(model, param_name):
+            return mock_module, "weight"
+
+        # Patch the function
+        import transformers.quantizers.quantizer_fbgemm_fp8 as quantizer_module
+
+        original_get_module_from_name = quantizer_module.get_module_from_name
+        quantizer_module.get_module_from_name = mock_get_module_from_name
+
+        try:
+            param_name = "test.weight"
+            state_dict = {}
+
+            # Test with correct fp8 tensor (should return False for pre-quantized)
+            fp8_tensor = torch.randn(10, 5).to(torch.float8_e4m3fn)
+            result = quantizer.check_quantized_param(mock_model, fp8_tensor, param_name, state_dict)
+            self.assertFalse(result)  # Pre-quantized weights return False
+
+        finally:
+            # Restore original function
+            quantizer_module.get_module_from_name = original_get_module_from_name
+
+    @unittest.skipIf(not _safetensors_available, "safetensors not available")
+    def test_check_quantized_param_as_slice(self):
+        r"""
+        Test the `check_quantized_param` method with PySafeSlice objects.
+        This verifies that the method correctly handles safetensors slices with get_dtype() method.
+        """
+        from unittest.mock import Mock
+
+        from transformers.integrations.fbgemm_fp8 import FbgemmFp8Linear
+        from transformers.quantizers.quantizer_fbgemm_fp8 import FbgemmFp8HfQuantizer
+
+        # Create quantizer directly
+        config = FbgemmFp8Config()
+        quantizer = FbgemmFp8HfQuantizer(config)
+        quantizer.pre_quantized = True
+
+        # Create a mock model with a mock module that has FbgemmFp8Linear
+        mock_model = Mock()
+        mock_module = Mock(spec=FbgemmFp8Linear)
+
+        # Mock the get_module_from_name function
+        def mock_get_module_from_name(model, param_name):
+            return mock_module, "weight"
+
+        # Patch the function
+        import transformers.quantizers.quantizer_fbgemm_fp8 as quantizer_module
+
+        original_get_module_from_name = quantizer_module.get_module_from_name
+        quantizer_module.get_module_from_name = mock_get_module_from_name
+
+        try:
+            param_name = "test.weight"
+            state_dict = {}
+
+            # Create a safetensors file with fp8 data
+            A = torch.randn(10, 5).to(torch.float8_e4m3fn)
+            tensors = {"test_tensor": A}
+            safetensors_path = "./slice.safetensors"
+
+            try:
+                save_file_pt(tensors, safetensors_path)
+
+                # Load and test with safetensors slice (should return False for pre-quantized)
+                with safe_open(safetensors_path, framework="pt", device="cpu") as f:
+                    slice_ = f.get_slice("test_tensor")
+
+                    # Verify the slice has get_dtype method and returns "F8_E4M3" for fp8
+                    self.assertTrue(hasattr(slice_, "get_dtype"))
+                    self.assertEqual(slice_.get_dtype(), "F8_E4M3")
+
+                    # Test the check_quantized_param method with the slice
+                    result = quantizer.check_quantized_param(mock_model, slice_, param_name, state_dict)
+                    self.assertFalse(result)  # Pre-quantized weights return False
+
+            finally:
+                # Clean up safetensors file
+                if os.path.exists(safetensors_path):
+                    os.remove(safetensors_path)
+
+        finally:
+            # Restore original function
+            quantizer_module.get_module_from_name = original_get_module_from_name


### PR DESCRIPTION
# What does this PR do?
Fixes a case where when loading a quantized model from safetensors with tensor parallelism enabled (`device_mesh!=None`) , `check_quantized_param(...)` method was failing as it was expecting a torch.Tensor as input for `param_value` and it was supplied with a `slice`.
More details: #40361 

Fixes #40361 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. - #40361 
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@SunMarc @S1ro1 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
