### PR TITLE
Pin torchcodec to 0.5 in AMD docker

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -20,8 +20,6 @@ WORKDIR /
 ADD https://api.github.com/repos/huggingface/transformers/git/refs/heads/main version.json
 RUN git clone https://github.com/huggingface/transformers && cd transformers && git checkout $REF
 
-# On ROCm, torchcodec is required to decode audio files
-# RUN python3 -m pip install --no-cache-dir torchcodec
 # Install transformers
 RUN python3 -m pip install --no-cache-dir -e ./transformers[dev-torch,testing,video,audio]
 
@@ -37,3 +35,6 @@ RUN python3 -m pip uninstall py3nvml pynvml nvidia-ml-py apex -y
 
 # `kernels` may causes many failing tests
 RUN python3 -m pip uninstall -y kernels
+
+# On ROCm, torchcodec is required to decode audio files and 0.4 or 0.6 fails
+RUN python3 -m pip install --no-cache-dir "torchcodec==0.5"


### PR DESCRIPTION
Some tests are failing on the AMD CI ([like in this run](https://github.com/huggingface/transformers/actions/runs/17351600834/job/49258855146)) because of `torchcodec` with the follwing error: 
```
FAILED tests/models/internvl/test_processing_internvl.py::InternVLProcessorTest::test_apply_chat_template_video_frame_sampling - RuntimeError: torchcodec_ns::get_frames_at_indices() Expected a value of type 'List[int]' for argument 'frame_indices' but instead found type 'Tensor'.
Position: 1
Value: tensor([ 50, 150, 250], dtype=torch.int32)
Declaration: torchcodec_ns::get_frames_at_indices(Tensor(a!) decoder, *, int[] frame_indices) -> (Tensor, Tensor, Tensor)
Cast error details: Unable to cast Python instance of type <class 'torch.Tensor'> to C++ type '?' (#define PYBIND11_DETAILED_ERROR_MESSAGES or compile in debug mode for details)
```
and pining `torchcodec` version to 0.5 in the docker, instead of the current 0.4, fixes this. Tested 0.6 as well and it did not work. 