### PR TITLE
Support initializing FakeTensors

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -103,6 +103,8 @@ def init_on_device(device: "torch.device", include_buffers: bool = False):
             param_cls = type(module._parameters[name])
             kwargs = module._parameters[name].__dict__
             kwargs["requires_grad"] = param.requires_grad
+            if "fake_device" in kwargs:
+                kwargs["device"] = kwargs.pop("fake_device")
             module._parameters[name] = param_cls(module._parameters[name].to(device), **kwargs)
 
     def register_empty_buffer(module, name, buffer, persistent=True):


### PR DESCRIPTION
# What does this PR do?

Addresses https://github.com/pytorch/pytorch/issues/161636 by correctly constructing the kwarg for FakeTensors: in fake_tensors the device property is stored as "fake_device" when accessed via `__dict__`. However the initializer expects the device to be passed in as "device". This PR updates to logic to handle this special case.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Cyrilvallez