### PR TITLE
fix: continuous batching in `transformers serve`

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -25,6 +25,7 @@ import threading
 import time
 from argparse import ArgumentParser, Namespace
 from collections.abc import Generator, Iterable
+from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from io import BytesIO
 from threading import Thread
@@ -279,6 +280,9 @@ def create_generation_config_from_req(
         generation_config.top_p = float(req["top_p"])
     if req.get("seed") is not None:
         torch.manual_seed(req["seed"])
+    if generation_config.max_new_tokens is None:
+        # Default to 512 tokens if not set
+        generation_config.max_new_tokens = 512
 
     return generation_config
 
@@ -313,16 +317,16 @@ class TimedModel:
         self._name_or_path = str(model.name_or_path)
         self.processor = processor
         self.timeout_seconds = timeout_seconds
-        self._timer = threading.Timer(self.timeout_seconds, self._delete_model)
+        self._timer = threading.Timer(self.timeout_seconds, self.timeout_reached)
         self._timer.start()
 
     def reset_timer(self):
         """Reset the timer for the deletion of the instances."""
         self._timer.cancel()
-        self._timer = threading.Timer(self.timeout_seconds, self._delete_model)
+        self._timer = threading.Timer(self.timeout_seconds, self.timeout_reached)
         self._timer.start()
 
-    def _delete_model(self):
+    def delete_model(self):
         """Delete the wrapped model and processor and clean up resources."""
         if hasattr(self, "model") and self.model is not None:
             del self.model
@@ -335,9 +339,12 @@ class TimedModel:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
 
-            logger.info(
-                f"{self._name_or_path} was removed from memory after {self.timeout_seconds} seconds of inactivity"
-            )
+            # XXX: in case we manually delete the model, like on server shutdown
+            self._timer.cancel()
+
+    def timeout_reached(self):
+        self.delete_model()
+        logger.info(f"{self._name_or_path} was removed from memory after {self.timeout_seconds} seconds of inactivity")
 
     def is_deleted(self):
         """Check if the instances have been deleted."""
@@ -353,6 +360,10 @@ class ServeArguments:
     `transformers serve --help`
     """
 
+    continuous_batching: bool = field(
+        default=False,
+        metadata={"help": "Whether to use continuous batching for chat completions."},
+    )
     device: str = field(
         default="auto",
         metadata={
@@ -469,7 +480,7 @@ class ServeCommand(BaseTransformersCLICommand):
 
         # Store and process input arguments
         self.args = args
-        self.use_continuous_batching = self.args.attn_implementation == "sdpa_paged"
+        self.use_continuous_batching = self.args.continuous_batching
         self.enable_cors = self.args.enable_cors
 
         if self.args.default_seed is not None:
@@ -635,7 +646,15 @@ class ServeCommand(BaseTransformersCLICommand):
         return f"data: {response.model_dump_json(exclude_none=True)}\n\n"
 
     def run(self):
-        app = FastAPI()
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            yield
+            for model in self.loaded_models.values():
+                model.delete_model()
+            if self.running_continuous_batching_manager is not None:
+                self.running_continuous_batching_manager.stop(block=True, timeout=5)
+
+        app = FastAPI(lifespan=lifespan)
 
         # Some apps that make requests from external domains (e.g. Cursor) require CORS to be enabled. However, for
         # security purposes, it's disabled by default
@@ -774,10 +793,7 @@ class ServeCommand(BaseTransformersCLICommand):
             eos_token_id=tokenizer.eos_token_id,
             pad_token_id=tokenizer.pad_token_id,
             use_cache=False,
-            num_blocks=1,
-            block_size=1024,
             do_sample=False,
-            max_batch_tokens=10,
             scheduler="fifo",
         )
 
@@ -802,25 +818,14 @@ class ServeCommand(BaseTransformersCLICommand):
                     _inputs, request_id=req.get("request_id"), max_new_tokens=generation_config.max_new_tokens
                 )
 
-                queue_is_flushed = False
-
                 # Emit the assistant role to start the stream. Other chunks won't have a role, as it is implicit
                 # they come from the assistant.
                 yield self.build_chat_completion_chunk(request_id, role="assistant", model=model_id_and_revision)
 
-                for result in self.running_continuous_batching_manager:
-                    if result.request_id != request_id:
-                        continue
-                    if req.get("request_id") is not None and not queue_is_flushed:
-                        if result.status == RequestStatus.FINISHED:
-                            continue
-                        else:
-                            queue_is_flushed = True
-
-                    finish_reason = "stop" if result.status == RequestStatus.FINISHED else None
+                for result in self.running_continuous_batching_manager.request_id_iter(request_id):
                     if result.status == RequestStatus.FINISHED:
                         yield self.build_chat_completion_chunk(
-                            request_id, finish_reason=finish_reason, model=model_id_and_revision
+                            request_id, finish_reason="stop", model=model_id_and_revision
                         )
                         break
                     else:

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -830,9 +830,7 @@ class ServeCommand(BaseTransformersCLICommand):
 
         def stream_chat_completion(_inputs):
             try:
-                decode_stream = DecodeStream(skip_special_tokens=False)
-                for id in _inputs:
-                    decode_stream.step(tokenizer._tokenizer, id.item())
+                decode_stream = DecodeStream([id.item() for id in _inputs], False)
                 request_id = self.running_continuous_batching_manager.add_request(
                     _inputs, request_id=req.get("request_id"), max_new_tokens=generation_config.max_new_tokens
                 )

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -651,6 +651,9 @@ class ServeCommand(BaseTransformersCLICommand):
         return f"data: {response.model_dump_json(exclude_none=True)}\n\n"
 
     def run(self):
+        # NOTE:
+        # This is how you handle startup and shutdown events in FastAPI
+        # cf https://fastapi.tiangolo.com/advanced/events/#async-context-manager
         @asynccontextmanager
         async def lifespan(app: FastAPI):
             yield

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -648,9 +648,20 @@ class ServeCommand(BaseTransformersCLICommand):
         return f"data: {response.model_dump_json(exclude_none=True)}\n\n"
 
     def run(self):
-        # NOTE:
-        # This is how you handle startup and shutdown events in FastAPI
-        # cf https://fastapi.tiangolo.com/advanced/events/#async-context-manager
+        """
+        Setup and run the FastAPI server for transformers serve.
+
+        Models will be loaded and unloaded automatically based on usage and a timeout.
+
+        The server will expose the following endpoints:
+        - POST /v1/chat/completions: Generates chat completions.
+        - POST /v1/responses: Generates responses.
+        - POST /v1/audio/transcriptions: Generates transcriptions from audio.
+        - GET /v1/models: Lists available models for 3rd party tools.
+
+        Requires FastAPI and Uvicorn to be installed.
+        """
+
         @asynccontextmanager
         async def lifespan(app: FastAPI):
             yield

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -281,9 +281,6 @@ def create_generation_config_from_req(
         generation_config.top_p = float(req["top_p"])
     if req.get("seed") is not None:
         torch.manual_seed(req["seed"])
-    if generation_config.max_new_tokens is None:
-        # Default to 512 tokens if not set
-        generation_config.max_new_tokens = 512
 
     return generation_config
 

--- a/src/transformers/generation/continuous_batching/classes.py
+++ b/src/transformers/generation/continuous_batching/classes.py
@@ -15,10 +15,9 @@
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional, Union
+from typing import Optional
 
 import torch
-from tokenizers.decoders import DecodeStream
 
 from ...utils.logging import logging
 from ...utils.metrics import traced
@@ -76,7 +75,6 @@ class GenerationOutput:
         error (Optional[str]): Any error message associated with the request. When None, the request was successful.
         status (RequestStatus): The status of the request.
         created_time (float): The time the request was created.
-        next_token (Optional[int]): The next token to be generated.
     """
 
     request_id: str
@@ -86,7 +84,6 @@ class GenerationOutput:
     error: Optional[str] = None
     status: RequestStatus = RequestStatus.PENDING
     created_time: float = field(default_factory=time.time)
-    next_token: Optional[Union[int, str]] = field(default_factory=int)
 
 
 @dataclass
@@ -107,7 +104,6 @@ class RequestState:
         eos_token_id (int): The ID of the end-of-sequence token.
         created_time (float): The time the request was created.
         error (Optional[str]): Any error message associated with the request. When None, has had no error yet.
-        next_token (Optional[str]): The next token to be generated.
     """
 
     # Required fields
@@ -123,11 +119,7 @@ class RequestState:
     eos_token_id: int = -1  # ID of the end-of-sequence token
     created_time: float = field(default_factory=time.time)  # Time the request was created
     error: Optional[str] = None  # Error message if the request failed
-    next_token: Optional[Union[int, str]] = (
-        None  # Next token to be generated, either the raw ID or the decoded token depending on wether a DecodeStream was set
-    )
     lifespan: tuple[float, float] = (-1, -1)  # (time request was no longer pending, time request finished)
-    decode_stream: Optional[DecodeStream] = None
 
     @property
     def status(self) -> RequestStatus:
@@ -210,5 +202,4 @@ class RequestState:
             generated_tokens=self.static_outputs,
             logprobs=[],
             error=self.error,
-            next_token=self.next_token,
         )

--- a/src/transformers/generation/continuous_batching/classes.py
+++ b/src/transformers/generation/continuous_batching/classes.py
@@ -15,9 +15,10 @@
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Optional, Union
 
 import torch
+from tokenizers.decoders import DecodeStream
 
 from ...utils.logging import logging
 from ...utils.metrics import traced
@@ -85,7 +86,7 @@ class GenerationOutput:
     error: Optional[str] = None
     status: RequestStatus = RequestStatus.PENDING
     created_time: float = field(default_factory=time.time)
-    next_token: Optional[int] = field(default_factory=int)
+    next_token: Optional[Union[int, str]] = field(default_factory=int)
 
 
 @dataclass
@@ -122,8 +123,11 @@ class RequestState:
     eos_token_id: int = -1  # ID of the end-of-sequence token
     created_time: float = field(default_factory=time.time)  # Time the request was created
     error: Optional[str] = None  # Error message if the request failed
-    next_token: Optional[str] = None  # Next token to be generated
+    next_token: Optional[Union[int, str]] = (
+        None  # Next token to be generated, either the raw ID or the decoded token depending on wether a DecodeStream was set
+    )
     lifespan: tuple[float, float] = (-1, -1)  # (time request was no longer pending, time request finished)
+    decode_stream: Optional[DecodeStream] = None
 
     @property
     def status(self) -> RequestStatus:


### PR DESCRIPTION
Fixing continuous batching in `transformers serve`.

- added a `--continuous_batching` cmd line flag to enable, open to change this!
- ~`max_new_tokens` can sometimes be `None`, set a default so it doesn't break CB which expects it to be set~ can't repro my previous error, removed the added code and added a test to check if defaults are set correctly
- fix server hang on shutdown, added a `lifespan` to the `FastAPI` instance
  - calling continuous batching manager `stop`
  - refactored `TimedModel` to make `delete_model` "public" so we cancel the `threading.Timer` that was causing the server to hang on SIGINT
- added `request_id_iter` to iterate only on tokens linked to a given request_id
  - refactored the `get_result` to requeue tokens if `request_id is not None && req.request_id != request_id` (before we were losing tokens while iterating directly on all output_queue tokens)
- fix iterator to continue looping even if output_queue is empty
- ~moved the `DecodeStream` object to live in the `RequestState` rather than being single instance linked to the manager~ removed any trace of tokenizer within CB impl, didn't make sense to have here as we already are expecting encoded tokens. Leaving it up to the caller to decode (updated the serving code adequately)
- removed `next_token` from `RequestState` as it wasn't used, in streaming I've used `generated_tokens[-1]` to get latest token
- changed `prepare_next_batch` signature, now returns a bool to short circuit inner generation loop when it didn't prepare anything