### PR TITLE
Simplify and improve model loading logic

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -64,8 +64,7 @@ NOT_DEVICE_TESTS = {
     "test_load_save_without_tied_weights",
     "test_tied_weights_keys",
     "test_model_weights_reload_no_missing_tied_weights",
-    "test_mismatched_shapes_have_properly_initialized_weights",
-    "test_matched_shapes_have_loaded_weights_when_some_mismatched_shapes_exist",
+    "test_can_load_ignoring_mismatched_shapes",
     "test_model_is_small",
     "ModelTest::test_pipeline_",  # None of the pipeline tests from PipelineTesterMixin (of which XxxModelTest inherits from) are running on device
     "ModelTester::test_pipeline_",

--- a/examples/quantization/custom_quantization_int8_example.py
+++ b/examples/quantization/custom_quantization_int8_example.py
@@ -187,7 +187,6 @@ class Int8SymmetricQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         """
         Quantizes weights to INT8 symmetric format.

--- a/examples/quantization/custom_quantization_int8_example.py
+++ b/examples/quantization/custom_quantization_int8_example.py
@@ -159,7 +159,7 @@ class Int8SymmetricQuantizer(HfQuantizer):
             pre_quantized=self.pre_quantized,
         )
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model,
         param_value: "torch.Tensor",

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5315,7 +5315,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         model._move_missing_keys_from_meta_to_cpu(missing_keys + mismatched_keys, dtype, hf_quantizer)
 
         # correctly initialize the missing (and potentially mismatched) keys
-        model._initialize_missing_keys(checkpoint_keys, ignore_mismatched_sizes, is_quantized)
+        model._initialize_missing_keys(missing_keys + mismatched_keys, is_quantized)
 
         # Set some modules to fp32 if needed
         if keep_in_fp32_regex is not None:
@@ -5853,11 +5853,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 else:
                     hf_quantizer.create_quantized_param(self, value, key, "cpu", model_state_dict)
 
-    def _initialize_missing_keys(
-        self,
-        missing_keys: list[str],
-        is_quantized: bool,
-    ) -> "PreTrainedModel":
+    def _initialize_missing_keys(self, missing_keys: list[str], is_quantized: bool) -> None:
         """Initialize the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts), according to
         `_initialize_weights`. Indeed, since the corresponding weights are missing from the state dict, they will not be replaced and need to
         be initialized correctly (i.e. weight initialization distribution).

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1389,7 +1389,6 @@ def _find_missing_and_unexpected_keys(
 
     if hf_quantizer is not None:
         missing_keys = hf_quantizer.update_missing_keys(model, missing_keys, prefix)
-        unexpected_keys = hf_quantizer.update_unexpected_keys(model, unexpected_keys, prefix)
 
     return missing_keys, unexpected_keys
 
@@ -4951,14 +4950,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             torch.set_default_dtype(dtype_orig)
 
         # Finalize model weight initialization
-        (
-            model,
-            missing_keys,
-            unexpected_keys,
-            mismatched_keys,
-            offload_index,
-            error_msgs,
-        ) = cls._load_pretrained_model(
+        model, missing_keys, unexpected_keys, mismatched_keys, offload_index, error_msgs = cls._load_pretrained_model(
             model,
             state_dict,
             checkpoint_files,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2951,7 +2951,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             and all(
                 getattr(buffer, "_is_hf_initialized", False)
                 for buffer in module.buffers(recurse=False)
-                if buffer.is_persistent
+                if buffer not in module._non_persistent_buffers_set
             )
         ):
             # Mark the module itself as initialized so that higher modules in the graph see it

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5177,7 +5177,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # In this case, we need to add the prefix to the keys, to match them to the expected keys
             if loading_task_model_from_base_state_dict:
                 # small sanity check: if a key has the same name as a task-specific key, it's ambiguous and we raise
-                # (we cannot which key it refers to, the one from base model or the one from task-specific?)
+                # (we cannot know which key it refers to, the one from base model or the one from task-specific?)
                 if new_key in task_specific_expected_keys:
                     raise ValueError(
                         "The state dictionary of the model you are trying to load is corrupted. Are you sure it was "

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5808,8 +5808,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         return cls._supports_attention_backend
 
     def _move_missing_keys_from_meta_to_cpu(
-        self, missing_keys: list[str], dtype: Optional[torch.dtype], hf_quantizer: Optional[HfQuantizer]
-    ) -> "PreTrainedModel":
+        self, missing_keys: list[str], dtype: torch.dtype, hf_quantizer: Optional[HfQuantizer]
+    ) -> None:
         """Move the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts) back
         from meta device to cpu.
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5389,9 +5389,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             save_offload_index(disk_offload_index, disk_offload_folder)
             disk_offload_index = None
 
-        if hf_quantizer is not None:
-            missing_keys = hf_quantizer.update_missing_keys_after_loading(model, missing_keys, prefix)
-
         # Post-processing for tensor parallelism
         if device_mesh is not None:
             # When using TP, the device map is a single device for all parameters

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5318,7 +5318,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         # Move missing (and potentially mismatched) keys back to cpu from meta device (because they won't be moved when
         # loading the weights as they are not in the loaded state dict)
-        model._move_missing_keys_from_meta_to_cpu(missing_keys + mismatched_keys, unexpected_keys, dtype, hf_quantizer)
+        model._move_missing_keys_from_meta_to_cpu(missing_keys + mismatched_keys, dtype, hf_quantizer)
 
         # correctly initialize the missing (and potentially mismatched) keys
         model._initialize_missing_keys(checkpoint_keys, ignore_mismatched_sizes, is_quantized)
@@ -5829,10 +5829,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         return cls._supports_attention_backend
 
     def _move_missing_keys_from_meta_to_cpu(
-        self,
-        missing_keys: list[str],
-        dtype: Optional[torch.dtype],
-        hf_quantizer: Optional[HfQuantizer],
+        self, missing_keys: list[str], dtype: Optional[torch.dtype], hf_quantizer: Optional[HfQuantizer]
     ) -> "PreTrainedModel":
         """Move the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts) back
         from meta device to cpu.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -711,7 +711,6 @@ def _load_state_dict_into_meta_model(
     hf_quantizer: Optional[HfQuantizer] = None,
     is_safetensors: bool = False,
     keep_in_fp32_regex: Optional[re.Pattern] = None,
-    unexpected_keys: Optional[list[str]] = None,  # passing `unexpected` for cleanup from quantization items
     device_mesh: Optional["torch.distributed.device_mesh.DeviceMesh"] = None,
 ) -> tuple[Optional[dict], Optional[dict]]:
     """Load parameters from `meta_state_dict` into the model. The parameters of the `meta_state_dict` are on the meta
@@ -791,7 +790,6 @@ def _load_state_dict_into_meta_model(
                     param_name,
                     device_mesh.get_local_rank(),
                     state_dict,
-                    unexpected_keys,
                     **sharding_kwargs,
                 )
         else:
@@ -836,9 +834,7 @@ def _load_state_dict_into_meta_model(
 
             else:
                 # TODO naming is stupid it loads it as well
-                hf_quantizer.create_quantized_param(
-                    model, param, param_name, param_device, state_dict, unexpected_keys
-                )
+                hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict)
 
                 # For quantized modules with FSDP/DeepSpeed Stage 3, we need to quantize the parameter on the GPU
                 # and then cast it to CPU to avoid excessive memory usage on each GPU
@@ -887,7 +883,6 @@ def load_shard_file(args):
         cpu_offload_index,
         is_offloaded_safetensors,
         keep_in_fp32_regex,
-        unexpected_keys,
         device_mesh,
     ) = args
 
@@ -949,7 +944,6 @@ def load_shard_file(args):
             hf_quantizer=hf_quantizer,
             is_safetensors=is_offloaded_safetensors,
             keep_in_fp32_regex=keep_in_fp32_regex,
-            unexpected_keys=unexpected_keys,
             device_mesh=device_mesh,
         )
 
@@ -5455,7 +5449,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 cpu_offload_index,
                 is_offloaded_safetensors,
                 keep_in_fp32_regex,
-                unexpected_keys,
                 device_mesh,
             )
             for shard_file in checkpoint_files
@@ -5838,7 +5831,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
     def _move_missing_keys_from_meta_to_cpu(
         self,
         missing_keys: list[str],
-        unexpected_keys: list[str],
         dtype: Optional[torch.dtype],
         hf_quantizer: Optional[HfQuantizer],
     ) -> "PreTrainedModel":
@@ -5868,7 +5860,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 ):
                     _load_parameter_into_model(self, key, value)
                 else:
-                    hf_quantizer.create_quantized_param(self, value, key, "cpu", model_state_dict, unexpected_keys)
+                    hf_quantizer.create_quantized_param(self, value, key, "cpu", model_state_dict)
 
     def _initialize_missing_keys(
         self,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5769,13 +5769,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """
         ignore_missing_regex, ignore_unexpected_regex = None, None
         if self._keys_to_ignore_on_load_missing is not None:
-            ignore_missing_regex = re.compile(
-                "|".join(rf"({re.escape(pattern)})" for pattern in self._keys_to_ignore_on_load_missing)
-            )
+            ignore_missing_regex = re.compile("|".join(rf"({p})" for p in self._keys_to_ignore_on_load_missing))
         if self._keys_to_ignore_on_load_unexpected is not None:
-            ignore_unexpected_regex = re.compile(
-                "|".join(rf"({re.escape(pattern)})" for pattern in self._keys_to_ignore_on_load_unexpected)
-            )
+            ignore_unexpected_regex = re.compile("|".join(rf"({p})" for p in self._keys_to_ignore_on_load_unexpected))
 
         # Clean-up missing keys
         true_missing_keys = missing_keys

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5774,7 +5774,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         additional_unexpected_patterns = [r"rotary_emb\.inv_freq"] if has_inv_freq_buffers else []
 
         missing_patterns = self._keys_to_ignore_on_load_missing or []
-        unexpected_patterns = self._keys_to_ignore_on_load_unexpected or [] + additional_unexpected_patterns
+        unexpected_patterns = (self._keys_to_ignore_on_load_unexpected or []) + additional_unexpected_patterns
         ignore_missing_regex, ignore_unexpected_regex = None, None
         if len(missing_patterns) > 0:
             ignore_missing_regex = re.compile("|".join(rf"({pattern})" for pattern in missing_patterns))

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5786,7 +5786,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             missing_keys = [key for key in missing_keys if ignore_missing_regex.search(key) is None]
 
         # Clean-up unexpected keys
-        if ignore_missing_regex is not None:
+        if ignore_unexpected_regex is not None:
             unexpected_keys = [key for key in unexpected_keys if ignore_unexpected_regex.search(key) is None]
 
         # Note: only the unexpected keys should remove the added prefix here, to correctly display the original name

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -870,13 +870,12 @@ def load_shard_file(args):
 
     # Fix the key names
     state_dict = {key_renaming_mapping[k]: v for k, v in state_dict.items() if k in key_renaming_mapping}
-    metadata = None
-    if shard_file.endswith(".safetensors") and is_safetensors_available():
-        with safe_open(shard_file, framework="pt") as f:
-            metadata = f.metadata()
 
-    if hf_quantizer:
-        state_dict = hf_quantizer.update_state_dict_with_metadata(state_dict, metadata)
+    if hf_quantizer is not None and hf_quantizer.quantization_config.quant_method == QuantizationMethod.TORCHAO:
+        if shard_file.endswith(".safetensors") and is_safetensors_available():
+            with safe_open(shard_file, framework="pt") as f:
+                metadata = f.metadata()
+            state_dict = hf_quantizer.update_state_dict_with_metadata(state_dict, metadata)
 
     error_msgs = []
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2942,9 +2942,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """
         Initialize the weights if they are not already initialized.
         """
-        # Since this is applied recursively in a depth-first manner, a module is already initialized if and only if
-        # all its children are also already initialized, and all its immediate `nn.Parameter` and persistent buffers
-        # are also already initialized
         if getattr(module, "_is_hf_initialized", False):
             return
         self._init_weights(module)

--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -911,7 +911,7 @@ class DebertaV2OnlyMLMHead(nn.Module):
 @auto_docstring
 class DebertaV2ForMaskedLM(DebertaV2PreTrainedModel):
     _tied_weights_keys = ["cls.predictions.decoder.weight", "cls.predictions.decoder.bias"]
-    _keys_to_ignore_on_load_unexpected = r"mask_predictions.*"
+    _keys_to_ignore_on_load_unexpected = [r"mask_predictions.*"]
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -128,16 +128,6 @@ class HfQuantizer(ABC):
         """
         return missing_keys
 
-    def update_unexpected_keys(self, model, unexpected_keys: list[str], prefix: str) -> list[str]:
-        """
-        Override this method if you want to adjust the `unexpected_keys`.
-
-        Args:
-            unexpected_keys (`list[str]`, *optional*):
-                The list of unexpected keys in the checkpoint compared to the state dict of the model
-        """
-        return unexpected_keys
-
     def update_expected_keys(self, model, expected_keys: list[str], loaded_keys: list[str]) -> list[str]:
         """
         Override this method if you want to adjust the `update_expected_keys`.

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -169,14 +169,7 @@ class HfQuantizer(ABC):
         )
         return self.param_needs_quantization(*args, **kwargs)
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         """
         Check whether a given param needs quantization as defined by `create_quantized_param`.
         """

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -182,7 +182,7 @@ class HfQuantizer(ABC):
         """adjust max_memory argument for infer_auto_device_map() if extra memory is needed for quantization"""
         return max_memory
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",
@@ -191,9 +191,7 @@ class HfQuantizer(ABC):
         **kwargs,
     ) -> bool:
         """
-        checks if a loaded state_dict component is part of quantized param + some validation; only defined if
-        requires_parameters_quantization == True for quantization methods that require to create a new parameters
-        for quantization.
+        Check whether a given param needs quantization as defined by `create_quantized_param`.
         """
         return False
 

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -138,17 +138,6 @@ class HfQuantizer(ABC):
         """
         return unexpected_keys
 
-    def update_missing_keys_after_loading(self, model, missing_keys: list[str], prefix: str) -> list[str]:
-        """
-        Override this method if you want to adjust the `missing_keys` after loading the model params,
-        but before the model is post-processed.
-
-        Args:
-            missing_keys (`list[str]`, *optional*):
-                The list of missing keys in the checkpoint compared to the state dict of the model
-        """
-        return missing_keys
-
     def update_expected_keys(self, model, expected_keys: list[str], loaded_keys: list[str]) -> list[str]:
         """
         Override this method if you want to adjust the `update_expected_keys`.

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -171,6 +171,14 @@ class HfQuantizer(ABC):
         """adjust max_memory argument for infer_auto_device_map() if extra memory is needed for quantization"""
         return max_memory
 
