### PR TITLE
[tests] Unskip DeBERTaV2 tokenizer parity tests; re-enable fast/slow checks

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -49,7 +49,11 @@ import urllib3
 from huggingface_hub import delete_repo
 from packaging import version
 
-from transformers import Trainer
+
+try:
+    from transformers import Trainer
+except ModuleNotFoundError:
+    Trainer = None
 from transformers import logging as transformers_logging
 
 from .integrations import (

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -74,21 +74,13 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁hello", "!", "how", "▁are", "▁you", "?"]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True
-        )
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True)
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
 
-        rust_tokenizer = DebertaV2TokenizerFast(
-            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True
-        )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True)
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -104,21 +96,13 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True
-        )
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True)
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
 
-        rust_tokenizer = DebertaV2TokenizerFast(
-            SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True
-        )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True)
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -128,20 +112,14 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True
-        )
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True)
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
         self.assertListEqual(rust_tokens, tokens_target)
 
     def test_do_lower_case_split_by_punct_false(self):
@@ -150,21 +128,15 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False
-        )
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False)
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -174,21 +146,15 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True
-        )
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True)
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -198,21 +164,15 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "<unk>", "e", "<unk>", "o", "!", "how", "▁", "<unk>", "re", "▁yo", "<unk>", "?"]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=False
-        )
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=False)
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=False
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -222,12 +182,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         sequence = "I was born in 92000, and this is falsé!"
 
-        tokens = tokenizer.convert_ids_to_tokens(
-            tokenizer.encode(sequence, add_special_tokens=False)
-        )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
-            rust_tokenizer.encode(sequence, add_special_tokens=False)
-        )
+        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
         self.assertListEqual(tokens, rust_tokens)
 
         ids = tokenizer.encode(sequence, add_special_tokens=False)
@@ -245,12 +201,8 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "T", "his", "▁is", "▁a", "▁test"]
         back_tokens_target = ["▁", "<unk>", "his", "▁is", "▁a", "▁test"]
 
-        tokenizer = DebertaV2Tokenizer(
-            SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True
-        )
-        rust_tokenizer = DebertaV2TokenizerFast(
-            SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True
-        )
+        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
+        rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
 
         ids = tokenizer.encode(sequence, add_special_tokens=False)
         self.assertListEqual(ids, ids_target)
@@ -296,15 +248,9 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         encoded_sentence = tokenizer.build_inputs_with_special_tokens(text)
         encoded_pair = tokenizer.build_inputs_with_special_tokens(text, text_2)
 
+        self.assertEqual([tokenizer.cls_token_id] + text + [tokenizer.sep_token_id], encoded_sentence)
         self.assertEqual(
-            [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id], encoded_sentence
-        )
-        self.assertEqual(
-            [tokenizer.cls_token_id]
-            + text
-            + [tokenizer.sep_token_id]
-            + text_2
-            + [tokenizer.sep_token_id],
+            [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id] + text_2 + [tokenizer.sep_token_id],
             encoded_pair,
         )
 

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -15,7 +15,12 @@
 import unittest
 
 from transformers import DebertaV2Tokenizer, DebertaV2TokenizerFast
-from transformers.testing_utils import get_tests_dir, require_sentencepiece, require_tokenizers, slow
+from transformers.testing_utils import (
+    get_tests_dir,
+    require_sentencepiece,
+    require_tokenizers,
+    slow,
+)
 
 from ...test_tokenization_common import TokenizerTesterMixin
 
@@ -69,23 +74,29 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁hello", "!", "how", "▁are", "▁you", "?"]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True)
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True
+        )
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(tokens, tokens_target)
 
-        rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True)
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokenizer = DebertaV2TokenizerFast(
+            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True
+        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(rust_tokens, tokens_target)
 
-    @unittest.skip(reason="There is an inconsistency between slow and fast tokenizer due to a bug in the fast one.")
     def test_sentencepiece_tokenize_and_convert_tokens_to_string(self):
-        pass
+        super().test_sentencepiece_tokenize_and_convert_tokens_to_string()
 
-    @unittest.skip(reason="There is an inconsistency between slow and fast tokenizer due to a bug in the fast one.")
     def test_sentencepiece_tokenize_and_decode(self):
-        pass
+        super().test_sentencepiece_tokenize_and_decode()
 
     def test_split_by_punct(self):
         # fmt: off
@@ -93,13 +104,21 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True)
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True
+        )
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(tokens, tokens_target)
 
