### PR TITLE
Harmonize CacheLayer names

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -148,6 +148,5 @@ if is_torch_available():
     # the patched version will always run with `fullgraph=True`.
     patch_torch_compile_force_graph()
 
-
 if os.environ.get("PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS", "").lower() in ("yes", "true", "on", "y", "1"):
     patch_testing_methods_to_collect_info()

--- a/conftest.py
+++ b/conftest.py
@@ -149,6 +149,5 @@ if is_torch_available():
     patch_torch_compile_force_graph()
 
 
-
 if os.environ.get("PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS", "").lower() in ("yes", "true", "on", "y", "1"):
     patch_testing_methods_to_collect_info()

--- a/conftest.py
+++ b/conftest.py
@@ -148,5 +148,6 @@ if is_torch_available():
     # the patched version will always run with `fullgraph=True`.
     patch_torch_compile_force_graph()
 
+
 if os.environ.get("PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS", "").lower() in ("yes", "true", "on", "y", "1"):
     patch_testing_methods_to_collect_info()

--- a/docs/source/en/cache_explanation.md
+++ b/docs/source/en/cache_explanation.md
@@ -85,7 +85,7 @@ When you use Transformers' [`Cache`] class, the self-attention module performs s
 
 Caches are structured as a list of layers, where each layer contains a key and value cache. The key and value caches are tensors with the shape `[batch_size, num_heads, seq_len, head_dim]`.
 
-Layers can be of different types (e.g. `DynamicLayer`, `StaticLayer`, `SlidingWindowLayer`), which mostly changes how sequence length is handled and how the cache is updated.
+Layers can be of different types (e.g. `DynamicLayer`, `StaticLayer`, `StaticSlidingWindowLayer`), which mostly changes how sequence length is handled and how the cache is updated.
 
 The simplest is a `DynamicLayer` that grows as more tokens are processed. The sequence length dimension (`seq_len`) increases with each new token:
 
@@ -94,7 +94,7 @@ cache.layers[idx].keys = torch.cat([cache.layers[idx].keys, key_states], dim=-2)
 cache.layers[idx].values = torch.cat([cache.layers[idx].values, value_states], dim=-2)
 ```
 
-Other layer types like `StaticLayer` and `SlidingWindowLayer` have a fixed sequence length that is set when the cache is created. This makes them compatible with `torch.compile`. In the case of `SlidingWindowLayer`, existing tokens are shifted out of the cache when a new token is added.
+Other layer types like `StaticLayer` and `StaticSlidingWindowLayer` have a fixed sequence length that is set when the cache is created. This makes them compatible with `torch.compile`. In the case of `StaticSlidingWindowLayer`, existing tokens are shifted out of the cache when a new token is added.
 
 The example below demonstrates how to create a generation loop with [`DynamicCache`]. As discussed, the attention mask is a concatenation of past and current token values and `1` is added to the cache position for the next token.
 

--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -250,7 +250,7 @@ A [`Constraint`] can be used to force the generation to include specific tokens 
     - update
     - lazy_initialization
 
-[[autodoc]] SlidingWindowLayer
+[[autodoc]] StaticSlidingWindowLayer
     - update
     - lazy_initialization
 

--- a/docs/source/ko/cache_explanation.md
+++ b/docs/source/ko/cache_explanation.md
@@ -84,7 +84,7 @@ Transformers의 [`Cache`] 클래스를 사용할 때, 셀프 어텐션 모듈은
 
 캐시는 각 레이어가 key와 value 캐시를 포함하는 레이어 목록 형태로 구성되어 있습니다. key 및 value 캐시는 `[batch_size, num_heads, seq_len, head_dim]` 형태의 텐서입니다.
 
-레이어는 서로 다른 타입일 수 있으며(예: `DynamicLayer`, `StaticLayer`, `SlidingWindowLayer`), 이는 주로 시퀀스 길이를 어떻게 처리하고 캐시를 어떻게 갱신하는지에 따라 달라집니다.
+레이어는 서로 다른 타입일 수 있으며(예: `DynamicLayer`, `StaticLayer`, `StaticSlidingWindowLayer`), 이는 주로 시퀀스 길이를 어떻게 처리하고 캐시를 어떻게 갱신하는지에 따라 달라집니다.
 
 가장 단순한 형태는 `DynamicLayer`로, 더 많은 토큰이 처리됨에 따라 점진적으로 확장됩니다. 시퀀스 길이 차원(`seq_len`)은 새로운 토큰이 추가될 때마다 증가합니다:
 
@@ -93,7 +93,7 @@ cache.layers[idx].keys = torch.cat([cache.layers[idx].keys, key_states], dim=-2)
 cache.layers[idx].values = torch.cat([cache.layers[idx].values, value_states], dim=-2)
 ```
 
-`StaticLayer`나 `SlidingWindowLayer`와 같은 다른 레이어 타입은 캐시가 생성될 때 고정된 시퀀스 길이를 가지며, 이는 `torch.compile`과 호환되도록 만듭니다. `SlidingWindowLayer`의 경우, 새로운 토큰이 추가되면 기존 토큰은 캐시에서 제거됩니다.
+`StaticLayer`나 `StaticSlidingWindowLayer`와 같은 다른 레이어 타입은 캐시가 생성될 때 고정된 시퀀스 길이를 가지며, 이는 `torch.compile`과 호환되도록 만듭니다. `StaticSlidingWindowLayer`의 경우, 새로운 토큰이 추가되면 기존 토큰은 캐시에서 제거됩니다.
 
 아래 예제는 [`DynamicCache`]로 생성 루프를 만드는 방법을 보여줍니다. 논의된 바와 같이, 어텐션 마스크는 과거와 현재 토큰값의 연결이며 다음 토큰을 위해 캐시 위치에 `1`이 추가됩니다.
 

