### PR TITLE
Qwen3 moe

### DIFF
--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -231,11 +231,10 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         self.top_k = config.num_experts_per_tok
         self.norm_topk_prob = config.norm_topk_prob
 
-        # gating
-        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         import os
 
         if os.environ.get("USE_NEW_MOE", "false") == "false":
+            self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
             self.experts = nn.ModuleList(
                 [Qwen3MoeMLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(self.num_experts)]
             )
@@ -456,6 +455,7 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
         ):
             self.mlp = Qwen3MoeSparseMoeBlock(config)
         else:
+            self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
             self.mlp = Qwen3MoeMLP(config, intermediate_size=config.intermediate_size)
 
         self.input_layernorm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
@@ -520,7 +520,7 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
             b, s, h = hidden_states.shape
             hidden_states = hidden_states.view(-1, h)
 
-            router_logits = self.mlp.gate(hidden_states)
+            router_logits = self.gate(hidden_states)
             routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
             routing_weights, selected_experts = torch.topk(routing_weights, self.mlp.top_k, dim=-1)
 

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -89,7 +89,9 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     batch, num_key_value_heads, slen, head_dim = hidden_states.shape
     if n_rep == 1:
         return hidden_states
-    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    hidden_states = hidden_states[:, :, None, :, :].expand(
+        batch, num_key_value_heads, n_rep, slen, head_dim
+    )
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
@@ -111,8 +113,12 @@ def eager_attention_forward(
         causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
         attn_weights = attn_weights + causal_mask
 
-    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
-    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
+        query.dtype
+    )
+    attn_weights = nn.functional.dropout(
+        attn_weights, p=dropout, training=module.training
+    )
     attn_output = torch.matmul(attn_weights, value_states)
     attn_output = attn_output.transpose(1, 2).contiguous()
 
@@ -126,26 +132,42 @@ class Qwen3MoeAttention(nn.Module):
         super().__init__()
         self.config = config
         self.layer_idx = layer_idx
