### PR TITLE
Remove overwritten `GitModelTest::test_beam_search_generate`

### DIFF
--- a/tests/models/git/test_modeling_git.py
+++ b/tests/models/git/test_modeling_git.py
@@ -331,24 +331,6 @@ class GitModelTester:
         self.parent.assertEqual(result.loss.shape, ())
         self.parent.assertTrue(result.loss.item() > 0)
 
-    def _test_beam_search_generate(self, config, input_ids, input_mask, pixel_values):
-        model = GitForCausalLM(config=config)
-        model.to(torch_device)
-        model.eval()
-
-        # generate
-        generated_ids = model.generate(
-            input_ids,
-            attention_mask=input_mask,
-            pixel_values=pixel_values,
-            do_sample=False,
-            max_length=20,
-            num_beams=2,
-            num_return_sequences=2,
-        )
-
-        self.parent.assertEqual(generated_ids.shape, (self.batch_size * 2, 20))
-
     def _test_batched_generate_captioning(self, config, input_ids, input_mask, pixel_values):
         model = GitForCausalLM(config=config)
         model.to(torch_device)
@@ -430,10 +412,6 @@ class GitModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
     def test_for_causal_lm(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_for_causal_lm(*config_and_inputs)
-
-    def test_beam_search_generate(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester._test_beam_search_generate(*config_and_inputs)
 
     def test_batched_generate_captioning(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()


### PR DESCRIPTION
# What does this PR do?

This test overwrites the one from `GenerationTesterMixin`

and we have it being flaky

> FAILED tests/models/git/test_modeling_git.py::GitModelTest::test_beam_search_generate - AssertionError: torch.Size([26, 16]) != (26, 20)

https://app.circleci.com/pipelines/github/huggingface/transformers/144061/workflows/5cf0ad7e-25c7-4396-8e17-f58dfdf0adbf/jobs/1904264/parallel-runs/6

The `GenerationTesterMixin::test_beam_search_generate` has some new updates after `GitModelTest::test_beam_search_generate` being added.

Remove the overwritten one and the test works well: all pass in 3000 runs