### PR TITLE
[generate] add faster `stop_strings` stopping criteria

### DIFF
--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -198,6 +198,9 @@ A [`StoppingCriteria`] can be used to change when to stop generation (other than
 [[autodoc]] StopStringCriteria
     - __call__
 
+[[autodoc]] StopStringTextMatchCriteria
+    - __call__
+
 [[autodoc]] EosTokenCriteria
     - __call__
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -445,6 +445,7 @@ else:
             "StoppingCriteria",
             "StoppingCriteriaList",
             "StopStringCriteria",
+            "StopStringTextMatchCriteria",
             "SuppressTokensAtBeginLogitsProcessor",
             "SuppressTokensLogitsProcessor",
             "SynthIDTextWatermarkDetector",
@@ -706,6 +707,7 @@ if TYPE_CHECKING:
     from .generation import StoppingCriteria as StoppingCriteria
     from .generation import StoppingCriteriaList as StoppingCriteriaList
     from .generation import StopStringCriteria as StopStringCriteria
+    from .generation import StopStringTextMatchCriteria as StopStringTextMatchCriteria
     from .generation import SuppressTokensAtBeginLogitsProcessor as SuppressTokensAtBeginLogitsProcessor
     from .generation import SuppressTokensLogitsProcessor as SuppressTokensLogitsProcessor
     from .generation import SynthIDTextWatermarkDetector as SynthIDTextWatermarkDetector

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -96,6 +96,7 @@ else:
         "StoppingCriteriaList",
         "validate_stopping_criteria",
         "StopStringCriteria",
+        "StopStringTextMatchCriteria",
     ]
     _import_structure["continuous_batching"] = [
         "ContinuousMixin",
@@ -259,6 +260,7 @@ if TYPE_CHECKING:
             StoppingCriteria,
             StoppingCriteriaList,
             StopStringCriteria,
+            StopStringTextMatchCriteria,
             validate_stopping_criteria,
         )
         from .utils import (

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -252,6 +252,9 @@ class StopStringCriteria(StoppingCriteria):
     def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, list[str]]):
         if isinstance(stop_strings, str):
             stop_strings = [stop_strings]
+        if len(stop_strings) == 0 or any("" == stop_string for stop_string in stop_strings):
+            raise ValueError("`stop_strings` cannot be an empty list or contain empty strings")
+
         self.stop_strings: tuple[str, ...] = tuple(stop_strings)
         vocab = tokenizer.get_vocab()
         token_list, token_indices = tuple(vocab.keys()), tuple(vocab.values())
@@ -509,6 +512,8 @@ class StopStringTextMatchCriteria(StoppingCriteria):
     def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, list[str]]):
         if isinstance(stop_strings, str):
             stop_strings = [stop_strings]
+        if len(stop_strings) == 0 or any("" == stop_string for stop_string in stop_strings):
+            raise ValueError("`stop_strings` cannot be an empty list or contain empty strings")
 
         self.stop_strings = stop_strings
         self.tokenizer = tokenizer

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -116,7 +116,7 @@ class StopStringCriteria(StoppingCriteria):
     <Tip>
 
     [`StopStringTextMatchCriteria`] and this class have equivalent functionality. This class is compatible with
-    `torch.compile`, but its considerably slower than [`StopStringTextMatchCriteria`] when not compiled.
+    `torch.compile`, but it's considerably slower than [`StopStringTextMatchCriteria`] when not compiled.
 
     </Tip>
 
@@ -466,7 +466,7 @@ class StopStringTextMatchCriteria(StoppingCriteria):
     <Tip>
 
     [`StopStringCriteria`] and this class have equivalent functionality. This class is faster than
-    [`StopStringCriteria`], but it is not compatible with `torch.compile`.
+    [`StopStringCriteria`], but it isn't compatible with `torch.compile`.
 
     </Tip>
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -113,6 +113,13 @@ class StopStringCriteria(StoppingCriteria):
     This class can be used to stop generation whenever specific string sequences are generated. It preprocesses
     the strings together with the tokenizer vocab to find positions where tokens can validly complete the stop strings.
 
+    <Tip>
+
+    [`StopStringTextMatchCriteria`] and this class have equivalent functionality. This class is compatible with
+    `torch.compile`, but its considerably slower than [`StopStringTextMatchCriteria`] when not compiled.
+
+    </Tip>
+
     Generation is stopped as soon as a token is generated that completes any of the stop strings.
     We want to catch any instance in which the stop string would be present in the decoded output, which means
     we must also catch cases with "overhangs" off one or both ends. To make this more concrete, for the stop string
