### PR TITLE
`report_to` default changed to "none" + cleaning deprecated env var

### DIFF
--- a/docs/source/en/tasks/knowledge_distillation_for_image_classification.md
+++ b/docs/source/en/tasks/knowledge_distillation_for_image_classification.md
@@ -108,7 +108,6 @@ training_args = TrainingArguments(
     output_dir="my-awesome-model",
     num_train_epochs=30,
     fp16=True,
-    logging_dir=f"{repo_name}/logs",
     logging_strategy="epoch",
     eval_strategy="epoch",
     save_strategy="epoch",

--- a/docs/source/ja/tasks/knowledge_distillation_for_image_classification.md
+++ b/docs/source/ja/tasks/knowledge_distillation_for_image_classification.md
@@ -110,7 +110,6 @@ training_args = TrainingArguments(
     output_dir="my-awesome-model",
     num_train_epochs=30,
     fp16=True,
-    logging_dir=f"{repo_name}/logs",
     logging_strategy="epoch",
     eval_strategy="epoch",
     save_strategy="epoch",

--- a/docs/source/ko/tasks/knowledge_distillation_for_image_classification.md
+++ b/docs/source/ko/tasks/knowledge_distillation_for_image_classification.md
@@ -115,7 +115,6 @@ training_args = TrainingArguments(
     output_dir="my-awesome-model",
     num_train_epochs=30,
     fp16=True,
-    logging_dir=f"{repo_name}/logs",
     logging_strategy="epoch",
     eval_strategy="epoch",
     save_strategy="epoch",

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -106,6 +106,7 @@ from ..utils import ENV_VARS_TRUE_VALUES, is_torch_xla_available  # noqa: E402
 def is_wandb_available():
     if importlib.util.find_spec("wandb") is not None:
         import wandb
+
         # wandb might still be detected by find_spec after an uninstall (leftover files or metadata), but not actually
         # import correctly. To confirm it's fully installed and usable, we check for a key attribute like "run".
         return hasattr(wandb, "run")
@@ -647,6 +648,7 @@ def rewrite_logs(d):
             new_d["train/" + k] = v
     return new_d
 
+
 def default_logdir() -> str:
     """
     Same default as PyTorch
@@ -657,6 +659,7 @@ def default_logdir() -> str:
     current_time = datetime.now().strftime("%b%d_%H-%M-%S")
     return os.path.join("runs", current_time + "_" + socket.gethostname())
 
+
 class TensorBoardCallback(TrainerCallback):
     """
     A [`TrainerCallback`] that sends the logs to [TensorBoard](https://www.tensorflow.org/tensorboard).
@@ -664,7 +667,6 @@ class TensorBoardCallback(TrainerCallback):
     Args:
         tb_writer (`SummaryWriter`, *optional*):
             The writer to use. Will instantiate one if not set.
-            
     Environment:
         - **TENSORBOARD_LOGGING_DIR** (`str`, *optional*, defaults to `None`):
             The logging dir to log the results. Default value is os.path.join(args.output_dir, default_logdir())
@@ -686,7 +688,7 @@ class TensorBoardCallback(TrainerCallback):
         self.logging_dir = os.getenv("TENSORBOARD_LOGGING_DIR", None)
         if self.logging_dir is not None:
             self.logging_dir = os.path.expanduser(self.logging_dir)
- 
+
     def _init_summary_writer(self, args):
         if self._SummaryWriter is not None:
             self.tb_writer = self._SummaryWriter(log_dir=self.logging_dir)
@@ -700,7 +702,7 @@ class TensorBoardCallback(TrainerCallback):
             if trial_name is not None:
                 # overwrite logging dir for trials
                 self.logging_dir = os.path.join(args.output_dir, default_logdir(), trial_name)
-                
+
         if self.logging_dir is None:
             self.logging_dir = os.path.join(args.output_dir, default_logdir())
 
@@ -785,8 +787,9 @@ class WandbCallback(TrainerCallback):
         has_wandb = is_wandb_available()
         if not has_wandb:
             raise RuntimeError("WandbCallback requires wandb to be installed. Run `pip install wandb`.")
-        
+
         import wandb
+
         self._wandb = wandb
         self._initialized = False
         self._log_model = WandbLogModel(os.getenv("WANDB_LOG_MODEL", "false"))

--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -104,16 +104,8 @@ from ..utils import ENV_VARS_TRUE_VALUES, is_torch_xla_available  # noqa: E402
 
 # Integration functions:
 def is_wandb_available():
-    # any value of WANDB_DISABLED disables wandb
-    if os.getenv("WANDB_DISABLED", "").upper() in ENV_VARS_TRUE_VALUES:
-        logger.warning(
-            "Using the `WANDB_DISABLED` environment variable is deprecated and will be removed in v5. Use the "
-            "--report_to flag to control the integrations used for logging result (for instance --report_to none)."
-        )
-        return False
     if importlib.util.find_spec("wandb") is not None:
         import wandb
-
         # wandb might still be detected by find_spec after an uninstall (leftover files or metadata), but not actually
         # import correctly. To confirm it's fully installed and usable, we check for a key attribute like "run".
         return hasattr(wandb, "run")
@@ -130,13 +122,6 @@ def is_clearml_available():
 
 
 def is_comet_available():
-    if os.getenv("COMET_MODE", "").upper() == "DISABLED":
-        logger.warning(
-            "Using the `COMET_MODE=DISABLED` environment variable is deprecated and will be removed in v5. Use the "
-            "--report_to flag to control the integrations used for logging result (for instance --report_to none)."
-        )
-        return False
-
     if _is_comet_installed is False:
         return False
 
@@ -662,6 +647,15 @@ def rewrite_logs(d):
             new_d["train/" + k] = v
     return new_d
 
+def default_logdir() -> str:
+    """
+    Same default as PyTorch
+    """
+    import socket
+    from datetime import datetime
+
+    current_time = datetime.now().strftime("%b%d_%H-%M-%S")
+    return os.path.join("runs", current_time + "_" + socket.gethostname())
 
 class TensorBoardCallback(TrainerCallback):
     """
@@ -670,49 +664,48 @@ class TensorBoardCallback(TrainerCallback):
     Args:
         tb_writer (`SummaryWriter`, *optional*):
             The writer to use. Will instantiate one if not set.
+            
+    Environment:
+        - **TENSORBOARD_LOGGING_DIR** (`str`, *optional*, defaults to `None`):
+            The logging dir to log the results. Default value is os.path.join(args.output_dir, default_logdir())
     """
 
     def __init__(self, tb_writer=None):
-        has_tensorboard = is_tensorboard_available()
-        if not has_tensorboard:
+        if not is_tensorboard_available():
             raise RuntimeError(
                 "TensorBoardCallback requires tensorboard to be installed. Either update your PyTorch version or"
                 " install tensorboardX."
             )
-        if has_tensorboard:
-            try:
-                from torch.utils.tensorboard import SummaryWriter
+        try:
+            from torch.utils.tensorboard import SummaryWriter
+        except ImportError:
+            from tensorboardX import SummaryWriter
 
-                self._SummaryWriter = SummaryWriter
-            except ImportError:
-                try:
-                    from tensorboardX import SummaryWriter
-
-                    self._SummaryWriter = SummaryWriter
-                except ImportError:
-                    self._SummaryWriter = None
-        else:
-            self._SummaryWriter = None
+        self._SummaryWriter = SummaryWriter
         self.tb_writer = tb_writer
-
-    def _init_summary_writer(self, args, log_dir=None):
-        log_dir = log_dir or args.logging_dir
+        self.logging_dir = os.getenv("TENSORBOARD_LOGGING_DIR", None)
+        if self.logging_dir is not None:
+            self.logging_dir = os.path.expanduser(self.logging_dir)
+ 
+    def _init_summary_writer(self, args):
         if self._SummaryWriter is not None:
-            self.tb_writer = self._SummaryWriter(log_dir=log_dir)
+            self.tb_writer = self._SummaryWriter(log_dir=self.logging_dir)
 
     def on_train_begin(self, args, state, control, **kwargs):
         if not state.is_world_process_zero:
             return
 
-        log_dir = None
-
         if state.is_hyper_param_search:
             trial_name = state.trial_name
             if trial_name is not None:
-                log_dir = os.path.join(args.logging_dir, trial_name)
+                # overwrite logging dir for trials
+                self.logging_dir = os.path.join(args.output_dir, default_logdir(), trial_name)
+                
+        if self.logging_dir is None:
+            self.logging_dir = os.path.join(args.output_dir, default_logdir())
 
         if self.tb_writer is None:
-            self._init_summary_writer(args, log_dir)
+            self._init_summary_writer(args)
 
         if self.tb_writer is not None:
             self.tb_writer.add_text("args", args.to_json_string())
@@ -777,13 +770,6 @@ class WandbLogModel(str, Enum):
     def _missing_(cls, value: Any) -> "WandbLogModel":
         if not isinstance(value, str):
             raise TypeError(f"Expecting to have a string `WANDB_LOG_MODEL` setting, but got {type(value)}")
-        if value.upper() in ENV_VARS_TRUE_VALUES:
-            raise DeprecationWarning(
-                f"Setting `WANDB_LOG_MODEL` as {os.getenv('WANDB_LOG_MODEL')} is deprecated and will be removed in "
-                "version 5 of transformers. Use one of `'end'` or `'checkpoint'` instead."
-            )
-            logger.info(f"Setting `WANDB_LOG_MODEL` from {os.getenv('WANDB_LOG_MODEL')} to `end` instead")
-            return WandbLogModel.END
         logger.warning(
             f"Received unrecognized `WANDB_LOG_MODEL` setting value={value}; so disabling `WANDB_LOG_MODEL`"
         )
@@ -798,24 +784,10 @@ class WandbCallback(TrainerCallback):
     def __init__(self):
         has_wandb = is_wandb_available()
         if not has_wandb:
-            # Check if wandb is actually installed but disabled via WANDB_DISABLED
-            if importlib.util.find_spec("wandb") is not None:
-                # wandb is installed but disabled
-                wandb_disabled = os.getenv("WANDB_DISABLED", "").upper() in ENV_VARS_TRUE_VALUES
-                if wandb_disabled:
-                    raise RuntimeError(
-                        "You specified `report_to='wandb'` but also set the `WANDB_DISABLED` environment variable.\n"
-                        "This disables wandb logging, even though it was explicitly requested.\n\n"
-                        "- To enable wandb logging: unset `WANDB_DISABLED`.\n"
-                        "- To disable logging: use `report_to='none'`.\n\n"
-                        "Note: WANDB_DISABLED is deprecated and will be removed in v5."
-                    )
-            # If wandb is not installed at all, use the original error message
             raise RuntimeError("WandbCallback requires wandb to be installed. Run `pip install wandb`.")
-        if has_wandb:
-            import wandb
-
-            self._wandb = wandb
+        
+        import wandb
+        self._wandb = wandb
         self._initialized = False
         self._log_model = WandbLogModel(os.getenv("WANDB_LOG_MODEL", "false"))
 
@@ -833,19 +805,11 @@ class WandbCallback(TrainerCallback):
             to `"end"`, the model will be uploaded at the end of training. If set to `"checkpoint"`, the checkpoint
             will be uploaded every `args.save_steps` . If set to `"false"`, the model will not be uploaded. Use along
             with [`~transformers.TrainingArguments.load_best_model_at_end`] to upload best model.
-
-            <Deprecated version="5.0">
-
-            Setting `WANDB_LOG_MODEL` as `bool` will be deprecated in version 5 of 🤗 Transformers.
-
-            </Deprecated>
         - **WANDB_WATCH** (`str`, *optional* defaults to `"false"`):
             Can be `"gradients"`, `"all"`, `"parameters"`, or `"false"`. Set to `"all"` to log gradients and
             parameters.
         - **WANDB_PROJECT** (`str`, *optional*, defaults to `"huggingface"`):
             Set this to a custom string to store results in a different project.
-        - **WANDB_DISABLED** (`bool`, *optional*, defaults to `False`):
-            Whether to disable wandb entirely. Set `WANDB_DISABLED=true` to disable.
         """
         if self._wandb is None:
             return
@@ -855,9 +819,6 @@ class WandbCallback(TrainerCallback):
         from wandb.sdk.lib.config_util import ConfigError as WandbConfigError
 
         if state.is_world_process_zero:
-            logger.info(
-                'Automatic Weights & Biases logging enabled, to disable set os.environ["WANDB_DISABLED"] = "true"'
-            )
             combined_dict = {**args.to_dict()}
 
             if hasattr(model, "config") and model.config is not None:
@@ -1214,13 +1175,8 @@ class CometCallback(TrainerCallback):
                 * `create`: Always create a new Comet Experiment.
                 * `get`: Always try to append to an Existing Comet Experiment.
                   Requires `COMET_EXPERIMENT_KEY` to be set.
-                * `ONLINE`: **deprecated**, used to create an online
-                  Experiment. Use `COMET_START_ONLINE=1` instead.
-                * `OFFLINE`: **deprecated**, used to created an offline
-                  Experiment. Use `COMET_START_ONLINE=0` instead.
-                * `DISABLED`: **deprecated**, used to disable Comet logging.
-                  Use the `--report_to` flag to control the integrations used
-                  for logging result instead.
+        - **COMET_START_ONLINE** (`bool`, *optional*):
+            Whether to create an online or offline Experiment.
         - **COMET_PROJECT_NAME** (`str`, *optional*):
             Comet project name for experiments.
         - **COMET_LOG_ASSETS** (`str`, *optional*, defaults to `TRUE`):
@@ -1242,12 +1198,7 @@ class CometCallback(TrainerCallback):
 
             if comet_old_mode is not None:
                 comet_old_mode = comet_old_mode.lower()
-
-                if comet_old_mode == "online":
-                    online = True
-                elif comet_old_mode == "offline":
-                    online = False
-                elif comet_old_mode in ("get", "get_or_create", "create"):
+                if comet_old_mode in ("get", "get_or_create", "create"):
                     mode = comet_old_mode
                 elif comet_old_mode:
                     logger.warning("Invalid COMET_MODE env value %r, Comet logging is disabled", comet_old_mode)

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -906,12 +906,6 @@ class TrainingArguments:
             )
         },
     )
-    logging_dir: Optional[str] = field(
-        default=None,
-        metadata={
-            "help": "This argument is deprecated and will be removed in v5.2. Set `TENSORBOARD_LOGGING_DIR` instead"
-        },
-    )
     logging_strategy: Union[IntervalStrategy, str] = field(
         default="steps",
         metadata={"help": "The logging strategy to use."},
@@ -1480,12 +1474,6 @@ class TrainingArguments:
         # see https://github.com/huggingface/transformers/issues/10628
         if self.output_dir is not None:
             self.output_dir = os.path.expanduser(self.output_dir)
-
-        if self.logging_dir is not None:
-            logging.warning(
-                "`logging_dir` is deprecated and will be removed in v5.2. Set `TENSORBOARD_LOGGING_DIR` instead"
-            )
-            os.environ["TENSORBOARD_LOGGING_DIR"] = self.logging_dir
 
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -107,6 +107,7 @@ if is_sagemaker_mp_enabled():
 
     smp.init()
 
+
 def get_int_from_env(env_keys, default):
     """Returns the first positive env value found in the `env_keys` list or the default."""
     for e in env_keys:
@@ -905,7 +906,12 @@ class TrainingArguments:
             )
         },
     )
-    logging_dir: Optional[str] = field(default=None, metadata={"help": "This argument is deprecated and will be removed in v5.2. Set `TENSORBOARD_LOGGING_DIR` instead"})
+    logging_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "This argument is deprecated and will be removed in v5.2. Set `TENSORBOARD_LOGGING_DIR` instead"
+        },
+    )
     logging_strategy: Union[IntervalStrategy, str] = field(
         default="steps",
         metadata={"help": "The logging strategy to use."},
@@ -1476,9 +1482,11 @@ class TrainingArguments:
             self.output_dir = os.path.expanduser(self.output_dir)
 
         if self.logging_dir is not None:
-            logging.warning("`logging_dir` is deprecated and will be removed in v5.2. Set `TENSORBOARD_LOGGING_DIR` instead")
+            logging.warning(
+                "`logging_dir` is deprecated and will be removed in v5.2. Set `TENSORBOARD_LOGGING_DIR` instead"
+            )
             os.environ["TENSORBOARD_LOGGING_DIR"] = self.logging_dir
-    
+
         if self.disable_tqdm is None:
             self.disable_tqdm = logger.getEffectiveLevel() > logging.WARN
 


### PR DESCRIPTION
# What does this PR do?

This PR changes the default for reporting to "none" as we move to v5. Moreover, we clean some deprecations messages around some env env + we deprecate `logging_dir` that was solely used for tensorboard. Instead the user needs to pass a global variable. 