### PR TITLE
[causallm tester] automate pipeline mappings + bloom tests

### DIFF
--- a/tests/causal_lm_tester.py
+++ b/tests/causal_lm_tester.py
@@ -144,6 +144,23 @@ class CausalLMModelTester:
             if model_class is not None
         ]
 
+    @property
+    def pipeline_model_mapping(self):
+        # This is the default pipeline mapping.
+        mapping = {
+            "feature-extraction": self.base_model_class,
+            "text-generation": self.causal_lm_class,
+        }
+        if self.question_answering_class is not None:
+            mapping["question-answering"] = self.question_answering_class
+        if self.sequence_classification_class is not None:
+            mapping["text-classification"] = self.sequence_classification_class
+        if self.token_classification_class is not None:
+            mapping["token-classification"] = self.token_classification_class
+        if self.sequence_classification_class is not None:
+            mapping["zero-shot"] = self.sequence_classification_class
+        return mapping
+
     def __init__(
         self,
         parent,
@@ -298,12 +315,20 @@ class CausalLMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
             )
         self.model_tester = self.model_tester_class(self)
         self.config_tester = ConfigTester(self, config_class=self.model_tester.config_class)
+
+        if self.pipeline_model_mapping is None:
+            # If `all_model_classes` is not the default, maybe there are more pipeline mappings to be set.
+            if self.all_model_classes is not None:
+                raise ValueError(
+                    "Testes that inherit from `CausalLMModelTest` and set `all_model_classes` must manually set "
+                    "`pipeline_model_mapping`."
+                )
+            # Otherwise, we know the pipeline mapping is the default.
+            else:
+                self.pipeline_model_mapping = self.model_tester.pipeline_model_mapping
+
         if self.all_model_classes is None:
             self.all_model_classes = self.model_tester.all_model_classes
-        if self.pipeline_model_mapping is None:
-            raise ValueError(
-                "You have inherited from CausalLMModelTest but did not set the pipeline_model_mapping attribute."
-            )
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/apertus/test_modeling_apertus.py
+++ b/tests/models/apertus/test_modeling_apertus.py
@@ -34,7 +34,6 @@ from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 if is_torch_available():
     from transformers import (
         ApertusForCausalLM,
-        ApertusForTokenClassification,
         ApertusModel,
     )
 
@@ -46,15 +45,6 @@ class ApertusModelTester(CausalLMModelTester):
 
 @require_torch
 class ApertusModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": ApertusModel,
-            "text-generation": ApertusForCausalLM,
-            "token-classification": ApertusForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     model_tester_class = ApertusModelTester
 
     # Need to use `0.8` instead of `0.9` for `test_cpu_offload`

--- a/tests/models/arcee/test_modeling_arcee.py
+++ b/tests/models/arcee/test_modeling_arcee.py
@@ -34,9 +34,6 @@ if is_torch_available():
     from transformers import (
         ArceeConfig,
         ArceeForCausalLM,
-        ArceeForQuestionAnswering,
-        ArceeForSequenceClassification,
-        ArceeForTokenClassification,
         ArceeModel,
     )
 
@@ -48,18 +45,6 @@ class ArceeModelTester(CausalLMModelTester):
 
 @require_torch
 class ArceeModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": ArceeModel,
-            "text-classification": ArceeForSequenceClassification,
-            "text-generation": ArceeForCausalLM,
-            "zero-shot": ArceeForSequenceClassification,
-            "question-answering": ArceeForQuestionAnswering,
-            "token-classification": ArceeForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
     model_tester_class = ArceeModelTester
 

--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -16,13 +16,11 @@
 import math
 import unittest
 
-from transformers import BloomConfig, is_torch_available
+from transformers import is_torch_available
 from transformers.testing_utils import require_torch, require_torch_accelerator, slow, torch_device
 
-from ...generation.test_utils import GenerationTesterMixin
-from ...test_configuration_common import ConfigTester
-from ...test_modeling_common import ModelTesterMixin, ids_tensor, random_attention_mask
-from ...test_pipeline_mixin import PipelineTesterMixin
+from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
+from ...test_modeling_common import ids_tensor
 
 
 if is_torch_available():
@@ -30,120 +28,18 @@ if is_torch_available():
 
     from transformers import (
         BloomForCausalLM,
-        BloomForQuestionAnswering,
-        BloomForSequenceClassification,
-        BloomForTokenClassification,
         BloomModel,
         BloomTokenizerFast,
     )
 
 
 @require_torch
-class BloomModelTester:
-    def __init__(
-        self,
-        parent,
-        batch_size=14,
-        seq_length=7,
-        is_training=True,
-        use_token_type_ids=False,
-        use_input_mask=True,
-        use_labels=True,
-        use_mc_token_ids=True,
-        vocab_size=99,
-        hidden_size=32,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        intermediate_size=37,
-        hidden_act="gelu",
-        hidden_dropout_prob=0.1,
-        attention_dropout_prob=0.1,
-        max_position_embeddings=512,
-        type_vocab_size=16,
-        type_sequence_label_size=2,
-        initializer_range=0.02,
-        num_labels=3,
-        num_choices=4,
-        scope=None,
-    ):
-        self.parent = parent
-        self.batch_size = batch_size
-        self.seq_length = seq_length
-        self.is_training = is_training
-        self.use_token_type_ids = use_token_type_ids
-        self.use_input_mask = use_input_mask
-        self.use_labels = use_labels
-        self.use_mc_token_ids = use_mc_token_ids
-        self.vocab_size = vocab_size
-        self.hidden_size = hidden_size
-        self.num_hidden_layers = num_hidden_layers
-        self.num_attention_heads = num_attention_heads
-        self.intermediate_size = intermediate_size
-        self.hidden_act = hidden_act
-        self.hidden_dropout_prob = hidden_dropout_prob
-        self.attention_dropout_prob = attention_dropout_prob
-        self.max_position_embeddings = max_position_embeddings
-        self.type_vocab_size = type_vocab_size
-        self.type_sequence_label_size = type_sequence_label_size
-        self.initializer_range = initializer_range
-        self.num_labels = num_labels
-        self.num_choices = num_choices
-        self.scope = None
-        self.bos_token_id = vocab_size - 1
-        self.eos_token_id = vocab_size - 1
-        self.pad_token_id = vocab_size - 1
+class BloomModelTester(CausalLMModelTester):
+    if is_torch_available():
+        base_model_class = BloomModel
 
-    def get_large_model_config(self):
-        return BloomConfig.from_pretrained("bigscience/bloom")
-
-    def prepare_config_and_inputs(self, gradient_checkpointing=False):
-        input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
-
-        input_mask = None
-        if self.use_input_mask:
-            input_mask = random_attention_mask([self.batch_size, self.seq_length])
-
-        sequence_labels = None
-        if self.use_labels:
-            sequence_labels = ids_tensor([self.batch_size], self.type_sequence_label_size)
-
-        config = self.get_config(gradient_checkpointing=gradient_checkpointing)
-
-        return (config, input_ids, input_mask, sequence_labels)
-
-    def get_config(self, gradient_checkpointing=False, slow_but_exact=True):
-        return BloomConfig(
-            vocab_size=self.vocab_size,
-            seq_length=self.seq_length,
-            hidden_size=self.hidden_size,
-            n_layer=self.num_hidden_layers,
-            n_head=self.num_attention_heads,
-            hidden_dropout=self.hidden_dropout_prob,
-            attention_dropout=self.attention_dropout_prob,
-            n_positions=self.max_position_embeddings,
-            type_vocab_size=self.type_vocab_size,
-            initializer_range=self.initializer_range,
-            use_cache=True,
-            bos_token_id=self.bos_token_id,
-            eos_token_id=self.eos_token_id,
-            pad_token_id=self.pad_token_id,
-            num_labels=self.num_labels,
-            gradient_checkpointing=gradient_checkpointing,
-            slow_but_exact=slow_but_exact,
-            dtype="float32",
-        )
-
-    def create_and_check_bloom_model(self, config, input_ids, input_mask, *args):
-        model = BloomModel(config=config)
-        model.to(torch_device)
-        model.eval()
-
-        result = model(input_ids)
-
-        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
-        self.parent.assertEqual(len(result.past_key_values), config.n_layer)
-
-    def create_and_check_bloom_model_past(self, config, input_ids, input_mask, *args):
+    def create_and_check_bloom_model_past(self, config, *args):
+        input_ids, _, input_mask, _, _, _ = args
         model = BloomModel(config=config)
 
         model.to(torch_device)
@@ -176,7 +72,8 @@ class BloomModelTester:
         # test that outputs are equal for slice
         self.parent.assertTrue(torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3))
 
-    def create_and_check_bloom_model_attention_mask_past(self, config, input_ids, input_mask, *args):
+    def create_and_check_bloom_model_attention_mask_past(self, config, *args):
+        input_ids, _, input_mask, _, _, _ = args
         model = BloomModel(config=config)
         model.to(torch_device)
         model.eval()
@@ -216,7 +113,8 @@ class BloomModelTester:
         # test that outputs are equal for slice
         self.parent.assertTrue(torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3))
 
