### PR TITLE
Make quantizers good citizens loading-wise

### DIFF
--- a/examples/quantization/custom_quantization_int8_example.py
+++ b/examples/quantization/custom_quantization_int8_example.py
@@ -175,11 +175,8 @@ class Int8SymmetricQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        Quantizes weights to INT8 symmetric format.
-        """
         # Sanity check
         module, tensor_name = get_module_from_name(model, param_name)
         if isinstance(module, Int8SymmetricLinear):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -726,9 +726,7 @@ def _load_state_dict_into_meta_model(
         )
 
         if device_mesh is not None:
-            if not is_quantized or not hf_quantizer.param_needs_quantization(
-                model, param, param_name, state_dict, device_map=device_map
-            ):
+            if not is_quantized or not hf_quantizer.param_needs_quantization(model, param_name):
                 # In this case, the param is already on the correct device!
                 shard_and_distribute_module(
                     model,
@@ -775,9 +773,7 @@ def _load_state_dict_into_meta_model(
             if param_device == "disk":
                 if not is_safetensors:
                     disk_offload_index = offload_weight(param, param_name, disk_offload_folder, disk_offload_index)
-            elif not is_quantized or not hf_quantizer.param_needs_quantization(
-                model, param, param_name, state_dict, param_device=param_device, device_map=device_map
-            ):
+            elif not is_quantized or not hf_quantizer.param_needs_quantization(model, param_name):
                 if is_fsdp_enabled():
                     param_device = "cpu" if is_local_dist_rank_0() else "meta"
 
@@ -5711,9 +5707,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # Buffers are not initialized on the meta device, so we still need this check to avoid overwriting them
             if param.device == torch.device("meta"):
                 value = torch.empty_like(param, dtype=dtype, device="cpu")
-                if not is_quantized or not hf_quantizer.param_needs_quantization(
-                    self, param_value=value, param_name=key, state_dict={}
-                ):
+                if not is_quantized or not hf_quantizer.param_needs_quantization(self, key):
                     _load_parameter_into_model(self, key, value)
                 else:
                     hf_quantizer.create_quantized_param(self, value, key, "cpu", model_state_dict)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -698,8 +698,7 @@ def _load_state_dict_into_meta_model(
         device_map_regex = "|".join([re.escape(k) for k in sorted(device_map.keys(), reverse=True)])
 
     is_quantized = hf_quantizer is not None
-    is_hqq_or_bnb_or_ao = is_quantized and hf_quantizer.quantization_config.quant_method in {
-        QuantizationMethod.HQQ,
+    is_bnb_or_ao = is_quantized and hf_quantizer.quantization_config.quant_method in {
         QuantizationMethod.BITS_AND_BYTES,
         QuantizationMethod.TORCHAO,
     }
@@ -819,7 +818,7 @@ def load_shard_file(args):
         shard_file,
         state_dict,
         disk_only_shard_files,
-        is_hqq_or_bnb_or_ao,
+        is_bnb_or_ao,
         is_quantized,
         device_map,
         hf_quantizer,
@@ -840,7 +839,7 @@ def load_shard_file(args):
     map_location = "cpu"
     if (
         shard_file.endswith(".safetensors")
-        and not is_hqq_or_bnb_or_ao
+        and not is_bnb_or_ao
         and not (is_deepspeed_zero3_enabled() and not is_quantized)
     ):
         map_location = "meta"
@@ -5199,8 +5198,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             QuantizationMethod.HQQ,
             QuantizationMethod.QUARK,
         }
-        is_hqq_or_bnb_or_ao = is_quantized and hf_quantizer.quantization_config.quant_method in {
-            QuantizationMethod.HQQ,
+        is_bnb_or_ao = is_quantized and hf_quantizer.quantization_config.quant_method in {
             QuantizationMethod.BITS_AND_BYTES,
             QuantizationMethod.TORCHAO,
         }
@@ -5336,7 +5334,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 shard_file,
                 state_dict,
                 disk_only_shard_files,
-                is_hqq_or_bnb_or_ao,
+                is_bnb_or_ao,
                 is_quantized,
                 device_map,
                 hf_quantizer,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -703,7 +703,7 @@ def _load_state_dict_into_meta_model(
         QuantizationMethod.TORCHAO,
     }
     is_safetensors = shard_file.endswith(".safetensors")
-    is_meta_state_dict = is_safetensors and not is_hqq_or_bnb_or_ao
+    is_meta_state_dict = is_safetensors and not is_bnb_or_ao
     file_pointer = safe_open(shard_file, framework="pt", device=tensor_device) if is_meta_state_dict else None
     params_to_load = list(state_dict.keys())
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -644,6 +644,7 @@ def _infer_parameter_dtype(
             QuantizationMethod.HQQ,
             QuantizationMethod.QUARK,
             QuantizationMethod.MXFP4,
+            QuantizationMethod.BITS_AND_BYTES,
         }:
             return True, None
         else:
@@ -1379,6 +1380,7 @@ def _find_missing_and_unexpected_keys(
 
     if hf_quantizer is not None:
         missing_keys = hf_quantizer.update_missing_keys(model, missing_keys, prefix)
+        unexpected_keys = hf_quantizer.update_unexpected_keys(model, unexpected_keys)
 
     return missing_keys, unexpected_keys
 
@@ -4395,9 +4397,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether or not to force the (re-)download of the model weights and configuration files, overriding the
                 cached versions if they exist.
-            resume_download:
-                Deprecated and ignored. All downloads are now resumed by default when possible.
-                Will be removed in v5 of Transformers.
             proxies (`dict[str, str]`, *optional*):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., `{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}`. The proxies are used on each request.

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -737,7 +737,8 @@ def _load_state_dict_into_meta_model(
                     device_mesh.get_local_rank(),
                     device_mesh,
                 )
-            else:  # we have a device mesh but the param needs to be quantized, so we shard inside create_quantized_param:
+            else:
+                # we have a device mesh but the param needs to be quantized, so we shard inside create_quantized_param
                 sharding_kwargs = {
                     "empty_param": empty_param,
                     "casting_dtype": casting_dtype,
@@ -750,7 +751,6 @@ def _load_state_dict_into_meta_model(
                     param,
                     param_name,
                     device_mesh.get_local_rank(),
-                    state_dict,
                     **sharding_kwargs,
                 )
         else:
@@ -779,8 +779,7 @@ def _load_state_dict_into_meta_model(
                 _load_parameter_into_model(model, param_name, param.to(param_device))
 
             else:
-                # TODO naming is stupid it loads it as well
-                hf_quantizer.create_quantized_param(model, param, param_name, param_device, state_dict)
+                hf_quantizer.create_quantized_param(model, param, param_name, param_device)
 
                 # For quantized modules with FSDP/DeepSpeed Stage 3, we need to quantize the parameter on the GPU
                 # and then cast it to CPU to avoid excessive memory usage on each GPU
@@ -5701,7 +5700,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 if not is_quantized or not hf_quantizer.param_needs_quantization(self, key):
                     _load_parameter_into_model(self, key, value)
                 else:
-                    hf_quantizer.create_quantized_param(self, value, key, "cpu", model_state_dict)
+                    hf_quantizer.create_quantized_param(self, value, key, "cpu")
 
     def _initialize_missing_keys(self, missing_keys: list[str], is_quantized: bool) -> None:
         """Initialize the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts), according to

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -140,6 +140,9 @@ class HfQuantizer(ABC):
         """
         return expected_keys
 
+    def update_unexpected_keys(self, model, unexpected_keys: list[str]) -> list[str]:
+        return unexpected_keys
+
     def get_special_dtypes_update(self, model, dtype: "torch.dtype") -> dict[str, "torch.dtype"]:
         """
         returns dtypes for modules that are not quantized - used for the computation of the device_map in case

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -178,10 +178,12 @@ class HfQuantizer(ABC):
         """
         return False
 
-    def create_quantized_param(self, *args, **kwargs) -> "torch.nn.Parameter":
+    def create_quantized_param(self, *args, **kwargs):
         """
