### PR TITLE
Fix `_get_test_info` for inherited tests

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3657,6 +3657,14 @@ def _patch_with_call_info(module_or_class, attr_name, _parse_call_info_func, tar
             info = _parse_call_info_func(orig_method, args, kwargs, call_argument_expressions, target_args)
             info = _prepare_debugging_info(test_info, info)
 
+            # If the test is running in a CI environment (e.g. not a manual run), let's raise and fail the test, so it
+            # behaves as usual.
+            # This is to avoid the patched function being called `with self.assertRaises(AssertionError):` and fails
+            # because of the missing expected `AssertionError`.
+            # TODO (ydshieh): If there is way to raise only when we are inside such context managers?
+            if os.getenv("CI") == "true":
+                raise captured_exception.with_traceback(test_traceback)
+
             # Save this, so we can raise at the end of the current test
             captured_failure = {
                 "result": "failed",

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3659,9 +3659,12 @@ def _patch_with_call_info(module_or_class, attr_name, _parse_call_info_func, tar
 
             # If the test is running in a CI environment (e.g. not a manual run), let's raise and fail the test, so it
             # behaves as usual.
+            # On Github Actions or CircleCI, this is set automatically.
+            # When running manually, it's the user to determine if to set it.
             # This is to avoid the patched function being called `with self.assertRaises(AssertionError):` and fails
             # because of the missing expected `AssertionError`.
             # TODO (ydshieh): If there is way to raise only when we are inside such context managers?
+            # TODO (ydshieh): How not to record the failure if it happens inside `self.assertRaises(AssertionError)`?
             if os.getenv("CI") == "true":
                 raise captured_exception.with_traceback(test_traceback)
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3357,13 +3357,17 @@ def _get_test_info():
     stack_from_inspect = inspect.stack()
     # but visit from the top frame to the most recent frame
 
-    actual_test_file, actual_test_class = test_file, test_class
+    actual_test_file, _actual_test_class = test_file, test_class
     test_frame, test_obj, test_method = None, None, None
     for frame in reversed(stack_from_inspect):
         # if test_file in str(frame).replace(r"\\", "/"):
         # check frame's function + if it has `self` as locals; double check if self has the (function) name
         # TODO: Question: How about expanded?
-        if frame.function == test_name and 'self' in frame.frame.f_locals and hasattr(frame.frame.f_locals["self"], test_name):
+        if (
+            frame.function == test_name
+            and "self" in frame.frame.f_locals
+            and hasattr(frame.frame.f_locals["self"], test_name)
+        ):
             # if test_name == frame.frame.f_locals["self"]._testMethodName:
             test_frame = frame
             # The test instance
@@ -3371,7 +3375,6 @@ def _get_test_info():
             # TODO: Do we get the (relative?) path or it's just a file name?
             # TODO: Does `test_obj` always have `tearDown` object?
             actual_test_file = frame.filename
-            actual_test_class = test_obj.__class__.__name__
             # TODO: check `test_method` will work used at the several places!
             test_method = getattr(test_obj, test_name)
             break
@@ -3388,7 +3391,11 @@ def _get_test_info():
     # From the most outer (i.e. python's `runpy.py`) frame to most inner frame (i.e. the frame of this method)
     # Between `the test method being called` and `before entering `patched``.
     for frame in reversed(stack_from_inspect):
-        if frame.function == test_name and 'self' in frame.frame.f_locals and hasattr(frame.frame.f_locals["self"],                                                                          test_name):
+        if (
+            frame.function == test_name
+            and "self" in frame.frame.f_locals
+            and hasattr(frame.frame.f_locals["self"], test_name)
+        ):
             to_capture = True
         # TODO: check simply with the name is not robust.
         elif "patched" == frame.frame.f_code.co_name:
@@ -3434,9 +3441,7 @@ def _get_test_info():
         source = Source(s)
         caller_code_context = "\n".join(source.getstatement(caller_lineno - 1).lines)
 
-    test_info = (
-        f"test:\n\n{full_test_name}\n\n{'-' * 80}\n\ntest context: {actual_test_file}:{test_lineno}\n\n{test_code_context}"
-    )
+    test_info = f"test:\n\n{full_test_name}\n\n{'-' * 80}\n\ntest context: {actual_test_file}:{test_lineno}\n\n{test_code_context}"
     test_info = f"{test_info}\n\n{'-' * 80}\n\ncaller context: {caller_path}:{caller_lineno}\n\n{caller_code_context}"
 
     return (


### PR DESCRIPTION
# What does this PR do?

Fix `_get_test_info` for inherited tests. Currently, there are 2 issues:

- when a test class inherits from a base class, say `VaultGemmaModelTest` is from `CausalLMModelTest`, and a test is not overwritten in the subclass (so only defined in `CausalLMModelTest` here), the current way to identify the test stack frame object is not working, as the frame will point to the file of the base class (`CausalLMModelTest`), not the subclass `VaultGemmaModelTest` (which is the one given by `PYTEST_CURRENT_TEST`).
  - [A failed job run](https://github.com/huggingface/transformers/actions/runs/17923228517/job/50963413195)
    - error: `E       UnboundLocalError: local variable 'tb' referenced before assignment` 
  - This PR uses a more reliable way. 

- When a patched method is called within `with self.assertRaises(AssertionError)`, we should raise it (if it happens) instead of record and raise in a later stage (insider tearDown), otherwise we will get error about missing expected AssertionError. 
  - I don't find a clean and short way to identify if we are inside such context.
  - I decide, for now, to just raise if we are running inside Github Actions or CircleCI environment, so we are not breaking the workflow runs.



