### PR TITLE
Fixed loading LongT5 from legacy checkpoints

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -1270,6 +1270,36 @@ class LongT5PreTrainedModel(PreTrainedModel):
         }
         return dummy_inputs
 
+    def _try_load_missing_tied_module(self, key):
+        module = self
+        if key.endswith(".weight"):
+            key = key[: -len(".weight")]
+        for sub_key in key.split("."):
+            if not hasattr(module, sub_key):
+                return
+            module = getattr(module, sub_key)
+
+        self._tie_or_clone_weights(module, self.shared)
+
+    @classmethod
+    def from_pretrained(self, *args, **kwargs):
+        requested_loading_info = kwargs.get("output_loading_info", False)
+        kwargs["output_loading_info"] = True
+        model, loading_info = super().from_pretrained(*args, **kwargs)
+        missing_keys = loading_info.get("missing_keys", [])
+
+        if hasattr(model, "shared") and hasattr(model, "_tied_weights_keys"):
+            for missing_key in missing_keys:
+                logger.warning(
+                    f"Recovering a missing tied weight {missing_key} from a legacy LongT5 checkpoint. "
+                    f"Consider saving {missing_key} in your checkpoint or updating the config (tie_word_embeddings=true)."
+                )
+                model._try_load_missing_tied_module(missing_key)
+
+        if requested_loading_info:
+            return model, loading_info
+        return model
+
     def _init_weights(self, module):
         """Initialize the weights"""
         factor = self.config.initializer_factor  # Used for testing weights initialization
@@ -1345,19 +1375,6 @@ class LongT5PreTrainedModel(PreTrainedModel):
         shifted_input_ids.masked_fill_(shifted_input_ids == -100, pad_token_id)
 
         return shifted_input_ids
-
-    @classmethod
-    def from_pretrained(self, *args, **kwargs):
-        model = super().from_pretrained(*args, **kwargs)
-        if hasattr(model, "shared"):
-            logger.warning(
-                "Loading a legacy LongT5 checkpoint. Setting embed_tokens weights to shared weights in the decoder and encoder."
-            )
-            if hasattr(model, "encoder") and hasattr(model.encoder, "embed_tokens"):
-                model.encoder.embed_tokens.weight = model.shared.weight
-            if hasattr(model, "decoder") and hasattr(model.decoder, "embed_tokens"):
-                model.decoder.embed_tokens.weight = model.shared.weight
-        return model
 
 
 class LongT5Stack(LongT5PreTrainedModel):

--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -1346,6 +1346,19 @@ class LongT5PreTrainedModel(PreTrainedModel):
 
         return shifted_input_ids
 
+    @classmethod
+    def from_pretrained(self, *args, **kwargs):
+        model = super().from_pretrained(*args, **kwargs)
+        if hasattr(model, "shared"):
+            logger.warning(
+                "Loading a legacy LongT5 checkpoint. Setting embed_tokens weights to shared weights in the decoder and encoder."
+            )
+            if hasattr(model, "encoder") and hasattr(model.encoder, "embed_tokens"):
+                model.encoder.embed_tokens.weight = model.shared.weight
+            if hasattr(model, "decoder") and hasattr(model.decoder, "embed_tokens"):
+                model.decoder.embed_tokens.weight = model.shared.weight
+        return model
+
 
 class LongT5Stack(LongT5PreTrainedModel):
     def __init__(self, config, embed_tokens=None):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #40635

The problem with loading legacy LongT5 checkpoints stems from the way the shared embedding tokens are defined in the model: 
https://github.com/huggingface/transformers/blob/96a5774f2e048c21b9c0408c4fddfcf23a8934c5/src/transformers/models/longt5/modeling_longt5.py#L1350-L1356
In most legacy checkpoints they are not tied via the tied keys, but were still trained from the same shared weight that is created here:
https://github.com/huggingface/transformers/blob/96a5774f2e048c21b9c0408c4fddfcf23a8934c5/src/transformers/models/longt5/modeling_longt5.py#L1901

The solution to this problem is to manually assign the weights in overriden `from_pretrained` if the model contains the shared weights.
This fix is somewhat dirty, it would be much better to just update them directly in the state_dict to avoid the missing keys warning, but there is currently no public interface of the `PretrainedModel` class that allows for that.

If the reviewer has a better idea of how this could be accounted for I'm ready to devote my time towards fixing this issue.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Rocketknight1 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
