### PR TITLE
Skip `test_fast_is_faster_than_slow` for `Owlv2ImageProcessingTest`

### DIFF
--- a/tests/models/owlv2/test_image_processing_owlv2.py
+++ b/tests/models/owlv2/test_image_processing_owlv2.py
@@ -99,6 +99,10 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
     def image_processor_dict(self):
         return self.image_processor_tester.prepare_image_processor_dict()
 
+    @unittest.skip(reason="FIXME: @yoni. It always fails: `0.12 not less than or equal to 0.03`.")
+    def test_fast_is_faster_than_slow(self):
+        super().test_fast_is_faster_than_slow()
+
     def test_image_processor_properties(self):
         for image_processing_class in self.image_processor_list:
             image_processing = image_processing_class(**self.image_processor_dict)


### PR DESCRIPTION
# What does this PR do?

Similar to #40599 

Never pass, but not reported due to CI pytest worker crash for some time