-    def create_and_check_bloom_model_past_large_inputs(self, config, input_ids, input_mask, *args):
+    def create_and_check_bloom_model_past_large_inputs(self, config, *args):
+        input_ids, _, input_mask, _, _, _ = args
         model = BloomModel(config=config)
         model.to(torch_device)
         model.eval()
@@ -248,7 +146,8 @@ class BloomModelTester:
         # test that outputs are equal for slice
         self.parent.assertTrue(torch.allclose(output_from_past_slice, output_from_no_past_slice, atol=1e-3))
 
-    def create_and_check_lm_head_model(self, config, input_ids, input_mask, *args):
+    def create_and_check_lm_head_model(self, config, *args):
+        input_ids, _, input_mask, _, _, _ = args
         model = BloomForCausalLM(config)
         model.to(torch_device)
         model.eval()
@@ -256,36 +155,6 @@ class BloomModelTester:
         result = model(input_ids, labels=input_ids)
         self.parent.assertEqual(result.loss.shape, ())
         self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.vocab_size))
-
-    def create_and_check_sequence_classification_model(self, config, input_ids, input_mask, *args):
-        config.num_labels = self.num_labels
-        model = BloomForSequenceClassification(config)
-        model.to(torch_device)
-        model.eval()
-
-        result = model(input_ids, attention_mask=input_mask)
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.num_labels))
-
-    def create_and_check_token_classification_model(self, config, input_ids, input_mask, *args):
-        model = BloomForTokenClassification(config)
-        model.to(torch_device)
-        model.eval()
-
-        result = model(input_ids, attention_mask=input_mask)
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.num_labels))
-
-    def create_and_check_forward_and_backwards(
-        self, config, input_ids, input_mask, *args, gradient_checkpointing=False
-    ):
-        model = BloomForCausalLM(config)
-        model.to(torch_device)
-        if gradient_checkpointing:
-            model.gradient_checkpointing_enable()
-
-        result = model(input_ids, labels=input_ids)
-        self.parent.assertEqual(result.loss.shape, ())
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.seq_length, self.vocab_size))
-        result.loss.backward()
 
     def create_and_check_bloom_weight_initialization(self, config, *args):
         model = BloomModel(config)
@@ -295,57 +164,13 @@ class BloomModelTester:
                 self.parent.assertLessEqual(abs(torch.std(model.state_dict()[key]) - model_std), 0.001)
                 self.parent.assertLessEqual(abs(torch.mean(model.state_dict()[key]) - 0.0), 0.01)
 
-    def prepare_config_and_inputs_for_common(self):
-        config_and_inputs = self.prepare_config_and_inputs()
-
-        config, input_ids, input_mask, sequence_labels = config_and_inputs
-
-        inputs_dict = {"input_ids": input_ids}
-
-        return config, inputs_dict
-
 
 @require_torch
-class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin, unittest.TestCase):
-    all_model_classes = (
-        (
-            BloomModel,
-            BloomForCausalLM,
-            BloomForSequenceClassification,
-            BloomForTokenClassification,
-            BloomForQuestionAnswering,
-        )
-        if is_torch_available()
-        else ()
-    )
-
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": BloomModel,
-            "question-answering": BloomForQuestionAnswering,
-            "text-classification": BloomForSequenceClassification,
-            "text-generation": BloomForCausalLM,
-            "token-classification": BloomForTokenClassification,
-            "zero-shot": BloomForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
+class BloomModelTest(CausalLMModelTest, unittest.TestCase):
+    model_tester_class = BloomModelTester
     fx_compatible = True
     test_missing_keys = False
-
     test_torchscript = True  # torch.autograd functions seems not to be supported
