### PR TITLE
[kernels] Kernel Config 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -90,7 +90,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "torch_compile_test: mark test which tests torch compile functionality")
     config.addinivalue_line("markers", "torch_export_test: mark test which tests torch export functionality")
 
-    os.environ['DISABLE_SAFETENSORS_CONVERSION'] = 'true'
+    os.environ["DISABLE_SAFETENSORS_CONVERSION"] = "true"
 
 
 def pytest_collection_modifyitems(items):

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -218,6 +218,11 @@
   title: Quantization
 - isExpanded: false
   sections:
+  - local: kernel_doc/overview
+    title: Kernels in transformers
+  title: Kernels
+- isExpanded: false
+  sections:
   - local: serialization
     title: ONNX
   - local: executorch

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -373,6 +373,8 @@
       title: Image Processor
     - local: main_classes/video_processor
       title: Video Processor
+    - local: main_classes/kernels
+      title: Kernels
     title: Main Classes
   - sections:
     - sections:

--- a/docs/source/en/kernel_doc/overview.md
+++ b/docs/source/en/kernel_doc/overview.md
@@ -1,3 +1,3 @@
-# Kernels in transformers
+# Overview
 
 Kernels in transformers are used to optimize the performance of models with custom layers from the hub and very low effort.

--- a/docs/source/en/kernel_doc/overview.md
+++ b/docs/source/en/kernel_doc/overview.md
@@ -1,0 +1,3 @@
+# Kernels in transformers
+
+Kernels in transformers are used to optimize the performance of models with custom layers from the hub and very low effort.

--- a/docs/source/en/main_classes/kernels.md
+++ b/docs/source/en/main_classes/kernels.md
@@ -1,0 +1,3 @@
+## KernelConfig
+
+[[autodoc]] KernelConfig

--- a/docs/source/en/main_classes/kernels.md
+++ b/docs/source/en/main_classes/kernels.md
@@ -1,3 +1,7 @@
-## KernelConfig
+## Kernels
+
+This page documents the kernels configuration utilities.
+
+### KernelConfig
 
 [[autodoc]] KernelConfig

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -769,7 +769,6 @@ if TYPE_CHECKING:
     from .utils import is_torch_npu_available as is_torch_npu_available
     from .utils import is_torch_xla_available as is_torch_xla_available
     from .utils import is_torch_xpu_available as is_torch_xpu_available
-    from .utils import logging as logging
     from .utils.kernel_config import KernelConfig as KernelConfig
 
     # bitsandbytes config

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -769,6 +769,8 @@ if TYPE_CHECKING:
     from .utils import is_torch_npu_available as is_torch_npu_available
     from .utils import is_torch_xla_available as is_torch_xla_available
     from .utils import is_torch_xpu_available as is_torch_xpu_available
+    from .utils import logging as logging
+    from .utils.kernel_config import KernelConfig as KernelConfig
 
     # bitsandbytes config
     from .utils.quantization_config import AqlmConfig as AqlmConfig
@@ -790,8 +792,6 @@ if TYPE_CHECKING:
     from .utils.quantization_config import TorchAoConfig as TorchAoConfig
     from .utils.quantization_config import VptqConfig as VptqConfig
     from .video_processing_utils import BaseVideoProcessor as BaseVideoProcessor
-
-    from .utils.kernel_config import KernelConfig as KernelConfig
 else:
     import sys
 

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -266,6 +266,7 @@ _import_structure = {
         "VptqConfig",
     ],
     "video_utils": [],
+    "utils.kernel_config": ["KernelConfig"],
 }
 
 # tokenizers-backed objects
@@ -790,6 +791,7 @@ if TYPE_CHECKING:
     from .utils.quantization_config import VptqConfig as VptqConfig
     from .video_processing_utils import BaseVideoProcessor as BaseVideoProcessor
 
+    from .utils.kernel_config import KernelConfig as KernelConfig
 else:
     import sys
 

