### PR TITLE
Read config pattern for Qwen3Next

### DIFF
--- a/src/transformers/models/qwen3_next/configuration_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/configuration_qwen3_next.py
@@ -243,8 +243,10 @@ class Qwen3NextConfig(PretrainedConfig):
 
         self.layer_types = layer_types
         if self.layer_types is None:
+            interval_pattern = kwargs.get("full_attention_interval", 4)
             self.layer_types = [
-                "linear_attention" if bool((i + 1) % 4) else "full_attention" for i in range(self.num_hidden_layers)
+                "linear_attention" if bool((i + 1) % interval_pattern) else "full_attention"
+                for i in range(self.num_hidden_layers)
             ]
         layer_type_validation(self.layer_types)
 


### PR DESCRIPTION
# What does this PR do?

If it's present on the hub config, and layer_types is not, it will be read