-        takes needed components from state_dict and creates quantized param; only applicable if
-        requires_parameters_quantization == True
+        Take needed components from state_dict (those from which `param_needs_quantization` is True) and create
+        quantized param.
+        It usually also load the new param directly in the `model`.
+        Note: only applicable if requires_parameters_quantization == True.
         """
         if not self.requires_parameters_quantization:
             raise AttributeError(

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -132,14 +132,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                 "calculation. You may encounter unexpected behavior, or pass your own device map"
             )
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         import bitsandbytes as bnb
 
         module, tensor_name = get_module_from_name(model, param_name)
@@ -147,8 +140,6 @@ class Bnb4BitHfQuantizer(HfQuantizer):
             # Add here check for loaded components' dtypes once serialization is implemented
             return True
         elif isinstance(module, bnb.nn.Linear4bit) and tensor_name == "bias":
-            # bias could be loaded by regular set_module_tensor_to_device() from accelerate,
-            # but it would wrongly use uninitialized weight there.
             return True
         else:
             return False

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -14,7 +14,7 @@
 import importlib
 from collections import defaultdict
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from packaging import version
 
@@ -160,11 +160,8 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        combines logic from _load_state_dict_into_meta_model and .integrations.bitsandbytes.py::set_module_quantized_tensor_to_device()
-        """
         import bitsandbytes as bnb
 
         is_quant_stat = any(param_name.endswith(x) for x in self.bnb_keys)

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from packaging import version
 
