### PR TITLE
Fix generate outputs and simplify cache tests

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2809,6 +2809,10 @@ class GenerationMixin(ContinuousMixin):
             streamer.end()
 
         if return_dict_in_generate:
+            cache = None
+            if any(cache_key in model_kwargs for cache_key in ALL_CACHE_NAMES):
+                cache_key = next(cache_key for cache_key in ALL_CACHE_NAMES if cache_key in model_kwargs)
+                cache = model_kwargs[cache_key]
             if self.config.is_encoder_decoder:
                 return GenerateEncoderDecoderOutput(
                     sequences=input_ids,
@@ -2819,7 +2823,7 @@ class GenerationMixin(ContinuousMixin):
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
+                    past_key_values=cache,
                 )
             else:
                 return GenerateDecoderOnlyOutput(
@@ -2828,7 +2832,7 @@ class GenerationMixin(ContinuousMixin):
                     logits=raw_logits,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
+                    past_key_values=cache,
                 )
         else:
             return input_ids
@@ -3372,6 +3376,11 @@ class GenerationMixin(ContinuousMixin):
             if not output_scores:
                 beam_scores = None
 
+            cache = None
+            if any(cache_key in model_kwargs for cache_key in ALL_CACHE_NAMES):
+                cache_key = next(cache_key for cache_key in ALL_CACHE_NAMES if cache_key in model_kwargs)
+                cache = model_kwargs[cache_key]
+
             if self.config.is_encoder_decoder:
                 return GenerateBeamEncoderDecoderOutput(
                     sequences=sequences,
@@ -3384,7 +3393,7 @@ class GenerationMixin(ContinuousMixin):
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
+                    past_key_values=cache,
                 )
             else:
                 return GenerateBeamDecoderOnlyOutput(
@@ -3395,7 +3404,7 @@ class GenerationMixin(ContinuousMixin):
                     beam_indices=beam_indices,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
+                    past_key_values=cache,
                 )
         else:
             return sequences
@@ -3670,6 +3679,10 @@ class GenerationMixin(ContinuousMixin):
                 candidate_generator.num_assistant_tokens
             )
         if return_dict_in_generate:
+            cache = None
+            if any(cache_key in model_kwargs for cache_key in ALL_CACHE_NAMES):
+                cache_key = next(cache_key for cache_key in ALL_CACHE_NAMES if cache_key in model_kwargs)
+                cache = model_kwargs[cache_key]
             if self.config.is_encoder_decoder:
                 return GenerateEncoderDecoderOutput(
                     sequences=input_ids,
@@ -3680,7 +3693,7 @@ class GenerationMixin(ContinuousMixin):
                     decoder_attentions=decoder_attentions,
                     cross_attentions=cross_attentions,
                     decoder_hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
+                    past_key_values=cache,
                 )
             else:
                 return GenerateDecoderOnlyOutput(
@@ -3689,7 +3702,7 @@ class GenerationMixin(ContinuousMixin):
                     logits=raw_logits,
                     attentions=decoder_attentions,
                     hidden_states=decoder_hidden_states,
-                    past_key_values=model_kwargs.get("past_key_values"),
+                    past_key_values=cache,
                 )
         else:
             return input_ids

--- a/src/transformers/models/mistral/configuration_mistral.py
+++ b/src/transformers/models/mistral/configuration_mistral.py
@@ -143,7 +143,7 @@ class MistralConfig(PreTrainedConfig):
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
         self.sliding_window = sliding_window
-        self.head_dim = head_dim
+        self.head_dim = head_dim if head_dim is not None else hidden_size // num_attention_heads
 
         # for backward compatibility
         if num_key_value_heads is None:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2207,7 +2207,7 @@ class GenerationTesterMixin:
         prompt_length = getattr(self.model_tester, "encoder_seq_length", prompt_length)
         prompt_length = getattr(self.model_tester, "text_seq_length", prompt_length)
 
-        config = config.get_text_config(decoder=True)
+        config = config.text_config if hasattr(config, "text_config") else config
 
         generated_length = (
             output.sequences.shape[1] - 1 if config.is_encoder_decoder else output.sequences.shape[1] - prompt_length

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1027,16 +1027,15 @@ class GenerationTesterMixin:
             torch.testing.assert_close(next_logits_wo_padding, next_logits_with_padding, rtol=1e-5, atol=1e-5)
 
     @pytest.mark.generate
-    def test_past_key_values_format(self, custom_all_cache_shapes=None):
+    def test_past_key_values_format(self):
         """
-        Test that the KV cache is formatted correctly. Exceptions need to explicitly overwrite this test, or pass the
-        expected cache shapes.
+        Test that the KV cache is formatted correctly.
         Having a standard KV cache format is important for a consistent API (and for advanced generation methods).
         """
         for model_class in self.all_generative_model_classes:
             config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
 
-            # 1. If it doesn't support cache, skip the test
+            # If it doesn't support cache, skip the test
             decoder_config = config.get_text_config(decoder=True)
             if not hasattr(decoder_config, "use_cache"):
                 self.skipTest(reason=f"{model_class.__name__} doesn't support caching")
@@ -1050,82 +1049,14 @@ class GenerationTesterMixin:
             if "past_key_values" not in outputs:
                 self.skipTest(reason="This model doesn't return `past_key_values`")
 
-            # 2. retrieve the KV cache and compute its default expected shapes (if no custom shapes are provided)
-            past_kv = outputs["past_key_values"]
-
-            num_decoder_layers = decoder_config.num_hidden_layers
-            if custom_all_cache_shapes is None:
-                num_query_attention_heads = decoder_config.num_attention_heads
-                embed_dim = getattr(decoder_config, "d_model", decoder_config.hidden_size)
-                per_head_embed_dim = (
-                    getattr(decoder_config, "head_dim", None) or embed_dim // num_query_attention_heads
-                )
-                num_key_value_heads = getattr(decoder_config, "num_key_value_heads", None) or num_query_attention_heads
-                if config.is_encoder_decoder:
-                    batch_size, seq_length = inputs["decoder_input_ids"].shape[:2]
-                    # The sequence length for the encoder K V depends on the model. Since it is not manipulated in
-                    # autoregressive generation, we're keeping the test general and not checking the 3rd dim
-                    default_cross_attention_shape = (batch_size, num_key_value_heads, per_head_embed_dim)
-                    default_self_attention_shape = (batch_size, num_key_value_heads, seq_length, per_head_embed_dim)
-                    all_cache_shapes = [
-                        [
-                            default_self_attention_shape,
-                            default_self_attention_shape,
-                            default_cross_attention_shape,
-                            default_cross_attention_shape,
-                        ]
-                        for _ in range(num_decoder_layers)
-                    ]
-                else:
-                    batch_size, seq_length = inputs["input_ids"].shape[:2]
-                    default_self_attention_shape = (batch_size, num_key_value_heads, seq_length, per_head_embed_dim)
-                    all_cache_shapes = [
-                        [default_self_attention_shape, default_self_attention_shape] for _ in range(num_decoder_layers)
-                    ]
-
-            else:
-                all_cache_shapes = custom_all_cache_shapes
-
-            # 3. Check cache shapes
-            # 3.1. Encoder-Decoder checks
+            cache = outputs["past_key_values"]
             if config.is_encoder_decoder:
-                num_cache_decoder_layers = len(past_kv)
-                self.assertEqual(num_cache_decoder_layers, num_decoder_layers)
-
-                for i in range(num_decoder_layers):
-                    # Self attention
-                    self_attention_layer_keys = past_kv.self_attention_cache.layers[i].keys
-                    self_attention_layer_values = past_kv.self_attention_cache.layers[i].values
-                    self.assertEqual(self_attention_layer_keys.shape, all_cache_shapes[i][0])
-                    self.assertEqual(self_attention_layer_values.shape, all_cache_shapes[i][1])
-
-                    # Cross attention (ignore 3rd dim, see default shape preparation)
-                    cross_attention_layer_keys = past_kv.cross_attention_cache.layers[i].keys
-                    cross_attention_layer_values = past_kv.cross_attention_cache.layers[i].values
-                    cross_attention_layer_keys = cross_attention_layer_keys[:, :, 0, :]
-                    cross_attention_layer_values = cross_attention_layer_values[:, :, 0, :]
-                    self.assertEqual(cross_attention_layer_keys.shape, all_cache_shapes[i][2])
-                    self.assertEqual(cross_attention_layer_values.shape, all_cache_shapes[i][3])
-
-            # 3.2. Decoder-only checks
+                batch_size, seq_length = inputs["decoder_input_ids"].shape[:2]
             else:
-                num_cache_decoder_layers = len(past_kv)
-                self.assertEqual(
-                    # we may have skipped layers
-                    num_cache_decoder_layers + getattr(decoder_config, "num_kv_shared_layers", 0),
-                    num_decoder_layers,
-                )
+                batch_size, seq_length = inputs["input_ids"].shape[:2]
 
-                for i in range(num_cache_decoder_layers):
-                    # Cache is lot layered (i.e, Mamba derivatives)
-                    if getattr(past_kv, "layers", None) is None:
-                        self_attention_layer_keys = past_kv.key_cache[i]
-                        self_attention_layer_values = past_kv.value_cache[i]
-                    else:
-                        self_attention_layer_keys = past_kv.layers[i].keys
-                        self_attention_layer_values = past_kv.layers[i].values
-                    self.assertEqual(self_attention_layer_keys.shape, all_cache_shapes[i][0])
-                    self.assertEqual(self_attention_layer_values.shape, all_cache_shapes[i][1])
+            # Check the format
+            self._check_past_key_values_for_generate(batch_size, cache, seq_length, config)
 
     @pytest.mark.generate
     def test_generate_from_random_inputs_embeds(self):
@@ -2281,9 +2212,9 @@ class GenerationTesterMixin:
         generated_length = (
             output.sequences.shape[1] - 1 if config.is_encoder_decoder else output.sequences.shape[1] - prompt_length
         )
-        decoder_past_key_values = getattr(output, "past_key_values", None)
-        if config.is_encoder_decoder and isinstance(decoder_past_key_values, EncoderDecoderCache):
-            decoder_past_key_values = decoder_past_key_values.self_attention_cache
+
+        cache = getattr(output, "past_key_values", None)
+        decoder_past_key_values = cache.self_attention_cache if isinstance(cache, EncoderDecoderCache) else cache
 
         # in some models we subsample the sequence length in inner layers
         if hasattr(self.model_tester, "get_subsampled_output_lengths"):
@@ -2354,36 +2285,17 @@ class GenerationTesterMixin:
                 use_cache=use_cache,
             )
 
