### PR TITLE
Jitter noise PR

### DIFF
--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -629,7 +629,7 @@ class SwitchTransformersPreTrainedModel(PreTrainedModel):
             module.weight.data.fill_(factor * 1.0)
         elif isinstance(
             module,
-            (SwitchTransformersModel, SwitchTransformersForConditionalGeneration, SwitchTransformersEncoderModel),
+            SwitchTransformersModel | SwitchTransformersForConditionalGeneration | SwitchTransformersEncoderModel,
         ):
             module.shared.weight.data.normal_(mean=0.0, std=factor * 1.0)
             if hasattr(module, "lm_head") and not self.config.tie_word_embeddings:

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -898,7 +898,7 @@ class SwitchTransformersStack(SwitchTransformersPreTrainedModel):
         **kwargs,
     ):
         """
-        Creates a causal 4D mask of shape `(batch_size, 1, query_length, key_value_length)` from a 2D mask of shape
+        Creates causal 4D mask of shape `(batch_size, 1, query_length, key_value_length)` from a 2D mask of shape
         `(batch_size, key_value_length)`, or if the input `attention_mask` is already 4D, do nothing.
 
         Args:

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -109,7 +109,9 @@ class SwitchTransformersTop1Router(nn.Module):
 
         if self.training and self.jitter_noise > 0:
             # Apply jitter noise only to the routing copy
-            routing_states *= torch.empty_like(routing_states).uniform_(1.0 - self.jitter_noise, 1.0 + self.jitter_noise)
+            routing_states *= torch.empty_like(routing_states).uniform_(
+                1.0 - self.jitter_noise, 1.0 + self.jitter_noise
+            )
 
         # Use jittered states for routing decisions
         router_logits = self.classifier(routing_states)

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -360,7 +360,7 @@ class SwitchTransformersPreTrainedModel(PreTrainedModel):
             module.weight.data.fill_(factor * 1.0)
         elif isinstance(
             module,
-            (SwitchTransformersModel, SwitchTransformersForConditionalGeneration, SwitchTransformersEncoderModel),
+            SwitchTransformersModel | SwitchTransformersForConditionalGeneration | SwitchTransformersEncoderModel,
         ):
             module.shared.weight.data.normal_(mean=0.0, std=factor * 1.0)
             if hasattr(module, "lm_head") and not self.config.tie_word_embeddings:

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -159,11 +159,19 @@ class SwitchTransformersTop1Router(nn.Module):
         # https://huggingface.co/papers/2101.03961.
         # We also store the previous dtype to cast back the output to the previous dtype
         self.input_dtype = hidden_states.dtype
-        hidden_states = hidden_states.to(self.dtype)
+
+        # Create a copy for applying jitter noise
+        routing_states = hidden_states.clone()
+        routing_states = routing_states.to(self.dtype)
+
         if self.training and self.jitter_noise > 0:
-            # Multiply the token inputs by the uniform distribution - adding some noise
-            hidden_states *= torch.empty_like(hidden_states).uniform_(1.0 - self.jitter_noise, 1.0 + self.jitter_noise)
-        router_logits = self.classifier(hidden_states)
+            # Apply jitter noise only to the routing copy
+            routing_states *= torch.empty_like(routing_states).uniform_(
+                1.0 - self.jitter_noise, 1.0 + self.jitter_noise
+            )
+
+        # Use jittered states for routing decisions
+        router_logits = self.classifier(routing_states)
 
         # Apply Softmax and cast back to the original `dtype`
         router_probs = nn.functional.softmax(router_logits, dim=-1, dtype=self.dtype).to(self.input_dtype)

--- a/tests/models/switch_transformers/test_modeling_switch_transformers.py
+++ b/tests/models/switch_transformers/test_modeling_switch_transformers.py
@@ -1024,6 +1024,53 @@ class SwitchTransformerRouterTest(unittest.TestCase):
 
         assert torch.sum(expert_index) <= batch_size * self.config.num_experts * self.config.expert_capacity
 
+    def test_jitter_noise_preserves_hidden_states(self):
+        r"""
+        Test that jitter noise is applied only to routing decisions and does not modify the original hidden states.
+        This tests the fix for the jitter noise issue where noise was corrupting the input hidden states.
+        """
+        # Create a config with jitter noise enabled
+        config = SwitchTransformersConfig(
+            num_experts=2,
+            hidden_size=4,
+            d_ff=8,
+            router_jitter_noise=0.1,  # Enable jitter noise
+            expert_capacity=4,
+        )
+
+        # Create router
+        router = SwitchTransformersTop1Router(config)
+        router.eval()  # Set to eval mode first to test training mode separately
+
+        # Create input hidden states
+        hidden_states = torch.tensor([
+            [[0.5, 0.2, 0.1, 0.3],
+             [0.4, 0.6, 0.2, 0.8]]
+        ], dtype=torch.float32)
+
+        # Test in eval mode - no jitter noise should be applied
+        original_hidden_states = hidden_states.clone()
+        with torch.no_grad():
+            router_probs, expert_index, router_logits = router(hidden_states)
+
+        # Hidden states should remain unchanged in eval mode
+        self.assertTrue(torch.equal(hidden_states, original_hidden_states))
+
+        # Test in training mode - jitter noise should be applied only internally
+        router.train()
+        torch.manual_seed(42)  # Set seed for reproducible results
+
+        original_hidden_states = hidden_states.clone()
+        with torch.no_grad():
+            router_probs_train, expert_index_train, router_logits_train = router(hidden_states)
+
+        # Hidden states should still remain unchanged after router call
+        self.assertTrue(torch.equal(hidden_states, original_hidden_states))
+
+        # Results should be different between eval and train mode due to jitter noise
+        # (though this might occasionally fail due to randomness, it's very unlikely with seed)
+        self.assertFalse(torch.allclose(router_logits, router_logits_train, atol=1e-5))
+
 
 @slow
 @require_torch

--- a/tests/models/switch_transformers/test_modeling_switch_transformers.py
+++ b/tests/models/switch_transformers/test_modeling_switch_transformers.py
@@ -1043,10 +1043,7 @@ class SwitchTransformerRouterTest(unittest.TestCase):
         router.eval()  # Set to eval mode first to test training mode separately
 
         # Create input hidden states
-        hidden_states = torch.tensor([
-            [[0.5, 0.2, 0.1, 0.3],
-             [0.4, 0.6, 0.2, 0.8]]
-        ], dtype=torch.float32)
+        hidden_states = torch.tensor([[[0.5, 0.2, 0.1, 0.3], [0.4, 0.6, 0.2, 0.8]]], dtype=torch.float32)
 
         # Test in eval mode - no jitter noise should be applied
         original_hidden_states = hidden_states.clone()


### PR DESCRIPTION
## Issue Description

This pull request addresses a bug in the Switch Transformers architecture where the jitter noise (intended to be applied only for routing decisions) was also being unintentionally applied to the expert inputs.

Fixes : #33969 

## Problem Statement

In Switch Transformers, a small amount of jitter noise is added to the inputs at routing time to ensure route diversity. However, these jittered inputs were incorrectly passed along to the experts, which contradicts the original paper’s design and led to unexpected discrepancies in outputs.

## Root Cause

It was discovered that the code used the same hidden states for both routing and expert processing. When jitter noise was enabled in training mode, it directly modified these states in place, causing the experts to receive noisy inputs.

## Implementation

1. We now clone the original hidden states before applying jitter noise.  
2. A separate copy is used exclusively for computing router logits and probabilities.  
3. The unchanged hidden states are then fed to the experts to maintain the original semantics.

## Screenshot

<img width="1293" alt="Screenshot 2025-01-23 at 1 14 26 AM" src="https://github.com/user-attachments/assets/2d46438d-6344-4994-aa18-1e14376597e7" />

## Test Cases

1. **test_router_training_mode**  
   • Objective: Ensures that jitter noise is only applied during training.  
   • Checks that outputs differ between consecutive runs (due to noise) but original inputs remain unchanged.

2. **test_router_jitter_noise_separation **  
   • Objective: Verifies that jitter noise affects only the router’s internal computations and not the expert inputs.  
   • Confirms the logits differ when jitter is applied, while the main input stays the same.

3. **test_expert_inputs_consistency**  
   • Objective: Asserts that all expert inputs remain consistent, even when jitter is applied during training.  
   • Uses a forward hook on the first expert to capture its inputs across multiple runs and compares them.

With these changes and test additions, we ensure that Switch Transformers adhere to the original design while preserving backward compatibility and correctness.

**cc :** @ArthurZucker 

original pr refrence : #35847 