@@ -174,12 +174,8 @@ class Bnb8BitHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        combines logic from _load_state_dict_into_meta_model and .integrations.bitsandbytes.py::set_module_quantized_tensor_to_device()
-        needs aux items from state dicts, if found
-        """
         import bitsandbytes as bnb
 
         module, tensor_name = get_module_from_name(model, param_name)

--- a/src/transformers/quantizers/quantizer_eetq.py
+++ b/src/transformers/quantizers/quantizer_eetq.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from .base import HfQuantizer
 
@@ -118,11 +118,8 @@ class EetqHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        quantizes weights into qweight and weight_scales
-        """
         from eetq import EetqLinear, quantize_and_preprocess_weights
 
         module, tensor_name = get_module_from_name(model, param_name)

--- a/src/transformers/quantizers/quantizer_fbgemm_fp8.py
+++ b/src/transformers/quantizers/quantizer_fbgemm_fp8.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from .base import HfQuantizer
 
@@ -128,12 +128,8 @@ class FbgemmFp8HfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        Quantizes weights into weight and weight_scale
-        """
-
         from ..integrations import FbgemmFp8Linear, FbgemmFp8Llama4TextExperts
 
         module, tensor_name = get_module_from_name(model, param_name)

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ..utils import is_accelerate_available, is_torch_available, is_torch_xpu_available, logging
 from .base import HfQuantizer
@@ -81,11 +81,8 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        Quantizes weights to FP8 format using Block-wise quantization
-        """
         from ..integrations.finegrained_fp8 import FP8Linear
         from ..modeling_utils import _load_parameter_into_model
 

--- a/src/transformers/quantizers/quantizer_fp_quant.py
+++ b/src/transformers/quantizers/quantizer_fp_quant.py
@@ -159,14 +159,7 @@ class FPQuantHfQuantizer(HfQuantizer):
     def is_serializable(self, safe_serialization=None):
         return True
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         from fp_quant import FPQuantLinear
 
         module, tensor_name = get_module_from_name(model, param_name)

--- a/src/transformers/quantizers/quantizer_fp_quant.py
+++ b/src/transformers/quantizers/quantizer_fp_quant.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from .base import HfQuantizer
 from .quantizers_utils import get_module_from_name
@@ -89,7 +89,7 @@ class FPQuantHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
         module, _ = get_module_from_name(model, param_name)
 

