### PR TITLE
[tests] Really use small models in all fast tests

### DIFF
--- a/src/transformers/models/gemma3n/configuration_gemma3n.py
+++ b/src/transformers/models/gemma3n/configuration_gemma3n.py
@@ -502,10 +502,10 @@ class Gemma3nVisionConfig(PretrainedConfig):
         **kwargs,
     ):
         super().__init__(**kwargs)
+        self.architecture = architecture
         self.initializer_range = initializer_range
         self.do_pooling = do_pooling
         self.model_args = model_args  # named "model_args" for BC with timm
-        self.architecture = architecture
         self.hidden_size = hidden_size
         self.vocab_size = vocab_size
         self.vocab_offset = vocab_offset

--- a/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
@@ -41,7 +41,7 @@ class TimmWrapperConfig(PretrainedConfig):
     imagenet models is set to `None` due to occlusions in the label descriptions.
 
     Args:
-        architecture (`str`, *optional*):
+        architecture (`str`, *optional*, defaults to `"resnet50"`):
             The timm architecture to load.
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.

--- a/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/configuration_timm_wrapper.py
@@ -41,6 +41,8 @@ class TimmWrapperConfig(PretrainedConfig):
     imagenet models is set to `None` due to occlusions in the label descriptions.
 
     Args:
+        architecture (`str`, *optional*):
+            The timm architecture to load.
         initializer_range (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated_normal_initializer for initializing all weight matrices.
         do_pooling (`bool`, *optional*, defaults to `True`):
@@ -65,11 +67,13 @@ class TimmWrapperConfig(PretrainedConfig):
 
     def __init__(
         self,
+        architecture: str = "resnet50",
         initializer_range: float = 0.02,
         do_pooling: bool = True,
         model_args: Optional[dict[str, Any]] = None,
         **kwargs,
     ):
+        self.architecture = architecture
         self.initializer_range = initializer_range
         self.do_pooling = do_pooling
         self.model_args = model_args  # named "model_args" for BC with timm

--- a/tests/models/chameleon/test_modeling_chameleon.py
+++ b/tests/models/chameleon/test_modeling_chameleon.py
@@ -76,7 +76,7 @@ class ChameleonModelTester:
         pad_token_id=0,
         vq_num_embeds=5,
         vq_embed_dim=5,
-        vq_channel_multiplier=[1, 4],
+        vq_channel_multiplier=[1, 2],
         vq_img_token_start_id=10,  # has to be less than vocab size when added with vq_num_embeds
         scope=None,
     ):
@@ -255,10 +255,6 @@ class ChameleonModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_batching_equivalence(self):
         pass
 
-    @unittest.skip("Chameleon VQ model cannot be squishes more due to hardcoded layer params in model code")
-    def test_model_is_small(self):
-        pass
-
 
 class ChameleonVision2SeqModelTester(ChameleonModelTester):
     def __init__(self, parent, image_size=10, **kwargs):
