### PR TITLE
Fix mxfp4 dequantization

### DIFF
--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -343,7 +343,6 @@ def dequantize(module, param_name, param_value, target_device, dq_param_name, **
                     to_contiguous,
                     rank,
                     device_mesh,
-                    set_param=False,
                 )
             blocks_attr = f"{proj}_blocks"
             scales_attr = f"{proj}_scales"


### PR DESCRIPTION
# What does this PR do?

https://github.com/huggingface/transformers/pull/41222 changed the signature of a caller in TP without updating the function calls, so `dequantization` is currently broken. This fixes it.