+    def check_quantized_param(self, *args, **kwargs) -> bool:
+        """DEPRECATED -> remove in v5"""
+        logger.warning_once(
+            "`check_quantized_param` is deprecated in favor of `param_needs_quantization`, which is a much "
+            "more self.explanatory name for what the method achieves. It will be removed in v5"
+        )
+        return self.param_needs_quantization(*args, **kwargs)
+
     def param_needs_quantization(
         self,
         model: "PreTrainedModel",

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -160,7 +160,6 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         """
         combines logic from _load_state_dict_into_meta_model and .integrations.bitsandbytes.py::set_module_quantized_tensor_to_device()
@@ -218,8 +217,6 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             for k, v in state_dict.items():
                 if param_name + "." in k:
                     quantized_stats[k] = v
-                    if unexpected_keys is not None and k in unexpected_keys:
-                        unexpected_keys.remove(k)
 
             param_kwargs = {}
             if self.is_bnb_supports_quant_storage_module:

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -238,6 +238,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                 new_value = new_value.T
 
             kwargs = old_value.__dict__
+            kwargs.pop("_is_hf_initialized", None)
             new_value = bnb.nn.Params4bit(new_value, requires_grad=False, **kwargs).to(target_device)
 
         module._parameters[tensor_name] = new_value

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -132,7 +132,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                 "calculation. You may encounter unexpected behavior, or pass your own device map"
             )
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -226,6 +226,7 @@ class Bnb8BitHfQuantizer(HfQuantizer):
                 new_value = new_value.T
 
         kwargs = old_value.__dict__
+        kwargs.pop("_is_hf_initialized", None)
         new_value = bnb.nn.Int8Params(new_value, requires_grad=False, **kwargs).to(target_device)
 
         module._parameters[tensor_name] = new_value

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -158,7 +158,7 @@ class Bnb8BitHfQuantizer(HfQuantizer):
             logger.info("target_dtype {target_dtype} is replaced by `torch.int8` for 8-bit BnB quantization")
         return torch.int8
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_eetq.py
+++ b/src/transformers/quantizers/quantizer_eetq.py
@@ -130,7 +130,6 @@ class EetqHfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         """
         quantizes weights into qweight and weight_scales

--- a/src/transformers/quantizers/quantizer_eetq.py
+++ b/src/transformers/quantizers/quantizer_eetq.py
@@ -100,7 +100,7 @@ class EetqHfQuantizer(HfQuantizer):
             logger.info("We suggest you to set `dtype=torch.float16` for better efficiency with EETQ.")
         return dtype
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_fbgemm_fp8.py
+++ b/src/transformers/quantizers/quantizer_fbgemm_fp8.py
@@ -142,7 +142,6 @@ class FbgemmFp8HfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         """
         Quantizes weights into weight and weight_scale
@@ -194,8 +193,6 @@ class FbgemmFp8HfQuantizer(HfQuantizer):
 
         module._parameters[tensor_name] = torch.nn.Parameter(new_value.to(target_device))
 
-        if unexpected_keys is not None and param_name in unexpected_keys:
-            unexpected_keys.remove(param_name)
         del param_name
 
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):

--- a/src/transformers/quantizers/quantizer_fbgemm_fp8.py
+++ b/src/transformers/quantizers/quantizer_fbgemm_fp8.py
@@ -105,7 +105,7 @@ class FbgemmFp8HfQuantizer(HfQuantizer):
             )
         return dtype
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -82,7 +82,6 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         """
         Quantizes weights to FP8 format using Block-wise quantization

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -128,7 +128,7 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         _load_parameter_into_model(model, param_name, quantized_param)
         _load_parameter_into_model(model, param_name.rsplit(".", 1)[0] + ".weight_scale_inv", scale)
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_fp_quant.py
+++ b/src/transformers/quantizers/quantizer_fp_quant.py
@@ -90,7 +90,6 @@ class FPQuantHfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         module, _ = get_module_from_name(model, param_name)
 
@@ -121,9 +120,6 @@ class FPQuantHfQuantizer(HfQuantizer):
         module.weight = torch.nn.Parameter(param_value.to(target_device))
         # Let pre-forward handle the quantization and set None where necessary
         module.pre_forward()
-
-        if unexpected_keys is not None and param_name in unexpected_keys:
-            unexpected_keys.remove(param_name)
 
     def _process_model_before_weight_loading(
         self,

--- a/src/transformers/quantizers/quantizer_fp_quant.py
+++ b/src/transformers/quantizers/quantizer_fp_quant.py
@@ -159,7 +159,7 @@ class FPQuantHfQuantizer(HfQuantizer):
     def is_serializable(self, safe_serialization=None):
         return True
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_higgs.py
+++ b/src/transformers/quantizers/quantizer_higgs.py
@@ -88,7 +88,6 @@ class HiggsHfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
     ):
         from ..integrations import quantize_with_higgs
 
@@ -116,9 +115,6 @@ class HiggsHfQuantizer(HfQuantizer):
                 self.quantization_config.tune_metadata[module_name] = value.to_dict()
             else:
                 raise ValueError(f"Unexpected key {key} in module {module}")
-
-        if unexpected_keys is not None and param_name in unexpected_keys:
-            unexpected_keys.remove(param_name)
 
     def _process_model_before_weight_loading(
         self,

--- a/src/transformers/quantizers/quantizer_higgs.py
+++ b/src/transformers/quantizers/quantizer_higgs.py
@@ -180,7 +180,7 @@ class HiggsHfQuantizer(HfQuantizer):
     def is_serializable(self, safe_serialization=None):
         return True
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -182,7 +182,6 @@ class HqqHfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: list[str],
     ):
         """
         Each nn.Linear layer is processed here.
@@ -216,8 +215,6 @@ class HqqHfQuantizer(HfQuantizer):
         for k, v in state_dict.items():
             if layer_name + "." in k:
                 module_state_dict[k.split(".")[-1]] = v
-                if unexpected_keys is not None and k in unexpected_keys:
-                    unexpected_keys.remove(k)
 
         if self.pre_quantized:
             if isinstance(module, HQQLinear):

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -46,7 +46,6 @@ class HqqHfQuantizer(HfQuantizer):
     """
     HQQ quantizer base HF class.
     nn.Linear modules are first tagged with quant_config in _process_model_before_weight_loading().
-    The actual quantization and offloading to the GPU is done in check_quantized_param().
     """
 
     use_keep_in_fp32_modules = False
@@ -152,7 +151,7 @@ class HqqHfQuantizer(HfQuantizer):
 
         return list(new_keys)
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_mxfp4.py
+++ b/src/transformers/quantizers/quantizer_mxfp4.py
@@ -178,7 +178,6 @@ class Mxfp4HfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: Optional[list[str]] = None,
         **kwargs,
     ):
         from ..integrations import (

--- a/src/transformers/quantizers/quantizer_mxfp4.py
+++ b/src/transformers/quantizers/quantizer_mxfp4.py
@@ -147,7 +147,7 @@ class Mxfp4HfQuantizer(HfQuantizer):
             )
         return dtype
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_quanto.py
+++ b/src/transformers/quantizers/quantizer_quanto.py
@@ -103,7 +103,7 @@ class QuantoHfQuantizer(HfQuantizer):
                         not_missing_keys.append(missing)
         return [k for k in missing_keys if k not in not_missing_keys]
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",
@@ -111,9 +111,6 @@ class QuantoHfQuantizer(HfQuantizer):
         state_dict: dict[str, Any],
         **kwargs,
     ) -> bool:
-        """
-        Check if a parameter needs to be quantized.
-        """
         if is_optimum_quanto_available():
             from optimum.quanto import QModuleMixin
 

--- a/src/transformers/quantizers/quantizer_quark.py
+++ b/src/transformers/quantizers/quantizer_quark.py
@@ -92,9 +92,7 @@ class QuarkHfQuantizer(HfQuantizer):
     ) -> bool:
         return True
 
-    def create_quantized_param(
-        self, model, param, param_name, param_device, state_dict, unexpected_keys
-    ) -> "torch.nn.Parameter":
+    def create_quantized_param(self, model, param, param_name, param_device, state_dict) -> "torch.nn.Parameter":
         postfix = param_name.split(".")[-1]
 
         if postfix in CHECKPOINT_KEYS:

--- a/src/transformers/quantizers/quantizer_quark.py
+++ b/src/transformers/quantizers/quantizer_quark.py
@@ -82,7 +82,7 @@ class QuarkHfQuantizer(HfQuantizer):
 
         return model
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -229,7 +229,7 @@ class TorchAoHfQuantizer(HfQuantizer):
             ]
         return
 
-    def check_quantized_param(
+    def param_needs_quantization(
         self,
         model: "PreTrainedModel",
         param_value: "torch.Tensor",

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -170,7 +170,7 @@ class TorchAoHfQuantizer(HfQuantizer):
                     f"In order to use safetensors with torchao, please use torchao version >= 0.14.0. Current version: {TORCHAO_VERSION}"
                 )
         else:
-            return super().get_state_dict_and_metadata(model)
+            return None, {}
 
     def adjust_target_dtype(self, dtype: "torch.dtype") -> "torch.dtype":
         if version.parse(importlib.metadata.version("accelerate")) > version.parse("0.19.0"):
@@ -321,7 +321,7 @@ class TorchAoHfQuantizer(HfQuantizer):
         if TORCHAO_VERSION >= version.parse("0.14.0") and is_metadata_torchao(metadata):
             return unflatten_tensor_state_dict(state_dict, metadata)
         else:
-            return super().update_state_dict_with_metadata(state_dict, metadata)
+            return state_dict
 
     def _process_model_after_weight_loading(self, model, **kwargs):
         """No process required for torchao quantized model"""

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -262,7 +262,6 @@ class TorchAoHfQuantizer(HfQuantizer):
         param_name: str,
         target_device: "torch.device",
         state_dict: dict[str, Any],
-        unexpected_keys: list[str],
     ):
         """
         Each nn.Linear layer that needs to be quantized is processed here.

--- a/tests/models/bamba/test_modeling_bamba.py
+++ b/tests/models/bamba/test_modeling_bamba.py
@@ -360,13 +360,6 @@ class BambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
                             msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                         )
 
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        r"""
-        Overriding the test_mismatched_shapes_have_properly_initialized_weights test because A_log and D params of the
-        Bamba mixer are initialized differently and we tested that in test_initialization
-        """
-        self.skipTest(reason="Cumbersome and redundant for Bamba")
-
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the Bamba model outputs attention only for its attention layers