--- a/src/transformers/quantizers/quantizer_higgs.py
+++ b/src/transformers/quantizers/quantizer_higgs.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from ..utils.logging import tqdm
 from .base import HfQuantizer
@@ -87,13 +87,10 @@ class HiggsHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
         from ..integrations import quantize_with_higgs
 
-        """
-        Quantizes weights into weight and weight_scale
-        """
         flute_dict = quantize_with_higgs(
             param_value.to(target_device),
             self.quantization_config.bits,

--- a/src/transformers/quantizers/quantizer_higgs.py
+++ b/src/transformers/quantizers/quantizer_higgs.py
@@ -180,18 +180,11 @@ class HiggsHfQuantizer(HfQuantizer):
     def is_serializable(self, safe_serialization=None):
         return True
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         from ..integrations import HiggsLinear
 
         module, tensor_name = get_module_from_name(model, param_name)
-        if isinstance(module, HiggsLinear) and tensor_name == "weight" and param_value.dtype != torch.int16:
+        if isinstance(module, HiggsLinear) and tensor_name == "weight":
             # Only quantize weights of HiggsLinear modules that are not already quantized
             return True
         else:

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -151,14 +151,7 @@ class HqqHfQuantizer(HfQuantizer):
 
         return list(new_keys)
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         if is_hqq_available():
             from hqq.core.quantize import HQQLinear
         module, tensor_name = get_module_from_name(model, param_name)

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -199,7 +199,6 @@ class HqqHfQuantizer(HfQuantizer):
             # If they are all present and saved, make it a HQQLinear layer! (we cannot do it param after param because
             # hqq does not support it...)
             if all(k in module.hqq_params for k in hqq_keys) and ("bias" in module.hqq_params or module.bias is None):
-                print(module.hqq_params)
                 hqq_layer = HQQLinear(
                     linear_layer=None,
                     quant_config=None,

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -35,8 +35,8 @@ if is_hqq_available():
     # but some models attempt to access `weight.dtype` during the forward pass. To prevent runtime errors,
     # we patch HQQLinear with a dummy `weight` property that returns an empty tensor with the correct dtype and device.
     @property
-    def weight(_self):
-        return torch.empty(0, dtype=_self.compute_dtype, device=_self.device)
+    def weight(self):
+        return torch.empty(0, dtype=self.compute_dtype, device=self.device)
 
     HQQLinear.weight = weight
 

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -30,15 +30,6 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 
-# Finds the parent of a node module named "name"
-def find_parent(model, name):
-    module_tree = name.split(".")[:-1]
-    parent = model
-    for m in module_tree:
-        parent = parent._modules[m]
-    return parent
-
-
 class HqqHfQuantizer(HfQuantizer):
     """
     HQQ quantizer base HF class.

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from collections import defaultdict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..integrations import prepare_for_hqq_linear
 from ..utils import is_hqq_available, is_torch_available, logging
@@ -163,13 +163,8 @@ class HqqHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        Each nn.Linear layer is processed here.
-        We first check if the corresponding module state_dict contains already HQQ quantized parameters.
-        If not, we create a temp linear layer with the module state_dict params and use it for quantization
-        """
         module, tensor_name = get_module_from_name(model, param_name)
         module_name = param_name.rsplit(".", 1)[0]
         parent_module, node = get_module_from_name(model, module_name)

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -29,6 +29,8 @@ if is_torch_available():
     import torch
 
 if is_hqq_available():
+    from hqq.core.quantize import HQQLinear
+
     # This is a compatibility hack. HQQ-quantized linear layers do not have a `weight` attribute,
     # but some models attempt to access `weight.dtype` during the forward pass. To prevent runtime errors,
     # we patch HQQLinear with a dummy `weight` property that returns an empty tensor with the correct dtype and device.
@@ -36,11 +38,7 @@ if is_hqq_available():
     def weight(_self):
         return torch.empty(0, dtype=_self.compute_dtype, device=_self.device)
 
-    import hqq
-
-    hqq.core.quantize.HQQLinear.weight = weight
-
-    from hqq.core.quantize import HQQLinear
+    HQQLinear.weight = weight
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/quantizers/quantizer_hqq.py
+++ b/src/transformers/quantizers/quantizer_hqq.py
@@ -190,12 +190,14 @@ class HqqHfQuantizer(HfQuantizer):
         # We need this hack as the model is not pre-prepared as an empty skeleton on meta device
         if self.pre_quantized:
             hqq_keys = HQQLinear(None, None).state_dict_keys() - {"bias"}
+            # Save them for later
             if hasattr(module, "hqq_params"):
                 module.hqq_params[tensor_name] = param_value
             else:
                 module.hqq_params = {tensor_name: param_value}
 
-            # If they are all present and saved, make it a HQQLinear layer! (we cannot do it param after param...)
+            # If they are all present and saved, make it a HQQLinear layer! (we cannot do it param after param because
+            # hqq does not support it...)
             if all(k in module.hqq_params for k in hqq_keys) and ("bias" in module.hqq_params or module.bias is None):
                 print(module.hqq_params)
                 hqq_layer = HQQLinear(

--- a/src/transformers/quantizers/quantizer_mxfp4.py
+++ b/src/transformers/quantizers/quantizer_mxfp4.py
@@ -147,14 +147,7 @@ class Mxfp4HfQuantizer(HfQuantizer):
             )
         return dtype
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ):
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         from ..integrations import Mxfp4GptOssExperts
         from ..models.gpt_oss.modeling_gpt_oss import GptOssExperts
 

--- a/src/transformers/quantizers/quantizer_mxfp4.py
+++ b/src/transformers/quantizers/quantizer_mxfp4.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from .base import HfQuantizer
 
@@ -170,7 +170,6 @@ class Mxfp4HfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
         **kwargs,
     ):
         from ..integrations import (

--- a/src/transformers/quantizers/quantizer_quanto.py
+++ b/src/transformers/quantizers/quantizer_quanto.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import importlib
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from packaging import version
 
@@ -103,25 +103,9 @@ class QuantoHfQuantizer(HfQuantizer):
                         not_missing_keys.append(missing)
         return [k for k in missing_keys if k not in not_missing_keys]
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         if is_optimum_quanto_available():
             from optimum.quanto import QModuleMixin
-
-        device_map = kwargs.get("device_map")
-        param_device = kwargs.get("param_device")
-        # we don't quantize the model if the module is going to be offloaded to the cpu
-        if device_map is not None and param_device is not None:
-            device_map_values = set(device_map.values())
-            if param_device == "cpu" and len(device_map_values) > 1:
-                if not (device_map_values == {"cpu"} or device_map_values == {"cpu", "disk"}):
-                    return False
 
         module, tensor_name = get_module_from_name(model, param_name)
         # We only quantize the weights and the bias is not quantized.

--- a/src/transformers/quantizers/quantizer_quanto.py
+++ b/src/transformers/quantizers/quantizer_quanto.py
@@ -127,9 +127,9 @@ class QuantoHfQuantizer(HfQuantizer):
         target_device: "torch.device",
         **kwargs,
     ):
