### PR TITLE
Fix CI jobs being all red 🔴 (false positive)

### DIFF
--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -141,8 +141,8 @@ jobs:
           script -q -c "PATCH_TESTING_METHODS_TO_COLLECT_OUTPUTS=yes _PATCHED_TESTING_METHODS_OUTPUT_DIR=/transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports python3 -m pytest -rsfE -v --make-reports=${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports tests/${{ matrix.folders }}" test_outputs.txt
           ls -la
           # Extract the exit code from the output file
-          PYTEST_EXIT_CODE=$(tail -1 test_outputs.txt | grep "PYTEST_EXIT_CODE:" | cut -d: -f2)
-          exit ${PYTEST_EXIT_CODE:-1}
+          EXIT_CODE=$(tail -1 test_outputs.txt | grep -o 'COMMAND_EXIT_CODE="[0-9]*"' | cut -d'"' -f2)
+          exit ${EXIT_CODE:-1}
 
       - name: Failure short reports
         if: ${{ failure() }}


### PR DESCRIPTION
# What does this PR do?

In my previous PR #40981, there is an issue. When checking `tests_output.txt` produced by running `pytest` with `script` command, we should search instead  `COMMAND_EXIT_CODE` of `PYTEST_EXIT_CODE`.

In the previous PR, I did run the workflow, but I ran it with a job that is know to fail, so I didn't realize the problem.

For a job that has no failure, because there is no `PYTEST_EXIT_CODE` in `tests_output.txt` and the exit code inferred is wrong, cause the job being red.

See https://github.com/huggingface/transformers/actions/runs/17874224681 for example.

This PR fix this target name issue.