### PR TITLE
feat: use `aws-highcpu-32-priv` for amd docker img build

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - build_ci_docker_image*
   repository_dispatch:
+  workflow_dispatch:
   workflow_call:
     inputs:
       image_postfix:

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -221,7 +221,7 @@ jobs:
   latest-pytorch-amd:
     name: "Latest PyTorch (AMD) [dev]"
     runs-on:
-      group: aws-general-8-plus
+      group: aws-highcpu-32-priv
     steps:
       -
         name: Set up Docker Buildx


### PR DESCRIPTION
change the runner group to something more powerful, amd docker image build is very greedy in resources