### PR TITLE
Video processor accepts single frames on cuda

### DIFF
--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -196,7 +196,9 @@ def make_batched_videos(videos) -> list[Union[np.ndarray, "torch.Tensor", "URL",
         return convert_pil_frames_to_video([videos])
     # only one frame passed, thus we unsqueeze time dim
     elif is_valid_image(videos):
-        return [np.array(videos)[None, ...]]
+        if isinstance(videos, PIL.Image.Image):
+            videos = np.array(videos)
+        return [videos[None, ...]]
     elif not isinstance(videos, list):
         raise ValueError(
             f"Invalid video input. Expected either a list of video frames or an input of 4 or 5 dimensions, but got"

--- a/tests/utils/test_video_utils.py
+++ b/tests/utils/test_video_utils.py
@@ -122,7 +122,7 @@ class BaseVideoProcessorTester(unittest.TestCase):
         torch_video = torch.from_numpy(video)
         videos_list = make_batched_videos(torch_video)
         self.assertIsInstance(videos_list, list)
-        self.assertIsInstance(videos_list[0], np.ndarray)
+        self.assertIsInstance(videos_list[0], torch.Tensor)
         self.assertEqual(videos_list[0].shape, (1, 16, 32, 3))
         self.assertTrue(np.array_equal(videos_list[0][0], video))
 


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/40867 and allows input videos to be a "3D tensor on cuda device"