### PR TITLE
refactor: use `tolist` instead of list comprehension calling `.item()`

### DIFF
--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -830,7 +830,7 @@ class ServeCommand(BaseTransformersCLICommand):
 
         def stream_chat_completion(_inputs):
             try:
-                decode_stream = DecodeStream([id.item() for id in _inputs], False)
+                decode_stream = DecodeStream(_inputs.tolist(), False)
                 request_id = self.running_continuous_batching_manager.add_request(
                     _inputs, request_id=req.get("request_id"), max_new_tokens=generation_config.max_new_tokens
                 )


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/40479#discussion_r2317826193