--- a/src/transformers/integrations/__init__.py
+++ b/src/transformers/integrations/__init__.py
@@ -217,11 +217,11 @@ if TYPE_CHECKING:
     from .higgs import HiggsLinear, dequantize_higgs, quantize_with_higgs, replace_with_higgs_linear
     from .hqq import prepare_for_hqq_linear
     from .hub_kernels import (
+        _KERNEL_MAPPING,
         LayerRepository,
         register_kernel_mapping,
         replace_kernel_forward_from_hub,
         use_kernel_forward_from_hub,
-        _KERNEL_MAPPING,
     )
     from .integration_utils import (
         INTEGRATION_TO_CALLBACK,

--- a/src/transformers/integrations/__init__.py
+++ b/src/transformers/integrations/__init__.py
@@ -75,6 +75,7 @@ _import_structure = {
         "register_kernel_mapping",
         "replace_kernel_forward_from_hub",
         "use_kernel_forward_from_hub",
+        "_KERNEL_MAPPING",
     ],
     "integration_utils": [
         "INTEGRATION_TO_CALLBACK",
@@ -220,6 +221,7 @@ if TYPE_CHECKING:
         register_kernel_mapping,
         replace_kernel_forward_from_hub,
         use_kernel_forward_from_hub,
+        _KERNEL_MAPPING,
     )
     from .integration_utils import (
         INTEGRATION_TO_CALLBACK,

--- a/src/transformers/integrations/__init__.py
+++ b/src/transformers/integrations/__init__.py
@@ -75,7 +75,6 @@ _import_structure = {
         "register_kernel_mapping",
         "replace_kernel_forward_from_hub",
         "use_kernel_forward_from_hub",
-        "_KERNEL_MAPPING",
     ],
     "integration_utils": [
         "INTEGRATION_TO_CALLBACK",
@@ -217,7 +216,6 @@ if TYPE_CHECKING:
     from .higgs import HiggsLinear, dequantize_higgs, quantize_with_higgs, replace_with_higgs_linear
     from .hqq import prepare_for_hqq_linear
     from .hub_kernels import (
-        _KERNEL_MAPPING,
         LayerRepository,
         register_kernel_mapping,
         replace_kernel_forward_from_hub,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -84,6 +84,7 @@ from .utils import (
     WEIGHTS_INDEX_NAME,
     WEIGHTS_NAME,
     ContextManagers,
+    KernelConfig,
     PushToHubMixin,
     cached_file,
     check_torch_load_is_safe,
@@ -107,7 +108,6 @@ from .utils import (
     is_torch_xla_available,
     is_torch_xpu_available,
     logging,
-    KernelConfig,
 )
 from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder
 from .utils.hub import create_and_tag_model_card, get_checkpoint_shard_files

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4893,12 +4893,17 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             from kernels import use_kernel_mapping
 
             if kernel_config is not None and isinstance(kernel_config, KernelConfig):
+                # This will make sure the mapping is valid, and the layers are registered in the model
                 kernel_config.sanitize_kernel_mapping(model)
 
+                # This is a context manager to override the default kernel mapping
+                # We are calling kernelize inside this context manager using the use_kernels setter
                 with use_kernel_mapping(kernel_config.kernel_mapping):
                     model.use_kernels = True
+            # We use the default kernel mapping in .integrations.hub_kernels
             else:
                 model.use_kernels = True
+
         # If it is a model with generation capabilities, attempt to load generation files (generation config,
         # custom generate function)
         if model.can_generate() and generation_config is not None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4883,6 +4883,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         model.eval()
 
         # check if using kernels
+        print(model.model.layers[0].input_layernorm.kernel_layer_name)
         if use_kernels:
             model.use_kernels = True
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4896,6 +4896,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 # This will make sure the mapping is valid, and the layers are registered in the model
                 kernel_config.sanitize_kernel_mapping(model)
 
+                # This will create a compatible mapping for the model with the kernels library
+                kernel_config.create_compatible_mapping(model)
+
                 # This is a context manager to override the default kernel mapping
                 # We are calling kernelize inside this context manager using the use_kernels setter
                 with use_kernel_mapping(kernel_config.kernel_mapping):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -261,6 +261,7 @@ from .import_utils import (
     requires_backends,
     torch_only_method,
 )
+from .kernel_config import KernelConfig
 from .peft_utils import (
     ADAPTER_CONFIG_NAME,
     ADAPTER_SAFE_WEIGHTS_NAME,
@@ -269,7 +270,6 @@ from .peft_utils import (
     find_adapter_config_file,
 )
 
-from .kernel_config import KernelConfig
 
 WEIGHTS_NAME = "pytorch_model.bin"
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -269,6 +269,7 @@ from .peft_utils import (
     find_adapter_config_file,
 )
 
+from .kernel_config import KernelConfig
 
 WEIGHTS_NAME = "pytorch_model.bin"
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utils import is_kernels_available, is_torch_available, PushToHubMixin
+from ..utils import PushToHubMixin, is_kernels_available, is_torch_available
 
 
 if is_kernels_available():

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# from ..configuration_utils import ConfigMixin
+
 from ..utils import is_kernels_available, is_torch_available, PushToHubMixin
 
 
@@ -23,6 +23,14 @@ if is_torch_available():
 
 
 def infer_device(model):
+    """
+    Infers the device type from the model parameters.
+    Args:
+        model: The model instance.
+
+    Returns:
+        The device type.
+    """
     EXAMPLE_MAPPING = """
     {
         "RMSNorm": {
@@ -48,6 +56,7 @@ def infer_device(model):
 
     return dev_type
 
+
 def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
     if device not in ["cuda", "rocm", "xpu"]:
         raise ValueError(f"Only cuda, rocm, and xpu devices supported, got: {device}")
@@ -62,7 +71,14 @@ def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
         }
     }
 
+
 class KernelConfig(PushToHubMixin):
+    """
+    Kernel configuration class.
+    Args:
+        kernel_mapping: The kernel mapping to register.
+    """
+
     def __init__(self, kernel_mapping={}):
         self.kernel_mapping = kernel_mapping
         self.registered_layer_names = {}

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -15,7 +15,7 @@ from ..utils import is_kernels_available, is_torch_available
 
 
 if is_kernels_available():
-    from kernels import Device, LayerRepository, Mode
+    from kernels import LayerRepository, Mode
 
 if is_torch_available():
     import torch
@@ -117,7 +117,7 @@ class KernelConfig:
                 )
 
             if isinstance(kernel, str):
-                if ("/" not in kernel or ":" not in kernel):
+                if "/" not in kernel or ":" not in kernel:
                     raise ValueError(
                         f"Kernel mapping for '{layer_name}' must be a valid repo name with a layer name (e.g., 'org/repo:layer_name'), got: {kernel}"
                     )

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -74,9 +74,7 @@ def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
 
 class KernelConfig(PushToHubMixin):
     """
-    Kernel configuration class.
-    Args:
-        kernel_mapping: The kernel mapping to register.
+    Kernel configuration class. This class is used to configure the kernel mapping for a model.
     """
 
     def __init__(self, kernel_mapping={}):

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # from ..configuration_utils import ConfigMixin
-from ..utils import is_kernels_available, is_torch_available
+from ..utils import is_kernels_available, is_torch_available, PushToHubMixin
 
 
 if is_kernels_available():
@@ -62,7 +62,7 @@ def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
         }
     }
 
-class KernelConfig:
+class KernelConfig(PushToHubMixin):
     def __init__(self, kernel_mapping={}):
         self.kernel_mapping = kernel_mapping
         self.registered_layer_names = {}

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -62,10 +62,8 @@ class KernelConfig:
                     if mode not in valid_modes:
                         raise ValueError(f"Mode {mode} is not supported")
                     # Check that the value is a LayerRepository
-                    if is_kernels_available():
-                        from kernels import LayerRepository
 
-                        if not isinstance(repo, LayerRepository):
-                            raise ValueError(
-                                f"Value for {layer_name} -> {device} -> {mode} must be a LayerRepository instance"
-                            )
+                    if not repo.__class__.__name__ == "LayerRepository1":
+                        raise ValueError(
+                            f"Value for {layer_name} -> {device} -> {mode} must be a LayerRepository instance"
+                        )

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -1,0 +1,39 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ..utils import is_kernels_available
+from ..integrations.hub_kernels import _KERNEL_MAPPING
+
+if is_kernels_available():
+    from kernels import LayerRepository, Mode
+
+class KernelsConfig:
+    def __init__(self, kernel_mapping):
+        self.kernel_mapping = kernel_mapping
+
+    def update_kernel(self, repo_id, layer_name, device = "cuda", mode = Mode.INFERENCE, revision=None):
+        self.kernel_mapping[layer_name] = {
+            device: {
+                mode: LayerRepository(
+                    repo_id=repo_id,
+                    layer_name=layer_name,
+                    revision=revision,
+                )
+            }
+        }
+        return self.kernel_mapping
+
+    def update_kernel_mapping(self, new_kernel_mapping):
+        self.kernel_mapping = new_kernel_mapping
+        return self.kernel_mapping
+

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -17,23 +17,69 @@ from ..integrations.hub_kernels import _KERNEL_MAPPING
 if is_kernels_available():
     from kernels import LayerRepository, Mode
 
-class KernelsConfig:
-    def __init__(self, kernel_mapping):
+class KernelConfig:
+    def __init__(self, kernel_mapping = {}):
         self.kernel_mapping = kernel_mapping
 
-    def update_kernel(self, repo_id, layer_name, device = "cuda", mode = Mode.INFERENCE, revision=None):
-        self.kernel_mapping[layer_name] = {
-            device: {
-                mode: LayerRepository(
-                    repo_id=repo_id,
-                    layer_name=layer_name,
-                    revision=revision,
-                )
+    def update_kernel(self, model,repo_id, layer_name, device = "cuda", mode = Mode.INFERENCE, revision=None):
+        if self.check_if_layer_name_registered(layer_name, model):
+            self.kernel_mapping[layer_name] = {
+                device: {
+                    mode: LayerRepository(
+                        repo_id=repo_id,
+                        layer_name=layer_name,
+                        revision=revision,
+                    )
+                }
             }
-        }
+        else:
+            raise ValueError(f"Layer {layer_name} is not registered in the model")
+
         return self.kernel_mapping
 
-    def update_kernel_mapping(self, new_kernel_mapping):
-        self.kernel_mapping = new_kernel_mapping
+    def check_if_layer_name_registered(self, layer_name, model):
+        for name, module in model.named_modules():
+            if hasattr(module, "kernel_layer_name") and module.kernel_layer_name == layer_name:
+                return True
+        return False
+
+    def update_all_kernel_mapping(self, model,new_kernel_mapping):
+        for layer_name, mapping in new_kernel_mapping.items():
+            if self.check_if_layer_name_registered(layer_name, model):
+                self.kernel_mapping[layer_name] = mapping
+            else:
+                raise ValueError(f"Layer {layer_name} is not registered in the model")
         return self.kernel_mapping
 
+    def check_if_layer_name_in_global_mapping(self, layer_name):
+        return layer_name in _KERNEL_MAPPING.keys()
+
+    def sanitize_kernel_mapping(self, model):
+        for layer_name, mapping in self.kernel_mapping.items():
+            if not self.check_if_layer_name_registered(layer_name, model):
+                raise ValueError(f"Layer {layer_name} is not registered in the model")
+            if not isinstance(mapping, dict):
+                raise ValueError(f"Mapping for layer {layer_name} must be a dict")
+            for device, mode_dict in mapping.items():
+                if device not in ["cuda", "rocm", "xpu"]:
+                    raise ValueError(f"Device {device} is not supported")
+                if not isinstance(mode_dict, dict):
+                    raise ValueError(f"Device mapping for {device} in layer {layer_name} must be a dict")
+                for mode, repo in mode_dict.items():
+                    valid_modes = [
+                        Mode.INFERENCE,
+                        Mode.TRAINING,
+                        Mode.TORCH_COMPILE,
+                        Mode.TRAINING | Mode.TORCH_COMPILE,
+                        Mode.INFERENCE | Mode.TORCH_COMPILE,
+                        Mode.FALLBACK,
+                    ]
+                    if mode not in valid_modes:
+                        raise ValueError(f"Mode {mode} is not supported")
+                    # Check that the value is a LayerRepository
+                    if is_kernels_available():
+                        from kernels import LayerRepository
+                        if not isinstance(repo, LayerRepository):
+                            raise ValueError(
+                                f"Value for {layer_name} -> {device} -> {mode} must be a LayerRepository instance"
+                            )

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from ..utils import is_kernels_available
-from ..integrations.hub_kernels import _KERNEL_MAPPING
 
 if is_kernels_available():
     from kernels import LayerRepository, Mode
@@ -21,38 +20,22 @@ class KernelConfig:
     def __init__(self, kernel_mapping = {}):
         self.kernel_mapping = kernel_mapping
 
-    def update_kernel(self, model,repo_id, layer_name, device = "cuda", mode = Mode.INFERENCE, revision=None):
-        if self.check_if_layer_name_registered(layer_name, model):
-            self.kernel_mapping[layer_name] = {
-                device: {
-                    mode: LayerRepository(
-                        repo_id=repo_id,
-                        layer_name=layer_name,
-                        revision=revision,
-                    )
-                }
+    def update_kernel(self,repo_id, registered_name, layer_name, device, mode, revision=None):
+        self.kernel_mapping[registered_name] = {
+            device: {
+                mode: LayerRepository(
+                    repo_id=repo_id,
+                    layer_name=layer_name,
+                    revision=revision,
+                )
             }
-        else:
-            raise ValueError(f"Layer {layer_name} is not registered in the model")
-
-        return self.kernel_mapping
+        }
 
     def check_if_layer_name_registered(self, layer_name, model):
         for name, module in model.named_modules():
             if hasattr(module, "kernel_layer_name") and module.kernel_layer_name == layer_name:
                 return True
         return False
-
-    def update_all_kernel_mapping(self, model,new_kernel_mapping):
-        for layer_name, mapping in new_kernel_mapping.items():
-            if self.check_if_layer_name_registered(layer_name, model):
-                self.kernel_mapping[layer_name] = mapping
-            else:
-                raise ValueError(f"Layer {layer_name} is not registered in the model")
-        return self.kernel_mapping
-
-    def check_if_layer_name_in_global_mapping(self, layer_name):
-        return layer_name in _KERNEL_MAPPING.keys()
 
     def sanitize_kernel_mapping(self, model):
         for layer_name, mapping in self.kernel_mapping.items():

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -13,14 +13,16 @@
 # limitations under the License.
 from ..utils import is_kernels_available
 
+
 if is_kernels_available():
     from kernels import LayerRepository, Mode
 
+
 class KernelConfig:
-    def __init__(self, kernel_mapping = {}):
+    def __init__(self, kernel_mapping={}):
         self.kernel_mapping = kernel_mapping
 
-    def update_kernel(self,repo_id, registered_name, layer_name, device, mode, revision=None):
+    def update_kernel(self, repo_id, registered_name, layer_name, device, mode, revision=None):
         self.kernel_mapping[registered_name] = {
             device: {
                 mode: LayerRepository(
@@ -62,6 +64,7 @@ class KernelConfig:
                     # Check that the value is a LayerRepository
                     if is_kernels_available():
                         from kernels import LayerRepository
+
                         if not isinstance(repo, LayerRepository):
                             raise ValueError(
                                 f"Value for {layer_name} -> {device} -> {mode} must be a LayerRepository instance"

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -43,11 +43,9 @@ def infer_device(model):
     if dev_type == "cuda":
         # Refine based on actual platform
         if torch.version.hip is not None:
-            return Device(type="rocm")
-        elif torch.version.cuda is not None:
-            return Device(type="cuda")
+            return "rocm"
 
-    return Device(type=dev_type)
+    return dev_type
 
 
 class KernelConfig:
@@ -118,10 +116,11 @@ class KernelConfig:
                     f"Layer {layer_name} is not registered in the model, please register it first using register_kernel_forward_from_hub"
                 )
 
-            if isinstance(kernel, str) and ("/" not in kernel or ":" not in kernel):
-                raise ValueError(
-                    f"Kernel mapping for '{layer_name}' must be a valid repo name with a layer name (e.g., 'org/repo:layer_name'), got: {kernel}"
-                )
+            if isinstance(kernel, str):
+                if ("/" not in kernel or ":" not in kernel):
+                    raise ValueError(
+                        f"Kernel mapping for '{layer_name}' must be a valid repo name with a layer name (e.g., 'org/repo:layer_name'), got: {kernel}"
+                    )
 
             elif isinstance(kernel, dict):
                 for device, repo_name in kernel.items():


### PR DESCRIPTION
# What does this PR do?

Adding a kernel config in `from_pretrained` to allow users to use custom kernels. This requires though that the layer is already registered to be used with kernels like `RMSNorm`. Other prs will follow to allow to register kernels without doing that in the modeling.
For `RMSNorm` it looks like this: 
```python
from transformers import AutoModelForCausalLM, AutoTokenizer, KernelConfig
import torch

model_id = "meta-llama/Llama-3.2-1B"

kernel_mapping = {
    "RMSNorm": "kernels-community/layer_norm:LlamaRMSNorm"
}

kernel_config = KernelConfig(kernel_mapping)
model = AutoModelForCausalLM.from_pretrained(
    model_id,
    device_map="auto",
    torch_dtype=torch.bfloat16,
    use_kernels=True,
    kernel_config=kernel_config
)

tokenizer = AutoTokenizer.from_pretrained(model_id)

prompts = ["The capital of France is"]
token_dict = tokenizer(prompts, return_tensors="pt").to(model.device)
outputs = model.generate(**token_dict, max_new_tokens=10)
print(tokenizer.decode(outputs[0], skip_special_tokens=True))
```