### PR TITLE
Add captured actual outputs to CI artifacts

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -128,28 +128,35 @@ jobs:
           echo "machine_type=$machine_type" >> $GITHUB_ENV
           echo "machine_type=$machine_type" >> $GITHUB_OUTPUT
 
+      - name: Create report directory if it doesn't exist
+        shell: bash
+        run: |
+          mkdir -p /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
+          echo "dummy" > /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports/dummy.txt
+          ls -la /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
+
       - name: Run all tests on GPU
         working-directory: /transformers
-        run: python3 -m pytest -rsfE -v --make-reports=${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports tests/${{ matrix.folders }}
+        run: |
+          PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports python3 -m pytest -rsfE -v --make-reports=${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports tests/${{ matrix.folders }}
 
       - name: Failure short reports
         if: ${{ failure() }}
         continue-on-error: true
-        run: cat /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports/failures_short.txt
+        run: cat /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports/failures_short.txt
 
-      - name: Run test
-        shell: bash
+      - name: Captured information
+        if: ${{ failure() }}
+        continue-on-error: true
         run: |
-          mkdir -p /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports
-          echo "hello" > /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports/hello.txt
-          echo "${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports"
+          cat /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports/captured_info.txt
 
       - name: "Test suite reports artifacts: ${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports"
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
-          path: /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports
+          path: /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
 
   collated_reports:
     name: Collated Reports

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1196,7 +1196,7 @@ if __name__ == "__main__":
             "time_spent": [],
             "failures": {},
             "job_link": {},
-            "captured_info": {}
+            "captured_info": {},
         }
         for matrix_name in job_matrix
         if f"{report_name_prefix}_{matrix_name}_test_reports" in available_artifacts
@@ -1234,7 +1234,7 @@ if __name__ == "__main__":
                             step_number = step["number"]
                             break
                     if step_number is not None:
-                        step_link = f'{job["html_url"]}#step:{step_number}:1'
+                        step_link = f"{job['html_url']}#step:{step_number}:1"
                         matrix_job_results[matrix_name]["captured_info"][artifact_gpu] = {
                             "link": step_link,
                             "captured_info": artifact["captured_info"],

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1202,6 +1202,14 @@ if __name__ == "__main__":
         if f"{report_name_prefix}_{matrix_name}_test_reports" in available_artifacts
     }
 
+    matrix_job_results_extra = {
+        matrix_name: {
+            "captured_info": {},
+        }
+        for matrix_name in job_matrix
+        if f"{report_name_prefix}_{matrix_name}_test_reports" in available_artifacts
+    }
+
     unclassified_model_failures = []
 
     for matrix_name in matrix_job_results:
@@ -1235,7 +1243,8 @@ if __name__ == "__main__":
                             break
                     if step_number is not None:
                         step_link = f"{job['html_url']}#step:{step_number}:1"
-                        matrix_job_results[matrix_name]["captured_info"][artifact_gpu] = {
+                        matrix_job_results[matrix_name]["captured_info"][artifact_gpu] = step_link
+                        matrix_job_results_extra[matrix_name]["captured_info"][artifact_gpu] = {
                             "link": step_link,
                             "captured_info": artifact["captured_info"],
                         }
@@ -1441,6 +1450,15 @@ if __name__ == "__main__":
         api.upload_file(
             path_or_fileobj=f"ci_results_{job_name}/{test_to_result_name[test_name]}_results.json",
             path_in_repo=f"{report_repo_folder}/ci_results_{job_name}/{test_to_result_name[test_name]}_results.json",
+            repo_id=report_repo_id,
+            repo_type="dataset",
+            token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),
+        )
+
+    if len(matrix_job_results_extra) > 0:
+        api.upload_file(
+            path_or_fileobj=f"ci_results_{job_name}/matrix_job_results_extra.json",
+            path_in_repo=f"{report_repo_folder}/ci_results_{job_name}/matrix_job_results_extra.json",
             repo_id=report_repo_id,
             repo_type="dataset",
             token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1196,6 +1196,7 @@ if __name__ == "__main__":
             "time_spent": [],
             "failures": {},
             "job_link": {},
+            "captured_info": {}
         }
         for matrix_name in job_matrix
         if f"{report_name_prefix}_{matrix_name}_test_reports" in available_artifacts
@@ -1224,6 +1225,20 @@ if __name__ == "__main__":
                 matrix_job_results[matrix_name]["time_spent"].append(float(time_spent[:-1]))
 
                 stacktraces = handle_stacktraces(artifact["failures_line"])
+
+                # Add the captured actual outputs for patched methods (`torch.testing.assert_close`, `assertEqual` etc.)
+                if "captured_info" in artifact:
+                    step_number = None
+                    for step in job.get("steps", []):
+                        if step["name"] == "Captured information":
+                            step_number = step["number"]
+                            break
+                    if step_number is not None:
+                        step_link = f'{job["html_url"]}#step:{step_number}:1'
+                        matrix_job_results[matrix_name]["captured_info"][artifact_gpu] = {
+                            "link": step_link,
+                            "captured_info": artifact["captured_info"],
+                        }
 
                 # TODO: ???
                 for line in artifact["summary_short"].split("\n"):

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1456,6 +1456,11 @@ if __name__ == "__main__":
         )
 
     if len(matrix_job_results_extra) > 0:
+        with open(
+            f"ci_results_{job_name}/{test_to_result_name[test_name]}_results_extra.json", "w", encoding="UTF-8"
+        ) as fp:
+            json.dump(matrix_job_results_extra, fp, indent=4, ensure_ascii=False)
+
         api.upload_file(
             path_or_fileobj=f"ci_results_{job_name}/{test_to_result_name[test_name]}_results_extra.json",
             path_in_repo=f"{report_repo_folder}/ci_results_{job_name}/{test_to_result_name[test_name]}_results_extra.json",

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1457,8 +1457,8 @@ if __name__ == "__main__":
 
     if len(matrix_job_results_extra) > 0:
         api.upload_file(
-            path_or_fileobj=f"ci_results_{job_name}/matrix_job_results_extra.json",
-            path_in_repo=f"{report_repo_folder}/ci_results_{job_name}/matrix_job_results_extra.json",
+            path_or_fileobj=f"ci_results_{job_name}/{test_to_result_name[test_name]}_results_extra.json",
+            path_in_repo=f"{report_repo_folder}/ci_results_{job_name}/{test_to_result_name[test_name]}_results_extra.json",
             repo_id=report_repo_id,
             repo_type="dataset",
             token=os.environ.get("TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN", None),

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1240,7 +1240,6 @@ if __name__ == "__main__":
                             "captured_info": artifact["captured_info"],
                         }
 
-                # TODO: ???
                 for line in artifact["summary_short"].split("\n"):
                     if line.startswith("FAILED "):
                         # Avoid the extra `FAILED` entry given by `run_test_using_subprocess` causing issue when calling


### PR DESCRIPTION
# What does this PR do?

Follow up work of #40727:

- In the pytest step, add the following so we get the captured actual outputs (for patched methods)
    > PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=...
- Add a new step `Captured information` to show it on the job run page
- Add the link (of the new step `Captured information`) and the content of `captured_info.txt` to `model_results.json`

This could help the update of expected output values faster.

[Example run](https://github.com/huggingface/transformers/actions/runs/17821624855/job/50665488057#step:16:30)