### PR TITLE
Restore cuda graphs to continuous batching

### DIFF
--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -26,6 +26,7 @@ from tqdm import tqdm
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.generation import GenerationConfig
+from transformers.generation.continuous_batching.requests import logger
 
 
 # MODEL_ID = "Qwen/Qwen3-4B-Instruct-2507"
@@ -190,11 +191,15 @@ if __name__ == "__main__":
 
     parser.add_argument("--samples", type=int, default=500)
     parser.add_argument("--displayed", type=int, default=0, help="Number of samples to display")
+    parser.add_argument("--log-level", type=str, default="INFO")
     parser.add_argument("--output-file", type=str, default=None)
     parser.add_argument("--compare", action="store_true")
     parser.add_argument("--metrics", action="store_true")
     parser.add_argument("--profile", type=str, default=None)
     args = parser.parse_args()
+
+    # Set log level
+    logger.setLevel(args.log_level)
 
     # If turned on, we setup metrics
     if args.metrics:

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -40,11 +40,11 @@ def generate_simple(
     attn_impl: str, simple_batch_inputs: list[int], generation_config: GenerationConfig
 ) -> dict[str, str]:
     attn_impl = {
-        "sdpa_paged": "sdpa",
-        "eager_paged": "eager",
+        "sdpa": "sdpa",
+        "eager": "eager",
         "paged_attention": "eager",  # TODO: this does not work on AMD docker
         "flash_paged": "flash_attention_2",  # TODO: this does not work on AMD docker
-        "paged_attention|kernels-community/flash-attn": "eager",
+        "kernels-community/flash-attn": "eager",
     }[attn_impl]
 
     model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16, attn_implementation=attn_impl)

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -126,7 +126,9 @@ def batch_generate(
 
         # Try to decode the output
         try:
-            output_text = tokenizer.decode(batch_outputs[request].generated_tokens, skip_special_tokens=SKIP_SPECIAL_TOKENS)
+            output_text = tokenizer.decode(
+                batch_outputs[request].generated_tokens, skip_special_tokens=SKIP_SPECIAL_TOKENS
+            )
             token_count += len(batch_outputs[request].generated_tokens[1:])
             data[-1]["cb_outputs"] = output_text
         except Exception as e:

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -185,11 +185,10 @@ if __name__ == "__main__":
 
     parser.add_argument("--attn", type=str, default="kernels-community/flash-attn", help="Attention implementation")
     parser.add_argument("--matmul-precision", "-mp", type=str, default="high")  # set to "none" to disable
-    parser.add_argument("--no-slice-inputs", action="store_true")  # slicing is enabled by default because much faster
-    parser.add_argument("--use-cuda-graph", "-cg", action="store_true")
-    parser.add_argument("--compile", action="store_true")
+    parser.add_argument("--cuda-graph", "-cg", help="Use cuda graphs", default=None)
+    parser.add_argument("--compile", action="store_true", help="Compile the model using torch.compile")
 
-    parser.add_argument("--samples", type=int, default=500)
+    parser.add_argument("--samples", type=int, default=500, help="Number of samples to generate")
     parser.add_argument("--displayed", type=int, default=0, help="Number of samples to display")
     parser.add_argument("--log-level", type=str, default="INFO")
     parser.add_argument("--output-file", type=str, default=None)
@@ -235,7 +234,7 @@ if __name__ == "__main__":
     # Prepare generation config
     generation_config = GenerationConfig(
         max_new_tokens=512,
-        use_cuda_graph=args.use_cuda_graph,
+        use_cuda_graph=(None if args.cuda_graph is None else bool(args.cuda_graph)),
         eos_token_id=tokenizer.pad_token_id if FORCE_MAX_LENGTH else tokenizer.eos_token_id,
         pad_token_id=tokenizer.pad_token_id,
         do_sample=True,

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -31,7 +31,7 @@ from transformers.generation.continuous_batching.requests import logger
 
 # MODEL_ID = "Qwen/Qwen3-4B-Instruct-2507"
 SLIDING_WINDOW = 0
-MODEL_ID = "google/gemma-2-2b-it" if SLIDING_WINDOW > 0 else "Qwen/Qwen3-4B-Instruct-2507"
+MODEL_ID = "google/gemma-2-2b-it" if SLIDING_WINDOW > 0 else "Qwen/Qwen3-4B-Instruct-2507" # "meta-llama/Meta-Llama-3-8B"
 FORCE_MAX_LENGTH = False  # should be False unless you are debugging sliding window features
 
 
@@ -199,7 +199,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Set log level
-    logger.setLevel(args.log_level)
+    logger.setLevel(args.log_level.upper())
 
     # If turned on, we setup metrics
     if args.metrics:

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -31,7 +31,7 @@ from transformers.generation.continuous_batching.requests import logger
 
 # MODEL_ID = "Qwen/Qwen3-4B-Instruct-2507"
 SLIDING_WINDOW = 0
-MODEL_ID = "google/gemma-2-2b-it" if SLIDING_WINDOW > 0 else "Qwen/Qwen3-4B-Instruct-2507" # "meta-llama/Meta-Llama-3-8B"
+MODEL_ID = "google/gemma-2-2b-it" if SLIDING_WINDOW > 0 else "meta-llama/Meta-Llama-3-8B"
 FORCE_MAX_LENGTH = False  # should be False unless you are debugging sliding window features
 SKIP_SPECIAL_TOKENS = False
 
@@ -248,7 +248,7 @@ if __name__ == "__main__":
         use_cuda_graph=use_cuda_graph,
         eos_token_id=tokenizer.pad_token_id if FORCE_MAX_LENGTH else tokenizer.eos_token_id,
         pad_token_id=tokenizer.pad_token_id,
-        do_sample=True,
+        do_sample=not args.compare,
         temperature=0.8,
         top_p=0.9,
         num_blocks=args.num_blocks,

--- a/examples/pytorch/continuous_batching_simple.py
+++ b/examples/pytorch/continuous_batching_simple.py
@@ -68,7 +68,6 @@ if __name__ == "__main__":
     _ = model.generate_batch(
         inputs=simple_batch_inputs[: min(5, args.samples)],
         generation_config=generation_config,
-        slice_inputs=True,
     )
 
     # Actual batch generation
@@ -77,7 +76,6 @@ if __name__ == "__main__":
     batch_outputs = model.generate_batch(
         inputs=simple_batch_inputs,
         generation_config=generation_config,
-        slice_inputs=True,
     )
     end_time = time.time()
     print("Done with batch generation.")

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -290,7 +290,6 @@ class PagedAttentionCache:
         layer_idx: int,
         read_index: list[torch.Tensor],  # shape [num_layer_groups, seqlen_kv + past_length]
         write_index: list[torch.Tensor],  # shape [num_layer_groups, seqlen_q]
-        **kwargs,
     ) -> tuple[torch.Tensor, torch.Tensor]:  # shape [seqlen_kv + past_length, num_kv_heads, head_dim]
         """Update the cache with new key-value states for a specific layer. This method writes new KV states to the
         appropriate cache locations. The behavior differs based on the layer's attention type:

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -323,11 +323,11 @@ class PagedAttentionCache:
         # the only case where you may write over cache you need to use
         else:
             # Add the cache to the key and value states
-            mask = layer_read_index == -1  # TODO: can this can be efficiently precomputed?
+            mask = (layer_read_index == -1).unsqueeze(-1).unsqueeze(-1)  # TODO: should this be precomputed?
             key_states_with_cache = k_cache[layer_read_index, :, :]
-            key_states_with_cache[mask] = key_states
+            key_states_with_cache.masked_scatter_(mask, key_states)
             value_states_with_cache = v_cache[layer_read_index, :, :]
-            value_states_with_cache[mask] = value_states
+            value_states_with_cache.masked_scatter_(mask, value_states)
             # Write new KV values to the cache
             k_cache[layer_write_index, :, :] = key_states
             v_cache[layer_write_index, :, :] = value_states

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -204,8 +204,8 @@ class PagedAttentionCache:
         # Initialize the cache
         self.key_cache: list[torch.Tensor] = []
         self.value_cache: list[torch.Tensor] = []
-        # We add one extra token to the cache to handle padding and generally discard unwanted tokens
-        self.cache_shape = (num_blocks * self.block_size + 1, self.num_key_value_heads, self.head_dim)
+        # We add two extra tokens to the cache to handle padding and generally discard unwanted tokens
+        self.cache_shape = (num_blocks * self.block_size + 2, self.num_key_value_heads, self.head_dim)
         for _ in range(group_size):
             new_layer_key_cache = torch.empty(self.cache_shape, dtype=self.dtype, device=self.device)
             new_layer_value_cache = torch.empty(self.cache_shape, dtype=self.dtype, device=self.device)

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -150,7 +150,6 @@ class ContinuousBatchProcessor:
         model_dtype: torch.dtype,
         scheduler: Scheduler,
         manual_eviction: bool = False,
-        slice_inputs: bool = True,  # TODO: There should be an heuristic to decide on slicing, compile, cuda graphs...
     ) -> None:
         """Initialize the continuous batch processor.
 
@@ -165,7 +164,6 @@ class ContinuousBatchProcessor:
             model_dtype: Data type for model inputs/outputs
             scheduler: The [`Scheduler`] to use
             manual_eviction: Whether to manually evict blocks from the cache
-            slice_inputs: Whether to slice the inputs to the model
         """
         self.cache = cache
         self.config = config
@@ -177,7 +175,6 @@ class ContinuousBatchProcessor:
         self.model_dtype = model_dtype
         self.scheduler = scheduler
         self.manual_eviction = manual_eviction
-        self.slice_inputs = slice_inputs
 
         # Retrieve the size of the sliding window if there is one
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
@@ -250,14 +247,9 @@ class ContinuousBatchProcessor:
         """Reset static tensors for the next batch. In between batches, reset only the parts that were used in the last
         batch, but for initialisation, we can reset everything using the (full_reset) flag."""
         # Compute the slice to reset
-        if full_reset or not self.slice_inputs:
-            q_len = self.write_index_storage[0].size(-1)
-            k_len = self.read_index_storage[0].size(-1)
-            b_size = self.write_index_storage[0].size(0)
-        else:
-            q_len = self.total_query_length
-            k_len = self.total_key_length
-            b_size = self.total_batch_size
+        q_len = self.write_index_storage[0].size(-1) if full_reset else self.total_query_length
+        k_len = self.read_index_storage[0].size(-1) if full_reset else self.total_key_length
+        b_size = self.write_index_storage[0].size(0) if full_reset else self.total_batch_size
 
         # Reset the attributes that always have the same shape
         self.input_ids[:, :q_len].zero_()
@@ -282,8 +274,8 @@ class ContinuousBatchProcessor:
     def get_model_kwargs(self) -> PagedAttentionArgs:
         """Get model keyword arguments for the current batch."""
         # Compute the slice to return
-        q_len = self.total_query_length if self.slice_inputs else self.write_index_storage[0].size(-1)
-        b_size = self.total_batch_size if self.slice_inputs else self.cumulative_seqlens_q.size(-1) - 1
+        q_len = self.total_query_length
+        b_size = self.total_batch_size
 
         # Prepare the kwargs, the attributes that are either tensors or dict of tensors are initialized to empty dicts
         kwargs = {
@@ -308,7 +300,7 @@ class ContinuousBatchProcessor:
                 kwargs["cu_seq_lens_k"][layer_type] = seqlens_k[: b_size + 1]
                 kwargs["max_seqlen_k"][layer_type] = self.max_seqlen_k[layer_type]
                 if self.attention_mask is not None:
-                    k_len = seqlens_k[b_size] if self.slice_inputs else self.attention_mask[layer_type].size(-1)
+                    k_len = seqlens_k[b_size]
                     kwargs["attention_mask"][layer_type] = self.attention_mask[layer_type][..., :q_len, :k_len]
         else:
             layer_type = layer_types[0]
@@ -316,7 +308,6 @@ class ContinuousBatchProcessor:
             kwargs["max_seqlen_k"] = self.max_seqlen_k[layer_type]
             if self.attention_mask is not None:
                 k_len = self.cumulative_seqlens_k[layer_type][b_size]
-                k_len = k_len if self.slice_inputs else self.attention_mask[layer_type].size(-1)
                 kwargs["attention_mask"] = self.attention_mask[layer_type][..., :q_len, :k_len]
 
         if self.attention_mask is None:
@@ -382,7 +373,7 @@ class ContinuousBatchProcessor:
         self.metrics.record_batch_metrics(self.requests_in_batch)
 
         # Reset the static tensors used for storage
-        self.reset_static_tensors()  # TODO: with slice_inputs, this might be unnecessary
+        self.reset_static_tensors()  # TODO: this might be unnecessary
 
         # Prepare accumulators
         self.total_query_length = 0
@@ -496,8 +487,8 @@ class ContinuousBatchProcessor:
             self.read_index_storage[i][: len(group_read_indices)] = to_tensor(group_read_indices)
             self.write_index_storage[i][: len(group_write_indices)] = to_tensor(group_write_indices)
             # Slice to the right size
-            r = len(group_read_indices) if self.slice_inputs else self.read_index_storage[i].size(-1)
-            w = len(group_write_indices) if self.slice_inputs else self.write_index_storage[i].size(-1)
+            r = len(group_read_indices)
+            w = len(group_write_indices)
             # Add to the index
             self.read_index.append(self.read_index_storage[i][:r])
             self.write_index.append(self.write_index_storage[i][:w])
@@ -588,7 +579,6 @@ class ContinuousBatchingManager:
         generation_config: GenerationConfig,
         manual_eviction: bool = False,
         max_queue_size: int = 0,
-        slice_inputs: bool = True,
     ) -> None:
         """Initialize the continuous batching manager.
 
@@ -625,7 +615,6 @@ class ContinuousBatchingManager:
         self.profile = getattr(generation_config, "profile", False)  # TODO: not supported yet
         self.manual_eviction = manual_eviction
         self.batch_processor: Optional[ContinuousBatchProcessor] = None
-        self.slice_inputs = slice_inputs
 
         if self.use_cuda_graph:
             raise NotImplementedError("Cuda graphs are not supported yet")
@@ -867,7 +856,6 @@ class ContinuousBatchingManager:
                 self.model.dtype,
                 scheduler(paged_attention_cache, self.manual_eviction),
                 self.manual_eviction,
-                slice_inputs=self.slice_inputs,
             )
             self.batch_processor = batch_processor
             self.current_batch = 0
