### PR TITLE
Guard torchvision imports to prevent crashes in text-only pipelines

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -44,8 +44,7 @@ from .utils.constants import (  # noqa: F401
 )
 
 
-# Fallback values for torchvision-dependent variables.
-# These are used when torchvision is unavailable or fails to import.
+# Safe import of torchvision transforms (avoid crashing text-only users if torchvision is broken)
 InterpolationMode = None
 pil_torch_interpolation_mapping = {}
 
@@ -64,12 +63,7 @@ if is_torchvision_available():
             PILImageResampling.BICUBIC: InterpolationMode.BICUBIC,
             PILImageResampling.LANCZOS: InterpolationMode.LANCZOS,
         }
-<<<<<<< HEAD
     except Exception as e:
-=======
-        _TORCHVISION_OK = True
-    except (ImportError, ModuleNotFoundError, AttributeError) as e:
->>>>>>> 1d9ebde18c45821d6245dd671d5389804aff4c1c
         logger.warning(
             "Torchvision is installed but failed to import (%s). "
             "Continuing without torchvision; image pipelines that require it "

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -47,7 +47,6 @@ from .utils.constants import (  # noqa: F401
 # Safe import of torchvision transforms (avoid crashing text-only users if torchvision is broken)
 InterpolationMode = None
 pil_torch_interpolation_mapping = {}
-_TORCHVISION_OK = False
 
 if is_torchvision_available():
     try:
@@ -64,12 +63,12 @@ if is_torchvision_available():
             PILImageResampling.BICUBIC: InterpolationMode.BICUBIC,
             PILImageResampling.LANCZOS: InterpolationMode.LANCZOS,
         }
-        _TORCHVISION_OK = True
     except Exception as e:
         logger.warning(
             "Torchvision is installed but failed to import (%s). "
             "Continuing without torchvision; image pipelines that require it "
-            "will raise at runtime.", e
+            "will raise at runtime.",
+            e,
         )
         InterpolationMode = None
         pil_torch_interpolation_mapping = {}

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -66,7 +66,7 @@ if is_torchvision_available():
             PILImageResampling.LANCZOS: InterpolationMode.LANCZOS,
         }
         _TORCHVISION_OK = True
-    except Exception as e:
+    except (ImportError, ModuleNotFoundError, AttributeError) as e:
         logger.warning(
             "Torchvision is installed but failed to import (%s). "
             "Continuing without torchvision; image pipelines that require it "

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -44,7 +44,8 @@ from .utils.constants import (  # noqa: F401
 )
 
 
-# Safe import of torchvision transforms (avoid crashing text-only users if torchvision is broken)
+# Fallback values for torchvision-dependent variables.
+# These are used when torchvision is unavailable or fails to import.
 InterpolationMode = None
 pil_torch_interpolation_mapping = {}
 _TORCHVISION_OK = False


### PR DESCRIPTION
### Problem
Users running text-only pipelines (like pipeline("text-generation")) currently crash if torchvision is installed but not version-matched with torch. The error looks like:

```
RuntimeError: operator torchvision::nms does not exist
...
ModuleNotFoundError: Could not import module 'pipeline'
```

This happens because image_utils.py unconditionally imports torchvision transforms at import time, even if the user never touches an image pipeline.

Solution
* Guard torchvision imports in image_utils.py with try/except.
* If torchvision fails to import, log a warning and fall back to no-op mappings.
* Vision-specific pipelines will still raise later if torchvision is truly required, but text-only workflows are unaffected.

Impact
* Fixes a common pain point for text-only users who don’t care about image pipelines.
* No behavior change for healthy torch/torchvision stacks.
* Provides a clearer warning instead of a hard crash.

How to test
* Uninstall torchvision: pip uninstall torchvision → text-only pipeline still works.
* Install mismatched torchvision (simulate bad build) → text-only pipeline still works with warning.
* Run vision pipeline with working torchvision → behaves as before.

Notes
This change is deliberately minimal and does not alter API. It only makes import-time more robust.

Resolves #41146.

---

## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Models:
@ArthurZucker

Library:
@Rocketknight1 
