### PR TITLE
docs: Add Hacktoberfest banner, Contributing and License sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ limitations under the License.
     <a href="https://zenodo.org/badge/latestdoi/155220641"><img src="https://zenodo.org/badge/155220641.svg" alt="DOI"></a>
 </p>
 
+
+<p align="center">
+  <a href="https://hacktoberfest.com/">
+    <img src="https://img.shields.io/badge/Hacktoberfest-2025-blueviolet?style=for-the-badge&logo=hackthebox" alt="Hacktoberfest 2025" />
+  </a>
+</p>
+
 <h4 align="center">
     <p>
         <b>English</b> |

--- a/README.md
+++ b/README.md
@@ -255,6 +255,14 @@ incredible projects built with Transformers.
 
 If you own or use a project that you believe should be part of the list, please open a PR to add it!
 
+## Contributing
+
+We welcome contributions from the community! Whether you're fixing bugs, adding new features, improving documentation, or helping others, your contributions are valuable.
+
+Please read our [Contributing Guidelines](CONTRIBUTING.md) to learn how to contribute to Transformers. Make sure to also review our [Code of Conduct](https://github.com/huggingface/transformers/blob/main/CODE_OF_CONDUCT.md).
+
+For beginners, check out issues labeled with [good first issue](https://github.com/huggingface/transformers/labels/good%20first%20issue) to get started.
+
 ## Example models
 
 You can test most of our models directly on their [Hub model pages](https://huggingface.co/models).
@@ -333,3 +341,7 @@ We now have a [paper](https://www.aclweb.org/anthology/2020.emnlp-demos.6/) you 
     pages = "38--45"
 }
 ```
+
+## License
+
+Transformers is licensed under the [Apache License 2.0](LICENSE).


### PR DESCRIPTION
Closes #41246 and #41244

## What does this PR do?

Adds missing sections to the README:
- Contributing Guidelines section with link to CONTRIBUTING.md and Code of Conduct
- License section with link to LICENSE file

Adds:
- Hacktoberfest 2025 banner to the top.

## Why?

Makes the project more professional and contributor-friendly by following open-source best practices. These sections help new contributors understand how to get involved and clarify the project's licensing terms. It also allows Hacktoberfest participants to more easily understand that this repository is a part of Hacktoberfest.