### PR TITLE
Resume training by trained samples to avoid elastic job loss or over-reading of data.

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1574,6 +1574,16 @@ class TrainingArguments:
         },
     )
 
+    sample_based_train: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether or not to enable sample-based training. If enabled, the trainer will save or load the "
+                "checkpoint based on the number of samples processed instead of the number of steps."
+            )
+        },
+    )
+
     def __post_init__(self):
         # Set default output_dir if not provided
         if self.output_dir is None:


### PR DESCRIPTION
# What does this PR do?

Resume training by trained samples. Then we can avoid reading more or less data due to changes in the number of workers.

Fixes: #40245 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
