### PR TITLE
Update kosmos2_5 README to use torch_dtype in model loading example

### DIFF
--- a/docs/source/en/model_doc/kosmos2_5.md
+++ b/docs/source/en/model_doc/kosmos2_5.md
@@ -51,7 +51,7 @@ from transformers import AutoProcessor, Kosmos2_5ForConditionalGeneration, infer
 repo = "microsoft/kosmos-2.5"
 device = "cuda:0"
 dtype = torch.bfloat16
-model = Kosmos2_5ForConditionalGeneration.from_pretrained(repo, device_map=device, dtype=dtype)
+model = Kosmos2_5ForConditionalGeneration.from_pretrained(repo, device_map=device, torch_dtype=dtype)
 processor = AutoProcessor.from_pretrained(repo)
 
 # sample image
@@ -90,7 +90,7 @@ from transformers import AutoProcessor, Kosmos2_5ForConditionalGeneration, infer
 repo = "microsoft/kosmos-2.5"
 device = "cuda:0"
 dtype = torch.bfloat16
-model = Kosmos2_5ForConditionalGeneration.from_pretrained(repo, device_map=device, dtype=dtype)
+model = Kosmos2_5ForConditionalGeneration.from_pretrained(repo, device_map=device, torch_dtype=dtype)
 processor = AutoProcessor.from_pretrained(repo)
 
 # sample image


### PR DESCRIPTION
# Update kosmos2_5 README to use `torch_dtype` in model loading example

This pull request updates the `kosmos2_5.md` README file to correct the `Kosmos2_5ForConditionalGeneration.from_pretrained` example. Specifically, it replaces the `dtype` parameter with `torch_dtype` to align with the Hugging Face Transformers API for specifying data types during model loading. This change improves clarity and ensures compatibility with the library's conventions.

### Changes Made
- Modified `kosmos2_5.md` to update the model loading example from:
  ```python
  model = Kosmos2_5ForConditionalGeneration.from_pretrained(repo, device_map=device, dtype=dtype)
  ```
  to:
  ```python
  model = Kosmos2_5ForConditionalGeneration.from_pretrained(repo, device_map=device, torch_dtype=dtype)
  ```

### Related Issue
- No specific issue is linked to this change, as it is a minor documentation improvement. I checked existing issues and PRs to ensure no duplicate work.

### Pull Request Checklist
- [x] The pull request title summarizes the contribution.
- [ ] This PR does not address a specific issue, as it is a minor documentation fix.
- [ ] This PR is not a work in progress (no `[WIP]` prefix needed).
- [x] Existing tests pass (no code changes, only README update, so no new tests required).
- [ ] No new features or models added, so no new tests or `ModelTester.all_model_classes` updates needed.
- [ ] No new public methods added, so no docstrings required.
- [ ] No images, videos, or non-text files added (change is text-only in README).
- [x] Documentation build checked locally with:
  ```bash
  pip install hf-doc-builder
  doc-builder build transformers docs/source/en --build_dir ~/tmp/test-build
  ```
  The updated `kosmos2_5.md` file builds without errors.
- [x] Code style and quality checks not applicable (README change), but ran:
  ```bash
  make style
  make quality
  make repo-consistency
  ```
  to ensure no unintended issues.
- [x] Commit message is clear and descriptive.

### Notes
- This is a documentation-only change, so no functional tests were modified or added.
- I verified the documentation build locally to ensure the updated README renders correctly.
- The change aligns with the Transformers API documentation for `from_pretrained`.

Please review and let me know if any adjustments are needed!