### PR TITLE
Fix equality-vs-assignment bug in GptqHfQuantizer.update_device_map

### DIFF
--- a/src/transformers/quantizers/quantizer_gptq.py
+++ b/src/transformers/quantizers/quantizer_gptq.py
@@ -92,7 +92,7 @@ class GptqHfQuantizer(HfQuantizer):
             device_map = {"": torch.device("cpu")}
         # Only with auto-gptq do not support CPU, we should move the model to cuda if available.
         if not is_gptqmodel_available() and device_map in ("cpu", {"": torch.device("cpu")}):
-            device_map == {"": 0}
+            device_map = {"": 0}
         return device_map
 
     def _process_model_before_weight_loading(self, model: "PreTrainedModel", **kwargs):


### PR DESCRIPTION
Fixes a typo in `GptqHfQuantizer.update_device_map` where an equality comparison (`==`) was used instead of an assignment (`=`). Due to this, `device_map` was never updated to CUDA when using `auto-gptq` (which does not support CPU), leaving the model on CPU contrary to the intent expressed in the comment.

- File: [src/transformers/quantizers/quantizer_gptq.py](https://github.com/huggingface/transformers/blob/e54defcfc265a1cc4f62edbf977747a0a443c812/src/transformers/quantizers/quantizer_gptq.py)
- Function: `GptqHfQuantizer.update_device_map`

Before:
```python
if not is_gptqmodel_available() and device_map in ("cpu", {"": torch.device("cpu")}):
    device_map == {"": 0}
```

After:
```python
if not is_gptqmodel_available() and device_map in ("cpu", {"": torch.device("cpu")}):
    device_map = {"": 0}
```

This change makes the code match the intended behavior: when `gptqmodel` is not available and the model would otherwise be placed on CPU, move to CUDA device map (`{"": 0}`).

## Who can review?

- quantization (bitsandbytes, autogpt, gptqmodel): @SunMarc @MekkCyber

Anyone in the community is also welcome to review.