### PR TITLE
Fix early CUDA initialisation

### DIFF
--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -27,7 +27,6 @@ from tqdm import tqdm
 
 from ...configuration_utils import PreTrainedConfig
 from ...generation.configuration_utils import GenerationConfig
-from ...integrations.hub_kernels import load_and_register_kernel
 from ...utils.logging import logging
 from ...utils.metrics import ContinuousBatchProcessorMetrics, attach_tracer, traced
 from .cache import PagedAttentionCache
@@ -609,6 +608,8 @@ class ContinuousBatchingManager:
         """
         self.model = model.eval()
         if "paged|" not in model.config._attn_implementation:
+            from ...integrations.hub_kernels import load_and_register_kernel
+
             attn_implementation = "paged|" + self.model.config._attn_implementation
             load_and_register_kernel(attn_implementation)
             model.set_attn_implementation(attn_implementation)


### PR DESCRIPTION
This import added in https://github.com/huggingface/transformers/pull/41370 was identified to be causing CUDA to initialise early.

It was identified in vLLM's Transformers nightly test https://buildkite.com/vllm/ci/builds/33777/steps/canvas?sid=0199bcd4-8cf7-442a-a94d-df2969d65bde