### PR TITLE
docs: standardized GIT model card according to the issue #36979

### DIFF
--- a/docs/source/en/model_doc/git.md
+++ b/docs/source/en/model_doc/git.md
@@ -15,70 +15,217 @@ rendered properly in your Markdown viewer.
 -->
 *This model was released on 2022-05-27 and added to Hugging Face Transformers on 2023-01-03.*
 
-# GIT
 
-<div class="flex flex-wrap space-x-1">
-<img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
+
+<div style="float: right;">
+  <div class="flex flex-wrap space-x-1">
+    <img alt="Hugging Face" src="https://img.shields.io/badge/huggingface-GIT-blue?logo=huggingface">
+    <img alt="License" src="https://img.shields.io/badge/license-MIT-green">
+  </div>
 </div>
 
-## Overview
+# GIT
 
-The GIT model was proposed in [GIT: A Generative Image-to-text Transformer for Vision and Language](https://huggingface.co/papers/2205.14100) by
-Jianfeng Wang, Zhengyuan Yang, Xiaowei Hu, Linjie Li, Kevin Lin, Zhe Gan, Zicheng Liu, Ce Liu, Lijuan Wang. GIT is a decoder-only Transformer
-that leverages [CLIP](clip)'s vision encoder to condition the model on vision inputs besides text. The model obtains state-of-the-art results on
-image captioning and visual question answering benchmarks.
+**[GIT](https://huggingface.co/papers/2205.14100) (Generative Image-to-Text Transformer)** is a multimodal model developed by Microsoft that generates natural language descriptions from images. It is a decoder-only Transformer that leverages [CLIP's](https://huggingface.co/docs/transformers/main/en/model_doc/clip) vision encoder to condition the model on vision inputs in addition to text.
+GIT extends the standard Transformer architecture to jointly process visual and textual information: image features from a vision backbone are fed into a text decoder to produce captions or answers. Unlike older captioning systems that relied on handcrafted fusion modules, GIT treats the task as a straightforward sequence-to-sequence generation problem, making the design simpler and more scalable. It was trained on large collections of image–text pairs and can be used for tasks like image captioning, visual question answering, and other vision-language applications.
+The model obtains state-of-the-art results on image captioning and visual question answering benchmarks.
 
-The abstract from the paper is the following:
+You can find all the original GIT checkpoints under the [GIT collection](https://huggingface.co/collections/microsoft/git-6601c19e9a0401ea1f8ab8c1).
 
-*In this paper, we design and train a Generative Image-to-text Transformer, GIT, to unify vision-language tasks such as image/video captioning and question answering. While generative models provide a consistent network architecture between pre-training and fine-tuning, existing work typically contains complex structures (uni/multi-modal encoder/decoder) and depends on external modules such as object detectors/taggers and optical character recognition (OCR). In GIT, we simplify the architecture as one image encoder and one text decoder under a single language modeling task. We also scale up the pre-training data and the model size to boost the model performance. Without bells and whistles, our GIT establishes new state of the arts on 12 challenging benchmarks with a large margin. For instance, our model surpasses the human performance for the first time on TextCaps (138.2 vs. 125.5 in CIDEr). Furthermore, we present a new scheme of generation-based image classification and scene text recognition, achieving decent performance on standard benchmarks.*
+> Click on the GIT models in the right sidebar for more examples of how to apply GIT to different vision and language tasks.
 
-<img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/model_doc/git_architecture.jpg"
-alt="drawing" width="600"/>
+---
 
-<small> GIT architecture. Taken from the <a href="https://huggingface.co/papers/2205.14100" target="_blank">original paper</a>. </small>
+## Usage
 
-This model was contributed by [nielsr](https://huggingface.co/nielsr).
-The original code can be found [here](https://github.com/microsoft/GenerativeImage2Text).
+The example below demonstrates how to generate captions from images or answer questions about images with [`pipeline`] or the [`AutoModel`] class.
 
-## Usage tips
+<hfoptions id="usage">
+<hfoption id="Pipeline">
 
-- GIT is implemented in a very similar way to GPT-2, the only difference being that the model is also conditioned on `pixel_values`.
+### Using `pipeline` for image captioning
 
-## Resources
+```py
+from transformers import pipeline
 
-A list of official Hugging Face and community (indicated by 🌎) resources to help you get started with GIT.
+captioner = pipeline("image-to-text", model="microsoft/git-base")
 
-- Demo notebooks regarding inference + fine-tuning GIT on custom data can be found [here](https://github.com/NielsRogge/Transformers-Tutorials/tree/master/GIT).
-- See also: [Causal language modeling task guide](../tasks/language_modeling)
+result = captioner("https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png")
+print(result[0]['generated_text'])
+````
 
-If you're interested in submitting a resource to be included here, please feel free to open a Pull Request and we will review it.
-The resource should ideally demonstrate something new instead of duplicating an existing resource.
+### Using `pipeline` for visual question answering
 
-## GitVisionConfig
+```python
+from transformers import pipeline
+
+vqa = pipeline("visual-question-answering", model="microsoft/git-base")
+
+result = vqa(
+    image="https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png",
+    question="How many birds are in the picture?"
+)
+print(result[0]['generated_text'])
+```
+
+</hfoption>
+<hfoption id="AutoModel">
+
+### Using `AutoProcessor` and `AutoModelForCausalLM`
+
+```python
+from transformers import AutoProcessor, AutoModelForCausalLM
+from PIL import Image
+import requests
+
+processor = AutoProcessor.from_pretrained("microsoft/git-base")
+model = AutoModelForCausalLM.from_pretrained("microsoft/git-base")
+
+url = "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"
+image = Image.open(requests.get(url, stream=True).raw)
+
+inputs = processor(images=image, return_tensors="pt")
+generated_ids = model.generate(pixel_values=inputs["pixel_values"], max_length=50)
+caption = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+print(caption)
+```
+
+</hfoption>
+<hfoption id="transformers-cli">
+
+### Using `transformers-cli` pipeline
+
+```bash
+transformers-cli pipeline \
+  --task "image-to-text" \
+  --model "microsoft/git-base" \
+  --input "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"
+```
+
+</hfoption>
+</hfoptions>
+
+---
+
+## Quantization
+
+Quantization reduces the memory burden of large models by representing the weights in lower precision. Refer to the [Quantization overview](../quantization/overview) for more available quantization backends.
+The example below uses dynamic INT8 quantization with [🤗 Optimum](https://huggingface.co/docs/optimum) to only quantize the weights to INT8.
+
+```python
+from transformers import AutoProcessor
+from optimum.intel import INCModelForCausalLM
+from PIL import Image
+import requests
+
+# Load processor
+processor = AutoProcessor.from_pretrained("microsoft/git-base")
+
+# Load model with dynamic INT8 quantization
+model = INCModelForCausalLM.from_pretrained(
+    "microsoft/git-base",
+    quantization_config="dynamic"
+)
+
+# Prepare input
+url = "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"
+image = Image.open(requests.get(url, stream=True).raw)
+inputs = processor(images=image, return_tensors="pt")
+
+# Run generation
+generated_ids = model.generate(**inputs, max_length=50)
+caption = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+print(caption)
+```
+
+---
+
+## Attention Visualization
+
+GIT supports returning text-token attentions by setting `output_attentions=True` during the forward pass. However, the `AttentionMaskVisualizer` utility currently only supports text-only models.
+
+```python
+import matplotlib.pyplot as plt
+import seaborn as sns
+from transformers import AutoProcessor, AutoModelForCausalLM
+from PIL import Image
+import requests
+
+# Load processor and model
+processor = AutoProcessor.from_pretrained("microsoft/git-base")
+model = AutoModelForCausalLM.from_pretrained("microsoft/git-base")
+
+# Example input
+url = "https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"
+image = Image.open(requests.get(url, stream=True).raw)
+inputs = processor(images=image, text="Describe this image:", return_tensors="pt")
+
+# Forward pass with attentions
+outputs = model(**inputs, output_attentions=True)
+
+# Pick the first layer, first head
+attn = outputs.attentions[0][0, 0].detach().cpu().numpy()  # shape: (seq_len, seq_len)
+
+# Plot attention heatmap
+plt.figure(figsize=(6, 6))
+sns.heatmap(attn, cmap="viridis")
+plt.title("Attention map (Layer 0, Head 0)")
+plt.xlabel("Key positions")
+plt.ylabel("Query positions")
+plt.show()
+```
+
+> This returns raw attention maps for each transformer layer.
+> Cross-modal attention (image ↔ text) is not fully visualizable with current tools; manual plotting is required to inspect attentions.
+
+---
+
+## Notes
+
+* **Multimodal input**: GIT takes both images and text prompts. Clear, concise prompts (e.g., *"Describe this image:"*) guide generation.
+* **Image preprocessing**: Use the `GitProcessor` for resizing, normalization, and tokenization. Supplying raw images may cause errors or poor results.
+* **Generation behavior**: GIT can hallucinate or misinterpret content, especially for small details or fine-grained reasoning tasks. Verify outputs before using in critical applications.
+* **Efficiency**: Larger checkpoints (e.g., `git-large`) are resource intensive. For experimentation or limited hardware, use `git-base` or quantization.
+* **Attention maps**: `output_attentions=True` works in forward passes, but cross-modal attentions are not fully visualizable.
+* **Biases**: Captions may reflect social or cultural biases from web data. Use responsibly.
+* **License**: Check the license of the model checkpoint (e.g., `microsoft/git-base`) for compliance.
+
+---
+
+## API
+
+### GitVisionConfig
 
 [[autodoc]] GitVisionConfig
 
-## GitVisionModel
+### GitVisionModel
 
 [[autodoc]] GitVisionModel
     - forward
 
-## GitConfig
+### GitConfig
 
 [[autodoc]] GitConfig
     - all
 
-## GitProcessor
+### GitProcessor
 
 [[autodoc]] GitProcessor
     - __call__
 
-## GitModel
+### GitModel
 
 [[autodoc]] GitModel
     - forward
 
-## GitForCausalLM
+### GitForCausalLM
 
 [[autodoc]] GitForCausalLM
     - forward
+
+---
+
+## Resources
+
+* [GIT paper](https://arxiv.org/abs/2205.14100)
+* [Microsoft GIT collection on Hugging Face](https://huggingface.co/collections/microsoft/git-6601c19e9a0401ea1f8ab8c1)


### PR DESCRIPTION
# What does this PR do?

This PR adds a standardized model card for the **Generative Image-to-Text Transformer (GIT)** following the ongoing documentation cleanup and model card standardization effort.

Specifically, it:

* Creates `git.md` with standardized structure (badges placeholder, model overview, usage examples, quantization, attention visualization, notes, and autodoc sections).
* Adds runnable code snippets for pipelines (`image-to-text`, `visual-question-answering`), `AutoModel`, and CLI usage.
* Includes an **INT8 quantization example** with 🤗 Optimum.
* Adds an **attention visualization example** (using raw attention maps, since `AttentionMaskVisualizer` doesn’t support multimodal GIT).
* Fills in the **Notes** section with details on multimodal input, preprocessing, biases, efficiency, and license considerations, similar to other model doc updates.
* Standardizes autodoc placeholders for `GitVisionConfig`, `GitModel`, `GitForCausalLM`, etc.

This improves discoverability and usability of GIT models in the Transformers docs and aligns its card with recent model doc PRs.

Related to #36979 

---

## Before submitting

* [x] This PR improves the docs.
* [x] I have read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request).
* [x] This was discussed in the Git model card standardization issue (link above).
* [x] Documentation updated with runnable code snippets.
* [ ] No tests required (doc-only change).

---

## Who can review?

* Documentation: @stevhliu
* Vision models: @amyeroberts, @qubvel
* Generate (vision-language models): @zucchini-nlp