-        from accelerate.utils import set_module_tensor_to_device
+        from ..modeling_utils import _load_parameter_into_model
 
-        set_module_tensor_to_device(model, param_name, target_device, param_value)
+        _load_parameter_into_model(model, param_name, param_value.to(target_device))
         module, _ = get_module_from_name(model, param_name)
         module.freeze()
         module.weight.requires_grad = False

--- a/src/transformers/quantizers/quantizer_quanto.py
+++ b/src/transformers/quantizers/quantizer_quanto.py
@@ -125,12 +125,8 @@ class QuantoHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        *args,
         **kwargs,
     ):
-        """
-        Create the quantized parameter by calling .freeze() after setting it to the module.
-        """
         from accelerate.utils import set_module_tensor_to_device
 
         set_module_tensor_to_device(model, param_name, target_device, param_value)

--- a/src/transformers/quantizers/quantizer_quark.py
+++ b/src/transformers/quantizers/quantizer_quark.py
@@ -21,11 +21,8 @@ from .base import HfQuantizer
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 
-from ..utils import is_accelerate_available, is_quark_available, logging
+from ..utils import is_quark_available, logging
 
-
-if is_accelerate_available():
-    from accelerate.utils import set_module_tensor_to_device
 
 logger = logging.get_logger(__name__)
 
