### PR TITLE
Configure assistant model's generation_config with user parameters

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2357,6 +2357,20 @@ class GenerationMixin(ContinuousMixin):
         self._validate_model_kwargs(model_kwargs.copy())
         self._validate_generation_mode(generation_mode, generation_config, generation_mode_kwargs)
 
+        # Configure assistant model's generation_config with user parameters
+        if assistant_model is not None:
+            # The assistant model inherits ALL generation parameters from the main generate() call, including:
+            #   - Assistant-specific parameters (num_assistant_tokens, assistant_confidence_threshold, etc.)
+            #   - General generation parameters (do_sample, max_new_tokens, temperature, etc.)
+            # This ensures consistent behavior between main and assistant models. In the future,
+            # assistant-specific overrides could be added (e.g., assistant_do_sample) to allow
+            # different generation strategies for draft vs target models while maintaining the
+            # inheritance-by-default behavior.
+            assistant_generation_config, _ = assistant_model._prepare_generation_config(
+                assistant_model.generation_config, use_model_defaults, **kwargs
+            )
+            assistant_model.generation_config = assistant_generation_config
+
         # Deprecation-related step: set Hub repo for deprecated strategies.
         # NOTE: This must come after initializing generation_config, since we need it to determine if this is a deprecated mode.
         # It must also be before any preparation steps, since Hub repos expect to be loaded before preparation steps.

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -3406,6 +3406,41 @@ class GenerationIntegrationTests(unittest.TestCase):
         # update_candidate_strategy is called only once and therefore, assistant_model.generation_config.num_assistant_tokens should be either 4 or 7
         self.assertTrue(assistant_model.generation_config.num_assistant_tokens in (4, 7))
 
+    def test_assisted_decoding_parameter_inheritance(self):
+        # This test ensures that assistant models inherit generation parameters from the main generate() call.
+        # Before the fix, assistant models would use their default values instead of user-specified values.
+
+        prompt = "Alice and Bob"
+        checkpoint = "EleutherAI/pythia-160m-deduped"
+        tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+        inputs = tokenizer(prompt, return_tensors="pt")
+
+        model = AutoModelForCausalLM.from_pretrained(checkpoint)
+        assistant_model = AutoModelForCausalLM.from_pretrained(checkpoint)
+
+        # Check assistant model defaults
+        self.assertEqual(assistant_model.generation_config.num_assistant_tokens, 20)
+        self.assertEqual(assistant_model.generation_config.assistant_confidence_threshold, 0.4)
+        self.assertEqual(assistant_model.generation_config.do_sample, False)
+
+        # Generate with user-specified values that differ from assistant defaults
+        generation_kwargs = {
+            "eos_token_id": -1,
+            "max_new_tokens": 5,
+            "assistant_model": assistant_model,
+            "do_sample": True,
+            "num_assistant_tokens": 7,
+            "assistant_confidence_threshold": 0.8,
+        }
+
+        model.generate(**inputs, **generation_kwargs)
+
+        # After generation, assistant model should have the user-specified values, not its defaults
+        # Inheritance applies to all main model parameters, not just ones that have "assistant" slots
+        self.assertEqual(assistant_model.generation_config.num_assistant_tokens, 7)
+        self.assertEqual(assistant_model.generation_config.assistant_confidence_threshold, 0.8)
+        self.assertEqual(assistant_model.generation_config.do_sample, True)
+
     def test_assisted_decoding_num_assistant_tokens_heuristic_transient_schedule(self):
         # This test ensures that the assisted generation num_assistant_tokens 'heuristic' schedule works properly.
 


### PR DESCRIPTION
# What does this PR do?

Fixes issue where num_assistant_tokens and other parameters intended for the assistant model are not properly passed down, leaving the assistant model with default values.

Ultimately, we want to configure the assistant model properly, so that it:

1. Is properly configured with user-provided parameters
2. Inherits defaults from the main model instead of class defaults

Tests added to illustrate the issue, and detailed comments to illustrate behaviors.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # [40739](https://github.com/huggingface/transformers/issues/40739)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
