### PR TITLE
[config] accept non-full dtypes

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -1059,7 +1059,7 @@ class PretrainedConfig(PushToHubMixin):
             if isinstance(d["dtype"], dict):
                 d["dtype"] = {k: str(v).split(".")[-1] for k, v in d["dtype"].items()}
             elif not isinstance(d["dtype"], str):
-                d["dtype"] = str(d["dtype"]).split(".")[1]
+                d["dtype"] = str(d["dtype"]).split(".")[-1]
         for value in d.values():
             if isinstance(value, dict):
                 self.dict_dtype_to_str(value)


### PR DESCRIPTION
# What does this PR do?

Fixes the error following script:

(root cause: the existing logic was expecting things like `torch_dtype="torch.float32"`, as opposed to `torch_dtype="float32"`. With this PR, we now accept both)

```py
from transformers import AutoConfig

config = AutoConfig.from_pretrained("BAAI/Emu3-Chat-hf")
```