### PR TITLE
Fixes for continuous batching

### DIFF
--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -187,8 +187,8 @@ if __name__ == "__main__":
         "--attn", type=str, default="paged_attention|kernels-community/flash-attn", help="Attention implementation"
     )
     parser.add_argument("--matmul-precision", "-mp", type=str, default="high")  # set to "none" to disable
-    parser.add_argument("--slice-inputs", action="store_false")  # enabled by default because much faster
-    parser.add_argument("--use-cuda-graph", action="store_true")
+    parser.add_argument("--no-slice-inputs", action="store_true")  # slicing is enabled by default because much faster
+    parser.add_argument("--use-cuda-graph", "-cg", action="store_true")
     parser.add_argument("--compile", action="store_true")
 
     parser.add_argument("--samples", type=int, default=500)
@@ -198,6 +198,8 @@ if __name__ == "__main__":
     parser.add_argument("--metrics", action="store_true")
     parser.add_argument("--profile", type=str, default=None)
     args = parser.parse_args()
+
+    args.slice_inputs = not args.no_slice_inputs
 
     # If turned on, we setup metrics
     if args.metrics:

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -187,15 +187,15 @@ if __name__ == "__main__":
         "--attn", type=str, default="paged_attention|kernels-community/flash-attn", help="Attention implementation"
     )
     parser.add_argument("--matmul-precision", "-mp", type=str, default="high")  # set to "none" to disable
-    parser.add_argument("--slice-inputs", action="store_true", default=False)
-    parser.add_argument("--use-cuda-graph", action="store_true", default=False)
-    parser.add_argument("--compile", action="store_true", default=False)
+    parser.add_argument("--slice-inputs", action="store_false")  # enabled by default because much faster
+    parser.add_argument("--use-cuda-graph", action="store_true")
+    parser.add_argument("--compile", action="store_true")
 
     parser.add_argument("--samples", type=int, default=500)
     parser.add_argument("--displayed", type=int, default=0, help="Number of samples to display")
     parser.add_argument("--output-file", type=str, default=None)
-    parser.add_argument("--compare", action="store_true", default=False)
-    parser.add_argument("--metrics", action="store_true", default=False)
+    parser.add_argument("--compare", action="store_true")
+    parser.add_argument("--metrics", action="store_true")
     parser.add_argument("--profile", type=str, default=None)
     args = parser.parse_args()
 

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -481,7 +481,7 @@ class PagedAttentionMemoryHandler:
         b = 2 * (self.group_size * self.page_size * cache_dtype.itemsize + 2 * self.num_groups)
         b += m * (self.peak_activation_per_token * self._activation_dtype.itemsize + 28 + 4 * self.num_groups)
         c = -cache_memory
-        logger.info(f"Coefficients of 2nd degree polynomial: {a = }, {b = }, {c = }")
+        logger.debug(f"Coefficients of 2nd degree polynomial: {a = }, {b = }, {c = }")
 
         # Compute discriminant and greatest solution
         discriminant = b**2 - 4 * a * c
@@ -495,11 +495,11 @@ class PagedAttentionMemoryHandler:
         num_pages = floor(greatest_solution)
         num_blocks = num_pages // self.block_size
         if num_blocks > self._upper_bound_num_blocks:
-            logger.warning(f"{num_blocks = } is too large, setting to {self._upper_bound_num_blocks = }")
+            logger.info(f"{num_blocks = } is too large, setting to {self._upper_bound_num_blocks = }")
             num_blocks = self._upper_bound_num_blocks
         max_batch_tokens = int(greatest_solution * m)
         if max_batch_tokens > self._upper_bound_max_batch_tokens:
-            logger.warning(f"{max_batch_tokens = } is too large, setting to {self._upper_bound_max_batch_tokens = }")
+            logger.info(f"{max_batch_tokens = } is too large, setting to {self._upper_bound_max_batch_tokens = }")
             max_batch_tokens = self._upper_bound_max_batch_tokens
         return num_blocks, max_batch_tokens
 
@@ -527,7 +527,7 @@ class PagedAttentionMemoryHandler:
         # Compute max batch tokens and return
         max_batch_tokens = floor(num / denum)
         if max_batch_tokens > self._upper_bound_max_batch_tokens:
-            logger.warning(f"{max_batch_tokens = } is too large, setting to {self._upper_bound_max_batch_tokens = }")
+            logger.info(f"{max_batch_tokens = } is too large, setting to {self._upper_bound_max_batch_tokens = }")
             max_batch_tokens = self._upper_bound_max_batch_tokens
         return max_batch_tokens
 
@@ -555,7 +555,7 @@ class PagedAttentionMemoryHandler:
         num_pages = floor(num / denum)
         num_blocks = num_pages // self.block_size
         if num_blocks > self._upper_bound_num_blocks:
-            logger.warning(f"{num_blocks = } is too large, setting to {self._upper_bound_num_blocks = }")
+            logger.info(f"{num_blocks = } is too large, setting to {self._upper_bound_num_blocks = }")
             num_blocks = self._upper_bound_num_blocks
         return num_blocks
 

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -198,7 +198,7 @@ class PagedAttentionCache:
         # Add the inferred attributes to the class
         self.num_blocks = num_blocks
         self.max_batch_tokens = max_batch_tokens