--- a/docs/source/ko/internal/generation_utils.md
+++ b/docs/source/ko/internal/generation_utils.md
@@ -330,7 +330,7 @@ generation_output[:2]
 [[autodoc]] StaticLayer
     - update
 
-[[autodoc]] SlidingWindowLayer
+[[autodoc]] StaticSlidingWindowLayer
     - update
 
 [[autodoc]] QuantoQuantizedLayer

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -378,8 +378,8 @@ else:
         "CacheLayerMixin",
         "DynamicLayer",
         "StaticLayer",
-        "SlidingWindowLayer",
-        "ChunkedSlidingLayer",
+        "StaticSlidingWindowLayer",
+        "StaticChunkedLayer",
         "QuantoQuantizedLayer",
         "HQQQuantizedLayer",
         "Cache",
@@ -583,7 +583,7 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
-    from .cache_utils import ChunkedSlidingLayer as ChunkedSlidingLayer
+    from .cache_utils import StaticChunkedLayer as StaticChunkedLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache
@@ -597,7 +597,7 @@ if TYPE_CHECKING:
     from .cache_utils import QuantoQuantizedLayer as QuantoQuantizedLayer
     from .cache_utils import SinkCache as SinkCache
     from .cache_utils import SlidingWindowCache as SlidingWindowCache
-    from .cache_utils import SlidingWindowLayer as SlidingWindowLayer
+    from .cache_utils import StaticSlidingWindowLayer as StaticSlidingWindowLayer
     from .cache_utils import StaticCache as StaticCache
     from .cache_utils import StaticLayer as StaticLayer
     from .configuration_utils import PretrainedConfig as PretrainedConfig

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -583,7 +583,6 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
-    from .cache_utils import StaticChunkedLayer as StaticChunkedLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache
@@ -597,9 +596,10 @@ if TYPE_CHECKING:
     from .cache_utils import QuantoQuantizedLayer as QuantoQuantizedLayer
     from .cache_utils import SinkCache as SinkCache
     from .cache_utils import SlidingWindowCache as SlidingWindowCache
-    from .cache_utils import StaticSlidingWindowLayer as StaticSlidingWindowLayer
     from .cache_utils import StaticCache as StaticCache
+    from .cache_utils import StaticChunkedLayer as StaticChunkedLayer
     from .cache_utils import StaticLayer as StaticLayer
+    from .cache_utils import StaticSlidingWindowLayer as StaticSlidingWindowLayer
     from .configuration_utils import PretrainedConfig as PretrainedConfig
     from .convert_slow_tokenizer import SLOW_TO_FAST_CONVERTERS as SLOW_TO_FAST_CONVERTERS
     from .convert_slow_tokenizer import convert_slow_tokenizer as convert_slow_tokenizer

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -379,7 +379,8 @@ else:
         "DynamicLayer",
         "StaticLayer",
         "StaticSlidingWindowLayer",
-        "StaticChunkedLayer",
+        "SlidingWindowLayer",
+        "ChunkedLayer",
         "QuantoQuantizedLayer",
         "HQQQuantizedLayer",
         "Cache",
@@ -583,6 +584,7 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
+    from .cache_utils import ChunkedLayer as ChunkedLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache
@@ -596,8 +598,8 @@ if TYPE_CHECKING:
     from .cache_utils import QuantoQuantizedLayer as QuantoQuantizedLayer
     from .cache_utils import SinkCache as SinkCache
     from .cache_utils import SlidingWindowCache as SlidingWindowCache
+    from .cache_utils import SlidingWindowLayer as SlidingWindowLayer
     from .cache_utils import StaticCache as StaticCache
-    from .cache_utils import StaticChunkedLayer as StaticChunkedLayer
     from .cache_utils import StaticLayer as StaticLayer
     from .cache_utils import StaticSlidingWindowLayer as StaticSlidingWindowLayer
     from .configuration_utils import PretrainedConfig as PretrainedConfig

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -380,7 +380,7 @@ else:
         "StaticLayer",
         "StaticSlidingWindowLayer",
         "SlidingWindowLayer",
-        "ChunkedLayer",
+        "ChunkedSlidingLayer",
         "QuantoQuantizedLayer",
         "HQQQuantizedLayer",
         "Cache",
@@ -584,7 +584,7 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
-    from .cache_utils import ChunkedLayer as ChunkedLayer
+    from .cache_utils import ChunkedSlidingLayer as ChunkedSlidingLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1084,7 +1084,9 @@ class StaticCache(Cache):
             elif layer_type == "chunked_attention":
                 # From a cache point of view, both sliding and chunked are the same in how they should behave and how many
                 # states they should return - only the mask changes to make them different at the end!
-                layer = StaticSlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.attention_chunk_size)
+                layer = StaticSlidingWindowLayer(
+                    max_cache_len=max_cache_len, sliding_window=config.attention_chunk_size
+                )
             else:
                 layer = StaticLayer(max_cache_len=max_cache_len)
             layers.append(layer)
@@ -1355,6 +1357,7 @@ class EncoderDecoderCache(Cache):
 
 
 ### Deprecated classes
+
 
 class SlidingWindowLayer(StaticSlidingWindowLayer):
     def __init__(self, max_cache_len: int, sliding_window: int):


### PR DESCRIPTION
# What does this PR do?

As per the title. As it's only used internally in the Caches, it does not necessarily needs a deprecation cycle where we keep the old names IMO. We can however do it, will let you judge @ArthurZucker 

cc @gante and @manueldeprada as well, we talked about it before!
