### PR TITLE
Skip `test_prompt_lookup_decoding_matches_greedy_search` for `voxtral`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -797,7 +797,7 @@ class GenerationTesterMixin:
                     "internvl",
                     "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model class is `Qwen2_5Omni`,
                     # All models below: shouldn't suggest audio tokens. Can be fixed by passing `suppress_ids` to candidate generator: @joaa @raushan
-                    "voxtral", 
+                    "voxtral",
                 ]
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -779,6 +779,7 @@ class GenerationTesterMixin:
                     "blip2",  # overridden `generate()` for all BLIP models
                     "instructblip",
                     "instructblipvideo",
+                    # TODO: The list is growing huge 🙃! Let's try to check if the config has any of audio/image/video token id and skip the test!
                     # All models below: shouldn't suggest image tokens. Can be fixed by passing `suppress_ids` to candidate generator: @joaa @raushan
                     "llava",
                     "idefics2",

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -796,6 +796,8 @@ class GenerationTesterMixin:
                     "chameleon",
                     "internvl",
                     "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model class is `Qwen2_5Omni`,
+                    # All models below: shouldn't suggest audio tokens. Can be fixed by passing `suppress_ids` to candidate generator: @joaa @raushan
+                    "voxtral", 
                 ]
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")


### PR DESCRIPTION
# What does this PR do?

> tests/models/voxtral/test_modeling_voxtral.py::VoxtralForConditionalGenerationModelTest::test_prompt_lookup_decoding_matches_greedy_search

is flaky

https://app.circleci.com/pipelines/github/huggingface/transformers/144445/workflows/829f1347-398e-493f-a531-36c3178da153/jobs/1909491

```bash
    @can_return_tuple
    @auto_docstring
    def forward(
        self,
        input_ids: Optional[torch.LongTensor] = None,
        input_features: Optional[torch.FloatTensor] = None,
        attention_mask: Optional[torch.Tensor] = None,
        position_ids: Optional[torch.LongTensor] = None,
        past_key_values: Optional[Cache] = None,
        inputs_embeds: Optional[torch.FloatTensor] = None,
        labels: Optional[torch.LongTensor] = None,
        use_cache: Optional[bool] = None,
        cache_position: Optional[torch.LongTensor] = None,
        logits_to_keep: Union[int, torch.Tensor] = 0,
        **kwargs: Unpack[TransformersKwargs],
    ) -> CausalLMOutputWithPast:
        if inputs_embeds is None:
            inputs_embeds = self.get_input_embeddings()(input_ids)
    
        if input_features is not None:
            audio_embeds = self.get_audio_embeds(input_features)
    
            # replace text-audio token placeholders with audio embeddings
            audio_token_mask = input_ids == self.config.audio_token_id
>           inputs_embeds[audio_token_mask] = audio_embeds
E           RuntimeError: shape mismatch: value tensor of shape [30, 32] cannot be broadcast to indexing result of shape [32, 32]

/usr/local/lib/python3.9/site-packages/transformers/models/voxtral/modeling_voxtral.py:512: RuntimeError```