### PR TITLE
flash_paged: s_aux may not exist

### DIFF
--- a/src/transformers/integrations/flash_paged.py
+++ b/src/transformers/integrations/flash_paged.py
@@ -53,7 +53,7 @@ def paged_attention_forward(
     sliding_window = (-1, -1) if not getattr(module, "sliding_window", False) else (module.sliding_window, 0)
     if implementation is not None:
         flash_attn_varlen_func = implementation.flash_attn_varlen_func
-    custom_kwargs = {"s_aux": kwargs.get("s_aux")}
+    custom_kwargs = {"s_aux": kwargs.get("s_aux")} if "s_aux" in kwargs else {}
     attn_output = flash_attn_varlen_func(
         q.transpose(1, 2).squeeze(0).contiguous(),
         k.transpose(1, 2).squeeze(0).contiguous(),


### PR DESCRIPTION
Some implementations (i.e.,
https://huggingface.co/kernels-community/vllm-flash-attn3) support an `s_aux` arg for attention sinks, but others
(https://huggingface.co/kernels-community/flash-attn) do not. If s_aux is present in the kwargs, we forward it, otherwise we don't.

The user will still get an error if they use a model like gpt-oss-20b with an implementation that does not support `s_aux`, but models that don't use it won't error out. For example, [this is currently failing](https://github.com/huggingface/transformers/blob/399cd5c04b11ba3f740b4f76e8067326786405cc/examples/pytorch/continuous_batching.py#L16) because we are sending `s_aux: None` in the dict. We get:

```
TypeError: flash_attn_varlen_func() got an unexpected keyword argument 's_aux'
```
