### PR TITLE
Fix flaky `Gemma3nAudioFeatureExtractionTest::test_dither`

### DIFF
--- a/tests/models/gemma3n/test_feature_extraction_gemma3n.py
+++ b/tests/models/gemma3n/test_feature_extraction_gemma3n.py
@@ -279,9 +279,10 @@ class Gemma3nAudioFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unit
         # features are not identical
         assert np.abs(diff).mean() > 1e-6
         # features are not too different
-        assert np.abs(diff).mean() < 1e-4
-        # the heuristic value `1e-1` is obtained by running 50000 times (maximal value is around 5e-2 ~ 6e-2).
-        assert np.abs(diff).max() < 1e-1
+        # the heuristic value `7e-4` is obtained by running 50000 times (maximal value is around 3e-4).
+        assert np.abs(diff).mean() < 7e-4
+        # the heuristic value `8e-1` is obtained by running 50000 times (maximal value is around 5e-1).
+        assert np.abs(diff).max() < 8e-1
 
     @require_torch
     def test_double_precision_pad(self):

--- a/tests/models/gemma3n/test_feature_extraction_gemma3n.py
+++ b/tests/models/gemma3n/test_feature_extraction_gemma3n.py
@@ -277,11 +277,11 @@ class Gemma3nAudioFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unit
         diff = input_features_dither - input_features_no_dither
 
         # features are not identical
-        self.assertTrue(np.abs(diff).mean() > 1e-6)
+        assert np.abs(diff).mean() > 1e-6
         # features are not too different
-        self.assertTrue(np.abs(diff).mean() <= 1e-4)
-        # the heuristic value `1e-1` is obtained by running 50000 times (maximal value is ``).
-        self.assertTrue(np.abs(diff).max() <= 1e-1)
+        assert np.abs(diff).mean() < 1e-4
+        # the heuristic value `1e-1` is obtained by running 50000 times (maximal value is around 5e-2 ~ 6e-2).
+        assert np.abs(diff).max() < 1e-1
 
     @require_torch
     def test_double_precision_pad(self):

--- a/tests/models/gemma3n/test_feature_extraction_gemma3n.py
+++ b/tests/models/gemma3n/test_feature_extraction_gemma3n.py
@@ -280,7 +280,8 @@ class Gemma3nAudioFeatureExtractionTest(SequenceFeatureExtractionTestMixin, unit
         self.assertTrue(np.abs(diff).mean() > 1e-6)
         # features are not too different
         self.assertTrue(np.abs(diff).mean() <= 1e-4)
-        self.assertTrue(np.abs(diff).max() <= 5e-3)
+        # the heuristic value `1e-1` is obtained by running 50000 times (maximal value is ``).
+        self.assertTrue(np.abs(diff).max() <= 1e-1)
 
     @require_torch
     def test_double_precision_pad(self):


### PR DESCRIPTION
# What does this PR do?

> tests/models/gemma3n/test_feature_extraction_gemma3n.py::Gemma3nAudioFeatureExtractionTest::test_dither

is flaky since it is added in #39059, the failing ratio is 0.72 % (running 10K times).

I run it 50K times to get the maximal value for the difference, which could go up to `0.5`.

This PR set the tolerance to `0.8` to avoid flakiness.

