### PR TITLE
Fix outdated version checks of accelerator

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -241,10 +241,9 @@ if is_accelerate_available():
     DATA_SAMPLERS = [RandomSampler]
     if version.parse(accelerate_version) > version.parse("1.3.0"):
         from accelerate.utils import TorchTensorParallelPlugin
-    if version.parse(accelerate_version) > version.parse("0.23.0"):
-        from accelerate.data_loader import SeedableRandomSampler
+    from accelerate.data_loader import SeedableRandomSampler
 
-        DATA_SAMPLERS += [SeedableRandomSampler]
+    DATA_SAMPLERS += [SeedableRandomSampler]
 
     if is_deepspeed_available():
         from accelerate.utils import DeepSpeedSchedulerWrapper
@@ -4196,9 +4195,7 @@ class Trainer:
         elif (tp_size := getattr(self.model, "_tp_size", 0)) is not None and tp_size > 1:
             self._save(output_dir)
         elif self.is_fsdp_enabled:
-            if ("FULL_STATE_DICT" in str(self.accelerator.state.fsdp_plugin.state_dict_type)) and (
-                version.parse(accelerate_version) > version.parse("0.24.1")
-            ):
+            if "FULL_STATE_DICT" in str(self.accelerator.state.fsdp_plugin.state_dict_type):
                 state_dict = self.accelerator.get_state_dict(self.model)
                 if self.args.should_save:
                     self._save(output_dir, state_dict=state_dict)

--- a/tests/fsdp/test_fsdp.py
+++ b/tests/fsdp/test_fsdp.py
@@ -88,22 +88,11 @@ def get_master_port(real_launcher=False):
 
 
 if is_torch_available():
-    from tests.trainer.test_trainer import (  # noqa
-        RegressionModelConfig,
-        RegressionPreTrainedModel,
-    )
-
     # hack to restore original logging level pre #21700
     get_regression_trainer = partial(tests.trainer.test_trainer.get_regression_trainer, log_level="info")
 
-require_fsdp_version = require_fsdp
 if is_accelerate_available():
-    from accelerate.utils.constants import (
-        FSDP_PYTORCH_VERSION,
-        FSDP_SHARDING_STRATEGY,
-    )
-
-    require_fsdp_version = partial(require_fsdp, min_version=FSDP_PYTORCH_VERSION)
+    from accelerate.utils.constants import FSDP_SHARDING_STRATEGY
 
 
 FSDP2_ACCELERATE_VERSION = "1.6.0"
@@ -142,7 +131,6 @@ def _parameterized_custom_name_func(func, param_num, param):
 
 @require_accelerate
 @require_torch_accelerator
-@require_fsdp_version
 class TrainerIntegrationFSDP(TestCasePlus, TrainerIntegrationCommon):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
# What does this PR do?

Because `ACCELERATE_MIN_VERSION` is 0.26