### PR TITLE
feat: add qwen3 pruning support

### DIFF
--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -68,11 +68,14 @@ class Qwen3RMSNorm(nn.Module):
 
 
 class Qwen3MLP(nn.Module):
-    def __init__(self, config):
+    def __init__(self, config, layer_idx):
         super().__init__()
         self.config = config
         self.hidden_size = config.hidden_size
-        self.intermediate_size = config.intermediate_size
+        if hasattr(config, 'layer_inter_size'):
+            self.intermediate_size = config.layer_inter_size[layer_idx]
+        else:
+            self.intermediate_size = config.intermediate_size
         self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
@@ -163,13 +166,17 @@ class Qwen3Attention(nn.Module):
         self.config = config
         self.layer_idx = layer_idx
         self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        if hasattr(config, 'layer_head_num'):
+            self.num_heads = config.layer_head_num[layer_idx]
+        else:
+            self.num_heads = config.num_attention_heads
         self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size, self.num_heads * self.head_dim, bias=config.attention_bias
         )
         self.k_proj = nn.Linear(
             config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
@@ -178,7 +185,7 @@ class Qwen3Attention(nn.Module):
             config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            self.num_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
         )
         self.q_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)  # unlike olmo, only on the head dim!
         self.k_norm = Qwen3RMSNorm(self.head_dim, eps=config.rms_norm_eps)  # thus post q_norm does not need reshape
@@ -237,7 +244,7 @@ class Qwen3DecoderLayer(GradientCheckpointingLayer):
 
         self.self_attn = Qwen3Attention(config=config, layer_idx=layer_idx)
 
-        self.mlp = Qwen3MLP(config)
+        self.mlp = Qwen3MLP(config, layer_idx)
         self.input_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.attention_type = config.layer_types[layer_idx]

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -170,7 +170,7 @@ class Qwen3Attention(nn.Module):
             self.num_heads = config.layer_head_num[layer_idx]
         else:
             self.num_heads = config.num_attention_heads
-        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // config.num_key_value_heads
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True


### PR DESCRIPTION
# What does this PR do?

This PR enables models with structured pruning to be loaded correctly. The model configuration files after structured pruning will be modified, as the layer_head_num and layer_inter_size parameters may vary across different layers of the network. When the Transformers library loads the configuration file, it must now map these parameters layer-by-layer. This PR specifically adjusts the Qwen3 configuration loading logic in Transformers to ensure compatibility with models that have undergone structured pruning.


## Before submitting
1. Verify that the model after structured pruning can be loaded correctly by the Transformers library.  
2. Confirm that unpruned models can still be loaded normally by the Transformers library.  