### PR TITLE
feat: err when unsupported attn impl is set w/ `--continuous_batching`

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -487,7 +487,7 @@ class ServeCommand(BaseTransformersCLICommand):
             default_attn_impl = ContinuousBatchingManager.default_attention_implementation()
             # checking if attn_implementation is supported by continuous batching
             if self.args.attn_implementation is None:
-                self.args.attn_implementation =   # default to sdpa_paged
+                self.args.attn_implementation = default_attn_impl  # default to sdpa_paged
             supported_attn_impl = ContinuousBatchingManager.supported_attention_implementations()
             if self.args.attn_implementation not in supported_attn_impl:
                 raise ValueError(

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -483,14 +483,15 @@ class ServeCommand(BaseTransformersCLICommand):
         # Store and process input arguments
         self.args = args
         self.use_continuous_batching = self.args.continuous_batching
-        supported_cb_attn_implementations = {"eager_paged", "sdpa_paged", "flash_attention_2"}
         if self.use_continuous_batching:
+            default_attn_impl = ContinuousBatchingManager.default_attention_implementation()
             # checking if attn_implementation is supported by continuous batching
             if self.args.attn_implementation is None:
-                self.args.attn_implementation = "sdpa_paged"  # default to sdpa_paged
-            if self.args.attn_implementation not in supported_cb_attn_implementations:
+                self.args.attn_implementation =   # default to sdpa_paged
+            supported_attn_impl = ContinuousBatchingManager.supported_attention_implementations()
+            if self.args.attn_implementation not in supported_attn_impl:
                 raise ValueError(
-                    f"Continuous batching only supports {supported_cb_attn_implementations} as attn_implementation, got "
+                    f"Continuous batching only supports {supported_attn_impl} as attn_implementation, got "
                     f"{self.args.attn_implementation}"
                 )
         self.enable_cors = self.args.enable_cors

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -493,6 +493,7 @@ class ServeCommand(BaseTransformersCLICommand):
                 raise ValueError(
                     f"Continuous batching only supports {supported_attn_impl} as attn_implementation, got "
                     f"{self.args.attn_implementation}"
+                    f"Try setting `--attn_implementation={default_attn_impl}`"
                 )
         self.enable_cors = self.args.enable_cors
 

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -488,6 +488,7 @@ class ServeCommand(BaseTransformersCLICommand):
             # checking if attn_implementation is supported by continuous batching
             if self.args.attn_implementation is None:
                 self.args.attn_implementation = default_attn_impl  # default to sdpa_paged
+                logger.info(f"No attn_implementation passed, defaulting to {default_attn_impl}")
             supported_attn_impl = ContinuousBatchingManager.supported_attention_implementations()
             if self.args.attn_implementation not in supported_attn_impl:
                 raise ValueError(

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -483,6 +483,16 @@ class ServeCommand(BaseTransformersCLICommand):
         # Store and process input arguments
         self.args = args
         self.use_continuous_batching = self.args.continuous_batching
+        supported_cb_attn_implementations = {"eager_paged", "sdpa_paged", "flash_attention_2"}
+        if self.use_continuous_batching:
+            # checking if attn_implementation is supported by continuous batching
+            if self.args.attn_implementation is None:
+                self.args.attn_implementation = "sdpa_paged"  # default to sdpa_paged
+            if self.args.attn_implementation not in supported_cb_attn_implementations:
+                raise ValueError(
+                    f"Continuous batching only supports {supported_cb_attn_implementations} as attn_implementation, got "
+                    f"{self.args.attn_implementation}"
+                )
         self.enable_cors = self.args.enable_cors
 
         if self.args.default_seed is not None:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -595,6 +595,14 @@ class ContinuousBatchingManager:
             if self.batch_processor is not None:
                 request_cancelled = self.batch_processor.scheduler.request_is_cancelled(request_id)
 
+    @staticmethod
+    def supported_attention_implementations() -> set[str]:
+        return {"eager_paged", "sdpa_paged", "flash_attention_2"}
+
+    @staticmethod
+    def default_attention_implementation() -> str:
+        return "sdpa_paged"
+
     @traced
     def warmup(self, batch_processor):
         stream = torch.cuda.Stream(device=self.model.device)

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -442,6 +442,10 @@ class ContinuousBatchingManager:
             max_queue_size: Maximum size of the request queue (0 = unlimited)
             streaming: Whether to stream tokens as they are generated
         """
+        if model.config._attn_implementation not in self.supported_attention_implementations():
+            raise ValueError(
+                f"Model attention implementation '{model.config._attn_implementation}' is not supported for continuous batching. Supported implementations: {self.supported_attention_implementations()}"
+            )
         self.model = model.eval()
         generation_config = model.generation_config if generation_config is None else generation_config
         self.generation_config = generation_config

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -442,10 +442,6 @@ class ContinuousBatchingManager:
             max_queue_size: Maximum size of the request queue (0 = unlimited)
             streaming: Whether to stream tokens as they are generated
         """
-        if model.config._attn_implementation not in self.supported_attention_implementations():
-            raise ValueError(
-                f"Model attention implementation '{model.config._attn_implementation}' is not supported for continuous batching. Supported implementations: {self.supported_attention_implementations()}"
-            )
         self.model = model.eval()
         generation_config = model.generation_config if generation_config is None else generation_config
         self.generation_config = generation_config


### PR DESCRIPTION
In #40479, we introduced a new `--continuous_batching` flag. Here we add a check to make sure the `--attn_implementation` is compatible with CB and error when not.