### PR TITLE
[model deprecations] Define new version-based model deprecation/deletions with user warnings/exceptions

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -50,9 +50,9 @@ logger = logging.get_logger(__name__)
 SpecificPretrainedConfigType = TypeVar("SpecificPretrainedConfigType", bound="PretrainedConfig")
 
 
-# Map containing deprecated/deleted model types, and the last version that supports them.
+# Map containing deprecated/deleted model types, and the first version that does NOT support them.
 # - set version > current version: the model type is deprecated, and users will see a warning;
-# - set version < current version: the model type is deleted, and users will see an exception pointing to the last
+# - set version <= current version: the model type is deleted, and users will see an exception pointing to the last
 #   version that supported it.
 # NOTE: this variable is set here (and not in `models.auto`) to avoid circular imports. We want to use it with
 # `PretrainedConfig` to make sure the deprecation warning is seen even if the user doesn't use auto classes.


### PR DESCRIPTION
# What does this PR do?

PR 1 out of 3 regarding model deprecation/deletions for v5

We now define a new `{model type: last version where it was supported}` mapping, which we use to:
- automatically set deprecation warnings (when set version > current version)
- automatically trigger informative exceptions in AutoClasses (when set version < current version, i.e. after the corresponding model is deleted)

This should improve our messaging to the users and allow us to stop investing energy in low-usage architectures.

🤗 inspired by our [vllm](https://github.com/vllm-project/vllm/blob/ef283548f75122b0e8ce49ce2548fbb49446d7c7/vllm/model_executor/models/registry.py#L334) friends 🤗 

________________
Follow-up PRs:
- 2 out of 3: Move a few models into the deprecated folder, as discussed on slack (target deletion version: 5.2, two minor versions after the first release that will have the deprecation warning)
- 3 out of 3: Delete models that were previously in the `deprecated` folder (most of them don't work in `main` in any case 👀 ). If it's not too complex, define import-time exceptions for the deleted classes (e.g. when a user tries to call `from transformers import XXXModel`, `XXXModel` being a deleted class).