### PR TITLE
Fix seedoss

### DIFF
--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -93,42 +93,6 @@ class SeedOssIntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
 
-    def test_model_36b_fp16(self):
-        EXPECTED_TEXTS = [
-            "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
-            "Hi ByteDance-Seed team,\nI am trying to run the code on my local machine. I have installed all the",
-        ]
-
-        model = AutoModelForCausalLM.from_pretrained(self.model_id, torch_dtype=torch.float16, device_map="auto")
-
-        tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True, return_token_type_ids=False).to(
-            model.model.embed_tokens.weight.device
-        )
-
-        output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
-        output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
-
-        self.assertEqual(output_text, EXPECTED_TEXTS)
-
-    def test_model_36b_bf16(self):
-        EXPECTED_TEXTS = [
-            "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
-            "Hi ByteDance-Seed team,\nI am trying to run the code on my local machine. I have installed all the",
-        ]
-
-        model = AutoModelForCausalLM.from_pretrained(self.model_id, torch_dtype=torch.bfloat16, device_map="auto")
-
-        tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
-            model.model.embed_tokens.weight.device
-        )
-
-        output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
-        output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
-
-        self.assertEqual(output_text, EXPECTED_TEXTS)
-
     def test_model_36b_eager(self):
         EXPECTED_TEXTS = ""
 

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -103,7 +103,10 @@ class SeedOssIntegrationTest(unittest.TestCase):
         ]
 
         model = AutoModelForCausalLM.from_pretrained(
-            "ByteDance-Seed/Seed-OSS-36B-Base", torch_dtype=torch.bfloat16, attn_implementation="eager", device_map="auto"
+            "ByteDance-Seed/Seed-OSS-36B-Base",
+            torch_dtype=torch.bfloat16,
+            attn_implementation="eager",
+            device_map="auto",
         )
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
@@ -122,9 +125,8 @@ class SeedOssIntegrationTest(unittest.TestCase):
             "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed",
         ]
 
-        model = AutoModelForCausalLM.from_pretrained(
-            self.model_id, torch_dtype=torch.bfloat16, attn_implementation="sdpa", device_map="auto"
-        )
+        # default attention is `sdpa` (and this model repo. doesn't specify explicitly) --> we get `sdpa` here
+        model = AutoModelForCausalLM.from_pretrained(self.model_id, torch_dtype=torch.bfloat16, device_map="auto")
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True, return_token_type_ids=False).to(

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -101,10 +101,9 @@ class SeedOssIntegrationTest(unittest.TestCase):
         )
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
+        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True, return_token_type_ids=False).to(
             model.model.embed_tokens.weight.device
         )
-        del inputs["token_type_ids"]
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
@@ -122,10 +121,9 @@ class SeedOssIntegrationTest(unittest.TestCase):
         )
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
+        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True, return_token_type_ids=False).to(
             model.model.embed_tokens.weight.device
         )
-        del inputs["token_type_ids"]
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
@@ -144,10 +142,9 @@ class SeedOssIntegrationTest(unittest.TestCase):
         model.to(torch_device)
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
-        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
+        inputs = tokenizer(self.input_text, return_tensors="pt", padding=True, return_token_type_ids=False).to(
             model.model.embed_tokens.weight.device
         )
