### PR TITLE
Fix Qwen3-Omni audio_token_id serialization issue

### DIFF
--- a/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
@@ -431,11 +431,8 @@ class Qwen3OmniMoeThinkerConfig(PretrainedConfig):
     ```"""
 
     model_type = "qwen3_omni_moe_thinker"
-    attribute_map = {
-        "image_token_id": "image_token_index",
-        "video_token_id": "video_token_index",
-        "audio_token_id": "audio_token_index",
-    }
+    # Override parent's attribute_map as we use audio_token_id directly, not audio_token_index
+    attribute_map = {}
     sub_configs = {
         "audio_config": Qwen3OmniMoeAudioEncoderConfig,
         "vision_config": Qwen3OmniMoeVisionEncoderConfig,

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -264,6 +264,10 @@ class Qwen3OmniMoeThinkerConfig(Qwen2_5OmniThinkerConfig):
     >>> configuration = model.config
     ```"""
 
+    model_type = "qwen3_omni_moe_thinker"
+    # Override parent's attribute_map as we use audio_token_id directly, not audio_token_index
+    attribute_map = {}
+
     def __init__(
         self,
         audio_config=None,


### PR DESCRIPTION
# What does this PR do?

This PR fixes a critical bug in Qwen3-Omni model configuration where `audio_token_id` was not properly preserved during `save_pretrained`/`from_pretrained` operations, causing incorrect inference results in training scenarios.

## Problem

When using `save_pretrained()` followed by `from_pretrained()` on Qwen3-Omni models, the `audio_token_id` value was being reset to the default value (151646) instead of preserving the original value (e.g., 151675), leading to abnormal audio training/inference results.

## Root Cause

The issue was caused by a mismatch between the `attribute_map` in `Qwen3OmniMoeThinkerConfig` and the actual implementation:

- `attribute_map` was mapping `audio_token_id` → `audio_token_index`
- But the modular implementation deletes `audio_token_index` and uses `audio_token_id` directly
- This caused serialization/deserialization to fail silently

## Solution

Remove the conflicting `attribute_map` from `Qwen3OmniMoeThinkerConfig` to allow `audio_token_id` to be serialized directly, matching the actual implementation pattern used in the modular version.

## Verification

- ✅ Tested with real Qwen3-Omni model: `audio_token_id` now preserves correctly (151675 → 151675)
- ✅ Basic configuration tests pass
- ✅ No breaking changes to existing functionality

Fixes #41191

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue? Yes: #41191
- [x] Did you make sure existing tests pass?
- [x] This is a bug fix that doesn't require documentation updates

## Who can review?

@ArthurZucker @SunMarc (text models and configuration)