### PR TITLE
Fix: PIL image load in Processing utils apply_chat_template

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1637,8 +1637,8 @@ class ProcessorMixin(PushToHubMixin):
             ):
                 kwargs["do_sample_frames"] = True
 
-            images_exist = any(len(im) > 0 for im_list in batch_images for im in im_list)
-            videos_exist = any(len(vid) > 0 for vid_list in batch_videos for vid in vid_list)
+            images_exist = any((im is not None) for im_list in batch_images for im in im_list)
+            videos_exist = any((vid is not None) for vid_list in batch_videos for vid in vid_list)
             out = self(
                 text=prompt,
                 images=batch_images if images_exist else None,


### PR DESCRIPTION
# What does this PR do?

This PR #36682 introduced the batch size for images, everything is working correctly but the check for image existence don't support the PPIL images. The `len()` function could work with path or other things. So I converted it to check `is not None` it works for both PIL images and paths or URLs

Note: I made the same fix for videos also 

Fixes #40603 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@zucchini-nlp 