### PR TITLE
Fix `test_eager_matches_sdpa_inference` not run for `CLIP`

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -174,11 +174,6 @@ def _test_eager_matches_sdpa_inference(
     This test is written as a regular function to be able to overload it easily with different tolerances.
     Otherwise, `paramterezie.expand` prevents it as it removes the original function from the namespace.
     """
-    # TODO: we shouldn't need to do this skip, i.e. the test would be composable from the model tester. CLIP-like
-    # models have a custom mixin, which we detect to skip this test.
-    if any(".CLIPModelTesterMixin" in str(base) for base in self.__class__.__bases__):
-        self.skipTest(reason="CLIP-like models have a different `test_eager_matches_sdpa_inference`")
-
     if not self.has_attentions:
         self.skipTest(reason="Model architecture does not support attentions")
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes  `test_eager_matches_sdpa_inference` not run for `CLIP` after #37498.

#37498 changed `tests/models/clip/test_modeling_clip.py` from

```python
    def test_eager_matches_sdpa_inference(self, torch_dtype: str):
        super().test_eager_matches_sdpa_inference(
            torch_dtype=torch_dtype,
            logit_keys=("last_hidden_state", "pooler_output", "image_embeds"),
            use_attention_mask_options=(None,),
        )
```
to
```python
    def test_eager_matches_sdpa_inference(self, *args):
        # adding only flaky decorator here and call the parent test method
        return getattr(ModelTesterMixin, self._testMethodName)(self)
```

This change invalided the comment in a previous PR 

https://github.com/huggingface/transformers/pull/36650#discussion_r1989959059

After #37498, this (parametrized) test is not run at all for CLIP with

> SKIPPED (CLIP-like models have a different `test_eager_matches_sdpa_infere...)

, while a commit before it, we still have 3 tests (the overwritten ones) being run.


