### PR TITLE
Bug: Fix device/dtype mismatch in DetaForObjectDetection bias initialization .

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -94,6 +94,7 @@ from .utils import (
     download_url,
     extract_commit_hash,
     has_file,
+    init_empty_weights,
     is_accelerate_available,
     is_bitsandbytes_available,
     is_flash_attn_2_available,

--- a/src/transformers/models/deprecated/deta/modeling_deta.py
+++ b/src/transformers/models/deprecated/deta/modeling_deta.py
@@ -1857,7 +1857,10 @@ class DetaForObjectDetection(DetaPreTrainedModel):
 
         prior_prob = 0.01
         bias_value = -math.log((1 - prior_prob) / prior_prob)
-        self.class_embed.bias.data = torch.ones(config.num_labels) * bias_value
+        self.class_embed.bias.data = torch.ones(config.num_labels,
+            device=self.class_embed.bias.data.device,
+            dtype=self.class_embed.bias.data.dtype,
+        ) * bias_value
         nn.init.constant_(self.bbox_embed.layers[-1].weight.data, 0)
         nn.init.constant_(self.bbox_embed.layers[-1].bias.data, 0)
 


### PR DESCRIPTION
#40853
This PR fixes a bug that prevented DETA object detection models from loading in recent Transformers versions due to a device/dtype mismatch when initializing self.class_embed.bias.data. The fix ensures the tensor is created on the correct device and with the correct dtype, resolving error .

Please let me know if my approach or fix needs any improvements . I’m open to feedback and happy to make changes based on suggestions.
Thankyou !