### PR TITLE
fix broken offline mode when loading tokenizer from hub

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -176,7 +176,7 @@ def list_repo_templates(
             ]
         except (GatedRepoError, RepositoryNotFoundError, RevisionNotFoundError):
             raise  # valid errors => do not catch
-        except (HTTPError, requests.exceptions.ConnectionError):
+        except (HTTPError, OfflineModeIsEnabled, requests.exceptions.ConnectionError):
             pass  # offline mode, internet down, etc. => try local files
 
     # check local files

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -204,9 +204,7 @@ class GetFromCacheTests(unittest.TestCase):
 
 class OfflineModeTests(unittest.TestCase):
     def test_list_repo_templates_w_offline(self):
-        with mock.patch(
-            "transformers.utils.hub.list_repo_tree", side_effect=OfflineModeIsEnabled()
-        ):
+        with mock.patch("transformers.utils.hub.list_repo_tree", side_effect=OfflineModeIsEnabled()):
             with mock.patch(
                 "transformers.utils.hub.snapshot_download", side_effect=LocalEntryNotFoundError("no snapshot found")
             ):

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -29,7 +29,8 @@ from transformers.utils import (
     TRANSFORMERS_CACHE,
     WEIGHTS_NAME,
     cached_file,
-    has_file, list_repo_templates,
+    has_file,
+    list_repo_templates,
 )
 
 

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -19,6 +19,7 @@ import unittest.mock as mock
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import OfflineModeIsEnabled, LocalEntryNotFoundError
 from requests.exceptions import HTTPError
 
 from transformers.utils import (
@@ -28,7 +29,7 @@ from transformers.utils import (
     TRANSFORMERS_CACHE,
     WEIGHTS_NAME,
     cached_file,
-    has_file,
+    has_file, list_repo_templates,
 )
 
 
@@ -198,3 +199,14 @@ class GetFromCacheTests(unittest.TestCase):
             with self.assertRaises(ModuleNotFoundError):
                 # The error should be re-raised by cached_files, not caught in the exception handling block
                 cached_file(RANDOM_BERT, "nonexistent.json")
+
+
+class OfflineModeTests(unittest.TestCase):
+    def test_list_repo_templates_w_offline(self):
+        with mock.patch(
+            "transformers.utils.hub.list_repo_tree", side_effect=OfflineModeIsEnabled()
+        ):
+            with mock.patch(
+                "transformers.utils.hub.snapshot_download", side_effect=LocalEntryNotFoundError("no snapshot found")
+            ):
+                self.assertEqual(list_repo_templates(RANDOM_BERT, local_files_only=False), [])

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -19,7 +19,7 @@ import unittest.mock as mock
 from pathlib import Path
 
 from huggingface_hub import hf_hub_download
-from huggingface_hub.errors import OfflineModeIsEnabled, LocalEntryNotFoundError
+from huggingface_hub.errors import LocalEntryNotFoundError, OfflineModeIsEnabled
 from requests.exceptions import HTTPError
 
 from transformers.utils import (


### PR DESCRIPTION
# What does this PR do?

#39874 broke loading tokenizers from_pretrained when using offline mode. Hub's `OfflineModeIsEnabled` extends python's builtin `ConnectionError` , not `requests.exceptions.ConnectionError` 
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