-        # Past Key Value States -- a few notes here:
-        # 1. Its inner sequence length is with respect to the inputs of the latest forward pass, hence the "-1"
-        # 2. We ignore models that have unique cache structures (e.g. mamba) or are in need of refatoring to match the
-        #    standard cache format (e.g.mamba architecture )
-        models_without_standard_cache = (
-            "bamba",
-            "granitemoehybrid",
-            "reformer",
-            "jamba",
-            "mamba",
-            "xlnet",
-            "zamba",
-            "zamba2",
-            "lfm2",
-            "lfm2-vl",
-        )
-        has_standard_cache = not any(
-            model_name in config.__class__.__name__.lower() for model_name in models_without_standard_cache
-        )
-        if has_standard_cache:
-            if use_cache:
-                cache_length = output.sequences.shape[1] - 1
-                self._check_past_key_values_for_generate(
-                    batch_size=internal_batch_size,
-                    decoder_past_key_values=decoder_past_key_values,
-                    cache_length=cache_length,
-                    config=config,
-                )
-            elif use_cache is False:
-                self.assertTrue(decoder_past_key_values is None)
+        # Check the cache shape
+        if use_cache:
+            cache_length = output.sequences.shape[1] - 1
+            self._check_past_key_values_for_generate(
+                batch_size=internal_batch_size,
+                past_key_values=cache,
+                seq_length=cache_length,
+                config=config,
+            )
+        else:
+            self.assertTrue(cache is None)
 
     def _check_scores(self, batch_size, scores, generated_length, config):
         vocab_size = config.get_text_config(decoder=True).vocab_size
@@ -2483,28 +2395,42 @@ class GenerationTesterMixin:
             [encoder_expected_shape] * len(hidden_states),
         )
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, (tuple, Cache))
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        # Raise a useful error, asking to explicitly override the method
+        if not isinstance(past_key_values, Cache):
+            raise ValueError("The cache is not standard! Please overwrite `_check_past_key_values_for_generate`")
 
-        # (batch, # kv heads, seq_length, head_features)
+        # In this case, we simply call recursively the function on both internal caches
+        if isinstance(past_key_values, EncoderDecoderCache):
+            self._check_past_key_values_for_generate(
+                batch_size, past_key_values.self_attention_cache, seq_length, config
+            )
+            # For cross attention cache, the seq_length depends on the model, so we remove that dim
+            self._check_past_key_values_for_generate(batch_size, past_key_values.cross_attention_cache, None, config)
+            return
+
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        # hidden_size = getattr(decoder_config, "d_model", decoder_config.hidden_size)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+
+        # For cross attention cache, the seq_length depends on the model, so we remove that dim
         expected_shape = (
-            batch_size,
-            getattr(config, "num_key_value_heads", None) or config.num_attention_heads,
-            cache_length,
-            getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads,
+            (batch_size, num_heads, seq_length, head_dim)
+            if seq_length is not None
+            else (batch_size, num_heads, 1, head_dim)
         )
 
-        if isinstance(decoder_past_key_values, Cache):
-            self.assertListEqual(
-                [layer.keys.shape for layer in decoder_past_key_values.layers],
-                [expected_shape] * len(decoder_past_key_values.layers),
-            )
-            self.assertListEqual(
-                [layer.values.shape for layer in decoder_past_key_values.layers],
-                [expected_shape] * len(decoder_past_key_values.layers),
-            )
-        else:
-            raise ValueError("The cache is not standard! Please overwrite `_check_past_key_values_for_generate`")
+        # Check the size is coherent
+        self.assertEqual(config.num_hidden_layers, len(past_key_values))
+
+        # Check each layer has the correct shape
+        for layer in past_key_values.layers:
+            # Remove the seq_length dim for cross-attention cache (it changes based on the model)
+            keys = layer.keys if seq_length is not None else layer.keys[:, :, 0, :]
+            values = layer.values if seq_length is not None else layer.values[:, :, 0, :]
+            self.assertEqual(keys.shape, expected_shape)
+            self.assertEqual(values.shape, expected_shape)
 
     def _check_sequence_inside_sequence(self, tensor_1, tensor_2):
         # check if tensor_1 inside tensor_2 or tensor_2 inside tensor_1.

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2424,7 +2424,7 @@ class GenerationTesterMixin:
         # Check the size is coherent
         num_hidden_layers = config.num_hidden_layers
         if getattr(config, "num_kv_shared_layers", None) is not None:
-            num_hidden_layers += config.num_kv_shared_layers
+            num_hidden_layers -= config.num_kv_shared_layers
         self.assertEqual(num_hidden_layers, len(past_key_values))
 
         # Check each layer has the correct shape

--- a/tests/models/bamba/test_modeling_bamba.py
+++ b/tests/models/bamba/test_modeling_bamba.py
@@ -296,24 +296,21 @@ class BambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     # This is because we are hitting edge cases with the causal_mask buffer
     model_split_percents = [0.5, 0.7, 0.8]
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, HybridMambaAttentionDynamicCache)
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, HybridMambaAttentionDynamicCache)
 
