### PR TITLE
🚨🚨🚨 Refactor CLIP structure

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -19,7 +19,6 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 from torch import nn
-from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ...activations import ACT2FN
 from ...modeling_attn_mask_utils import _create_4d_causal_attention_mask, _prepare_4d_attention_mask
@@ -574,6 +573,7 @@ class CLIPEncoder(nn.Module):
             attentions=all_attentions,
         )
 
+
 @auto_docstring(
     custom_intro="""
     The text model from CLIP without any head or projection on top.
@@ -599,7 +599,7 @@ class CLIPTextModel(CLIPPreTrainedModel):
 
         # For attention mask, it differs between `flash_attention_2` and other attention implementations
         self._use_flash_attention_2 = config._attn_implementation == "flash_attention_2"
-        
+
         self.post_init()
 
     def get_input_embeddings(self) -> nn.Module:

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -1056,6 +1056,7 @@ class CLIPTextModelWithProjection(CLIPPreTrainedModel):
             position_ids=position_ids,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            return_dict=True,
         )
         pooled_output = text_outputs.pooler_output
         text_embeds = self.text_projection(pooled_output)
@@ -1119,6 +1120,7 @@ class CLIPVisionModelWithProjection(CLIPPreTrainedModel):
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
             interpolate_pos_encoding=interpolate_pos_encoding,
+            return_dict=True,
         )
         pooled_output = vision_outputs.pooler_output
         image_embeds = self.visual_projection(pooled_output)
@@ -1178,6 +1180,7 @@ class CLIPForImageClassification(CLIPPreTrainedModel):
             pixel_values,
             output_attentions=output_attentions,
             output_hidden_states=output_hidden_states,
+            return_dict=True,
         )
 
         sequence_output = outputs.last_hidden_state


### PR DESCRIPTION
# What does this PR do?

Remove excessive abstraction by merging `CLIPVisionTransformers` and `CLIPVisionModel` into a single `CLIPVisionModel`. This is a breaking change, the `CLIPVisionTransformers` class will no longer exist, and weights will be saved with a different prefix (weights loading is OK). Motivation - code refactoring for unbloating and  `@check_model_inputs` use
