### PR TITLE
use `skip_predictor=True` in vjepa2 `get_vision_features`

### DIFF
--- a/src/transformers/models/vjepa2/modeling_vjepa2.py
+++ b/src/transformers/models/vjepa2/modeling_vjepa2.py
@@ -1125,7 +1125,7 @@ class VJEPA2Model(VJEPA2PreTrainedModel):
         return encoder_output
 
     def get_vision_features(self, pixel_values_videos) -> torch.Tensor:
-        encoder_output = self.forward(pixel_values_videos)
+        encoder_output = self.forward(pixel_values_videos, skip_predictor=True)
         return encoder_output.last_hidden_state
 
 


### PR DESCRIPTION
# What does this PR do?

`VJEPA2Model`'s `get_vision_features` method is meant to only forward pass through the encoder however it uses the model's `forward` method and omits `skip_predictor=True` meaning it also passes through the `predictor` which is wasted computation. This pr sets `skip_predictor=True` so that we only do the necessary calculations.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Maybe @pcuenca, @LysandreJik or @koustuvsinha as reviewers of the original VJEPA-2 pr?
