### PR TITLE
Fix 8bit bnb loading

### DIFF
--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -204,7 +204,8 @@ class Bnb8BitHfQuantizer(HfQuantizer):
         # Need to pop SCB and reset it because of bnb internals that modifies its value when switching devices ...
         SCB = kwargs.pop("SCB", None)
         new_value = bnb.nn.Int8Params(param_value.to("cpu"), requires_grad=False, **kwargs).to(target_device)
-        setattr(new_value, "SCB", SCB)
+        if SCB is not None:
+            setattr(new_value, "SCB", SCB)
         # Set it to the module
         module._parameters[tensor_name] = new_value
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes some code related to 8-bit models that was changed during a recent refactor https://github.com/huggingface/transformers/pull/41138. The issue was that `SCB` value was actually modified when moving the param from cpu to cuda. 