### PR TITLE
Fix None quantization_config equivalence with omitted param in AutoModel.from_pretrained

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -543,7 +543,7 @@ class _BaseAutoModelClass:
             if kwargs.get("dtype") == "auto":
                 _ = kwargs.pop("dtype")
             # to not overwrite the quantization_config if config has a quantization_config
-            if kwargs.get("quantization_config") is not None:
+            if "quantization_config" in kwargs:
                 _ = kwargs.pop("quantization_config")
 
             config, kwargs = AutoConfig.from_pretrained(
@@ -560,7 +560,7 @@ class _BaseAutoModelClass:
                 kwargs["torch_dtype"] = "auto"
             if kwargs_orig.get("dtype", None) == "auto":
                 kwargs["dtype"] = "auto"
-            if kwargs_orig.get("quantization_config", None) is not None:
+            if "quantization_config" in kwargs_orig:
                 kwargs["quantization_config"] = kwargs_orig["quantization_config"]
 
         has_remote_code = hasattr(config, "auto_map") and cls.__name__ in config.auto_map


### PR DESCRIPTION
Fix `quantization_config=None` equivalence with omitted parameter in `AutoModel.from_pretrained`.

Currently, `AutoModel.from_pretrained` treats differently missing and `None` `quantization_config`. I think passing `None` should be treated the same as omitting the key altogether, not as an invalid quantization config.

This PR:
- Fixes inconsistent handling of `quantization_config=None` vs omitted parameter in `AutoModel.from_pretrained`
- Ensures `quantization_config=None` behaves identically to omitting the parameter entirely

## Problem

When using TRL CLI with GPT OSS models, calls like:
```python
  model = AutoModelForCausalLM.from_pretrained("my_model", quantization_config=None)
```
would fail with `AttributeError: 'NoneType' object has no attribute 'to_dict'`, differently than:
```python
model = AutoModelForCausalLM.from_pretrained("my_model")
```

Error traceback:
```python
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/fsx/albert/dev/transformers/src/transformers/models/auto/auto_factory.py", line 549, in from_pretrained
    config, kwargs = AutoConfig.from_pretrained(
  File "/fsx/albert/dev/transformers/src/transformers/models/auto/configuration_auto.py", line 1323, in from_pretrained
    return config_class.from_dict(config_dict, **unused_kwargs)
  File "/fsx/albert/dev/transformers/src/transformers/configuration_utils.py", line 839, in from_dict
    logger.info(f"Model config {config}")
  File "/fsx/albert/dev/transformers/src/transformers/configuration_utils.py", line 873, in __repr__
    return f"{self.__class__.__name__} {self.to_json_string()}"
  File "/fsx/albert/dev/transformers/src/transformers/configuration_utils.py", line 985, in to_json_string
    config_dict = self.to_diff_dict()
  File "/fsx/albert/dev/transformers/src/transformers/configuration_utils.py", line 887, in to_diff_dict
    config_dict = self.to_dict()
  File "/fsx/albert/dev/transformers/src/transformers/configuration_utils.py", line 964, in to_dict
    self.quantization_config.to_dict()
AttributeError: 'NoneType' object has no attribute 'to_dict'
```

See comment in downstream hotfix:
- https://github.com/huggingface/trl/pull/4019#pullrequestreview-3199965520

CC: @qgallouedec 