### PR TITLE
Bump hfh prerelease version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ _deps = [
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
     "hf_xet",
-    "huggingface-hub==1.0.0.rc1",
+    "huggingface-hub==1.0.0.rc2",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "jinja2>=3.1.0",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -23,7 +23,7 @@ deps = {
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
     "hf_xet": "hf_xet",
-    "huggingface-hub": "huggingface-hub==1.0.0.rc1",
+    "huggingface-hub": "huggingface-hub==1.0.0.rc2",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "jinja2": "jinja2>=3.1.0",


### PR DESCRIPTION
From `1.0.0.rc1` to `1.0.0.rc2` (minor fix in `@strict` dataclass so shouldn't change anything).