### PR TITLE
Diabled FA on AMD docker

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -36,9 +36,10 @@ RUN python3 -m pip uninstall -y kernels
 # On ROCm, torchcodec is required to decode audio files and 0.4 or 0.6 fails
 RUN python3 -m pip install --no-cache-dir "torchcodec==0.5"
 
+# This step is disabled because it takes too long on the CI
 # Install flash attention from source. Tested with commit 6387433156558135a998d5568a9d74c1778666d8
-RUN git clone https://github.com/ROCm/flash-attention/ -b tridao && \
-    cd flash-attention && \
-    GPU_ARCHS="gfx942" python setup.py install
+# RUN git clone https://github.com/ROCm/flash-attention/ -b tridao && \
+#     cd flash-attention && \
+#     GPU_ARCHS="gfx942" python setup.py install
 
-RUN python3 -m pip install --no-cache-dir einops
+# RUN python3 -m pip install --no-cache-dir einops


### PR DESCRIPTION
In a recent PR #41069 we enabled `flash-attention` in the AMD docker by adding a step to build it from source. But it turns out this is taking too long to be done on our CI runners, so this PR disables it until we find a faster installation process. 