-        # (batch, head, seq_length, head_features)
-        expected_shape = (
-            batch_size,
-            config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads,
-            cache_length,
-            config.hidden_size // config.num_attention_heads,
-        )
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        expected_shape = (batch_size, num_heads, seq_length, head_dim)
 
         self.assertListEqual(
-            [key_tensor.shape for key_tensor in decoder_past_key_values.key_cache],
-            [expected_shape] * len(decoder_past_key_values.key_cache),
+            [key_tensor.shape for key_tensor in past_key_values.key_cache],
+            [expected_shape] * len(past_key_values.key_cache),
         )
         self.assertListEqual(
-            [value_cache.shape for value_cache in decoder_past_key_values.value_cache],
-            [expected_shape] * len(decoder_past_key_values.value_cache),
+            [value_cache.shape for value_cache in past_key_values.value_cache],
+            [expected_shape] * len(past_key_values.value_cache),
         )
 
     def _check_caches_are_equal(

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -73,6 +73,23 @@ class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
     # used in `test_torch_compile_for_training`
     _torch_compile_train_cls = DeepseekV2ForCausalLM if is_torch_available() else None
 
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        """Needs to be overridden as deepseek has special MLA cache format (though we don't really use the MLA)"""
+        self.assertIsInstance(past_key_values, Cache)
+
+        # (batch, head, seq_length, head_features)
+        expected_common_shape = (
+            batch_size,
+            getattr(config, "num_key_value_heads", config.num_attention_heads),
+            seq_length,
+        )
+        expected_key_shape = expected_common_shape + (config.qk_nope_head_dim + config.qk_rope_head_dim,)
+        expected_value_shape = expected_common_shape + (config.v_head_dim,)
+
+        for layer in past_key_values.layers:
+            self.assertEqual(layer.keys.shape, expected_key_shape)
+            self.assertEqual(layer.values.shape, expected_value_shape)
+
     def test_model_rope_scaling_frequencies(self):
         """
         Overwritten: DeepseekV2 implements RoPE in the complex domain, as opposed to in the real domain with
@@ -129,23 +146,6 @@ class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
             torch.testing.assert_close(yarn_freqs_cis_short, original_freqs_cis_short)
         with self.assertRaises(AssertionError):
             torch.testing.assert_close(yarn_freqs_cis_long, original_freqs_cis_long)
-
-    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
-        """Needs to be overridden as deepseek has special MLA cache format (though we don't really use the MLA)"""
-        self.assertIsInstance(past_key_values, Cache)
-
-        # (batch, head, seq_length, head_features)
-        expected_common_shape = (
-            batch_size,
-            getattr(config, "num_key_value_heads", config.num_attention_heads),
-            seq_length,
-        )
-        expected_key_shape = expected_common_shape + (config.qk_nope_head_dim + config.qk_rope_head_dim,)
-        expected_value_shape = expected_common_shape + (config.v_head_dim,)
-
-        for layer in past_key_values.layers:
-            self.assertEqual(layer.keys.shape, expected_key_shape)
-            self.assertEqual(layer.values.shape, expected_value_shape)
 
     @unittest.skip("Dynamic control flow in MoE")
     @pytest.mark.torch_compile_test

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -130,41 +130,22 @@ class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
         with self.assertRaises(AssertionError):
             torch.testing.assert_close(yarn_freqs_cis_long, original_freqs_cis_long)
 
-    def test_past_key_values_format(self):
-        """
-        Overwriting to pass the expected cache shapes (Deepseek-V3 uses MLA so the cache shapes are non-standard)
-        """
-        config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-        batch_size, seq_length = inputs["input_ids"].shape
-        # difference: last dim
-        k_embed_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
-        v_embed_dim = config.v_head_dim
-        self_attention_key_cache_shape = (batch_size, config.num_key_value_heads, seq_length, k_embed_dim)
-        self_attention_value_cache_shape = (batch_size, config.num_key_value_heads, seq_length, v_embed_dim)
-        # build the full cache shapes
-        num_hidden_layers = config.num_hidden_layers
-        all_cache_shapes = [
-            [self_attention_key_cache_shape, self_attention_value_cache_shape] for _ in range(num_hidden_layers)
-        ]
-        super().test_past_key_values_format(custom_all_cache_shapes=all_cache_shapes)
-
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
         """Needs to be overridden as deepseek has special MLA cache format (though we don't really use the MLA)"""
-        self.assertIsInstance(decoder_past_key_values, Cache)
+        self.assertIsInstance(past_key_values, Cache)
 
         # (batch, head, seq_length, head_features)
         expected_common_shape = (
             batch_size,
-            config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads,
-            cache_length,
+            getattr(config, "num_key_value_heads", config.num_attention_heads),
+            seq_length,
         )
         expected_key_shape = expected_common_shape + (config.qk_nope_head_dim + config.qk_rope_head_dim,)
         expected_value_shape = expected_common_shape + (config.v_head_dim,)
 
-        if isinstance(decoder_past_key_values, Cache):
-            for layer in decoder_past_key_values.layers:
-                self.assertEqual(layer.keys.shape, expected_key_shape)
-                self.assertEqual(layer.values.shape, expected_value_shape)
+        for layer in past_key_values.layers:
+            self.assertEqual(layer.keys.shape, expected_key_shape)
+            self.assertEqual(layer.values.shape, expected_value_shape)
 
     @unittest.skip("Dynamic control flow in MoE")
     @pytest.mark.torch_compile_test

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -378,22 +378,6 @@ class DeepseekV3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
         with self.assertRaises(AssertionError):
             torch.testing.assert_close(yarn_sin_long, original_sin_long)
 
-    def test_past_key_values_format(self):
-        """
-        Overwriting to pass the expected cache shapes (Deepseek-V3 uses MLA so the cache shapes are non-standard)
-        """
-        config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-        batch_size, seq_length = inputs["input_ids"].shape
-        # difference: last dim
-        k_embed_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
-        v_embed_dim = config.v_head_dim
-        self_attention_keys_shape = (batch_size, config.num_key_value_heads, seq_length, k_embed_dim)
-        self_attention_values_shape = (batch_size, config.num_key_value_heads, seq_length, v_embed_dim)
-        # build the full cache shapes
-        num_hidden_layers = config.num_hidden_layers
-        all_cache_shapes = [[self_attention_keys_shape, self_attention_values_shape] for _ in range(num_hidden_layers)]
-        super().test_past_key_values_format(custom_all_cache_shapes=all_cache_shapes)
-
     @require_torch_large_accelerator
     @slow
     def test_eager_matches_sdpa_generate(self):

--- a/tests/models/dia/test_modeling_dia.py
+++ b/tests/models/dia/test_modeling_dia.py
@@ -52,7 +52,6 @@ if is_torch_available():
         PreTrainedModel,
     )
     from transformers.cache_utils import (
-        Cache,
         StaticCache,
     )
     from transformers.models.dia.modeling_dia import DiaDecoder, DiaEncoder
@@ -375,26 +374,6 @@ class DiaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
         self.assertListEqual(
             [layer_hidden_states.shape for layer_hidden_states in hidden_states],
             [encoder_expected_shape] * len(hidden_states),
-        )
-
-    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
-        self.assertIsInstance(past_key_values, Cache)
-
-        # we need the decoder config here
-        config = config.decoder_config
-
-        # (batch, kv heads, seq_length, head_dim)
-        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
-        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
-        expected_shape = (batch_size, num_heads, seq_length, head_dim)
-
-        self.assertListEqual(
-            [layer.keys.shape for layer in past_key_values.layers],
-            [expected_shape] * len(past_key_values.layers),
-        )
-        self.assertListEqual(
-            [layer.values.shape for layer in past_key_values.layers],
-            [expected_shape] * len(past_key_values.layers),
         )
 
     def _check_scores(self, batch_size, scores, generated_length, config):

--- a/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
+++ b/tests/models/falcon_mamba/test_modeling_falcon_mamba.py
@@ -40,11 +40,8 @@ from ...test_pipeline_mixin import PipelineTesterMixin
 if is_torch_available():
     import torch
 
-    from transformers import (
-        FalconMambaCache,
-        FalconMambaForCausalLM,
-        FalconMambaModel,
-    )
+    from transformers import FalconMambaForCausalLM, FalconMambaModel
+    from transformers.models.falcon_mamba.modeling_falcon_mamba import FalconMambaCache
 
 
 # Copied from transformers.tests.models.mamba.MambaModelTester with Mamba->FalconMamba,mamba->falcon_mamba
@@ -284,6 +281,18 @@ class FalconMambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTest
         self.config_tester = ConfigTester(
             self, config_class=FalconMambaConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
+
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, FalconMambaCache)
+
+        conv_shape = (batch_size, config.intermediate_size, config.conv_kernel)
+        ssm_shape = (batch_size, config.intermediate_size, config.state_size)
+
+        self.assertTrue(config.num_hidden_layers, len(past_key_values.conv_states))
+
+        for idx in range(len(past_key_values.conv_states)):
+            self.assertEqual(past_key_values.conv_states[idx].shape, conv_shape)
+            self.assertEqual(past_key_values.ssm_states[idx].shape, ssm_shape)
 
     def assertInterval(self, member, container, msg=None):
         r"""

--- a/tests/models/jamba/test_modeling_jamba.py
+++ b/tests/models/jamba/test_modeling_jamba.py
@@ -342,24 +342,21 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     )
     test_pruning = False
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, HybridMambaAttentionDynamicCache)
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, HybridMambaAttentionDynamicCache)
 
-        # (batch, head, seq_length, head_features)
-        expected_shape = (
-            batch_size,
-            config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads,
-            cache_length,
-            config.hidden_size // config.num_attention_heads,
-        )
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        expected_shape = (batch_size, num_heads, seq_length, head_dim)
 
         self.assertListEqual(
-            [key_tensor.shape for key_tensor in decoder_past_key_values.key_cache],
-            [expected_shape] * len(decoder_past_key_values.key_cache),
+            [key_tensor.shape for key_tensor in past_key_values.key_cache],
+            [expected_shape] * len(past_key_values.key_cache),
         )
         self.assertListEqual(
-            [value_cache.shape for value_cache in decoder_past_key_values.value_cache],
-            [expected_shape] * len(decoder_past_key_values.value_cache),
+            [value_cache.shape for value_cache in past_key_values.value_cache],
+            [expected_shape] * len(past_key_values.value_cache),
         )
 
     def _check_caches_are_equal(
@@ -550,10 +547,6 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
                 _ = model(dummy_input)
                 # with attention mask
                 _ = model(dummy_input, attention_mask=dummy_attention_mask)
-
-    @unittest.skip("Jamba has a non standard cache format (mamba cache)")
-    def test_past_key_values_format(self):
-        pass
 
     @unittest.skip("Jamba has a non standard cache which is not compatible with dp/ddp")
     def test_multi_gpu_data_parallel_forward(self):

--- a/tests/models/lfm2/test_modeling_lfm2.py
+++ b/tests/models/lfm2/test_modeling_lfm2.py
@@ -15,8 +15,6 @@
 
 import unittest
 
-import pytest
-
 from transformers import is_torch_available
 from transformers.testing_utils import (
     require_read_token,
@@ -64,24 +62,21 @@ class Lfm2ModelTest(CausalLMModelTest, unittest.TestCase):
     # used in `test_torch_compile_for_training`
     _torch_compile_train_cls = Lfm2ForCausalLM if is_torch_available() else None
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, Lfm2HybridConvCache)
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, Lfm2HybridConvCache)
 
-        # (batch, head, seq_length, head_features)
-        attention_shape = (
-            batch_size,
-            config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads,
-            cache_length,
-            config.hidden_size // config.num_attention_heads,
-        )
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        attention_shape = (batch_size, num_heads, seq_length, head_dim)
         conv_shape = (batch_size, config.hidden_size, config.conv_L_cache)
 
         for i in range(config.num_hidden_layers):
             if config.layer_types[i] == "full_attention":
-                self.assertEqual(decoder_past_key_values.key_cache[i].shape, attention_shape)
-                self.assertEqual(decoder_past_key_values.value_cache[i].shape, attention_shape)
+                self.assertEqual(past_key_values.key_cache[i].shape, attention_shape)
+                self.assertEqual(past_key_values.value_cache[i].shape, attention_shape)
             else:
-                self.assertEqual(decoder_past_key_values.conv_cache[i], conv_shape)
+                self.assertEqual(past_key_values.conv_cache[i], conv_shape)
 
     def _check_caches_are_equal(self, cache1: Lfm2HybridConvCache, cache2: Lfm2HybridConvCache):
         if not isinstance(cache1, Lfm2HybridConvCache) or not isinstance(cache2, Lfm2HybridConvCache):
@@ -137,41 +132,6 @@ class Lfm2ModelTest(CausalLMModelTest, unittest.TestCase):
             self.assertEqual(out_len + 1, len(outputs))
             self.assertEqual(len(self_attentions), sum(layer == "full_attention" for layer in config.layer_types))
             self.assertListEqual(list(self_attentions[0].shape[-3:]), [config.num_attention_heads, seq_len, seq_len])
-
-    @pytest.mark.generate
-    def test_past_key_values_format(self):
-        """Lfm2Moe has a special cache format as it alternates between attention and conv layers"""
-        for model_class in self.all_generative_model_classes:
-            config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-
-            model = model_class(config).to(torch_device).eval()
-            if "use_cache" not in inputs:
-                inputs["use_cache"] = True
-            outputs = model(**inputs)
-
-            past_kv = outputs["past_key_values"]
-
-            num_query_attention_heads = config.num_attention_heads
-            embed_dim = config.hidden_size
-            per_head_embed_dim = embed_dim // num_query_attention_heads
-            num_key_value_heads = getattr(config, "num_key_value_heads", num_query_attention_heads)
-
-            batch_size, seq_length = inputs["input_ids"].shape[:2]
-            default_self_attention_shape = (batch_size, num_key_value_heads, seq_length, per_head_embed_dim)
-            default_conv_shape = (batch_size, config.hidden_size, config.conv_L_cache)
-
-            num_cache_decoder_layers = len(past_kv)
-            self.assertEqual(num_cache_decoder_layers, config.num_hidden_layers)
-
-            for i in range(config.num_hidden_layers):
-                if config.layer_types[i] == "full_attention":
-                    self_attention_layer_keys = past_kv.key_cache[i]
-                    self_attention_layer_values = past_kv.value_cache[i]
-                    self.assertEqual(self_attention_layer_keys.shape, default_self_attention_shape)
-                    self.assertEqual(self_attention_layer_values.shape, default_self_attention_shape)
-                else:
-                    conv_layer = past_kv.conv_cache[i]
-                    self.assertEqual(conv_layer.shape, default_conv_shape)
 
 
 @require_torch_accelerator

--- a/tests/models/lfm2/test_modeling_lfm2.py
+++ b/tests/models/lfm2/test_modeling_lfm2.py
@@ -76,7 +76,7 @@ class Lfm2ModelTest(CausalLMModelTest, unittest.TestCase):
                 self.assertEqual(past_key_values.key_cache[i].shape, attention_shape)
                 self.assertEqual(past_key_values.value_cache[i].shape, attention_shape)
             else:
-                self.assertEqual(past_key_values.conv_cache[i], conv_shape)
+                self.assertEqual(past_key_values.conv_cache[i].shape, conv_shape)
 
     def _check_caches_are_equal(self, cache1: Lfm2HybridConvCache, cache2: Lfm2HybridConvCache):
         if not isinstance(cache1, Lfm2HybridConvCache) or not isinstance(cache2, Lfm2HybridConvCache):

--- a/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
+++ b/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
@@ -16,8 +16,6 @@
 
 import unittest
 
-import pytest
-
 from transformers import AutoTokenizer, is_torch_available, set_seed
 from transformers.testing_utils import (
     cleanup,
@@ -85,7 +83,7 @@ class Lfm2MoeModelTest(CausalLMModelTest, unittest.TestCase):
                 self.assertEqual(past_key_values.key_cache[i].shape, attention_shape)
                 self.assertEqual(past_key_values.value_cache[i].shape, attention_shape)
             else:
-                self.assertEqual(past_key_values.conv_cache[i], conv_shape)
+                self.assertEqual(past_key_values.conv_cache[i].shape, conv_shape)
 
     def _check_caches_are_equal(self, cache1: Lfm2MoeHybridConvCache, cache2: Lfm2MoeHybridConvCache):
         if not isinstance(cache1, Lfm2MoeHybridConvCache) or not isinstance(cache2, Lfm2MoeHybridConvCache):
@@ -141,41 +139,6 @@ class Lfm2MoeModelTest(CausalLMModelTest, unittest.TestCase):
             self.assertEqual(out_len + 1, len(outputs))
             self.assertEqual(len(self_attentions), sum(layer == "full_attention" for layer in config.layer_types))
             self.assertListEqual(list(self_attentions[0].shape[-3:]), [config.num_attention_heads, seq_len, seq_len])
-
-    @pytest.mark.generate
-    def test_past_key_values_format(self):
-        """Lfm2Moe has a special cache format as it alternates between attention and conv layers"""
-        for model_class in self.all_generative_model_classes:
-            config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-
-            model = model_class(config).to(torch_device).eval()
-            if "use_cache" not in inputs:
-                inputs["use_cache"] = True
-            outputs = model(**inputs)
-
-            past_kv = outputs["past_key_values"]
-
-            num_query_attention_heads = config.num_attention_heads
-            embed_dim = config.hidden_size
-            per_head_embed_dim = embed_dim // num_query_attention_heads
-            num_key_value_heads = getattr(config, "num_key_value_heads", num_query_attention_heads)
-
-            batch_size, seq_length = inputs["input_ids"].shape[:2]
-            default_self_attention_shape = (batch_size, num_key_value_heads, seq_length, per_head_embed_dim)
-            default_conv_shape = (batch_size, config.hidden_size, config.conv_L_cache)
-
-            num_cache_decoder_layers = len(past_kv)
-            self.assertEqual(num_cache_decoder_layers, config.num_hidden_layers)
-
-            for i in range(config.num_hidden_layers):
-                if config.layer_types[i] == "full_attention":
-                    self_attention_layer_keys = past_kv.key_cache[i]
-                    self_attention_layer_values = past_kv.value_cache[i]
-                    self.assertEqual(self_attention_layer_keys.shape, default_self_attention_shape)
-                    self.assertEqual(self_attention_layer_values.shape, default_self_attention_shape)
-                else:
-                    conv_layer = past_kv.conv_cache[i]
-                    self.assertEqual(conv_layer.shape, default_conv_shape)
 
 
 @require_torch_accelerator

--- a/tests/models/lfm2_vl/test_modeling_lfm2_vl.py
+++ b/tests/models/lfm2_vl/test_modeling_lfm2_vl.py
@@ -196,10 +196,6 @@ class Lfm2VlModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
     def test_attention_outputs(self):
         pass
 
-    @unittest.skip("Lfm2 backbone has a special cache format as it alternates between attention and conv layers")
-    def test_past_key_values_format(self):
-        pass
-
     @unittest.skip(
         "Lfm2 backbone has a special cache format which is not compatible with compile as it has static address for conv cache"
     )

--- a/tests/models/lfm2_vl/test_modeling_lfm2_vl.py
+++ b/tests/models/lfm2_vl/test_modeling_lfm2_vl.py
@@ -173,6 +173,22 @@ class Lfm2VlModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
             self, config_class=Lfm2VlConfig, has_text_modality=False, common_properties=common_properties
         )
 
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, Lfm2HybridConvCache)
+
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        attention_shape = (batch_size, num_heads, seq_length, head_dim)
+        conv_shape = (batch_size, config.hidden_size, config.conv_L_cache)
+
+        for i in range(config.num_hidden_layers):
+            if config.layer_types[i] == "full_attention":
+                self.assertEqual(past_key_values.key_cache[i].shape, attention_shape)
+                self.assertEqual(past_key_values.value_cache[i].shape, attention_shape)
+            else:
+                self.assertEqual(past_key_values.conv_cache[i].shape, conv_shape)
+
     def _check_caches_are_equal(self, cache1: Lfm2HybridConvCache, cache2: Lfm2HybridConvCache):
         """Text model uses lfm2, which has non-standard cache"""
         if not isinstance(cache1, Lfm2HybridConvCache) or not isinstance(cache2, Lfm2HybridConvCache):

--- a/tests/models/longcat_flash/test_modeling_longcat_flash.py
+++ b/tests/models/longcat_flash/test_modeling_longcat_flash.py
@@ -231,21 +231,6 @@ class LongcatFlashModelTest(CausalLMModelTest, unittest.TestCase):
     def test_save_load_fast_init_to_base(self):
         pass
 
-    def test_past_key_values_format(self):
-        config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-        batch_size, seq_length = inputs["input_ids"].shape
-
-        k_embed_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
-        v_embed_dim = config.v_head_dim
-
-        self_attention_keys_shape = (batch_size, config.num_key_value_heads, seq_length, k_embed_dim)
-        self_attention_values_shape = (batch_size, config.num_key_value_heads, seq_length, v_embed_dim)
-
-        num_hidden_layers = config.num_hidden_layers
-        all_cache_shapes = [[self_attention_keys_shape, self_attention_values_shape] for _ in range(num_hidden_layers)]
-
-        super().test_past_key_values_format(custom_all_cache_shapes=all_cache_shapes)
-
     def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
         self.assertIsInstance(past_key_values, Cache)
 

--- a/tests/models/longcat_flash/test_modeling_longcat_flash.py
+++ b/tests/models/longcat_flash/test_modeling_longcat_flash.py
@@ -38,7 +38,7 @@ from ...test_modeling_common import ids_tensor
 if is_torch_available():
     import torch
 
-    from transformers import AutoTokenizer, LongcatFlashForCausalLM, LongcatFlashModel
+    from transformers import AutoTokenizer, Cache, LongcatFlashForCausalLM, LongcatFlashModel
 
 
 class LongcatFlashModelTester(CausalLMModelTester):
@@ -246,25 +246,18 @@ class LongcatFlashModelTest(CausalLMModelTest, unittest.TestCase):
 
         super().test_past_key_values_format(custom_all_cache_shapes=all_cache_shapes)
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        from transformers.cache_utils import Cache
-
-        self.assertIsInstance(decoder_past_key_values, (tuple, Cache))
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, Cache)
 
         k_embed_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
         v_embed_dim = config.v_head_dim
 
-        expected_key_shape = (batch_size, config.num_key_value_heads, cache_length, k_embed_dim)
-        expected_value_shape = (batch_size, config.num_key_value_heads, cache_length, v_embed_dim)
+        expected_key_shape = (batch_size, config.num_key_value_heads, seq_length, k_embed_dim)
+        expected_value_shape = (batch_size, config.num_key_value_heads, seq_length, v_embed_dim)
 
-        if isinstance(decoder_past_key_values, Cache):
-            for layer_idx in range(config.num_hidden_layers):
-                self.assertEqual(decoder_past_key_values.layers[layer_idx].keys.shape, expected_key_shape)
-                self.assertEqual(decoder_past_key_values.layers[layer_idx].values.shape, expected_value_shape)
-        else:
-            for layer_past in decoder_past_key_values:
-                self.assertEqual(layer_past[0].shape, expected_key_shape)
-                self.assertEqual(layer_past[1].shape, expected_value_shape)
+        for layer_idx in range(config.num_hidden_layers):
+            self.assertEqual(past_key_values.layers[layer_idx].keys.shape, expected_key_shape)
+            self.assertEqual(past_key_values.layers[layer_idx].values.shape, expected_value_shape)
 
     @unittest.skip("MoE experts may not receive gradients with small test data")
     def test_training_gradient_checkpointing(self):

--- a/tests/models/mamba/test_modeling_mamba.py
+++ b/tests/models/mamba/test_modeling_mamba.py
@@ -32,10 +32,10 @@ if is_torch_available():
     import torch
 
     from transformers import (
-        MambaCache,
         MambaForCausalLM,
         MambaModel,
     )
+    from transformers.models.mamba.modeling_mamba import MambaCache
 
 
 class MambaModelTester:
@@ -251,6 +251,18 @@ class MambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
         self.config_tester = ConfigTester(
             self, config_class=MambaConfig, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
+
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, MambaCache)
+
+        conv_shape = (batch_size, config.intermediate_size, config.conv_kernel)
+        ssm_shape = (batch_size, config.intermediate_size, config.state_size)
+
+        self.assertTrue(config.num_hidden_layers, len(past_key_values.conv_states))
+
+        for idx in range(len(past_key_values.conv_states)):
+            self.assertEqual(past_key_values.conv_states[idx].shape, conv_shape)
+            self.assertEqual(past_key_values.ssm_states[idx].shape, ssm_shape)
 
     def assertInterval(self, member, container, msg=None):
         r"""

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -256,6 +256,21 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
             self, config_class=Mamba2Config, n_embd=37, common_properties=["hidden_size", "num_hidden_layers"]
         )
 
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, Mamba2Cache)
+
+        intermediate_size = config.expand * config.hidden_size
+        conv_shape = (
+            config.num_hidden_layers,
+            batch_size,
+            intermediate_size + 2 * config.n_groups * config.state_size,
+            config.conv_kernel,
+        )
+        ssm_shape = (config.num_hidden_layers, batch_size, config.num_heads, config.head_dim, config.state_size)
+
+        self.assertEqual(past_key_values.conv_states.shape, conv_shape)
+        self.assertEqual(past_key_values.ssm_states.shape, ssm_shape)
+
     def test_mamba2_caching(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_caching(*config_and_inputs)

--- a/tests/models/minimax/test_modeling_minimax.py
+++ b/tests/models/minimax/test_modeling_minimax.py
@@ -15,8 +15,6 @@
 
 import unittest
 
-import pytest
-
 from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,
@@ -141,14 +139,14 @@ class MiniMaxModelTest(CausalLMModelTest, unittest.TestCase):
                 if config.layer_types[layer_idx] == "full_attention":
                     self.assertEqual(layer_attention.shape, expected_shape)
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, MiniMaxCache)
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, MiniMaxCache)
 
         # (batch, head, seq_length, head_features)
         key_value_cache_expected_shape = (
             batch_size,
             config.num_key_value_heads,
-            cache_length,
+            seq_length,
             config.hidden_size // config.num_attention_heads,
         )
         # (batch, head, head_features, head_features)