-
-    def setUp(self):
-        self.model_tester = BloomModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=BloomConfig, n_embd=37)
-
-    def test_config(self):
-        self.config_tester.run_common_tests()
-
-    def test_bloom_model(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_bloom_model(*config_and_inputs)
 
     def test_bloom_model_past(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
@@ -363,142 +188,9 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_lm_head_model(*config_and_inputs)
 
-    def test_bloom_sequence_classification_model(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_sequence_classification_model(*config_and_inputs)
-
-    def test_bloom_token_classification_model(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_token_classification_model(*config_and_inputs)
-
-    def test_bloom_gradient_checkpointing(self):
-        config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_forward_and_backwards(*config_and_inputs, gradient_checkpointing=True)
-
     def test_bloom_weight_initialization(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_bloom_weight_initialization(*config_and_inputs)
-
-    @slow
-    def test_model_from_pretrained(self):
-        model_name = "bigscience/bigscience-small-testing"
-        model = BloomModel.from_pretrained(model_name)
-        self.assertIsNotNone(model)
-
-    @slow
-    @require_torch_accelerator
-    def test_simple_generation(self):
-        # This test is a bit flaky. For some GPU architectures, pytorch sets by default allow_fp16_reduced_precision_reduction = True and some operations
-        # do not give the same results under this configuration, especially torch.baddmm and torch.bmm. https://pytorch.org/docs/stable/notes/numerical_accuracy.html#fp16-on-mi200
-        # As we leave the default value (True) for allow_fp16_reduced_precision_reduction, the tests failed when running in half-precision with smaller models (560m)
-        # Please see: https://pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-fp16-gemms
-        # This discrepancy is observed only when using small models and seems to be stable for larger models.
-        # Our conclusion is that these operations are flaky for small inputs but seems to be stable for larger inputs (for the functions `baddmm` and `bmm`), and therefore for larger models.
-
-        # Here is a summary of an ablation study of our observations
-        # EXPECTED_OUTPUT = "I enjoy walking with my cute dog, and I love to watch the kids play. I am a very active person, and I am a very good listener. I am a very good person, and I am a very good person. I am a"
-        # 560m + allow_fp16_reduced_precision_reduction = False  + torch.bmm  ==> PASS
-        # 560m + allow_fp16_reduced_precision_reduction = False  + torch.baddm  ==> PASS
-        # 560m + allow_fp16_reduced_precision_reduction = True  + torch.baddm  ==> PASS
-        # 560m + allow_fp16_reduced_precision_reduction = True  + torch.bmm  ==> FAIL
-
-        # EXPECTED_OUTPUT = "I enjoy walking with my cute dog, but I also enjoy hiking, biking, and swimming. I love to cook and bake. I love to cook and bake. I love to cook and bake. I love to cook and bake. I love"
-        # >=1b1 + allow_fp16_reduced_precision_reduction = True  + torch.baddm  ==> PASS  (for use_cache=True and use_cache=False)
-        # >=1b1 + allow_fp16_reduced_precision_reduction = True  + torch.bmm  ==> PASS
-        # >=1b1 + allow_fp16_reduced_precision_reduction = False  + torch.bmm  ==> PASS
-
-        path_560m = "bigscience/bloom-560m"
-        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
-        model = model.eval()
-        tokenizer = BloomTokenizerFast.from_pretrained(path_560m)
-
-        input_sentence = "I enjoy walking with my cute dog"
-        # This output has been obtained using fp32 model on the huggingface DGX workstation - NVIDIA A100 GPU
-        EXPECTED_OUTPUT = (
-            "I enjoy walking with my cute dog, and I love to watch the kids play with the kids. I am a very "
-            "active person, and I enjoy working out, and I am a very active person. I am a very active person, and I"
-        )
-
-        input_ids = tokenizer.encode(input_sentence, return_tensors="pt")
-        greedy_output = model.generate(input_ids.to(torch_device), max_length=50)
-
-        self.assertEqual(tokenizer.decode(greedy_output[0], skip_special_tokens=True), EXPECTED_OUTPUT)
-
-    @slow
-    @require_torch_accelerator
-    def test_batch_generation(self):
-        path_560m = "bigscience/bloom-560m"
-        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
-        model = model.eval()
-        tokenizer = BloomTokenizerFast.from_pretrained(path_560m, padding_side="left")
-
-        input_sentence = ["I enjoy walking with my cute dog", "I enjoy walking with my cute dog"]
-
-        inputs = tokenizer.batch_encode_plus(input_sentence, return_tensors="pt", padding=True)
-        input_ids = inputs["input_ids"].to(torch_device)
-        attention_mask = inputs["attention_mask"]
-        greedy_output = model.generate(input_ids, attention_mask=attention_mask, max_length=50, do_sample=False)
-
-        self.assertEqual(
-            tokenizer.decode(greedy_output[0], skip_special_tokens=True),
-            tokenizer.decode(greedy_output[1], skip_special_tokens=True),
-        )
-
-    @slow
-    @require_torch_accelerator
-    def test_batch_generation_padding(self):
-        path_560m = "bigscience/bloom-560m"
-        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
-        model = model.eval()
-        tokenizer = BloomTokenizerFast.from_pretrained(path_560m, padding_side="left")
-
-        input_sentence = ["I enjoy walking with my cute dog", "Hello my name is"]
-        input_sentence_without_pad = "Hello my name is"
-
-        input_ids = tokenizer.batch_encode_plus(input_sentence, return_tensors="pt", padding=True)
-        input_ids_without_pad = tokenizer.encode(input_sentence_without_pad, return_tensors="pt")
-
-        input_ids, attention_mask = input_ids["input_ids"].to(torch_device), input_ids["attention_mask"]
-        greedy_output = model.generate(input_ids, attention_mask=attention_mask, max_length=50, do_sample=False)
-        greedy_output_without_pad = model.generate(
-            input_ids_without_pad.to(torch_device), max_length=50, do_sample=False
-        )
-
-        # test token values
-        self.assertEqual(greedy_output[-1, 3:].tolist(), greedy_output_without_pad[0, :-3].tolist())
-
-        # test reconstructions
-        self.assertEqual(
-            tokenizer.decode(greedy_output[-1, 3:], skip_special_tokens=True),
-            tokenizer.decode(greedy_output_without_pad[0, :-3], skip_special_tokens=True),
-        )
-
-    @slow
-    @require_torch_accelerator
-    def test_batch_generated_text(self):
-        path_560m = "bigscience/bloom-560m"
-
-        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
-        model = model.eval()
-        tokenizer = BloomTokenizerFast.from_pretrained(path_560m, padding_side="left")
-
-        input_sentences = [
-            "Hello what is",
-            "Running a quick test with the",
-        ]
-        inputs = tokenizer(input_sentences, return_tensors="pt", padding=True, truncation=True)
-        generated_ids = model.generate(
-            inputs["input_ids"].to(torch_device), attention_mask=inputs["attention_mask"], max_length=20
-        )
-        generated_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
-
-        # these generations match those of the PyTorch model
-        EXPECTED_GENERATIONS = [
-            "Hello what is the best way to get the data from the server? I have tried",
-            "Running a quick test with the following command:\nsudo apt-get install python3\nsudo apt-get install python2",
-        ]
-
-        self.assertListEqual(generated_text, EXPECTED_GENERATIONS)
 
     @unittest.skip("Bloom needs a 2D attention for alibi")
     def test_custom_4d_attention_mask(self):
@@ -506,34 +198,33 @@ class BloomModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
 
 
 @require_torch
-class BloomEmbeddingTest(unittest.TestCase):
-    """
-    The goal here is to compare the embeddings generated by the model trained
-    using Megatron-LM with the one from the transformers library, with a small GPT2-like model
-    to ensure that the conversion from Megatron-LM to transformers has been done successfully.
-    The script compares the logits of the embedding layer and the transformer layers.
-
-    WARNING: It is expected that these logits will not have exactly the same statistics when running
-    the code on CPU or GPU. For more info, please visit:
-      - https://github.com/pytorch/pytorch/issues/76052#issuecomment-1103193548
-      - https://discuss.pytorch.org/t/reproducibility-issue-between-intel-and-amd-cpus/144779/9
-
-
-    You need to install tokenizers following this readme:
-        - https://huggingface.co/bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles
-
-    Tokenizer used during training:
-        - https://huggingface.co/bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles
-
-    # TODO change the script (or just add skip) when building the env with tokenizers 0.12.0
-    """
-
+class BloomIntegrationTest(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.path_bigscience_model = "bigscience/bigscience-small-testing"
 
     @require_torch
     def test_embeddings(self):
+        """
+        The goal here is to compare the embeddings generated by the model trained
+        using Megatron-LM with the one from the transformers library, with a small GPT2-like model
+        to ensure that the conversion from Megatron-LM to transformers has been done successfully.
+        The script compares the logits of the embedding layer and the transformer layers.
+
+        WARNING: It is expected that these logits will not have exactly the same statistics when running
+        the code on CPU or GPU. For more info, please visit:
+        - https://github.com/pytorch/pytorch/issues/76052#issuecomment-1103193548
+        - https://discuss.pytorch.org/t/reproducibility-issue-between-intel-and-amd-cpus/144779/9
+
+
+        You need to install tokenizers following this readme:
+            - https://huggingface.co/bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles
+
+        Tokenizer used during training:
+            - https://huggingface.co/bigscience-catalogue-data-dev/byte-level-bpe-tokenizer-no-norm-250k-whitespace-and-eos-regex-alpha-v3-dedup-lines-articles
+
+        # TODO change the script (or just add skip) when building the env with tokenizers 0.12.0
+        """
         # The config in this checkpoint has `bfloat16` as `dtype` -> model in `bfloat16`
         model = BloomForCausalLM.from_pretrained(self.path_bigscience_model, dtype="auto")
         model.eval()
@@ -805,3 +496,118 @@ class BloomEmbeddingTest(unittest.TestCase):
         output_gpu_1, output_gpu_2 = output.split(125440, dim=-1)
         self.assertAlmostEqual(output_gpu_1.mean().item(), MEAN_LOGITS_GPU_1, places=6)
         self.assertAlmostEqual(output_gpu_2.mean().item(), MEAN_LOGITS_GPU_2, places=6)
+
+    @slow
+    @require_torch_accelerator
+    def test_simple_generation(self):
+        # This test is a bit flaky. For some GPU architectures, pytorch sets by default allow_fp16_reduced_precision_reduction = True and some operations
+        # do not give the same results under this configuration, especially torch.baddmm and torch.bmm. https://pytorch.org/docs/stable/notes/numerical_accuracy.html#fp16-on-mi200
+        # As we leave the default value (True) for allow_fp16_reduced_precision_reduction, the tests failed when running in half-precision with smaller models (560m)
+        # Please see: https://pytorch.org/docs/stable/notes/cuda.html#reduced-precision-reduction-in-fp16-gemms
+        # This discrepancy is observed only when using small models and seems to be stable for larger models.
+        # Our conclusion is that these operations are flaky for small inputs but seems to be stable for larger inputs (for the functions `baddmm` and `bmm`), and therefore for larger models.
+
+        # Here is a summary of an ablation study of our observations
+        # EXPECTED_OUTPUT = "I enjoy walking with my cute dog, and I love to watch the kids play. I am a very active person, and I am a very good listener. I am a very good person, and I am a very good person. I am a"
+        # 560m + allow_fp16_reduced_precision_reduction = False  + torch.bmm  ==> PASS
+        # 560m + allow_fp16_reduced_precision_reduction = False  + torch.baddm  ==> PASS
+        # 560m + allow_fp16_reduced_precision_reduction = True  + torch.baddm  ==> PASS
+        # 560m + allow_fp16_reduced_precision_reduction = True  + torch.bmm  ==> FAIL
+
+        # EXPECTED_OUTPUT = "I enjoy walking with my cute dog, but I also enjoy hiking, biking, and swimming. I love to cook and bake. I love to cook and bake. I love to cook and bake. I love to cook and bake. I love"
+        # >=1b1 + allow_fp16_reduced_precision_reduction = True  + torch.baddm  ==> PASS  (for use_cache=True and use_cache=False)
+        # >=1b1 + allow_fp16_reduced_precision_reduction = True  + torch.bmm  ==> PASS
+        # >=1b1 + allow_fp16_reduced_precision_reduction = False  + torch.bmm  ==> PASS
+
+        path_560m = "bigscience/bloom-560m"
+        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
+        model = model.eval()
+        tokenizer = BloomTokenizerFast.from_pretrained(path_560m)
+
+        input_sentence = "I enjoy walking with my cute dog"
+        # This output has been obtained using fp32 model on the huggingface DGX workstation - NVIDIA A100 GPU
+        EXPECTED_OUTPUT = (
+            "I enjoy walking with my cute dog, and I love to watch the kids play with the kids. I am a very "
+            "active person, and I enjoy working out, and I am a very active person. I am a very active person, and I"
+        )
+
+        input_ids = tokenizer.encode(input_sentence, return_tensors="pt")
+        greedy_output = model.generate(input_ids.to(torch_device), max_length=50)
+
+        self.assertEqual(tokenizer.decode(greedy_output[0], skip_special_tokens=True), EXPECTED_OUTPUT)
+
+    @slow
+    @require_torch_accelerator
+    def test_batch_generation(self):
+        path_560m = "bigscience/bloom-560m"
+        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
+        model = model.eval()
+        tokenizer = BloomTokenizerFast.from_pretrained(path_560m, padding_side="left")
+
+        input_sentence = ["I enjoy walking with my cute dog", "I enjoy walking with my cute dog"]
+
+        inputs = tokenizer.batch_encode_plus(input_sentence, return_tensors="pt", padding=True)
+        input_ids = inputs["input_ids"].to(torch_device)
+        attention_mask = inputs["attention_mask"]
+        greedy_output = model.generate(input_ids, attention_mask=attention_mask, max_length=50, do_sample=False)
+
+        self.assertEqual(
+            tokenizer.decode(greedy_output[0], skip_special_tokens=True),
+            tokenizer.decode(greedy_output[1], skip_special_tokens=True),
+        )
+
+    @slow
+    @require_torch_accelerator
+    def test_batch_generation_padding(self):
+        path_560m = "bigscience/bloom-560m"
+        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
+        model = model.eval()
+        tokenizer = BloomTokenizerFast.from_pretrained(path_560m, padding_side="left")
+
+        input_sentence = ["I enjoy walking with my cute dog", "Hello my name is"]
+        input_sentence_without_pad = "Hello my name is"
+
+        input_ids = tokenizer.batch_encode_plus(input_sentence, return_tensors="pt", padding=True)
+        input_ids_without_pad = tokenizer.encode(input_sentence_without_pad, return_tensors="pt")
+
+        input_ids, attention_mask = input_ids["input_ids"].to(torch_device), input_ids["attention_mask"]
+        greedy_output = model.generate(input_ids, attention_mask=attention_mask, max_length=50, do_sample=False)
+        greedy_output_without_pad = model.generate(
+            input_ids_without_pad.to(torch_device), max_length=50, do_sample=False
+        )
+
+        # test token values
+        self.assertEqual(greedy_output[-1, 3:].tolist(), greedy_output_without_pad[0, :-3].tolist())
+
+        # test reconstructions
+        self.assertEqual(
+            tokenizer.decode(greedy_output[-1, 3:], skip_special_tokens=True),
+            tokenizer.decode(greedy_output_without_pad[0, :-3], skip_special_tokens=True),
+        )
+
+    @slow
+    @require_torch_accelerator
+    def test_batch_generated_text(self):
+        path_560m = "bigscience/bloom-560m"
+
+        model = BloomForCausalLM.from_pretrained(path_560m, use_cache=True, revision="gs555750").to(torch_device)
+        model = model.eval()
+        tokenizer = BloomTokenizerFast.from_pretrained(path_560m, padding_side="left")
+
+        input_sentences = [
+            "Hello what is",
+            "Running a quick test with the",
+        ]
+        inputs = tokenizer(input_sentences, return_tensors="pt", padding=True, truncation=True)
+        generated_ids = model.generate(
+            inputs["input_ids"].to(torch_device), attention_mask=inputs["attention_mask"], max_length=20
+        )
+        generated_text = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
+
+        # these generations match those of the PyTorch model
+        EXPECTED_GENERATIONS = [
+            "Hello what is the best way to get the data from the server? I have tried",
+            "Running a quick test with the following command:\nsudo apt-get install python3\nsudo apt-get install python2",
+        ]
+
+        self.assertListEqual(generated_text, EXPECTED_GENERATIONS)

--- a/tests/models/blt/test_modeling_blt.py
+++ b/tests/models/blt/test_modeling_blt.py
@@ -41,7 +41,6 @@ if is_torch_available():
     import torch
 
     from transformers import BltConfig, BltForCausalLM, BltModel
-from transformers.models.blt.modeling_blt import BltRotaryEmbedding
 
 
 class BltModelTester(CausalLMModelTester):
@@ -170,26 +169,8 @@ class BltModelTester(CausalLMModelTester):
 
 @require_torch
 class BltModelTest(CausalLMModelTest, unittest.TestCase):
-    all_model_classes = (
-        (
-            BltModel,
-            BltForCausalLM,
-        )
-        if is_torch_available()
-        else ()
-    )
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": BltModel,
-            "text-generation": BltForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     fx_compatible = False
     model_tester_class = BltModelTester
-    rotary_embedding_layer = BltRotaryEmbedding  # Enables RoPE tests if set
 
     # Need to use `0.8` instead of `0.9` for `test_cpu_offload`
     # This is because we are hitting edge cases with the causal_mask buffer
@@ -245,8 +226,6 @@ class BltModelTest(CausalLMModelTest, unittest.TestCase):
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
     def test_model_rope_scaling_from_config(self, scaling_type):
         """Override rope scaling from config test to handle Blt's sub-config structure."""
-        if self.rotary_embedding_layer is None:
-            self.skipTest("Rotary embedding layer not set")
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         short_input = ids_tensor([1, 10], config.vocab_size)
         long_input = ids_tensor([1, int(config.max_position_embeddings * 1.5)], config.vocab_size)

--- a/tests/models/codegen/test_modeling_codegen.py
+++ b/tests/models/codegen/test_modeling_codegen.py
@@ -86,9 +86,6 @@ class CodeGenModelTester:
         self.eos_token_id = vocab_size - 1
         self.pad_token_id = vocab_size - 1
 
-    def get_large_model_config(self):
-        return CodeGenConfig.from_pretrained("Salesforce/codegen-2B-mono")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 

--- a/tests/models/dbrx/test_modeling_dbrx.py
+++ b/tests/models/dbrx/test_modeling_dbrx.py
@@ -86,15 +86,6 @@ class DbrxModelTester(CausalLMModelTester):
 
 @require_torch
 class DbrxModelTest(CausalLMModelTest, unittest.TestCase):
-    all_model_classes = (DbrxModel, DbrxForCausalLM) if is_torch_available() else ()
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": DbrxModel,
-            "text-generation": DbrxForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     model_tester_class = DbrxModelTester
 
     @slow

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -27,7 +27,7 @@ from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 if is_torch_available():
     import torch
 
-    from transformers import AutoTokenizer, DeepseekV2ForCausalLM, DeepseekV2ForSequenceClassification, DeepseekV2Model
+    from transformers import AutoTokenizer, DeepseekV2ForCausalLM, DeepseekV2Model
     from transformers.models.deepseek_v2.modeling_deepseek_v2 import DeepseekV2RotaryEmbedding
 
 
@@ -54,16 +54,6 @@ class DeepseekV2ModelTester(CausalLMModelTester):
 
 @require_torch
 class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": DeepseekV2Model,
-            "text-classification": DeepseekV2ForSequenceClassification,
-            "text-generation": DeepseekV2ForCausalLM,
-            "zero-shot": DeepseekV2ForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
     test_torchscript = False
     test_all_params_have_gradient = False

--- a/tests/models/dots1/test_modeling_dots1.py
+++ b/tests/models/dots1/test_modeling_dots1.py
@@ -60,23 +60,6 @@ class Dots1ModelTester(CausalLMModelTester):
 
 @require_torch
 class Dots1ModelTest(CausalLMModelTest, unittest.TestCase):
-    all_model_classes = (
-        (
-            Dots1Model,
-            Dots1ForCausalLM,
-        )
-        if is_torch_available()
-        else ()
-    )
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Dots1Model,
-            "text-generation": Dots1ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_tester_class = Dots1ModelTester
 
 

--- a/tests/models/ernie4_5/test_modeling_ernie4_5.py
+++ b/tests/models/ernie4_5/test_modeling_ernie4_5.py
@@ -45,14 +45,6 @@ class Ernie4_5ModelTester(CausalLMModelTester):
 
 @require_torch
 class Ernie4_5ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Ernie4_5Model,
-            "text-generation": Ernie4_5ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False  # Broken by attention refactor cc @Cyrilvallez
     model_tester_class = Ernie4_5ModelTester
 

--- a/tests/models/ernie4_5_moe/test_modeling_ernie4_5_moe.py
+++ b/tests/models/ernie4_5_moe/test_modeling_ernie4_5_moe.py
@@ -52,15 +52,6 @@ class Ernie4_5_MoeModelTester(CausalLMModelTester):
 
 @require_torch
 class Ernie4_5_MoeModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Ernie4_5_MoeModel,
-            "text-generation": Ernie4_5_MoeForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     test_all_params_have_gradient = False
     model_tester_class = Ernie4_5_MoeModelTester
 

--- a/tests/models/exaone4/test_modeling_exaone4.py
+++ b/tests/models/exaone4/test_modeling_exaone4.py
@@ -41,9 +41,6 @@ if is_torch_available():
 
     from transformers import (
         Exaone4ForCausalLM,
-        Exaone4ForQuestionAnswering,
-        Exaone4ForSequenceClassification,
-        Exaone4ForTokenClassification,
         Exaone4Model,
     )
 
@@ -55,18 +52,6 @@ class Exaone4ModelTester(CausalLMModelTester):
 
 @require_torch
 class Exaone4ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Exaone4Model,
-            "question-answering": Exaone4ForQuestionAnswering,
-            "text-classification": Exaone4ForSequenceClassification,
-            "text-generation": Exaone4ForCausalLM,
-            "zero-shot": Exaone4ForSequenceClassification,
-            "token-classification": Exaone4ForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False  # Broken by attention refactor cc @Cyrilvallez
     model_tester_class = Exaone4ModelTester
     model_split_percents = [0.5, 0.6]

--- a/tests/models/falcon/test_modeling_falcon.py
+++ b/tests/models/falcon/test_modeling_falcon.py
@@ -37,8 +37,6 @@ if is_torch_available():
 
     from transformers import (
         FalconForCausalLM,
-        FalconForSequenceClassification,
-        FalconForTokenClassification,
         FalconModel,
     )
 
@@ -55,17 +53,6 @@ class FalconModelTester(CausalLMModelTester):
 @require_torch
 class FalconModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = FalconModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": FalconModel,
-            "text-classification": FalconForSequenceClassification,
-            "token-classification": FalconForTokenClassification,
-            "text-generation": FalconForCausalLM,
-            "zero-shot": FalconForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146
     def is_pipeline_test_to_skip(

--- a/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
+++ b/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
@@ -90,10 +90,6 @@ class FalconMambaModelTester:
         self.pad_token_id = vocab_size - 1
         self.tie_word_embeddings = tie_word_embeddings
 
-    # Ignore copy
-    def get_large_model_config(self):
-        return FalconMambaConfig.from_pretrained("tiiuae/falcon-mamba-7b")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/flex_olmo/test_modeling_flex_olmo.py
+++ b/tests/models/flex_olmo/test_modeling_flex_olmo.py
@@ -38,7 +38,6 @@ if is_torch_available():
         FlexOlmoForCausalLM,
         FlexOlmoModel,
     )
-    from transformers.models.flex_olmo.modeling_flex_olmo import FlexOlmoRotaryEmbedding
 
 
 class FlexOlmoModelTester(CausalLMModelTester):
@@ -48,20 +47,10 @@ class FlexOlmoModelTester(CausalLMModelTester):
 
 @require_torch
 class FlexOlmoModelTest(CausalLMModelTest, unittest.TestCase):
-    all_model_classes = (FlexOlmoModel, FlexOlmoForCausalLM) if is_torch_available() else ()
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": FlexOlmoModel,
-            "text-generation": FlexOlmoForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
     test_torchscript = False
     test_all_params_have_gradient = False
     model_tester_class = FlexOlmoModelTester
-    rotary_embedding_layer = FlexOlmoRotaryEmbedding
 
     # Need to use `0.8` instead of `0.9` for `test_cpu_offload`
     # This is because we are hitting edge cases with the causal_mask buffer

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -42,8 +42,6 @@ if is_torch_available():
 
     from transformers import (
         GemmaForCausalLM,
-        GemmaForSequenceClassification,
-        GemmaForTokenClassification,
         GemmaModel,
     )
 
@@ -56,17 +54,6 @@ class GemmaModelTester(CausalLMModelTester):
 
 @require_torch
 class GemmaModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": GemmaModel,
-            "text-classification": GemmaForSequenceClassification,
-            "token-classification": GemmaForTokenClassification,
-            "text-generation": GemmaForCausalLM,
-            "zero-shot": GemmaForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     model_tester_class = GemmaModelTester
 
     # used in `test_torch_compile_for_training`

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -45,9 +45,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        Gemma2ForCausalLM,
-        Gemma2ForSequenceClassification,
-        Gemma2ForTokenClassification,
         Gemma2Model,
     )
 
@@ -59,18 +56,6 @@ class Gemma2ModelTester(CausalLMModelTester):
 
 @require_torch
 class Gemma2ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Gemma2Model,
-            "text-classification": Gemma2ForSequenceClassification,
-            "token-classification": Gemma2ForTokenClassification,
-            "text-generation": Gemma2ForCausalLM,
-            "zero-shot": Gemma2ForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
     model_tester_class = Gemma2ModelTester

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -72,15 +72,6 @@ class Gemma3TextModelTester(CausalLMModelTester):
 @require_torch
 class Gemma3TextModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Gemma3TextModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Gemma3TextModel,
-            "text-classification": Gemma3TextForSequenceClassification,
-            "text-generation": Gemma3ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -323,14 +323,6 @@ class Gemma3nTextModelTester(CausalLMModelTester):
 @require_torch
 class Gemma3nTextModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Gemma3nTextModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Gemma3nTextModel,
-            "text-generation": Gemma3nForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 

--- a/tests/models/glm/test_modeling_glm.py
+++ b/tests/models/glm/test_modeling_glm.py
@@ -34,9 +34,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        GlmForCausalLM,
-        GlmForSequenceClassification,
-        GlmForTokenClassification,
         GlmModel,
     )
 
@@ -49,17 +46,6 @@ class GlmModelTester(CausalLMModelTester):
 
 @require_torch
 class GlmModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": GlmModel,
-            "text-classification": GlmForSequenceClassification,
-            "token-classification": GlmForTokenClassification,
-            "text-generation": GlmForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_tester_class = GlmModelTester
 
 

--- a/tests/models/glm4/test_modeling_glm4.py
+++ b/tests/models/glm4/test_modeling_glm4.py
@@ -37,9 +37,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        Glm4ForCausalLM,
-        Glm4ForSequenceClassification,
-        Glm4ForTokenClassification,
         Glm4Model,
     )
 
@@ -52,17 +49,6 @@ class Glm4ModelTester(CausalLMModelTester):
 @require_torch
 class Glm4ModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Glm4ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Glm4Model,
-            "text-classification": Glm4ForSequenceClassification,
-            "token-classification": Glm4ForTokenClassification,
-            "text-generation": Glm4ForCausalLM,
-            "zero-shot": Glm4ForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 

--- a/tests/models/glm4_moe/test_modeling_glm4_moe.py
+++ b/tests/models/glm4_moe/test_modeling_glm4_moe.py
@@ -58,14 +58,6 @@ class Glm4MoeModelTester(CausalLMModelTester):
 
 @require_torch
 class Glm4MoeModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Glm4MoeModel,
-            "text-generation": Glm4MoeForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
     model_tester_class = Glm4MoeModelTester
     # used in `test_torch_compile_for_training`. Skip as "Dynamic control flow in MoE"

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -156,6 +156,7 @@ class GPT2ModelTest(CausalLMModelTest, unittest.TestCase):
         if is_torch_available()
         else ()
     )
+    # We need to set `pipeline_model_mapping` because we overwrite `all_model_classes`
     pipeline_model_mapping = (
         {
             "feature-extraction": GPT2Model,

--- a/tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py
+++ b/tests/models/gpt_bigcode/test_modeling_gpt_bigcode.py
@@ -95,9 +95,6 @@ class GPTBigCodeModelTester:
         self.pad_token_id = vocab_size - 3
         self.multi_query = multi_query
 
-    def get_large_model_config(self):
-        return GPTBigCodeConfig.from_pretrained("bigcode/gpt_bigcode-santacoder")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/gpt_neo/test_modeling_gpt_neo.py
+++ b/tests/models/gpt_neo/test_modeling_gpt_neo.py
@@ -94,9 +94,6 @@ class GPTNeoModelTester:
         self.pad_token_id = vocab_size - 1
         self.attention_types = attention_types
 
-    def get_large_model_config(self):
-        return GPTNeoConfig.from_pretrained("gpt-neo-125M")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -45,9 +45,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        GptOssForCausalLM,
-        GptOssForSequenceClassification,
-        GptOssForTokenClassification,
         GptOssModel,
     )
 
@@ -61,17 +58,6 @@ class GptOssModelTester(CausalLMModelTester):
 
 @require_torch
 class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": GptOssModel,
-            "text-classification": GptOssForSequenceClassification,
-            "text-generation": GptOssForCausalLM,
-            "token-classification": GptOssForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
     model_tester_class = GptOssModelTester

--- a/tests/models/gptj/test_modeling_gptj.py
+++ b/tests/models/gptj/test_modeling_gptj.py
@@ -96,9 +96,6 @@ class GPTJModelTester:
         self.eos_token_id = vocab_size - 1
         self.pad_token_id = vocab_size - 1
 
-    def get_large_model_config(self):
-        return GPTJConfig.from_pretrained("EleutherAI/gpt-j-6B")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 

--- a/tests/models/helium/test_modeling_helium.py
+++ b/tests/models/helium/test_modeling_helium.py
@@ -31,9 +31,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        HeliumForCausalLM,
-        HeliumForSequenceClassification,
-        HeliumForTokenClassification,
         HeliumModel,
     )
 
@@ -45,20 +42,8 @@ class HeliumModelTester(CausalLMModelTester):
 
 @require_torch
 class HeliumModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": HeliumModel,
-            "text-classification": HeliumForSequenceClassification,
-            "token-classification": HeliumForTokenClassification,
-            "text-generation": HeliumForCausalLM,
-            "zero-shot": HeliumForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
-
     model_tester_class = HeliumModelTester
 
 

--- a/tests/models/hunyuan_v1_dense/test_modeling_hunyuan_v1_dense.py
+++ b/tests/models/hunyuan_v1_dense/test_modeling_hunyuan_v1_dense.py
@@ -28,8 +28,6 @@ from transformers.testing_utils import (
 
 if is_torch_available():
     from transformers import (
-        HunYuanDenseV1ForCausalLM,
-        HunYuanDenseV1ForSequenceClassification,
         HunYuanDenseV1Model,
     )
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -43,15 +41,6 @@ class HunYuanDenseV1ModelTester(CausalLMModelTester):
 @require_torch
 class HunYuanDenseV1ModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = HunYuanDenseV1ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": HunYuanDenseV1Model,
-            "text-generation": HunYuanDenseV1ForCausalLM,
-            "text-classification": HunYuanDenseV1ForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     def is_pipeline_test_to_skip(
         self,

--- a/tests/models/hunyuan_v1_moe/test_modeling_hunyuan_v1_moe.py
+++ b/tests/models/hunyuan_v1_moe/test_modeling_hunyuan_v1_moe.py
@@ -31,8 +31,6 @@ if is_torch_available():
     from transformers import (
         AutoModelForCausalLM,
         AutoTokenizer,
-        HunYuanMoEV1ForCausalLM,
-        HunYuanMoEV1ForSequenceClassification,
         HunYuanMoEV1Model,
     )
 
@@ -48,15 +46,6 @@ class HunYuanMoEV1ModelTester(CausalLMModelTester):
 class HunYuanMoEV1ModelTest(CausalLMModelTest, unittest.TestCase):
     test_all_params_have_gradient = False
     model_tester_class = HunYuanMoEV1ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": HunYuanMoEV1Model,
-            "text-generation": HunYuanMoEV1ForCausalLM,
-            "text-classification": HunYuanMoEV1ForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     def is_pipeline_test_to_skip(
         self,

--- a/tests/models/imagegpt/test_modeling_imagegpt.py
+++ b/tests/models/imagegpt/test_modeling_imagegpt.py
@@ -93,9 +93,6 @@ class ImageGPTModelTester:
         self.num_choices = num_choices
         self.scope = None
 
-    def get_large_model_config(self):
-        return ImageGPTConfig.from_pretrained("imagegpt")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/jetmoe/test_modeling_jetmoe.py
+++ b/tests/models/jetmoe/test_modeling_jetmoe.py
@@ -35,7 +35,6 @@ if is_torch_available():
 
     from transformers import (
         JetMoeForCausalLM,
-        JetMoeForSequenceClassification,
         JetMoeModel,
     )
 
@@ -106,15 +105,6 @@ class JetMoeModelTest(CausalLMModelTest, unittest.TestCase):
     test_disk_offload_bin = False
     test_disk_offload_safetensors = False
     model_tester_class = JetMoeModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": JetMoeModel,
-            "text-classification": JetMoeForSequenceClassification,
-            "text-generation": JetMoeForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     @require_flash_attn
     @require_torch_gpu

--- a/tests/models/lfm2/test_modeling_lfm2.py
+++ b/tests/models/lfm2/test_modeling_lfm2.py
@@ -49,14 +49,6 @@ class Lfm2ModelTester(CausalLMModelTester):
 
 @require_torch
 class Lfm2ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Lfm2Model,
-            "text-generation": Lfm2ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
     model_tester_class = Lfm2ModelTester
     # used in `test_torch_compile_for_training`

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -39,9 +39,6 @@ if is_torch_available():
 
     from transformers import (
         LlamaForCausalLM,
-        LlamaForQuestionAnswering,
-        LlamaForSequenceClassification,
-        LlamaForTokenClassification,
         LlamaModel,
         LlamaTokenizer,
     )
@@ -54,18 +51,6 @@ class LlamaModelTester(CausalLMModelTester):
 
 @require_torch
 class LlamaModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": LlamaModel,
-            "text-classification": LlamaForSequenceClassification,
-            "text-generation": LlamaForCausalLM,
-            "zero-shot": LlamaForSequenceClassification,
-            "question-answering": LlamaForQuestionAnswering,
-            "token-classification": LlamaForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False  # Broken by attention refactor cc @Cyrilvallez
     model_tester_class = LlamaModelTester
 

--- a/tests/models/longcat_flash/test_modeling_longcat_flash.py
+++ b/tests/models/longcat_flash/test_modeling_longcat_flash.py
@@ -210,15 +210,6 @@ class LongcatFlashModelTester(CausalLMModelTester):
 
 @require_torch
 class LongcatFlashModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": LongcatFlashModel,
-            "text-generation": LongcatFlashForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_split_percents = [0.5, 0.8]
 
     model_tester_class = LongcatFlashModelTester

--- a/tests/models/longt5/test_modeling_longt5.py
+++ b/tests/models/longt5/test_modeling_longt5.py
@@ -98,9 +98,6 @@ class LongT5ModelTester:
         self.decoder_layers = decoder_layers
         self.large_model_config_path = large_model_config_path
 
-    def get_large_model_config(self):
-        return LongT5Config.from_pretrained(self.large_model_config_path)
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)
         decoder_input_ids = ids_tensor([self.batch_size, self.decoder_seq_length], self.vocab_size)
@@ -935,9 +932,6 @@ class LongT5EncoderOnlyModelTester:
         self.scope = None
         self.is_training = is_training
         self.large_model_config_path = large_model_config_path
-
-    def get_large_model_config(self):
-        return LongT5Config.from_pretrained(self.large_model_config_path)
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)

--- a/tests/models/mamba/test_modeling_mamba.py
+++ b/tests/models/mamba/test_modeling_mamba.py
@@ -82,9 +82,6 @@ class MambaModelTester:
         self.pad_token_id = vocab_size - 1
         self.tie_word_embeddings = tie_word_embeddings
 
-    def get_large_model_config(self):
-        return MambaConfig.from_pretrained("hf-internal-testing/mamba-2.8b")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -119,9 +119,6 @@ class Mamba2ModelTester:
         self.pad_token_id = vocab_size - 1
         self.tie_word_embeddings = tie_word_embeddings
 
-    def get_large_model_config(self):
-        return Mamba2Config.from_pretrained("mistralai/Mamba-Codestral-7B-v0.1")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/minimax/test_modeling_minimax.py
+++ b/tests/models/minimax/test_modeling_minimax.py
@@ -30,9 +30,6 @@ if is_torch_available():
 
     from transformers import (
         MiniMaxForCausalLM,
-        MiniMaxForQuestionAnswering,
-        MiniMaxForSequenceClassification,
-        MiniMaxForTokenClassification,
         MiniMaxModel,
     )
     from transformers.models.minimax.modeling_minimax import MiniMaxCache
@@ -51,17 +48,6 @@ class MiniMaxModelTester(CausalLMModelTester):
 
 @require_torch
 class MiniMaxModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": MiniMaxModel,
-            "text-classification": MiniMaxForSequenceClassification,
-            "token-classification": MiniMaxForTokenClassification,
-            "text-generation": MiniMaxForCausalLM,
-            "question-answering": MiniMaxForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
     model_tester_class = MiniMaxModelTester
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146

--- a/tests/models/ministral/test_modeling_ministral.py
+++ b/tests/models/ministral/test_modeling_ministral.py
@@ -39,9 +39,6 @@ if is_torch_available():
     from transformers import (
         AutoModelForCausalLM,
         MinistralForCausalLM,
-        MinistralForQuestionAnswering,
-        MinistralForSequenceClassification,
-        MinistralForTokenClassification,
         MinistralModel,
     )
 
@@ -57,17 +54,6 @@ class MinistralModelTester(CausalLMModelTester):
 @require_torch
 class MinistralModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = MinistralModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": MinistralModel,
-            "text-classification": MinistralForSequenceClassification,
-            "token-classification": MinistralForTokenClassification,
-            "text-generation": MinistralForCausalLM,
-            "question-answering": MinistralForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146
     def is_pipeline_test_to_skip(

--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -43,9 +43,6 @@ if is_torch_available():
 
     from transformers import (
         MistralForCausalLM,
-        MistralForQuestionAnswering,
-        MistralForSequenceClassification,
-        MistralForTokenClassification,
         MistralModel,
     )
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -58,17 +55,6 @@ class MistralModelTester(CausalLMModelTester):
 
 @require_torch
 class MistralModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": MistralModel,
-            "text-classification": MistralForSequenceClassification,
-            "token-classification": MistralForTokenClassification,
-            "text-generation": MistralForCausalLM,
-            "question-answering": MistralForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
     model_tester_class = MistralModelTester
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -34,9 +34,6 @@ if is_torch_available():
 
     from transformers import (
         MixtralForCausalLM,
-        MixtralForQuestionAnswering,
-        MixtralForSequenceClassification,
-        MixtralForTokenClassification,
         MixtralModel,
     )
 
@@ -50,18 +47,6 @@ class MixtralModelTester(CausalLMModelTester):
 
 @require_torch
 class MixtralModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": MixtralModel,
-            "text-classification": MixtralForSequenceClassification,
-            "token-classification": MixtralForTokenClassification,
-            "text-generation": MixtralForCausalLM,
-            "question-answering": MixtralForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_tester_class = MixtralModelTester
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146

--- a/tests/models/modernbert_decoder/test_modeling_modernbert_decoder.py
+++ b/tests/models/modernbert_decoder/test_modeling_modernbert_decoder.py
@@ -41,15 +41,6 @@ class ModernBertDecoderModelTester(CausalLMModelTester):
 
 @require_torch
 class ModernBertDecoderModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": ModernBertDecoderModel,
-            "text-generation": ModernBertDecoderForCausalLM,
-            "text-classification": ModernBertDecoderForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     model_tester_class = ModernBertDecoderModelTester
 
 

--- a/tests/models/mpnet/test_modeling_mpnet.py
+++ b/tests/models/mpnet/test_modeling_mpnet.py
@@ -85,9 +85,6 @@ class MPNetModelTester:
         self.num_choices = num_choices
         self.scope = scope
 
-    def get_large_model_config(self):
-        return MPNetConfig.from_pretrained("microsoft/mpnet-base")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 

--- a/tests/models/mpt/test_modeling_mpt.py
+++ b/tests/models/mpt/test_modeling_mpt.py
@@ -100,9 +100,6 @@ class MptModelTester:
         self.eos_token_id = vocab_size - 1
         self.pad_token_id = vocab_size - 1
 
-    def get_large_model_config(self):
-        return MptConfig.from_pretrained("mosaicml/mpt-7b")
-
     def prepare_config_and_inputs(self, gradient_checkpointing=False):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 

--- a/tests/models/mt5/test_modeling_mt5.py
+++ b/tests/models/mt5/test_modeling_mt5.py
@@ -100,9 +100,6 @@ class MT5ModelTester:
         self.scope = None
         self.decoder_layers = decoder_layers
 
-    def get_large_model_config(self):
-        return MT5Config.from_pretrained("google-t5/t5-base")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size).clamp(2)
         input_ids[:, -1] = self.eos_token_id  # Eos Token
@@ -907,9 +904,6 @@ class MT5EncoderOnlyModelTester:
         self.is_encoder_decoder = is_encoder_decoder
         self.scope = None
         self.is_training = is_training
-
-    def get_large_model_config(self):
-        return MT5Config.from_pretrained("google-t5/t5-base")
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)

--- a/tests/models/nemotron/test_modeling_nemotron.py
+++ b/tests/models/nemotron/test_modeling_nemotron.py
@@ -37,9 +37,6 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         NemotronForCausalLM,
-        NemotronForQuestionAnswering,
-        NemotronForSequenceClassification,
-        NemotronForTokenClassification,
         NemotronModel,
     )
 
@@ -55,18 +52,6 @@ class NemotronModelTest(CausalLMModelTest, unittest.TestCase):
     # Need to use `0.8` instead of `0.9` for `test_cpu_offload`
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": NemotronModel,
-            "text-classification": NemotronForSequenceClassification,
-            "text-generation": NemotronForCausalLM,
-            "zero-shot": NemotronForSequenceClassification,
-            "question-answering": NemotronForQuestionAnswering,
-            "token-classification": NemotronForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
 
     # used in `test_torch_compile_for_training`

--- a/tests/models/olmo3/test_modeling_olmo3.py
+++ b/tests/models/olmo3/test_modeling_olmo3.py
@@ -52,19 +52,10 @@ class Olmo3ModelTester(CausalLMModelTester):
 
 @require_torch
 class Olmo3ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Olmo3Model,
-            "text-generation": Olmo3ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False
     test_torchscript = False
     test_all_params_have_gradient = False
     model_tester_class = Olmo3ModelTester
-    rotary_embedding_layer = Olmo3RotaryEmbedding
 
     # Need to use `0.8` instead of `0.9` for `test_cpu_offload`
     # This is because we are hitting edge cases with the causal_mask buffer
@@ -75,8 +66,6 @@ class Olmo3ModelTest(CausalLMModelTest, unittest.TestCase):
 
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
     def test_model_rope_scaling_from_config(self, scaling_type):
-        if self.rotary_embedding_layer is None:
-            self.skipTest("Rotary embedding layer not set")
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 
         # Rope only gets applied to full attention layers in Olmo3, so make all layers full attention.

--- a/tests/models/phi/test_modeling_phi.py
+++ b/tests/models/phi/test_modeling_phi.py
@@ -32,8 +32,6 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         PhiForCausalLM,
-        PhiForSequenceClassification,
-        PhiForTokenClassification,
         PhiModel,
     )
 