@@ -82,12 +79,14 @@ class QuarkHfQuantizer(HfQuantizer):
         return True
 
     def create_quantized_param(self, model, param, param_name, param_device, **kwargs):
+        from ..modeling_utils import _load_parameter_into_model
+
         postfix = param_name.split(".")[-1]
 
         if postfix in CHECKPOINT_KEYS:
             param_name = param_name.replace(postfix, CHECKPOINT_KEYS[postfix])
 
-        set_module_tensor_to_device(model, param_name, param_device, value=param)
+        _load_parameter_into_model(model, param_name, param.to(param_device))
 
     def _process_model_after_weight_loading(self, model: "PreTrainedModel", **kwargs):
         return model

--- a/src/transformers/quantizers/quantizer_quark.py
+++ b/src/transformers/quantizers/quantizer_quark.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ..file_utils import is_torch_available
 from .base import HfQuantizer
@@ -82,14 +82,7 @@ class QuarkHfQuantizer(HfQuantizer):
 
         return model
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         return True
 
     def create_quantized_param(self, model, param, param_name, param_device, state_dict) -> "torch.nn.Parameter":

--- a/src/transformers/quantizers/quantizer_quark.py
+++ b/src/transformers/quantizers/quantizer_quark.py
@@ -15,15 +15,11 @@
 
 from typing import TYPE_CHECKING
 
-from ..file_utils import is_torch_available
 from .base import HfQuantizer
 
 
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
-
-    if is_torch_available():
-        import torch
 
 from ..utils import is_accelerate_available, is_quark_available, logging
 
@@ -85,7 +81,7 @@ class QuarkHfQuantizer(HfQuantizer):
     def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         return True
 
-    def create_quantized_param(self, model, param, param_name, param_device, state_dict) -> "torch.nn.Parameter":
+    def create_quantized_param(self, model, param, param_name, param_device, **kwargs):
         postfix = param_name.split(".")[-1]
 
         if postfix in CHECKPOINT_KEYS:

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -25,7 +25,6 @@ from .quantizers_utils import get_module_from_name
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 
-from typing import Any
 
 from ..utils import is_torch_available, is_torchao_available, logging
 from ..utils.quantization_config import TorchAoConfig
@@ -250,12 +249,8 @@ class TorchAoHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
-        """
-        Each nn.Linear layer that needs to be quantized is processed here.
-        First, we set the value the weight tensor, then we move it to the target device. Finally, we quantize the module.
-        """
         if self.quantization_config.quant_type == "autoquant":
             return
 

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -229,23 +229,12 @@ class TorchAoHfQuantizer(HfQuantizer):
             ]
         return
 
-    def param_needs_quantization(
-        self,
-        model: "PreTrainedModel",
-        param_value: "torch.Tensor",
-        param_name: str,
-        state_dict: dict[str, Any],
-        **kwargs,
-    ) -> bool:
+    def param_needs_quantization(self, model: "PreTrainedModel", param_name: str, **kwargs) -> bool:
         if self.quantization_config.quant_type == "autoquant":
             return False
 
-        param_device = kwargs.pop("param_device", None)
         # check if the param_name is not in self.modules_to_not_convert
         if any((key + "." in param_name) or (key == param_name) for key in self.modules_to_not_convert):
-            return False
-        elif param_device == "cpu" and self.offload:
-            # We don't quantize weights that we offload
             return False
         else:
             # we only quantize the weight of nn.Linear and nn.Embedding

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -46,6 +46,7 @@ if is_torchao_available():
             flatten_tensor_state_dict,
             unflatten_tensor_state_dict,
         )