@@ -161,12 +159,10 @@ class MiniMaxModelTest(CausalLMModelTest, unittest.TestCase):
 
         for layer_idx in range(config.num_hidden_layers):
             if config.layer_types[layer_idx] == "full_attention":
-                self.assertEqual(decoder_past_key_values.layers[layer_idx].keys.shape, key_value_cache_expected_shape)
-                self.assertEqual(
-                    decoder_past_key_values.layers[layer_idx].values.shape, key_value_cache_expected_shape
-                )
+                self.assertEqual(past_key_values.layers[layer_idx].keys.shape, key_value_cache_expected_shape)
+                self.assertEqual(past_key_values.layers[layer_idx].values.shape, key_value_cache_expected_shape)
             else:
-                self.assertEqual(decoder_past_key_values.linear_cache[layer_idx].shape, linear_cache_expected_shape)
+                self.assertEqual(past_key_values.linear_cache[layer_idx].shape, linear_cache_expected_shape)
 
     def _check_caches_are_equal(self, cache1: MiniMaxCache, cache2: MiniMaxCache):
         if not isinstance(cache1, MiniMaxCache) or not isinstance(cache2, MiniMaxCache):
@@ -182,25 +178,6 @@ class MiniMaxModelTest(CausalLMModelTest, unittest.TestCase):
                 torch.testing.assert_close(cache1.layers[idx].keys, cache1.layers[idx].keys)
                 torch.testing.assert_close(cache1.layers[idx].values, cache1.layers[idx].values)
             torch.testing.assert_close(cache1.linear_cache[idx], cache2.linear_cache[idx])
