### PR TITLE
when _validate_request, remove request_id, or error will like Unexpec…

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -520,6 +520,8 @@ class ServeCommand(BaseTransformersCLICommand):
 
         # Validate unexpected keys -- Pydantic doesn't validate extra keys in the request.
         input_keys = set(request.keys())
+        if "request_id" in input_keys:
+            input_keys.remove("request_id")
         possible_keys = schema.__mutable_keys__
         unexpected_keys = input_keys - possible_keys
         if unexpected_keys:


### PR DESCRIPTION
…ted keys in the request: {'request_id'} INFO: ::1:44814 - "POST /v1/chat/completions HTTP/1.1" 422 Unprocessable Entity

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

@gante please review the PR.

how to produce the issue
transformers serve --log_level debug

transformers chat Qwen/Qwen2.5-0.5B-Instruct do_sample=False max_new_tokens=10

send 1st request-> OK
send 2st request->crash. client log:

  File "/home/ywan171/transformers/src/transformers/commands/chat.py", line 742, in _inner_run
    model_output, request_id = await interface.stream_output(stream)
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ywan171/transformers/src/transformers/commands/chat.py", line 130, in stream_output
    async for token in await stream:
                       ^^^^^^^^^^^^
  File "/workspace/ywan171/miniforge3/envs/optimum-intel/lib/python3.11/site-packages/huggingface_hub/inference/_generated/_async_client.py", line 963, in chat_completion
    data = await self._inner_post(request_parameters, stream=stream)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/ywan171/miniforge3/envs/optimum-intel/lib/python3.11/site-packages/huggingface_hub/inference/_generated/_async_client.py", line 289, in _inner_post
    raise error
  File "/workspace/ywan171/miniforge3/envs/optimum-intel/lib/python3.11/site-packages/huggingface_hub/inference/_generated/_async_client.py", line 275, in _inner_post
    response.raise_for_status()
  File "/workspace/ywan171/miniforge3/envs/optimum-intel/lib/python3.11/site-packages/aiohttp/client_reqrep.py", line 1161, in raise_for_status
    raise ClientResponseError(
aiohttp.client_exceptions.ClientResponseError: 422, message='Unprocessable Entity', url='http://localhost:8000/v1/chat/completions'

server log:
INFO:     ::1:51300 - "POST /v1/chat/completions HTTP/1.1" 200 OK
Validating request: {'model': 'Qwen/Qwen2.5-0.5B-Instruct@main', 'stream': True, 'request_id': 'req_0', 'generation_config': '{\n  "bos_token_id": 151643,\n  "eos_token_id": [\n    151645,\n    151643\n  ],\n  "max_new_tokens": 10,\n  "pad_token_id": 151643,\n  "repetition_penalty": 1.1,\n  "temperature": 0.7,\n  "top_k": 20,\n  "top_p": 0.8,\n  "transformers_version": "4.56.0.dev0"\n}\n', 'messages': [{'role': 'user', 'content': 'hi'}, {'role': 'assistant', 'content': 'Hello! How can I assist you today? If'}, {'role': 'user', 'content': 'hi'}]}
Unexpected keys in the request: {'request_id'}
INFO:     ::1:39042 - "POST /v1/chat/completions HTTP/1.1" 422 Unprocessable Entity