@@ -45,17 +43,6 @@ class PhiModelTester(CausalLMModelTester):
 
 @require_torch
 class PhiModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": PhiModel,
-            "text-classification": PhiForSequenceClassification,
-            "token-classification": PhiForTokenClassification,
-            "text-generation": PhiForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_tester_class = PhiModelTester
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79292/workflows/fa2ba644-8953-44a6-8f67-ccd69ca6a476/jobs/1012905

--- a/tests/models/phi3/test_modeling_phi3.py
+++ b/tests/models/phi3/test_modeling_phi3.py
@@ -36,8 +36,6 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         Phi3ForCausalLM,
-        Phi3ForSequenceClassification,
-        Phi3ForTokenClassification,
         Phi3Model,
     )
 
@@ -92,17 +90,6 @@ class Phi3ModelTester(CausalLMModelTester):
 
 @require_torch
 class Phi3ModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Phi3Model,
-            "text-classification": Phi3ForSequenceClassification,
-            "token-classification": Phi3ForTokenClassification,
-            "text-generation": Phi3ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_tester_class = Phi3ModelTester
 
 

--- a/tests/models/phimoe/test_modeling_phimoe.py
+++ b/tests/models/phimoe/test_modeling_phimoe.py
@@ -35,7 +35,6 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         PhimoeForCausalLM,
-        PhimoeForSequenceClassification,
         PhimoeModel,
     )
 
