### PR TITLE
[Docs] Add missing class documentation for optimizer_schedules (#31870,  #23010)

### DIFF
--- a/docs/source/en/main_classes/optimizer_schedules.md
+++ b/docs/source/en/main_classes/optimizer_schedules.md
@@ -47,6 +47,10 @@ The `.optimization` module provides:
 
 [[autodoc]] get_cosine_with_hard_restarts_schedule_with_warmup
 
+[[autodoc]] get_cosine_with_min_lr_schedule_with_warmup
+
+[[autodoc]] get_cosine_with_min_lr_schedule_with_warmup_lr_rate
+
 <img alt="" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/warmup_cosine_hard_restarts_schedule.png"/>
 
 [[autodoc]] get_linear_schedule_with_warmup
@@ -56,5 +60,7 @@ The `.optimization` module provides:
 [[autodoc]] get_polynomial_decay_schedule_with_warmup
 
 [[autodoc]] get_inverse_sqrt_schedule
+
+[[autodoc]] get_reduce_on_plateau_schedule
 
 [[autodoc]] get_wsd_schedule

--- a/docs/source/en/main_classes/optimizer_schedules.md
+++ b/docs/source/en/main_classes/optimizer_schedules.md
@@ -29,38 +29,62 @@ The `.optimization` module provides:
 
 ## Schedules
 
-### Learning Rate Schedules
+### SchedulerType
 
 [[autodoc]] SchedulerType
 
+### get_scheduler
+
 [[autodoc]] get_scheduler
 
+### get_constant_schedule
+
 [[autodoc]] get_constant_schedule
+
+### get_constant_schedule_with_warmup
 
 [[autodoc]] get_constant_schedule_with_warmup
 
 <img alt="" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/warmup_constant_schedule.png"/>
 
+### get_cosine_schedule_with_warmup
+
 [[autodoc]] get_cosine_schedule_with_warmup
 
 <img alt="" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/warmup_cosine_schedule.png"/>
 
+### get_cosine_with_hard_restarts_schedule_with_warmup
+
 [[autodoc]] get_cosine_with_hard_restarts_schedule_with_warmup
 
+### get_cosine_with_min_lr_schedule_with_warmup
+
 [[autodoc]] get_cosine_with_min_lr_schedule_with_warmup
+
+### get_cosine_with_min_lr_schedule_with_warmup_lr_rate
 
 [[autodoc]] get_cosine_with_min_lr_schedule_with_warmup_lr_rate
 
 <img alt="" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/warmup_cosine_hard_restarts_schedule.png"/>
 
+### get_linear_schedule_with_warmup
+
 [[autodoc]] get_linear_schedule_with_warmup
 
 <img alt="" src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/warmup_linear_schedule.png"/>
 
+### get_polynomial_decay_schedule_with_warmup
+
 [[autodoc]] get_polynomial_decay_schedule_with_warmup
+
+### get_inverse_sqrt_schedule
 
 [[autodoc]] get_inverse_sqrt_schedule
 
+### get_reduce_on_plateau_schedule
+
 [[autodoc]] get_reduce_on_plateau_schedule
+
+### get_wsd_schedule
 
 [[autodoc]] get_wsd_schedule

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -477,11 +477,14 @@ else:
         "get_constant_schedule_with_warmup",
         "get_cosine_schedule_with_warmup",
         "get_cosine_with_hard_restarts_schedule_with_warmup",
+        "get_cosine_with_min_lr_schedule_with_warmup",
+        "get_cosine_with_min_lr_schedule_with_warmup_lr_rate",
         "get_inverse_sqrt_schedule",
         "get_linear_schedule_with_warmup",
         "get_polynomial_decay_schedule_with_warmup",
         "get_scheduler",
         "get_wsd_schedule",
+        "get_reduce_on_plateau_schedule",
     ]
     _import_structure["pytorch_utils"] = [
         "Conv1D",
@@ -795,6 +798,12 @@ if TYPE_CHECKING:
     from .optimization import get_cosine_schedule_with_warmup as get_cosine_schedule_with_warmup
     from .optimization import (
         get_cosine_with_hard_restarts_schedule_with_warmup as get_cosine_with_hard_restarts_schedule_with_warmup,
+    )
+    from .optimization import (
+        get_cosine_with_min_lr_schedule_with_warmup as get_cosine_with_min_lr_schedule_with_warmup,
+    )
+    from .optimization import (
+        get_cosine_with_min_lr_schedule_with_warmup_lr_rate as get_cosine_with_min_lr_schedule_with_warmup_lr_rate,
     )
     from .optimization import get_inverse_sqrt_schedule as get_inverse_sqrt_schedule
     from .optimization import get_linear_schedule_with_warmup as get_linear_schedule_with_warmup

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -421,16 +421,17 @@ class SchedulerType(ExplicitEnum):
     Scheduler names for the parameter `lr_scheduler_type` in [`TrainingArguments`].
     By default, it uses "linear". Internally, this retrieves `get_linear_schedule_with_warmup` scheduler from [`Trainer`].
     Scheduler types:
-       - "linear" = get_linear_schedule_with_warmup
-       - "cosine" = get_cosine_schedule_with_warmup
-       - "cosine_with_restarts" = get_cosine_with_hard_restarts_schedule_with_warmup
-       - "polynomial" = get_polynomial_decay_schedule_with_warmup
-       - "constant" =  get_constant_schedule
-       - "constant_with_warmup" = get_constant_schedule_with_warmup
-       - "inverse_sqrt" = get_inverse_sqrt_schedule
-       - "reduce_lr_on_plateau" = get_reduce_on_plateau_schedule
-       - "cosine_with_min_lr" = get_cosine_with_min_lr_schedule_with_warmup
-       - "warmup_stable_decay" = get_wsd_schedule
+       - "linear" = [`get_linear_schedule_with_warmup`]
+       - "cosine" = [`get_cosine_schedule_with_warmup`]
+       - "cosine_with_restarts" = [`get_cosine_with_hard_restarts_schedule_with_warmup`]
+       - "polynomial" = [`get_polynomial_decay_schedule_with_warmup`]
+       - "constant" =  [`get_constant_schedule`]
+       - "constant_with_warmup" = [`get_constant_schedule_with_warmup`]
+       - "inverse_sqrt" = [`get_inverse_sqrt_schedule`]
+       - "reduce_lr_on_plateau" = [`get_reduce_on_plateau_schedule`]
+       - "cosine_with_min_lr" = [`get_cosine_with_min_lr_schedule_with_warmup`]
+       - "cosine_warmup_with_min_lr" = [`get_cosine_with_min_lr_schedule_with_warmup_lr_rate`]
+       - "warmup_stable_decay" = [`get_wsd_schedule`]
     """
 
     LINEAR = "linear"


### PR DESCRIPTION
# What does this PR do?

I found some missing infos in [doc for Optimization classes](https://huggingface.co/docs/transformers/main_classes/optimizer_schedules)
From #31870, #23010, new optimizer schedules were merged but these features aren't included at the document yet.
So simply I just included those classes that's all.


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
