### PR TITLE
`tokenizers` bump tokenizers version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ _deps = [
     "timeout-decorator",
     "tiktoken",
     "timm<=1.0.19,!=1.0.18",
-    "tokenizers>=0.22,<0.23",
+    "tokenizers==0.22.0rc0,
     "torch>=2.2",
     "torchaudio",
     "torchvision",

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ _deps = [
     "timeout-decorator",
     "tiktoken",
     "timm<=1.0.19,!=1.0.18",
-    "tokenizers=0.22.0rc0,
+    "tokenizers==0.22.0rc0",
     "torch>=2.2",
     "torchaudio",
     "torchvision",

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ _deps = [
     "timeout-decorator",
     "tiktoken",
     "timm<=1.0.19,!=1.0.18",
-    "tokenizers==0.22.0rc0",
+    "tokenizers==0.22.0",
     "torch>=2.2",
     "torchaudio",
     "torchvision",

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ _deps = [
     "timeout-decorator",
     "tiktoken",
     "timm<=1.0.19,!=1.0.18",
-    "tokenizers==0.22.0rc0,
+    "tokenizers=0.22.0rc0,
     "torch>=2.2",
     "torchaudio",
     "torchvision",

--- a/setup.py
+++ b/setup.py
@@ -189,7 +189,7 @@ _deps = [
     "timeout-decorator",
     "tiktoken",
     "timm<=1.0.19,!=1.0.18",
-    "tokenizers>=0.21,<0.22",
+    "tokenizers>=0.22,<0.23",
     "torch>=2.2",
     "torchaudio",
     "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -91,7 +91,7 @@ deps = {
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
     "timm": "timm<=1.0.19,!=1.0.18",
-    "tokenizers": "tokenizers>=0.21,<0.22",
+    "tokenizers": "tokenizers>=0.22,<0.23",
     "torch": "torch>=2.2",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -91,7 +91,7 @@ deps = {
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
     "timm": "timm<=1.0.19,!=1.0.18",
-    "tokenizers": "tokenizers>=0.22,<0.23",
+    "tokenizers": "tokenizers==0.22.0rc0",
     "torch": "torch>=2.2",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -91,7 +91,7 @@ deps = {
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
     "timm": "timm<=1.0.19,!=1.0.18",
-    "tokenizers": "tokenizers==0.22.0rc0",
+    "tokenizers": "tokenizers=0.22.0rc0",
     "torch": "torch>=2.2",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -91,7 +91,7 @@ deps = {
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
     "timm": "timm<=1.0.19,!=1.0.18",
-    "tokenizers": "tokenizers==0.22.0rc0",
+    "tokenizers": "tokenizers==0.22.0",
     "torch": "torch>=2.2",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -91,7 +91,7 @@ deps = {
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
     "timm": "timm<=1.0.19,!=1.0.18",
-    "tokenizers": "tokenizers=0.22.0rc0",
+    "tokenizers": "tokenizers==0.22.0rc0",
     "torch": "torch>=2.2",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",


### PR DESCRIPTION
# What does this PR do?
Mostly breaking for the DecodeStream API but also adds `async` usage for `tokenizers`