### PR TITLE
Fix `Glm4vModelTest::test_eager_matches_fa2_generate`

### DIFF
--- a/tests/models/glm4v/test_modeling_glm4v.py
+++ b/tests/models/glm4v/test_modeling_glm4v.py
@@ -159,7 +159,7 @@ class Glm4vVisionText2TextModelTester:
 
         inputs_dict = {
             "pixel_values": pixel_values,
-            "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size),
+            "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device),
             "input_ids": input_ids,
             "attention_mask": attention_mask,
         }

--- a/tests/models/glm4v/test_modeling_glm4v.py
+++ b/tests/models/glm4v/test_modeling_glm4v.py
@@ -159,7 +159,9 @@ class Glm4vVisionText2TextModelTester:
 
         inputs_dict = {
             "pixel_values": pixel_values,
-            "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device),
+            "image_grid_thw": torch.tensor(
+                [[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device
+            ),
             "input_ids": input_ids,
             "attention_mask": attention_mask,
         }

--- a/tests/models/glm4v_moe/test_modeling_glm4v_moe.py
+++ b/tests/models/glm4v_moe/test_modeling_glm4v_moe.py
@@ -170,7 +170,7 @@ class Glm4vMoeVisionText2TextModelTester:
 
         inputs_dict = {
             "pixel_values": pixel_values,
-            "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size),
+            "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device),
             "input_ids": input_ids,
             "attention_mask": attention_mask,
         }

--- a/tests/models/glm4v_moe/test_modeling_glm4v_moe.py
+++ b/tests/models/glm4v_moe/test_modeling_glm4v_moe.py
@@ -170,7 +170,9 @@ class Glm4vMoeVisionText2TextModelTester:
 
         inputs_dict = {
             "pixel_values": pixel_values,
-            "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device),
+            "image_grid_thw": torch.tensor(
+                [[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device
+            ),
             "input_ids": input_ids,
             "attention_mask": attention_mask,
         }


### PR DESCRIPTION
# What does this PR do?

This test is failing on GPU due to

> FAILED tests/models/glm4v/test_modeling_glm4v.py::Glm4vModelTest::test_eager_matches_fa2_generate - RuntimeError: cu_seqlens_q must be on CUDA

see [here](https://github.com/huggingface/transformers/actions/runs/17784986682/job/50551078682)

We need to change from

>  "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size),

to 

>  "image_grid_thw": torch.tensor([[1, patches_per_side, patches_per_side]] * self.batch_size, device=torch_device),it
