### PR TITLE
[serve] fix ` request_id` unexpected

### DIFF
--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -129,7 +129,6 @@ class RichInterface:
             text = ""
             async for token in await stream:
                 outputs = token.choices[0].delta.content
-                request_id = token.id
 
                 if not outputs:
                     continue
@@ -168,7 +167,7 @@ class RichInterface:
 
         self._console.print()
 
-        return text, request_id
+        return text
 
     def input(self) -> str:
         """Gets user input from the console."""
@@ -700,8 +699,6 @@ class ChatCommand(BaseTransformersCLICommand):
         interface.clear()
         chat = self.clear_chat_history(args.system_prompt)
 
-        request_id = None
-
         # Starts the session with a minimal help message at the top, so that a user doesn't get stuck
         interface.print_help(minimal=True)
         while True:
@@ -733,13 +730,12 @@ class ChatCommand(BaseTransformersCLICommand):
                     chat,
                     stream=True,
                     extra_body={
-                        "request_id": request_id,
                         "generation_config": generation_config.to_json_string(),
                         "model": model,
                     },
                 )
 
-                model_output, request_id = await interface.stream_output(stream)
+                model_output = await interface.stream_output(stream)
 
                 chat.append({"role": "assistant", "content": model_output})
 

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -125,11 +125,10 @@ if serve_dependencies_available:
 
     class TransformersCompletionCreateParamsStreaming(CompletionCreateParamsStreaming, total=False):
         """
-        OpenAI's CompletionCreateParamsStreaming with an additional field for the generation config (as a json string) and the request ID to re-use the previous KV cache.
+        OpenAI's CompletionCreateParamsStreaming with an additional field for the generation config (as a json string).
         """
 
         generation_config: str
-        request_id: Optional[str]
 
     class TransformersTranscriptionCreateParams(TranscriptionCreateParamsBase, total=False):
         """

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -125,7 +125,7 @@ if serve_dependencies_available:
 
     class TransformersCompletionCreateParamsStreaming(CompletionCreateParamsStreaming, total=False):
         """
-        OpenAI's CompletionCreateParamsStreaming with an additional field for the generation config (as a json string).
+        OpenAI's CompletionCreateParamsStreaming with an additional field for the generation config (as a json string) and the request ID to re-use the previous KV cache.
         """
 
         generation_config: str

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -129,6 +129,7 @@ if serve_dependencies_available:
         """
 
         generation_config: str
+        request_id: Optional[str]
 
     class TransformersTranscriptionCreateParams(TranscriptionCreateParamsBase, total=False):
         """


### PR DESCRIPTION
# What does this PR do?

This PR fixes transformers serve as it is currently not working due to an unexpected field being passed `request_id`

# reproducer 
```python 
transformers serve
transformers chat localhost:8000 --model-name-or-path HuggingFaceTB/SmolLM3-3B
```
the second message will trigger an error. 