### PR TITLE
feat(deepseek_v3): Add grouped GEMM kernel for faster MoE computation

### DIFF
--- a/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
@@ -93,6 +93,8 @@ class DeepseekV3Config(PretrainedConfig):
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should return the last key/values attentions (not used by all models). Only
             relevant if `config.is_decoder=True`.
+        use_grouped_gemm (`bool`, *optional*, defaults to `False`):
+            Whether to use grouped GEMM.
         pad_token_id (`int`, *optional*):
             Padding token id.
         bos_token_id (`int`, *optional*, defaults to 0):
@@ -179,6 +181,7 @@ class DeepseekV3Config(PretrainedConfig):
         initializer_range=0.02,
         rms_norm_eps=1e-6,
         use_cache=True,
+        use_grouped_gemm=False,
         pad_token_id=None,
         bos_token_id=0,
         eos_token_id=1,
@@ -225,6 +228,7 @@ class DeepseekV3Config(PretrainedConfig):
         self.rms_norm_eps = rms_norm_eps
         self.pretraining_tp = pretraining_tp
         self.use_cache = use_cache
+        self.use_grouped_gemm = use_grouped_gemm
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
         self.attention_bias = attention_bias
@@ -238,6 +242,16 @@ class DeepseekV3Config(PretrainedConfig):
             for key in ["beta_fast", "beta_slow", "factor"]:
                 if key in self.rope_scaling:
                     self.rope_scaling[key] = float(self.rope_scaling[key])
+
+        if self.use_grouped_gemm:
+            # https://github.com/fanshiqing/grouped_gemm
+            import importlib.util
+
+            if importlib.util.find_spec("grouped_gemm") is None:
+                raise ImportError(
+                    "Please install grouped_gemm to use use_grouped_gemm=True. "
+                    "You can install it with `pip install git+https://github.com/fanshiqing/grouped_gemm@main`"
+                )
 
         rope_config_validation(self)
 

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -9,7 +9,9 @@ from typing import Callable, Optional, Union
 
 import torch
 import torch.nn.functional as F
+import torch.nn.init as init
 from torch import nn
+from tqdm import tqdm
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
@@ -149,59 +151,114 @@ class DeepseekV3TopkRouter(nn.Module):
         return topk_indices, topk_weights
 
 