+        from torchao.prototype.safetensors.safetensors_utils import is_metadata_torchao
 
 
 logger = logging.get_logger(__name__)
@@ -285,6 +286,9 @@ class TorchAoHfQuantizer(HfQuantizer):
                     param_value.to(target_device), requires_grad=param_value.requires_grad
                 )
                 return
+            # Sanity check for the new serialization format
+            elif not (TORCHAO_VERSION >= version.parse("0.14.0") and is_metadata_torchao(self.metadata)):
+                raise ValueError("To use `safetensors` serialization, you should have `torch>=0.14.0` installed")
 
             # Save the states for later quantization when they are all gathered
             if not hasattr(self, "ao_params"):

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -288,7 +288,7 @@ class TorchAoHfQuantizer(HfQuantizer):
                 return
             # Sanity check for the new serialization format
             elif not (TORCHAO_VERSION >= version.parse("0.14.0") and is_metadata_torchao(self.metadata)):
-                raise ValueError("To use `safetensors` serialization, you should have `torch>=0.14.0` installed")
+                raise ValueError("To use `safetensors` serialization, you should have `torchao>=0.14.0` installed")
 
             # Save the states for later quantization when they are all gathered
             if not hasattr(self, "ao_params"):

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -26,7 +26,6 @@ from .quantizers_utils import get_module_from_name
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 
-from typing import Any
 
 from ..utils import is_safetensors_available, is_torch_available, is_torchao_available, logging
 
@@ -263,7 +262,7 @@ class TorchAoHfQuantizer(HfQuantizer):
         param_value: "torch.Tensor",
         param_name: str,
         target_device: "torch.device",
-        state_dict: dict[str, Any],
+        **kwargs,
     ):
         """
         Each nn.Linear layer that needs to be quantized is processed here.

--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -278,8 +278,9 @@ class TorchAoHfQuantizer(HfQuantizer):
 
         if self.pre_quantized:
             # If it's a bias, no need to do anything special (except removing the ":_data" part of the key, but was
-            # already done)
-            if tensor_name == "bias":
+            # already done) - if it's unsafe-serialized (i.e. not safetensors), not need for anything either
+            is_unsafe_serialization = ":" not in full_name
+            if tensor_name == "bias" or is_unsafe_serialization:
                 module._parameters[tensor_name] = torch.nn.Parameter(
                     param_value.to(target_device), requires_grad=param_value.requires_grad
                 )


### PR DESCRIPTION
# What does this PR do?

The quantizers should NEVER need to access the `state_dict` during `param_needs_quantization` or `create_quantized_param`. This is mostly for the following reasons:

- Most models have a lot of different state dict (due to restricting the size of each file to 5GB), so relying on other params of the state dict for quantizing a given param is a very bad idea -> if the needed params happen to live on different saved state dicts (representing the same model), then the whole loading logic collapses without any possibility of fallback
- Without quantizers, we load parameters one by one without ever materializing the whole state dict at once, and it's quite annoying to have to change that logic only for a few quantizers, as it's a good thing in general

If the quantizers need several serialized keys to retrieve a given quantized param, then they should cache them individually, and then quantize back once all the needed keys are retrieved. Note that this DOES NOT incur a memory cost, as previously the whole state dict was loaded on memory, so the memory footprint was always higher before (-> a param will necessarily get quantized back, and its serialized tensors cleaned, before the whole state dict is materialized, assuming they all reside on the same state_dict as was done previously). So we actually have a gain of memory during loading with this PR.

Note that the current PR has less slow tests failing than main, especially for bitsandbytes, i.e. it actually solves a few issues in addition to simplifying the whole loading logic of the library.

A following PR will come to unify the `update_expected_keys`, `update_missing_keys`, and `update_unexpected_keys` methods, as some are currently redundant/not practical regarding the whole loading logic.