### PR TITLE
Remove `set_model_tester_for_less_flaky_tests`

### DIFF
--- a/tests/models/efficientloftr/test_modeling_efficientloftr.py
+++ b/tests/models/efficientloftr/test_modeling_efficientloftr.py
@@ -23,7 +23,6 @@ from transformers.testing_utils import (
     require_vision,
     set_config_for_less_flaky_test,
     set_model_for_less_flaky_test,
-    set_model_tester_for_less_flaky_test,
     slow,
     torch_device,
 )
@@ -359,8 +358,6 @@ class EfficientLoFTRModelTest(ModelTesterMixin, unittest.TestCase):
                         msg = f"Batched and Single row outputs are not equal in {model_name} for key={key}.\n\n"
                         msg += str(e)
                         raise AssertionError(msg)
-
-        set_model_tester_for_less_flaky_test(self)
 
         config, batched_input = self.model_tester.prepare_config_and_inputs_for_common()
         set_config_for_less_flaky_test(config)


### PR DESCRIPTION
# What does this PR do?

As per the title. It's a very bad idea to dynamically change the whole `tester`, and brings a lot of issues for models with `layer_types`. @gante removed most of its usage already, just cleaning up what's left!