### PR TITLE
🚨 [v5] Remove deprecated cache classes

### DIFF
--- a/docs/source/en/internal/generation_utils.md
+++ b/docs/source/en/internal/generation_utils.md
@@ -253,21 +253,7 @@ A [`StoppingCriteria`] can be used to change when to stop generation (other than
 
 [[autodoc]] QuantizedCache
 
-[[autodoc]] QuantoQuantizedCache
-
-[[autodoc]] HQQQuantizedCache
-
-[[autodoc]] OffloadedCache
-
 [[autodoc]] StaticCache
-
-[[autodoc]] OffloadedStaticCache
-
-[[autodoc]] HybridCache
-
-[[autodoc]] HybridChunkedCache
-
-[[autodoc]] SlidingWindowCache
 
 [[autodoc]] EncoderDecoderCache
     - to_legacy_cache

--- a/docs/source/ko/internal/generation_utils.md
+++ b/docs/source/ko/internal/generation_utils.md
@@ -237,21 +237,7 @@ generation_output[:2]
 
 [[autodoc]] QuantizedCache
 
-[[autodoc]] QuantoQuantizedCache
-
-[[autodoc]] HQQQuantizedCache
-
-[[autodoc]] OffloadedCache
-
 [[autodoc]] StaticCache
-
-[[autodoc]] OffloadedStaticCache
-
-[[autodoc]] HybridCache
-
-[[autodoc]] HybridChunkedCache
-
-[[autodoc]] SlidingWindowCache
 
 [[autodoc]] EncoderDecoderCache
     - to_legacy_cache

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -355,21 +355,12 @@ else:
         "DynamicLayer",
         "StaticLayer",
         "StaticSlidingWindowLayer",
-        "SlidingWindowLayer",
-        "ChunkedSlidingLayer",
         "QuantoQuantizedLayer",
         "HQQQuantizedLayer",
         "Cache",
         "DynamicCache",
         "EncoderDecoderCache",
-        "HQQQuantizedCache",
-        "HybridCache",
-        "HybridChunkedCache",
-        "OffloadedCache",
-        "OffloadedStaticCache",
         "QuantizedCache",
-        "QuantoQuantizedCache",
-        "SlidingWindowCache",
         "StaticCache",
     ]
     _import_structure["data.datasets"] = [
@@ -474,20 +465,12 @@ else:
 if TYPE_CHECKING:
     # All modeling imports
     from .cache_utils import Cache as Cache
-    from .cache_utils import ChunkedSlidingLayer as ChunkedSlidingLayer
     from .cache_utils import DynamicCache as DynamicCache
     from .cache_utils import DynamicLayer as DynamicLayer
     from .cache_utils import EncoderDecoderCache as EncoderDecoderCache
-    from .cache_utils import HQQQuantizedCache as HQQQuantizedCache
     from .cache_utils import HQQQuantizedLayer as HQQQuantizedLayer
-    from .cache_utils import HybridCache as HybridCache
-    from .cache_utils import OffloadedCache as OffloadedCache
-    from .cache_utils import OffloadedStaticCache as OffloadedStaticCache
     from .cache_utils import QuantizedCache as QuantizedCache
-    from .cache_utils import QuantoQuantizedCache as QuantoQuantizedCache
     from .cache_utils import QuantoQuantizedLayer as QuantoQuantizedLayer
-    from .cache_utils import SlidingWindowCache as SlidingWindowCache
-    from .cache_utils import SlidingWindowLayer as SlidingWindowLayer
     from .cache_utils import StaticCache as StaticCache
     from .cache_utils import StaticLayer as StaticLayer
     from .cache_utils import StaticSlidingWindowLayer as StaticSlidingWindowLayer

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -581,7 +581,8 @@ class QuantoQuantizedLayer(QuantizedLayer):
             from optimum.quanto import MaxOptimizer, qint2, qint4
         else:
             raise ImportError(
-                "You need optimum-quanto package version to be greater or equal than 0.2.5 to use `QuantoQuantizedCache`. "
+                "You need optimum-quanto package version to be greater or equal than 0.2.5 to use "
+                "`QuantizedCache(backend='quanto', ...)`. "
             )
 
         if self.nbits not in [2, 4]:
@@ -1367,112 +1368,3 @@ class EncoderDecoderCache(Cache):
     @property
     def is_compileable(self) -> bool:
         return self.self_attention_cache.is_compileable
-
-
-### Deprecated classes
-
-
-class SlidingWindowLayer(StaticSlidingWindowLayer):
-    def __init__(self, max_cache_len: int, sliding_window: int):
-        logger.warning_once(
-            "`SlidingWindowLayer` is deprecated and will be removed in version v4.59 "
-            "Use `StaticSlidingWindowLayer` instead, which is a better name for it."
-        )
-        super().__init__(max_cache_len, sliding_window)
-
-
-class ChunkedSlidingLayer(StaticSlidingWindowLayer):
-    def __init__(self, max_cache_len: int, sliding_window: int):
-        logger.warning_once(
-            "`ChunkedSlidingLayer` is deprecated and will be removed in version v4.59 "
-            "Use `StaticSlidingWindowLayer` instead, which has the exact same functionalities."
-        )
-        super().__init__(max_cache_len, sliding_window)
-
-
-class OffloadedCache(DynamicCache):
-    def __init__(self) -> None:
-        logger.warning_once(
-            "`OffloadedCache` is deprecated and will be removed in version v4.59 "
-            "Use `DynamicCache(offloading=True)` instead"
-        )
-        super().__init__(offloading=True)
-
-
-class OffloadedStaticCache(StaticCache):
-    def __init__(self, config: PreTrainedConfig, max_cache_len: int, *args, **kwargs):
-        logger.warning_once(
-            "`OffloadedStaticCache` is deprecated and will be removed in version v4.59 "
-            "Use `StaticCache(..., offloading=True)` instead"
-        )
-        super().__init__(config=config, max_cache_len=max_cache_len, offloading=True)
-
-
-class SlidingWindowCache(StaticCache):
-    def __init__(self, config: PreTrainedConfig, max_cache_len: int, *args, **kwargs):
-        logger.warning_once(
-            "`SlidingWindowCache` is deprecated and will be removed in version v4.59 "
-            "Use `StaticCache(...)` instead which will correctly infer the type of each layer."
-        )
-        super().__init__(config=config, max_cache_len=max_cache_len)
-
-
-class HybridCache(StaticCache):
-    def __init__(self, config: PreTrainedConfig, max_cache_len: int, *args, **kwargs):
-        logger.warning_once(
-            "`HybridCache` is deprecated and will be removed in version v4.59 "
-            "Use `StaticCache(...)` instead which will correctly infer the type of each layer."
-        )
-        super().__init__(config=config, max_cache_len=max_cache_len)
-
-
-class HybridChunkedCache(StaticCache):
-    def __init__(self, config: PreTrainedConfig, max_cache_len: int, *args, **kwargs):
-        logger.warning_once(
-            "`HybridChunkedCache` is deprecated and will be removed in version v4.59 "
-            "Use `StaticCache(...)` instead which will correctly infer the type of each layer."
-        )
-        super().__init__(config=config, max_cache_len=max_cache_len)
-
-
-class OffloadedHybridCache(StaticCache):
-    def __init__(self, config: PreTrainedConfig, max_cache_len: int, *args, **kwargs):
-        logger.warning_once(
-            "`OffloadedHybridCache` is deprecated and will be removed in version v4.59 "
-            "Use `StaticCache(..., offload=True)` instead which will correctly infer the type of each layer."
-        )
-        super().__init__(config=config, max_cache_len=max_cache_len, offloading=True)
-
-
-class QuantoQuantizedCache(QuantizedCache):
-    def __init__(
-        self,
-        config: PreTrainedConfig,
-        nbits: int = 4,
-        axis_key: int = 0,
-        axis_value: int = 0,
-        q_group_size: int = 64,
-        residual_length: int = 128,
-    ):
-        logger.warning_once(
-            "`QuantoQuantizedCache` is deprecated and will be removed in version v4.59 "
-            "Use `QuantizedCache(backend='quanto', ...)` instead."
-        )
-        super().__init__("quanto", config, nbits, axis_key, axis_value, q_group_size, residual_length)
-
-
-class HQQQuantizedCache(QuantizedCache):
-    def __init__(
-        self,
-        config: PreTrainedConfig,
-        nbits: int = 4,
-        axis_key: int = 0,
-        axis_value: int = 0,
-        q_group_size: int = 64,
-        residual_length: int = 128,
-    ):
-        logger.warning_once(
-            "`HQQQuantizedCache` is deprecated and will be removed in version v4.59 "
-            "Use `QuantizedCache(backend='hqq', ...)` instead."
-        )
-        super().__init__("hqq", config, nbits, axis_key, axis_value, q_group_size, residual_length)

--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -23,49 +23,7 @@ class EncoderDecoderCache(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class HQQQuantizedCache(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class HybridCache(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class OffloadedCache(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class OffloadedStaticCache(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class QuantizedCache(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class QuantoQuantizedCache(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class SlidingWindowCache(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -223,7 +223,8 @@ class CacheIntegrationTest(unittest.TestCase):
         """
         _skip_on_failed_cache_prerequisites(self, cache_implementation)
         if cache_implementation == "offloaded_hybrid_chunked":
-            # TODO (joao, cyril): something is off with `offloaded_hybrid_chunked` aka `OffloadedHybridCache`: the
+            # TODO (joao, cyril): something is off with `offloaded_hybrid_chunked` aka
+            # `StaticCache(..., offload=True)`: the
             # output sequence (and the corresponding beam scores, if we add `output_scores=True`) are significantly
             # different from the other caches.
             self.skipTest("`offloaded_hybrid_chunked` fails this test")


### PR DESCRIPTION
# What does this PR do?

🚨🚨🚨 DO NOT MERGE 🚨🚨🚨
- Depends on #41889

Merging this PR will break `from transformers import Trainer` on the latest PEFT release (`0.17.1`), which in turn breaks our `make fixup` when PEFT is installed. PEFT `main` already sorted this issue ([here](https://github.com/huggingface/peft/commit/41c07f0445879da0e73ca3c682a0c359cd027f50)), but it is yet unreleased as of 7-oct-2025.

cc @BenjaminBossan (chatted on slack -- when `transformers` has a concrete timeline for v5, we can best evaluate an adequate timing for a PEFT release)
cc @Cyrilvallez FYI 

_______________________________

This PR removes the deprecated cache classes in `cache_utils.py`.