@@ -139,15 +146,16 @@ class StopStringCriteria(StoppingCriteria):
     somewhere in the past input_ids.
 
     How is the match actually performed, though? We do it in quite a confusing way, because we want the entire match
-    process to be compilable with Torch or XLA, which means we cannot use standard string methods. However, it is possible,
-    with some work, to do string matching with pure tensor operations. We'll begin by describing the algorithm we use
-    with standard string operations, and then at the end we'll explain how this is converted to pure tensor operations.
+    process to be compilable with Torch or XLA, which means we cannot use standard string methods. However, it is
+    possible, with some work, to do string matching with pure tensor operations. We'll begin by describing the
+    algorithm we use with standard string operations, and then at the end we'll explain how this is converted to
+    pure tensor operations.
 
-    The key to the algorithm is an observation: Because the stop string must overlap with the end of the token sequence, we can start at
-    the end of the sequence and work backwards. Specifically, we check that there is an overlap between the start of
-    the final token and the end of the stop_string, or to put it another way, stop_string[-i:] == token[:i] for
-    some i > 0. If you look at the positive examples above, you'll see the last token in all of them fulfills this
-    property:
+    The key to the algorithm is an observation: Because the stop string must overlap with the end of the token
+    sequence, we can start at the end of the sequence and work backwards. Specifically, we check that there is
+    an overlap between the start of the final token and the end of the stop_string, or to put it another way,
+    stop_string[-i:] == token[:i] for some i > 0. If you look at the positive examples above, you'll see the last
+    token in all of them fulfills this property:
 
     - ["st", "op"] (overlap is "op", overlap length == 2)
     - ["stop"]  (overlap is "stop", overlap length == 4)
