### PR TITLE
ENH: Enable readline support for transformers chat

### DIFF
--- a/src/transformers/commands/chat.py
+++ b/src/transformers/commands/chat.py
@@ -40,6 +40,12 @@ from transformers.commands.serving import ServeArguments, ServeCommand
 from transformers.utils import is_rich_available, is_torch_available
 
 
+try:
+    import readline  # noqa importing this enables GNU readline capabilities
+except ImportError:
+    # some platforms may not support readline: https://docs.python.org/3/library/readline.html
+    pass
+
 if platform.system() != "Windows":
     import pwd
 


### PR DESCRIPTION
# What does this PR do?

This small change enables GNU readline support for the `transformers chat` command. This includes:

- advanced navigation and editing: `ctrl + a` `ctrl + e` `alt + b` `alt + f` `ctrl + k` `alt + d` etc.
- navigate and search history: `↑` `↓` `ctrl + p` `ctrl + n`  `ctrl + r`
- undo: `ctrl + _`
- clear screen: `ctrl + l`

## Implementation

Although it may look strange, just [importing readline is enough to enable it in Python](https://docs.python.org/3/library/functions.html#input).

As readline is [not available on some platforms](https://docs.python.org/3/library/readline.html), the import is guarded.

Readline should work on Linux, MacOS, and with WSL, I'm not sure about Windows though. Ideally, someone can give it a try. It's possible that Windows users would have to install [pyreadline](https://pypi.org/project/pyreadline3/).

I checked the existing tests but I think there is no easy way to actually test this functionality. As it's basic Python functionality, I think we can live without further tests.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? => discussed internally
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?