-        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
-        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.head_dim = getattr(
+            config, "head_dim", config.hidden_size // config.num_attention_heads
+        )
+        self.num_key_value_groups = (
+            config.num_attention_heads // config.num_key_value_heads
+        )
         self.scaling = self.head_dim**-0.5
         self.attention_dropout = config.attention_dropout
         self.is_causal = True
 
         self.q_proj = nn.Linear(
-            config.hidden_size, config.num_attention_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_attention_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.k_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.v_proj = nn.Linear(
-            config.hidden_size, config.num_key_value_heads * self.head_dim, bias=config.attention_bias
+            config.hidden_size,
+            config.num_key_value_heads * self.head_dim,
+            bias=config.attention_bias,
         )
         self.o_proj = nn.Linear(
-            config.num_attention_heads * self.head_dim, config.hidden_size, bias=config.attention_bias
+            config.num_attention_heads * self.head_dim,
+            config.hidden_size,
+            bias=config.attention_bias,
         )
-        self.q_norm = Qwen3MoeRMSNorm(self.head_dim, eps=config.rms_norm_eps)  # unlike olmo, only on the head dim!
-        self.k_norm = Qwen3MoeRMSNorm(self.head_dim, eps=config.rms_norm_eps)  # thus post q_norm does not need reshape
+        self.q_norm = Qwen3MoeRMSNorm(
+            self.head_dim, eps=config.rms_norm_eps
+        )  # unlike olmo, only on the head dim!
+        self.k_norm = Qwen3MoeRMSNorm(
+            self.head_dim, eps=config.rms_norm_eps
+        )  # thus post q_norm does not need reshape
         self.sliding_window = getattr(config, "sliding_window", None)
 
     @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
@@ -161,21 +183,31 @@ class Qwen3MoeAttention(nn.Module):
         input_shape = hidden_states.shape[:-1]
         hidden_shape = (*input_shape, -1, self.head_dim)
 
-        query_states = self.q_norm(self.q_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
-        key_states = self.k_norm(self.k_proj(hidden_states).view(hidden_shape)).transpose(1, 2)
+        query_states = self.q_norm(
+            self.q_proj(hidden_states).view(hidden_shape)
+        ).transpose(1, 2)
+        key_states = self.k_norm(
+            self.k_proj(hidden_states).view(hidden_shape)
+        ).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
         cos, sin = position_embeddings
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+        query_states, key_states = apply_rotary_pos_emb(
+            query_states, key_states, cos, sin
+        )
 
         if past_key_values is not None:
             # sin and cos are specific to RoPE models; cache_position needed for the static cache
             cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
-            key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
 
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+            attention_interface = ALL_ATTENTION_FUNCTIONS[
+                self.config._attn_implementation
+            ]
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -199,7 +231,11 @@ class Qwen3MoeMLP(nn.Module):
         super().__init__()
         self.config = config
         self.hidden_size = config.hidden_size
-        self.intermediate_size = intermediate_size if intermediate_size is not None else config.intermediate_size
+        self.intermediate_size = (
+            intermediate_size
+            if intermediate_size is not None
+            else config.intermediate_size
+        )
         self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
         self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
@@ -224,26 +260,58 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
         # gating
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
-        self.experts = nn.ModuleList(
-            [Qwen3MoeMLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(self.num_experts)]
-        )
+        import os
+
+        if os.environ.get("USE_NEW_MOE", "false") == "false":
+            self.experts = nn.ModuleList(
+                [
+                    Qwen3MoeMLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(self.num_experts)
+                ]
+            )
+        else:
+            self.gate_proj = nn.Parameter(
+                torch.randn(
+                    self.num_experts,
+                    config.moe_intermediate_size,
+                    config.hidden_size,
+                ),
+                requires_grad=True,
+            )
+            self.up_proj = nn.Parameter(
+                torch.randn(
+                    self.num_experts,
+                    config.moe_intermediate_size,
+                    config.hidden_size,
+                ),
+                requires_grad=True,
+            )
+            self.down_proj = nn.Parameter(
+                torch.randn(
+                    self.num_experts,
+                    config.hidden_size,
+                    config.moe_intermediate_size,
+                ),
+                requires_grad=True,
+            )
 
         self.act_fn = ACT2FN[config.hidden_act]
 
     def moe_forward(self, x, num_tokens_per_expert):
-        import os
-
-        if not hasattr(self, "gate_proj") and os.environ.get("USE_NEW_MOE", "false") != "false":
-            setattr(self, "gate_proj", nn.Parameter(torch.stack([expert.gate_proj.weight for expert in self.experts])))
-            setattr(self, "up_proj", nn.Parameter(torch.stack([expert.up_proj.weight for expert in self.experts])))
-            setattr(self, "down_proj", nn.Parameter(torch.stack([expert.down_proj.weight for expert in self.experts])))
-            del self.experts
         offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
-        g = self.act_fn(torch._grouped_mm(x.bfloat16(), self.gate_proj.bfloat16().transpose(-2, -1), offs=offsets))
+        g = self.act_fn(
+            torch._grouped_mm(
+                x.bfloat16(), self.gate_proj.bfloat16().transpose(-2, -1), offs=offsets
+            )
+        )
 
-        g2 = g * torch._grouped_mm(x.bfloat16(), self.up_proj.bfloat16().transpose(-2, -1), offs=offsets)
+        g2 = g * torch._grouped_mm(
+            x.bfloat16(), self.up_proj.bfloat16().transpose(-2, -1), offs=offsets
+        )
 
-        out = torch._grouped_mm(g2, self.down_proj.bfloat16().transpose(-2, -1), offs=offsets).type_as(x)
+        out = torch._grouped_mm(
+            g2, self.down_proj.bfloat16().transpose(-2, -1), offs=offsets
+        ).type_as(x)
         return out
 
     def _reorder(self, routing_weights, selected_experts):
@@ -259,20 +327,31 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
         router_logits = self.gate(hidden_states)
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )
         if self.norm_topk_prob:  # only diff with mixtral sparse moe block!
             routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
 
-        tokens_per_expert = torch.histc(selected_experts.view(-1), bins=self.num_experts, min=0, max=self.num_experts)
+        tokens_per_expert = torch.histc(
+            selected_experts.view(-1),
+            bins=self.num_experts,
+            min=0,
+            max=self.num_experts,
+        )
 
-        sorted_routing_weights, sorted_selected_experts = self._reorder(routing_weights, selected_experts)
+        sorted_routing_weights, sorted_selected_experts = self._reorder(
+            routing_weights, selected_experts
+        )
 
         sorted_selected_experts = sorted_selected_experts.reshape(-1, 1).expand(-1, h)
 
         routed_input = torch.gather(hidden_states, dim=0, index=sorted_selected_experts)
 
         routed_output = self.moe_forward(routed_input, tokens_per_expert)
-        routed_output = routed_output * sorted_routing_weights.reshape(-1, 1).type_as(hidden_states)
+        routed_output = routed_output * sorted_routing_weights.reshape(-1, 1).type_as(
+            hidden_states
+        )
 
         out = torch.zeros_like(hidden_states)
 
@@ -294,19 +373,25 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
         router_logits = self.gate(hidden_states)
 
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )
         if self.norm_topk_prob:  # only diff with mixtral sparse moe block!
             routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         # we cast back to the input dtype
         routing_weights = routing_weights.to(hidden_states.dtype)
 
         final_hidden_states = torch.zeros(
-            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+            (batch_size * sequence_length, hidden_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
         )
 
         # One hot encode the selected experts to create an expert mask
         # this will be used to easily index which expert is going to be sollicitated
-        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+        expert_mask = torch.nn.functional.one_hot(
+            selected_experts, num_classes=self.num_experts
+        ).permute(2, 1, 0)
 
         # Loop over all available experts in the model and perform the computation on each expert
         expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -318,12 +403,18 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             # the current expert. We need to make sure to multiply the output hidden
             # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
             current_state = hidden_states[None, top_x].reshape(-1, hidden_dim)
-            current_hidden_states = expert_layer(current_state) * routing_weights[top_x, idx, None]
+            current_hidden_states = (
+                expert_layer(current_state) * routing_weights[top_x, idx, None]
+            )
 
             # However `index_add_` only support torch tensors for indexing so we'll use
             # the `top_x` tensor here.
-            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
-        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+            final_hidden_states.index_add_(
+                0, top_x, current_hidden_states.to(hidden_states.dtype)
+            )
+        final_hidden_states = final_hidden_states.reshape(
+            batch_size, sequence_length, hidden_dim
+        )
         return final_hidden_states, router_logits
 
 
@@ -362,8 +453,12 @@ class Qwen3MoeDecoderLayer(GradientCheckpointingLayer):
         else:
             self.mlp = Qwen3MoeMLP(config, intermediate_size=config.intermediate_size)
 
-        self.input_layernorm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_layernorm = Qwen3MoeRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.post_attention_layernorm = Qwen3MoeRMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
 
     @deprecate_kwarg("past_key_value", new_name="past_key_values", version="4.58")
     def forward(
@@ -435,7 +530,9 @@ class Qwen3MoeRotaryEmbedding(nn.Module):
         super().__init__()
         # BC: "rope_type" was originally "type"
         if hasattr(config, "rope_scaling") and isinstance(config.rope_scaling, dict):
-            self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+            self.rope_type = config.rope_scaling.get(
+                "rope_type", config.rope_scaling.get("type")
+            )
         else:
             self.rope_type = "default"
         self.max_seq_len_cached = config.max_position_embeddings
@@ -451,12 +548,23 @@ class Qwen3MoeRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None]
+            .float()
+            .expand(position_ids.shape[0], -1, 1)
+            .to(x.device)
+        )
         position_ids_expanded = position_ids[:, None, :].float()
 
