### PR TITLE
Fix `SeamlessM4Tv2ModelWithTextInputTest::test_retain_grad_hidden_states_attentions`

### DIFF
--- a/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
+++ b/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
@@ -225,6 +225,9 @@ class SeamlessM4Tv2ModelTester:
             right_max_position_embeddings=self.right_max_position_embeddings,
             speech_encoder_chunk_size=self.speech_encoder_chunk_size,
             speech_encoder_left_chunk_num=self.speech_encoder_left_chunk_num,
+            encoder_layerdrop=self.encoder_layerdrop,
+            speech_encoder_layerdrop=self.speech_encoder_layerdrop,
+            decoder_layerdrop=self.decoder_layerdrop,
         )
 
     def prepare_config_and_inputs_for_decoder(self):

--- a/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
+++ b/tests/models/seamless_m4t_v2/test_modeling_seamless_m4t_v2.py
@@ -76,6 +76,9 @@ class SeamlessM4Tv2ModelTester:
         decoder_layers=2,
         encoder_ffn_dim=6,
         decoder_ffn_dim=6,
+        encoder_layerdrop=0.0,
+        speech_encoder_layerdrop=0.0,
+        decoder_layerdrop=0.0,
         t2u_encoder_layers=2,
         t2u_decoder_layers=2,
         t2u_encoder_ffn_dim=6,
@@ -153,6 +156,10 @@ class SeamlessM4Tv2ModelTester:
         self.right_max_position_embeddings = right_max_position_embeddings
         self.speech_encoder_chunk_size = speech_encoder_chunk_size
         self.speech_encoder_left_chunk_num = speech_encoder_left_chunk_num
+
+        self.encoder_layerdrop = encoder_layerdrop
+        self.speech_encoder_layerdrop = speech_encoder_layerdrop
+        self.decoder_layerdrop = decoder_layerdrop
 
     def prepare_config_and_inputs(self):
         if self.input_modality == "text":


### PR DESCRIPTION
# What does this PR do?

We have in `SeamlessM4Tv2Encoder`


```python
            to_drop = False
            if self.training:
                dropout_probability = torch.rand([])
                if dropout_probability < self.layerdrop:  # skip the layer
                    to_drop = True

            if to_drop:
                layer_outputs = (None, None)
```
which causes some outputs being `None` from time to time, and cause `test_retain_grad_hidden_states_attentions` fails at

```python
            if self.has_attentions:
                attentions = outputs.attentions[0]
                attentions.retain_grad()
```

Let's just not drop randomly for the test