### PR TITLE
[testing] update `test_longcat_generation_cpu`

### DIFF
--- a/tests/models/longcat_flash/test_modeling_longcat_flash.py
+++ b/tests/models/longcat_flash/test_modeling_longcat_flash.py
@@ -445,6 +445,6 @@ class LongcatFlashIntegrationTest(unittest.TestCase):
             outputs = model.generate(inputs, max_new_tokens=3, do_sample=False)
 
         response = tokenizer.batch_decode(outputs, skip_special_tokens=False)[0]
-        expected_output = "[Round 0] USER:Paris is... ASSISTANT:Paris is... a city of timeless charm, where"
+        expected_output = "[Round 0] USER:Paris is... ASSISTANT:Paris is..."
 
         self.assertEqual(response, expected_output)

--- a/tests/models/longcat_flash/test_modeling_longcat_flash.py
+++ b/tests/models/longcat_flash/test_modeling_longcat_flash.py
@@ -435,14 +435,14 @@ class LongcatFlashIntegrationTest(unittest.TestCase):
     @require_large_cpu_ram
     def test_longcat_generation_cpu(self):
         # takes absolutely forever and a lot RAM, but allows to test the output in the CI
-        model = LongcatFlashForCausalLM.from_pretrained(self.model_id, device_map="cpu", dtype=torch.bfloat16)
+        model = LongcatFlashForCausalLM.from_pretrained(self.model_id, device_map="auto", dtype=torch.bfloat16)
         tokenizer = AutoTokenizer.from_pretrained(self.model_id)
 
         chat = [{"role": "user", "content": "Paris is..."}]
         inputs = tokenizer.apply_chat_template(chat, tokenize=True, add_generation_prompt=True, return_tensors="pt")
 
         with torch.no_grad():
-            outputs = model.generate(inputs, max_new_tokens=10, do_sample=False)
+            outputs = model.generate(inputs, max_new_tokens=3, do_sample=False)
 
         response = tokenizer.batch_decode(outputs, skip_special_tokens=False)[0]
         expected_output = "[Round 0] USER:Paris is... ASSISTANT:Paris is... a city of timeless charm, where"


### PR DESCRIPTION
# What does this PR do?

Use "auto" instead of "cpu" to avoid the pytest process being killed. 

(#40132 has issue with using "auto" for this model, and we still need an fix for that)

Also using `max_new_tokens=3` to run this test within 8 minutes (on a single A10 CI runner)

The expected output is not updated yet: will do it after the above mentioned issue is fixed.