--- a/tests/models/falcon_h1/test_modeling_falcon_h1.py
+++ b/tests/models/falcon_h1/test_modeling_falcon_h1.py
@@ -310,37 +310,6 @@ class FalconH1ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_decoder_model_past_large_inputs(*config_and_inputs)
 
-    # def test_initialization(self):
-    #     r"""
-    #     Overriding the test_initialization test as the A_log and D params of the FalconH1 mixer are initialized differently
-    #     """
-    #     config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-
-    #     configs_no_init = _config_zero_init(config)
-    #     for model_class in self.all_model_classes:
-    #         model = model_class(config=configs_no_init)
-    #         for name, param in model.named_parameters():
-    #             if param.requires_grad:
-    #                 if "A_log" in name:
-    #                     A = torch.arange(1, config.mamba_n_heads + 1, dtype=torch.float32)
-    #                     torch.testing.assert_close(param.data, torch.log(A), rtol=1e-5, atol=1e-5)
-    #                 elif "D" in name:
-    #                     D = torch.ones(config.mamba_n_heads, dtype=torch.float32)
-    #                     torch.testing.assert_close(param.data, D, rtol=1e-5, atol=1e-5)
-    #                 else:
-    #                     self.assertIn(
-    #                         ((param.data.mean() * 1e9).round() / 1e9).item(),
-    #                         [0.0, 1.0],
-    #                         msg=f"Parameter {name} of model {model_class} seems not properly initialized",
-    #                     )
-
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        r"""
-        Overriding the test_mismatched_shapes_have_properly_initialized_weights test because A_log and D params of the
-        FalconH1 mixer are initialized differently and we tested that in test_initialization
-        """
-        self.skipTest(reason="Cumbersome and redundant for FalconH1")
-
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the FalconH1 model outputs attention only for its attention layers

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -356,10 +356,6 @@ class Gemma3Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
     def test_load_with_mismatched_shapes(self):
         pass
 
