### PR TITLE
Clarify passing is_causal in sdpa_attention_paged_forward

### DIFF
--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -23,7 +23,6 @@ def sdpa_attention_paged_forward(
     attention_mask: Optional[Union[torch.Tensor, dict]],
     dropout: float = 0.0,
     scaling: Optional[float] = None,
-    is_causal: bool = False,
     **kwargs,
 ) -> tuple[torch.Tensor, None]:
     # Add KV cache to the key and value tensors
@@ -58,7 +57,9 @@ def sdpa_attention_paged_forward(
         attn_mask=causal_mask,
         dropout_p=dropout,
         scale=scaling,
-        is_causal=is_causal,
+        # It is assume that either the caller specifies `attention_mask` or in otherwise non-causal context.
+        # See discussions in https://github.com/huggingface/transformers/pull/40838
+        is_causal=False,
     )
     attn_output = attn_output.transpose(1, 2).contiguous()
 

--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -23,7 +23,7 @@ def sdpa_attention_paged_forward(
     attention_mask: Optional[torch.Tensor],
     dropout: float = 0.0,
     scaling: Optional[float] = None,
-    is_causal: Optional[bool] = None,
+    is_causal: bool = False,
     **kwargs,
 ) -> tuple[torch.Tensor, None]:
     # Add KV cache to the key and value tensors
@@ -58,7 +58,7 @@ def sdpa_attention_paged_forward(
         attn_mask=causal_mask,
         dropout_p=dropout,
         scale=scaling,
-        is_causal=False,
+        is_causal=is_causal,
     )
     attn_output = attn_output.transpose(1, 2).contiguous()
 

--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Optional
 
 import torch
 
@@ -20,7 +20,7 @@ def sdpa_attention_paged_forward(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    attention_mask: Optional[Union[torch.Tensor, dict]],
+    attention_mask: Optional[torch.Tensor],
     dropout: float = 0.0,
     scaling: Optional[float] = None,
     **kwargs,

--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -57,8 +57,7 @@ def sdpa_attention_paged_forward(
         attn_mask=causal_mask,
         dropout_p=dropout,
         scale=scaling,
-        # It is assume that either the caller specifies `attention_mask` or in otherwise non-causal context.
-        # See discussions in https://github.com/huggingface/transformers/pull/40838
+        # Packed sequence format is used for input, so that it can never be causal.
         is_causal=False,
     )
     attn_output = attn_output.transpose(1, 2).contiguous()

--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Union
 
 import torch
 
@@ -20,7 +20,7 @@ def sdpa_attention_paged_forward(
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
-    attention_mask: Optional[torch.Tensor],
+    attention_mask: Optional[Union[torch.Tensor, dict]],
     dropout: float = 0.0,
     scaling: Optional[float] = None,
     is_causal: bool = False,


### PR DESCRIPTION
# What does this PR do?

`is_causal` is not forwarded in `sdpa_attention_paged_forward`. If that is intentional, a comment should be added.