@@ -93,16 +92,6 @@ class PhimoeModelTester(CausalLMModelTester):
 class PhimoeModelTest(CausalLMModelTest, unittest.TestCase):
     test_all_params_have_gradient = False
     model_tester_class = PhimoeModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": PhimoeModel,
-            "text-classification": PhimoeForSequenceClassification,
-            "text-generation": PhimoeForCausalLM,
-            "zero-shot": PhimoeForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79292/workflows/fa2ba644-8953-44a6-8f67-ccd69ca6a476/jobs/1012905
     def is_pipeline_test_to_skip(

--- a/tests/models/qwen2/test_modeling_qwen2.py
+++ b/tests/models/qwen2/test_modeling_qwen2.py
@@ -37,9 +37,6 @@ if is_torch_available():
 
     from transformers import (
         Qwen2ForCausalLM,
-        Qwen2ForQuestionAnswering,
-        Qwen2ForSequenceClassification,
-        Qwen2ForTokenClassification,
         Qwen2Model,
     )
 
@@ -55,17 +52,6 @@ class Qwen2ModelTester(CausalLMModelTester):
 @require_torch
 class Qwen2ModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Qwen2ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Qwen2Model,
-            "text-classification": Qwen2ForSequenceClassification,
-            "token-classification": Qwen2ForTokenClassification,
-            "text-generation": Qwen2ForCausalLM,
-            "question-answering": Qwen2ForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146
     def is_pipeline_test_to_skip(

--- a/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
+++ b/tests/models/qwen2_moe/test_modeling_qwen2_moe.py
@@ -35,9 +35,6 @@ if is_torch_available():
 
     from transformers import (
         Qwen2MoeForCausalLM,
-        Qwen2MoeForQuestionAnswering,
-        Qwen2MoeForSequenceClassification,
-        Qwen2MoeForTokenClassification,
         Qwen2MoeModel,
     )
 
@@ -52,18 +49,6 @@ class Qwen2MoeModelTester(CausalLMModelTester):
 
 @require_torch
 class Qwen2MoeModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Qwen2MoeModel,
-            "text-classification": Qwen2MoeForSequenceClassification,
-            "token-classification": Qwen2MoeForTokenClassification,
-            "text-generation": Qwen2MoeForCausalLM,
-            "question-answering": Qwen2MoeForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     test_all_params_have_gradient = False
     model_tester_class = Qwen2MoeModelTester
 

--- a/tests/models/qwen3/test_modeling_qwen3.py
+++ b/tests/models/qwen3/test_modeling_qwen3.py
@@ -36,9 +36,6 @@ if is_torch_available():
 
     from transformers import (
         Qwen3ForCausalLM,
-        Qwen3ForQuestionAnswering,
-        Qwen3ForSequenceClassification,
-        Qwen3ForTokenClassification,
         Qwen3Model,
     )
 
@@ -53,17 +50,6 @@ class Qwen3ModelTester(CausalLMModelTester):
 @require_torch
 class Qwen3ModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Qwen3ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Qwen3Model,
-            "text-classification": Qwen3ForSequenceClassification,
-            "token-classification": Qwen3ForTokenClassification,
-            "text-generation": Qwen3ForCausalLM,
-            "question-answering": Qwen3ForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     # TODO (ydshieh): Check this. See https://app.circleci.com/pipelines/github/huggingface/transformers/79245/workflows/9490ef58-79c2-410d-8f51-e3495156cf9c/jobs/1012146
     def is_pipeline_test_to_skip(

--- a/tests/models/qwen3_moe/test_modeling_qwen3_moe.py
+++ b/tests/models/qwen3_moe/test_modeling_qwen3_moe.py
@@ -34,10 +34,7 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        Qwen3ForQuestionAnswering,
         Qwen3MoeForCausalLM,
-        Qwen3MoeForSequenceClassification,
-        Qwen3MoeForTokenClassification,
         Qwen3MoeModel,
     )
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
@@ -50,18 +47,6 @@ class Qwen3MoeModelTester(CausalLMModelTester):
 
 @require_torch
 class Qwen3MoeModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Qwen3MoeModel,
-            "text-classification": Qwen3MoeForSequenceClassification,
-            "token-classification": Qwen3MoeForTokenClassification,
-            "text-generation": Qwen3MoeForCausalLM,
-            "question-answering": Qwen3ForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     test_all_params_have_gradient = False
     model_tester_class = Qwen3MoeModelTester
 

--- a/tests/models/qwen3_next/test_modeling_qwen3_next.py
+++ b/tests/models/qwen3_next/test_modeling_qwen3_next.py
@@ -27,10 +27,6 @@ if is_torch_available():
 
     from transformers import (
         Cache,
-        Qwen3NextForCausalLM,
-        Qwen3NextForQuestionAnswering,
-        Qwen3NextForSequenceClassification,
-        Qwen3NextForTokenClassification,
         Qwen3NextModel,
     )
     from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextDynamicCache
@@ -58,18 +54,6 @@ class Qwen3NextModelTester(CausalLMModelTester):
 
 @require_torch
 class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Qwen3NextModel,
-            "text-classification": Qwen3NextForSequenceClassification,
-            "token-classification": Qwen3NextForTokenClassification,
-            "text-generation": Qwen3NextForCausalLM,
-            "question-answering": Qwen3NextForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     model_tester_class = Qwen3NextModelTester
 
     def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):

--- a/tests/models/recurrent_gemma/test_modeling_recurrent_gemma.py
+++ b/tests/models/recurrent_gemma/test_modeling_recurrent_gemma.py
@@ -33,7 +33,7 @@ from transformers.testing_utils import (
 if is_torch_available():
     import torch
 
-    from transformers import RecurrentGemmaForCausalLM, RecurrentGemmaModel
+    from transformers import RecurrentGemmaModel
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 
@@ -45,14 +45,6 @@ class RecurrentGemmaModelTester(CausalLMModelTester):
 
 @require_torch
 class RecurrentGemmaModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": RecurrentGemmaModel,
-            "text-generation": RecurrentGemmaForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
     has_attentions = False
     model_tester_class = RecurrentGemmaModelTester
 

--- a/tests/models/rwkv/test_modeling_rwkv.py
+++ b/tests/models/rwkv/test_modeling_rwkv.py
@@ -84,9 +84,6 @@ class RwkvModelTester:
         self.eos_token_id = vocab_size - 1
         self.pad_token_id = vocab_size - 1
 
-    def get_large_model_config(self):
-        return RwkvConfig.from_pretrained("sgugger/rwkv-4-pile-7b")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/seed_oss/test_modeling_seed_oss.py
+++ b/tests/models/seed_oss/test_modeling_seed_oss.py
@@ -35,9 +35,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        SeedOssForCausalLM,
-        SeedOssForSequenceClassification,
-        SeedOssForTokenClassification,
         SeedOssModel,
     )
 
@@ -50,17 +47,6 @@ class SeedOssModelTester(CausalLMModelTester):
 @require_torch
 class SeedOssModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = SeedOssModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": SeedOssModel,
-            "text-classification": SeedOssForSequenceClassification,
-            "token-classification": SeedOssForTokenClassification,
-            "text-generation": SeedOssForCausalLM,
-            "zero-shot": SeedOssForSequenceClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
 

--- a/tests/models/smollm3/test_modeling_smollm3.py
+++ b/tests/models/smollm3/test_modeling_smollm3.py
@@ -66,17 +66,6 @@ class SmolLM3ModelTester(CausalLMModelTester):
 @require_torch
 class SmolLM3ModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = SmolLM3ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": SmolLM3Model,
-            "text-classification": SmolLM3ForSequenceClassification,
-            "token-classification": SmolLM3ForTokenClassification,
-            "text-generation": SmolLM3ForCausalLM,
-            "question-answering": SmolLM3ForQuestionAnswering,
-        }
-        if is_torch_available()
-        else {}
-    )
 
     @parameterized.expand(TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION)
     @is_flaky()

