### PR TITLE
Mark `LongformerModelTest::test_attention_outputs` as flaky

### DIFF
--- a/tests/models/longformer/test_modeling_longformer.py
+++ b/tests/models/longformer/test_modeling_longformer.py
@@ -16,7 +16,14 @@
 import unittest
 
 from transformers import LongformerConfig, is_torch_available
-from transformers.testing_utils import require_sentencepiece, require_tokenizers, require_torch, slow, torch_device
+from transformers.testing_utils import (
+    is_flaky,
+    require_sentencepiece,
+    require_tokenizers,
+    require_torch,
+    slow,
+    torch_device,
+)
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
@@ -354,6 +361,14 @@ class LongformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
     def setUp(self):
         self.model_tester = LongformerModelTester(self)
         self.config_tester = ConfigTester(self, config_class=LongformerConfig, hidden_size=37)
+
+    # Without this, 0.02% failure rate.
+    @is_flaky(
+        max_attempts=2,
+        description="When `inputs_dict['attention_mask'][:, -1]` is all `0`s, we get shorter length along the last dimension of the output's `attentions`.",
+    )
+    def test_attention_outputs(self):
+        super().test_attention_outputs()
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/longformer/test_modeling_longformer.py
+++ b/tests/models/longformer/test_modeling_longformer.py
@@ -362,7 +362,7 @@ class LongformerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
         self.model_tester = LongformerModelTester(self)
         self.config_tester = ConfigTester(self, config_class=LongformerConfig, hidden_size=37)
 
-    # Without this, 0.02% failure rate.
+    # Without this, 0.01% failure rate.
     @is_flaky(
         max_attempts=2,
         description="When `inputs_dict['attention_mask'][:, -1]` is all `0`s, we get shorter length along the last dimension of the output's `attentions`.",


### PR DESCRIPTION
# What does this PR do?

Small failure rate, but still seeing it

https://app.circleci.com/pipelines/github/huggingface/transformers/143883/workflows/85ccd674-ccf8-4880-9144-4a2660676b0b/jobs/1902199

Not sure the way `LongformerAttention` and/or `LongformerSelfAttention` processing the attentions they would return.

No bandwidth to check this (and questionable of the worth of the time)