### PR TITLE
Fix extra template loading

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2015,7 +2015,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             revision=revision,
                             cache_dir=cache_dir,
                         ):
-                            vocab_files[f"chat_template_{template.removesuffix(".jinja")}"] = f"{CHAT_TEMPLATE_DIR}/{template}"
+                            template = template.removesuffix(".jinja")
+                            vocab_files[f"chat_template_{template}"] = f"{CHAT_TEMPLATE_DIR}/{template}.jinja"
 
         # Get files from url, cache, or disk depending on the case
         resolved_vocab_files = {}

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2015,7 +2015,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             revision=revision,
                             cache_dir=cache_dir,
                         ):
-                            vocab_files[f"chat_template_{template}"] = f"{CHAT_TEMPLATE_DIR}/{template}.jinja"
+                            vocab_files[f"chat_template_{template.removesuffix(".jinja")}"] = f"{CHAT_TEMPLATE_DIR}/{template}"
 
         # Get files from url, cache, or disk depending on the case
         resolved_vocab_files = {}


### PR DESCRIPTION
We had a bug in how we loaded extra templates in the new format (where each template ends up in its own file). This sometimes affected template loading from the Hub.