### PR TITLE
Set accepts_loss_kwargs to False for ConvNext(|V2)ForImageClassification

### DIFF
--- a/src/transformers/models/convnext/modeling_convnext.py
+++ b/src/transformers/models/convnext/modeling_convnext.py
@@ -310,6 +310,8 @@ class ConvNextModel(ConvNextPreTrainedModel):
     """
 )
 class ConvNextForImageClassification(ConvNextPreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config):
         super().__init__(config)
 

--- a/src/transformers/models/convnextv2/modeling_convnextv2.py
+++ b/src/transformers/models/convnextv2/modeling_convnextv2.py
@@ -332,6 +332,8 @@ class ConvNextV2Model(ConvNextV2PreTrainedModel):
 )
 # Copied from transformers.models.convnext.modeling_convnext.ConvNextForImageClassification with CONVNEXT->CONVNEXTV2,ConvNext->ConvNextV2,convnext->convnextv2
 class ConvNextV2ForImageClassification(ConvNextV2PreTrainedModel):
+    accepts_loss_kwargs = False
+
     def __init__(self, config):
         super().__init__(config)
 


### PR DESCRIPTION
The forward methods of these classes accept `kwargs`, which leads `Trainer`'s `compute_loss()` to incorrectly assume that they can handle `num_items_per_batch`, leading to training failure.  This sets `accepts_loss_kwargs` to false explicitly to mitigate that assumption.

cc: @muellerzr @SunMarc