### PR TITLE
[serve] re-enable tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -366,6 +366,7 @@ extras["testing"] = (
     + extras["retrieval"]
     + extras["modelcreation"]
     + extras["mistral-common"]
+    + extras["serving"]
 )
 
 extras["deepspeed-testing"] = extras["deepspeed"] + extras["testing"] + extras["optuna"] + extras["sentencepiece"]

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -687,10 +687,6 @@ class ServeCommand(BaseTransformersCLICommand):
             logger.warning_once(
                 "CORS allow origin is set to `*`. This is not recommended for production environments."
             )
-        else:
-            logger.warning_once(
-                "Some apps may require CORS. Consider launching the server with `--enable-cors` if you see errors."
-            )
 
         @app.post("/v1/chat/completions")
         def chat_completion(request: dict):


### PR DESCRIPTION
# What does this PR do?

`RUN_SLOW=1 py.test tests/commands/test_serving.py` is crashing locally. I couldn't pin the exact cause, the but it is triggered by a UX-related warning.

This PR:
- removes the test-crashing warning, so we can run tests
- adds the needed requirements to `extras[testing]` so these tests actually run in our daily CI 👀 (atm, we're skipping a few tests, see [here](https://github.com/huggingface/transformers/actions/runs/17482128457/job/49654564234))