### PR TITLE
Improved exception handling for apply_transpose

### DIFF
--- a/src/transformers/modeling_tf_pytorch_utils.py
+++ b/src/transformers/modeling_tf_pytorch_utils.py
@@ -157,9 +157,8 @@ def apply_transpose(transpose: TransposeType, weight, match_shape=None, pt_to_tf
     if list(match_shape) != list(weight.shape):
         try:
             weight = reshape(weight, match_shape)
-        except AssertionError as e:
-            e.args += (match_shape, match_shape)
-            raise e
+        except (RuntimeError, ValueError) as e:
+            raise RuntimeError(f"Cannot reshape tensor from {list(weight.shape)} to {match_shape}.") from e
 
     return weight
 


### PR DESCRIPTION
# What does this PR do?
**Before**
RuntimeError from PyTorch reshape, not caught by apply_transpose. 
```
Traceback (most recent call last):
  File "/transformers/repro.py", line 12, in <module>
    result = apply_transpose(
             ^^^^^^^^^^^^^^^^
  File "/transformers/modeling_tf_pytorch_utils.py", line 159, in apply_transpose
    weight = reshape(weight, match_shape)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/transformers/utils/generic.py", line 644, in reshape
    return array.reshape(*newshape)
           ^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: shape '[128, 16]' is invalid for input of size 6144
```
**After**
RuntimeError correctly caught and augmented with useful tensor shape information.
```
Traceback (most recent call last):
  File "/transformers/modeling_tf_pytorch_utils.py", line 159, in apply_transpose
    weight = reshape(weight, match_shape)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/transformers/utils/generic.py", line 644, in reshape
    return array.reshape(*newshape)
           ^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: shape '[128, 16]' is invalid for input of size 6144

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/transformers/repro.py", line 12, in <module>
    result = apply_transpose(
             ^^^^^^^^^^^^^^^^
  File "/transformers/modeling_tf_pytorch_utils.py", line 161, in apply_transpose
    raise RuntimeError(f"Cannot reshape tensor from {list(weight.shape)} to {match_shape}.") from e
RuntimeError: Cannot reshape tensor from [3, 32, 64] to [128, 16].
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