-    @unittest.skip("Loading nested configs with overwritten `kwargs` isn't supported yet, FIXME @raushan.")
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        pass
-
     def test_automodelforcausallm(self):
         """
         Regression test for #36741/#36917 -- make sure `AutoModelForCausalLM` works with a Gemma3 config, i.e. that

--- a/tests/models/jamba/test_modeling_jamba.py
+++ b/tests/models/jamba/test_modeling_jamba.py
@@ -454,13 +454,6 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
                             msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                         )
 
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        r"""
-        Overriding the test_mismatched_shapes_have_properly_initialized_weights test because A_log and D params of the
-        Mamba block are initialized differently and we tested that in test_initialization
-        """
-        self.skipTest(reason="Cumbersome and redundant for Jamba")
-
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the Jamba model outputs attention only for its attention layers

--- a/tests/models/qwen3_next/test_modeling_qwen3_next.py
+++ b/tests/models/qwen3_next/test_modeling_qwen3_next.py
@@ -315,10 +315,6 @@ class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
                         msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                     )
 
-    @unittest.skip("Redundant with `test_initialization`, and fails because of the same param (`A_log`)")
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        pass
-
     @parameterized.expand(TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION)
     def test_eager_matches_sdpa_inference(
         self,

--- a/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
+++ b/tests/models/timm_wrapper/test_modeling_timm_wrapper.py
@@ -163,10 +163,6 @@ class TimmWrapperModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
     def test_initialization(self):
         pass
 
-    @unittest.skip(reason="TimmWrapper initialization is managed on the timm side")
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        pass
-
     def test_gradient_checkpointing(self):
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         model = TimmWrapperModel._from_config(config)

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -391,13 +391,6 @@ class ZambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
                             msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                         )
 
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        r"""
-        Overriding the test_mismatched_shapes_have_properly_initialized_weights test because A_log and D params of the
-        Mamba block are initialized differently and we tested that in test_initialization
-        """
-        self.skipTest("Cumbersome and redundant for Zamba")
-
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the Zamba model outputs attention only for its attention layers

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -420,14 +420,6 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
                             msg=f"Parameter {name} of model {model_class} seems not properly initialized",
                         )
 
-    @unittest.skip(reason="Cumbersome and redundant for Zamba2")
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
-        r"""
-        Overriding the test_mismatched_shapes_have_properly_initialized_weights test because A_log and D params of the
-        Mamba block are initialized differently and we tested that in test_initialization
-        """
-        pass
-
     def test_attention_outputs(self):
         r"""
         Overriding the test_attention_outputs test as the Zamba2 model outputs attention only for its attention layers

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3323,7 +3323,7 @@ class ModelTesterMixin:
                             # Make sure the mean of the new Linear layer is correctly centered around 0 (we cannot use
                             # a lower value for the check as some models hardcode a std of 0.02 instead of using the
                             # config, which we set very small with `config_no_init`)
