### PR TITLE
Avoid night torch CI not run because of irrelevant docker image failing to build 

### DIFF
--- a/.github/workflows/build-nightly-ci-docker-images.yml
+++ b/.github/workflows/build-nightly-ci-docker-images.yml
@@ -2,6 +2,10 @@ name: Build docker images (Nightly CI)
 
 on:
   workflow_call:
+    inputs:
+      job:
+        required: true
+        type: string
   push:
     branches:
       - build_nightly_ci_docker_image*
@@ -12,7 +16,8 @@ concurrency:
 
 jobs:
   latest-with-torch-nightly-docker:
-    name: "Nightly PyTorch + Stable TensorFlow"
+    name: "Nightly PyTorch"
+    if: inputs.job == 'latest-with-torch-nightly-docker' || inputs.job == ''
     runs-on:
       group: aws-general-8-plus
     steps:
@@ -41,6 +46,7 @@ jobs:
 
   nightly-torch-deepspeed-docker:
     name: "Nightly PyTorch + DeepSpeed"
+    if: inputs.job == 'nightly-torch-deepspeed-docker' || inputs.job == ''
     runs-on:
       group: aws-g4dn-2xlarge-cache
     steps:

--- a/.github/workflows/self-nightly-caller.yml
+++ b/.github/workflows/self-nightly-caller.yml
@@ -22,6 +22,8 @@ jobs:
   build_nightly_torch_ci_images:
     name: Build CI Docker Images with nightly torch
     uses: ./.github/workflows/build-nightly-ci-docker-images.yml
+    with:
+      job: latest-with-torch-nightly-docker
     secrets: inherit
 
   setup:


### PR DESCRIPTION
# What does this PR do?

Currently, the workflow 

> .github/workflows/self-nightly-caller.yml

calls

```
  build_nightly_torch_ci_images:
    name: Build CI Docker Images with nightly torch
    uses: ./.github/workflows/build-nightly-ci-docker-images.yml
```

which builds 2 docker images in 2 jobs

```
  latest-with-torch-nightly-docker:
  nightly-torch-deepspeed-docker:
```

However, after #40306,

> .github/workflows/self-nightly-caller.yml

only calls `model-ci` and no longer call `deepspeed-ci`, see

https://github.com/huggingface/transformers/pull/40306/files#r2287368451

And we only need to build `latest-with-torch-nightly-docker` image for `model-ci` instead of the 2 docker image.

Before this PR, we had `nightly-torch-deepspeed-docker` fails to build

https://github.com/huggingface/transformers/actions/runs/17431117913

and prevent the nightly torch CI to be run, which is not good.

This PR avoids this situation by adding `if` conditions in the 2 jobs in `build-nightly-ci-docker-images.yml`