### PR TITLE
Mark `Aimv2ModelTest::test_eager_matches_sdpa_inference_04_fp16_pad_right_sdpa_kernels` as flaky

### DIFF
--- a/tests/models/aimv2/test_modeling_aimv2.py
+++ b/tests/models/aimv2/test_modeling_aimv2.py
@@ -24,6 +24,7 @@ from parameterized import parameterized
 
 from transformers import Aimv2Config, Aimv2TextConfig, Aimv2VisionConfig
 from transformers.testing_utils import (
+    is_flaky,
     require_torch,
     require_vision,
     slow,
@@ -469,6 +470,9 @@ class Aimv2ModelTest(Aimv2ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
             self.assertDictEqual(config.text_config.to_dict(), text_config.to_dict())
 
     @parameterized.expand(TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION)
+    @is_flaky(
+        description="sdpa gets nan values in some places while eager is fine. Except those places, the values are close"
+    )
     def test_eager_matches_sdpa_inference(
         self,
         name,

--- a/tests/models/aimv2/test_modeling_aimv2.py
+++ b/tests/models/aimv2/test_modeling_aimv2.py
@@ -471,7 +471,8 @@ class Aimv2ModelTest(Aimv2ModelTesterMixin, PipelineTesterMixin, unittest.TestCa
 
     @parameterized.expand(TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION)
     @is_flaky(
-        description="sdpa gets nan values in some places while eager is fine. Except those places, the values are close"
+        max_attempts=2,
+        description="sdpa gets nan values in some places while eager is fine. Except those places, the values are close",
     )
     def test_eager_matches_sdpa_inference(
         self,


### PR DESCRIPTION
# What does this PR do?

Without this, we get 0.026% of failure rate.