### PR TITLE
Improve `add_dates` script

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -555,8 +555,6 @@
         title: LED
       - local: model_doc/lfm2
         title: LFM2
-      - local: model_doc/lfm2_vl
-        title: LFM2-VL
       - local: model_doc/llama
         title: LLaMA
       - local: model_doc/llama2
@@ -1087,6 +1085,8 @@
         title: LayoutLMV3
       - local: model_doc/layoutxlm
         title: LayoutXLM
+      - local: model_doc/lfm2_vl
+        title: LFM2-VL
       - local: model_doc/lilt
         title: LiLT
       - local: model_doc/llama4

--- a/docs/source/en/model_doc/blt.md
+++ b/docs/source/en/model_doc/blt.md
@@ -13,6 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
+*This model was released on 2024-12-13 and added to Hugging Face Transformers on 2025-09-19.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">
@@ -28,7 +29,7 @@ rendered properly in your Markdown viewer.
 
 ## Overview
 
-The BLT model was proposed in [Byte Latent Transformer: Patches Scale Better Than Tokens](<https://arxiv.org/pdf/2412.09871>) by Artidoro Pagnoni, Ram Pasunuru, Pedro Rodriguez, John Nguyen, Benjamin Muller, Margaret Li1, Chunting Zhou, Lili Yu, Jason Weston, Luke Zettlemoyer, Gargi Ghosh, Mike Lewis, Ari Holtzman†, Srinivasan Iyer.
+The BLT model was proposed in [Byte Latent Transformer: Patches Scale Better Than Tokens](https://huggingface.co/papers/2412.09871) by Artidoro Pagnoni, Ram Pasunuru, Pedro Rodriguez, John Nguyen, Benjamin Muller, Margaret Li1, Chunting Zhou, Lili Yu, Jason Weston, Luke Zettlemoyer, Gargi Ghosh, Mike Lewis, Ari Holtzman†, Srinivasan Iyer.
 BLT is a byte-level LLM that achieves tokenization-level performance through entropy-based dynamic patching.
 
 The abstract from the paper is the following:
@@ -64,8 +65,8 @@ from transformers import AutoTokenizer, AutoModelForCausalLM
 
 tokenizer = AutoTokenizer.from_pretrained("itazap/blt-1b-hf")
 model = AutoModelForCausalLM.from_pretrained(
-    "itazap/blt-1b-hf", 
-    device_map="auto", 
+    "itazap/blt-1b-hf",
+    device_map="auto",
 )
 
 inputs = tokenizer(prompt, return_tensors="pt").to(model.device)

--- a/docs/source/en/model_doc/kosmos2_5.md
+++ b/docs/source/en/model_doc/kosmos2_5.md
@@ -9,7 +9,7 @@ Unless required by applicable law or agreed to in writing, software distributed 
 an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 specific language governing permissions and limitations under the License.
 -->
-*This model was released on {release_date} and added to Hugging Face Transformers on 2025-08-19.*
+*This model was released on 2023-09-20 and added to Hugging Face Transformers on 2025-08-19.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">

--- a/docs/source/en/model_doc/parakeet.md
+++ b/docs/source/en/model_doc/parakeet.md
@@ -13,6 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
+*This model was released on {release_date} and added to Hugging Face Transformers on 2025-09-25.*
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">

--- a/docs/source/en/model_doc/qwen3_omni_moe.md
+++ b/docs/source/en/model_doc/qwen3_omni_moe.md
@@ -13,9 +13,9 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on 2025-03-26 and added to Hugging Face Transformers on 2025-04-14.*
+*This model was released on 2025-03-26 and added to Hugging Face Transformers on 2025-09-21.*
 
-# Qwen2.5-Omni
+# Qwen3-Omni-MOE
 
 <div class="flex flex-wrap space-x-1">
 <img alt="PyTorch" src="https://img.shields.io/badge/PyTorch-DE3412?style=flat&logo=pytorch&logoColor=white">
@@ -25,22 +25,22 @@ rendered properly in your Markdown viewer.
 
 ## Overview
 
-The [Qwen2.5-Omni](https://qwenlm.github.io/blog/qwen2.5-omni/) model is a unified multiple modalities model proposed in [Qwen2.5-Omni Technical Report](https://huggingface.co/papers/2503.20215) from Qwen team, Alibaba Group.
+The Qwen3-Omni-MOE model is a unified multiple modalities model proposed in [Qwen3-Omni Technical Report](https://huggingface.co/papers/2509.17765) from Qwen team, Alibaba Group.
 
 The abstract from the technical report is the following:
 
-*We present Qwen2.5-Omni, an end-to-end multimodal model designed to perceive diverse modalities, including text, images, audio, and video, while simultaneously generating text and natural speech responses in a streaming manner. To enable the streaming of multimodal information inputs, both audio and visual encoders utilize a block-wise processing approach. This strategy effectively decouples the handling of long sequences of multimodal data, assigning the perceptual responsibilities to the multimodal encoder and entrusting the modeling of extended sequences to a large language model. Such a division of labor enhances the fusion of different modalities via the shared attention mechanism. To synchronize the timestamps of video inputs with audio, we organized the audio and video sequentially in an interleaved manner and propose a novel position embedding approach, named TMRoPE (Time-aligned Multimodal RoPE). To concurrently generate text and speech while avoiding interference between the two modalities, we propose Thinker-Talker architecture. In this framework, Thinker functions as a large language model tasked with text generation, while Talker is a dual-track autoregressive model that directly utilizes the hidden representations from the Thinker to produce audio tokens as output. Both the Thinker and Talker models are designed to be trained and inferred in an end-to-end manner. For decoding audio tokens in a streaming manner, we introduce a sliding-window DiT that restricts the receptive field, aiming to reduce the initial package delay. Qwen2.5-Omni outperforms the similarly sized Qwen2-VL and Qwen2-Audio in both image and audio capabilities. Furthermore, Qwen2.5-Omni achieves state-of-the-art performance on multimodal benchmarks like Omni-Bench. Notably, Qwen2.5-Omni is the first open-source model to achieve a level of performance in end-to-end speech instruction following that is comparable to its capabilities with text inputs, as evidenced by benchmarks such as MMLU and GSM8K. As for speech generation, Qwen2.5-Omni's streaming Talker outperform most existing streaming and non-streaming alternatives in robustness and naturalness.*
+*We present Qwen3-Omni, a single multimodal model that, for the first time, maintains state-of-the-art performance across text, image, audio, and video without any degradation relative to single-modal counterparts. Qwen3-Omni matches the performance of same-sized single-modal models within the Qwen series and excels particularly on audio tasks. Across 36 audio and audio-visual benchmarks, Qwen3-Omni achieves open-source SOTA on 32 benchmarks and overall SOTA on 22, outperforming strong closed-source models such as Gemini-2.5-Pro, Seed-ASR, and GPT-4o-Transcribe. Qwen3-Omni adopts a Thinker-Talker MoE architecture that unifies perception and generation across text, images, audio, and video, yielding fluent text and natural real-time speech. It supports text interaction in 119 languages, speech understanding in 19 languages, and speech generation in 10 languages. To reduce first-packet latency in streaming synthesis, Talker autoregressively predicts discrete speech codecs using a multi-codebook scheme. Leveraging the representational capacity of these codebooks, we replace computationally intensive block-wise diffusion with a lightweight causal ConvNet, enabling streaming from the first codec frame. In cold-start settings, Qwen3-Omni achieves a theoretical end-to-end first-packet latency of 234 ms. To further strengthen multimodal reasoning, we introduce a Thinking model that explicitly reasons over inputs from any modality. Since the research community currently lacks a general-purpose audio captioning model, we fine-tuned Qwen3-Omni-30B-A3B to obtain Qwen3-Omni-30B-A3B-Captioner, which produces detailed, low-hallucination captions for arbitrary audio inputs. Qwen3-Omni-30B-A3B, Qwen3-Omni-30B-A3B-Thinking, and Qwen3-Omni-30B-A3B-Captioner are publicly released under the Apache 2.0 license.
 
 ## Notes
 
-- Use [`Qwen2_5OmniForConditionalGeneration`] to generate audio and text output. To generate only one output type, use [`Qwen2_5OmniThinkerForConditionalGeneration`] for text-only and [`Qwen2_5OmniTalkersForConditionalGeneration`] for audio-only outputs.
-- Audio generation with [`Qwen2_5OmniForConditionalGeneration`] supports only single batch size at the moment.
+- Use [`Qwen3OmniMoeForConditionalGeneration`] to generate audio and text output. To generate only one output type, use [`Qwen3OmniMoeThinkerForConditionalGeneration`] for text-only and [`Qwen3OmniMoeTalkerForConditionalGeneration`] for audio-only outputs.
+- Audio generation with [`Qwen3OmniMoeForConditionalGeneration`] supports only single batch size at the moment.
 - In case out out-of-memory errors hwen working with video input, decrease `processor.max_pixels`. By default the maximum is set to a very arge value and high resolution visuals will not be resized, unless resolution exceeds `processor.max_pixels`.
 - The processor has its own [`~ProcessorMixin.apply_chat_template`] method to convert chat messages to model inputs.
 
 ## Usage example
 
-`Qwen2.5-Omni` can be found on the [Huggingface Hub](https://huggingface.co/Qwen).
+`Qwen3-Omni` can be found on the [Huggingface Hub](https://huggingface.co/Qwen).
 
 ### Single Media inference
 
@@ -48,14 +48,14 @@ The model can accept text, images, audio and videos as input. Here's an example 
 
 ```python
 import soundfile as sf
-from transformers import Qwen2_5OmniForConditionalGeneration, Qwen2_5OmniProcessor
+from transformers import Qwen3OmniMoeForConditionalGeneration, Qwen3OmniMoeProcessor
 
-model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
-    "Qwen/Qwen2.5-Omni-7B",
+model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     dtype="auto",
     device_map="auto"
 )
-processor = Qwen2_5OmniProcessor.from_pretrained("Qwen/Qwen2.5-Omni-7B")
+processor = Qwen3OmniMoeProcessor.from_pretrained("Qwen/Qwen3-Omni-30B-A3B-Instruct")
 
 conversations = [
     {
@@ -82,7 +82,7 @@ inputs = processor.apply_chat_template(
     return_tensors="pt",
     video_fps=1,
 
-    # kwargs to be passed to `Qwen2-5-OmniProcessor`
+    # kwargs to be passed to `Qwen3OmniMoeProcessor`
     padding=True,
     use_audio_in_video=True,
 ).to(model.device)
@@ -101,17 +101,17 @@ print(text)
 
 ### Text-only generation
 
-To generate only text output and save compute by not loading the audio generation model, we can use `Qwen2_5OmniThinkerForConditionalGeneration` model.  
+To generate only text output and save compute by not loading the audio generation model, we can use `Qwen3OmniMoeThinkerForConditionalGeneration` model.
 
 ```python
-from transformers import Qwen2_5OmniThinkerForConditionalGeneration, Qwen2_5OmniProcessor
+from transformers import Qwen3OmniMoeThinkerForConditionalGeneration, Qwen3OmniMoeProcessor
 
-model = Qwen2_5OmniThinkerForConditionalGeneration.from_pretrained(
-    "Qwen/Qwen2.5-Omni-7B",
+model = Qwen3OmniMoeThinkerForConditionalGeneration.from_pretrained(
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     dtype="auto",
     device_map="auto",
 )
-processor = Qwen2_5OmniProcessor.from_pretrained("Qwen/Qwen2.5-Omni-7B")
+processor = Qwen3OmniMoeProcessor.from_pretrained("Qwen/Qwen3-Omni-30B-A3B-Instruct")
 
 conversations = [
     {
@@ -138,7 +138,7 @@ inputs = processor.apply_chat_template(
     return_tensors="pt",
     video_fps=1,
 
-    # kwargs to be passed to `Qwen2-5-OmniProcessor`
+    # kwargs to be passed to `Qwen3OmniMoeProcessor`
     padding=True,
     use_audio_in_video=True,
 ).to(model.device)
@@ -157,18 +157,18 @@ print(text)
 
 ### Batch Mixed Media Inference
 
-The model can batch inputs composed of mixed samples of various types such as text, images, audio and videos as input when using `Qwen2_5OmniThinkerForConditionalGeneration` model. Here is an example.
+The model can batch inputs composed of mixed samples of various types such as text, images, audio and videos as input when using `Qwen3OmniMoeThinkerForConditionalGeneration` model. Here is an example.
 
 ```python
 import soundfile as sf
-from transformers import Qwen2_5OmniForConditionalGeneration, Qwen2_5OmniProcessor
+from transformers import Qwen3OmniMoeForConditionalGeneration, Qwen3OmniMoeProcessor
 
-model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
-    "Qwen/Qwen2.5-Omni-7B",
+model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     dtype="auto",
     device_map="auto"
 )
-processor = Qwen2_5OmniProcessor.from_pretrained("Qwen/Qwen2.5-Omni-7B")
+processor = Qwen3OmniMoeProcessor.from_pretrained("Qwen/Qwen3-Omni-30B-A3B-Instruct")
 
 # Conversation with video only
 conversation1 = [
@@ -247,7 +247,7 @@ inputs = processor.apply_chat_template(
     return_tensors="pt",
     video_fps=1,
 
-    # kwargs to be passed to `Qwen2-5-OmniProcessor`
+    # kwargs to be passed to `Qwen3OmniMoeProcessor`
     padding=True,
     use_audio_in_video=True,
 ).to(model.thinker.device)
@@ -267,7 +267,7 @@ The model supports a wide range of resolution inputs. By default, it uses the na
 ```python
 min_pixels = 128*28*28
 max_pixels = 768*28*28
-processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-Omni-7B", min_pixels=min_pixels, max_pixels=max_pixels)
+processor = AutoProcessor.from_pretrained("Qwen/Qwen3-Omni-30B-A3B-Instruct", min_pixels=min_pixels, max_pixels=max_pixels)
 ```
 
 #### Prompt for audio output
@@ -285,8 +285,8 @@ If users need audio output, the system prompt must be set as "You are Qwen, a vi
 The model supports both text and audio outputs, if users do not need audio outputs, they can set `enable_audio_output` in the `from_pretrained` function. This option will save about `~2GB` of GPU memory but the `return_audio` option for `generate` function will only allow to be set at `False`.
 
 ```python
-model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
-    "Qwen/Qwen2.5-Omni-7B",
+model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     dtype="auto",
     device_map="auto",
     enable_audio_output=False,
@@ -296,8 +296,8 @@ model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
 In order to obtain a flexible experience, we recommend that users set `enable_audio_output` at `True` when initializing the model through `from_pretrained` function, and then decide whether to return audio when `generate` function is called. When `return_audio` is set to `False`, the model will only return text outputs to get text responses faster.
 
 ```python
-model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
-    "Qwen/Qwen2.5-Omni-7B",
+model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     dtype="auto",
     device_map="auto",
     enable_audio_output=True,
@@ -307,7 +307,7 @@ text_ids = model.generate(**inputs, return_audio=False)
 ```
 
 #### Change voice type of output audio
-Qwen2.5-Omni supports the ability to change the voice of the output audio. Users can use the `spk` parameter of `generate` function to specify the voice type. The `"Qwen/Qwen2.5-Omni-7B"` checkpoint support two voice types: `Chelsie` and `Ethan`, while `Chelsie` is a female voice and `Ethan` is a male voice. By default, if `spk` is not specified, the default voice type is `Chelsie`.
+Qwen3-Omni-MOE supports the ability to change the voice of the output audio. Users can use the `spk` parameter of `generate` function to specify the voice type. The `"Qwen/Qwen3-Omni-30B-A3B-Instruct"` checkpoint support two voice types: `Chelsie` and `Ethan`, while `Chelsie` is a female voice and `Ethan` is a male voice. By default, if `spk` is not specified, the default voice type is `Chelsie`.
 
 ```python
 text_ids, audio = model.generate(**inputs, spk="Chelsie")
@@ -330,10 +330,10 @@ Also, you should have hardware that is compatible with FlashAttention 2. Read mo
 To load and run a model using FlashAttention-2, add `attn_implementation="flash_attention_2"` when loading the model:
 
 ```python
-from transformers import Qwen2_5OmniForConditionalGeneration
+from transformers import Qwen3OmniMoeForConditionalGeneration
 
-model = Qwen2_5OmniForConditionalGeneration.from_pretrained(
-    "Qwen/Qwen2.5-Omni-7B",
+model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(
+    "Qwen/Qwen3-Omni-30B-A3B-Instruct",
     device_map="auto",
     dtype=torch.bfloat16,
     attn_implementation="flash_attention_2",

--- a/docs/source/en/model_doc/qwen3_vl.md
+++ b/docs/source/en/model_doc/qwen3_vl.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on None and added to Hugging Face Transformers on 2025-09-15.*
+*This model was released on 2025-02-19 and added to Hugging Face Transformers on 2025-09-15.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">

--- a/docs/source/en/model_doc/qwen3_vl_moe.md
+++ b/docs/source/en/model_doc/qwen3_vl_moe.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on None and added to Hugging Face Transformers on 2025-09-15.*
+*This model was released on 2025-02-19 and added to Hugging Face Transformers on 2025-09-15.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">

--- a/docs/source/en/model_doc/vaultgemma.md
+++ b/docs/source/en/model_doc/vaultgemma.md
@@ -15,7 +15,7 @@ limitations under the License.
 ⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be rendered properly in your Markdown viewer.
 
 -->
-*This model was released on {release_date} and added to Hugging Face Transformers on 2025-09-12.*
+*This model was released on 2016-07-01 and added to Hugging Face Transformers on 2025-09-12.*
 
 # VaultGemma
 

--- a/utils/add_dates.py
+++ b/utils/add_dates.py
@@ -2,6 +2,7 @@ import argparse
 import os
 import re
 import subprocess
+from datetime import date
 from typing import Optional
 
 from huggingface_hub import paper_info
@@ -36,15 +37,14 @@ ARXIV_PAPERS_NOT_IN_HF_PAPERS = {
 def get_modified_cards() -> list[str]:
     """Get the list of model names from modified files in docs/source/en/model_doc/"""
 
-    result = subprocess.check_output(["git", "status", "--porcelain"], text=True)
+    result = subprocess.check_output(["git", "diff", "--name-only", "upstream/main"], text=True)
 
     model_names = []
     for line in result.strip().split("\n"):
         if line:
-            # Split on whitespace and take the last part (filename)
-            filename = line.split()[-1]
-            if filename.startswith("docs/source/en/model_doc/") and filename.endswith(".md"):
-                model_name = os.path.splitext(os.path.basename(filename))[0]
+            # Check if the file is in the model_doc directory
+            if line.startswith("docs/source/en/model_doc/") and line.endswith(".md"):
+                model_name = os.path.splitext(os.path.basename(line))[0]
                 if model_name not in ["auto", "timm_wrapper"]:
                     model_names.append(model_name)
 
@@ -61,13 +61,10 @@ def get_paper_link(model_card: Optional[str], path: Optional[str]) -> str:
     with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    if "blog" in content or "report" in content or "post" in content:
-        print(f"Insert the release date of the blog post or technical report at the top of {model_card}")
-        return "blog"
-
     # Find known paper links
     paper_ids = re.findall(r"https://huggingface\.co/papers/\d+\.\d+", content)
     paper_ids += re.findall(r"https://arxiv\.org/abs/\d+\.\d+", content)
+    paper_ids += re.findall(r"https://arxiv\.org/pdf/\d+\.\d+", content)
 
     # If no known paper links are found, look for other potential paper links
     if len(paper_ids) == 0:
@@ -109,10 +106,19 @@ def get_first_commit_date(model_name: Optional[str]) -> str:
     if not os.path.exists(file_path):
         file_path = os.path.join(DOCS_PATH, f"{model_name}.md")
 
-    result = subprocess.check_output(
-        ["git", "log", "--reverse", "--pretty=format:%ad", "--date=iso", file_path], text=True
+    # Check if file exists in upstream/main
+    result_main = subprocess.check_output(
+        ["git", "ls-tree", "upstream/main", "--", file_path], text=True, stderr=subprocess.DEVNULL
     )
-    return result.strip().split("\n")[0][:10]
+    if not result_main:
+        # File does not exist in upstream/main (new model), use today's date
+        final_date = date.today().isoformat()
+    else:
+        # File exists in upstream/main, get the first commit date
+        final_date = subprocess.check_output(
+            ["git", "log", "--reverse", "--pretty=format:%ad", "--date=iso", file_path], text=True
+        )
+    return final_date.strip().split("\n")[0][:10]
 
 
 def get_release_date(link: str) -> str:
@@ -125,7 +131,7 @@ def get_release_date(link: str) -> str:
         except Exception as e:
             print(f"Error fetching release date for the paper https://huggingface.co/papers/{link}: {e}")
 
-    elif link.startswith("https://arxiv.org/abs/"):
+    elif link.startswith("https://arxiv.org/abs/") or link.startswith("https://arxiv.org/pdf/"):
         print(f"This paper {link} is not yet available in Hugging Face papers, skipping the release date attachment.")
         return r"{release_date}"
 
@@ -144,6 +150,7 @@ def replace_paper_links(file_path: str) -> bool:
 
     # Find all arxiv links
     arxiv_links = re.findall(r"https://arxiv\.org/abs/(\d+\.\d+)", content)
+    arxiv_links += re.findall(r"https://arxiv\.org/pdf/(\d+\.\d+)", content)
 
     for paper_id in arxiv_links:
         try:
@@ -151,6 +158,8 @@ def replace_paper_links(file_path: str) -> bool:
             paper_info(paper_id)
             # If no exception, replace the link
             old_link = f"https://arxiv.org/abs/{paper_id}"
+            if old_link not in content:
+                old_link = f"https://arxiv.org/pdf/{paper_id}"
             new_link = f"https://huggingface.co/papers/{paper_id}"
             content = content.replace(old_link, new_link)
             print(f"Replaced {old_link} with {new_link}")
@@ -204,13 +213,25 @@ def insert_dates(model_card_list: list[str]):
 
         hf_commit_date = get_first_commit_date(model_name=model_card)
 
+        paper_link = get_paper_link(model_card=model_card, path=file_path)
+        release_date = ""
+        if not (paper_link == "No_paper" or paper_link == "blog"):
+            release_date = get_release_date(paper_link)
+        else:
+            release_date = r"{release_date}"
+
         match = re.search(pattern, content)
 
-        # If the dates info line already exists, only check and update the hf_commit_date, don't modify the existing release date
+        # If the dates info line already exists, preserve the existing release date unless it's a placeholder, and update the HF commit date if needed
         if match:
-            release_date = match.group(1)  # The release date part
+            existing_release_date = match.group(1)  # The release date part
             existing_hf_date = match.group(2)  # The existing HF date part
-            if existing_hf_date != hf_commit_date:
+            release_date = (
+                release_date
+                if (existing_release_date == r"{release_date}" or existing_release_date == "None")
+                else existing_release_date
+            )
+            if existing_hf_date != hf_commit_date or existing_release_date != release_date:
                 old_line = match.group(0)  # Full matched line
                 new_line = f"\n*This model was released on {release_date} and added to Hugging Face Transformers on {hf_commit_date}.*"
 
@@ -220,14 +241,6 @@ def insert_dates(model_card_list: list[str]):
 
         # If the dates info line does not exist, add it
         else:
-            paper_link = get_paper_link(model_card=model_card, path=file_path)
-            release_date = ""
-
-            if not (paper_link == "No_paper" or paper_link == "blog"):
-                release_date = get_release_date(paper_link)
-            else:
-                release_date = r"{release_date}"
-
             insert_index = markers[0].end()
 
             date_info = f"\n*This model was released on {release_date} and added to Hugging Face Transformers on {hf_commit_date}.*"


### PR DESCRIPTION
# What does this PR do?

Improve the script to automatically add dates in the model doc files.
One big issue was that the script was checking for the first commit merged into main to get the transformers release dates, but that can't work for new models. So now if the model is not on main (new model), we use today's date.
Also when check-all is not used, we now check which files have been changed against upstream main instead of checking against the local branch.
Also fixes Qwen3OmniMoe doc.