### PR TITLE
Update expected values for some `test_speculative_generation`

### DIFF
--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -254,7 +254,7 @@ class MistralIntegrationTest(unittest.TestCase):
 
     @slow
     def test_speculative_generation(self):
-        EXPECTED_TEXT_COMPLETION = "My favourite condiment is 100% ketchup. I ^`^ym not a fan of mustard, relish"
+        EXPECTED_TEXT_COMPLETION = "My favourite condiment is 100% ketchup. I’m not a fan of mustard, relish"
         prompt = "My favourite condiment is "
         tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1", use_fast=False)
         model = MistralForCausalLM.from_pretrained("mistralai/Mistral-7B-v0.1", device_map="auto", dtype=torch.float16)

--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -254,7 +254,7 @@ class MistralIntegrationTest(unittest.TestCase):
 
     @slow
     def test_speculative_generation(self):
-        EXPECTED_TEXT_COMPLETION = "My favourite condiment is 100% Sriracha. I love it on everything. I have it on my"
+        EXPECTED_TEXT_COMPLETION = "My favourite condiment is 100% ketchup. I ^`^ym not a fan of mustard, relish"
         prompt = "My favourite condiment is "
         tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-v0.1", use_fast=False)
         model = MistralForCausalLM.from_pretrained("mistralai/Mistral-7B-v0.1", device_map="auto", dtype=torch.float16)

--- a/tests/models/qwen2/test_modeling_qwen2.py
+++ b/tests/models/qwen2/test_modeling_qwen2.py
@@ -207,7 +207,7 @@ class Qwen2IntegrationTest(unittest.TestCase):
     @slow
     def test_speculative_generation(self):
         EXPECTED_TEXT_COMPLETION = (
-            "My favourite condiment is 100% natural honey, and I always like to use it in my recipes. I love"
+            "My favourite condiment is 100% natural and organic, and I love to use it to make my own sauces."
         )
         prompt = "My favourite condiment is "
         tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2-7B", use_fast=False)

--- a/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
+++ b/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
@@ -252,7 +252,7 @@ class Qwen2MoeIntegrationTest(unittest.TestCase):
     @slow
     def test_speculative_generation(self):
         EXPECTED_TEXT_COMPLETION = (
-            "To be or not to be, that is the question. Whether 'tis nobler in the mind to suffer the sl"
+            "To be or not to be, that is the question: Whether 'tis nobler in the mind to suffer The sl"
         )
         prompt = "To be or not to"
         tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen1.5-MoE-A2.7B", use_fast=False)

--- a/tests/models/qwen3/test_modeling_qwen3.py
+++ b/tests/models/qwen3/test_modeling_qwen3.py
@@ -199,7 +199,7 @@ class Qwen3IntegrationTest(unittest.TestCase):
             {
                 ("xpu", 3): "My favourite condiment is 100% peanut butter. I love it so much that I can't help but use it",
                 ("cuda", 7): "My favourite condiment is 100% natural. It's a little spicy and a little sweet, but it's the",
-                ("cuda", 8): "My favourite condiment is 100% peanut butter. I love it so much that I can't help but use it",
+                ("cuda", 8): "My favourite condiment is 100% beef, 100% beef, 100% beef.",
             }
         )  # fmt: skip
         EXPECTED_TEXT_COMPLETION = EXPECTED_TEXT_COMPLETIONS.get_expectation()


### PR DESCRIPTION
# What does this PR do?

These tests are failing after #40657.

As discussed offline [here](https://huggingface.slack.com/archives/C01NE71C4F7/p1758117410373159?thread_ts=1758031736.841469&cid=C01NE71C4F7), it's expected 

TL:DR

> The logits are updated due to changes in assistant temperature, as we move from implicit T=1 to explicit calibrated defaults.

Details

> turns out the PR inadvertently changed an implicit algorithmic bias: candidate_generator (the assistant model) was getting logits_processor while the decoding method (main model) was getting prepared_logits_processor. This meant that the assistant was running with T=1 while the main model was using lower temp.
We investigated and its good for speculation to have a hotter assistant model (so it was a good bug that we were not applying the lower temp to the assistant),
But it should be explicitly set and not a hidden argument forwarding consequence. So its correct as is for now, and in the future we will bring better defaults for assisted generation, after benchmarking a little more.

<img width="904" height="575" alt="image" src="https://github.com/user-attachments/assets/b4e329ea-9b23-4629-8bba-2d1515a73289" />