@@ -949,7 +937,6 @@ class ContinuousMixin:
         generation_config: Optional[GenerationConfig] = None,
         manual_eviction: bool = False,
         max_queue_size: int = 0,
-        slice_inputs: bool = True,
     ) -> ContinuousBatchingManager:
         """Initialize a manager for continuous batching inference.
 
@@ -977,7 +964,6 @@ class ContinuousMixin:
             generation_config=gen_config,
             manual_eviction=manual_eviction,
             max_queue_size=max_queue_size,
-            slice_inputs=slice_inputs,
         )
 
     @traced
@@ -987,7 +973,6 @@ class ContinuousMixin:
         inputs: list[list[int]],
         generation_config: Optional[GenerationConfig] = None,
         progress_bar: bool = True,
-        slice_inputs: bool = True,
         **kwargs,
     ) -> dict[str, GenerationOutput]:
         """Generate sequences for a batch of prompts using continuous batching.
@@ -1009,7 +994,7 @@ class ContinuousMixin:
             progress_bar = False
 
         # Initialize manager with the batch inputs
-        manager = self.init_continuous_batching(generation_config=generation_config, slice_inputs=slice_inputs)
+        manager = self.init_continuous_batching(generation_config=generation_config)
         manager.start()
         results = {}
         num_requests = len(inputs)
