### PR TITLE
Use begin_of_sequence token in all sliding windows for correct model behaviour

### DIFF
--- a/docs/source/en/perplexity.md
+++ b/docs/source/en/perplexity.md
@@ -106,32 +106,44 @@ from tqdm import tqdm
 max_length = model.config.n_positions
 stride = 512
 seq_len = encodings.input_ids.size(1)
+begin_of_sequence_token = model.config.bos_token_id
 
 nll_sum = 0.0
 n_tokens = 0
 prev_end_loc = 0
 for begin_loc in tqdm(range(0, seq_len, stride)):
-    end_loc = min(begin_loc + max_length, seq_len)
-    trg_len = end_loc - prev_end_loc  # may be different from stride on last loop
-    input_ids = encodings.input_ids[:, begin_loc:end_loc].to(device)
+    
+    # For all windows except the first, prepend begin_of_sequence token (if available)
+    if begin_loc == 0 or begin_of_sequence_token is None:
+        # First window will have gotten bos token already from the models tokenizer
+        end_loc = min(begin_loc + max_length, seq_len)
+        input_ids = encodings.input_ids[:, begin_loc:end_loc].to(device)
+        trg_len = end_loc - prev_end_loc
+    else:
+        # Subsequent windows - prepend begin_of_sequence token and adjust end_loc
+        end_loc = min(begin_loc + max_length - 1, seq_len)  # subtract 1 for prepended token
+        window_ids = encodings.input_ids[:, begin_loc:end_loc]
+        batch_size = window_ids.size(0)
+        bos_tokens = torch.full((batch_size, 1), begin_of_sequence_token, dtype=window_ids.dtype, device=device)
+        input_ids = torch.cat([bos_tokens, window_ids], dim=1).to(device)
+        trg_len = end_loc - prev_end_loc
+    
     target_ids = input_ids.clone()
     target_ids[:, :-trg_len] = -100
-
+    
     with torch.no_grad():
         outputs = model(input_ids, labels=target_ids)
-
         # loss is calculated using CrossEntropyLoss which averages over valid labels
         # N.B. the model only calculates loss over trg_len - 1 labels, because it internally shifts the labels
         # to the left by 1.
         neg_log_likelihood = outputs.loss
-
+    
     # Accumulate the total negative log-likelihood and the total number of tokens
     num_valid_tokens = (target_ids != -100).sum().item()  # number of valid tokens in target_ids
     batch_size = target_ids.size(0)
     num_loss_tokens = num_valid_tokens - batch_size  # subtract batch_size due to internal label shift
     nll_sum += neg_log_likelihood * num_loss_tokens
     n_tokens += num_loss_tokens
-
     prev_end_loc = end_loc
     if end_loc == seq_len:
         break


### PR DESCRIPTION
Testing with models employing bos tokens (eg Llama) resulted in much higher perplexity for all tokens but those in the first window. Reason was that if we tokenize only once, then only the first window will get the bos token. However for correct model behaviour, each forward pass/each sliding window needs to have a bos token as first token (otherwise perplexity values are significantly higher).

Note: Since inserted bos token is the first token, we do not need to set its label to -100 due to causal model internal label shift.

Note: if custom attention masks are used, always ensure bos token gets attention - otherwise unexpected behaviour (eg perplexity spikes for first three tokens experiencing lack of bos token)