### PR TITLE
Use torch._check instead of a test in Gemma3Model

### DIFF
--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -875,10 +875,11 @@ class Gemma3Model(Gemma3PreTrainedModel):
         n_image_tokens = special_image_mask.sum()
         special_image_mask = special_image_mask.unsqueeze(-1).expand_as(inputs_embeds).to(inputs_embeds.device)
         n_image_features = image_features.shape[0] * image_features.shape[1]
-        if inputs_embeds[special_image_mask].numel() != image_features.numel():
-            raise ValueError(
-                f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
-            )
+        # torch._check does not fail torch.export.export.
+        torch._check(
+            inputs_embeds[special_image_mask].numel() == image_features.numel(),
+            lambda: f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}",
+        )
         return special_image_mask
 
     @can_return_tuple


### PR DESCRIPTION
# What does this PR do?

``torch.export.export`` fails because of a test checking two dimension are equal. This PR replaces the test by ``torch._check``.
