### PR TITLE
# fix: Prevent auto_docstring from crashing when running with python -OO

### DIFF
--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -18,7 +18,7 @@ import os
 import textwrap
 from pathlib import Path
 from typing import Optional, Union, get_args
-
+import sys
 import regex as re
 
 from .doc import (
@@ -1811,8 +1811,8 @@ def auto_class_docstring(cls, custom_intro=None, custom_args=None, checkpoint=No
     name = re.findall(rf"({'|'.join(ClassDocstring.__dict__.keys())})$", cls.__name__)
     if name == [] and custom_intro is None and not is_dataclass:
         raise ValueError(
-            f"`{cls.__name__}` is not registered in the auto doc. Here are the available classes: {ClassDocstring.__dict__.keys()}.\n"
-            "Add a `custom_intro` to the decorator if you want to use `auto_docstring` on a class not registered in the auto doc."
+            f"`{cls.__name__}` is not registered in the . Here are the available classes: {ClassDocstring.__dict__.keys()}.\n"
+            "Add a `custom_intro` to the decorator if you want to use `auto_docstring` on a class not registered in the ."
         )
     if name != [] or custom_intro is not None or is_dataclass:
         name = name[0] if name else None
@@ -2035,6 +2035,10 @@ def auto_docstring(obj=None, *, custom_intro=None, custom_args=None, checkpoint=
           and docstring.
         - Return value documentation is automatically generated for methods that return ModelOutput subclasses.
     """
+    if sys.flags.optimize >= 2:
+        if obj is None:
+            return lambda x: x
+        return obj
 
     def auto_docstring_decorator(obj):
         if len(obj.__qualname__.split(".")) > 1:

--- a/tests/utils/test_oo_flag.py
+++ b/tests/utils/test_oo_flag.py
@@ -1,0 +1,15 @@
+import subprocess
+import sys
+
+def test_from_pretrained_with_oo_flag():
+    """Tests that AutoModel.from_pretrained works with the -OO flag."""
+    script = 'from transformers import AutoModel; model = AutoModel.from_pretrained("google-bert/bert-base-cased")'
+
+    # Run the script using the -OO flag
+    result = subprocess.run(
+        [sys.executable, "-OO", "-c", script],
+        capture_output=True
+    )
+
+    # The test passes if the command returns an exit code of 0 (meaning success)
+    assert result.returncode == 0, f"Script failed with -OO flag: {result.stderr.decode()}"


### PR DESCRIPTION
This PR addresses an issue where `AutoModel.from_pretrained` fails when the Python interpreter is run with the `-OO` flag.

The root cause is that the `-OO` flag strips all docstrings from the code. The `auto_docstring` utility in `transformers` relies on introspecting these docstrings at runtime to generate documentation. When the docstrings are missing, this utility crashes with a `ValueError`, preventing models from being loaded in this optimized environment.

This fix adds a guard clause to the beginning of the `auto_docstring` decorator. It checks `sys.flags.optimize` to detect if the `-OO` flag is active. If it is, the decorator bypasses all the docstring-generation logic, allowing the library to function correctly. This makes the library more robust for users running in highly optimized or stripped-down environments.

A new test has been added to verify that `AutoModel.from_pretrained` works correctly with the `-OO` flag, ensuring this issue does not regress in the future.

Fixes #40659

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

## Images

<img width="695" height="412" alt="Screenshot 2025-09-05 081103" src="https://github.com/user-attachments/assets/84278ea7-6f5b-4b44-9669-ab59003e5f25" />

#
<img width="695" height="412" alt="Screenshot 2025-09-05 081103" src="https://github.com/user-attachments/assets/49bf8941-8415-4eb6-915c-d9204a3979e6" />

# 
<img width="951" height="396" alt="Screenshot 2025-09-05 081332" src="https://github.com/user-attachments/assets/844638e1-889e-439a-a2ab-09d33ff376d3" />
