### PR TITLE
Remove Python 3.9 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -434,7 +434,7 @@ setup(
             "transformers=transformers.commands.transformers_cli:main",
         ]
     },
-    python_requires=">=3.9.0",
+    python_requires=">=3.10.0",
     install_requires=list(install_requires),
     classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -444,7 +444,6 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
# What does this PR do?

Follows recent clean-up.