### PR TITLE
fix(timm): Catch 'Unknown model' RuntimeError in the Gemma 3n MobileNetV5 vision encoder

### DIFF
--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -69,6 +69,13 @@ def _create_timm_model_with_error_handling(config: "TimmWrapperConfig", **model_
         return model
     except RuntimeError as e:
         if "Unknown model" in str(e):
+            if "mobilenetv5_300m_enc" in config.architecture:
+                raise ImportError(
+                    f"You are trying to load a model that uses '{config.architecture}', the vision backbone for Gemma 3n. "
+                    f"This architecture is not supported in your version of timm ({timm.__version__}). "
+                    "Please upgrade to timm >= 1.0.16 with: `pip install -U timm`."
+                ) from e
+            # A good general check for other unknown models too.
             raise ImportError(
                 f"The model architecture '{config.architecture}' is not supported in your version of timm ({timm.__version__}). "
                 "Please upgrade timm to a more recent version with `pip install -U timm`."

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -69,13 +69,7 @@ def _create_timm_model_with_error_handling(config: "TimmWrapperConfig", **model_
         return model
     except RuntimeError as e:
         if "Unknown model" in str(e):
-            if "mobilenetv5_300m_enc" in config.architecture:
-                raise ImportError(
-                    f"You are trying to load a model that uses '{config.architecture}', the vision backbone for Gemma 3n. "
-                    f"This architecture is not supported in your version of timm ({timm.__version__}). "
-                    "Please upgrade to timm >= 1.0.16 with: `pip install -U timm`."
-                ) from e
-            # A good general check for other unknown models too.
+            # A good general check for unknown models.
             raise ImportError(
                 f"The model architecture '{config.architecture}' is not supported in your version of timm ({timm.__version__}). "
                 "Please upgrade timm to a more recent version with `pip install -U timm`."

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -55,6 +55,27 @@ class TimmWrapperModelOutput(ModelOutput):
     attentions: Optional[tuple[torch.FloatTensor, ...]] = None
 
 
+def _create_timm_model_with_error_handling(config: "TimmWrapperConfig", **model_kwargs):
+    """
+    Creates a timm model and provides a clear error message if the model is not found,
+    suggesting a library update.
+    """
+    try:
+        model = timm.create_model(
+            config.architecture,
+            pretrained=False,
+            **model_kwargs,
+        )
+        return model
+    except RuntimeError as e:
+        if "Unknown model" in str(e):
+            raise ImportError(
+                f"The model architecture '{config.architecture}' is not supported in your version of timm ({timm.__version__}). "
+                "Please upgrade timm to a more recent version with `pip install -U timm`."
+            ) from e
+        raise e
+
+
 @auto_docstring
 class TimmWrapperPreTrainedModel(PreTrainedModel):
     main_input_name = "pixel_values"
@@ -138,7 +159,7 @@ class TimmWrapperModel(TimmWrapperPreTrainedModel):
         super().__init__(config)
         # using num_classes=0 to avoid creating classification head
         extra_init_kwargs = config.model_args or {}
-        self.timm_model = timm.create_model(config.architecture, pretrained=False, num_classes=0, **extra_init_kwargs)
+        self.timm_model = _create_timm_model_with_error_handling(config, num_classes=0, **extra_init_kwargs)
         self.post_init()
 
     @auto_docstring
@@ -254,8 +275,8 @@ class TimmWrapperForImageClassification(TimmWrapperPreTrainedModel):
             )
 
         extra_init_kwargs = config.model_args or {}
-        self.timm_model = timm.create_model(
-            config.architecture, pretrained=False, num_classes=config.num_labels, **extra_init_kwargs
+        self.timm_model = _create_timm_model_with_error_handling(
+            config, num_classes=config.num_labels, **extra_init_kwargs
         )
         self.num_labels = config.num_labels
         self.post_init()


### PR DESCRIPTION
A first time contributor to HF here!

### What does this PR do?

→ Fixes a `RuntimeError` that occurs when loading the Gemma 3n model with an outdated version of the `timm` library; it's caused by the absence of the required `mobilenetv5_300m_enc` vision model in older `timm` versions.
→ The newer error explicitly tells the user that the vision model for Gemma 3n is missing and provides them with the exact command to upgrade timm to a compatible version, resolving the issue.

Closes #39208.

cc: @ArthurZucker @qubvel

### Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).