-        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        device_type = (
+            x.device.type
+            if isinstance(x.device.type, str) and x.device.type != "mps"
+            else "cpu"
+        )
         with torch.autocast(device_type=device_type, enabled=False):  # Force float32
-            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            freqs = (
+                inv_freq_expanded.float() @ position_ids_expanded.float()
+            ).transpose(1, 2)
             emb = torch.cat((freqs, freqs), dim=-1)
             cos = emb.cos() * self.attention_scaling
             sin = emb.sin() * self.attention_scaling
@@ -490,9 +598,14 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size
 
-        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, self.padding_idx
+        )
         self.layers = nn.ModuleList(
-            [Qwen3MoeDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+            [
+                Qwen3MoeDecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
         )
         self.norm = Qwen3MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Qwen3MoeRotaryEmbedding(config=config)
@@ -515,7 +628,9 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
         **kwargs: Unpack[TransformersKwargs],
     ) -> MoeModelOutputWithPast:
         if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+            raise ValueError(
+                "You must specify exactly one of input_ids or inputs_embeds"
+            )
 
         if use_cache and past_key_values is None:
             past_key_values = DynamicCache(config=self.config)
@@ -524,14 +639,22 @@ class Qwen3MoeModel(Qwen3MoePreTrainedModel):
             inputs_embeds = self.embed_tokens(input_ids)
 
         if cache_position is None:
-            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
             cache_position = torch.arange(
-                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
             )
         if position_ids is None:
             position_ids = cache_position.unsqueeze(0)
 
-        mask_function = create_causal_mask if self.config.sliding_window is None else create_sliding_window_causal_mask
+        mask_function = (
+            create_causal_mask
+            if self.config.sliding_window is None
+            else create_sliding_window_causal_mask
+        )
         causal_mask = mask_function(
             config=self.config,
             input_embeds=inputs_embeds,
@@ -600,7 +723,9 @@ def load_balancing_loss_func(
 
     if isinstance(gate_logits, tuple):
         compute_device = gate_logits[0].device
-        concatenated_gate_logits = torch.cat([layer_gate.to(compute_device) for layer_gate in gate_logits], dim=0)
+        concatenated_gate_logits = torch.cat(
+            [layer_gate.to(compute_device) for layer_gate in gate_logits], dim=0
+        )
 
     routing_weights = torch.nn.functional.softmax(concatenated_gate_logits, dim=-1)
 
@@ -616,20 +741,24 @@ def load_balancing_loss_func(
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
     else:
         batch_size, sequence_length = attention_mask.shape
-        num_hidden_layers = concatenated_gate_logits.shape[0] // (batch_size * sequence_length)
+        num_hidden_layers = concatenated_gate_logits.shape[0] // (
+            batch_size * sequence_length
+        )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of expert_mask
         expert_attention_mask = (
             attention_mask[None, :, :, None, None]
-            .expand((num_hidden_layers, batch_size, sequence_length, top_k, num_experts))
+            .expand(
+                (num_hidden_layers, batch_size, sequence_length, top_k, num_experts)
+            )
             .reshape(-1, top_k, num_experts)
             .to(compute_device)
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
-        )
+        tokens_per_expert = torch.sum(
+            expert_mask.float() * expert_attention_mask, dim=0
+        ) / torch.sum(expert_attention_mask, dim=0)
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert
         router_per_expert_attention_mask = (
@@ -640,9 +769,9 @@ def load_balancing_loss_func(
         )
 
         # Compute the average probability of routing to these experts
-        router_prob_per_expert = torch.sum(routing_weights * router_per_expert_attention_mask, dim=0) / torch.sum(
-            router_per_expert_attention_mask, dim=0
-        )
+        router_prob_per_expert = torch.sum(
+            routing_weights * router_per_expert_attention_mask, dim=0
+        ) / torch.sum(router_per_expert_attention_mask, dim=0)
 
     overall_loss = torch.sum(tokens_per_expert * router_prob_per_expert.unsqueeze(0))
     return overall_loss * num_experts
@@ -712,7 +841,9 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         ```"""
 
         output_router_logits = (
-            output_router_logits if output_router_logits is not None else self.config.output_router_logits
+            output_router_logits
+            if output_router_logits is not None
+            else self.config.output_router_logits
         )
 
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
@@ -730,7 +861,11 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
 
         hidden_states = outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
-        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        slice_indices = (
+            slice(-logits_to_keep, None)
+            if isinstance(logits_to_keep, int)
+            else logits_to_keep
+        )
         logits = self.lm_head(hidden_states[:, slice_indices, :])
 
         loss = None
@@ -746,7 +881,9 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
                 attention_mask,
             )
             if labels is not None:
-                loss += self.router_aux_loss_coef * aux_loss.to(loss.device)  # make sure to reside in the same device
+                loss += self.router_aux_loss_coef * aux_loss.to(
+                    loss.device
+                )  # make sure to reside in the same device
 
         return MoeCausalLMOutputWithPast(
             loss=loss,
@@ -759,16 +896,24 @@ class Qwen3MoeForCausalLM(Qwen3MoePreTrainedModel, GenerationMixin):
         )
 
 
-class Qwen3MoeForSequenceClassification(GenericForSequenceClassification, Qwen3MoePreTrainedModel):
+class Qwen3MoeForSequenceClassification(
+    GenericForSequenceClassification, Qwen3MoePreTrainedModel
+):
     pass
 
 
-class Qwen3MoeForTokenClassification(GenericForTokenClassification, Qwen3MoePreTrainedModel):
+class Qwen3MoeForTokenClassification(
+    GenericForTokenClassification, Qwen3MoePreTrainedModel
+):
     pass
 
 
-class Qwen3MoeForQuestionAnswering(GenericForQuestionAnswering, Qwen3MoePreTrainedModel):
-    base_model_prefix = "transformer"  # For BC, where `transformer` was used instead of `model`
+class Qwen3MoeForQuestionAnswering(
+    GenericForQuestionAnswering, Qwen3MoePreTrainedModel
+):
+    base_model_prefix = (
+        "transformer"  # For BC, where `transformer` was used instead of `model`
+    )
 
 
 __all__ = [

--- a/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
@@ -74,31 +74,138 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
         # gating
         self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
-        self.experts = nn.ModuleList(
-            [Qwen3MoeMLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(self.num_experts)]
+        import os
+
+        if os.environ.get("USE_NEW_MOE", "false") == "false":
+            self.experts = nn.ModuleList(
+                [
+                    Qwen3MoeMLP(config, intermediate_size=config.moe_intermediate_size)
+                    for _ in range(self.num_experts)
+                ]
+            )
+        else:
+            self.gate_proj = nn.Parameter(
+                torch.randn(
+                    self.num_experts,
+                    config.moe_intermediate_size,
+                    config.hidden_size,
+                ),
+                requires_grad=True,
+            )
+            self.up_proj = nn.Parameter(
+                torch.randn(
+                    self.num_experts,
+                    config.moe_intermediate_size,
+                    config.hidden_size,
+                ),
+                requires_grad=True,
+            )
+            self.down_proj = nn.Parameter(
+                torch.randn(
+                    self.num_experts,
+                    config.hidden_size,
+                    config.moe_intermediate_size,
+                ),
+                requires_grad=True,
+            )
+
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def moe_forward(self, x, num_tokens_per_expert):
+        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
+        g = self.act_fn(
+            torch._grouped_mm(
+                x.bfloat16(), self.gate_proj.bfloat16().transpose(-2, -1), offs=offsets
+            )
         )
+
+        g2 = g * torch._grouped_mm(
+            x.bfloat16(), self.up_proj.bfloat16().transpose(-2, -1), offs=offsets
+        )
+
+        out = torch._grouped_mm(
+            g2, self.down_proj.bfloat16().transpose(-2, -1), offs=offsets
+        ).type_as(x)
+        return out
+
+    def _reorder(self, routing_weights, selected_experts):
+        tokens_sorted = torch.argsort(selected_experts.view(-1), stable=True)
+        sorted_routing_weights = routing_weights.view(-1)[tokens_sorted]
+        sorted_selected_experts = tokens_sorted // self.top_k
+
+        return sorted_routing_weights, sorted_selected_experts
+
+    def new_forward(self, hidden_states: torch.Tensor):
+        b, s, h = hidden_states.shape
+        hidden_states = hidden_states.view(-1, h)
+
+        router_logits = self.gate(hidden_states)
+        routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )
+        if self.norm_topk_prob:  # only diff with mixtral sparse moe block!
+            routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
+
+        tokens_per_expert = torch.histc(
+            selected_experts.view(-1),
+            bins=self.num_experts,
+            min=0,
+            max=self.num_experts,
+        )
+
+        sorted_routing_weights, sorted_selected_experts = self._reorder(
+            routing_weights, selected_experts
+        )
+
+        sorted_selected_experts = sorted_selected_experts.reshape(-1, 1).expand(-1, h)
+
+        routed_input = torch.gather(hidden_states, dim=0, index=sorted_selected_experts)
+
+        routed_output = self.moe_forward(routed_input, tokens_per_expert)
+        routed_output = routed_output * sorted_routing_weights.reshape(-1, 1).type_as(
+            hidden_states
+        )
+
+        out = torch.zeros_like(hidden_states)
+
+        out = out.scatter_add(dim=0, index=sorted_selected_experts, src=routed_output)
+        out = out.reshape(b, s, h)
+
+        return out, router_logits
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         """ """
+        import os
+
+        if os.environ.get("USE_NEW_MOE", "false") != "false":
+            return self.new_forward(hidden_states)
+
         batch_size, sequence_length, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
         # router_logits: (batch * sequence_length, n_experts)
         router_logits = self.gate(hidden_states)
 
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
-        routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
+        routing_weights, selected_experts = torch.topk(
+            routing_weights, self.top_k, dim=-1
+        )
         if self.norm_topk_prob:  # only diff with mixtral sparse moe block!
             routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
         # we cast back to the input dtype
         routing_weights = routing_weights.to(hidden_states.dtype)
 
         final_hidden_states = torch.zeros(
-            (batch_size * sequence_length, hidden_dim), dtype=hidden_states.dtype, device=hidden_states.device
+            (batch_size * sequence_length, hidden_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
         )
 
         # One hot encode the selected experts to create an expert mask
         # this will be used to easily index which expert is going to be sollicitated
-        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
+        expert_mask = torch.nn.functional.one_hot(
+            selected_experts, num_classes=self.num_experts
+        ).permute(2, 1, 0)
 
         # Loop over all available experts in the model and perform the computation on each expert
         expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
@@ -110,12 +217,18 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             # the current expert. We need to make sure to multiply the output hidden
             # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
             current_state = hidden_states[None, top_x].reshape(-1, hidden_dim)
-            current_hidden_states = expert_layer(current_state) * routing_weights[top_x, idx, None]
+            current_hidden_states = (
+                expert_layer(current_state) * routing_weights[top_x, idx, None]
+            )
 
             # However `index_add_` only support torch tensors for indexing so we'll use
             # the `top_x` tensor here.
-            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
-        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+            final_hidden_states.index_add_(
+                0, top_x, current_hidden_states.to(hidden_states.dtype)
+            )
+        final_hidden_states = final_hidden_states.reshape(
+            batch_size, sequence_length, hidden_dim
+        )
         return final_hidden_states, router_logits
 
 

--- a/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
@@ -70,207 +70,78 @@ class Qwen3MoeMLP(nn.Module):
         return down_proj
 
 
+class Qwen3MoeExperts(nn.Module):
+    """
+    Module responsible for multiplying tokens by expert weights. Nothing else.
+    """
+    def __init__(self, config):
+        super().__init__()
+        self.gate_proj = nn.Parameter(
+            torch.empty(
+                config.num_experts,
+                config.moe_intermediate_size,
+                config.hidden_size,
+            )
+        )
+        self.up_proj = nn.Parameter(
+            torch.empty(
+                config.num_experts,
+                config.moe_intermediate_size,
+                config.hidden_size,
+            )
+        )
+        self.down_proj = nn.Parameter(
+            torch.empty(
+                config.num_experts,
+                config.hidden_size,
+                config.moe_intermediate_size,
+            )
+        )
+        self._use_grouped_gemm = os.environ.get("USE_GROUPED_MM", "true") == "true"
+
+    def forward(self, *args):
+        if self._use_grouped_gemm:
+            return self._grouped_gemm_forward(*args)
+        else:
+            return self._for_loop_forward(*args)
+
+    def _for_loop_forward(self, x, num_tokens_per_expert):
+        B, S, H = x.shape
+
+
+
 class Qwen3MoeSparseMoeBlock(nn.Module):
     def __init__(self, config):
         super().__init__()
-        self.num_experts = config.num_experts
+        self.experts = Qwen3MoeExperts(config)
+        self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
         self.top_k = config.num_experts_per_tok
-        self.norm_topk_prob = config.norm_topk_prob
-
-        if os.environ.get("USE_NEW_MOE", "false") == "false":
-            self.gate = nn.Linear(config.hidden_size, config.num_experts, bias=False)
-            self.experts = nn.ModuleList(
-                [Qwen3MoeMLP(config, intermediate_size=config.moe_intermediate_size) for _ in range(self.num_experts)]
-            )
-        else:
-            self.gate_proj = nn.Parameter(
-                torch.empty(
-                    self.num_experts,
-                    config.moe_intermediate_size,
-                    config.hidden_size,
-                ),
-                requires_grad=True,
-            )
-            self.up_proj = nn.Parameter(
-                torch.empty(
-                    self.num_experts,
-                    config.moe_intermediate_size,
-                    config.hidden_size,
-                ),
-                requires_grad=True,
-            )
-            self.down_proj = nn.Parameter(
-                torch.empty(
-                    self.num_experts,
-                    config.hidden_size,
-                    config.moe_intermediate_size,
-                ),
-                requires_grad=True,
-            )
-
         self.act_fn = ACT2FN[config.hidden_act]
 
-    def _fill_indices_cpu(
-        self,
-        tokens_per_expert_group: torch.Tensor,
-        start_index_values: torch.Tensor,
-        write_offsets: torch.Tensor,
-        experts_per_rank: int,
-        num_ranks: int,
-        max_len: int,
-    ):
-        # We need to preallocate the output - we ignore device and force it on cpu
-        # device = tokens_per_expert_group.device
-        permuted_indices = torch.full(
-            (max_len,),
-            -1,
-            dtype=torch.int32,
-        )  # device=device)
-        # Fill the permuted indices
-        # For each local expert
-        for e in range(experts_per_rank):
-            write_start = write_offsets[e].item()
-            # For each remote rank
-            for r in range(num_ranks):
-                i = r * experts_per_rank + e
-                start_index = start_index_values[i].item()
-                length = tokens_per_expert_group[i].item()
-                # Fill in the indices
-                if length > 0:
-                    end_idx = min(write_start + length, max_len)
-                    permuted_indices[write_start:end_idx] = torch.arange(
-                        start_index,
-                        start_index + (end_idx - write_start),
-                        dtype=torch.int32,
-                        # device=device,
-                    )
-                write_start += length
-        return permuted_indices
+        self.norm_topk_prob = config.norm_topk_prob
+        self.num_experts = config.num_experts
 
-    def _generate_permute_indices(
-        self,
-        tokens_per_expert_group: torch.Tensor,
-        experts_per_rank: int,
-        num_ranks: int,
-        max_len: int,
-        alignment: int,
-    ):
-        start_index_values = torch.cumsum(tokens_per_expert_group, 0) - tokens_per_expert_group
-
-        # chunk sizes for each expert
-        chunk_size_per_expert = tokens_per_expert_group.view(num_ranks, -1).sum(0)
-
-        # align the chunk sizes (cdiv)
-        m_sizes = ((chunk_size_per_expert + alignment - 1) // alignment * alignment).to(torch.int32)
-
-        # additional prefix sum to get write offset of each expert in permuted_indices
-        # write offsets is per local expert, not global
-        write_offsets = torch.cumsum(m_sizes, 0) - m_sizes
-
-        permuted_indices = self._fill_indices_cpu(
-            tokens_per_expert_group,
-            start_index_values,
-            write_offsets,
-            experts_per_rank,
-            num_ranks,
-            max_len,
-        )
-        return permuted_indices, m_sizes
-
-    def moe_forward(self, x, num_tokens_per_expert):
-
-        num_ep_ranks = int(os.environ.get("EP_SIZE", 1))
-        experts_per_ep_rank = self.num_experts // num_ep_ranks
-
-        gate_proj, up_proj, down_proj = self.gate_proj, self.up_proj, self.down_proj
-
-        if isinstance(self.gate_proj, torch.distributed.tensor.DTensor):
-            gate_proj = self.gate_proj.to_local()
-            up_proj = self.up_proj.to_local()
-            down_proj = self.down_proj.to_local()
-
-        with torch.no_grad():
-            permuted_indices, num_tokens_per_expert = self._generate_permute_indices(
-                num_tokens_per_expert,
-                experts_per_ep_rank,
-                num_ep_ranks,
-                x.shape[0] + experts_per_ep_rank * 16,
-                16,
-            )
-        x = torch.vstack((x, x.new_zeros((x.shape[-1]))))
-        input_shape = x.shape
-        x = x[permuted_indices, :]
-
-        offsets = torch.cumsum(num_tokens_per_expert, dim=0, dtype=torch.int32)
-        g = self.act_fn(torch._grouped_mm(x.bfloat16(), gate_proj.bfloat16().transpose(-2, -1), offs=offsets))
-
-        g2 = g * torch._grouped_mm(x.bfloat16(), up_proj.bfloat16().transpose(-2, -1), offs=offsets)
-
-        out = torch._grouped_mm(g2, down_proj.bfloat16().transpose(-2, -1), offs=offsets).type_as(x)
-
-        out_unpermuted = out.new_empty(input_shape)
-        out_unpermuted[permuted_indices, :] = out
-        out = out_unpermuted[:-1]
-
-        return out
-
-    def _reorder(self, routing_weights, selected_experts):
-        tokens_sorted = torch.argsort(selected_experts.view(-1), stable=True)
-        sorted_routing_weights = routing_weights.view(-1)[tokens_sorted]
-        sorted_selected_experts = tokens_sorted // self.top_k
-
-        return sorted_routing_weights, sorted_selected_experts
-
-    def new_forward(self, routed_input: torch.Tensor, tokens_per_expert: torch.Tensor):
-        routed_output = self.moe_forward(routed_input, tokens_per_expert)
-        return routed_output
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        """ """
-        import os
-
-        if os.environ.get("USE_NEW_MOE", "false") != "false":
-            return self.new_forward(hidden_states)
-
-        batch_size, sequence_length, hidden_dim = hidden_states.shape
-        hidden_states = hidden_states.view(-1, hidden_dim)
+        B, S, H = hidden_states.shape
+        hidden_states = hidden_states.view(-1, H)
         # router_logits: (batch * sequence_length, n_experts)
         router_logits = self.gate(hidden_states)
 
         routing_weights = F.softmax(router_logits, dim=1, dtype=torch.float)
         routing_weights, selected_experts = torch.topk(routing_weights, self.top_k, dim=-1)
-        if self.norm_topk_prob:  # only diff with mixtral sparse moe block!
+
+        if self.norm_topk_prob:
             routing_weights /= routing_weights.sum(dim=-1, keepdim=True)
-        # we cast back to the input dtype
-        routing_weights = routing_weights.to(hidden_states.dtype)
 
-        final_hidden_states = torch.zeros(
-            (batch_size * sequence_length, hidden_dim),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
+        tokens_per_expert = torch.histc(
+            selected_experts.view(-1),
+            bins=self.num_experts,
+            min=0,
+            max=self.num_experts,
         )
+        pass
 
-        # One hot encode the selected experts to create an expert mask
-        # this will be used to easily index which expert is going to be sollicitated
-        expert_mask = torch.nn.functional.one_hot(selected_experts, num_classes=self.num_experts).permute(2, 1, 0)
-
-        # Loop over all available experts in the model and perform the computation on each expert
-        expert_hit = torch.greater(expert_mask.sum(dim=(-1, -2)), 0).nonzero()
-        for expert_idx in expert_hit:
-            expert_layer = self.experts[expert_idx]
-            idx, top_x = torch.where(expert_mask[expert_idx].squeeze(0))
-
-            # Index the correct hidden states and compute the expert hidden state for
-            # the current expert. We need to make sure to multiply the output hidden
-            # states by `routing_weights` on the corresponding tokens (top-1 and top-2)
-            current_state = hidden_states[None, top_x].reshape(-1, hidden_dim)
-            current_hidden_states = expert_layer(current_state) * routing_weights[top_x, idx, None]
-
-            # However `index_add_` only support torch tensors for indexing so we'll use
-            # the `top_x` tensor here.
-            final_hidden_states.index_add_(0, top_x, current_hidden_states.to(hidden_states.dtype))
-        final_hidden_states = final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
-        return final_hidden_states, router_logits
 
 
 class Qwen3MoeRMSNorm(LlamaRMSNorm):
@@ -329,6 +200,7 @@ class Qwen3MoeDecoderLayer(Qwen2MoeDecoderLayer, nn.Module):
         hidden_states = self.post_attention_layernorm(hidden_states)
 
         if os.environ.get("USE_NEW_MOE", "false") != "false":
+            # hidden_states = self.mlp(hidden_states)
             b, s, h = hidden_states.shape
             hidden_states = hidden_states.view(-1, h)
 


### PR DESCRIPTION
```python
class Ep2DpParallel(ParallelStyle):
    def __init__(self):
        super().__init__()
        self._num_tokens_to_send = None
        self._num_tokens_to_recv = None
        self._reshuffle_indices = None
        self._reshuffled_counts = None

    def _token_dispatch(self, mod, inputs, device_mesh):
        routed_input, num_tokens_per_expert = inputs
        ep_size = device_mesh.shape[0]

        # num_tokens_per_expert is of shape (num_experts, ), where each element holds the amount of tokens for
        # the corresponding expert from the local rank
        with torch.no_grad():
            # we transpose num_tokens_per_expert on device_mesh ep axis, to get the number of tokens for the local rank
            # think of all2all as a transpose operation on the device mesh
            # grouped_tokens_per_rank is of shape (ep_size * num_experts_per_rank,)
            # such as:
            # [#tokens for local expert 0 from EP rank 0, #tokens for local expert 1 from EP rank 0, ..., # tokens for local expert n from EP rank 0, ...]
            grouped_tokens_per_rank = all_to_all_single(
                num_tokens_per_expert,
                None,
                None,
                group=device_mesh.get_group(),
            )

            # this is of shape (ep_size, )
            # [#tokens for rank 0, #tokens for rank 1, ...]
            num_tokens_to_send = (
                num_tokens_per_expert.view(ep_size, -1)
                .sum(dim=1)
                .to(torch.device("cpu"), non_blocking=True)
            )

            # this is of shape (ep_size, )
            # [#tokens from rank 0, #tokens from rank 1, ...]
            num_tokens_to_recv = (
                grouped_tokens_per_rank.view(ep_size, -1)
                .sum(dim=1)
                .to(torch.device("cpu"), non_blocking=False)
            )
            self._num_tokens_to_send = num_tokens_to_send.tolist()
            self._num_tokens_to_recv = num_tokens_to_recv.tolist()

        # perform all-to-all to send the tokens to the right ranks
        routed_input = all_to_all_single_autograd(
            routed_input,
            self._num_tokens_to_recv,
            self._num_tokens_to_send,
            device_mesh.get_group(),
        )

        # routed input is not sorted by expert anymore, rather looks like:
        # [tokens for local expert 0 from EP rank 0, tokens for local expert 0 from EP rank 1, ..., tokens for local expert 0 from EP rank n, ...]
        # this needs to be reshuffled back
        # same applies to grouped_tokens_per_rank
        # [#tokens for local expert 0 from EP rank 0, #tokens for local expert 0 from EP rank 1, ..., # tokens for local expert 0 from EP rank n, ...]
        return routed_input, grouped_tokens_per_rank

    @staticmethod
    def _partition_fn(name, mod, device_mesh):
        # shard on the expert dimension
        for name, param in mod.named_parameters(recurse=False):
            dist_param = nn.Parameter(distribute_tensor(param, device_mesh, [Shard(0)]))
            mod.register_parameter(name, dist_param)

    def _token_combine(self, mod, routed_output, device_mesh):
        # reverse all-to-all from dispatch
        routed_output = all_to_all_single_autograd(
            routed_output,
            self._num_tokens_to_send,
            self._num_tokens_to_recv,
            device_mesh.get_group(),
        )
        return routed_output

    def _apply(self, module: nn.Module, device_mesh: DeviceMesh) -> nn.Module:
        return distribute_module(
            module,
            device_mesh,
            partition_fn=Ep2DpParallel._partition_fn,
            input_fn=self._token_dispatch,
            output_fn=self._token_combine,
        )


        
        ```