@@ -216,11 +224,12 @@ class StopStringCriteria(StoppingCriteria):
     Examples:
 
     ```python
-    >>> from transformers import AutoModelForCausalLM, AutoTokenizer
+    >>> from transformers import AutoModelForCausalLM, AutoTokenizer, StoppingCriteriaList, StopStringCriteria
 
     >>> tokenizer = AutoTokenizer.from_pretrained("microsoft/phi-2")
     >>> model = AutoModelForCausalLM.from_pretrained("microsoft/phi-2")
     >>> inputs = tokenizer("The biggest states in the USA by land area:", return_tensors="pt")
+    >>> stopping_criteria = StoppingCriteriaList([StopStringCriteria(tokenizer, ["Texas"])])
 
     >>> gen_out = model.generate(**inputs)
     >>> print(tokenizer.batch_decode(gen_out, skip_special_tokens=True)[0])
@@ -449,6 +458,117 @@ class StopStringCriteria(StoppingCriteria):
         return torch.any(string_matches, dim=-1)
 
 
+class StopStringTextMatchCriteria(StoppingCriteria):
+    """
+    This class can be used to stop generation whenever specific string sequences are generated. It decodes the
+    generated tokens into text and then compares it against the stop strings.
+
+    <Tip>
+
+    [`StopStringCriteria`] and this class have equivalent functionality. This class is faster than
+    [`StopStringCriteria`], but it is not compatible with `torch.compile`.
+
+    </Tip>
+
+    Class suggested by @MaxBourdon.
+
+    Args:
+        tokenizer (`PreTrainedTokenizer`):
+            The model's associated tokenizer (necessary to extract vocab and tokenize the termination sequences)
+        stop_strings (`Union[str, list[str]]`):
+            A list of strings that should end generation. If a string is passed, it will be treated like a
+            list with a single element.
+
+    Examples:
+
+    ```python
+    >>> from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    >>> tokenizer = AutoTokenizer.from_pretrained("microsoft/phi-2")
+    >>> model = AutoModelForCausalLM.from_pretrained("microsoft/phi-2")
+    >>> inputs = tokenizer("The biggest states in the USA by land area:", return_tensors="pt")
+
+    >>> gen_out = model.generate(**inputs)
+    >>> print(tokenizer.batch_decode(gen_out, skip_special_tokens=True)[0])
+    The biggest states in the USA by land area:
+    - Alaska
+    - Texas
+    - California
+
+    >>> # Passing one or more stop strings will halt generation after those strings are emitted
+    >>> # Note that generating with stop strings requires you to pass the tokenizer too
+    >>> gen_out = model.generate(**inputs, stop_strings=["Texas"], tokenizer=tokenizer)
+    >>> print(tokenizer.batch_decode(gen_out, skip_special_tokens=True)[0])
+    The biggest states in the USA by land area:
+    - Alaska
+    - Texas
+    ```
+    """
+
+    def __init__(self, tokenizer: PreTrainedTokenizerBase, stop_strings: Union[str, list[str]]):
+        if isinstance(stop_strings, str):
+            stop_strings = [stop_strings]
+
+        self.stop_strings = stop_strings
+        self.tokenizer = tokenizer
+        # We only need to compare the last `max_tail_len` chars of the generated text, `max_tail_len` being the length
+        # of the longest stop string.
+        self.max_tail_len = max(len(s) for s in self.stop_strings)
+
+    @add_start_docstrings(STOPPING_CRITERIA_INPUTS_DOCSTRING)
+    def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, **kwargs) -> torch.Tensor:
+        # Initalize the returned tensor with False (should NOT stop generation). If a stop string is found, the
+        # corresponding index will be set to True.
+        should_stop = torch.zeros_like(input_ids[:, -1], dtype=torch.bool, device=input_ids.device)
+
+        # Primary check: check if the last generated text contains any of the stop strings
+        # NOTE: Depending on the tokenizer, decoding individual tokens may contain prefix symbols like "Ġ" or "##",
+        # which could derail the naive string comparison. At each step, we'll decode the latest `max_tail_len` tokens
+        # **together** (guaranteed to have at least one char per token, and thus at least `self.max_tail_len` chars)
+        last_generated_text = self.tokenizer.batch_decode(input_ids[:, -self.max_tail_len :])
+
+        # Check if stop strings are found in the latest generated tokens
+        for batch_idx in range(len(last_generated_text)):
+            for stop_string in self.stop_strings:
+                if stop_string in last_generated_text[batch_idx]:
+                    # Secondary check: the last token MUST be part of the stop string, to prevent the case where the
+                    # prompt contains a stop string to trigger this criteria right at the start of generation. More
+                    # precisely, the stop string must end with the starting characters of the last token AND the stop
+                    # string can't be complete without the last token
+                    # Examples:
+                    # - input text=["st", "op"], stop_strings=["stop"] -> should stop, perfect string match
+                    # - input text=["st", "opped"], stop_strings=["stop"] -> should stop, the start of the last token
+                    #     ("op") matches the end of the stop string.
+                    # - input text=["st", "op", "ped"], stop_strings=["stop"] -> should NOT stop, the last token does
+                    #     not contribute to the stop string (despite also starting with "p", which is the last char
+                    #     of the stop string)
+                    # NOTE: this secondary check is placed here because we're assuming that finding a stop string is
+                    # an uncommon occurrence.
+
+                    # the stop string can be complete without the last token -> we don't want to stop here, the
+                    # stop string is part of the prompt for this generation
+                    text_without_last_token = self.tokenizer.decode(input_ids[batch_idx, -self.max_tail_len : -1])
+                    if stop_string in text_without_last_token:
+                        continue
+
+                    # We are guaranteed to have at least 2 tokens in `input_ids` by this point (worst case: BOS +
+                    # 1st generated token). If we decode the last two tokens together and compare the resulting text
+                    # to the last token decoded separately, we can remove the unwanted prefix if it exists.
+                    last_two_tokens_text = self.tokenizer.decode(input_ids[batch_idx, -2:])
+                    last_tokens_with_prefix_text = self.tokenizer.decode(input_ids[batch_idx, -1:])
+                    last_token_text = ""
+                    for i in range(min(len(last_two_tokens_text), len(last_tokens_with_prefix_text))):
+                        if last_two_tokens_text[-i - 1] == last_tokens_with_prefix_text[-i - 1]:
+                            last_token_text += last_two_tokens_text[-i - 1]
+                        else:
+                            break
+                    last_token_partially_in_stop_string = any(
+                        stop_string.endswith(last_token_text[:i]) for i in range(len(last_token_text))
+                    )
+                    should_stop[batch_idx] = last_token_partially_in_stop_string
+        return should_stop
+
+
 class EosTokenCriteria(StoppingCriteria):
     """
     This class can be used to stop generation whenever the "end-of-sequence" token is generated.
@@ -475,8 +595,9 @@ class EosTokenCriteria(StoppingCriteria):
 
 class ConfidenceCriteria(StoppingCriteria):
     """
-    This class can be used to stop generation whenever assistant model's confidence in its prediction for the current token is lower than the threshold
-        `model.generation_config.assistant_confidence_threshold` even if the number of speculative tokens (defined by `num_assistant_tokens`) is not yet reached.
+    This class can be used to stop generation whenever assistant model's confidence in its prediction for the current
+    token is lower than the threshold `model.generation_config.assistant_confidence_threshold` even if the number of
+    speculative tokens (defined by `num_assistant_tokens`) is not yet reached.
 
     Args:
         assistant_confidence_threshold (`float`):

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -229,6 +229,9 @@ class StopStringCriteria(StoppingCriteria):
     >>> tokenizer = AutoTokenizer.from_pretrained("microsoft/phi-2")
     >>> model = AutoModelForCausalLM.from_pretrained("microsoft/phi-2")
     >>> inputs = tokenizer("The biggest states in the USA by land area:", return_tensors="pt")
+
+    >>> # Passing one or more stop strings will halt generation after those strings are emitted
+    >>> # Note that generating with stop strings requires you to pass the tokenizer too
     >>> stopping_criteria = StoppingCriteriaList([StopStringCriteria(tokenizer, ["Texas"])])
 
     >>> gen_out = model.generate(**inputs)
@@ -238,9 +241,7 @@ class StopStringCriteria(StoppingCriteria):
     - Texas
     - California
 
-    >>> # Passing one or more stop strings will halt generation after those strings are emitted
-    >>> # Note that generating with stop strings requires you to pass the tokenizer too
-    >>> gen_out = model.generate(**inputs, stop_strings=["Texas"], tokenizer=tokenizer)
+    >>> gen_out = model.generate(**inputs, stopping_criteria=stopping_criteria)
     >>> print(tokenizer.batch_decode(gen_out, skip_special_tokens=True)[0])
     The biggest states in the USA by land area:
     - Alaska

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -109,7 +109,7 @@ from .stopping_criteria import (
     MaxTimeCriteria,
     StoppingCriteria,
     StoppingCriteriaList,
-    StopStringCriteria,
+    StopStringTextMatchCriteria,
 )
 
 
@@ -1334,7 +1334,11 @@ class GenerationMixin(ContinuousMixin):
                     "model's generation config, but we could not locate a tokenizer. When generating with "
                     "stop strings, you must pass the model's tokenizer to the `tokenizer` argument of `generate`."
                 )
-            criteria.append(StopStringCriteria(stop_strings=generation_config.stop_strings, tokenizer=tokenizer))
+            # TODO (joao): when we support compilation of the decoding loop, we need to use StopStringCriteria here if
+            # want compilation support
+            criteria.append(
+                StopStringTextMatchCriteria(stop_strings=generation_config.stop_strings, tokenizer=tokenizer)
+            )
         if generation_config._eos_token_tensor is not None:
             criteria.append(EosTokenCriteria(eos_token_id=generation_config._eos_token_tensor))
         if (

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -301,6 +301,8 @@ class StoppingCriteriaTestCase(unittest.TestCase):
             "They completed the challenging puzzle, revealing the hidden image at the end",
             "Today a dragon flew over France",
             "The aroma of freshly baked pizza filled the kitchen",
+            "This should not trigger: the end is near",
+            "The following word should trigger: mend",  # important "mend" is a single token, != token for "end"
         ]
         stop_strings = ["end"]
 
@@ -318,7 +320,13 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         )
 
         # trigger stopping when at least one criteria is satisfied
-        self.assertListEqual(criteria(inputs["input_ids"], scores).tolist(), [True, False, False])
+        self.assertListEqual(
+            criteria(inputs["input_ids"], scores).tolist(),
+            [True, False, False, False, True],
+        )
 
         # False when neither is satisfied
-        self.assertListEqual(criteria(inputs["input_ids"][:, :-1], scores).tolist(), [False, False, False])
+        self.assertListEqual(
+            criteria(inputs["input_ids"][:, :-1], scores).tolist(),
+            [False, False, False, False, False],
+        )

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -15,6 +15,8 @@
 import time
 import unittest
 
+from parameterized import parameterized
+
 from transformers import AutoTokenizer, is_torch_available
 from transformers.testing_utils import require_torch, torch_device
 
@@ -31,6 +33,7 @@ if is_torch_available():
         MaxTimeCriteria,
         StoppingCriteriaList,
         StopStringCriteria,
+        StopStringTextMatchCriteria,
         validate_stopping_criteria,
     )
 
@@ -127,7 +130,13 @@ class StoppingCriteriaTestCase(unittest.TestCase):
 
         self.assertEqual(len(stopping_criteria), 1)
 
-    def test_stop_string_criteria(self):
+    @parameterized.expand(
+        [
+            ("StopStringCriteria", StopStringCriteria),
+            ("StopStringTextMatchCriteria", StopStringTextMatchCriteria),
+        ]
+    )
+    def test_stop_string_criteria(self, name, criteria_cls):
         true_strings = [
             "<|im_start|><|im_end|>",
             "<|im_start|><|im_end|<|im_end|>",
@@ -157,7 +166,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
 
         scores = None
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
+        criteria = criteria_cls(tokenizer=tokenizer, stop_strings=stop_strings)
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
@@ -169,25 +178,32 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         true_input_ids = tokenizer(true_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
         false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
 
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
+        criteria = criteria_cls(tokenizer=tokenizer, stop_strings=stop_strings)
         for i in range(len(true_strings)):
             self.assertTrue(criteria(true_input_ids["input_ids"][i : i + 1], scores))
         for i in range(len(false_strings)):
             self.assertFalse(criteria(false_input_ids["input_ids"][i : i + 1], scores))
 
-    def test_stop_string_criteria_vocab_size_mismatch(self):
+    @parameterized.expand(
+        [
+            ("StopStringCriteria", StopStringCriteria),
+            ("StopStringTextMatchCriteria", StopStringTextMatchCriteria),
+        ]
+    )
+    def test_stop_string_criteria_vocab_size_mismatch(self, name, criteria_cls):
         """Test that StopStringCriteria handles tokens above len(tokenizer) correctly."""
         tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt2")
 
         # Create input_ids with tokens above len(tokenizer)
         input_ids = torch.tensor([[len(tokenizer) + 1024, 1, 2]], device=torch_device)
         scores = None
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=["test"])
+        criteria = criteria_cls(tokenizer=tokenizer, stop_strings=["test"])
 
         # This should not raise an error and should return False since no stop string is matched
         self.assertFalse(criteria(input_ids, scores))
 
     def test_stop_string_matching_positions(self):
+        # This test only applies to StopStringCriteria, not StopStringTextMatchCriteria
         stop_string = "stop"
         token_list = ["last", "top", "topper", "s", "p"]
         token_indices = list(range(len(token_list)))
@@ -202,6 +218,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         self.assertEqual(end_overlaps, {"top": [3], "topper": [3], "p": [1]})
 
     def test_stop_string_embedding_vecs(self):
+        # This test only applies to StopStringCriteria, not StopStringTextMatchCriteria
         stop_string = "stop"
         token_list = ["last", "top", "topper", "s", "p"]
         token_indices = list(range(len(token_list)))
@@ -221,7 +238,13 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         token_lengths = embedding_vec[:-1, 2].tolist()
         self.assertEqual(token_lengths, [len(token) for token in token_list])
 
-    def test_single_letter_stop_string(self):
+    @parameterized.expand(
+        [
+            ("StopStringCriteria", StopStringCriteria),
+            ("StopStringTextMatchCriteria", StopStringTextMatchCriteria),
+        ]
+    )
+    def test_single_letter_stop_string(self, name, criteria_cls):
         true_strings = ["a", "baa", "abc"]  # "abc" is a single token
         false_strings = ["abbbbbbb", "b"]  # "abbbbbbb" is split into multiple tokens
         stop_strings = ["a"]
@@ -233,13 +256,19 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         false_input_ids = tokenizer(false_strings, return_tensors="pt", padding="longest", add_special_tokens=False)
 
         scores = None
-        criteria = StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings)
+        criteria = criteria_cls(tokenizer=tokenizer, stop_strings=stop_strings)
         for input_ids in true_input_ids["input_ids"]:
             self.assertTrue(criteria(input_ids.unsqueeze(0), scores))
         for input_ids in false_input_ids["input_ids"]:
             self.assertFalse(criteria(input_ids.unsqueeze(0), scores))
 
-    def test_criterias_per_row(self):
+    @parameterized.expand(
+        [
+            ("StopStringCriteria", StopStringCriteria),
+            ("StopStringTextMatchCriteria", StopStringTextMatchCriteria),
+        ]
+    )
+    def test_criterias_per_row(self, name, criteria_cls):
         text = "They completed the challenging puzzle, revealing the hidden image at the end"
         stop_strings = ["end"]
 
@@ -251,7 +280,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         criteria = StoppingCriteriaList(
             [
                 MaxLengthCriteria(max_length=20),
-                StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings),
+                criteria_cls(tokenizer=tokenizer, stop_strings=stop_strings),
             ]
         )
 
@@ -261,7 +290,13 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         # return False when neither is satisfied
         self.assertFalse(criteria(inputs["input_ids"][:, :-1], scores))
 
-    def test_criterias_per_row_batched(self):
+    @parameterized.expand(
+        [
+            ("StopStringCriteria", StopStringCriteria),
+            ("StopStringTextMatchCriteria", StopStringTextMatchCriteria),
+        ]
+    )
+    def test_criterias_per_row_batched(self, name, criteria_cls):
         text = [
             "They completed the challenging puzzle, revealing the hidden image at the end",
             "Today a dragon flew over France",
@@ -278,7 +313,7 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         criteria = StoppingCriteriaList(
             [
                 MaxLengthCriteria(max_length=20),
-                StopStringCriteria(tokenizer=tokenizer, stop_strings=stop_strings),
+                criteria_cls(tokenizer=tokenizer, stop_strings=stop_strings),
             ]
         )
 


### PR DESCRIPTION
# What does this PR do?

Adds `StopStringTextMatchCriteria`, a faster alternative to `StopStringCriteria`. Unlike `StopStringCriteria`, `StopStringTextMatchCriteria` **can't** be compiled.

Some additional context:
- when we added `StopStringCriteria`, we were looking forward having end-to-end `generate` compilation, so it made sense to focus on compilable options;
- As a user mentioned on [this issue](https://github.com/huggingface/smolagents/issues/1703), `StopStringCriteria` can be really slow in some contexts. More specifically, at initialization time (see benchamrks below);
- In general, `StopStringTextMatchCriteria` is faster, so it's the new default. `StopStringCriteria` is kept for `torch.compile` users.

Thank you @MaxBourdon for surfacing the problem

### Benchmarks

TL;DR `StopStringCriteria` is very slow to initialize on new `stop_strings` inputs, >2s on my machine. This is cached, so successive calls with the same `stop_strings` are not as bad. However, it's particularly troublesome when trying small models, as this initialization may take much more than the generation time. Excluding init time, the new `StopStringTextMatchCriteria` is also slightly faster.

<details>

<summary>Benchmark script</summary>

```py
from transformers import AutoModelForCausalLM, AutoTokenizer, StoppingCriteriaList, StopStringTextMatchCriteria, StopStringCriteria
from time import time
import torch

