### PR TITLE
Adding activation kernels

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -18,10 +18,10 @@ from collections import OrderedDict
 import torch
 from torch import Tensor, nn
 
+from .integrations.hub_kernels import use_kernel_forward_from_hub
 from .utils import logging
 from .utils.import_utils import is_torchdynamo_compiling
 
-from .integrations.hub_kernels import use_kernel_forward_from_hub
 
 logger = logging.get_logger(__name__)
 
@@ -38,6 +38,7 @@ class PytorchGELUTanh(nn.Module):
     def forward(self, input: Tensor) -> Tensor:
         return nn.functional.gelu(input, approximate="tanh")
 
+
 @use_kernel_forward_from_hub("NewGELU")
 class NewGELUActivation(nn.Module):
     """
@@ -46,6 +47,7 @@ class NewGELUActivation(nn.Module):
     """
 
     def forward(self, input: Tensor) -> Tensor:
+        print("hereeeeee")
         return 0.5 * input * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))))
 
 
@@ -69,6 +71,7 @@ class GELUActivation(nn.Module):
 
     def forward(self, input: Tensor) -> Tensor:
         return self.act(input)
+
 
 @use_kernel_forward_from_hub("FastGELU")
 class FastGELUActivation(nn.Module):

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -47,6 +47,7 @@ class NewGELUActivation(nn.Module):
     """
 
     def forward(self, input: Tensor) -> Tensor:
+        print("NewGELUActivation")
         return 0.5 * input * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))))
 
 

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -47,7 +47,6 @@ class NewGELUActivation(nn.Module):
     """
 
     def forward(self, input: Tensor) -> Tensor:
-        print("NewGELUActivation")
         return 0.5 * input * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))))
 
 

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -47,7 +47,6 @@ class NewGELUActivation(nn.Module):
     """
 
     def forward(self, input: Tensor) -> Tensor:
-        print("hereeeeee")
         return 0.5 * input * (1.0 + torch.tanh(math.sqrt(2.0 / math.pi) * (input + 0.044715 * torch.pow(input, 3.0))))
 
 

--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -21,6 +21,7 @@ from torch import Tensor, nn
 from .utils import logging
 from .utils.import_utils import is_torchdynamo_compiling
 
+from .integrations.hub_kernels import use_kernel_forward_from_hub
 
 logger = logging.get_logger(__name__)
 
@@ -37,7 +38,7 @@ class PytorchGELUTanh(nn.Module):
     def forward(self, input: Tensor) -> Tensor:
         return nn.functional.gelu(input, approximate="tanh")
 
-
+@use_kernel_forward_from_hub("NewGELU")
 class NewGELUActivation(nn.Module):
     """
     Implementation of the GELU activation function currently in Google BERT repo (identical to OpenAI GPT). Also see
@@ -69,7 +70,7 @@ class GELUActivation(nn.Module):
     def forward(self, input: Tensor) -> Tensor:
         return self.act(input)
 
-
+@use_kernel_forward_from_hub("FastGELU")
 class FastGELUActivation(nn.Module):
     """
     Applies GELU approximation that is slower than QuickGELU but more accurate. See: https://github.com/hendrycks/GELUs
@@ -79,6 +80,7 @@ class FastGELUActivation(nn.Module):
         return 0.5 * input * (1.0 + torch.tanh(input * 0.7978845608 * (1.0 + 0.044715 * input * input)))
 
 
+@use_kernel_forward_from_hub("QuickGELU")
 class QuickGELUActivation(nn.Module):
     """
     Applies GELU approximation that is fast but somewhat inaccurate. See: https://github.com/hendrycks/GELUs

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -84,6 +84,24 @@ try:
                 )
             },
         },
+        "FastGELU": {
+            "cuda": LayerRepository(
+                repo_id="kernels-community/activation",
+                layer_name="FastGELU",
+            )
+        },
+        "QuickGELU": {
+            "cuda": LayerRepository(
+                repo_id="kernels-community/activation",
+                layer_name="QuickGELU",
+            )
+        },
+        "NewGELU": {
+            "cuda": LayerRepository(
+                repo_id="kernels-community/activation",
+                layer_name="NewGELU",
+            )
+        },
     }
 
     register_kernel_mapping(_KERNEL_MAPPING)

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -85,22 +85,28 @@ try:
             },
         },
         "FastGELU": {
-            "cuda": LayerRepository(
-                repo_id="kernels-community/activation",
-                layer_name="FastGELU",
-            )
+            "cuda": {
+                Mode.INFERENCE: LayerRepository(
+                    repo_id="kernels-community/activation",
+                    layer_name="FastGELU",
+                )
+            }
         },
         "QuickGELU": {
-            "cuda": LayerRepository(
-                repo_id="kernels-community/activation",
-                layer_name="QuickGELU",
-            )
+            "cuda": {
+                Mode.INFERENCE: LayerRepository(
+                    repo_id="kernels-community/activation",
+                    layer_name="QuickGELU",
+                )
+            }
         },
         "NewGELU": {
-            "cuda": LayerRepository(
-                repo_id="kernels-community/activation",
-                layer_name="NewGELU",
-            )
+            "cuda": {
+                Mode.INFERENCE: LayerRepository(
+                    repo_id="kernels-community/activation",
+                    layer_name="NewGELU",
+                )
+            }
         },
     }
 

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -86,25 +86,28 @@ try:
         },
         "FastGELU": {
             "cuda": {
-                Mode.INFERENCE: LayerRepository(
+                Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                     repo_id="kernels-community/activation",
                     layer_name="FastGELU",
+                    version=">=0.0.4,<0.1.0",
                 )
             }
         },
         "QuickGELU": {
             "cuda": {
-                Mode.INFERENCE: LayerRepository(
+                Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                     repo_id="kernels-community/activation",
                     layer_name="QuickGELU",
+                    version=">=0.0.4,<0.1.0",
                 )
             }
         },
         "NewGELU": {
             "cuda": {
-                Mode.INFERENCE: LayerRepository(
+                Mode.INFERENCE | Mode.TORCH_COMPILE: LayerRepository(
                     repo_id="kernels-community/activation",
                     layer_name="NewGELU",
+                    version=">=0.0.4,<0.1.0",
                 )
             }
         },


### PR DESCRIPTION
# What does this PR do?

Adds GeLU activation kernels from https://huggingface.co/kernels-community/activation, to use them we simply need to pass `use_kernels=True`

Here are Some benchmarks comparing the `activation kernels` perfs with a `torch.compile` implementation

<img width="959" height="378" alt="Screenshot 2025-09-16 at 10 30 52" src="https://github.com/user-attachments/assets/2e0d4aac-4972-4a3b-88f9-33278d45ec3c" />
