### PR TITLE
feat: support request cancellation

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -128,10 +128,11 @@ if serve_dependencies_available:
 
     class TransformersCompletionCreateParamsStreaming(CompletionCreateParamsStreaming, total=False):
         """
-        OpenAI's CompletionCreateParamsStreaming with an additional field for the generation config (as a json string).
+        OpenAI's CompletionCreateParamsStreaming with additional fields for the generation config (as a json string) and passing the request_id
         """
 
         generation_config: str
+        request_id: str
 
     class TransformersTranscriptionCreateParams(TranscriptionCreateParamsBase, total=False):
         """
@@ -873,8 +874,8 @@ class ServeCommand(BaseTransformersCLICommand):
                     await asyncio.sleep(0)  # Yield control to the event loop to check for cancellations
             except asyncio.CancelledError:
                 if request_id is not None:
-                    logger.warning(f"Request {request_id} was cancelled. Cleaning up.")
                     self.running_continuous_batching_manager.cancel_request(request_id)
+                    logger.warning(f"Request {request_id} was cancelled.")
 
         return cancellation_wrapper(inputs[0])
 

--- a/tests/commands/test_serving.py
+++ b/tests/commands/test_serving.py
@@ -19,6 +19,7 @@ from threading import Thread
 from unittest.mock import patch
 
 import aiohttp.client_exceptions
+import httpx
 from huggingface_hub import AsyncInferenceClient, ChatCompletionStreamOutput
 from parameterized import parameterized
 
@@ -492,6 +493,60 @@ class ServeCompletionsGenerateIntegrationTest(ServeCompletionsMixin, unittest.Te
         self.assertTrue(all(reason is None for reason in finish_reasons[:-1]))
 
 
+def _get_scheduler(serve_command):
+    # Defensive navigation in case any layer is renamed in the future
+    cbm = getattr(serve_command, "running_continuous_batching_manager", None)
+    assert cbm is not None, "ServeCommand has no running_continuous_batching_manager"
+    bp = getattr(cbm, "batch_processor", None)
+    assert bp is not None, "CBM has no batch_processor"
+    sched = getattr(bp, "scheduler", None)
+    assert sched is not None, "batch_processor has no scheduler"
+    return sched
+
+
+def _contains_request_id(scheduler, request_id: str) -> bool:
+    active = getattr(scheduler, "active_requests", set()) or set()
+    waiting = getattr(scheduler, "waiting_request", set()) or set()
+    requests_to_cancel = getattr(scheduler, "requests_to_cancel", set()) or set()
+    return request_id in requests_to_cancel or (request_id not in active and request_id not in waiting)
+
+
+async def _open_stream_and_cancel(base_url: str, request_id: str):
+    async with httpx.AsyncClient(base_url=base_url, timeout=None) as client:
+        first_chunk = asyncio.Event()
+
+        async def _reader():
+            async with client.stream(
+                "POST",
+                "/v1/chat/completions",
+                json={
+                    "model": "Qwen/Qwen2.5-0.5B-Instruct",
+                    "stream": True,
+                    "messages": [{"role": "user", "content": "Count slowly so I can cancel you."}],
+                    "request_id": request_id,
+                },
+            ) as resp:
+                # Ensure stream started OK
+                assert resp.status_code == 200
+
+                try:
+                    # Read the first chunk to ensure the server has entered the generation loop
+                    async for _ in resp.aiter_raw():
+                        if not first_chunk.is_set():
+                            first_chunk.set()
+
+                except httpx.ReadError:
+                    pass
+
+        task = asyncio.create_task(_reader())
+        await asyncio.wait_for(first_chunk.wait(), timeout=30.0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
 @slow  # server startup time is slow on our push CI
 @require_openai
 class ServeCompletionsContinuousBatchingIntegrationTest(ServeCompletionsMixin, unittest.TestCase):
@@ -558,6 +613,33 @@ class ServeCompletionsContinuousBatchingIntegrationTest(ServeCompletionsMixin, u
             full_text.startswith(
                 "I can assist you with a wide range of tasks, from answering questions to providing information on various sports topics."
             )
+        )
+
+    def test_request_cancellation(self):
+        """Tests that a request can be cancelled."""
+
+        base_url = f"http://127.0.0.1:{self.port}"
+        request_id = "test-cancel"
+
+        asyncio.run(_open_stream_and_cancel(base_url, request_id))
+
+        scheduler = _get_scheduler(self.serve_command)
+
+        # Because cancellation is non-blocking, poll for a short, bounded time.
+        deadline = time.time() + 8.0  # generous but still CI-friendly
+        last_seen = None
+        while time.time() < deadline:
+            present = _contains_request_id(scheduler, request_id)
+            if not present:
+                break
+            last_seen = time.time()
+            time.sleep(0.1)  # don't spin the CPU
+
+        still_present = _contains_request_id(scheduler, request_id)
+        self.assertFalse(
+            still_present,
+            f"Request {request_id} still present in scheduler after cancellation "
+            f"(last seen at {last_seen}). Check cancellation propagation.",
         )
 
 


### PR DESCRIPTION
Support client-side request cancellation, so server avoids continuing to generate tokens needlessly, saving resources (also helps server exit).

Will rebase when #40479 is merged to get clearer diff.