### PR TITLE
fix TrainerIntegrationDeepSpeed UT failures

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -356,7 +356,7 @@ def deepspeed_optim_sched(trainer, hf_deepspeed_config, args, num_training_steps
 
     optimizer = None
     if "optimizer" in config:
-        if args.adafactor:
+        if args.optim == "adafactor":
             raise ValueError(
                 "--adafactor was passed, but also found `optimizer` configured in the DeepSpeed config. "
                 "Only one optimizer can be configured."


### PR DESCRIPTION
when run `TrainerIntegrationDeepSpeed` cases like `pytest -rA tests/deepspeed/test_deepspeed.py::TrainerIntegrationDeepSpeed::test_can_resume_training_normal_zero2_bf16_ds_optim_ds_scheduler`, it will fail w/

>         if "optimizer" in config:
>           if args.adafactor:
> E           AttributeError: 'RegressionTrainingArguments' object has no attribute 'adafactor'
> 
> src/transformers/integrations/deepspeed.py:359: AttributeError

Fix it by using `args.optim`

@ydshieh, @SunMarc  pls help review, thx very much.

