### PR TITLE
pin `pytest-rerunfailures<16.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -152,7 +152,7 @@ _deps = [
     "pydantic>=2",
     "pytest>=7.2.0",
     "pytest-asyncio",
-    "pytest-rerunfailures",
+    "pytest-rerunfailures<16.0",
     "pytest-timeout",
     "pytest-xdist",
     "pytest-order",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -58,7 +58,7 @@ deps = {
     "pydantic": "pydantic>=2",
     "pytest": "pytest>=7.2.0",
     "pytest-asyncio": "pytest-asyncio",
-    "pytest-rerunfailures": "pytest-rerunfailures",
+    "pytest-rerunfailures": "pytest-rerunfailures<16.0",
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",
     "pytest-order": "pytest-order",


### PR DESCRIPTION
# What does this PR do?

Avoid failures due to https://github.com/pytest-dev/pytest-rerunfailures/issues/303