### PR TITLE
disable `test_fast_is_faster_than_slow`

### DIFF
--- a/tests/models/depth_pro/test_image_processing_depth_pro.py
+++ b/tests/models/depth_pro/test_image_processing_depth_pro.py
@@ -15,7 +15,7 @@
 
 import unittest
 
-from transformers.testing_utils import is_flaky, require_torch, require_vision
+from transformers.testing_utils import require_torch, require_vision
 from transformers.utils import is_torchvision_available, is_vision_available
 
 from ...test_image_processing_common import ImageProcessingTestMixin, prepare_image_inputs
@@ -115,9 +115,3 @@ class DepthProImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
 
         image_processor = self.image_processing_class.from_dict(self.image_processor_dict, size=42)
         self.assertEqual(image_processor.size, {"height": 42, "width": 42})
-
-    @is_flaky(
-        description="fast and slow, both processors use torch implementation, see: https://github.com/huggingface/transformers/issues/34920",
-    )
-    def test_fast_is_faster_than_slow(self):
-        super().test_fast_is_faster_than_slow()

--- a/tests/models/efficientloftr/test_image_processing_efficientloftr.py
+++ b/tests/models/efficientloftr/test_image_processing_efficientloftr.py
@@ -143,6 +143,7 @@ class EfficientLoFTRImageProcessingTest(SuperGlueImageProcessingTest, unittest.T
 
         self._assert_slow_fast_tensors_equivalence(encoding_slow.pixel_values, encoding_fast.pixel_values)
 
+    @unittest.skip(reason="Many failing cases. This test needs a more deep investigation.")
     def test_fast_is_faster_than_slow(self):
         """Override the generic test since EfficientLoFTR requires image pairs."""
         if not self.test_slow_image_processor or not self.test_fast_image_processor:

--- a/tests/models/kosmos2_5/test_image_processing_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_image_processing_kosmos2_5.py
@@ -177,12 +177,6 @@ class Kosmos2_5ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             output_eager.pixel_values, output_compiled.pixel_values, atol=1e-4, rtol=1e-4, mean_atol=1e-5
         )
 
-    @unittest.skip(
-        reason="Kosmos2_5ImageProcessor already uses many torch operations. Fast image processor only works faster with sufficiently large batch size on GPU."
-    )
-    def test_fast_is_faster_than_slow(self):
-        super().test_fast_is_faster_than_slow()
-
     def test_image_processor_properties(self):
         image_processor = self.image_processing_class(**self.image_processor_dict)
         self.assertTrue(hasattr(image_processor, "do_normalize"))