-class DeepseekV3MoE(nn.Module):
-    """
-    A mixed expert module containing shared experts.
-    """
+class GroupedLinear(nn.Module):
+    def __init__(self, num_groups: int, in_features: int, out_features: int, bias: bool = False):
+        super().__init__()
+        self.num_groups = num_groups
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(num_groups, out_features, in_features))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(num_groups, out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
 
+    def reset_parameters(self) -> None:
+        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, x):
+        raise NotImplementedError("`GroupedLinear` is a weight container for use with specialized kernels.")
+
+    def extra_repr(self) -> str:
+        return f"num_groups={self.num_groups}, in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
+
+
+class GroupedDeepseekV3MLP(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
-        self.experts = nn.ModuleList(
-            [
-                DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size)
-                for _ in range(config.n_routed_experts)
-            ]
-        )
+        num_experts = config.n_routed_experts
+        hidden_size = config.hidden_size
+        intermediate_size = config.moe_intermediate_size
+
+        # Use the new GroupedLinear layer for a cleaner, more consistent structure
+        self.gate_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.up_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.down_proj = GroupedLinear(num_experts, intermediate_size, hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        raise NotImplementedError("The MoE computation is performed in the parent `DeepseekV3MoE` module.")
+
+
+class DeepseekV3MoE(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.use_grouped_gemm = config.use_grouped_gemm
         self.gate = DeepseekV3TopkRouter(config)
         self.shared_experts = DeepseekV3MLP(
-            config=config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
+            config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
         )
+        if self.use_grouped_gemm:
+            self.experts = GroupedDeepseekV3MLP(config)
+        else:
+            self.experts = nn.ModuleList(
+                [
+                    DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(config.n_routed_experts)
+                ]
+            )
 
-    def moe(self, hidden_states: torch.Tensor, topk_indices: torch.Tensor, topk_weights: torch.Tensor):
-        r"""
-        CALL FOR CONTRIBUTION! I don't have time to optimise this right now, but expert weights need to be fused
-        to not have to do a loop here (deepseek has 256 experts soooo yeah).
-        """
-        final_hidden_states = torch.zeros_like(hidden_states, dtype=topk_weights.dtype)
-        expert_mask = torch.nn.functional.one_hot(topk_indices, num_classes=len(self.experts))
-        expert_mask = expert_mask.permute(2, 0, 1)
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_grouped_gemm:
+            return self.grouped_forward(hidden_states)
+        else:
+            return self.vanilla_forward(hidden_states)
+
+    def grouped_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        import grouped_gemm.ops as ops
+
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        topk_indices = topk_indices.to(torch.int32)
+        batch_sizes = torch.bincount(topk_indices.flatten().cpu(), minlength=self.config.n_routed_experts)
+        permuted_hidden_states, row_id_map = ops.permute(flat_hidden_states, topk_indices)
+
+        gate_out = ops.gmm(permuted_hidden_states, self.experts.gate_proj.weight, batch_sizes, trans_b=True)
+        up_out = ops.gmm(permuted_hidden_states, self.experts.up_proj.weight, batch_sizes, trans_b=True)
+        intermediate_out = self.experts.act_fn(gate_out) * up_out
+        expert_out = ops.gmm(intermediate_out, self.experts.down_proj.weight, batch_sizes, trans_b=True)
+
+        moe_output = ops.unpermute(expert_out, row_id_map, topk_weights)
+        return moe_output.view(*orig_shape) + self.shared_experts(residuals)
+
+    def vanilla_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        final_hidden_states = torch.zeros_like(flat_hidden_states)
+        expert_mask = F.one_hot(topk_indices, num_classes=len(self.experts)).permute(2, 0, 1)
 
         for expert_idx in range(len(self.experts)):
             expert = self.experts[expert_idx]
-            mask = expert_mask[expert_idx]
-            token_indices, weight_indices = torch.where(mask)
-
+            token_indices, weight_indices = torch.where(expert_mask[expert_idx])
             if token_indices.numel() > 0:
-                expert_weights = topk_weights[token_indices, weight_indices]
-                expert_input = hidden_states[token_indices]
-                expert_output = expert(expert_input)
-                weighted_output = expert_output * expert_weights.unsqueeze(-1)
-                final_hidden_states.index_add_(0, token_indices, weighted_output)
+                expert_weights = topk_weights[token_indices, weight_indices].unsqueeze(1)
+                expert_output = expert(flat_hidden_states[token_indices])
+                final_hidden_states.index_add_(
+                    0, token_indices, (expert_output * expert_weights).to(final_hidden_states.dtype)
+                )
 
-        # in original deepseek, the output of the experts are gathered once we leave this module
-        # thus the moe module is itelsf an IsolatedParallel module
-        # and all expert are "local" meaning we shard but we don't gather
-        return final_hidden_states.type(hidden_states.dtype)
-
-    def forward(self, hidden_states):
-        residuals = hidden_states
-        orig_shape = hidden_states.shape
-        topk_indices, topk_weights = self.gate(hidden_states)
-        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
-        hidden_states = self.moe(hidden_states, topk_indices, topk_weights).view(*orig_shape)
-        hidden_states = hidden_states + self.shared_experts(residuals)
-        return hidden_states
+        return final_hidden_states.view(*orig_shape) + self.shared_experts(residuals)
 
 
 def rotate_half(x):
@@ -595,6 +652,44 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
             past_key_values=past_key_values,
         )
 
+    def _fuse_experts(self):
+        for layer in tqdm(self.layers, desc="Fusing experts"):
+            if isinstance(layer.mlp, DeepseekV3MoE) and not layer.mlp.use_grouped_gemm:
+                grouped_experts = GroupedDeepseekV3MLP(layer.mlp.config)
+
+                gate_weights = torch.stack([expert.gate_proj.weight for expert in layer.mlp.experts])
+                up_weights = torch.stack([expert.up_proj.weight for expert in layer.mlp.experts])
+                down_weights = torch.stack([expert.down_proj.weight for expert in layer.mlp.experts])
+
+                grouped_experts.gate_proj.weight.data = gate_weights
+                grouped_experts.up_proj.weight.data = up_weights
+                grouped_experts.down_proj.weight.data = down_weights
+
+                layer.mlp.experts = grouped_experts
+                layer.mlp.use_grouped_gemm = True
+
+    def _unfuse_experts(self):
+        for layer in tqdm(self.layers, desc="Unfusing experts"):
+            if isinstance(layer.mlp, DeepseekV3MoE) and layer.mlp.use_grouped_gemm:
+                grouped_experts = layer.mlp.experts
+                gate_weights = grouped_experts.gate_proj.weight.data
+                up_weights = grouped_experts.up_proj.weight.data
+                down_weights = grouped_experts.down_proj.weight.data
+
+                config = layer.mlp.config
+                num_experts = config.n_routed_experts
+                experts = nn.ModuleList(
+                    [DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(num_experts)]
+                )
+
+                for i in range(num_experts):
+                    experts[i].gate_proj.weight.data = gate_weights[i]
+                    experts[i].up_proj.weight.data = up_weights[i]
+                    experts[i].down_proj.weight.data = down_weights[i]
+
+                layer.mlp.experts = experts
+                layer.mlp.use_grouped_gemm = False
+
 
 @auto_docstring
 class DeepseekV3ForCausalLM(DeepseekV3PreTrainedModel, GenerationMixin):
@@ -670,6 +765,19 @@ class DeepseekV3ForCausalLM(DeepseekV3PreTrainedModel, GenerationMixin):
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
         )
+
+    def fuse_experts(self):
+        import importlib.util
+
+        if importlib.util.find_spec("grouped_gemm") is None:
+            raise ImportError(
+                "Please install grouped_gemm to use use_grouped_gemm=True. "
+                "You can install it with `pip install git+https://github.com/fanshiqing/grouped_gemm@main`"
+            )
+        self.model._fuse_experts()
+
+    def unfuse_experts(self):
+        self.model._unfuse_experts()
 
 
 class DeepseekV3ForSequenceClassification(GenericForSequenceClassification, DeepseekV3PreTrainedModel):

--- a/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
@@ -216,6 +216,7 @@ class DeepseekV3MoE(nn.Module):
 
     def grouped_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         import grouped_gemm.ops as ops
+
         residuals = hidden_states
         orig_shape = hidden_states.shape
         flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])

