### PR TITLE
[cache] Merge static sliding and static chunked layer

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -379,6 +379,7 @@ else:
         "DynamicLayer",
         "StaticLayer",
         "SlidingWindowLayer",
+        "ChunkedSlidingLayer",
         "QuantoQuantizedLayer",
         "HQQQuantizedLayer",
         "Cache",
@@ -582,6 +583,7 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
+    from .cache_utils import ChunkedSlidingLayer as ChunkedSlidingLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -379,7 +379,6 @@ else:
         "DynamicLayer",
         "StaticLayer",
         "SlidingWindowLayer",
-        "ChunkedSlidingLayer",
         "QuantoQuantizedLayer",
         "HQQQuantizedLayer",
         "Cache",
@@ -583,7 +582,6 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
-    from .cache_utils import ChunkedSlidingLayer as ChunkedSlidingLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -400,14 +400,6 @@ class SlidingWindowLayer(StaticLayer):
         # Update it now that we saved the value above
         self.cumulative_length += key_states.shape[-2]
 
-        # Handle prefill phase when prompt length > sliding_window_size.
-        # Note that we store cropped key/value states in the cache but return the full key/value states.
-        if cache_position.shape[0] > self.max_cache_len:
-            self.keys.copy_(key_states[:, :, -self.max_cache_len :, :])
-            self.values.copy_(value_states[:, :, -self.max_cache_len :, :])
-            # Return the full states here
-            return key_states, value_states
-
         if is_full:
             # In general, we should use a much simpler `cat` here as well, independently of the states size. However,
             # dynamo is currently bugged when doing it - see https://github.com/pytorch/pytorch/issues/159855 for more details

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1357,6 +1357,15 @@ class EncoderDecoderCache(Cache):
 ### Deprecated classes
 
 
+class ChunkedSlidingLayer(SlidingWindowLayer):
+    def __init__(self, max_cache_len: int, sliding_window: int):
+        logger.warning_once(
+            "`ChunkedSlidingLayer` is deprecated and will be removed in version v4.59 "
+            "Use `SlidingWindowLayer` instead, which has the exact same functionalities."
+        )
+        super().__init__(max_cache_len, sliding_window)
+
+
 class OffloadedCache(DynamicCache):
     def __init__(self) -> None:
         logger.warning_once(

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -962,6 +962,8 @@ class DynamicCache(Cache):
                 layer_types = layer_types[: -config.num_kv_shared_layers]
 
             for layer_type in layer_types:
+                # From a cache point of view, both sliding and chunked are the same in how they should behave and how many
+                # states they should return - only the mask changes to make them different at the end!
                 if layer_type in ("sliding_attention", "chunked_attention"):
                     layers.append(DynamicSlidingWindowLayer(sliding_window=sliding_window))
                 else:
@@ -1080,6 +1082,8 @@ class StaticCache(Cache):
             if layer_type == "sliding_attention":
                 layer = SlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.sliding_window)
             elif layer_type == "chunked_attention":
+                # From a cache point of view, both sliding and chunked are the same in how they should behave and how many
+                # states they should return - only the mask changes to make them different at the end!
                 layer = SlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.attention_chunk_size)
             else:
                 layer = StaticLayer(max_cache_len=max_cache_len)


### PR DESCRIPTION
# What does this PR do?

As per the title. As discussed quite a few times, they are exactly the same, except the Chunked version is more general, as it can handle an arbitrary number of new tokens even after prefill (i.e. prefill caching, chat continuation etc...).
This PR merges them both, to only keep the more general version, which will improve the scope of SlidingWindowLayer usage with the aforementioned use-cases!
Thus Static and Dynamic caches can now be used exactly the same way, in all generality

cc @gante @manueldeprada as well for viz! Finally merging them!

I made sure slow tests on fully sliding (Mistral) and hybrid (Gemma2) are still fine!