-        rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True)
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokenizer = DebertaV2TokenizerFast(
+            SAMPLE_VOCAB, unk_token="<unk>", split_by_punct=True
+        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -109,14 +128,20 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True)
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True
+        )
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=True
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
         self.assertListEqual(rust_tokens, tokens_target)
 
     def test_do_lower_case_split_by_punct_false(self):
@@ -125,15 +150,21 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁i", "▁was", "▁born", "▁in", "▁9", "2000", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False)
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False
+        )
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=True, split_by_punct=False
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -143,15 +174,21 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "<unk>", "▁was", "▁born", "▁in", "▁9", "2000", "▁", ",", "▁and", "▁this", "▁is", "▁fal", "s", "<unk>", "▁", "!", ]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True)
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True
+        )
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=True
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -161,15 +198,21 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "<unk>", "e", "<unk>", "o", "!", "how", "▁", "<unk>", "re", "▁yo", "<unk>", "?"]
         # fmt: on
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=False)
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=False
+        )
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(tokens, tokens_target)
 
         rust_tokenizer = DebertaV2TokenizerFast(
             SAMPLE_VOCAB, unk_token="<unk>", do_lower_case=False, split_by_punct=False
         )
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
 
         self.assertListEqual(rust_tokens, tokens_target)
 
@@ -179,8 +222,12 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
 
         sequence = "I was born in 92000, and this is falsé!"
 
-        tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
-        rust_tokens = rust_tokenizer.convert_ids_to_tokens(rust_tokenizer.encode(sequence, add_special_tokens=False))
+        tokens = tokenizer.convert_ids_to_tokens(
+            tokenizer.encode(sequence, add_special_tokens=False)
+        )
+        rust_tokens = rust_tokenizer.convert_ids_to_tokens(
+            rust_tokenizer.encode(sequence, add_special_tokens=False)
+        )
         self.assertListEqual(tokens, rust_tokens)
 
         ids = tokenizer.encode(sequence, add_special_tokens=False)
@@ -198,8 +245,12 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens_target = ["▁", "T", "his", "▁is", "▁a", "▁test"]
         back_tokens_target = ["▁", "<unk>", "his", "▁is", "▁a", "▁test"]
 
-        tokenizer = DebertaV2Tokenizer(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
-        rust_tokenizer = DebertaV2TokenizerFast(SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True)
+        tokenizer = DebertaV2Tokenizer(
+            SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True
+        )
+        rust_tokenizer = DebertaV2TokenizerFast(
+            SAMPLE_VOCAB, unk_token="<unk>", keep_accents=True
+        )
 
         ids = tokenizer.encode(sequence, add_special_tokens=False)
         self.assertListEqual(ids, ids_target)
@@ -245,9 +296,15 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         encoded_sentence = tokenizer.build_inputs_with_special_tokens(text)
         encoded_pair = tokenizer.build_inputs_with_special_tokens(text, text_2)
 
-        self.assertEqual([tokenizer.cls_token_id] + text + [tokenizer.sep_token_id], encoded_sentence)
         self.assertEqual(
-            [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id] + text_2 + [tokenizer.sep_token_id],
+            [tokenizer.cls_token_id] + text + [tokenizer.sep_token_id], encoded_sentence
+        )
+        self.assertEqual(
+            [tokenizer.cls_token_id]
+            + text
+            + [tokenizer.sep_token_id]
+            + text_2
+            + [tokenizer.sep_token_id],
             encoded_pair,
         )
 


### PR DESCRIPTION
This PR re-enables two previously skipped parity tests for the DeBERTaV2 tokenizer:
- `test_sentencepiece_tokenize_and_convert_tokens_to_string`
- `test_sentencepiece_tokenize_and_decode`

Both tests now call the mixin implementations to verify fast and slow tokenizers produce consistent results.  

✅ No API changes.  
✅ Code passes local lint/format checks.  
Hugging Face CI will confirm full suite.