--- a/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
@@ -3,8 +3,9 @@ from typing import Callable, Optional
 
 import torch
 import torch.nn.functional as F
-import torch.utils.checkpoint
+import torch.nn.init as init
 from torch import nn
+from tqdm import tqdm
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache
@@ -12,7 +13,6 @@ from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GenericForSequenceClassification
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
-from ...utils import logging
 from ...utils.deprecation import deprecate_kwarg
 from ..llama.modeling_llama import (
     LlamaDecoderLayer,
@@ -26,9 +26,6 @@ from ..llama.modeling_llama import (
     rotate_half,
 )
 from .configuration_deepseek_v3 import DeepseekV3Config
-
-
-logger = logging.get_logger(__name__)
 
 
 class DeepseekV3RMSNorm(LlamaRMSNorm):
@@ -147,59 +144,113 @@ class DeepseekV3TopkRouter(nn.Module):
         return topk_indices, topk_weights
 
 
-class DeepseekV3MoE(nn.Module):
-    """
-    A mixed expert module containing shared experts.
-    """
+class GroupedLinear(nn.Module):
+    def __init__(self, num_groups: int, in_features: int, out_features: int, bias: bool = False):
+        super().__init__()
+        self.num_groups = num_groups
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(num_groups, out_features, in_features))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(num_groups, out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
 
+    def reset_parameters(self) -> None:
+        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, x):
+        raise NotImplementedError("`GroupedLinear` is a weight container for use with specialized kernels.")
+
+    def extra_repr(self) -> str:
+        return f"num_groups={self.num_groups}, in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
+
+
+class GroupedDeepseekV3MLP(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
-        self.experts = nn.ModuleList(
-            [
-                DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size)
-                for _ in range(config.n_routed_experts)
-            ]
-        )
+        num_experts = config.n_routed_experts
+        hidden_size = config.hidden_size
+        intermediate_size = config.moe_intermediate_size
+
+        # Use the new GroupedLinear layer for a cleaner, more consistent structure
+        self.gate_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.up_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.down_proj = GroupedLinear(num_experts, intermediate_size, hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        raise NotImplementedError("The MoE computation is performed in the parent `DeepseekV3MoE` module.")
+
+
+class DeepseekV3MoE(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.use_grouped_gemm = config.use_grouped_gemm
         self.gate = DeepseekV3TopkRouter(config)
         self.shared_experts = DeepseekV3MLP(
-            config=config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
+            config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
         )
+        if self.use_grouped_gemm:
+            self.experts = GroupedDeepseekV3MLP(config)
+        else:
+            self.experts = nn.ModuleList(
+                [
+                    DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(config.n_routed_experts)
+                ]
+            )
 
-    def moe(self, hidden_states: torch.Tensor, topk_indices: torch.Tensor, topk_weights: torch.Tensor):
-        r"""
-        CALL FOR CONTRIBUTION! I don't have time to optimise this right now, but expert weights need to be fused
-        to not have to do a loop here (deepseek has 256 experts soooo yeah).
-        """
-        final_hidden_states = torch.zeros_like(hidden_states, dtype=topk_weights.dtype)
-        expert_mask = torch.nn.functional.one_hot(topk_indices, num_classes=len(self.experts))
-        expert_mask = expert_mask.permute(2, 0, 1)
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_grouped_gemm:
+            return self.grouped_forward(hidden_states)
+        else:
+            return self.vanilla_forward(hidden_states)
+
+    def grouped_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        import grouped_gemm.ops as ops
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        topk_indices = topk_indices.to(torch.int32)
+        batch_sizes = torch.bincount(topk_indices.flatten().cpu(), minlength=self.config.n_routed_experts)
+        permuted_hidden_states, row_id_map = ops.permute(flat_hidden_states, topk_indices)
+
+        gate_out = ops.gmm(permuted_hidden_states, self.experts.gate_proj.weight, batch_sizes, trans_b=True)
+        up_out = ops.gmm(permuted_hidden_states, self.experts.up_proj.weight, batch_sizes, trans_b=True)
+        intermediate_out = self.experts.act_fn(gate_out) * up_out
+        expert_out = ops.gmm(intermediate_out, self.experts.down_proj.weight, batch_sizes, trans_b=True)
+
+        moe_output = ops.unpermute(expert_out, row_id_map, topk_weights)
+        return moe_output.view(*orig_shape) + self.shared_experts(residuals)
+
+    def vanilla_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        final_hidden_states = torch.zeros_like(flat_hidden_states)
+        expert_mask = F.one_hot(topk_indices, num_classes=len(self.experts)).permute(2, 0, 1)
 
         for expert_idx in range(len(self.experts)):
             expert = self.experts[expert_idx]
-            mask = expert_mask[expert_idx]
-            token_indices, weight_indices = torch.where(mask)
-
+            token_indices, weight_indices = torch.where(expert_mask[expert_idx])
             if token_indices.numel() > 0:
-                expert_weights = topk_weights[token_indices, weight_indices]
-                expert_input = hidden_states[token_indices]
-                expert_output = expert(expert_input)
-                weighted_output = expert_output * expert_weights.unsqueeze(-1)
-                final_hidden_states.index_add_(0, token_indices, weighted_output)
+                expert_weights = topk_weights[token_indices, weight_indices].unsqueeze(1)
+                expert_output = expert(flat_hidden_states[token_indices])
+                final_hidden_states.index_add_(
+                    0, token_indices, (expert_output * expert_weights).to(final_hidden_states.dtype)
+                )
 
-        # in original deepseek, the output of the experts are gathered once we leave this module
-        # thus the moe module is itelsf an IsolatedParallel module
-        # and all expert are "local" meaning we shard but we don't gather
-        return final_hidden_states.type(hidden_states.dtype)
-
-    def forward(self, hidden_states):
-        residuals = hidden_states
-        orig_shape = hidden_states.shape
-        topk_indices, topk_weights = self.gate(hidden_states)
-        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
-        hidden_states = self.moe(hidden_states, topk_indices, topk_weights).view(*orig_shape)
-        hidden_states = hidden_states + self.shared_experts(residuals)
-        return hidden_states
+        return final_hidden_states.view(*orig_shape) + self.shared_experts(residuals)
 
 
 class DeepseekV3Attention(nn.Module):
@@ -352,9 +403,58 @@ class DeepseekV3PreTrainedModel(LlamaPreTrainedModel):
 class DeepseekV3Model(LlamaModel):
     _keys_to_ignore_on_load_unexpected = [r"model\.layers\.61.*"]
 
+    def _fuse_experts(self):
+        for layer in tqdm(self.layers, desc="Fusing experts"):
+            if isinstance(layer.mlp, DeepseekV3MoE) and not layer.mlp.use_grouped_gemm:
+                grouped_experts = GroupedDeepseekV3MLP(layer.mlp.config)
+
+                gate_weights = torch.stack([expert.gate_proj.weight for expert in layer.mlp.experts])
+                up_weights = torch.stack([expert.up_proj.weight for expert in layer.mlp.experts])
+                down_weights = torch.stack([expert.down_proj.weight for expert in layer.mlp.experts])
+
+                grouped_experts.gate_proj.weight.data = gate_weights
+                grouped_experts.up_proj.weight.data = up_weights
+                grouped_experts.down_proj.weight.data = down_weights
+
+                layer.mlp.experts = grouped_experts
+                layer.mlp.use_grouped_gemm = True
+
+    def _unfuse_experts(self):
+        for layer in tqdm(self.layers, desc="Unfusing experts"):
+            if isinstance(layer.mlp, DeepseekV3MoE) and layer.mlp.use_grouped_gemm:
+                grouped_experts = layer.mlp.experts
+                gate_weights = grouped_experts.gate_proj.weight.data
+                up_weights = grouped_experts.up_proj.weight.data
+                down_weights = grouped_experts.down_proj.weight.data
+
+                config = layer.mlp.config
+                num_experts = config.n_routed_experts
+                experts = nn.ModuleList(
+                    [DeepseekV3MLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(num_experts)]
+                )
+
+                for i in range(num_experts):
+                    experts[i].gate_proj.weight.data = gate_weights[i]
+                    experts[i].up_proj.weight.data = up_weights[i]
+                    experts[i].down_proj.weight.data = down_weights[i]
+
+                layer.mlp.experts = experts
+                layer.mlp.use_grouped_gemm = False
+
 
 class DeepseekV3ForCausalLM(LlamaForCausalLM):
-    pass
+    def fuse_experts(self):
+        import importlib.util
+
+        if importlib.util.find_spec("grouped_gemm") is None:
+            raise ImportError(
+                "Please install grouped_gemm to use use_grouped_gemm=True. "
+                "You can install it with `pip install git+https://github.com/fanshiqing/grouped_gemm@main`"
+            )
+        self.model._fuse_experts()
+
+    def unfuse_experts(self):
+        self.model._unfuse_experts()
 
 
 class DeepseekV3ForSequenceClassification(GenericForSequenceClassification, DeepseekV3PreTrainedModel):

--- a/src/transformers/models/dots1/configuration_dots1.py
+++ b/src/transformers/models/dots1/configuration_dots1.py
@@ -71,6 +71,8 @@ class Dots1Config(PretrainedConfig):
             Epsilon used by the RMS normalization layers.
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should return the last key/values attentions. Only relevant if `config.is_decoder=True`.
+        use_grouped_gemm (`bool`, *optional*, defaults to `False`):
+            Whether to use grouped gemm to speed up the model.
         tie_word_embeddings (`bool`, *optional*, defaults to `False`):
             Whether to tie the input and output word embeddings.
         rope_theta (`float`, *optional*, defaults to 10000.0):
@@ -152,6 +154,7 @@ class Dots1Config(PretrainedConfig):
         initializer_range=0.02,
         rms_norm_eps=1e-6,
         use_cache=True,
+        use_grouped_gemm=False,
         tie_word_embeddings=False,
         rope_theta=10000.0,
         rope_scaling=None,
@@ -184,6 +187,7 @@ class Dots1Config(PretrainedConfig):
         self.initializer_range = initializer_range
         self.rms_norm_eps = rms_norm_eps
         self.use_cache = use_cache
+        self.use_grouped_gemm = use_grouped_gemm
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
         self.attention_bias = attention_bias
@@ -201,6 +205,12 @@ class Dots1Config(PretrainedConfig):
                 for i in range(self.num_hidden_layers)
             ]
         layer_type_validation(self.layer_types)
+
+        if self.use_grouped_gemm:
+            import importlib.util
+
+            if importlib.util.find_spec("grouped_gemm") is None:
+                raise ImportError("Cannot fuse experts because 'grouped_gemm' is not installed.")
 
         super().__init__(
             tie_word_embeddings=tie_word_embeddings,

--- a/src/transformers/models/dots1/modeling_dots1.py
+++ b/src/transformers/models/dots1/modeling_dots1.py
@@ -18,10 +18,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 from typing import Callable, Optional, Union
 
 import torch
 import torch.nn.functional as F
+import torch.nn.init as init
 from torch import nn
 
 from ...activations import ACT2FN
@@ -262,56 +264,114 @@ class Dots1MLP(nn.Module):
         return down_proj
 
 
-class Dots1MoE(nn.Module):
-    """
-    A mixed expert module containing shared experts.
-    """
+class GroupedLinear(nn.Module):
+    def __init__(self, num_groups: int, in_features: int, out_features: int, bias: bool = False):
+        super().__init__()
+        self.num_groups = num_groups
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(num_groups, out_features, in_features))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(num_groups, out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
 
+    def reset_parameters(self) -> None:
+        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, x):
+        raise NotImplementedError("`GroupedLinear` is a weight container for use with specialized kernels.")
+
+    def extra_repr(self) -> str:
+        return f"num_groups={self.num_groups}, in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
+
+
+class GroupedDeepseekV3MLP(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.config = config
-        self.experts = nn.ModuleList(
-            [Dots1MLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(config.n_routed_experts)]
-        )
+        num_experts = config.n_routed_experts
+        hidden_size = config.hidden_size
+        intermediate_size = config.moe_intermediate_size
+
+        # Use the new GroupedLinear layer for a cleaner, more consistent structure
+        self.gate_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.up_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.down_proj = GroupedLinear(num_experts, intermediate_size, hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        raise NotImplementedError("The MoE computation is performed in the parent `Dots1MoE` module.")
+
+
+class Dots1MoE(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.use_grouped_gemm = config.use_grouped_gemm
         self.gate = Dots1TopkRouter(config)
         self.shared_experts = Dots1MLP(
-            config=config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
+            config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
         )
+        if self.use_grouped_gemm:
+            self.experts = GroupedDeepseekV3MLP(config)
+        else:
+            self.experts = nn.ModuleList(
+                [
+                    Dots1MLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(config.n_routed_experts)
+                ]
+            )
 
-    def moe(self, hidden_states: torch.Tensor, topk_indices: torch.Tensor, topk_weights: torch.Tensor):
-        r"""
-        CALL FOR CONTRIBUTION! I don't have time to optimise this right now, but expert weights need to be fused
-        to not have to do a loop here (deepseek has 256 experts soooo yeah).
-        """
-        final_hidden_states = torch.zeros_like(hidden_states, dtype=topk_weights.dtype)
-        expert_mask = torch.nn.functional.one_hot(topk_indices, num_classes=len(self.experts))
-        expert_mask = expert_mask.permute(2, 0, 1)
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_grouped_gemm:
+            return self.grouped_forward(hidden_states)
+        else:
+            return self.vanilla_forward(hidden_states)
+
+    def grouped_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        import grouped_gemm.ops as ops
+
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        topk_indices = topk_indices.to(torch.int32)
+        batch_sizes = torch.bincount(topk_indices.flatten().cpu(), minlength=self.config.n_routed_experts)
+        permuted_hidden_states, row_id_map = ops.permute(flat_hidden_states, topk_indices)
+
+        gate_out = ops.gmm(permuted_hidden_states, self.experts.gate_proj.weight, batch_sizes, trans_b=True)
+        up_out = ops.gmm(permuted_hidden_states, self.experts.up_proj.weight, batch_sizes, trans_b=True)
+        intermediate_out = self.experts.act_fn(gate_out) * up_out
+        expert_out = ops.gmm(intermediate_out, self.experts.down_proj.weight, batch_sizes, trans_b=True)
+
+        moe_output = ops.unpermute(expert_out, row_id_map, topk_weights)
+        return moe_output.view(*orig_shape) + self.shared_experts(residuals)
+
+    def vanilla_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        final_hidden_states = torch.zeros_like(flat_hidden_states)
+        expert_mask = F.one_hot(topk_indices, num_classes=len(self.experts)).permute(2, 0, 1)
 
         for expert_idx in range(len(self.experts)):
             expert = self.experts[expert_idx]
-            mask = expert_mask[expert_idx]
-            token_indices, weight_indices = torch.where(mask)
-
+            token_indices, weight_indices = torch.where(expert_mask[expert_idx])
             if token_indices.numel() > 0:
-                expert_weights = topk_weights[token_indices, weight_indices]
-                expert_input = hidden_states[token_indices]
-                expert_output = expert(expert_input)
-                weighted_output = expert_output * expert_weights.unsqueeze(-1)
-                final_hidden_states.index_add_(0, token_indices, weighted_output)
+                expert_weights = topk_weights[token_indices, weight_indices].unsqueeze(1)
+                expert_output = expert(flat_hidden_states[token_indices])
+                final_hidden_states.index_add_(
+                    0, token_indices, (expert_output * expert_weights).to(final_hidden_states.dtype)
+                )
 
-        # in original deepseek, the output of the experts are gathered once we leave this module
-        # thus the moe module is itelsf an IsolatedParallel module
-        # and all expert are "local" meaning we shard but we don't gather
-        return final_hidden_states.type(hidden_states.dtype)
-
-    def forward(self, hidden_states):
-        residuals = hidden_states
-        orig_shape = hidden_states.shape
-        topk_indices, topk_weights = self.gate(hidden_states)
-        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
-        hidden_states = self.moe(hidden_states, topk_indices, topk_weights).view(*orig_shape)
-        hidden_states = hidden_states + self.shared_experts(residuals)
-        return hidden_states
+        return final_hidden_states.view(*orig_shape) + self.shared_experts(residuals)
 
 
 class Dots1TopkRouter(nn.Module):

--- a/src/transformers/models/glm4_moe/modular_glm4_moe.py
+++ b/src/transformers/models/glm4_moe/modular_glm4_moe.py
@@ -82,6 +82,8 @@ class Glm4MoeConfig(PretrainedConfig):
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should return the last key/values attentions (not used by all models). Only
             relevant if `config.is_decoder=True`.
+        use_grouped_gemm (`bool`, *optional*, defaults to `False`):
+            Whether to use grouped gemm to speed up the model.
         tie_word_embeddings (`bool`, *optional*, defaults to `False`):
             Whether the model's input and output word embeddings should be tied.
         rope_theta (`float`, *optional*, defaults to 10000.0):
@@ -197,6 +199,7 @@ class Glm4MoeConfig(PretrainedConfig):
         initializer_range=0.02,
         rms_norm_eps=1e-5,
         use_cache=True,
+        use_grouped_gemm=False,
         tie_word_embeddings=False,
         rope_theta=10000.0,
         rope_scaling=None,
@@ -227,6 +230,7 @@ class Glm4MoeConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.rms_norm_eps = rms_norm_eps
         self.use_cache = use_cache
+        self.use_grouped_gemm = use_grouped_gemm
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
         self.attention_bias = attention_bias
@@ -235,6 +239,13 @@ class Glm4MoeConfig(PretrainedConfig):
         # BC: if there is a 'type' field, move it to 'rope_type'.
         if self.rope_scaling is not None and "type" in self.rope_scaling:
             self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+
+        if self.use_grouped_gemm:
+            import importlib.util
+
+            if importlib.util.find_spec("grouped_gemm") is None:
+                raise ImportError("Cannot fuse experts because 'grouped_gemm' is not installed.")
+
         rope_config_validation(self)
 
         # MoE arguments

--- a/src/transformers/models/glm4v_moe/configuration_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/configuration_glm4v_moe.py
@@ -160,6 +160,8 @@ class Glm4vMoeTextConfig(PretrainedConfig):
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should return the last key/values attentions (not used by all models). Only
             relevant if `config.is_decoder=True`.
+        use_grouped_gemm (`bool`, *optional*, defaults to `False`):
+            Whether to use grouped gemm to speed up the model.
         tie_word_embeddings (`bool`, *optional*, defaults to `False`):
             Whether the model's input and output word embeddings should be tied.
         rope_theta (`float`, *optional*, defaults to 10000.0):
@@ -252,6 +254,7 @@ class Glm4vMoeTextConfig(PretrainedConfig):
         initializer_range=0.02,
         rms_norm_eps=1e-5,
         use_cache=True,
+        use_grouped_gemm=False,
         tie_word_embeddings=False,
         rope_theta=10000.0,
         rope_scaling=None,
@@ -282,6 +285,7 @@ class Glm4vMoeTextConfig(PretrainedConfig):
         self.initializer_range = initializer_range
         self.rms_norm_eps = rms_norm_eps
         self.use_cache = use_cache
+        self.use_grouped_gemm = use_grouped_gemm
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
         self.attention_bias = attention_bias
@@ -290,6 +294,13 @@ class Glm4vMoeTextConfig(PretrainedConfig):
         # BC: if there is a 'type' field, move it to 'rope_type'.
         if self.rope_scaling is not None and "type" in self.rope_scaling:
             self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+
+        if self.use_grouped_gemm:
+            import importlib.util
+
+            if importlib.util.find_spec("grouped_gemm") is None:
+                raise ImportError("Cannot fuse experts because 'grouped_gemm' is not installed.")
+
         rope_config_validation(self, ignore_keys={"mrope_section"})
 
         # MoE arguments

--- a/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
@@ -19,12 +19,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import itertools
+import math
 from dataclasses import dataclass
 from typing import Any, Callable, Optional, Union
 
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+import torch.nn.init as init
 from torch.nn import LayerNorm
 
 from ...activations import ACT2FN
@@ -289,59 +291,120 @@ class Glm4vMoeTextTopkRouter(nn.Module):
         return topk_indices, topk_weights
 
 
-class Glm4vMoeTextMoE(nn.Module):
-    """
-    A mixed expert module containing shared experts.
-    """
+class GroupedLinear(nn.Module):
+    def __init__(self, num_groups: int, in_features: int, out_features: int, bias: bool = False):
+        super().__init__()
+        self.num_groups = num_groups
+        self.in_features = in_features
+        self.out_features = out_features
+        self.weight = nn.Parameter(torch.empty(num_groups, out_features, in_features))
+        if bias:
+            self.bias = nn.Parameter(torch.empty(num_groups, out_features))
+        else:
+            self.register_parameter("bias", None)
+        self.reset_parameters()
 
+    def reset_parameters(self) -> None:
+        init.kaiming_uniform_(self.weight, a=math.sqrt(5))
+        if self.bias is not None:
+            fan_in, _ = init._calculate_fan_in_and_fan_out(self.weight)
+            bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+            init.uniform_(self.bias, -bound, bound)
+
+    def forward(self, x):
+        raise NotImplementedError("`GroupedLinear` is a weight container for use with specialized kernels.")
+
+    def extra_repr(self) -> str:
+        return f"num_groups={self.num_groups}, in_features={self.in_features}, out_features={self.out_features}, bias={self.bias is not None}"
+
+
+class GroupedDeepseekV3MLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        num_experts = config.n_routed_experts
+        hidden_size = config.hidden_size
+        intermediate_size = config.moe_intermediate_size
+
+        # Use the new GroupedLinear layer for a cleaner, more consistent structure
+        self.gate_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.up_proj = GroupedLinear(num_experts, hidden_size, intermediate_size, bias=False)
+        self.down_proj = GroupedLinear(num_experts, intermediate_size, hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        raise NotImplementedError("The MoE computation is performed in the parent `Glm4vMoeTextMoE` module.")
+
+
+class Glm4vMoeTextMoE(nn.Module):
     def __init__(self, config: Glm4vMoeTextConfig):
         super().__init__()
         self.config = config
+        self.use_grouped_gemm = config.use_grouped_gemm
+        self.gate = Glm4vMoeTextTopkRouter(config)
+        self.shared_experts = Glm4vMoeTextMLP(
+            config=config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
+        )
+        if self.use_grouped_gemm:
+            self.experts = GroupedDeepseekV3MLP(config)
+        else:
+            self.experts = nn.ModuleList(
+                [
+                    Glm4vMoeTextMLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(config.n_routed_experts)
+                ]
+            )
         self.experts = nn.ModuleList(
             [
                 Glm4vMoeTextMLP(config, intermediate_size=config.moe_intermediate_size)
                 for _ in range(config.n_routed_experts)
             ]
         )
-        self.gate = Glm4vMoeTextTopkRouter(config)
-        self.shared_experts = Glm4vMoeTextMLP(
-            config=config, intermediate_size=config.moe_intermediate_size * config.n_shared_experts
-        )
 
-    def moe(self, hidden_states: torch.Tensor, topk_indices: torch.Tensor, topk_weights: torch.Tensor):
-        r"""
-        CALL FOR CONTRIBUTION! I don't have time to optimise this right now, but expert weights need to be fused
-        to not have to do a loop here (deepseek has 256 experts soooo yeah).
-        """
-        final_hidden_states = torch.zeros_like(hidden_states, dtype=topk_weights.dtype)
-        expert_mask = torch.nn.functional.one_hot(topk_indices, num_classes=len(self.experts))
-        expert_mask = expert_mask.permute(2, 0, 1)
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        if self.use_grouped_gemm:
+            return self.grouped_forward(hidden_states)
+        else:
+            return self.vanilla_forward(hidden_states)
+
+    def grouped_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        import grouped_gemm.ops as ops
+
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        topk_indices = topk_indices.to(torch.int32)
+        batch_sizes = torch.bincount(topk_indices.flatten().cpu(), minlength=self.config.n_routed_experts)
+        permuted_hidden_states, row_id_map = ops.permute(flat_hidden_states, topk_indices)
+
+        gate_out = ops.gmm(permuted_hidden_states, self.experts.gate_proj.weight, batch_sizes, trans_b=True)
+        up_out = ops.gmm(permuted_hidden_states, self.experts.up_proj.weight, batch_sizes, trans_b=True)
+        intermediate_out = self.experts.act_fn(gate_out) * up_out
+        expert_out = ops.gmm(intermediate_out, self.experts.down_proj.weight, batch_sizes, trans_b=True)
+
+        moe_output = ops.unpermute(expert_out, row_id_map, topk_weights)
+        return moe_output.view(*orig_shape) + self.shared_experts(residuals)
+
+    def vanilla_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residuals = hidden_states
+        orig_shape = hidden_states.shape
+        flat_hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
+        topk_indices, topk_weights = self.gate(hidden_states)
+        final_hidden_states = torch.zeros_like(flat_hidden_states)
+        expert_mask = F.one_hot(topk_indices, num_classes=len(self.experts)).permute(2, 0, 1)
 
         for expert_idx in range(len(self.experts)):
             expert = self.experts[expert_idx]
-            mask = expert_mask[expert_idx]
-            token_indices, weight_indices = torch.where(mask)
-
+            token_indices, weight_indices = torch.where(expert_mask[expert_idx])
             if token_indices.numel() > 0:
-                expert_weights = topk_weights[token_indices, weight_indices]
-                expert_input = hidden_states[token_indices]
-                expert_output = expert(expert_input)
-                weighted_output = expert_output * expert_weights.unsqueeze(-1)
-                final_hidden_states.index_add_(0, token_indices, weighted_output)
+                expert_weights = topk_weights[token_indices, weight_indices].unsqueeze(1)
+                expert_output = expert(flat_hidden_states[token_indices])
+                final_hidden_states.index_add_(
+                    0, token_indices, (expert_output * expert_weights).to(final_hidden_states.dtype)
+                )
 
-        # in original deepseek, the output of the experts are gathered once we leave this module
-        # thus the moe module is itelsf an IsolatedParallel module
-        # and all expert are "local" meaning we shard but we don't gather
-        return final_hidden_states.type(hidden_states.dtype)
-
-    def forward(self, hidden_states):
-        residuals = hidden_states
-        orig_shape = hidden_states.shape
-        topk_indices, topk_weights = self.gate(hidden_states)
-        hidden_states = hidden_states.view(-1, hidden_states.shape[-1])
-        hidden_states = self.moe(hidden_states, topk_indices, topk_weights).view(*orig_shape)
-        hidden_states = hidden_states + self.shared_experts(residuals)
-        return hidden_states
+        return final_hidden_states.view(*orig_shape) + self.shared_experts(residuals)
 
 
 class Glm4vMoeTextMLP(nn.Module):

--- a/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
@@ -90,6 +90,8 @@ class Glm4vMoeTextConfig(Glm4MoeConfig):
         use_cache (`bool`, *optional*, defaults to `True`):
             Whether or not the model should return the last key/values attentions (not used by all models). Only
             relevant if `config.is_decoder=True`.
+        use_grouped_gemm (`bool`, *optional*, defaults to `False`):
+            Whether to use grouped gemm to speed up the model.
         tie_word_embeddings (`bool`, *optional*, defaults to `False`):
             Whether the model's input and output word embeddings should be tied.
         rope_theta (`float`, *optional*, defaults to 10000.0):
@@ -182,6 +184,7 @@ class Glm4vMoeTextConfig(Glm4MoeConfig):
         initializer_range=0.02,
         rms_norm_eps=1e-5,
         use_cache=True,
+        use_grouped_gemm=False,
         tie_word_embeddings=False,
         rope_theta=10000.0,
         rope_scaling=None,
@@ -212,6 +215,7 @@ class Glm4vMoeTextConfig(Glm4MoeConfig):
         self.initializer_range = initializer_range
         self.rms_norm_eps = rms_norm_eps
         self.use_cache = use_cache
+        self.use_grouped_gemm = use_grouped_gemm
         self.rope_theta = rope_theta
         self.rope_scaling = rope_scaling
         self.attention_bias = attention_bias
@@ -220,6 +224,13 @@ class Glm4vMoeTextConfig(Glm4MoeConfig):
         # BC: if there is a 'type' field, move it to 'rope_type'.
         if self.rope_scaling is not None and "type" in self.rope_scaling:
             self.rope_scaling["rope_type"] = self.rope_scaling["type"]
+
+        if self.use_grouped_gemm:
+            import importlib.util
+
+            if importlib.util.find_spec("grouped_gemm") is None:
+                raise ImportError("Cannot fuse experts because 'grouped_gemm' is not installed.")
+
         rope_config_validation(self, ignore_keys={"mrope_section"})
 
         # MoE arguments


### PR DESCRIPTION
# What does this PR do?
This PR introduces an optimization that significantly accelerates the Mixture-of-Experts (MoE) layer computations in the `DeepseekV3` model by integrating the `grouped_gemm` library. This enhances performance for both training and inference.

The original MoE implementation processed expert networks sequentially using a Python loop, which created a performance bottleneck due to high GPU kernel launch overhead. This PR addresses that issue with the following key changes:

  * **🚀 Grouped GEMM Kernel Integration**: A new `grouped_forward` operational path replaces the iterative Python loop over experts with a single, high-performance kernel call from the `grouped_gemm` library. This minimizes GPU overhead and maximizes throughput.

  * **🧩 Expert Module Fusing**: To efficiently leverage the `grouped_gemm` kernel, this PR implements a `fuse_experts()` utility and a `GroupedDeepseekV3MLP` module. These tools combine the weights of multiple experts into a single, contiguous tensor, which is a prerequisite for the kernel.

  * **⚙️ Configuration and Usability**: A `use_grouped_gemm` flag has been added to `DeepseekV3Config` to enable this optimization.
    **Important**: If you set `use_grouped_gemm=True` directly when loading a model (e.g., in `.from_pretrained()`), you must provide a `state_dict` where the expert weights have already been fused. For standard checkpoints, the recommended workflow is to load the model normally and then call the `model.fuse_experts()` method.

  * **⚠️ Dependency Handling**: The model now gracefully handles the optional dependency. If `use_grouped_gemm` is enabled but the library isn't found, it raises a clear `ImportError` with installation instructions.

-----

## **How to use**

1.  **Install the required library**:

    ```bash
    pip install git+https://github.com/fanshiqing/grouped_gemm@main
    ```

2.  **Load a standard model and fuse the experts after loading** (Recommended method):

    ```python
    from transformers import AutoModelForCausalLM

    # Load a standard checkpoint from the Hub
    model = AutoModelForCausalLM.from_pretrained(
        "moonshotai/Moonlight-16B-A3B-Instruct",
        device_map="cuda:0",
        # Do not set use_grouped_gemm=True here
    )

    # Fuse the experts in-place
    model.fuse_experts()

    # The model is now optimized and ready for faster inference or training
    ```

For checkpoints that have already been saved in the fused format, you can load them directly by setting `use_grouped_gemm=True` in the `.from_pretrained()` call.

Fixes #40582


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @Rocketknight1 