### PR TITLE
Deprecate `max_size` in ConditionalDetrImageProcessor with warning

### DIFF
--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -852,13 +852,15 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
 
         if "max_size" in kwargs:
             logger.warning_once(
-                "The `max_size` parameter is deprecated and will be removed in a future release. "
-                "Please use `size={'shortest_edge': <int>, 'longest_edge': <int>}` instead."
+                "The `max_size` parameter is deprecated and will be removed in v4.26. "
+                "Please specify in `size['longest_edge'] instead`.",
             )
-            kwargs.pop("max_size")  # ignore it
+            max_size = kwargs.pop("max_size")
+        else:
+            max_size = None if size is None else 1333
 
         size = size if size is not None else {"shortest_edge": 800, "longest_edge": 1333}
-        size = get_size_dict(size, default_to_square=False)
+        size = get_size_dict(size, max_size=max_size, default_to_square=False)
 
         # Backwards compatibility
         if do_convert_annotations is None:
@@ -904,8 +906,8 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        created using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600)`
-        Note: max_size is deprecated. Use size={'shortest_edge': <int>, 'longest_edge': <int>} instead.
+        created using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600,
+        max_size=800)`
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -853,7 +853,7 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
         if "max_size" in kwargs:
             logger.warning_once(
                 "The `max_size` parameter is deprecated and will be removed in a future release. "
-                "Please use `size={'longest_edge': <int>}` instead."
+                "Please use `size={'shortest_edge': <int>, 'longest_edge': <int>}` instead."
             )
             kwargs.pop("max_size")  # ignore it
 