-                            self.assertLessEqual(v1.data.mean().item(), 1e-2, f"Issue with {k1}")
+                            self.assertLessEqual(v1.data.mean().item(), 1e-1, f"Issue with {k1}")
 
     def test_model_is_small(self):
         # Just a consistency check to make sure we are not running tests on 1M parameter models.

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -111,7 +111,6 @@ from transformers.utils import (
     is_torch_bf16_available_on_device,
     is_torch_fp16_available_on_device,
 )
-from transformers.utils.generic import ContextManagers
 
 from .generation.test_utils import GenerationTesterMixin
 
@@ -128,7 +127,7 @@ if is_torch_available():
 
     from transformers import MODEL_MAPPING
     from transformers.cache_utils import Cache, DynamicCache
-    from transformers.modeling_utils import load_state_dict, no_init_weights
+    from transformers.modeling_utils import load_state_dict
     from transformers.pytorch_utils import id_tensor_storage
 
 from transformers.utils.fx import _FX_SUPPORTED_MODELS_WITH_KV_CACHE, symbolic_trace
@@ -3242,12 +3241,13 @@ class ModelTesterMixin:
                     else:
                         new_model_without_prefix(input_ids)
 
-    def test_mismatched_shapes_have_properly_initialized_weights(self):
+    def test_can_load_ignoring_mismatched_shapes(self):
         if not self.test_mismatched_shapes:
             self.skipTest(reason="test_mismatched_shapes is set to False")
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         configs_no_init = _config_zero_init(config)
+        configs_no_init.num_labels = 3
 
         for model_class in self.all_model_classes:
             mappings = [
@@ -3260,66 +3260,6 @@ class ModelTesterMixin:
 
             if not is_classication_model:
                 continue
-
-            # TODO: ydshieh
-            is_special_classes = model_class.__name__ in [
-                "wav2vec2.masked_spec_embed",
-                "Wav2Vec2ForSequenceClassification",
-                "CLIPForImageClassification",
-                "MetaClip2ForImageClassification",
-                "Siglip2ForImageClassification",
-                "RegNetForImageClassification",
-                "ResNetForImageClassification",
-                "UniSpeechSatForSequenceClassification",
-                "Wav2Vec2BertForSequenceClassification",
-                "PvtV2ForImageClassification",
-                "Wav2Vec2ConformerForSequenceClassification",
-                "WavLMForSequenceClassification",
-                "SwiftFormerForImageClassification",
-                "SEWForSequenceClassification",
-                "BitForImageClassification",
-                "SEWDForSequenceClassification",
-                "SiglipForImageClassification",
-                "HubertForSequenceClassification",
-                "Swinv2ForImageClassification",
-                "Data2VecAudioForSequenceClassification",
-                "UniSpeechForSequenceClassification",
-                "PvtForImageClassification",
-                "ModernBertForSequenceClassification",
-                "ModernBertForTokenClassification",
-                "TimmWrapperForImageClassification",
-                "ModernBertForQuestionAnswering",
-                "ModernBertDecoderForSequenceClassification",
-                "ModernBertDecoderForCausalLM",
-            ]
-            special_param_names = [
-                r"^bit\.",
-                r"^classifier\.weight",
-                r"^classifier\.bias",
-                r"^classifier\..+\.weight",
-                r"^classifier\..+\.bias",
-                r"^data2vec_audio\.",
-                r"^dist_head\.",
-                r"^head\.",
-                r"^hubert\.",
-                r"^pvt\.",
-                r"^pvt_v2\.",
-                r"^regnet\.",
-                r"^resnet\.",
-                r"^sew\.",
-                r"^sew_d\.",
-                r"^swiftformer\.",
-                r"^swinv2\.",
-                r"^transformers\.models\.swiftformer\.",
-                r"^timm_model\.",
-                r"^unispeech\.",
-                r"^unispeech_sat\.",
-                r"^vision_model\.",
-                r"^wav2vec2\.",
-                r"^wav2vec2_bert\.",
-                r"^wav2vec2_conformer\.",
-                r"^wavlm\.",
-            ]
 
             with self.subTest(msg=f"Testing {model_class}"):
                 with tempfile.TemporaryDirectory() as tmp_dir:
@@ -3336,101 +3276,54 @@ class ModelTesterMixin:
                         new_model = model_class.from_pretrained(tmp_dir, num_labels=42, ignore_mismatched_sizes=True)
                     self.assertIn("the shapes did not match", cl.out)
 
-                    for name, param in new_model.named_parameters():
-                        if param.requires_grad:
-                            param_mean = ((param.data.mean() * 1e9).round() / 1e9).item()
-                            if not (
-                                is_special_classes
-                                and any(len(re.findall(target, name)) > 0 for target in special_param_names)
-                            ):
-                                self.assertIn(
-                                    param_mean,
-                                    [0.0, 1.0],
-                                    msg=f"Parameter {name} of model {model_class} seems not properly initialized",
-                                )
-                            else:
-                                # Here we allow the parameters' mean to be in the range [-5.0, 5.0] instead of being
-                                # either `0.0` or `1.0`, because their initializations are not using
-                                # `config.initializer_factor` (or something similar). The purpose of this test is simply
-                                # to make sure they are properly initialized (to avoid very large value or even `nan`).
-                                self.assertGreaterEqual(
-                                    param_mean,
-                                    -5.0,
-                                    msg=f"Parameter {name} of model {model_class} seems not properly initialized",
-                                )
-                                self.assertLessEqual(
-                                    param_mean,
-                                    5.0,
-                                    msg=f"Parameter {name} of model {model_class} seems not properly initialized",
-                                )
+                    # Find the name of the module with the mismatched size
+                    top_linear_modules = [
+                        (name, module) for name, module in new_model.named_children() if isinstance(module, nn.Linear)
+                    ]
+                    # Some old model have the Linear classification layer inside a ClassificationHead module or nn.Sequential
+                    if len(top_linear_modules) == 0:
+                        # ClassificationHead case
+                        if any(
+                            module.__class__.__name__.endswith("ClassificationHead") for module in new_model.children()
+                        ):
+                            head_name, head_module = next(
+                                (name, module)
+                                for name, module in new_model.named_children()
+                                if module.__class__.__name__.endswith("ClassificationHead")
+                            )
+                        # nn.Sequential case
+                        elif any(isinstance(module, nn.Sequential) for module in new_model.children()):
+                            head_name, head_module = next(
+                                (name, module)
+                                for name, module in new_model.named_children()
+                                if isinstance(module, nn.Sequential)
+                            )
+                        # Unknown at this point -> skip (only xlm, perceiver, levit, flaubert, audio_spectrogram_transformer as of 23/09/2025)
+                        else:
+                            self.skipTest("Could not locate the classification Linear layer.")
+                        top_linear_modules = [
+                            (f"{head_name}.{name}", module)
+                            for name, module in head_module.named_children()
+                            if isinstance(module, nn.Linear)
+                        ]
+                    # Usually we have only 1, but swiftformer and deit have 2 Linear layers using `num_labels`
+                    mismatched_modules = [name for name, module in top_linear_modules if module.out_features == 42]
 
-    def test_matched_shapes_have_loaded_weights_when_some_mismatched_shapes_exist(self):
-        # 1. Create a dummy class. Should have buffers as well? To make sure we test __init__
-        class MyClass(PreTrainedModel):
-            config_class = PretrainedConfig
-
-            def __init__(self, config=None):
-                super().__init__(config if config is not None else PretrainedConfig())
-                self.linear = nn.Linear(10, config.num_labels, bias=True)
-                self.embedding = nn.Embedding(10, 10)
-                self.std = 1
-
-            def _init_weights(self, module):
-                if isinstance(module, nn.Linear):
-                    module.weight.data = nn.init.kaiming_uniform_(module.weight.data, np.sqrt(5))
-                    if module.bias is not None:
-                        module.bias.data = module.bias.data.normal_(mean=0.0, std=self.std)
-
-        # Used to make sure the weights with matched shape are loaded correctly
-        config = PretrainedConfig()
-        config.num_labels = 3
-        model = MyClass(config=config)
-
-        # Used to make sure the weights with mismatched shape are properly initialized
-        set_seed(0)
-        config = PretrainedConfig()
-        config.num_labels = 4
-        # not to init. the weights during the creation: to match the logic in `from_pretrained`, so we can keep the
-        # same sequence of random ops in the execution path to allow us to compare `target_model` and `new_model` below
-        # for `linear` part.
-        with ContextManagers([no_init_weights()]):
-            target_model = MyClass(config=config)
-        target_model.apply(target_model._initialize_weights)
-
-        with tempfile.TemporaryDirectory() as tmpdirname:
-            state_dict = model.state_dict()
-            del state_dict["linear.weight"]
-
-            model.config.save_pretrained(tmpdirname)
-            torch.save(state_dict, os.path.join(tmpdirname, "pytorch_model.bin"))
-
-            set_seed(0)
-            new_model = MyClass.from_pretrained(tmpdirname, num_labels=4, ignore_mismatched_sizes=True)
-
-            for key in new_model.state_dict():
-                # check weight values for weights with matched shapes are identical
-                # (i.e. correctly loaded from the checkpoint)
-                if key not in ["linear.weight", "linear.bias"]:
-                    max_diff = torch.max(torch.abs(model.state_dict()[key] - new_model.state_dict()[key]))
-                    self.assertLessEqual(
-                        max_diff.item(),
-                        1e-6,
-                        msg=f"the weight values for `{key}` in `new_model` and `model` are  not identical",
-                    )
-                else:
-                    # check we have some mismatched shapes
-                    self.assertNotEqual(
-                        model.state_dict()[key].shape,
-                        new_model.state_dict()[key].shape,
-                        msg=f"the weight shapes for {key} in `model` and `new_model` should differ",
-                    )
-                    # check the weights with mismatched shape are properly initialized
-                    max_diff = torch.max(torch.abs(new_model.state_dict()[key] - target_model.state_dict()[key]))
-                    self.assertLessEqual(
-                        max_diff.item(),
-                        1e-6,
-                        msg=f"the weight values for `{key}` in `new_model` and `target_model` are not identical",
-                    )
+                    for (k1, v1), (k2, v2) in zip(new_model.named_parameters(), model.named_parameters()):
+                        # Sanity check: params must have all the same name
+                        self.assertEqual(k1, k2)
+                        # Each param except the mismatched ones must be exactly similar
+                        if not any(k1.startswith(mismatched_module) for mismatched_module in mismatched_modules):
+                            self.assertTrue((v1 == v2).all())
+                        # Check that the dims are indeed mismatched between old and new models
+                        else:
+                            # The old model should have `num_labels=3` (here it's the first dim of shape, as Linear layers
+                            # are transposed)
+                            self.assertEqual(v2.shape[0], 3)
+                            # Make sure the mean of the new Linear layer is correctly centered around 0 (we cannot use
+                            # a lower value for the check as some models hardcode a std of 0.02 instead of using the
+                            # config, which we set very small with `config_no_init`)
+                            self.assertLessEqual(v1.data.mean().item(), 1e-2, f"Issue with {k1}")
 
     def test_model_is_small(self):
         # Just a consistency check to make sure we are not running tests on 1M parameter models.


### PR DESCRIPTION
# What does this PR do?

Quite a bit of improvements in this PR to keep making things simpler:

- completely remove `offload_state_dict`: it was added several years ago to avoid loading 2x memory on cpu between the model and the state dict -> this is no longer needed from some time as the model is loaded on meta device, then params are loaded one after the other -> removes quite a bit of convoluted logic
- remove distinction between `model_to_load` and `model` in `_load_pretrained_model` -> this was there originally and is only confusing -> removes quite a bit of logic here as well
- rename `check_quantized_param() -> bool` to `param_needs_quantization() -> bool` in the quantizers -> muuuuch more self-explanatory, the old name was quite hard to understand
- removes `logger.info` messages -> if everything went normal, no need to tell me... Only tell me what went wrong
- rework the `mismatched_shapes` tests -> they were redundant and quite badly written, with a ton of unneeded exceptions and skips
- several other improvements in terms of logic/readability, as well as performances during init