N_RUNS = 100
MAX_NEW_TOKENS = 100
MODEL_ID = "Qwen/Qwen2.5-0.5B-Instruct"
STOP_STRINGS = ["Potato", "Carrots", "Onions", "Garlic", "Tomatoes", "Lettuce", "Cucumbers"]
BATCH_SIZE = 1

tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
model = AutoModelForCausalLM.from_pretrained(MODEL_ID, device_map="auto", dtype=torch.bfloat16)
inputs = tokenizer(["The quick brown"] * BATCH_SIZE, return_tensors="pt").to(model.device)

# warmup
for i in range(10):
    gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=MAX_NEW_TOKENS, min_new_tokens=MAX_NEW_TOKENS)
    assert gen_out.shape[1] == MAX_NEW_TOKENS + inputs.input_ids.shape[1]

# ------------------------------------------------
# No stopping criteria
# ------------------------------------------------
all_times = []
for i in range(N_RUNS):
    start_time = time()
    gen_out = model.generate(**inputs, do_sample=False, max_new_tokens=MAX_NEW_TOKENS, min_new_tokens=MAX_NEW_TOKENS)
    assert gen_out.shape[1] == MAX_NEW_TOKENS + inputs.input_ids.shape[1]
    end_time = time()
    all_times.append(end_time - start_time)