@@ -1043,3 +1028,12 @@ class ContinuousMixin:
         finally:
             manager.stop(block=True, timeout=5.0)
         return results
+
+"""
+ROADMAP:
+make slice inputs the default
+make .update graphable (add padding)
+enable cuda graphs for flash attention
+
+further reformat / cleanup
+"""

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -15,12 +15,13 @@
 # limitations under the License.
 import queue
 import threading
+from collections.abc import Generator
 from dataclasses import dataclass
 from functools import partial
 from itertools import count
 from math import ceil
 from time import perf_counter
-from typing import Generator, Optional, Union
+from typing import Optional, Union
 
 import torch
 from torch import nn
@@ -764,7 +765,6 @@ class ContinuousBatchingManager:
         self.profile = getattr(generation_config, "profile", False)  # TODO: not supported yet
         self.manual_eviction = manual_eviction
         self.batch_processor: Optional[ContinuousBatchProcessor] = None
-
 
         # If a number of cuda graphs was specified for either Q or KV, we activate cuda graphs
         if num_q_cuda_graphs > 0 or num_kv_cuda_graphs > 0:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -57,7 +57,7 @@ def build_attention_mask(
            █ █ █ █ █ █ █ █
 
     SLIDING WINDOW MASK:
-         ┌──────────────────────── seqlen_k - seqlen_q - sliding_window = 8 - 4 - 6 = -2 offset to the right
+         ┌──────────────────────── seqlen_k - seqlen_q - sliding_window = 8 - 4 - 6 = -2 offset to the left
        <─┴─>
      ░ █ | █ █ █ █ █ █ █ █
      ░ ░ | █ █ █ █ █ █ █ █
@@ -80,7 +80,7 @@ def build_attention_mask(
            █ █ █ █ █
 
     SLIDING WINDOW MASK:
-         ┌──────────────────────── seqlen_k - seqlen_q - sliding_window = 5 - 3 - 2 = 0 offset to the right
+         ┌──────────────────────── seqlen_k - seqlen_q - sliding_window = 5 - 3 - 2 = 0 offset to the left
         <┴>
          | ░ █ █ █ █
          | ░ ░ █ █ █
@@ -246,7 +246,7 @@ class ContinuousBatchProcessor:
 
     @traced
     @torch.no_grad()
-    def reset_static_tensors(self, full_reset: bool = False):
+    def reset_static_tensors(self, full_reset: bool = False) -> None:
         """Reset static tensors for the next batch. In between batches, reset only the parts that were used in the last
         batch, but for initialisation, we can reset everything using the (full_reset) flag."""
         # Compute the slice to reset
@@ -323,7 +323,7 @@ class ContinuousBatchProcessor:
             kwargs["attention_mask"] = None
         return kwargs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return (
             f"ContinuousBatchProcessor(input_queue={self.input_queue}, output_queue={self.output_queue}, "
             f"active_requests={self.scheduler.active_requests}, waiting_requests={self.scheduler.waiting_requests})"
@@ -331,7 +331,7 @@ class ContinuousBatchProcessor:
         )
 
     @traced
-    def _get_new_requests(self):
+    def _get_new_requests(self) -> None:
         """Pull new requests from the input queue and add to waiting list."""
         while not self.input_queue.empty():
             try:
@@ -349,7 +349,7 @@ class ContinuousBatchProcessor:
                     self._handle_request_error(e, state)
 
     @traced
-    def _handle_request_error(self, error, state: RequestState):
+    def _handle_request_error(self, error: Exception, state: RequestState) -> None:
         """Handle general request processing error."""
         state.status = RequestStatus.FAILED
         state.error = str(error)
@@ -503,18 +503,16 @@ class ContinuousBatchProcessor:
             self.write_index.append(self.write_index_storage[i][:w])
 
     @traced
-    def _sync(self):
+    def _sync(self) -> list[int]:
         if self.output_ids is not None:
             try:
-                out = self.output_ids.tolist()[0]  # should be the only sync we do
+                return self.output_ids.tolist()[0]
             except Exception:
-                out = [0, 1]
-        else:
-            out = [0, 0]
-        return out
+                return [0, 1]
+        return [0, 0]
 
     @traced
-    def _maybe_send_output(self, state: RequestState, token: int):
+    def _maybe_send_output(self, state: RequestState, token: int) -> None:
         """Send output to the queue based on streaming mode and request state."""
         if state.streaming:
             self.output_queue.put(state.to_generation_output())
@@ -522,12 +520,12 @@ class ContinuousBatchProcessor:
             self.output_queue.put(state.to_generation_output())
 
     @traced
-    def update_batch(self):
+    def update_batch(self) -> None:
         """Update request states based on generated tokens."""
         out_tokens = self._sync()
-        finished_request_ids = []
+        finished_request_ids = []  # CHECK: unused variable
         for i, state in enumerate(self.requests_in_batch):
-            req_id = state.request_id
+            req_id = state.request_id  # CHECK: unused variable
             if len(state.remaining_prompt_ids) == 0:
                 self.metrics.record_ttft_metric(state.created_time, state.request_id)
                 state.status = RequestStatus.DECODING
@@ -557,7 +555,7 @@ class ContinuousBatchProcessor:
             self.scheduler.finish_request(req.request_id)
 
     @traced
-    def fail_all_requests(self, error):
+    def fail_all_requests(self, error: Exception) -> None:
         """Fail all active requests with the given error.
 
         Args:
@@ -589,14 +587,13 @@ class ContinuousBatchingManager:
 
     def __init__(
         self,
-        model,
+        model: nn.Module,
         generation_config: GenerationConfig,
         manual_eviction: bool = False,
-        max_queue_size=0,
+        max_queue_size: int = 0,
         slice_inputs: bool = True,
-    ):
-        """
-        Initialize the continuous batching manager.
+    ) -> None:
+        """Initialize the continuous batching manager.
 
         Args:
             model: The language model for generation
@@ -637,7 +634,7 @@ class ContinuousBatchingManager:
             raise NotImplementedError("Cuda graphs are not supported yet")
 
     @traced
-    def start(self):
+    def start(self) -> None:
         """Start the background generation thread."""
         if self._generation_thread is not None and self._generation_thread.is_alive():
             logger.warning("Manager thread is already running.")
@@ -647,11 +644,11 @@ class ContinuousBatchingManager:
         self._generation_thread = threading.Thread(target=self._run_generation_loop)
         self._generation_thread.start()
 
-    def is_running(self):
+    def is_running(self) -> bool:
         """Check if the background generation thread is running."""
         return self._generation_thread is not None and self._generation_thread.is_alive()
 
-    def stop(self, block: bool = False, timeout: Optional[float] = None):
+    def stop(self, block: bool = False, timeout: Optional[float] = None) -> None:
         """Signal the background thread to stop.
 
         Args:
@@ -669,7 +666,7 @@ class ContinuousBatchingManager:
         if block:
             self.join(timeout)
 
-    def join(self, timeout: Optional[float] = None):
+    def join(self, timeout: Optional[float] = None) -> None:
         """Wait for the background thread to finish.
 
         Args:
@@ -722,11 +719,11 @@ class ContinuousBatchingManager:
         logger.debug(f"Added request {request_id} to queue.")
         return request_id
 
-    def add_requests(self, inputs: list[list[int]], **kwargs):
+    def add_requests(self, inputs: list[list[int]], **kwargs) -> None:
         for input_ids in inputs:
             self.add_request(input_ids, **kwargs)
 
-    def cancel_request(self, request_id: str):
+    def cancel_request(self, request_id: str) -> None:
         """Cancel a request by its ID.
 
         Args:
@@ -735,7 +732,7 @@ class ContinuousBatchingManager:
         if self.batch_processor is not None:
             self.batch_processor.scheduler.set_request_cancellation(request_id)
 
-    def get_result(self, request_id=None, timeout=None) -> Optional[GenerationOutput]:
+    def get_result(self, request_id: Optional[str] = None, timeout: Optional[float] = None) -> Optional[GenerationOutput]:
         """Retrieve one result from the output queue.
 
         Args:
@@ -763,7 +760,7 @@ class ContinuousBatchingManager:
             if result is not None:
                 yield result
 
-    def request_id_iter(self, request_id):
+    def request_id_iter(self, request_id: str) -> None:
         """Iterate over results matching a specific request id as they become available."""
         request_cancelled = False
         while self._generation_thread is not None and self._generation_thread.is_alive() and not request_cancelled:
@@ -774,7 +771,7 @@ class ContinuousBatchingManager:
                 request_cancelled = self.batch_processor.scheduler.request_is_cancelled(request_id)
 
     @traced
-    def warmup(self, batch_processor):
+    def warmup(self, batch_processor: ContinuousBatchProcessor) -> None:
         stream = torch.cuda.Stream(device=self.model.device)
         stream.wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(stream):
@@ -788,7 +785,7 @@ class ContinuousBatchingManager:
 
     @traced
     # @torch.compile
-    def _generation_step(self, batch_processor: ContinuousBatchProcessor):
+    def _generation_step(self, batch_processor: ContinuousBatchProcessor) -> None:
         """Perform a single generation step. This is cuda graphed"""
         batch_data = batch_processor.get_model_kwargs()
         with torch.no_grad():
@@ -799,11 +796,11 @@ class ContinuousBatchingManager:
             self._sample(batch_processor, probs)
 
     @traced(span_name="model_forward")
-    def _model_forward(self, batch_data):
+    def _model_forward(self, batch_data: dict) -> torch.Tensor:
         return self.model(**batch_data).logits
 
     @traced(span_name="logit_processing")
-    def _process_logit(self, batch_data, logits):
+    def _process_logit(self, batch_data: dict, logits: torch.Tensor) -> torch.Tensor:
         # Pass continuous batching context to logits processor if it supports it. TODO we should find a way to make this a little bit cleaner!
         if hasattr(self.logit_processor, "set_continuous_batching_context"):
             self.logit_processor.set_continuous_batching_context(
@@ -823,7 +820,7 @@ class ContinuousBatchingManager:
         return processed_logits_2d.view(batch_size, seq_len, vocab_size)
 
     @traced(span_name="sampling")
-    def _sample(self, batch_processor: ContinuousBatchProcessor, probs):
+    def _sample(self, batch_processor: ContinuousBatchProcessor, probs: torch.Tensor) -> None:
         if self.do_sample:  # sample
             probs = nn.functional.softmax(probs, dim=-1)
             # probs[0] has shape [seq_len, vocab_size], multinomial returns [seq_len, 1]
@@ -836,11 +833,11 @@ class ContinuousBatchingManager:
         tokens = next_tokens.size(1)  # Get seq_len dimension
         batch_processor.output_ids[:, :tokens].copy_(next_tokens)
 
-    def _run_generation_loop(self):
+    def _run_generation_loop(self) -> None:
         """Main processing loop running in the background thread."""
-        batch_processor = None
+        batch_processor: Optional[ContinuousBatchProcessor] = None
         try:
-            ref_time = perf_counter()
+            t0 = perf_counter()
             paged_attention_cache = PagedAttentionCache(
                 self.model.config,
                 self.generation_config,
@@ -848,7 +845,7 @@ class ContinuousBatchingManager:
                 self.model.dtype,
                 tp_size=getattr(self.model, "_tp_size", None),  # Use model's actual TP setting
             )
-            logger.debug(f"PagedAttentionCache created in {perf_counter() - ref_time} seconds")
+            logger.debug(f"PagedAttentionCache created in {perf_counter() - t0} seconds")
 
             scheduler = None
             if hasattr(self.generation_config, "scheduler"):
@@ -860,7 +857,7 @@ class ContinuousBatchingManager:
                 # Default to fifo
                 scheduler = FIFOScheduler
 
-            ref_time = perf_counter()
+            t1 = perf_counter()
             batch_processor = ContinuousBatchProcessor(
                 paged_attention_cache,
                 self.model.config,
@@ -876,7 +873,7 @@ class ContinuousBatchingManager:
             )
             self.batch_processor = batch_processor
             self.current_batch = 0
-            logger.debug(f"batch_processor created in {perf_counter() - ref_time} seconds")
+            logger.debug(f"batch_processor created in {perf_counter() - t1} seconds")
             while (not self.stop_event.is_set()) or batch_processor.has_pending_requests():
                 self._inner_generation_loop(batch_processor)
                 self.current_batch += 1
@@ -888,7 +885,7 @@ class ContinuousBatchingManager:
             logger.info("Generation loop finished.")
 
     @traced(span_name="generation_loop")
-    def _inner_generation_loop(self, batch_processor: ContinuousBatchProcessor):
+    def _inner_generation_loop(self, batch_processor: ContinuousBatchProcessor) -> None:
         if torch.cuda.is_available():
             torch.cuda.synchronize()
         if not batch_processor.prepare_next_batch():
@@ -915,11 +912,11 @@ class ContinuousBatchingManager:
         batch_processor.update_batch()
 
     @traced(span_name="graph_replay")
-    def _graph_replay(self):
+    def _graph_replay(self) -> None:
         self.graph.replay()
 
     @traced
-    def _handle_critical_error(self, error, batch_processor: Optional[ContinuousBatchProcessor]):
+    def _handle_critical_error(self, error: Exception, batch_processor: Optional[ContinuousBatchProcessor]) -> None:
         """Handle critical errors that terminate the generation loop."""
         # Signal stop
         self.stop_event.set()
@@ -938,7 +935,7 @@ class ContinuousBatchingManager:
             batch_processor.fail_all_requests(error)
 
     @traced
-    def evict_request_from_cache(self, request_id: str):
+    def evict_request_from_cache(self, request_id: str) -> None:
         """Evict a request from the cache. It is assumed that the request is already finished."""
         if not self.manual_eviction:
             raise RuntimeError("Manual eviction is not enabled for this manager.")
@@ -994,7 +991,7 @@ class ContinuousMixin:
         progress_bar: bool = True,
         slice_inputs: bool = True,
         **kwargs,
-    ) -> list[list[int]]:
+    ) -> dict[str, GenerationOutput]:
         """Generate sequences for a batch of prompts using continuous batching.
 
         Args:
@@ -1008,7 +1005,7 @@ class ContinuousMixin:
                                 Returns an empty list `[]` for requests that failed.
         """
         if not inputs:
-            return []
+            return {}
         if logger.getEffectiveLevel() <= logging.DEBUG:
             logger.warning("Progress bar is disabled when logger level is less than DEBUG")
             progress_bar = False

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -25,7 +25,6 @@ from ...utils.metrics import traced
 
 # We centralize the logger here to coordinate between logging and progress bar
 logger = logging.getLogger("ContinuousBatchingLogger")
-# logger.setLevel(logging.INFO)
 
 
 @staticmethod

--- a/src/transformers/integrations/flash_paged.py
+++ b/src/transformers/integrations/flash_paged.py
@@ -64,7 +64,13 @@ def paged_attention_forward(
 
     # .update changes the shape of k and v from [1, num_kv_heads, seqlen_kv, head_dim] to [-1, num_kv_heads, head_dim]
     if cache is not None:
-        k, v = cache.update(k, v, module.layer_idx, **kwargs)
+        k, v = cache.update(
+            key_states=k,
+            value_states=v,
+            layer_idx=module.layer_idx,
+            read_index=kwargs["read_index"],
+            write_index=kwargs["write_index"],
+        )
 
     # Retrieve the cumulative sequence lengths for the current layer
     if isinstance(cu_seq_lens_k, dict):

--- a/src/transformers/integrations/sdpa_paged.py
+++ b/src/transformers/integrations/sdpa_paged.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 import torch
 
+from ..generation.continuous_batching.cache import PagedAttentionCache
+
 
 def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     """
@@ -26,10 +28,16 @@ def sdpa_attention_paged_forward(
     **kwargs,
 ) -> tuple[torch.Tensor, None]:
     # Add KV cache to the key and value tensors
-    cache = kwargs.pop("cache", None)
+    cache: Optional[PagedAttentionCache] = kwargs.pop("cache", None)
     if cache is not None:
         # This changes the shape of k and v from [1, num_kv_heads, seqlen_kv, head_dim] to [-1, num_kv_heads, head_dim]
-        key, value = cache.update(key, value, module.layer_idx, **kwargs)
+        key, value = cache.update(
+            key_states=key,
+            value_states=value,
+            layer_idx=module.layer_idx,
+            read_index=kwargs["read_index"],
+            write_index=kwargs["write_index"],
+        )
         key = key.transpose(0, 1).unsqueeze(0)
         value = value.transpose(0, 1).unsqueeze(0)
 


### PR DESCRIPTION
This PR restores cuda graphs in continuous batching. The main changes associated with this are:
1. the logic of how to generate tokens have been moved to the CB processor, which also handles the cuda graphs
2. the generation step automatically slices the tensors to remove all padding unless cuda graphs are activated
3. cuda graphs are captured on padded shapes, which is 25%, 50%, 75% or 100% of the queries axis and 1/8, ... 8/8 of the keys values axis, to strike a balance between the amount of padding and the quantity of cuda graphs 

Documentation is kind of lacking but will be added in next commits, I am opening the PR so @ArthurZucker can test stuff out

- [x] Add more documentation
- [x] Test it out and add performance numbers with / without on AMD / Nvidia with the three main attn implementations