-
-    @pytest.mark.generate
-    def test_past_key_values_format(self, custom_all_cache_shapes=None):
-        """
-        Test that the KV cache is formatted correctly.
-        """
-        for model_class in self.all_generative_model_classes:
-            config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-
-            model = model_class(config).to(torch_device)
-            model = model.eval()
-            if "use_cache" not in inputs:
-                inputs["use_cache"] = True
-            outputs = model(**inputs)
-
-            past_kv = outputs["past_key_values"]
-
-            batch_size, seq_length = inputs["input_ids"].shape
-            self._check_past_key_values_for_generate(batch_size, past_kv, seq_length, config)
 
     @unittest.skip(reason="MiniMaxCache does not support `crop()` method")
     def test_prompt_lookup_decoding_matches_greedy_search(self):

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -398,86 +398,21 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
     def test_sdpa_padding_matches_padding_free_with_position_ids(self):
         pass
 
-    @pytest.mark.generate
-    # overridden because mllama is not an encoder-decoder model, but has encoder-decoder-like cache
-    def test_past_key_values_format(self):
-        # Test that the KV cache is formatted correctly. Exceptions need to explicitly overwrite this test. Having a
-        # standard KV cache format is important for a consistent API (and for advanced generation methods).
-        for model_class in self.all_generative_model_classes:
-            config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-
-            model = model_class(config).to(torch_device)
-            if "use_cache" not in inputs:
-                inputs["use_cache"] = True
-            outputs = model(**inputs)
-
-            text_config = config.get_text_config()
-            num_hidden_layers = (
-                getattr(text_config, "decoder_layers", None)
-                or getattr(text_config, "num_decoder_layers", None)
-                or text_config.num_hidden_layers
-            )
-            num_attention_heads = getattr(text_config, "decoder_attention_heads", text_config.num_attention_heads)
-            embed_dim = getattr(text_config, "d_model", text_config.hidden_size)
-            per_head_embed_dim = embed_dim // num_attention_heads
-
-            # some models have different num-head for query vs key/value so we need to assign correct value
-            # BUT only after `per_head_embed_dim` is set
-            num_attention_heads = (
-                text_config.num_key_value_heads
-                if getattr(text_config, "num_key_value_heads", None) is not None
-                else num_attention_heads
-            )
-
-            past_kv = outputs["past_key_values"]
-            self.assertEqual(len(past_kv), num_hidden_layers)
-            batch_size, seq_length = inputs["input_ids"].shape
-            for i in range(num_hidden_layers):
-                if i in self.model_tester.text_config["cross_attention_layers"]:
-                    self.assertEqual(
-                        past_kv.layers[i].keys.shape,
-                        (batch_size, num_attention_heads, self.model_tester.image_length, per_head_embed_dim),
-                    )
-                    self.assertEqual(
-                        past_kv.layers[i].values.shape,
-                        (batch_size, num_attention_heads, self.model_tester.image_length, per_head_embed_dim),
-                    )
-                else:
-                    self.assertEqual(
-                        past_kv.layers[i].keys.shape, (batch_size, num_attention_heads, seq_length, per_head_embed_dim)
-                    )
-                    self.assertEqual(
-                        past_kv.layers[i].values.shape,
-                        (batch_size, num_attention_heads, seq_length, per_head_embed_dim),
-                    )
-
     # overridden because mllama has special cache for self and cross attentions
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, Cache)
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, Cache)
 
