### PR TITLE
Tests: Apertus integration tests

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -220,8 +220,14 @@ class XIELUActivation(nn.Module):
         self._eps_scalar = float(self.eps.detach().cpu().float().item())
 
         self._xielu_cuda_obj = None
+
         try:
+            import os
+
             import xielu.ops  # noqa: F401
+
+            if int(os.environ.get("XIELU_DISABLE_CUDA", 0)) == 1:
+                raise Exception("Environment variable XIELU_DISABLE_CUDA is set to 1")
 
             self._xielu_cuda_obj = torch.classes.xielu.XIELU()
             msg = "Using experimental xIELU CUDA."

--- a/tests/models/apertus/test_modeling_apertus.py
+++ b/tests/models/apertus/test_modeling_apertus.py
@@ -20,18 +20,25 @@
 
 import unittest
 
+import torch
+
 from transformers import is_torch_available
+from transformers.models.auto.tokenization_auto import AutoTokenizer
 from transformers.testing_utils import (
+    cleanup,
     require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
+    torch_device,
 )
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 
 
 if is_torch_available():
+    import torch
+
     from transformers import (
         ApertusConfig,
         ApertusForCausalLM,
@@ -82,6 +89,145 @@ class ApertusModelTest(CausalLMModelTest, unittest.TestCase):
 
 @require_torch_accelerator
 @require_read_token
+@require_torch
 @slow
 class ApertusIntegrationTest(unittest.TestCase):
-    pass
+    # NOTE: Using XIELU cuda experimental and python (torch) version give different results when using dtype=bfloat16
+    @classmethod
+    def setUpClass(cls):
+        cls.model = None
+        cls.tokenizer = None
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.model
+        cleanup(torch_device, gc_collect=True)
+
+    def tearDown(self):
+        cleanup(torch_device, gc_collect=True)
+
+    @classmethod
+    def get_model(cls, size="8B", dtype=torch.bfloat16):
+        if cls.model is None:
+            cls.model = ApertusForCausalLM.from_pretrained(
+                f"swiss-ai/Apertus-{size}-Instruct-2509",
+                device_map="auto",
+                dtype=dtype,
+            )
+
+        return cls.model
+
+    @classmethod
+    def get_tokenizer(cls, size="8B"):
+        if cls.tokenizer is None:
+            cls.tokenizer = AutoTokenizer.from_pretrained(f"swiss-ai/Apertus-{size}-Instruct-2509", device_map="auto")
+
+        return cls.tokenizer
+
+    @slow
+    def test_model_8b_greedy_generation(self):
+        EXPECTED_TEXT_COMPLETION = """Simply put, the theory of relativity states that \nthe laws of physics are the same for all observers in uniform motion relative to one another. \nThis means that if you are moving at a constant speed, the laws of physics will behave the same way as they do when you are standing still. \nThe theory of relativity has two main parts: special relativity"""
+        prompt = "Simply put, the theory of relativity states that "
+        model = self.get_model()
+        tokenizer = self.get_tokenizer()
+        input_ids = tokenizer.encode(prompt, return_tensors="pt").to(model.device)
+
+        # greedy generation outputs
+        generated_ids = model.generate(input_ids, max_new_tokens=64, top_p=None, temperature=1, do_sample=False)
+        text = tokenizer.decode(generated_ids[0], skip_special_tokens=True)
+        self.assertEqual(EXPECTED_TEXT_COMPLETION, text)
+
+    @slow
+    def test_model_8b_logits(self):
+        input_ids = [1, 13517, 7072, 4283, 1044, 1278, 9191, 1307, 115847, 8164, 1455, 1032]
+        model = self.get_model()
+        input_ids = torch.tensor([input_ids]).to(model.device)
+        with torch.no_grad():
+            out = model(input_ids).logits.float()
+
+        # Expected mean on dim = -1
+        EXPECTED_MEAN = torch.tensor(
+            [[0.5109, 1.9118, -0.9534, 1.5958, -5.8428, -2.8495, -0.1818, -2.6219, -3.5842, -1.4742, -2.9235, 2.4903]], device=model.device
+        )  # fmt: skip
+
+        torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)
+
+        # slicing logits[0, 0, 0:30]
+        EXPECTED_SLICE = torch.tensor([0.6992,  5.3438, 10.9375,  2.8281,  3.6562,  3.2656,  3.2656,  3.2656, 3.2656,  3.1094, -0.5586,  2.5156,  1.8516,  1.0391,  2.3750,  3.4688, 5.8750,  3.0938,  9.5000, 10.0000,  4.4375,  5.2500,  5.0938,  2.4844, 3.9844,  0.9883,  1.2344,  1.8594,  3.5000,  5.6875], device=model.device)  # fmt: skip
+        torch.testing.assert_close(out[0, 0, :30], EXPECTED_SLICE, rtol=1e-4, atol=1e-4)
+
+    @slow
+    def test_model_8b_logits_no_xielu_cuda(self):
+        import os
+
+        os.environ["XIELU_DISABLE_CUDA"] = "1"
+
+        self.setUpClass()
+
+        input_ids = [1, 13517, 7072, 4283, 1044, 1278, 9191, 1307, 115847, 8164, 1455, 1032]
+        model = self.get_model()
+        input_ids = torch.tensor([input_ids]).to(model.device)
+        with torch.no_grad():
+            out = model(input_ids).logits.float()
+
+        # Expected mean on dim = -1
+        EXPECTED_MEAN = torch.tensor(
+            [[-0.0198, 1.8646, -0.9973, 0.4992, -5.5038, -8.0162, 0.5486, -1.9783, -3.1419, 0.6811, -1.6834, 3.4895]],
+            device=model.device,
+        )
+
+        torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)
+
+        # slicing logits[0, 0, 0:30]
+        EXPECTED_SLICE = torch.tensor([-0.0204,  6.4688, 11.6875,  2.4219,  2.5156,  2.4219,  2.4219,  2.4219, 2.4219,  2.2812, -1.2969,  1.7500,  1.9531,  0.3281,  2.9062,  4.0938, 5.9062,  2.7188,  9.5000, 10.1250,  3.5156,  5.3438,  5.0625,  1.7578, 4.0625,  1.4219,  1.0391,  1.7656,  2.7031,  5.3750], device=model.device)  # fmt: skip
+        torch.testing.assert_close(out[0, 0, :30], EXPECTED_SLICE, rtol=1e-4, atol=1e-4)
+
+    @slow
+    def test_model_8b_logits_float32(self):
+        # NOTE: I think float32 tests is not something we need (so remove after checking errors).
+
+        input_ids = [1, 13517, 7072, 4283, 1044, 1278, 9191, 1307, 115847, 8164, 1455, 1032]
+        model = self.get_model(dtype=torch.float32)
+        input_ids = torch.tensor([input_ids]).to(model.device)
+        with torch.no_grad():
+            out = model(input_ids).logits.float()
+
+        # Expected mean on dim = -1
+        EXPECTED_MEAN = torch.tensor(
+            [[0.5109, 1.9118, -0.9534, 1.5958, -5.8428, -2.8495, -0.1818, -2.6219, -3.5842, -1.4742, -2.9235, 2.4903]],
+            device=model.device,
+        )
+
+        torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)
+
+        # slicing logits[0, 0, 0:30]
+        EXPECTED_SLICE = torch.tensor([0.6992,  5.3438, 10.9375,  2.8281,  3.6562,  3.2656,  3.2656,  3.2656,3.2656,  3.1094, -0.5586,  2.5156,  1.8516,  1.0391,  2.3750,  3.4688, 5.8750,  3.0938,  9.5000, 10.0000,  4.4375,  5.2500,  5.0938,  2.4844, 3.9844,  0.9883,  1.2344,  1.8594,  3.5000,  5.6875], device=model.device)  # fmt: skip
+        torch.testing.assert_close(out[0, 0, :30], EXPECTED_SLICE, rtol=1e-4, atol=1e-4)
+
+    @slow
+    def test_model_8b_logits_float32_no_xielu_cuda(self):
+        # NOTE: I think float32 tests is not something we need (so remove after checking errors).
+
+        import os
+
+        os.environ["XIELU_DISABLE_CUDA"] = "1"
+
+        self.setUpClass()
+
+        input_ids = [1, 13517, 7072, 4283, 1044, 1278, 9191, 1307, 115847, 8164, 1455, 1032]
+        model = self.get_model(dtype=torch.float32)
+        input_ids = torch.tensor([input_ids]).to(model.device)
+        with torch.no_grad():
+            out = model(input_ids).logits.float()
+
+        # Expected mean on dim = -1
+        EXPECTED_MEAN = torch.tensor(
+            [[0.0812, 1.8028, -1.1248, 0.8004, -5.9161, -7.7755, 0.4919, -2.0355, -3.2272, 0.6626, -1.7287, 3.4431]],
+            device=model.device,
+        )
+
+        torch.testing.assert_close(out.mean(-1), EXPECTED_MEAN, rtol=1e-2, atol=1e-2)
+
+        # slicing logits[0, 0, 0:30]
+        EXPECTED_SLICE = torch.tensor([0.6404,  6.8661, 12.6953,  2.9036,  2.9236,  2.7907,  2.7907,  2.7907, 2.7907,  2.5965, -0.9208,  1.8292,  2.1176,  0.5388,  3.4888,  4.4509, 6.8699,  3.4439, 10.3936, 10.9893,  3.1937,  5.6061,  5.6495,  1.4633, 4.6484,  1.4452,  1.2131,  2.0822,  2.4203,  6.0496], device=model.device)  # fmt: skip
+        torch.testing.assert_close(out[0, 0, :30], EXPECTED_SLICE, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
# What does this PR do?

This PR adds integration tests for the Apertus model, the tests are:
- Check short greedy generation
- Check short instruct model greedy generation
- Check model logits in bfloat16, and compare with XIELU cuda output
- Check model logits in float32, and compare with XIELU cuda output (I think float32 tests are not desired?)

Note: Right now I do an environment variable just to show the difference between experimental XIELU cuda and no XIELU cuda outputs (but if this isn't desirable I'll remove it and just do a test for one of the two versions instead)

Related PR: #39381 

@ArthurZucker
