### PR TITLE
DOC Fix help for chat and serve commands

### DIFF
--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -273,11 +273,11 @@ class ChatArguments:
     )
     load_in_8bit: bool = field(
         default=False,
-        metadata={"help": "Whether to use 8 bit precision for the base model - works only with LoRA."},
+        metadata={"help": "Whether to use 8 bit precision for the base model."},
     )
     load_in_4bit: bool = field(
         default=False,
-        metadata={"help": "Whether to use 4 bit precision for the base model - works only with LoRA."},
+        metadata={"help": "Whether to use 4 bit precision for the base model."},
     )
     bnb_4bit_quant_type: str = field(default="nf4", metadata={"help": "Quantization type.", "choices": ["fp4", "nf4"]})
     use_bnb_nested_quant: bool = field(default=False, metadata={"help": "Whether to use nested quantization."})

--- a/src/transformers/commands/serving.py
+++ b/src/transformers/commands/serving.py
@@ -400,11 +400,11 @@ class ServeArguments:
     )
     load_in_8bit: bool = field(
         default=False,
-        metadata={"help": "Whether to use 8 bit precision for the base model - works only with LoRA."},
+        metadata={"help": "Whether to use 8 bit precision for the base model."},
     )
     load_in_4bit: bool = field(
         default=False,
-        metadata={"help": "Whether to use 4 bit precision for the base model - works only with LoRA."},
+        metadata={"help": "Whether to use 4 bit precision for the base model."},
     )
     bnb_4bit_quant_type: str = field(default="nf4", metadata={"help": "Quantization type.", "choices": ["fp4", "nf4"]})
     use_bnb_nested_quant: bool = field(default=False, metadata={"help": "Whether to use nested quantization."})


### PR DESCRIPTION
# What does this PR do?

For `transformers chat` and `transformers serve`, the `load_in_8bit` and `load_in_4bit` arguments wrongly state that they require LoRA. This is only true when it comes to training but for inference, LoRA is not required.

Note: The failing test seems to be unrelated.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).