### PR TITLE
Track the CI (model) jobs that don't produce test output files (process being killed etc.)

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -138,10 +138,16 @@ jobs:
       - name: Run all tests on GPU
         working-directory: /transformers
         run: |
-          PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports python3 -m pytest -rsfE -v --make-reports=${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports tests/${{ matrix.folders }}
+          script -q -c "PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports python3 -m pytest -rsfE -v --make-reports=${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports tests/${{ matrix.folders }}" test_outputs.txt
+          ls -la
+          # Extract the exit code from the output file
+          PYTEST_EXIT_CODE=$(tail -1 test_outputs.txt | grep "PYTEST_EXIT_CODE:" | cut -d: -f2)
+          exit ${PYTEST_EXIT_CODE:-1}
 
       - name: Failure short reports
         if: ${{ failure() }}
+        # This step is only to show information on Github Actions log.
+        # Always mark this step as successful, even if the report directory or the file `failures_short.txt` in it doesn't exist
         continue-on-error: true
         run: cat /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports/failures_short.txt
 
@@ -150,6 +156,12 @@ jobs:
         continue-on-error: true
         run: |
           cat /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports/captured_info.txt
+
+      - name: Copy test_outputs.txt
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cp /transformers/test_outputs.txt /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
 
       - name: "Test suite reports artifacts: ${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports"
         if: ${{ always() }}

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -244,7 +244,7 @@ class Message:
                 "type": "plain_text",
                 "text": (
                     f"There were {self.n_failures} failures, out of {self.n_tests} tests.\n"
-                    f"🚨 There were {self.n_jobs_errored_out} jobs errored out (not producing test output files). 🚨\n"
+                    f"🚨 There were {self.n_jobs_errored_out} jobs errored out (not producing test output files).\n"
                     f"The suite ran in {self.time}."
                 ),
                 "emoji": True,


### PR DESCRIPTION
# What does this PR do?

For a few CI jobs, the pytest process is killed, not producing test output files. In this case, currently, this is not tracked, so we somehow think those jobs have no failing tests.

This PR try to track such situation, and show at least on slack:

>  🚨 There were {self.n_jobs_errored_out} jobs errored out (not producing test output files). 🚨

When we see this on Slack, we can check the artifact `model_results.json` by searching `["error"]` to find which jobs have this issue, click the `["job_link"]` to get to the job run page for more details.

Might be better to extend this work to other jobs (deepspeed, pipeline), but let's see how it works with model jobs first.

<img width="906" height="337" alt="Screenshot 2025-09-18 182213" src="https://github.com/user-attachments/assets/aaa96116-36af-46b1-864f-9ff2cf1b5273" />