### PR TITLE
docs(tokenization): Add clarification for train_new_from_iterator 

### DIFF
--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -754,6 +754,8 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         Trains a tokenizer on a new corpus with the same defaults (in terms of special tokens or tokenization pipeline)
         as the current one.
 
+        Note that the `train_new_from_iterator()` method in the 🤗 Tokenizers library uses BPE to construct the vocabulary, not a true WordPiece implementation.
+
         Args:
             text_iterator (generator of `list[str]`):
                 The training corpus. Should be a generator of batches of texts, for instance a list of lists of texts


### PR DESCRIPTION

# Add a note to the documentation clarifying that the train_new_from_iterator method in the 🤗 Tokenizers library uses the BPE algorithm to construct the vocabulary, not a true WordPiece implementation.

## What does this PR do?
This PR improves the documentation of the `train_new_from_iterator` method in `tokenization_utils_fast.py` by adding an explicit note to clarify its underlying vocabulary construction logic. 

Specifically, a line is added to the method's docstring:  
`Note that the train_new_from_iterator() method in the 🤗 Tokenizers library uses BPE to construct the vocabulary, not a true WordPiece implementation.`

### Motivation & Context
The change addresses two key pain points observed in practical use and community contexts:
1. **End-user misunderstanding**: When relying solely on existing documentation, users (including the contributor's team) may expect the method to generate a WordPiece vocabulary (e.g., when working with WordPiece-based tokenizers like `BertTokenizerFast`), but instead receive a BPE-based vocabulary—leading to unintended discrepancies in workflow.
2. **Community confusion**: Multiple research papers reference "using WordPiece via the 🤗 Tokenizers library" without distinguishing that `train_new_from_iterator` relies on BPE under the hood. This note helps align documentation with real-world usage and reduces academic/developmental ambiguity.

The clarification is consistent with details provided in the [Hugging Face LLM Course](https://huggingface.co/course/chapter6/5), which explicitly states that the 🤗 Tokenizers library uses BPE for training (rather than WordPiece) due to incomplete clarity on WordPiece's internal mechanisms.


Fixes # (N/A – this is a proactive documentation improvement, not tied to an existing issue)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.  
  *Note: This is a proactive documentation update based on observed user/community confusion, not pre-discussed in an issue/forum.*
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?  
  *Note: No new tests are required, as this change only modifies documentation (no code logic updates).*


## Who can review?
Tag relevant reviewers below (fewer than 3 people):
- @ArthurZucker (relevant to tokenizer-related changes, per template guidance)
- @stevhliu (relevant to documentation improvements, per template guidance)