### PR TITLE
[generate] cache missing custom generate file

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 import torch
 import torch.distributed as dist
-from huggingface_hub import file_exists
 from packaging import version
 from torch import nn
 


### PR DESCRIPTION
# What does this PR do?

Reorders code in `load_custom_generate` such that we load the `.py` file first, and check whether it is to be used later. This way, we can cache the result of the Hub request even when the file doesn't exist.

⚠️ Since we try to load `custom_generate` at model-loading time, this results in much fewer Hub requests in situations like CIs. Some downstream CIs were hitting rate limits, in part due to this feature's uncached requests prior to this change.

______________________

✅ ran `custom_generation` tests, including existing slow tests.