### PR TITLE
Avoid `too many request` caused by `AutoModelTest::test_dynamic_saving_from_local_repo`

### DIFF
--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -39,6 +39,7 @@ from ..bert.test_modeling_bert import BertModelTester
 sys.path.append(str(Path(__file__).parent.parent.parent.parent / "utils"))
 
 from test_module.custom_configuration import CustomConfig  # noqa E402
+from utils.fetch_hub_objects_for_ci import url_to_local_path
 
 
 if is_torch_available():
@@ -556,7 +557,7 @@ class AutoModelTest(unittest.TestCase):
 
     def test_dynamic_saving_from_local_repo(self):
         with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as tmp_dir_out:
-            _ = Repository(local_dir=tmp_dir, clone_from="hf-internal-testing/tiny-random-custom-architecture")
+            _ = Repository(local_dir=tmp_dir, clone_from=url_to_local_path("hf-internal-testing/tiny-random-custom-architecture"))
             model = AutoModelForCausalLM.from_pretrained(tmp_dir, trust_remote_code=True)
             model.save_pretrained(tmp_dir_out)
             _ = AutoModelForCausalLM.from_pretrained(tmp_dir_out, trust_remote_code=True)

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 import copy
+import os
+import os.path
+import shutil
 import sys
 import tempfile
 import unittest
@@ -557,7 +560,18 @@ class AutoModelTest(unittest.TestCase):
 
     def test_dynamic_saving_from_local_repo(self):
         with tempfile.TemporaryDirectory() as tmp_dir, tempfile.TemporaryDirectory() as tmp_dir_out:
-            _ = Repository(local_dir=tmp_dir, clone_from=url_to_local_path("hf-internal-testing/tiny-random-custom-architecture"))
+            # `Repository` is deprecated and will be removed in `huggingface_hub v1.0`.
+            # TODO: Remove this test when this comes.
+            # Here is a ugly approach to avoid `too many requests`
+            repo_id = url_to_local_path("hf-internal-testing/tiny-random-custom-architecture")
+            if os.path.isdir(repo_id):
+                shutil.copytree(repo_id, tmp_dir, dirs_exist_ok=True)
+            else:
+                _ = Repository(
+                    local_dir=tmp_dir,
+                    clone_from=url_to_local_path("hf-internal-testing/tiny-random-custom-architecture"),
+                )
+
             model = AutoModelForCausalLM.from_pretrained(tmp_dir, trust_remote_code=True)
             model.save_pretrained(tmp_dir_out)
             _ = AutoModelForCausalLM.from_pretrained(tmp_dir_out, trust_remote_code=True)

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -60,4 +60,7 @@ if __name__ == "__main__":
             print(f"Error downloading {filename}: {e}")
 
     # Used in as `tests/models/auto/test_modeling_auto.py::AutoModelTest::test_dynamic_saving_from_local_repo --> _ = Repository( ... )`
-    _ = Repository(local_dir="tiny-random-custom-architecture", clone_from="hf-internal-testing/tiny-random-custom-architecture")
+    # TODO: Remove this and the above test when `huggingface_hub v1.0` comes (where `Repository` will be removed).
+    _ = Repository(
+        local_dir="tiny-random-custom-architecture", clone_from="hf-internal-testing/tiny-random-custom-architecture"
+    )

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -1,7 +1,7 @@
 import os
 
 import requests
-from huggingface_hub import hf_hub_download
+from huggingface_hub import Repository, hf_hub_download
 
 from transformers.testing_utils import _run_pipeline_tests
 
@@ -58,3 +58,6 @@ if __name__ == "__main__":
             print(f"Successfully downloaded: {filename}")
         except requests.exceptions.RequestException as e:
             print(f"Error downloading {filename}: {e}")
+
+    # Used in as `tests/models/auto/test_modeling_auto.py::AutoModelTest::test_dynamic_saving_from_local_repo --> _ = Repository( ... )`
+    _ = Repository(local_dir="tiny-random-custom-architecture", clone_from="hf-internal-testing/tiny-random-custom-architecture")


### PR DESCRIPTION
# What does this PR do?

This test uses `huggingface_hub's Repository` which doesn't have any cache mechanism, so from time to time we get `The requested URL returned error: 429` (`too many requests`) error.

```bash
FAILED tests/models/auto/test_modeling_auto.py::AutoModelTest::test_dynamic_saving_from_local_repo - OSError: WARNING: `git lfs clone` is deprecated and will not be updated
          with new flags from `git clone`

`git clone` has been updated in upstream Git to have comparable
speeds to `git lfs clone`.

--------------------------------------------
Cloning into '.'...
fatal: unable to access 'https://huggingface.co/hf-internal-testing/tiny-random-custom-architecture/': The requested URL returned error: 429
-------------------------------------------

Error(s) during clone:
`git clone` failed: exit status 128
```

https://app.circleci.com/pipelines/github/huggingface/transformers/143470/workflows/b339d736-e318-45e5-b708-ce89dc09b150/jobs/1897077