### PR TITLE
Don't convert to `safetensors` on the fly if the call is from testing

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -29,6 +29,7 @@ COMMON_ENV_VARIABLES = {
     "RUN_PIPELINE_TESTS": False,
     # will be adjust in `CircleCIJob.to_dict`.
     "RUN_FLAKY": True,
+    "DISABLE_SAFETENSORS_CONVERSION": False,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
 COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "vvv": None, "rsfE":None}

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -29,7 +29,7 @@ COMMON_ENV_VARIABLES = {
     "RUN_PIPELINE_TESTS": False,
     # will be adjust in `CircleCIJob.to_dict`.
     "RUN_FLAKY": True,
-    "DISABLE_SAFETENSORS_CONVERSION": False,
+    "DISABLE_SAFETENSORS_CONVERSION": True,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
 COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "vvv": None, "rsfE":None}

--- a/conftest.py
+++ b/conftest.py
@@ -90,6 +90,8 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "torch_compile_test: mark test which tests torch compile functionality")
     config.addinivalue_line("markers", "torch_export_test: mark test which tests torch export functionality")
 
+    os.environ['DISABLE_SAFETENSORS_CONVERSION'] = 'false'
+
 
 def pytest_collection_modifyitems(items):
     for item in items:

--- a/conftest.py
+++ b/conftest.py
@@ -90,7 +90,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "torch_compile_test: mark test which tests torch compile functionality")
     config.addinivalue_line("markers", "torch_export_test: mark test which tests torch export functionality")
 
-    os.environ['DISABLE_SAFETENSORS_CONVERSION'] = 'false'
+    os.environ['DISABLE_SAFETENSORS_CONVERSION'] = 'true'
 
 
 def pytest_collection_modifyitems(items):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1073,7 +1073,6 @@ def _get_resolved_checkpoint_files(
                     if resolved_archive_file is not None:
                         # In a CI environment (CircleCI / Github Actions workflow runs) or in a pytest run,
                         # we set `DISABLE_SAFETENSORS_CONVERSION=true` to prevent the conversion.
-                        breakpoint()
                         if (
                             filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]
                             and os.getenv("DISABLE_SAFETENSORS_CONVERSION", None) != "true"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1072,7 +1072,7 @@ def _get_resolved_checkpoint_files(
                 if not local_files_only and not is_offline_mode():
                     if resolved_archive_file is not None:
                         # In a CI environment (CircleCI / Github Actions workflow runs) or in a pytest run,
-                        # we set `DISABLE_SAFETENSORS_CONVERSION=true` to prevent to conversion.
+                        # we set `DISABLE_SAFETENSORS_CONVERSION=true` to prevent the conversion.
                         breakpoint()
                         if (
                             filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1072,7 +1072,8 @@ def _get_resolved_checkpoint_files(
                 if not local_files_only and not is_offline_mode():
                     if resolved_archive_file is not None:
                         # In a CI environment (CircleCI / Github Actions workflow runs) or in a pytest run,
-                        # we set `DISABLE_SAFETENSORS_CONVERSION=false` to prevent to conversion.
+                        # we set `DISABLE_SAFETENSORS_CONVERSION=true` to prevent to conversion.
+                        breakpoint()
                         if (
                             filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]
                             and os.getenv("DISABLE_SAFETENSORS_CONVERSION", None) != "true"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1071,7 +1071,12 @@ def _get_resolved_checkpoint_files(
                         is_sharded = True
                 if not local_files_only and not is_offline_mode():
                     if resolved_archive_file is not None:
-                        if filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]:
+                        # In a CI environment (CircleCI / Github Actions workflow runs) or in a pytest run, don't perform the conversion
+                        if (
+                            filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]
+                            and os.getenv("CI", "false") != "true"
+                            and os.getenv("PYTEST_CURRENT_TEST", None) is None
+                        ):
                             # If the PyTorch file was found, check if there is a safetensors file on the repository
                             # If there is no safetensors file on the repositories, start an auto conversion
                             safe_weights_name = SAFE_WEIGHTS_INDEX_NAME if is_sharded else SAFE_WEIGHTS_NAME

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1071,11 +1071,11 @@ def _get_resolved_checkpoint_files(
                         is_sharded = True
                 if not local_files_only and not is_offline_mode():
                     if resolved_archive_file is not None:
-                        # In a CI environment (CircleCI / Github Actions workflow runs) or in a pytest run, don't perform the conversion
+                        # In a CI environment (CircleCI / Github Actions workflow runs) or in a pytest run,
+                        # we set `DISABLE_SAFETENSORS_CONVERSION=false` to prevent to conversion.
                         if (
                             filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]
-                            and os.getenv("CI", "false") != "true"
-                            and os.getenv("PYTEST_CURRENT_TEST", None) is None
+                            and os.getenv("DISABLE_SAFETENSORS_CONVERSION", None) != "false"
                         ):
                             # If the PyTorch file was found, check if there is a safetensors file on the repository
                             # If there is no safetensors file on the repositories, start an auto conversion

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1075,7 +1075,7 @@ def _get_resolved_checkpoint_files(
                         # we set `DISABLE_SAFETENSORS_CONVERSION=false` to prevent to conversion.
                         if (
                             filename in [WEIGHTS_NAME, WEIGHTS_INDEX_NAME]
-                            and os.getenv("DISABLE_SAFETENSORS_CONVERSION", None) != "false"
+                            and os.getenv("DISABLE_SAFETENSORS_CONVERSION", None) != "true"
                         ):
                             # If the PyTorch file was found, check if there is a safetensors file on the repository
                             # If there is no safetensors file on the repositories, start an auto conversion


### PR DESCRIPTION
# What does this PR do?

Don't convert to `safetensors` on the fly if the call is from testing