### PR TITLE
Support automatic conversion from zero checkpoint to universal checkpoint.

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -526,14 +526,14 @@ def deepspeed_init(trainer, num_training_steps, inference=False):
     return optimizer, lr_scheduler
 
 
-def convert_zero_checkpoint_to_universal_checkpoint(input_path, num_workers):
+def convert_zero_checkpoint_to_universal_checkpoint(input_path, output_path, num_workers):
     import argparse
 
     from deepspeed.checkpoint.ds_to_universal import main as ds_to_universal_main
 
     param_dict = {
         "input_folder": input_path,
-        "output_folder": "universal_" + input_path,
+        "output_folder": output_path,
         "num_extract_workers": num_workers,
         "num_merge_workers": num_workers // 2,
         "keep_temp_folder": False,
@@ -573,7 +573,9 @@ def deepspeed_load_checkpoint(
                 deepspeed_engine._config.load_universal_checkpoint = True
                 if deepspeed_engine.global_rank == 0:
                     convert_zero_checkpoint_to_universal_checkpoint(
-                        deepspeed_checkpoint_dirs[0], loaded_checkpoint_dp_world_size
+                        deepspeed_checkpoint_dirs[0],
+                        os.path.join(checkpoint_path, "universal_" + os.path.basename(deepspeed_checkpoint_dirs[0])),
+                        loaded_checkpoint_dp_world_size,
                     )
                     logger.info(
                         f"Converted deepspeed checkpoint at {checkpoint_path} to universal format for "

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -562,6 +562,7 @@ def deepspeed_load_checkpoint(
             assert len(deepspeed_checkpoint_dirs) == 1
             import os
 
+            deepspeed_engine._config.load_universal_checkpoint = True
             ckpt_list = deepspeed_engine._get_all_ckpt_names(
                 checkpoint_path, os.path.basename(deepspeed_checkpoint_dirs[0])
             )

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -533,7 +533,7 @@ def convert_zero_checkpoint_to_universal_checkpoint(input_path, num_workers):
 
     param_dict = {
         "input_folder": input_path,
-        "output_folder": input_path + "_universal",
+        "output_folder": "universal_" + input_path,
         "num_extract_workers": num_workers,
         "num_merge_workers": num_workers // 2,
         "keep_temp_folder": False,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2501,7 +2501,10 @@ class Trainer:
         if resume_from_checkpoint is not None:
             if self.is_deepspeed_enabled:
                 deepspeed_load_checkpoint(
-                    self.model_wrapped, resume_from_checkpoint, load_module_strict=not _is_peft_model(self.model)
+                    self.model_wrapped,
+                    resume_from_checkpoint,
+                    load_module_strict=not _is_peft_model(self.model),
+                    convert_deepspeed_universal_checkpoint=args.convert_deepspeed_universal_checkpoint,
                 )
             elif is_sagemaker_mp_enabled() or self.is_fsdp_enabled:
                 self._load_from_checkpoint(resume_from_checkpoint, self.model_wrapped)
@@ -3050,6 +3053,7 @@ class Trainer:
                 self.model_wrapped,
                 self.state.best_model_checkpoint,
                 load_module_strict=not _is_peft_model(self.model),
+                convert_deepspeed_universal_checkpoint=self.args.convert_deepspeed_universal_checkpoint,
             )
         elif self.is_fsdp_enabled:
             load_result = load_fsdp_model(

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1469,6 +1469,16 @@ class TrainingArguments:
         },
     )
 
+    convert_deepspeed_universal_checkpoint: Optional[bool] = field(
+        default=False,
+        metadata={
+            "help": (
+                "Whether or not to convert deepspeed zero checkpoint to universal checkpoint when "
+                "loaded world size is changed."
+            )
+        },
+    )
+
     def __post_init__(self):
         # Set default output_dir if not provided
         if self.output_dir is None:


### PR DESCRIPTION
# What does this PR do?

When deepspeed's world_size changes, ds checkpoints need to be converted to universal checkpoints. This PR is used to support automatic conversion.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