-        del inputs["token_type_ids"]
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -99,11 +99,11 @@ class SeedOssIntegrationTest(unittest.TestCase):
     def test_model_36b_eager(self):
         EXPECTED_TEXTS = [
             "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
-            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed"
+            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed",
         ]
 
         model = AutoModelForCausalLM.from_pretrained(
-            self.model_id, torch_dtype=torch.bfloat16, attn_implementation="eager", device_map="auto"
+            "ByteDance-Seed/Seed-OSS-36B-Base", torch_dtype=torch.bfloat16, device_map="auto"
         )
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
@@ -119,7 +119,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
     def test_model_36b_sdpa(self):
         EXPECTED_TEXTS = [
             "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
-            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed"
+            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed",
         ]
 
         model = AutoModelForCausalLM.from_pretrained(
@@ -140,13 +140,14 @@ class SeedOssIntegrationTest(unittest.TestCase):
     @require_torch_large_gpu
     @pytest.mark.flash_attn_test
     def test_model_36b_flash_attn(self):
-        EXPECTED_TEXTS = ""
+        EXPECTED_TEXTS = [
+            "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
+            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed",
+        ]
 
         model = AutoModelForCausalLM.from_pretrained(
             self.model_id, torch_dtype=torch.bfloat16, attn_implementation="flash_attention_2", device_map="auto"
         )
-        model.to(torch_device)
-
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True, return_token_type_ids=False).to(
             model.model.embed_tokens.weight.device

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -90,11 +90,17 @@ class SeedOssIntegrationTest(unittest.TestCase):
     input_text = ["How to make pasta?", "Hi ByteDance-Seed"]
     model_id = "ByteDance-Seed/Seed-OSS-36B-Base"
 
+    def setUp(self):
+        cleanup(torch_device, gc_collect=True)
+
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
 
     def test_model_36b_eager(self):
-        EXPECTED_TEXTS = ""
+        EXPECTED_TEXTS = [
+            "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
+            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed"
+        ]
 
         model = AutoModelForCausalLM.from_pretrained(
             self.model_id, torch_dtype=torch.bfloat16, attn_implementation="eager", device_map="auto"
@@ -113,7 +119,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
     def test_model_36b_sdpa(self):
         EXPECTED_TEXTS = [
             "How to make pasta?\nHow to make pasta?\nPasta is a popular dish that is enjoyed by people all over",
-            "Hi ByteDance-Seed team,\nI am trying to run the code on my local machine. I have installed all the",
+            "Hi ByteDance-Seed team,\nI am trying to run the code on the <beginning of the code>seed"
         ]
 
         model = AutoModelForCausalLM.from_pretrained(

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -103,7 +103,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         ]
 
         model = AutoModelForCausalLM.from_pretrained(
-            "ByteDance-Seed/Seed-OSS-36B-Base", torch_dtype=torch.bfloat16, device_map="auto"
+            "ByteDance-Seed/Seed-OSS-36B-Base", torch_dtype=torch.bfloat16, attn_implementation="eager", device_map="auto"
         )
 
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -104,7 +104,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
             model.model.embed_tokens.weight.device
         )
-        del inputs.token_type_ids
+        del inputs["token_type_ids"]
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
@@ -125,7 +125,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
             model.model.embed_tokens.weight.device
         )
-        del inputs.token_type_ids
+        del inputs["token_type_ids"]
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
@@ -147,7 +147,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
             model.model.embed_tokens.weight.device
         )
-        del inputs.token_type_ids
+        del inputs["token_type_ids"]
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -104,6 +104,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
             model.model.embed_tokens.weight.device
         )
+        del inputs.token_type_ids
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
@@ -124,6 +125,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
             model.model.embed_tokens.weight.device
         )
+        del inputs.token_type_ids
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
@@ -145,6 +147,7 @@ class SeedOssIntegrationTest(unittest.TestCase):
         inputs = tokenizer(self.input_text, return_tensors="pt", padding=True).to(
             model.model.embed_tokens.weight.device
         )
+        del inputs.token_type_ids
 
         output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)


### PR DESCRIPTION
# What does this PR do?

We get

> tests/models/seed_oss/test_modeling_seed_oss.py::SeedOssIntegrationTest::test_model_36b_fp16 Killed

See [job run](https://github.com/huggingface/transformers/actions/runs/17874224681/job/50833177823)

Running this single test , it pass. When loading `dtype=fp16`, it consumes much more CPU memory , and when running the whole integration test suite, it cause the process being killed.

This PR removes this test and only keep the `bfloat16` one: we don't need to test with different dtypes in general.

Also remove redundant test `test_model_36b_bf16` as it is the same as `test_model_36b_sdpa` (default is `sdpa`)