### PR TITLE
remove vision2seq vs image-text-to-text

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -966,8 +966,6 @@ MODEL_FOR_VISION_2_SEQ_MAPPING_NAMES = OrderedDict(
         ("ovis2", "Ovis2ForConditionalGeneration"),
         ("paligemma", "PaliGemmaForConditionalGeneration"),
         ("pix2struct", "Pix2StructForConditionalGeneration"),
-        ("qwen2_5_vl", "Qwen2_5_VLForConditionalGeneration"),
-        ("qwen2_vl", "Qwen2VLForConditionalGeneration"),
         ("video_llava", "VideoLlavaForConditionalGeneration"),
         ("vipllava", "VipLlavaForConditionalGeneration"),
         ("vision-encoder-decoder", "VisionEncoderDecoderModel"),


### PR DESCRIPTION
reference internal chat: https://huggingface.slack.com/archives/C070Q9GGGGY/p1756985150983899

Qwen models are tagged as both vision2seq as well as `image-text-to-text`,  removing the former since it's deprecated.
