### PR TITLE
fix crash when using chat to send 2+ request to gptoss

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -957,7 +957,9 @@ class ServeCommand(BaseTransformersCLICommand):
 
         last_kv_cache = None
         if self.is_continuation(req) and not must_discard_cache:
-            last_kv_cache = self.last_kv_cache
+            seq_len = self.last_kv_cache.get_seq_length()
+            if inputs["input_ids"].shape[-1] > seq_len:
+                last_kv_cache = self.last_kv_cache
 
         generation_kwargs = {
             **inputs,
@@ -1144,7 +1146,9 @@ class ServeCommand(BaseTransformersCLICommand):
 
         last_kv_cache = None
         if self.is_continuation(req) and not must_discard_cache:
-            last_kv_cache = self.last_kv_cache
+            seq_len = self.last_kv_cache.get_seq_length()
+            if inputs["input_ids"].shape[-1] > seq_len:
+                last_kv_cache = self.last_kv_cache
 
         generation_kwargs = {
             "inputs": inputs,


### PR DESCRIPTION
without it， 2+ request in chat using gptoss will coredump，error like
Traceback (most recent call last):
  File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/threading.py", line 1038, in _bootstrap_inner
    self.run()
  File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/threading.py", line 975, in run
    self._target(*self._args, **self._kwargs)
  File "/home/wangyi/transformers/src/transformers/commands/serving.py", line 981, in generate_with_cache
    generate_output = model.generate(**kwargs)
                      ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/disk0/wangyi/miniforge3/envs/transformers/lib/python3.11/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangyi/transformers/src/transformers/generation/utils.py", line 2539, in generate
    result = self._sample(
             ^^^^^^^^^^^^^
  File "/home/wangyi/transformers/src/transformers/generation/utils.py", line 2860, in _sample
    model_inputs = self.prepare_inputs_for_generation(input_ids, **model_kwargs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangyi/transformers/src/transformers/generation/utils.py", line 569, in prepare_inputs_for_generation
    inputs_embeds, input_ids = self._cache_dependant_input_preparation(
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/wangyi/transformers/src/transformers/generation/utils.py", line 475, in _cache_dependant_input_preparation
    or (cache_position[-1] >= input_ids.shape[1])  # Exception 3
        ~~~~~~~~~~~~~~^^^^
IndexError: index -1 is out of bounds for dimension 0 with size 0
