### PR TITLE
Skip `test_prompt_lookup_decoding_matches_greedy_search` for `qwen2_audio`

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -799,7 +799,7 @@ class GenerationTesterMixin:
                     "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model class is `Qwen2_5Omni`,
                     # All models below: shouldn't suggest audio tokens. Can be fixed by passing `suppress_ids` to candidate generator: @joaa @raushan
                     "voxtral",
-                    "qwen2_audio",
+                    "qwen2audio",
                 ]
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -799,6 +799,7 @@ class GenerationTesterMixin:
                     "qwen2_5omni",  # the file is named `qwen2_5_omni`, but the model class is `Qwen2_5Omni`,
                     # All models below: shouldn't suggest audio tokens. Can be fixed by passing `suppress_ids` to candidate generator: @joaa @raushan
                     "voxtral",
+                    "qwen2_audio",
                 ]
             ):
                 self.skipTest(reason="May fix in the future: need model-specific fixes")


### PR DESCRIPTION
# What does this PR do?

Same as #40643

We will soon make it more automatically, but for now just skip this way.