@@ -319,10 +315,6 @@ class ChameleonVision2SeqModelTest(ModelTesterMixin, GenerationTesterMixin, unit
 
     @unittest.skip("Chameleon cannot do offload because it uses `self.linear.weight` in forward")
     def test_disk_offload_safetensors(self):
-        pass
-
-    @unittest.skip("Chameleon VQ model cannot be squishes more due to hardcoded layer params in model code")
-    def test_model_is_small(self):
         pass
 
     @unittest.skip("Chameleon applies key/query norm which doesn't work with packing")

--- a/tests/models/emu3/test_modeling_emu3.py
+++ b/tests/models/emu3/test_modeling_emu3.py
@@ -359,10 +359,6 @@ class Emu3Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
     def test_generate_with_static_cache(self):
         pass
 
-    # @unittest.skip("Emu3 can't be smaller than currently if we want to downsample images")
-    # def test_model_is_small(self):
-    #     pass
-
 
 @require_torch
 class Emu3IntegrationTest(unittest.TestCase):

--- a/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
@@ -70,7 +70,7 @@ class LayoutLMv2ModelTester:
         type_vocab_size=16,
         type_sequence_label_size=2,
         initializer_range=0.02,
-        image_feature_pool_shape=[7, 7, 256],
+        image_feature_pool_shape=[7, 7, 32],
         coordinate_size=6,
         shape_size=6,
         num_labels=3,
@@ -111,6 +111,7 @@ class LayoutLMv2ModelTester:
         detectron2_config["MODEL.RESNETS.DEPTH"] = 50
         detectron2_config["MODEL.RESNETS.RES2_OUT_CHANNELS"] = 4
         detectron2_config["MODEL.RESNETS.STEM_OUT_CHANNELS"] = 4
+        detectron2_config["MODEL.FPN.OUT_CHANNELS"] = 32
         self.detectron2_config = detectron2_config
 
     def prepare_config_and_inputs(self):

--- a/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
+++ b/tests/models/layoutlmv2/test_modeling_layoutlmv2.py
@@ -112,6 +112,7 @@ class LayoutLMv2ModelTester:
         detectron2_config["MODEL.RESNETS.RES2_OUT_CHANNELS"] = 4
         detectron2_config["MODEL.RESNETS.STEM_OUT_CHANNELS"] = 4
         detectron2_config["MODEL.FPN.OUT_CHANNELS"] = 32
+        detectron2_config["MODEL.RESNETS.NUM_GROUPS"] = 1
         self.detectron2_config = detectron2_config
 
     def prepare_config_and_inputs(self):

--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -441,10 +441,6 @@ class Qwen2_5_VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
     def test_multi_gpu_data_parallel_forward(self):
         pass
 
-    @unittest.skip(reason="We cannot configure to output a smaller model.")
-    def test_model_is_small(self):
-        pass
-
 
 @require_torch
 class Qwen2_5_VLIntegrationTest(unittest.TestCase):

--- a/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
@@ -394,10 +394,6 @@ class Qwen2VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
     def test_multi_gpu_data_parallel_forward(self):
         pass
 
-    @unittest.skip(reason="We cannot configure to output a smaller model.")
-    def test_model_is_small(self):
-        pass
-
 
 @require_torch
 class Qwen2VLIntegrationTest(unittest.TestCase):

--- a/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
+++ b/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
@@ -73,7 +73,9 @@ class TimmWrapperModelTester:
         return config, pixel_values
 
     def get_config(self):
-        return TimmWrapperConfig.from_pretrained(self.model_name)
+        config = TimmWrapperConfig.from_pretrained(self.model_name)
+        print(config)
+        return config
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()

--- a/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
+++ b/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
@@ -53,14 +53,15 @@ class TimmWrapperModelTester:
     def __init__(
         self,
         parent,
-        model_name="timm/resnet18.a1_in1k",
         batch_size=3,
         image_size=32,
         num_channels=3,
         is_training=True,
     ):
         self.parent = parent
-        self.model_name = model_name
+        self.architecture = "resnet26"
+        # We need this to make the model smaller
+        self.model_args = {"channels": (16, 16, 16, 16)}
         self.batch_size = batch_size
         self.image_size = image_size
         self.num_channels = num_channels
@@ -73,7 +74,7 @@ class TimmWrapperModelTester:
         return config, pixel_values
 
     def get_config(self):
-        return TimmWrapperConfig.from_pretrained(self.model_name)
+        return TimmWrapperConfig(architecture=self.architecture, model_args=self.model_args)
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
@@ -164,10 +165,6 @@ class TimmWrapperModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
 
     @unittest.skip(reason="TimmWrapper initialization is managed on the timm side")
     def test_mismatched_shapes_have_properly_initialized_weights(self):
-        pass
-
-    @unittest.skip(reason="Need to use a timm model and there is no tiny model available.")
-    def test_model_is_small(self):
         pass
 
     def test_gradient_checkpointing(self):

--- a/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
+++ b/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
@@ -73,9 +73,7 @@ class TimmWrapperModelTester:
         return config, pixel_values
 
     def get_config(self):
-        config = TimmWrapperConfig.from_pretrained(self.model_name)
-        print(config)
-        return config
+        return TimmWrapperConfig.from_pretrained(self.model_name)
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()

--- a/tests/models/xcodec/test_modeling_xcodec.py
+++ b/tests/models/xcodec/test_modeling_xcodec.py
@@ -51,7 +51,7 @@ class XcodecModelTester:
         num_channels=1,
         sample_rate=16000,
         codebook_size=1024,
-        num_samples=400,
+        num_samples=256,
         is_training=False,
     ):
         self.parent = parent
@@ -61,7 +61,9 @@ class XcodecModelTester:
         self.codebook_size = codebook_size
         self.is_training = is_training
         self.num_samples = num_samples
-        self.acoustic_model_config = DacConfig(decoder_hidden_size=8, encoder_hidden_size=8, codebook_size=16)
+        self.acoustic_model_config = DacConfig(
+            decoder_hidden_size=8, encoder_hidden_size=8, codebook_size=16, downsampling_ratios=[16, 16]
+        )
         self.semantic_model_config = HubertConfig(
             hidden_size=32,
             num_hidden_layers=2,

--- a/tests/models/xcodec/test_modeling_xcodec.py
+++ b/tests/models/xcodec/test_modeling_xcodec.py
@@ -39,7 +39,7 @@ from transformers.testing_utils import (
 if is_torch_available():
     import torch
 
-    from transformers import XcodecModel
+    from transformers import DacConfig, HubertConfig, XcodecModel
 
 
 @require_torch
@@ -61,6 +61,14 @@ class XcodecModelTester:
         self.codebook_size = codebook_size
         self.is_training = is_training
         self.num_samples = num_samples
+        self.acoustic_model_config = DacConfig(decoder_hidden_size=8, encoder_hidden_size=8, codebook_size=16)
+        self.semantic_model_config = HubertConfig(
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            intermediate_size=12,
+            conv_dim=(4, 4, 4, 4, 4, 4, 4),
+        )
 
     def prepare_config_and_inputs(self):
         config = self.get_config()
@@ -86,6 +94,8 @@ class XcodecModelTester:
             sample_rate=self.sample_rate,
             audio_channels=self.num_channels,
             codebook_size=self.codebook_size,
+            acoustic_model_config=self.acoustic_model_config,
+            semantic_model_config=self.semantic_model_config,
         )
 
     def create_and_check_model_forward(self, config, inputs_dict):
@@ -150,10 +160,6 @@ class XcodecModelTest(ModelTesterMixin, unittest.TestCase):
             config.decoder.gradient_checkpointing = True
             model = model_class(config)
             self.assertTrue(model.is_gradient_checkpointing)
-
-    @unittest.skip(reason="We cannot configure to output a smaller model.")
-    def test_model_is_small(self):
-        pass
 
     @unittest.skip(reason="The XcodecModel does not have `inputs_embeds` logics")
     def test_inputs_embeds(self):


### PR DESCRIPTION
Use small models in all tests. Only `timm_backbone` cannot enforce it, because it cannot propagate kwargs. ALL other models should never override this tests, otherwise the CI becomes super slow.

cc @ydshieh fir viz!