-        for layer_idx in range(len(decoder_past_key_values)):
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+
+        for layer_idx in range(len(past_key_values)):
             if layer_idx in self.model_tester.text_config["cross_attention_layers"]:
-                expected_shape = (
-                    batch_size,
-                    config.num_key_value_heads
-                    if hasattr(config, "num_key_value_heads")
-                    else config.num_attention_heads,
-                    self.model_tester.image_length,
-                    config.hidden_size // config.num_attention_heads,
-                )
+                expected_shape = (batch_size, num_heads, self.model_tester.image_length, head_dim)
             else:
-                # (batch, head, cache_length, head_features)
-                expected_shape = (
-                    batch_size,
-                    config.num_key_value_heads
-                    if hasattr(config, "num_key_value_heads")
-                    else config.num_attention_heads,
-                    cache_length,
-                    config.hidden_size // config.num_attention_heads,
-                )
+                expected_shape = (batch_size, num_heads, seq_length, head_dim)
             # check shape key, value
-            self.assertListEqual([decoder_past_key_values.layers[layer_idx].keys.shape], [expected_shape])
-            self.assertListEqual([decoder_past_key_values.layers[layer_idx].values.shape], [expected_shape])
+            self.assertEqual(past_key_values.layers[layer_idx].keys.shape, expected_shape)
+            self.assertEqual(past_key_values.layers[layer_idx].values.shape, expected_shape)
 
     def test_generate_text_only_with_cache(self):
         """

--- a/tests/models/qwen3_next/test_modeling_qwen3_next.py
+++ b/tests/models/qwen3_next/test_modeling_qwen3_next.py
@@ -16,7 +16,6 @@
 import tempfile
 import unittest
 
-import pytest
 from parameterized import parameterized
 
 from transformers import is_torch_available
@@ -73,25 +72,22 @@ class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
 
     model_tester_class = Qwen3NextModelTester
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
         "Qwen3-Next has a special Cache as it alternates with gated deltanet layers"
-        self.assertIsInstance(decoder_past_key_values, Qwen3NextDynamicCache)
+        self.assertIsInstance(past_key_values, Qwen3NextDynamicCache)
 
-        # (batch, head, seq_length, head_features)
-        expected_shape = (
-            batch_size,
-            config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads,
-            cache_length,
-            config.hidden_size // config.num_attention_heads,
-        )
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        expected_shape = (batch_size, num_heads, seq_length, head_dim)
 
-        attention_layer_indices = decoder_past_key_values.transformer_layers
+        attention_layer_indices = past_key_values.transformer_layers
         self.assertListEqual(
-            [decoder_past_key_values.key_cache[idx].shape for idx in attention_layer_indices],
+            [past_key_values.key_cache[idx].shape for idx in attention_layer_indices],
             [expected_shape] * len(attention_layer_indices),
         )
         self.assertListEqual(
-            [decoder_past_key_values.value_cache[idx].shape for idx in attention_layer_indices],
+            [past_key_values.value_cache[idx].shape for idx in attention_layer_indices],
             [expected_shape] * len(attention_layer_indices),
         )
 
@@ -105,38 +101,6 @@ class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
             if cache1.key_cache[idx] is not None:
                 torch.testing.assert_close(cache1.key_cache[idx], cache2.key_cache[idx])
                 torch.testing.assert_close(cache1.value_cache[idx], cache2.value_cache[idx])
-
-    @pytest.mark.generate
-    def test_past_key_values_format(self):
-        "Needs to be overwritten as Qwen3-Next alternates between attention layers and gated deltanet layers."
-        for model_class in self.all_generative_model_classes:
-            config, inputs = self.model_tester.prepare_config_and_inputs_for_common()
-
-            model = model_class(config).to(torch_device)
-            model = model.eval()
-            if "use_cache" not in inputs:
-                inputs["use_cache"] = True
-            outputs = model(**inputs)
-
-            past_kv = outputs["past_key_values"]
-
-            num_query_attention_heads = config.num_attention_heads
-            embed_dim = config.hidden_size
-            per_head_embed_dim = embed_dim // num_query_attention_heads
-            num_key_value_heads = getattr(config, "num_key_value_heads", num_query_attention_heads)
-
-            batch_size, seq_length = inputs["input_ids"].shape[:2]
-            default_self_attention_shape = (batch_size, num_key_value_heads, seq_length, per_head_embed_dim)
-
-            num_cache_decoder_layers = len(past_kv)
-            self.assertEqual(num_cache_decoder_layers, config.num_hidden_layers)
-
-            for i in range(config.num_hidden_layers):
-                if config.layer_types[i] == "full_attention":
-                    self_attention_layer_keys = past_kv.key_cache[i]
-                    self_attention_layer_values = past_kv.value_cache[i]
-                    self.assertEqual(self_attention_layer_keys.shape, default_self_attention_shape)
-                    self.assertEqual(self_attention_layer_values.shape, default_self_attention_shape)
 
     def test_attention_outputs(self):
         "Needs to be overwritten as Qwen3-Next alternates between attention layers and gated deltanet layers."

--- a/tests/models/reformer/test_modeling_reformer.py
+++ b/tests/models/reformer/test_modeling_reformer.py
@@ -43,7 +43,7 @@ if is_torch_available():
         ReformerModelWithLMHead,
         ReformerTokenizer,
     )
-    from transformers.models.reformer.modeling_reformer import ReformerLayer
+    from transformers.models.reformer.modeling_reformer import ReformerDynamicCache, ReformerLayer
 
 
 class ReformerModelTester:
@@ -689,6 +689,25 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, GenerationTesterMixin, Mod
                 [expected_shape] * len(iter_hidden_states),
             )
 
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, ReformerDynamicCache)
+
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        hidden_size = getattr(config, "d_model", config.hidden_size)
+        head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
+
+        # For cross attention cache, the seq_length depends on the model, so we remove that dim
+        expected_shape = (batch_size, num_heads, seq_length, head_dim)
+
+        # Check the size is coherent
+        self.assertEqual(config.num_hidden_layers, len(past_key_values))
+
+        # Check each layer has the correct shape
+        for idx in range(len(past_key_values)):
+            self.assertEqual(past_key_values.states_cache[idx].shape, expected_shape)
+            self.assertEqual(past_key_values.buckets_cache[idx].shape, ())
+
     @unittest.skip(reason="The model doesn't support left padding")  # and it's not used enough to be worth fixing :)
     def test_left_padding_compatibility(self):
         pass
@@ -865,6 +884,25 @@ class ReformerLSHAttnModelTest(
                 [layer_hidden_states.shape for layer_hidden_states in iter_hidden_states],
                 [expected_shape] * len(iter_hidden_states),
             )
+
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, ReformerDynamicCache)
+
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        hidden_size = getattr(config, "d_model", config.hidden_size)
+        head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
+
+        # For cross attention cache, the seq_length depends on the model, so we remove that dim
+        expected_shape = (batch_size, num_heads, seq_length, head_dim)
+
+        # Check the size is coherent
+        self.assertEqual(config.num_hidden_layers, len(past_key_values))
+
+        # Check each layer has the correct shape
+        for idx in range(len(past_key_values)):
+            self.assertEqual(past_key_values.states_cache[idx].shape, expected_shape)
+            self.assertEqual(past_key_values.buckets_cache[idx].shape, expected_shape)
 
     @unittest.skip(reason="Fails because the sequence length is not a multiple of 4")
     def test_problem_types(self):

--- a/tests/models/reformer/test_modeling_reformer.py
+++ b/tests/models/reformer/test_modeling_reformer.py
@@ -698,7 +698,7 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, GenerationTesterMixin, Mod
         head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
 
         # For cross attention cache, the seq_length depends on the model, so we remove that dim
-        expected_shape = (batch_size, num_heads, seq_length, head_dim)
+        expected_shape = (batch_size, seq_length, num_heads * head_dim)
 
         # Check the size is coherent
         self.assertEqual(config.num_hidden_layers, len(past_key_values))
@@ -706,7 +706,7 @@ class ReformerLocalAttnModelTest(ReformerTesterMixin, GenerationTesterMixin, Mod
         # Check each layer has the correct shape
         for idx in range(len(past_key_values)):
             self.assertEqual(past_key_values.states_cache[idx].shape, expected_shape)
-            self.assertEqual(past_key_values.buckets_cache[idx].shape, ())
+            self.assertEqual(past_key_values.buckets_cache[idx].shape, (0,))
 
     @unittest.skip(reason="The model doesn't support left padding")  # and it's not used enough to be worth fixing :)
     def test_left_padding_compatibility(self):
@@ -894,7 +894,7 @@ class ReformerLSHAttnModelTest(
         head_dim = getattr(config, "head_dim", hidden_size // config.num_attention_heads)
 
         # For cross attention cache, the seq_length depends on the model, so we remove that dim
-        expected_shape = (batch_size, num_heads, seq_length, head_dim)
+        expected_shape = (batch_size, seq_length, num_heads * head_dim)
 
         # Check the size is coherent
         self.assertEqual(config.num_hidden_layers, len(past_key_values))
@@ -902,7 +902,6 @@ class ReformerLSHAttnModelTest(
         # Check each layer has the correct shape
         for idx in range(len(past_key_values)):
             self.assertEqual(past_key_values.states_cache[idx].shape, expected_shape)
-            self.assertEqual(past_key_values.buckets_cache[idx].shape, expected_shape)
 
     @unittest.skip(reason="Fails because the sequence length is not a multiple of 4")
     def test_problem_types(self):

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -307,12 +307,12 @@ class ZambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
 
         # (batch, kv heads, seq_length, head_dim)
         num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
-        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        head_dim = getattr(config, "attention_head_dim")
         attention_shape = (batch_size, num_heads, seq_length, head_dim)
 
         intermediate_size = config.mamba_expand * config.hidden_size
         conv_shape = (batch_size, intermediate_size, config.mamba_d_conv)
-        ssm_shape = (batch_size, intermediate_size // config.n_mamba_heads, config.mamba_d_state)
+        ssm_shape = (batch_size, config.n_mamba_heads, intermediate_size // config.n_mamba_heads, config.mamba_d_state)
 
         self.assertTrue(config.num_hidden_layers, len(past_key_values))
 

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -308,16 +308,21 @@ class ZambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
         # (batch, kv heads, seq_length, head_dim)
         num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
         head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
-        expected_shape = (batch_size, num_heads, seq_length, head_dim)
+        attention_shape = (batch_size, num_heads, seq_length, head_dim)
 
-        self.assertListEqual(
-            [key_tensor.shape for key_tensor in past_key_values.key_cache],
-            [expected_shape] * len(past_key_values.key_cache),
-        )
-        self.assertListEqual(
-            [value_cache.shape for value_cache in past_key_values.value_cache],
-            [expected_shape] * len(past_key_values.value_cache),
-        )
+        intermediate_size = config.mamba_expand * config.hidden_size
+        conv_shape = (batch_size, intermediate_size, config.mamba_d_conv)
+        ssm_shape = (batch_size, intermediate_size // config.n_mamba_heads, config.mamba_d_state)
+
+        self.assertTrue(config.num_hidden_layers, len(past_key_values))
+
+        for idx in range(len(past_key_values)):
+            if config.layers_block_type[idx] == "mamba":
+                self.assertEqual(past_key_values.conv_states[idx].shape, conv_shape)
+                self.assertEqual(past_key_values.ssm_states[idx].shape, ssm_shape)
+            else:
+                self.assertEqual(past_key_values.key_cache[idx].shape, attention_shape)
+                self.assertEqual(past_key_values.value_cache[idx].shape, attention_shape)
 
     def _check_caches_are_equal(self, cache1: ZambaHybridDynamicCache, cache2: ZambaHybridDynamicCache):
         if not isinstance(cache1, ZambaHybridDynamicCache) or not isinstance(cache2, ZambaHybridDynamicCache):

--- a/tests/models/zamba/test_modeling_zamba.py
+++ b/tests/models/zamba/test_modeling_zamba.py
@@ -302,24 +302,21 @@ class ZambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
     )
     test_pruning = False
 
-    def _check_past_key_values_for_generate(self, batch_size, decoder_past_key_values, cache_length, config):
-        self.assertIsInstance(decoder_past_key_values, ZambaHybridDynamicCache)
+    def _check_past_key_values_for_generate(self, batch_size, past_key_values, seq_length, config):
+        self.assertIsInstance(past_key_values, ZambaHybridDynamicCache)
 
-        # (batch, head, seq_length, head_features)
-        expected_shape = (
-            batch_size,
-            config.num_key_value_heads if hasattr(config, "num_key_value_heads") else config.num_attention_heads,
-            cache_length,
-            config.hidden_size // config.num_attention_heads,
-        )
+        # (batch, kv heads, seq_length, head_dim)
+        num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
+        head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        expected_shape = (batch_size, num_heads, seq_length, head_dim)
 
         self.assertListEqual(
-            [key_tensor.shape for key_tensor in decoder_past_key_values.key_cache],
-            [expected_shape] * len(decoder_past_key_values.key_cache),
+            [key_tensor.shape for key_tensor in past_key_values.key_cache],
+            [expected_shape] * len(past_key_values.key_cache),
         )
         self.assertListEqual(
-            [value_cache.shape for value_cache in decoder_past_key_values.value_cache],
-            [expected_shape] * len(decoder_past_key_values.value_cache),
+            [value_cache.shape for value_cache in past_key_values.value_cache],
+            [expected_shape] * len(past_key_values.value_cache),
         )
 
     def _check_caches_are_equal(self, cache1: ZambaHybridDynamicCache, cache2: ZambaHybridDynamicCache):

--- a/tests/models/zamba2/test_modeling_zamba2.py
+++ b/tests/models/zamba2/test_modeling_zamba2.py
@@ -320,16 +320,25 @@ class Zamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         # (batch, kv heads, seq_length, head_dim)
         num_heads = getattr(config, "num_key_value_heads", config.num_attention_heads)
         head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
-        expected_shape = (batch_size, num_heads, seq_length, head_dim)
+        attention_shape = (batch_size, num_heads, seq_length, head_dim)
 
-        self.assertListEqual(
-            [key_tensor.shape for key_tensor in past_key_values.key_cache],
-            [expected_shape] * len(past_key_values.key_cache),
+        intermediate_size = config.mamba_expand * config.hidden_size
+        conv_shape = (
+            batch_size,
+            intermediate_size + 2 * config.mamba_ngroups * config.mamba_d_state,
+            config.mamba_d_conv,
         )
-        self.assertListEqual(
-            [value_cache.shape for value_cache in past_key_values.value_cache],
-            [expected_shape] * len(past_key_values.value_cache),
-        )
+        ssm_shape = (batch_size, config.n_mamba_heads, config.mamba_headdim, config.mamba_d_state)
+
+        self.assertTrue(config.num_hidden_layers, len(past_key_values))
+
+        for idx in range(len(past_key_values)):
+            if config.layers_block_type[idx] == "mamba":
+                self.assertEqual(past_key_values.conv_states[idx].shape, conv_shape)
+                self.assertEqual(past_key_values.ssm_states[idx].shape, ssm_shape)
+            else:
+                self.assertEqual(past_key_values.key_cache[idx].shape, attention_shape)
+                self.assertEqual(past_key_values.value_cache[idx].shape, attention_shape)
 
     def _check_caches_are_equal(self, cache1: Zamba2HybridDynamicCache, cache2: Zamba2HybridDynamicCache):
         if not isinstance(cache1, Zamba2HybridDynamicCache) or not isinstance(cache2, Zamba2HybridDynamicCache):


### PR DESCRIPTION
# What does this PR do?

Improve the cache tests.`test_past_key_values_format` should really rely on `_check_past_key_values_for_generate` as they do the same, and we otherwise have to overwrite both for models with non-standard cache format, which is really annoying!

This made me realize that `generate` does not correctly return the cache, if it's not called `past_key_values`. This fixes it as well.

cc @gante 