### PR TITLE
Fix trainer for py3.9

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -5206,7 +5206,7 @@ class Trainer:
                     self.model.hf_quantizer.quantization_config.bnb_4bit_quant_storage, override=True
                 )
 
-    def _get_num_items_in_batch(self, batch_samples: list, device: torch.device) -> int | None:
+    def _get_num_items_in_batch(self, batch_samples: list, device: torch.device) -> Optional[Union[torch.Tensor, int]]:
         """
         Counts the number of items in the batches to properly scale the loss.
         Args:


### PR DESCRIPTION
# What does this PR do?

This PR fixes trainer compatibility with py3.9. To be added in a patch for the latest release. Asked by optimum folks cc @IlyasMoutawwakil 