### PR TITLE
fix: XIELU act parameters not being casted to correct dtype

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -262,8 +262,8 @@ class XIELUActivation(nn.Module):
             )
         result = self._xielu_cuda_obj.forward(
             x,
-            self.alpha_p,
-            self.alpha_n,
+            self.alpha_p.to(x.dtype),
+            self.alpha_n.to(x.dtype),
             # Temporary until xIELU CUDA fully implemented -> self.{beta,eps}.item()
             self._beta_scalar,
             self._eps_scalar,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Was in the process of integrating the new Swiss-ai's Apertus model into axolotl and found an error with the xielu_cuda method. Ran with a 4bit QLoRA config.

```bash
  File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/activations.py", line 282, in forward
    return self._xielu_cuda_fn(input)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/miniconda3/envs/py3.11/lib/python3.11/site-packages/transformers/activations.py", line 268, in _xielu_cuda
    result = self._xielu_cuda_obj.forward(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Data type of x (c10::BFloat16) must match data type of alpha_p (float).
```

This error is raised from: 

```cuda
  TORCH_CHECK(x.dtype() == alpha_p.dtype(), "Data type of x (", x.dtype(),
              ") must match data type of alpha_p (", alpha_p.dtype(), ").");
  TORCH_CHECK(x.dtype() == alpha_n.dtype(), "Data type of x (", x.dtype(),
              ") must match data type of alpha_n (", alpha_n.dtype(), ").");
```
https://github.com/rubber-duck-debug/xielu/blob/59d60314edf567ad6b9895a1ff5d7533a14ddc96/xielu/cuda/src/xielu_impl.cu#L395-L398

I see that it does start with `dtype=bf16` https://github.com/huggingface/transformers/blob/de01a22aff21d16532d8dd68806589ca6c73dd5c/src/transformers/activations.py#L203-L210

However, it could be due to some casting (maybe peft and FA) that caused it to end up being fp32.

This PR solves it by casting it to the hidden states. Since they are both 1D Tensor of 1element, there should be very minor cost to this cast.

Tested working downstream via monkey patching https://github.com/axolotl-ai-cloud/axolotl/pull/3144


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts, @qubvel
- speech models: @eustlb
- graph models: @clefourrier

Library:

- flax: @gante and @Rocketknight1
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Rocketknight1
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @zach-huggingface, @SunMarc and @qgallouedec
- chat templates: @Rocketknight1

Integrations:

- deepspeed: HF Trainer/Accelerate: @SunMarc @zach-huggingface
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc @MekkCyber

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @Rocketknight1
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->