avg_time = sum(all_times) / N_RUNS
print(f"[No stopping criteria] Average generation time: {avg_time} seconds")


# ------------------------------------------------
# StopStringCriteria
# ------------------------------------------------
# IMPORTANT NOTE: initializing this for the first time is slow, >1s. Prior to this PR, this initialization was
# done inside `generate` when `stop_strings` is set
init_start_time = time()
custom_stopping_criteria = StoppingCriteriaList([StopStringCriteria(tokenizer, STOP_STRINGS)])
init_end_time = time()
print(f"[StopStringCriteria] first init time: {init_end_time - init_start_time} seconds")

init_start_time = time()
custom_stopping_criteria = StoppingCriteriaList([StopStringCriteria(tokenizer, STOP_STRINGS)])
init_end_time = time()
print(f"[StopStringCriteria] second init time: {init_end_time - init_start_time} seconds")

all_times = []
for i in range(N_RUNS):
    start_time = time()
    gen_out = model.generate(
        **inputs,
        do_sample=False,
        stopping_criteria=custom_stopping_criteria,
        max_new_tokens=MAX_NEW_TOKENS,
        min_new_tokens=MAX_NEW_TOKENS,
    )
    assert gen_out.shape[1] == MAX_NEW_TOKENS + inputs.input_ids.shape[1]
    end_time = time()
    all_times.append(end_time - start_time)