--- a/tests/models/stablelm/test_modeling_stablelm.py
+++ b/tests/models/stablelm/test_modeling_stablelm.py
@@ -33,8 +33,6 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         StableLmForCausalLM,
-        StableLmForSequenceClassification,
-        StableLmForTokenClassification,
         StableLmModel,
     )
 
@@ -48,17 +46,6 @@ class StableLmModelTester(CausalLMModelTester):
 
 @require_torch
 class StableLmModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": StableLmModel,
-            "text-classification": StableLmForSequenceClassification,
-            "text-generation": StableLmForCausalLM,
-            "zero-shot": StableLmForSequenceClassification,
-            "token-classification": StableLmForTokenClassification,
-        }
-        if is_torch_available()
-        else {}
-    )
     fx_compatible = False  # Broken by attention refactor cc @Cyrilvallez
     model_tester_class = StableLmModelTester
 

--- a/tests/models/starcoder2/test_modeling_starcoder2.py
+++ b/tests/models/starcoder2/test_modeling_starcoder2.py
@@ -35,8 +35,6 @@ if is_torch_available():
     from transformers import (
         AutoTokenizer,
         Starcoder2ForCausalLM,
-        Starcoder2ForSequenceClassification,
-        Starcoder2ForTokenClassification,
         Starcoder2Model,
     )
 