-        logger.warning(
+        logger.info(
             f"PagedAttentionCache initialized with {self.num_blocks = }, {self.block_size = }, {page_size = }, "
             f"{self.max_batch_tokens = } {num_attention_masks = }"
         )

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -275,9 +275,7 @@ class PagedAttentionCache:
             write_indices.extend(indices)
 
     @traced
-    def get_seqlens_k(
-        self, request_id: str, past_length: int, query_length: int
-    ) -> dict[str, int]:
+    def get_seqlens_k(self, request_id: str, past_length: int, query_length: int) -> dict[str, int]:
         """Retrieve the key sequence length for the given request_id across all layer types. Returns a dictionary of
         layer types to their corresponding key sequence lengths."""
         seqlens_k = {}

--- a/src/transformers/generation/continuous_batching/cache_manager.py
+++ b/src/transformers/generation/continuous_batching/cache_manager.py
@@ -58,6 +58,7 @@ class CacheAllocator(ABC):
         """Returns the attention type of the cache allocator and the key sequence length for the given request_id."""
         pass
 
+
 class FullAttentionCacheAllocator(CacheAllocator):
     """Cache manager for a group of full attention layers."""
 
@@ -116,6 +117,7 @@ class FullAttentionCacheAllocator(CacheAllocator):
         """Returns the attention type of the cache allocator and the key sequence length for the given request_id."""
         seqlens_k = past_length + query_length
         return "full_attention", seqlens_k
+
 
 class SlidingAttentionCacheAllocator(CacheAllocator):
     """Cache manager for sliding window attention layers."""

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -561,7 +561,7 @@ class ContinuousBatchingManager:
         self._request_counter = 0
         self._request_lock = threading.Lock()
         self.model.generation_config.top_p = None
-        self.do_sample = getattr(generation_config, "do_sample", False)  # TODO: restore default to True when suported
+        self.do_sample = getattr(generation_config, "do_sample", True)
         self.logit_processor = self.model._get_logits_processor(generation_config)
         self.use_cuda_graph = getattr(generation_config, "use_cuda_graph", False)  # TODO: same as do_sample
         self.profile = getattr(generation_config, "profile", False)
@@ -571,8 +571,6 @@ class ContinuousBatchingManager:
 
         if self.use_cuda_graph:
             raise NotImplementedError("Cuda graphs are not supported yet")
-        if self.do_sample:
-            raise NotImplementedError("Sampling is not supported yet")
 
     @traced
     def start(self):

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -174,7 +174,11 @@ class ContinuousBatchProcessor:
         self.max_seqlen_k = dict.fromkeys(layer_types, 0)
 
         if self.return_attention_mask():
-            attn_mask_kwargs = {"size": (1, 1, T, num_pages + T), "dtype": self.model_dtype, "device": self.model_device}
+            attn_mask_kwargs = {
+                "size": (1, 1, T, num_pages + T),
+                "dtype": self.model_dtype,
+                "device": self.model_device,
+            }
             self.attention_mask = {layer_type: torch.empty(**attn_mask_kwargs) for layer_type in layer_types}
         else:
             self.attention_mask = None

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -352,7 +352,6 @@ class ContinuousBatchProcessor:
 
         # Go through all the requests in the batch
         for state in self.requests_in_batch:
-
             # First we retrieve the lengths related to the request
             past_length = state.position_offset
             query_length = len(state.prompt_ids)
@@ -360,7 +359,7 @@ class ContinuousBatchProcessor:
 
             # Then we update the total lengths that are used for slicing
             self.total_query_length += query_length
-            self.total_key_length += max(seqlens_k.values())  # total_key_length is used to slice the keys, so we take the max
+            self.total_key_length += max(seqlens_k.values())  # this is used to slice the keys, so we need take the max
             self.total_batch_size += 1
             # And the attribute tracking the position in the request object
             state.position_offset += query_length
@@ -375,9 +374,9 @@ class ContinuousBatchProcessor:
                 logits_indices.append(cumulative_seqlens_q[-1] - 1)
 
             if isinstance(self.cumulative_seqlens_k, dict):
-                for layer_type, layer_type_seqlens_k in seqlens_k.items():
-                    cumulative_seqlens_k[layer_type].append(cumulative_seqlens_k[layer_type][-1] + layer_type_seqlens_k)
-                    self.max_seqlen_k[layer_type] = max(self.max_seqlen_k[layer_type], layer_type_seqlens_k)
+                for layer_type, layer_type_seqlen_k in seqlens_k.items():
+                    cumulative_seqlens_k[layer_type].append(cumulative_seqlens_k[layer_type][-1] + layer_type_seqlen_k)
+                    self.max_seqlen_k[layer_type] = max(self.max_seqlen_k[layer_type], layer_type_seqlen_k)
             else:
                 _, seqlens_k = seqlens_k.popitem()
                 cumulative_seqlens_k.append(cumulative_seqlens_k[-1] + seqlens_k)

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -254,7 +254,7 @@ class ContinuousBatchProcessor:
                 kwargs["cu_seq_lens_k"][layer_type] = seqlens_k[: b_size + 1]
                 kwargs["max_seqlen_k"][layer_type] = self.max_seqlen_k[layer_type]
                 if self.attention_mask is not None:
-                    k_len = seqlens_k[b_size]
+                    k_len = seqlens_k[b_size] if self.slice_inputs else self.attention_mask[layer_type].size(-1)
                     kwargs["attention_mask"][layer_type] = self.attention_mask[layer_type][..., :q_len, :k_len]
         else:
             layer_type = layer_types[0]
@@ -262,6 +262,7 @@ class ContinuousBatchProcessor:
             kwargs["max_seqlen_k"] = self.max_seqlen_k[layer_type]
             if self.attention_mask is not None:
                 k_len = self.cumulative_seqlens_k[layer_type][b_size]
+                k_len = k_len if self.slice_inputs else self.attention_mask[layer_type].size(-1)
                 kwargs["attention_mask"] = self.attention_mask[layer_type][..., :q_len, :k_len]
 
         if self.attention_mask is None:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from functools import partial
 from itertools import count
 from time import perf_counter
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 from torch import nn
@@ -102,11 +102,11 @@ class ContinuousBatchProcessor:
         streaming: bool = False,
         manual_eviction: bool = False,
         slice_inputs: bool = True,  # TODO: There should be an heuristic to decide on slicing, compile, cuda graphs...
-    ):
+    ) -> None:
         """Initialize the continuous batch processor.
 
         Args:
-            cache: The paged attention cache to use
+            cache: A [`PagedAttentionCache`] object
             config: The model configuration
             generation_config: The generation configuration
             input_queue: Queue for incoming requests
@@ -147,44 +147,53 @@ class ContinuousBatchProcessor:
         self.total_batch_size = 0
         self.setup_static_tensors(cache.num_groups)
 
-    def return_attention_mask(self) -> bool:
-        return self.config._attn_implementation != "paged_attention"  # we set `is_causal` to True in paged call
-
     @traced(standalone=True)
-    def setup_static_tensors(self, num_groups: int):
+    def setup_static_tensors(self, num_groups: int) -> None:
         T = self.max_batch_tokens
         num_pages = self.cache.num_blocks * self.cache.block_size
-        tensor_metadata = {"dtype": torch.int32, "device": self.model_device}
-        self.tensor_metadata = tensor_metadata
-        self.input_ids = torch.empty((1, T), **tensor_metadata)
-        self.position_ids = torch.empty((1, T), **tensor_metadata)
-        self.cumulative_seqlens_q = torch.empty((T + 1,), **tensor_metadata)
-        self.cumulative_seqlens_k = {
-            "full_attention": torch.empty((T + 1), **tensor_metadata),
-            "sliding_attention": torch.empty((T + 1), **tensor_metadata),
-            # TODO: can be generalized using layer types, for block-attn for instance
-        }
+        self.tensor_metadata = {"dtype": torch.int32, "device": self.model_device}
 
-        # There is one read and write index tensor per group
-        self.write_index_tensors = [torch.empty((T,), **tensor_metadata) for _ in range(num_groups)]
-        self.read_index_tensors = [torch.empty((num_pages + T), **tensor_metadata) for _ in range(num_groups)]
-        # +T is because there are -1 for seqlen_q when model uses a sliding window
-
-        self.logits_indices = torch.empty((T,), **tensor_metadata)
+        # Some tensors always have the same shape regardless of the model
+        self.input_ids = torch.empty((1, T), **self.tensor_metadata)
+        self.position_ids = torch.empty((1, T), **self.tensor_metadata)
+        self.cumulative_seqlens_q = torch.empty((T + 1,), **self.tensor_metadata)
         self.max_seqlen_q = 0
-        self.max_seqlen_k = {"full_attention": 0, "sliding_attention": 0}
-        self.output_ids = torch.empty((1, T), **tensor_metadata)
-        # Since attenention_mask is not always needed, we only allocate it if it is
+        self.logits_indices = torch.empty((T,), **self.tensor_metadata)
+        self.output_ids = torch.empty((1, T), **self.tensor_metadata)
+
+        # For some kwargs, if the model has more than one attention type, instead of a tensor we have a dict of tensors
+        layer_types = getattr(self.config, "layer_types", None)
+        num_attention_types = len(set(layer_types)) if layer_types is not None else 1
+
         if self.return_attention_mask():
-            # TODO: this could be 2 iff model is hybrid, and then we can also change memory handler to account for it
-            size_0 = 1 if self.sliding_window == 1 else 2
-            self.attention_mask = torch.empty(
-                (size_0, 1, T, num_pages), dtype=self.model_dtype, device=self.model_device
-            )
+            attn_mask_kwargs = {"size": (1, 1, T, num_pages), "dtype": self.model_dtype, "device": self.model_device}
         else:
-            logger.warning(f"Attention mask is not needed for {self.config._attn_implementation}")
             self.attention_mask = None
+            attn_mask_kwargs = {}
+
+        if num_attention_types >= 2:
+            self.cumulative_seqlens_k = {
+                layer_type: torch.empty((T + 1), **self.tensor_metadata) for layer_type in layer_types
+            }
+            self.max_seqlen_k = dict.fromkeys(layer_types, 0)
+            if attn_mask_kwargs:
+                self.attention_mask = {layer_type: torch.empty(**attn_mask_kwargs) for layer_type in layer_types}
+        else:
+            self.cumulative_seqlens_k = torch.empty((T + 1), **self.tensor_metadata)
+            self.max_seqlen_k = 0
+            if attn_mask_kwargs:
+                self.attention_mask = torch.empty(**attn_mask_kwargs)
+
+        # For other kwargs, we need a list of tensors with as many tensors as there are groups
+        self.write_index_storage = [torch.empty((T,), **self.tensor_metadata) for _ in range(num_groups)]
+        self.read_index_storage = [torch.empty((num_pages + T), **self.tensor_metadata) for _ in range(num_groups)]
+        # For read index, the +T is because there are -1 for seqlen_q when model uses a sliding window
+
+        # After allocating empty tensors, we reset them to the right value
         self.reset_static_tensors(full_reset=True)
+
+    def return_attention_mask(self) -> bool:
+        return self.config._attn_implementation != "paged_attention"  # we set `is_causal` to True in paged call
 
     @traced
     @torch.no_grad()
@@ -192,52 +201,73 @@ class ContinuousBatchProcessor:
         """Reset static tensors for the next batch. In between batches, reset only the parts that were used in the last
         batch, but for initialisation, we can reset everything using the (full_reset) flag."""
         # Compute the slice to reset
-        t = self.total_query_length if self.slice_inputs and not full_reset else self.write_index_tensors[0].size(-1)
-        c = self.total_key_length if self.slice_inputs and not full_reset else self.read_index_tensors[0].size(-1)
-        b = self.total_batch_size if self.slice_inputs and not full_reset else self.write_index_tensors[0].size(0)
-        # Reset the tensors
+        t = self.total_query_length if self.slice_inputs and not full_reset else self.write_index_storage[0].size(-1)
+        c = self.total_key_length if self.slice_inputs and not full_reset else self.read_index_storage[0].size(-1)
+        b = self.total_batch_size if self.slice_inputs and not full_reset else self.write_index_storage[0].size(0)
+
+        # Reset the attributes that always have the same shape
         self.input_ids[:, :t].zero_()
         self.position_ids[:, :t].zero_()
         self.cumulative_seqlens_q[: b + 1].zero_()
-        for layer_type in self.cumulative_seqlens_k:
-            self.cumulative_seqlens_k[layer_type][: b + 1].zero_()
-            self.max_seqlen_k[layer_type] = 0
-        for i in range(self.cache.num_groups):
-            self.write_index_tensors[i][:t].fill_(-1)
-            self.read_index_tensors[i][: t + c].fill_(-1)
-        self.logits_indices[:t].fill_(-1)
         self.max_seqlen_q = 0
+        self.logits_indices[:t].fill_(-1)
         self.output_ids[:, :t].fill_(-1)
-        if self.attention_mask is not None:
-            self.attention_mask[:, :, :t, :c].fill_(torch.finfo(self.model_dtype).min)
+
+        # Reset the attributes that are either tensors or dict of tensors
+        if isinstance(self.cumulative_seqlens_k, dict):
+            for layer_type in self.cumulative_seqlens_k:
+                self.cumulative_seqlens_k[layer_type][: b + 1].zero_()
+                self.max_seqlen_k[layer_type] = 0
+                if self.attention_mask is not None:
+                    self.attention_mask[layer_type][:, :, :t, :c].fill_(torch.finfo(self.model_dtype).min)
+        else:
+            self.cumulative_seqlens_k[: b + 1].zero_()
+            self.max_seqlen_k = 0
+            if self.attention_mask is not None:
+                self.attention_mask[:, :, :t, :c].fill_(torch.finfo(self.model_dtype).min)
+
+        # Reset the attributes that are lists of tensors
+        for i in range(self.cache.num_groups):
+            self.write_index_storage[i][:t].fill_(-1)
+            self.read_index_storage[i][: t + c].fill_(-1)
 
     def get_model_kwargs(self) -> PagedAttentionArgs:
         """Get model keyword arguments for the current batch."""
         # Compute the slice to return
-        t = self.total_query_length if self.slice_inputs else self.write_index.size(-1)
+        t = self.total_query_length if self.slice_inputs else self.write_index_storage[0].size(-1)
         b = self.total_batch_size
-        # Prepare the kwargs
+
+        # Prepare the kwargs, the attributes that are either tensors or dict of tensors are initialized to empty dicts
         kwargs = {
             "input_ids": self.input_ids[:, :t],
             "position_ids": self.position_ids[:, :t],
             "cu_seq_lens_q": self.cumulative_seqlens_q[: b + 1],
+            "max_seqlen_q": self.max_seqlen_q,
+            "logits_indices": self.logits_indices[:t],
             "cu_seq_lens_k": {},
+            "max_seqlen_k": {},
+            "attention_mask": {},
             "read_index": self.read_index,  # slicing is done during building
             "write_index": self.write_index,  # slicing is done during building
-            "logits_indices": self.logits_indices[:t],
-            "max_seqlen_q": self.max_seqlen_q,
-            "max_seqlen_k": self.max_seqlen_k,
             "cache": self.cache,
             "use_cache": False,
         }
-        for layer_type in self.cumulative_seqlens_k:
-            kwargs["cu_seq_lens_k"][layer_type] = self.cumulative_seqlens_k[layer_type][: b + 1]
-        # If the attention mask is not None, we slice it as the others
-        if self.attention_mask is not None:
-            kwargs["attention_mask"] = {}
-            for layer_type, seqlens_k in kwargs["cu_seq_lens_k"].items():
-                kwargs["attention_mask"][layer_type] = self.attention_mask[:1, :, :t, : seqlens_k[-1]]
+
+        # For the attributes that are tensors or dict of tensors, we populate the dict or replace it with the tensor
+        if isinstance(self.cumulative_seqlens_k, dict):
+            for layer_type, seqlens_k in self.cumulative_seqlens_k.items():
+                kwargs["cu_seq_lens_k"][layer_type] = seqlens_k[: b + 1]
+                kwargs["max_seqlen_k"][layer_type] = self.max_seqlen_k[layer_type]
+                if self.attention_mask is not None:
+                    kwargs["attention_mask"][layer_type] = self.attention_mask[layer_type][..., :t, : seqlens_k[b]]
+
         else:
+            kwargs["cu_seq_lens_k"] = self.cumulative_seqlens_k[: b + 1]
+            kwargs["max_seqlen_k"] = self.max_seqlen_k
+            if self.attention_mask is not None:
+                kwargs["attention_mask"] = self.attention_mask[..., :t, : self.cumulative_seqlens_k[b]]
+
+        if self.attention_mask is None:
             kwargs["attention_mask"] = None
         return kwargs
 
@@ -283,75 +313,80 @@ class ContinuousBatchProcessor:
 
     @traced
     def prepare_next_batch(self) -> bool:
-        """Prepare tensors and metadata for the next model forward pass."""
-        # Get new requests from the queue
+        """Prepare tensors and metadata for the next model forward pass. Returns True if there are requests to process,
+        False otherwise."""
+
+        # Get new requests from the queue, stop if there are no pending requests
         self._get_new_requests()
         self.scheduler.clear_cancelled_requests()
         if not self.scheduler.has_pending_requests():
             return False
-
         self.metrics.record_queue_metrics(len(self.scheduler.active_requests), len(self.scheduler.waiting_requests))
 
+        # Schedule the next batch of requests, stop if there are no requests in the batch
         self.requests_in_batch = self.scheduler.schedule_batch(self.max_batch_tokens)
         if not self.requests_in_batch:
             return False
-
-        # Get the request objects for this batch
-        self.reset_static_tensors()  # TOOD: with slice_inputs, this might be unnecessary
-        position_ids = []
-        input_ids = []
-        read_index = [[] for _ in range(self.cache.num_groups)]
-        write_index = [[] for _ in range(self.cache.num_groups)]
-        cumulative_seqlens_q = [0]
-        cumulative_seqlens_k = {"full_attention": [0], "sliding_attention": [0]}
-        logits_indices = []
         self.metrics.record_batch_metrics(self.requests_in_batch)
 
+        # Reset the static tensors used for storage
+        self.reset_static_tensors()  # TODO: with slice_inputs, this might be unnecessary
+
+        # Prepare accumulators
         self.total_query_length = 0
         self.total_key_length = 0
         self.total_batch_size = 0
 
+        input_ids = []
+        position_ids = []
+        cumulative_seqlens_q = [0]
+        logits_indices = []
+
+        if isinstance(self.cumulative_seqlens_k, dict):
+            cumulative_seqlens_k = {layer_type: [0] for layer_type in self.cumulative_seqlens_k}
+        else:
+            cumulative_seqlens_k = [0]
+
+        read_index = [[] for _ in range(self.cache.num_groups)]
+        write_index = [[] for _ in range(self.cache.num_groups)]
+
+        # Go through all the requests in the batch
         for state in self.requests_in_batch:
-            next_input_ids = state.prompt_ids
-            input_ids.extend(next_input_ids)
+
+            # First we retrieve the lengths related to the request
             past_length = state.position_offset
-            query_length = len(next_input_ids)
-            key_length = query_length + past_length
+            query_length = len(state.prompt_ids)
+            seqlens_k = self.cache.get_seqlens_k(state.request_id, past_length, query_length)
 
+            # Then we update the total lengths that are used for slicing
             self.total_query_length += query_length
-            self.total_key_length += key_length
+            self.total_key_length += max(seqlens_k.values())  # total_key_length is used to slice the keys, so we take the max
             self.total_batch_size += 1
-
-            positions_to_add = list(range(past_length, key_length))
-            self.cache.get_read_indices(state.request_id, past_length, query_length, read_index)
-            self.cache.get_write_indices(state.request_id, past_length, query_length, write_index)
-
-            position_ids.extend(positions_to_add)
-            cumulative_seqlens_q.append(cumulative_seqlens_q[-1] + query_length)
-
-            cumulative_seqlens_k["full_attention"].append(
-                cumulative_seqlens_k["full_attention"][-1] + query_length + past_length
-            )
-            cumulative_seqlens_k["sliding_attention"].append(
-                cumulative_seqlens_k["sliding_attention"][-1]
-                + query_length
-                + min(past_length, self.sliding_window - 1)
-            )
-
-            if len(state.remaining_prompt_ids) == 0:
-                logits_indices.append(cumulative_seqlens_q[-1] - 1)
-            self.max_seqlen_q = max(self.max_seqlen_q, query_length)
-            self.max_seqlen_k["full_attention"] = max(self.max_seqlen_k["full_attention"], query_length + past_length)
-            self.max_seqlen_k["sliding_attention"] = max(
-                self.max_seqlen_k["sliding_attention"], query_length + min(past_length, self.sliding_window - 1)
-            )
+            # And the attribute tracking the position in the request object
             state.position_offset += query_length
 
-        logger.debug(
-            f"Scheduled: {len(self.requests_in_batch)}, Waiting: {len(self.scheduler.waiting_requests)}, "
-            f"Active: {len(self.scheduler.active_requests)}. cum Q: {cumulative_seqlens_q[-1]}. "
-            f"cum KV: {max(ck[-1] for ck in cumulative_seqlens_k)}, free blocks: {self.cache.get_num_free_blocks()}"
-        )
+            # Then we accumulate for the object used in the kwargs
+            input_ids.extend(state.prompt_ids)
+            position_ids.extend(range(past_length, past_length + query_length))
+            cumulative_seqlens_q.append(cumulative_seqlens_q[-1] + query_length)
+            self.max_seqlen_q = max(self.max_seqlen_q, query_length)
+
+            if not state.remaining_prompt_ids:
+                logits_indices.append(cumulative_seqlens_q[-1] - 1)
+
+            if isinstance(self.cumulative_seqlens_k, dict):
+                for layer_type, layer_type_seqlens_k in seqlens_k.items():
+                    cumulative_seqlens_k[layer_type].append(cumulative_seqlens_k[layer_type][-1] + layer_type_seqlens_k)
+                    self.max_seqlen_k[layer_type] = max(self.max_seqlen_k[layer_type], layer_type_seqlens_k)
+            else:
+                _, seqlens_k = seqlens_k.popitem()
+                cumulative_seqlens_k.append(cumulative_seqlens_k[-1] + seqlens_k)
+                self.max_seqlen_k = max(self.max_seqlen_k, seqlens_k)
+
+            self.cache.extend_read_indices(state.request_id, past_length, query_length, read_index)
+            self.cache.extend_write_indices(state.request_id, past_length, query_length, write_index)
+
+        # When looping over request is done, we can build the actual tensors
         self._build_tensors(
             input_ids,
             position_ids,
@@ -361,54 +396,74 @@ class ContinuousBatchProcessor:
             cumulative_seqlens_k,
             logits_indices,
         )
-
         self.metrics.record_kv_cache_memory_metrics(self.cache)
 
+        if logger.isEnabledFor(logging.DEBUG):
+            if isinstance(self.cumulative_seqlens_k, dict):
+                ck = max(cumulative_seqlens_k[layer_type][-1] for layer_type in self.cumulative_seqlens_k)
+            else:
+                ck = cumulative_seqlens_k[-1]
+            logger.debug(
+                f"Scheduled: {len(self.requests_in_batch)}, Waiting: {len(self.scheduler.waiting_requests)}, "
+                f"Active: {len(self.scheduler.active_requests)}. cum Q: {cumulative_seqlens_q[-1]}. "
+                f"cum KV: {ck}, free blocks: {self.cache.get_num_free_blocks()}"
+            )
         return True
 
     @traced
     def _build_tensors(
         self,
-        input_ids,
-        position_ids,
+        input_ids: list[int],
+        position_ids: list[int],
         read_index: list[list[int]],
         write_index: list[list[int]],
-        cumulative_seqlens_q,
-        cumulative_seqlens_k,
-        logits_indices,
-    ):
+        cumulative_seqlens_q: list[int],
+        cumulative_seqlens_k: Union[list[int], dict[str, list[int]]],
+        logits_indices: list[int],
+    ) -> None:
+        """Builds the actual tensors for the current batch, by modifying the already allocated tensors in place."""
         to_tensor = partial(torch.tensor, **self.tensor_metadata)
+
+        # Those kwargs always have the same type regardless of the model
         self.input_ids[:, : len(input_ids)] = to_tensor(input_ids)
         self.position_ids[:, : len(position_ids)] = to_tensor(position_ids)
+        self.cumulative_seqlens_q[: len(cumulative_seqlens_q)] = to_tensor(cumulative_seqlens_q)
+        self.logits_indices[: len(logits_indices)] = to_tensor(logits_indices)
 
+        # Those kwargs are either dict of tensors or tensors, so we need to handle both cases
+        if isinstance(self.cumulative_seqlens_k, dict):
+            for layer_type, layer_type_seqlens_k in cumulative_seqlens_k.items():
+                self.cumulative_seqlens_k[layer_type][: len(layer_type_seqlens_k)] = to_tensor(layer_type_seqlens_k)
+                if self.attention_mask is not None:
+                    build_attention_mask(
+                        attention_mask=self.attention_mask[layer_type],
+                        cumulative_seqlens_q=cumulative_seqlens_q,
+                        cumulative_seqlens_k=layer_type_seqlens_k,
+                        sliding_window=self.sliding_window if layer_type == "sliding_attention" else 1,
+                    )
+        else:
+            self.cumulative_seqlens_k[: len(cumulative_seqlens_k)] = to_tensor(cumulative_seqlens_k)
+            if self.attention_mask is not None:
+                build_attention_mask(
+                    attention_mask=self.attention_mask,
+                    cumulative_seqlens_q=cumulative_seqlens_q,
+                    cumulative_seqlens_k=cumulative_seqlens_k,
+                    sliding_window=self.sliding_window,
+                )
+
+        # The index only contain references to the storage tensors, so we update the storage and their references
         self.read_index = []
         self.write_index = []
         for i, group_read_indices, group_write_indices in zip(count(), read_index, write_index):
             # Write in the actual tensors
-            self.read_index_tensors[i][: len(group_read_indices)] = to_tensor(group_read_indices)
-            self.write_index_tensors[i][: len(group_write_indices)] = to_tensor(group_write_indices)
+            self.read_index_storage[i][: len(group_read_indices)] = to_tensor(group_read_indices)
+            self.write_index_storage[i][: len(group_write_indices)] = to_tensor(group_write_indices)
             # Slice to the right size
-            r = len(group_read_indices) if self.slice_inputs else self.read_index_tensors[i].size(-1)
-            w = len(group_write_indices) if self.slice_inputs else self.write_index_tensors[i].size(-1)
+            r = len(group_read_indices) if self.slice_inputs else self.read_index_storage[i].size(-1)
+            w = len(group_write_indices) if self.slice_inputs else self.write_index_storage[i].size(-1)
             # Add to the index
-            self.read_index.append(self.read_index_tensors[i][:r])
-            self.write_index.append(self.write_index_tensors[i][:w])
-
-        self.cumulative_seqlens_q[: len(cumulative_seqlens_q)] = to_tensor(cumulative_seqlens_q)
-        for layer_type in self.cumulative_seqlens_k:
-            l = len(cumulative_seqlens_k[layer_type])
-            self.cumulative_seqlens_k[layer_type][:l] = to_tensor(cumulative_seqlens_k[layer_type])
-        self.logits_indices[: len(logits_indices)] = to_tensor(logits_indices)
-
-        if self.attention_mask is not None:
-            build_attention_mask(self.attention_mask[0], cumulative_seqlens_q, cumulative_seqlens_k["full_attention"])
-            if self.sliding_window != 1:
-                build_attention_mask(
-                    self.attention_mask[1],
-                    cumulative_seqlens_q,
-                    cumulative_seqlens_k["sliding_attention"],
-                    self.sliding_window,
-                )
+            self.read_index.append(self.read_index_storage[i][:r])
+            self.write_index.append(self.write_index_storage[i][:w])
 
     @traced
     def _sync(self):
@@ -524,13 +579,18 @@ class ContinuousBatchingManager:
         self._request_counter = 0
         self._request_lock = threading.Lock()
         self.model.generation_config.top_p = None
-        self.do_sample = getattr(generation_config, "do_sample", True)
+        self.do_sample = getattr(generation_config, "do_sample", False)  # TODO: restore default to True when suported
         self.logit_processor = self.model._get_logits_processor(generation_config)
-        self.use_cuda_graph = getattr(generation_config, "use_cuda_graph", True)
+        self.use_cuda_graph = getattr(generation_config, "use_cuda_graph", False)  # TODO: same as do_sample
         self.profile = getattr(generation_config, "profile", False)
         self.manual_eviction = manual_eviction
         self.batch_processor: Optional[ContinuousBatchProcessor] = None
         self.slice_inputs = slice_inputs
+
+        if self.use_cuda_graph:
+            raise NotImplementedError("Cuda graphs are not supported yet")
+        if self.do_sample:
+            raise NotImplementedError("Sampling is not supported yet")
 
     @traced
     def start(self):

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -174,7 +174,7 @@ class ContinuousBatchProcessor:
         self.max_seqlen_k = dict.fromkeys(layer_types, 0)
 
         if self.return_attention_mask():
-            attn_mask_kwargs = {"size": (1, 1, T, num_pages), "dtype": self.model_dtype, "device": self.model_device}
+            attn_mask_kwargs = {"size": (1, 1, T, num_pages + T), "dtype": self.model_dtype, "device": self.model_device}
             self.attention_mask = {layer_type: torch.empty(**attn_mask_kwargs) for layer_type in layer_types}
         else:
             self.attention_mask = None
@@ -229,7 +229,7 @@ class ContinuousBatchProcessor:
         """Get model keyword arguments for the current batch."""
         # Compute the slice to return
         q_len = self.total_query_length if self.slice_inputs else self.write_index_storage[0].size(-1)
-        b_size = self.total_batch_size
+        b_size = self.total_batch_size if self.slice_inputs else self.cumulative_seqlens_q.size(-1) - 1
 
         # Prepare the kwargs, the attributes that are either tensors or dict of tensors are initialized to empty dicts
         kwargs = {

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -25,7 +25,7 @@ from ...utils.metrics import traced
 
 # We centralize the logger here to coordinate between logging and progress bar
 logger = logging.getLogger("ContinuousBatchingLogger")
-logger.setLevel(logging.INFO)
+# logger.setLevel(logging.INFO)
 
 
 @staticmethod

--- a/src/transformers/integrations/eager_paged.py
+++ b/src/transformers/integrations/eager_paged.py
@@ -42,7 +42,7 @@ def eager_paged_attention_forward(
     # Get the right causal mask for the current layer
     if isinstance(attention_mask, dict):
         sliding_window = getattr(module, "sliding_window", 1)
-        layer_type = "full_attention" if sliding_window == 1 else "sliding_attention"
+        layer_type = "full_attention" if sliding_window == 1 or sliding_window is None else "sliding_attention"
         causal_mask = attention_mask[layer_type]
     else:
         causal_mask = attention_mask
@@ -51,7 +51,19 @@ def eager_paged_attention_forward(
     if causal_mask is not None:
         attn_weights = attn_weights + causal_mask
 
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    # Handle attention sinks if the model has them
+    if hasattr(module, "sinks"):
+        # Retrieve the sink and add it to the attention weights
+        sinks = module.sinks.reshape(1, -1, 1, 1).expand(query.shape[0], -1, query.shape[-2], -1)
+        attn_weights = torch.cat([attn_weights, sinks], dim=-1)
+        # Normalize the attention weights for better numerical stability
+        attn_weights = attn_weights - attn_weights.max(dim=-1, keepdim=True).values
+        # Apply softmax and drop the sink. Not exactly the same code as eager w/ sink, but the same code does not produce the same results.
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+        attn_weights = attn_weights[..., :-1]
+    else:
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+
     attn_output = torch.matmul(attn_weights, value)
     attn_output = attn_output.transpose(1, 2).contiguous()
 

--- a/src/transformers/integrations/flash_paged.py
+++ b/src/transformers/integrations/flash_paged.py
@@ -64,7 +64,6 @@ def paged_attention_forward(
         cu_seq_lens_k = cu_seq_lens_k.clone()
         max_seqlen_k = max_seqlen_k
 
-    # If there is no cache, we assume this is full attention, and we check if cu_seq_lens_k is a list of tensors
     if implementation is not None and hasattr(implementation, "flash_attn_varlen_func"):
         flash_attn_varlen_func = implementation.flash_attn_varlen_func
 

--- a/src/transformers/integrations/flash_paged.py
+++ b/src/transformers/integrations/flash_paged.py
@@ -56,18 +56,20 @@ def paged_attention_forward(
     if cache is not None:
         k, v = cache.update(k, v, module.layer_idx, **kwargs)
 
-        # Check if we are in a sliding window context
+    # Retrieve the cumulative sequence lengths for the current layer
+    if isinstance(cu_seq_lens_k, dict):
         cu_seq_lens_k = cu_seq_lens_k[layer_type].clone()
         max_seqlen_k = max_seqlen_k[layer_type]
+    else:
+        cu_seq_lens_k = cu_seq_lens_k.clone()
+        max_seqlen_k = max_seqlen_k
 
     # If there is no cache, we assume this is full attention, and we check if cu_seq_lens_k is a list of tensors
-    elif isinstance(cu_seq_lens_k, list):
-        cu_seq_lens_k = cu_seq_lens_k[layer_type].clone()
-        max_seqlen_k = max_seqlen_k[layer_type]
-
     if implementation is not None and hasattr(implementation, "flash_attn_varlen_func"):
         flash_attn_varlen_func = implementation.flash_attn_varlen_func
+
     custom_kwargs = {"s_aux": kwargs.get("s_aux")} if "s_aux" in kwargs else {}
+
     attn_output = flash_attn_varlen_func(
         q.transpose(1, 2).squeeze(0).contiguous(),
         k.contiguous(),

--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -42,7 +42,7 @@ def sdpa_attention_paged_forward(
     # Get the right causal mask for the current layer
     if isinstance(attention_mask, dict):
         sliding_window = getattr(module, "sliding_window", 1)
-        layer_type = "full_attention" if sliding_window == 1 else "sliding_attention"
+        layer_type = "full_attention" if sliding_window == 1 or sliding_window is None else "sliding_attention"
         causal_mask = attention_mask[layer_type]
     else:
         causal_mask = attention_mask

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -596,12 +596,12 @@ def require_flash_attn(test_case):
 
 def require_kernels(test_case):
     """
