### PR TITLE
Fix lr_scheduler_parsing

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -881,7 +881,7 @@ class TrainingArguments:
         metadata={"help": "The scheduler type to use."},
     )
     lr_scheduler_kwargs: Optional[Union[dict, str]] = field(
-        default_factory=None,
+        default=None,
         metadata={
             "help": (
                 "Extra parameters for the lr_scheduler such as {'num_cycles': 1} for the cosine with hard restarts."

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -298,7 +298,7 @@ class TrainingArguments:
             `max_steps` is reached.
         lr_scheduler_type (`str` or [`SchedulerType`], *optional*, defaults to `"linear"`):
             The scheduler type to use. See the documentation of [`SchedulerType`] for all possible values.
-        lr_scheduler_kwargs ('dict', *optional*, defaults to {}):
+        lr_scheduler_kwargs (`dict` or `str`, *optional*, defaults to `None`):
             The extra arguments for the lr_scheduler. See the documentation of each scheduler for possible values.
         warmup_ratio (`float`, *optional*, defaults to 0.0):
             Ratio of total training steps used for a linear warmup from 0 to `learning_rate`.
@@ -880,8 +880,8 @@ class TrainingArguments:
         default="linear",
         metadata={"help": "The scheduler type to use."},
     )
-    lr_scheduler_kwargs: Union[dict[str, Any], str] = field(
-        default_factory=dict,
+    lr_scheduler_kwargs: Optional[Union[dict, str]] = field(
+        default_factory=None,
         metadata={
             "help": (
                 "Extra parameters for the lr_scheduler such as {'num_cycles': 1} for the cosine with hard restarts."


### PR DESCRIPTION
# What does this PR do?

This PR fixes `lr_scheduler_kwargs` type to `Optional[Union[dict, str]] `as HfArgumentParser doesn't handled well args that needs to parsed into dict. For now, it is better to just follow what is done for fsdp_config for example. 