@@ -51,16 +49,6 @@ class Starcoder2ModelTester(CausalLMModelTester):
 @require_torch
 class Starcoder2ModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Starcoder2ModelTester
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": Starcoder2Model,
-            "text-classification": Starcoder2ForSequenceClassification,
-            "token-classification": Starcoder2ForTokenClassification,
-            "text-generation": Starcoder2ForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
 
 
 @slow

--- a/tests/models/switch_transformers/test_modeling_switch_transformers.py
+++ b/tests/models/switch_transformers/test_modeling_switch_transformers.py
@@ -109,9 +109,6 @@ class SwitchTransformersModelTester:
         self.expert_capacity = expert_capacity
         self.router_jitter_noise = router_jitter_noise
 
-    def get_large_model_config(self):
-        return SwitchTransformersConfig.from_pretrained("google/switch-base-8")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)
         decoder_input_ids = ids_tensor([self.batch_size, self.decoder_seq_length], self.vocab_size)
@@ -763,9 +760,6 @@ class SwitchTransformersEncoderOnlyModelTester:
         self.is_encoder_decoder = is_encoder_decoder
         self.scope = None
         self.is_training = is_training
-
-    def get_large_model_config(self):
-        return SwitchTransformersConfig.from_pretrained("google/switch-base-8")
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -109,9 +109,6 @@ class T5ModelTester:
         self.scope = None
         self.decoder_layers = decoder_layers
 