-    Decorator marking a test that requires Flash Attention.
+    Decorator marking a test that requires the kernels library.
 
-    These tests are skipped when Flash Attention isn't installed.
+    These tests are skipped when the kernels library isn't installed.
 
     """
-    return unittest.skipUnless(is_kernels_available(), "test requires Flash Attention")(test_case)
+    return unittest.skipUnless(is_kernels_available(), "test requires the kernels library")(test_case)
 
 
 def require_flash_attn_3(test_case):

--- a/src/transformers/utils/metrics.py
+++ b/src/transformers/utils/metrics.py
@@ -4,10 +4,6 @@ import time
 from enum import Enum
 from typing import Any, Callable, Optional, Union
 
-import torch
-
-from transformers.generation.continuous_batching.cache import PagedAttentionCache
-
 
 class RequestStatus(Enum):
     """Status of a generation request through its lifecycle."""

--- a/src/transformers/utils/metrics.py
+++ b/src/transformers/utils/metrics.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, Optional, Union
 
 import torch
 
+from transformers.generation.continuous_batching.cache import PagedAttentionCache
+
 
 class RequestStatus(Enum):
     """Status of a generation request through its lifecycle."""
@@ -337,42 +339,28 @@ class ContinuousBatchProcessorMetrics:
             return
 
         try:
-            # Calculate memory usage based on cache configuration
-            num_used_blocks = cache.num_blocks - len(cache._free_blocks)
-            num_layers = len(cache.key_cache)
+            # Retrieve the memory footprint of the cache
+            page_size = cache.head_dim * cache.num_key_value_heads
+            page_mem_in_bytes = page_size * cache.dtype.itemsize
+            # When a block is allocated, it is for both K and V, so we multiply by 2
+            # It's also allocated accross all cache tensors, so we multiply by the nb of tensors: len(cache.key_cache)
+            block_mem_in_bytes = 2 * len(cache.key_cache) * cache.block_size * page_mem_in_bytes
 
-            # Each used block stores key and value states
-            # Each with shape: (num_kv_heads, block_size, head_dim)
-            bytes_per_parameter = 2 if cache.dtype in [torch.float16, torch.bfloat16] else 4  # Size in bytes
+            # Retrieve the number of used and free blocks
+            free_blocks = cache.get_num_free_blocks()
+            used_blocks = cache.num_blocks - free_blocks
 
-            # Total bytes = num_layers * num_used_blocks * block_size *
-            #               num_kv_heads * head_dim * 2 (both K and V) * bytes_per_parameter
-            memory_bytes = (
-                num_layers
-                * num_used_blocks
-                * cache.block_size
-                * cache.num_key_value_heads
-                * cache.head_dim
-                * 2  # For both key and value caches
-                * bytes_per_parameter
-            )
+            # Convert that into used and free memory in bytes
+            used_memory_bytes = used_blocks * block_mem_in_bytes
+            free_memory_bytes = free_blocks * block_mem_in_bytes
 
-            free_memory_bytes = (
-                num_layers
-                * len(cache._free_blocks)
-                * cache.block_size
-                * cache.num_key_value_heads
-                * cache.head_dim
-                * 2  # For both key and value caches
-                * bytes_per_parameter
-            )
-
-            self.kv_cache_memory_gauge.set(memory_bytes)
+            # Update the telemetry gauges and add a message in the logs
+            self.kv_cache_memory_gauge.set(used_memory_bytes)
             self.kv_cache_free_memory_gauge.set(free_memory_bytes)
             logger.debug(
-                f"KV Cache memory: {memory_bytes / (1024 * 1024):.2f}MB, "
-                f"Used blocks: {num_used_blocks}/{cache.num_blocks} "
-                f"({num_used_blocks / cache.num_blocks * 100:.1f}%)"
+                f"KV Cache memory: {used_memory_bytes / (1024 * 1024):.2f}MB, "
+                f"Used blocks: {used_blocks}/{cache.num_blocks} "
+                f"({used_blocks / cache.num_blocks * 100:.1f}%)"
             )
         except Exception as e:
             logger.warning(f"Failed to record KV cache memory metrics: {e}")

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -20,7 +20,7 @@ from parameterized import parameterized
 
 from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
 from transformers.generation.continuous_batching.cache import group_layers_by_attn_type
-from transformers.testing_utils import require_torch_gpu, slow
+from transformers.testing_utils import require_kernels, require_torch_gpu, slow
 
 
 CB_MODELS_TO_TEST = [
@@ -123,6 +123,8 @@ class ContinuousBatchingTest(unittest.TestCase):
             non_cb_attn_implementation = "sdpa"
         elif attn_implementation == "eager_paged":
             non_cb_attn_implementation = "eager"
+        elif attn_implementation == "paged_attention|kernels-community/flash-attn":
+            non_cb_attn_implementation = "eager"
         else:
             raise ValueError(f"Invalid attention implementation: {attn_implementation}")
 
@@ -193,8 +195,8 @@ class ContinuousBatchingTest(unittest.TestCase):
         }.get(model_id, {})  # fmt: skip
         self._test_continuous_batching_parity(model_id, "sdpa_paged", expected_outputs)
 
-    # @require_torch_gpu
-    # @require_flash_attn
-    # @slow
-    # def test_continuous_batching_parity_flash(self, model_id: str) -> None:
-    #     self._test_continuous_batching_parity(model_id, "flash_attn")
+    @require_torch_gpu
+    @require_kernels
+    @slow
+    def test_continuous_batching_parity_flash(self, model_id: str) -> None:
+        self._test_continuous_batching_parity(model_id, "paged_attention|kernels-community/flash-attn")

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -172,7 +172,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_0": " $16. How did I get that answer? I used the following equation: 16 - 3 - 4 = 9. 9 x $2 = $18. $18 -"
             },
             ("cuda", (9, 0)): {
-                "req_1": " 3 bolts of blue fiber and 1.5 bolts of white fiber. The total number of bolts is 4.5. The total number of bolts is 4.5. The total"
+                "req_1": " $50,000. This is because the value of the house increased by 150%, which means that the value of the house increased by $50,000. This is because the value of the"
             }
         }).get_expectation() # fmt: skip
         self._test_continuous_batching_parity("meta-llama/Llama-3.1-8B", "eager_paged", expected_outputs)
@@ -183,6 +183,9 @@ class ContinuousBatchingTest(unittest.TestCase):
         expected_outputs = Expectations({
             ("rocm", (9, 4)): {
                 "req_1": " \n\n**Answer:** 3 bolts\n\n**Solution:**\n\n* **White fiber:** The robe needs half as much white fiber as blue fiber, so it needs 2 bolts / 2 ="
+            },
+            ("cuda", (9, 0)): {
+                "req_0": " \n\n**$12**\n\n**Here's how to solve it:**\n\n* **Eggs eaten:** 3\n* **Eggs left:** 16 - 3 = 13"
             }
         }).get_expectation() # fmt: skip
         self._test_continuous_batching_parity("google/gemma-2-2b-it", "eager_paged", expected_outputs)
@@ -198,7 +201,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     def test_continuous_batching_parity_gpt_oss_eager(self) -> None:
         expected_outputs = Expectations({
             ("cuda", (9, 0)): {
-                "req_1": " 2.5 bolts. The question: \"What is the answer to the riddle?\" The answer is 2.5 bolts. But the riddle is a trick: \"A robe takes",
+                "req_1": "  2.5 bolts. The question: \"What is the name of the puzzle that involves a robe taking 2 bolts of blue fiber and half that much white fiber?\" The answer: \"The",
             }
         }).get_expectation() # fmt: skip
         self._test_continuous_batching_parity("openai/gpt-oss-20b", "eager_paged", expected_outputs)
@@ -220,7 +223,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     def test_continuous_batching_parity_gemma_sdpa(self) -> None:
         expected_outputs = Expectations({
             ("cuda", (9, 0)): {
-                "req_1": " \n \n 2 + 1 = 3 bolts \n \n \n \n \n \n \n \n \n \n \n \n \n ",
+                "req_1": " \n\n**Answer:** 3 bolts\n\n**Solution:**\n\n* **White fiber:** The robe needs half as much white fiber as blue fiber, so it needs 2 bolts / 2 =",
             }
         }).get_expectation() # fmt: skip
         self._test_continuous_batching_parity("google/gemma-2-2b-it", "sdpa_paged", expected_outputs)
@@ -239,7 +242,11 @@ class ContinuousBatchingTest(unittest.TestCase):
     @require_kernels
     @slow
     def test_continuous_batching_parity_llama_flash(self) -> None:
-        expected_outputs = {}
+        expected_outputs = Expectations({
+            ("cuda", (9, 0)): {
+                "req_1": " 3 bolts of blue fiber and 1.5 bolts of white fiber. The total number of bolts is 4.5 bolts. The total number of bolts is 4.5 bolts.",
+            }
+        }).get_expectation() # fmt: skip
         self._test_continuous_batching_parity(
             "meta-llama/Llama-3.1-8B", "paged_attention|kernels-community/flash-attn", expected_outputs
         )
@@ -250,7 +257,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     def test_continuous_batching_parity_gemma_flash(self) -> None:
         expected_outputs = Expectations({
             ("cuda", (9, 0)): {
-                "req_1": " \n\n**Answer:** 3 bolts\n\n**Explanation:**\n\n* **White fiber:** The robe needs half the amount of white fiber as blue fiber, so it needs 2 bolts / 2",
+                "req_1": " \n \n 2 + 1 = 3 bolts \n \n \n \n \n \n \n \n \n \n \n \n \n ",
             }
         }).get_expectation() # fmt: skip
         self._test_continuous_batching_parity("google/gemma-2-2b-it", "paged_attention|kernels-community/flash-attn", expected_outputs)
@@ -269,5 +276,5 @@ class ContinuousBatchingTest(unittest.TestCase):
         expected_outputs = {}
         self._test_continuous_batching_parity("openai/gpt-oss-20b", "paged_attention|kernels-community/flash-attn", expected_outputs)
 
-# FIXME: the gemma test seem broken, there is a message about cuda graphs and the eager and flash expecteations are 
+# FIXME: the gemma test seem broken, there is a message about cuda graphs and the sdpa and flash expecteations are 
 # inverted on CUDA. On AMD they do fine.

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -165,7 +165,6 @@ class ContinuousBatchingTest(unittest.TestCase):
                         f"Exp:{repr(expected_output)}\nOut:{repr(cb_decoded_output)}",
                     )
 
-
     # Eager tests
     @require_torch_gpu
     @slow
@@ -178,7 +177,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_1": " 3 bolts of blue fiber and 1.5 bolts of white fiber. The total number of bolts is 4.5. The total number of bolts is 4.5. The total",
                 "req_2": " $50,000. This is because the value of the house increased by 150%, which means that the value of the house increased by $50,000. This is because the value of the"
             }
-        }).get_expectation() # fmt: skip
+        }).get_expectation()  # fmt: skip
         self._test_continuous_batching_parity("meta-llama/Llama-3.1-8B", "eager_paged", expected_outputs)
 
     @require_torch_gpu
@@ -192,7 +191,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_0": "\n\n**$12**\n\n**Here's how to solve it:**\n\n* **Eggs eaten:** 3\n* **Eggs left:** 16 - 3 = 13",
                 "req_1": " \n \n 2 + 1 = 3 bolts \n \n \n \n \n \n \n \n \n \n \n \n \n "
             }
-        }).get_expectation() # fmt: skip
+        }).get_expectation()  # fmt: skip
         self._test_continuous_batching_parity("google/gemma-2-2b-it", "eager_paged", expected_outputs)
 
     @require_torch_gpu
@@ -209,9 +208,8 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_1": " 2.5 bolts. The question: \"What is the name of the puzzle that involves a robe taking 2 bolts of blue fiber and half that much white fiber?\" The answer: \"The",
                 "req_2": " 50%.\"\n\nWe need to parse: He buys a house for $80,000. He puts in $50,000 in repairs. This increased the value of the house by 150%."
             }
-        }).get_expectation() # fmt: skip
+        }).get_expectation()  # fmt: skip
         self._test_continuous_batching_parity("openai/gpt-oss-20b", "eager_paged", expected_outputs)
-
 
     # SDPA tests
     @require_torch_gpu
@@ -221,7 +219,7 @@ class ContinuousBatchingTest(unittest.TestCase):
             ("rocm", (9, 4)): {
                 "req_2": " $50,000. This is because the value of the house increased by 150%, which means that the value of the house increased by $50,000. This is because the value of the"
             }
-        }).get_expectation() # fmt: skip
+        }).get_expectation()  # fmt: skip
         self._test_continuous_batching_parity("meta-llama/Llama-3.1-8B", "sdpa_paged", expected_outputs)
 
     @require_torch_gpu
@@ -231,7 +229,7 @@ class ContinuousBatchingTest(unittest.TestCase):
             ("cuda", (9, 0)): {
                 "req_1": " \n\n**Answer:** 3 bolts\n\n**Solution:**\n\n* **White fiber:** The robe needs half as much white fiber as blue fiber, so it needs 2 bolts / 2 =",
             }
-        }).get_expectation() # fmt: skip
+        }).get_expectation()  # fmt: skip
         self._test_continuous_batching_parity("google/gemma-2-2b-it", "sdpa_paged", expected_outputs)
 
     @require_torch_gpu
@@ -242,7 +240,6 @@ class ContinuousBatchingTest(unittest.TestCase):
 
     # GPT-OSS is not compatible with SDPA because it has an attention sink. TODO: is this fixable?
 
-
     # Flash attention test
     @require_torch_gpu
     @require_kernels
@@ -252,7 +249,7 @@ class ContinuousBatchingTest(unittest.TestCase):
             ("cuda", (9, 0)): {
                 "req_1": " 3 bolts of blue fiber and 1.5 bolts of white fiber. The total number of bolts is 4.5 bolts. The total number of bolts is 4.5 bolts.",
             }
-        }).get_expectation() # fmt: skip
+        }).get_expectation()  # fmt: skip
         self._test_continuous_batching_parity(
             "meta-llama/Llama-3.1-8B", "paged_attention|kernels-community/flash-attn", expected_outputs
         )
@@ -265,22 +262,29 @@ class ContinuousBatchingTest(unittest.TestCase):
             ("cuda", (9, 0)): {
                 "req_1": " \n \n 2 + 1 = 3 bolts \n \n \n \n \n \n \n \n \n \n \n \n \n ",
             }
-        }).get_expectation() # fmt: skip
-        self._test_continuous_batching_parity("google/gemma-2-2b-it", "paged_attention|kernels-community/flash-attn", expected_outputs)
+        }).get_expectation()  # fmt: skip
+        self._test_continuous_batching_parity(
+            "google/gemma-2-2b-it", "paged_attention|kernels-community/flash-attn", expected_outputs
+        )
 
     @require_torch_gpu
     @require_kernels
     @slow
     def test_continuous_batching_parity_qwen_flash(self) -> None:
         expected_outputs = {}
-        self._test_continuous_batching_parity("Qwen/Qwen3-4B-Instruct-2507", "paged_attention|kernels-community/flash-attn", expected_outputs)
+        self._test_continuous_batching_parity(
+            "Qwen/Qwen3-4B-Instruct-2507", "paged_attention|kernels-community/flash-attn", expected_outputs
+        )
 
     @require_torch_gpu
     @require_kernels
     @slow
     def test_continuous_batching_parity_gpt_oss_flash(self) -> None:
         expected_outputs = {}
-        self._test_continuous_batching_parity("openai/gpt-oss-20b", "paged_attention|kernels-community/flash-attn", expected_outputs)
+        self._test_continuous_batching_parity(
+            "openai/gpt-oss-20b", "paged_attention|kernels-community/flash-attn", expected_outputs
+        )
 
-# FIXME: the gemma test seem broken, there is a message about cuda graphs and the sdpa and flash expecteations are 
+
+# FIXME: the gemma test seem broken, there is a message about cuda graphs and the sdpa and flash expecteations are
 # inverted on CUDA. On AMD they do fine.

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -88,7 +88,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                     f"Test failed for: {layer_types_str = }, {sliding_window = }, {group_types = }",
                 )
 
-    def _test_continuous_batching_parity(
+    def _continuous_batching_parity(
         self, model_id: str, attn_implementation: str, expected_outputs: dict[str, str]
     ) -> None:
         # Prepare common elements
@@ -178,7 +178,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_2": " $50,000. This is because the value of the house increased by 150%, which means that the value of the house increased by $50,000. This is because the value of the"
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity("meta-llama/Llama-3.1-8B", "eager_paged", expected_outputs)
+        self._continuous_batching_parity("meta-llama/Llama-3.1-8B", "eager_paged", expected_outputs)
 
     @require_torch_gpu
     @slow
@@ -192,13 +192,13 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_1": " \n \n 2 + 1 = 3 bolts \n \n \n \n \n \n \n \n \n \n \n \n \n "
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity("google/gemma-2-2b-it", "eager_paged", expected_outputs)
+        self._continuous_batching_parity("google/gemma-2-2b-it", "eager_paged", expected_outputs)
 
     @require_torch_gpu
     @slow
     def test_continuous_batching_parity_qwen_eager(self) -> None:
         expected_outputs = {}
-        self._test_continuous_batching_parity("Qwen/Qwen3-4B-Instruct-2507", "eager_paged", expected_outputs)
+        self._continuous_batching_parity("Qwen/Qwen3-4B-Instruct-2507", "eager_paged", expected_outputs)
 
     @require_torch_gpu
     @slow
@@ -209,7 +209,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_2": " 50%.\"\n\nWe need to parse: He buys a house for $80,000. He puts in $50,000 in repairs. This increased the value of the house by 150%."
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity("openai/gpt-oss-20b", "eager_paged", expected_outputs)
+        self._continuous_batching_parity("openai/gpt-oss-20b", "eager_paged", expected_outputs)
 
     # SDPA tests
     @require_torch_gpu
@@ -220,7 +220,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_2": " $50,000. This is because the value of the house increased by 150%, which means that the value of the house increased by $50,000. This is because the value of the"
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity("meta-llama/Llama-3.1-8B", "sdpa_paged", expected_outputs)
+        self._continuous_batching_parity("meta-llama/Llama-3.1-8B", "sdpa_paged", expected_outputs)
 
     @require_torch_gpu
     @slow
@@ -230,13 +230,13 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_1": " \n\n**Answer:** 3 bolts\n\n**Solution:**\n\n* **White fiber:** The robe needs half as much white fiber as blue fiber, so it needs 2 bolts / 2 =",
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity("google/gemma-2-2b-it", "sdpa_paged", expected_outputs)
+        self._continuous_batching_parity("google/gemma-2-2b-it", "sdpa_paged", expected_outputs)
 
     @require_torch_gpu
     @slow
     def test_continuous_batching_parity_qwen_sdpa(self) -> None:
         expected_outputs = {}
-        self._test_continuous_batching_parity("Qwen/Qwen3-4B-Instruct-2507", "sdpa_paged", expected_outputs)
+        self._continuous_batching_parity("Qwen/Qwen3-4B-Instruct-2507", "sdpa_paged", expected_outputs)
 
     # GPT-OSS is not compatible with SDPA because it has an attention sink. TODO: is this fixable?
 
@@ -250,7 +250,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_1": " 3 bolts of blue fiber and 1.5 bolts of white fiber. The total number of bolts is 4.5 bolts. The total number of bolts is 4.5 bolts.",
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity(
+        self._continuous_batching_parity(
             "meta-llama/Llama-3.1-8B", "paged_attention|kernels-community/flash-attn", expected_outputs
         )
 
@@ -263,7 +263,7 @@ class ContinuousBatchingTest(unittest.TestCase):
                 "req_1": " \n \n 2 + 1 = 3 bolts \n \n \n \n \n \n \n \n \n \n \n \n \n ",
             }
         }).get_expectation()  # fmt: skip
-        self._test_continuous_batching_parity(
+        self._continuous_batching_parity(
             "google/gemma-2-2b-it", "paged_attention|kernels-community/flash-attn", expected_outputs
         )
 
@@ -272,7 +272,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     @slow
     def test_continuous_batching_parity_qwen_flash(self) -> None:
         expected_outputs = {}
-        self._test_continuous_batching_parity(
+        self._continuous_batching_parity(
             "Qwen/Qwen3-4B-Instruct-2507", "paged_attention|kernels-community/flash-attn", expected_outputs
         )
 
@@ -281,7 +281,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     @slow
     def test_continuous_batching_parity_gpt_oss_flash(self) -> None:
         expected_outputs = {}
-        self._test_continuous_batching_parity(
+        self._continuous_batching_parity(
             "openai/gpt-oss-20b", "paged_attention|kernels-community/flash-attn", expected_outputs
         )
 


### PR DESCRIPTION
Some architectures like `llama` alter the attention mask if it is not a tensor, which was not compatible with the way CB created and handled the attention mask. Now, arguments like `attention_mask`, `cumulative_seqlens_k` and `max_seqlen_k` are tensors or ints unless the model is hybrid, in which case they are dictonnaries. This is the main fix, but PR also:
- cleans up how those arguments are built, reset, and delivered to the model to make things tidier
- adds support for attention sink in `eager_paged`
- explicitly disables (for now) cuda graphs and sampling in CB
- adds test for CB that pass on MI325 and H100 (but it's a little sketchy for some models there)
- fixes some telemetry metrics that were broken when hybrid allocation were added