avg_time = sum(all_times) / N_RUNS
print(f"[StopStringCriteria] Average generation time: {avg_time} seconds")

# ------------------------------------------------
# StopStringTextMatchCriteria
# ------------------------------------------------
init_start_time = time()
custom_stopping_criteria = StoppingCriteriaList([StopStringTextMatchCriteria(tokenizer, STOP_STRINGS)])
init_end_time = time()
print(f"[StopStringTextMatchCriteria] first init time: {init_end_time - init_start_time} seconds")

init_start_time = time()
custom_stopping_criteria = StoppingCriteriaList([StopStringTextMatchCriteria(tokenizer, STOP_STRINGS)])
init_end_time = time()
print(f"[StopStringTextMatchCriteria] second init time: {init_end_time - init_start_time} seconds")

all_times = []
for i in range(N_RUNS):
    start_time = time()
    gen_out = model.generate(
        **inputs,
        do_sample=False,
        stopping_criteria=custom_stopping_criteria,
        max_new_tokens=MAX_NEW_TOKENS,
        min_new_tokens=MAX_NEW_TOKENS,
    )
    assert gen_out.shape[1] == MAX_NEW_TOKENS + inputs.input_ids.shape[1]
    end_time = time()
    all_times.append(end_time - start_time)

avg_time = sum(all_times) / N_RUNS
print(f"[StopStringTextMatchCriteria] Average generation time: {avg_time} seconds")


