### PR TITLE
Add Setup section to README for dev dependencies and doc-builder

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+# Setup
+
+```bash
+pip install -e ".[dev]"  # Installs dev dependencies
+pip install git+https://github.com/huggingface/doc-builder  # Installs doc-builder
+
+```
+
 # Generating the documentation
 
 To generate the documentation, you first have to build it. Several packages are necessary to build the doc, 


### PR DESCRIPTION
Title:
Add Setup section for installing dev dependencies and doc-builder

Description:
This PR adds a Setup section to docs/README.md that guides contributors on installing the necessary development dependencies and the Hugging Face doc-builder tool. This makes it easier for new contributors to generate and preview documentation locally.

Motivation & Context:

Improves contributor onboarding with clear setup instructions.

Ensures the documentation can be built locally without errors.

Checklist:

 Improves documentation.

 Follows contributor guidelines.

 No new tests are required (documentation-only change).

Who can review:
Any contributor familiar with documentation or the docs setup.
@zucchini-nlp tagging for prioritising review 