@@ -375,12 +369,6 @@ class Kosmos2_5ImageProcessingTestFourChannels(ImageProcessingTestMixin, unittes
     @unittest.skip(reason="Kosmos2_5ImageProcessor does not support 4 channels yet")
     def test_can_compile_fast_image_processor(self):
         return super().test_can_compile_fast_image_processor()
-
-    @unittest.skip(
-        reason="Kosmos2_5ImageProcessor already uses many torch operations. Fast image processor only works faster with sufficiently large batch size on GPU."
-    )
-    def test_fast_is_faster_than_slow(self):
-        super().test_fast_is_faster_than_slow()
 
     def test_image_processor_properties(self):
         image_processor = self.image_processing_class(**self.image_processor_dict)

--- a/tests/models/layoutlmv2/test_image_processing_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_image_processing_layoutlmv2.py
@@ -105,10 +105,6 @@ class LayoutLMv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
     def image_processor_dict(self):
         return self.image_processor_tester.prepare_image_processor_dict()
 
-    @unittest.skip(reason="FIXME: @yoni.")
-    def test_fast_is_faster_than_slow(self):
-        pass
-
     def test_image_processor_properties(self):
         for image_processing_class in self.image_processor_list:
             image_processing = image_processing_class(**self.image_processor_dict)

--- a/tests/models/layoutlmv3/test_image_processing_layoutlmv3.py
+++ b/tests/models/layoutlmv3/test_image_processing_layoutlmv3.py
@@ -86,10 +86,6 @@ class LayoutLMv3ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
     def image_processor_dict(self):
         return self.image_processor_tester.prepare_image_processor_dict()
 
-    @unittest.skip(reason="FIXME: @yoni.")
-    def test_fast_is_faster_than_slow(self):
-        pass
-
     def test_image_processor_properties(self):
         for image_processing_class in self.image_processor_list:
             image_processing = image_processing_class(**self.image_processor_dict)

--- a/tests/models/owlv2/test_image_processing_owlv2.py
+++ b/tests/models/owlv2/test_image_processing_owlv2.py
@@ -99,10 +99,6 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
     def image_processor_dict(self):
         return self.image_processor_tester.prepare_image_processor_dict()
 
-    @unittest.skip(reason="FIXME: @yoni. It always fails: `0.12 not less than or equal to 0.03`.")
-    def test_fast_is_faster_than_slow(self):
-        super().test_fast_is_faster_than_slow()
-
     def test_image_processor_properties(self):
         for image_processing_class in self.image_processor_list:
             image_processing = image_processing_class(**self.image_processor_dict)

--- a/tests/models/rt_detr/test_image_processing_rt_detr.py
+++ b/tests/models/rt_detr/test_image_processing_rt_detr.py
@@ -16,7 +16,6 @@ import unittest
 
 from transformers.image_utils import load_image
 from transformers.testing_utils import (
-    is_flaky,
     require_torch,
     require_torch_accelerator,
     require_torchvision,
@@ -435,9 +434,3 @@ class RtDetrImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         )
         # verify size
         torch.testing.assert_close(encoding_cpu["labels"][0]["size"], encoding_gpu["labels"][0]["size"].to("cpu"))
-
-    @is_flaky(
-        description="Still flaky with a failing ratio of ~0.6% after #36240",
-    )
-    def test_fast_is_faster_than_slow(self):
-        super().test_fast_is_faster_than_slow()

--- a/tests/models/swin2sr/test_image_processing_swin2sr.py
+++ b/tests/models/swin2sr/test_image_processing_swin2sr.py
@@ -187,10 +187,6 @@ class Swin2SRImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
         expected_output_image_shape = self.image_processor_tester.expected_output_image_shape([image_inputs[0]])
         self.assertEqual(tuple(encoded_images.shape), (1, *expected_output_image_shape))
 
-    @unittest.skip(reason="No speed gain on CPU due to minimal processing.")
-    def test_fast_is_faster_than_slow(self):
-        pass
-
     def test_slow_fast_equivalence_batched(self):
         image_inputs = self.image_processor_tester.prepare_image_inputs(equal_resolution=True, torchify=True)
 

--- a/tests/models/vitmatte/test_image_processing_vitmatte.py
+++ b/tests/models/vitmatte/test_image_processing_vitmatte.py
@@ -266,7 +266,7 @@ class VitMatteImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             self.assertGreaterEqual(len(raised_warnings), 1)
             self.assertIn("extra_argument", messages)
 
-    @unittest.skip(reason="TODO: Yoni")
+    @unittest.skip(reason="Many failing cases. This test needs a more deep investigation.")
     def test_fast_is_faster_than_slow(self):
         if not self.test_slow_image_processor or not self.test_fast_image_processor:
             self.skipTest(reason="Skipping speed test")

--- a/tests/test_image_processing_common.py
+++ b/tests/test_image_processing_common.py
@@ -18,6 +18,7 @@ import os
 import pathlib
 import tempfile
 import time
+import unittest
 import warnings
 from copy import deepcopy
 
@@ -30,7 +31,6 @@ from transformers import AutoImageProcessor, BatchFeature
 from transformers.image_utils import AnnotationFormat, AnnotionFormat
 from transformers.testing_utils import (
     check_json_file_has_correct_format,
-    is_flaky,
     require_torch,
     require_torch_accelerator,
     require_vision,
@@ -216,7 +216,7 @@ class ImageProcessingTestMixin:
 
     @require_vision
     @require_torch
-    @is_flaky()
+    @unittest.skip(reason="Many failing cases. This test needs a more deep investigation.")
     def test_fast_is_faster_than_slow(self):
         if not self.test_slow_image_processor or not self.test_fast_image_processor:
             self.skipTest(reason="Skipping speed test")


### PR DESCRIPTION
# What does this PR do?

This test causes too much trouble and energy. As discussed offline, skip it until someone can check if this test makes sense on cpu and with small batch size.

Last time seeing such failure is 1 day ago:

https://app.circleci.com/pipelines/github/huggingface/transformers/146100/workflows/67352be5-2494-42cb-8613-c221afe0b6f5/jobs/1930135

> FAILED tests/models/efficientloftr/test_image_processing_efficientloftr.py::EfficientLoFTRImageProcessingTest::test_fast_is_faster_than_slow - AssertionError: 0.9246523380279541 not less than or equal to 0.8492918014526367 : Fast processor should not be significantly slower than slow processor

cc @zucchini-nlp 