# ------------------------------------------------
# generate with stop strings (using `StopStringTextMatchCriteria` under the hood)
# ------------------------------------------------
all_times = []
for i in range(N_RUNS):
    start_time = time()
    gen_out = model.generate(
        **inputs,
        do_sample=False,
        stop_strings=STOP_STRINGS,
        tokenizer=tokenizer,
        max_new_tokens=MAX_NEW_TOKENS,
        min_new_tokens=MAX_NEW_TOKENS,
    )
    assert gen_out.shape[1] == MAX_NEW_TOKENS + inputs.input_ids.shape[1]
    end_time = time()
    all_times.append(end_time - start_time)

avg_time = sum(all_times) / N_RUNS
print(f"[Default `stop_strings` criteria] Average generation time: {avg_time} seconds")
```

</details>

Benchmark results on my machine:

```
[No stopping criteria] Average generation time: 1.3314339590072632 seconds
[StopStringCriteria] first init time: 2.4044578075408936 seconds  # <------- this is the issue, init time > generation time!
[StopStringCriteria] second init time: 0.0518953800201416 seconds
[StopStringCriteria] Average generation time: 1.3567428421974181 seconds
[StopStringTextMatchCriteria] first init time: 6.4373016357421875e-06 seconds
[StopStringTextMatchCriteria] second init time: 1.9073486328125e-06 seconds
[StopStringTextMatchCriteria] Average generation time: 1.343175311088562 seconds
[Default `stop_strings` criteria] Average generation time: 1.3437320828437804 seconds  # <---- uses `StopStringTextMatchCriteria`
```
