### PR TITLE
Improve torch_dtype checks

### DIFF
--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -293,7 +293,10 @@ class ChatArguments:
             if self.dtype is None:
                 self.dtype = self.torch_dtype
             elif self.torch_dtype != self.dtype:
-                raise ValueError(f"torch_dtype {self.torch_dtype} and dtype {self.dtype} have different values")
+                raise ValueError(
+                    f"`torch_dtype` {self.torch_dtype} and `dtype` {self.dtype} have different values. `torch_dtype` is deprecated and "
+                    "will be removed in 4.59.0, please set `dtype` instead."
+                )
 
 
 def chat_command_factory(args: Namespace):

--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -289,8 +289,11 @@ class ChatArguments:
     def __post_init__(self):
         """Only used for BC `torch_dtype` argument."""
         # In this case only the BC torch_dtype was given
-        if self.torch_dtype is not None and self.dtype == "auto":
-            self.dtype = self.torch_dtype
+        if self.torch_dtype is not None:
+            if self.dtype is None:
+                self.dtype = self.torch_dtype
+            elif self.torch_dtype != self.dtype:
+                raise ValueError(f"torch_dtype {self.torch_dtype} and dtype {self.dtype} have different values")
 
 
 def chat_command_factory(args: Namespace):

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -461,7 +461,10 @@ class ServeArguments:
             if self.dtype is None:
                 self.dtype = self.torch_dtype
             elif self.torch_dtype != self.dtype:
-                raise ValueError(f"torch_dtype {self.torch_dtype} and dtype {self.dtype} have different values")
+                raise ValueError(
+                    f"`torch_dtype` {self.torch_dtype} and `dtype` {self.dtype} have different values. `torch_dtype` is deprecated and "
+                    "will be removed in 4.59.0, please set `dtype` instead."
+                )
 
 
 class ServeCommand(BaseTransformersCLICommand):

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -457,8 +457,11 @@ class ServeArguments:
     def __post_init__(self):
         """Only used for BC `torch_dtype` argument."""
         # In this case only the BC torch_dtype was given
-        if self.torch_dtype is not None and self.dtype == "auto":
-            self.dtype = self.torch_dtype
+        if self.torch_dtype is not None:
+            if self.dtype is None:
+                self.dtype = self.torch_dtype
+            elif self.torch_dtype != self.dtype:
+                raise ValueError(f"torch_dtype {self.torch_dtype} and dtype {self.dtype} have different values")
 
 
 class ServeCommand(BaseTransformersCLICommand):

--- a/src/transformers/pipelines/keypoint_matching.py
+++ b/src/transformers/pipelines/keypoint_matching.py
@@ -147,7 +147,7 @@ class KeypointMatchingPipeline(Pipeline):
     def preprocess(self, images, timeout=None):
         images = [load_image(image, timeout=timeout) for image in images]
         model_inputs = self.image_processor(images=images, return_tensors=self.framework)
-        model_inputs = model_inputs.to(self.torch_dtype)
+        model_inputs = model_inputs.to(self.dtype)
         target_sizes = [image.size for image in images]
         preprocess_outputs = {"model_inputs": model_inputs, "target_sizes": target_sizes}
         return preprocess_outputs


### PR DESCRIPTION
# What does this PR do?

Improve `torch_dtype` checks. The old check overwrites `dtype` when `torch_dtype`=`bf16` and `dtype` =`auto`. However, the intention of specifiying `auto` is different from not specifying the value.