@@ -905,7 +905,7 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
         created using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600)`
-        Note: max_size is deprecated. Use size={'longest_edge': <int>} instead.
+        Note: max_size is deprecated. Use size={'shortest_edge': <int>, 'longest_edge': <int>} instead.
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:

--- a/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/image_processing_conditional_detr.py
@@ -852,15 +852,13 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
 
         if "max_size" in kwargs:
             logger.warning_once(
-                "The `max_size` parameter is deprecated and will be removed in v4.26. "
-                "Please specify in `size['longest_edge'] instead`.",
+                "The `max_size` parameter is deprecated and will be removed in a future release. "
+                "Please use `size={'longest_edge': <int>}` instead."
             )
-            max_size = kwargs.pop("max_size")
-        else:
-            max_size = None if size is None else 1333
+            kwargs.pop("max_size")  # ignore it
 
         size = size if size is not None else {"shortest_edge": 800, "longest_edge": 1333}
-        size = get_size_dict(size, max_size=max_size, default_to_square=False)
+        size = get_size_dict(size, default_to_square=False)
 
         # Backwards compatibility
         if do_convert_annotations is None:
@@ -906,8 +904,8 @@ class ConditionalDetrImageProcessor(BaseImageProcessor):
     def from_dict(cls, image_processor_dict: dict[str, Any], **kwargs):
         """
         Overrides the `from_dict` method from the base class to make sure parameters are updated if image processor is
-        created using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600,
-        max_size=800)`
+        created using from_dict and kwargs e.g. `ConditionalDetrImageProcessor.from_pretrained(checkpoint, size=600)`
+        Note: max_size is deprecated. Use size={'longest_edge': <int>} instead.
         """
         image_processor_dict = image_processor_dict.copy()
         if "max_size" in kwargs:

--- a/src/transformers/models/metaclip_2/convert_metaclip_2_to_hf.py
+++ b/src/transformers/models/metaclip_2/convert_metaclip_2_to_hf.py
@@ -26,6 +26,7 @@ from PIL import Image
 
 # Import MetaCLIP modules
 from src.mini_clip.factory import create_model_and_transforms
+
 from transformers import (
     AutoTokenizer,
     CLIPImageProcessor,

--- a/tests/models/conditional_detr/test_image_processing_conditional_detr.py
+++ b/tests/models/conditional_detr/test_image_processing_conditional_detr.py
@@ -608,5 +608,18 @@ class ConditionalDetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcess
 
     def test_deprecated_max_size(self):
         # Should not crash, but log a warning
-        processor = ConditionalDetrImageProcessor(max_size=512)
+        from transformers.utils import logging
+        from transformers.testing_utils import CaptureLogger, LoggingLevel
+        
+        logger = logging.get_logger("transformers.models.conditional_detr.image_processing_conditional_detr")
+        logger.warning_once.cache_clear()
+        
+        with LoggingLevel(logging.WARNING):
+            with CaptureLogger(logger) as cl:
+                processor = ConditionalDetrImageProcessor(max_size=512)
+        
         self.assertIsInstance(processor, ConditionalDetrImageProcessor)
+        self.assertIn("max_size", cl.out)
+        self.assertIn("deprecated", cl.out)
+        self.assertIn("shortest_edge", cl.out)
+        self.assertIn("longest_edge", cl.out)

--- a/tests/models/conditional_detr/test_image_processing_conditional_detr.py
+++ b/tests/models/conditional_detr/test_image_processing_conditional_detr.py
@@ -161,7 +161,7 @@ class ConditionalDetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcess
             self.assertEqual(image_processor.do_pad, True)
 
             image_processor = image_processing_class.from_dict(
-                self.image_processor_dict, size=42, max_size=84, pad_and_return_pixel_mask=False
+                self.image_processor_dict, size={"shortest_edge": 42, "longest_edge": 84}, pad_and_return_pixel_mask=False
             )
             self.assertEqual(image_processor.size, {"shortest_edge": 42, "longest_edge": 84})
             self.assertEqual(image_processor.do_pad, False)

--- a/tests/models/conditional_detr/test_image_processing_conditional_detr.py
+++ b/tests/models/conditional_detr/test_image_processing_conditional_detr.py
@@ -605,3 +605,8 @@ class ConditionalDetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcess
         )
         inputs = image_processor(images=[image_5], return_tensors="pt")
         self.assertEqual(inputs["pixel_values"].shape, torch.Size([1, 3, 50, 50]))
+
+    def test_deprecated_max_size(self):
+        # Should not crash, but log a warning
+        processor = ConditionalDetrImageProcessor(max_size=512)
+        self.assertIsInstance(processor, ConditionalDetrImageProcessor)

--- a/tests/models/conditional_detr/test_image_processing_conditional_detr.py
+++ b/tests/models/conditional_detr/test_image_processing_conditional_detr.py
@@ -621,5 +621,5 @@ class ConditionalDetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcess
         self.assertIsInstance(processor, ConditionalDetrImageProcessor)
         self.assertIn("max_size", cl.out)
         self.assertIn("deprecated", cl.out)
-        self.assertIn("shortest_edge", cl.out)
-        self.assertIn("longest_edge", cl.out)
+        self.assertIn("v4.26", cl.out)
+        self.assertIn("size['longest_edge']", cl.out)


### PR DESCRIPTION
# What does this PR do?

Deprecates the `max_size` parameter in `ConditionalDetrImageProcessor` with a proper warning message and guides users to use the new `size={'longest_edge': <int>}` format instead.

## Why this change?

This aligns the ConditionalDetrImageProcessor with other processors (like DETR) and provides a clearer migration path for users. The current `max_size` parameter is deprecated and should be replaced with the more explicit `size` parameter format.

## Changes Made

- Added deprecation warning in `ConditionalDetrImageProcessor.__init__()` that warns users about the deprecated `max_size` parameter
- Updated warning message to guide users to use `size={'longest_edge': <int>}` instead
- Updated docstring in `from_dict` method to document the deprecation
- Simplified parameter handling by ignoring `max_size` instead of trying to use it
- Added test case to verify the deprecation warning works and processor still functions correctly

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

This affects vision models and image processing, so tagging: @amyeroberts @qubvel