-    def get_large_model_config(self):
-        return T5Config.from_pretrained("google-t5/t5-base")
-
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size).clamp(2)
         input_ids[:, -1] = self.eos_token_id  # Eos Token
@@ -914,9 +911,6 @@ class T5EncoderOnlyModelTester:
         self.is_encoder_decoder = is_encoder_decoder
         self.scope = None
         self.is_training = is_training
-
-    def get_large_model_config(self):
-        return T5Config.from_pretrained("google-t5/t5-base")
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)

--- a/tests/models/umt5/test_modeling_umt5.py
+++ b/tests/models/umt5/test_modeling_umt5.py
@@ -99,9 +99,6 @@ class UMT5ModelTester:
         self.scope = None
         self.decoder_layers = decoder_layers
 
-    def get_large_model_config(self):
-        return UMT5Config.from_pretrained("google/umt5-base")
-
     def prepare_inputs_dict(
         self,
         config,
@@ -534,9 +531,6 @@ class UMT5EncoderOnlyModelTester:
         self.is_encoder_decoder = is_encoder_decoder
         self.scope = None
         self.is_training = is_training
-
-    def get_large_model_config(self):
-        return UMT5Config.from_pretrained("google-t5/t5-base")
 
     def prepare_config_and_inputs(self):
         input_ids = ids_tensor([self.batch_size, self.encoder_seq_length], self.vocab_size)

--- a/tests/models/vaultgemma/test_modeling_vaultgemma.py
+++ b/tests/models/vaultgemma/test_modeling_vaultgemma.py
@@ -47,7 +47,6 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        VaultGemmaForCausalLM,
         VaultGemmaModel,
     )
 
@@ -59,15 +58,6 @@ class VaultGemmaModelTester(CausalLMModelTester):
 
 @require_torch
 class VaultGemmaModelTest(CausalLMModelTest, unittest.TestCase):
-    pipeline_model_mapping = (
-        {
-            "feature-extraction": VaultGemmaModel,
-            "text-generation": VaultGemmaForCausalLM,
-        }
-        if is_torch_available()
-        else {}
-    )
-
     _is_stateful = True
     model_split_percents = [0.5, 0.6]
     model_tester_class = VaultGemmaModelTester

--- a/tests/models/xglm/test_modeling_xglm.py
+++ b/tests/models/xglm/test_modeling_xglm.py
@@ -81,9 +81,6 @@ class XGLMModelTester:
         self.eos_token_id = 2
         self.pad_token_id = 1
 
-    def get_large_model_config(self):
-        return XGLMConfig.from_pretrained("facebook/xglm-564M")
-
     def prepare_config_and_inputs(
         self, gradient_checkpointing=False, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False
     ):

--- a/tests/models/xlstm/test_modeling_xlstm.py
+++ b/tests/models/xlstm/test_modeling_xlstm.py
@@ -86,10 +86,6 @@ class xLSTMModelTester:
         self.step_kernel = step_kernel
         self.tie_word_embeddings = tie_word_embeddings
 
-    def get_large_model_config(self):
-        cfg = xLSTMConfig.from_pretrained("NX-AI/xLSTM-7b")
-        return cfg
-
     def prepare_config_and_inputs(self, scale_attn_by_inverse_layer_idx=False, reorder_and_upcast_attn=False):
         input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
 


### PR DESCRIPTION
# What does this PR do?

👉 `CausalLMModelTest`-level changes:
- automate `pipeline_model_mapping` whenever possible -- when `all_model_classes` contains the default classes, then `pipeline_model_mapping` must also contain the default mappings. This should reduce room for human error 🙏 

👉 `Bloom` (the original target of this PR)
- `CausalLMModelTest` refactor
- moves integration tests into the correct tester

👉 misc
- removes `get_large_model_config` in multiple model testers (this function was never being used)