### PR TITLE
Qwen3: fix bool attention_mask in eager_attention_forward

### DIFF
--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -182,9 +182,13 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
-        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        if attention_mask.dtype==torch.bool:
+            casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)
+            causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
+            casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]
+        else:
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
         attn_weights = attn_weights + causal_mask
-
     attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
     attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
     attn_output = torch.matmul(attn_weights, value_states)

--- a/src/transformers/models/llama/modeling_llama.py
+++ b/src/transformers/models/llama/modeling_llama.py
@@ -182,7 +182,7 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
-        if attention_mask.dtype==torch.bool:
+        if attention_mask.dtype == torch.bool:
             casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)
             causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
             casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -107,7 +107,12 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
-        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        if attention_mask.dtype==torch.bool:
+            casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)
+            causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
+            casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]
+        else:
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
         attn_weights = attn_weights + causal_mask
 
     attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)

--- a/src/transformers/models/qwen2/modeling_qwen2.py
+++ b/src/transformers/models/qwen2/modeling_qwen2.py
@@ -107,7 +107,7 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
-        if attention_mask.dtype==torch.bool:
+        if attention_mask.dtype == torch.bool:
             casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)
             causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
             casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -143,7 +143,7 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
-        if attention_mask.dtype==torch.bool:
+        if attention_mask.dtype == torch.bool:
             casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)
             causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
             casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -143,7 +143,12 @@ def eager_attention_forward(
 
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
-        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        if attention_mask.dtype==torch.bool:
+            casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)   
+            causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
+            casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]
+        else:
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
         attn_weights = attn_weights + causal_mask
 
     attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)

--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -144,7 +144,7 @@ def eager_attention_forward(
     attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
     if attention_mask is not None:
         if attention_mask.dtype==torch.bool:
-            casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)   
+            casual_mask = torch.zeros_like(attention_mask, dtype=torch.float)
             causal_mask = casual_mask.masked_fill(~attention_mask, float("-inf"))
             casual_mask = causal_mask[:, :, :, : key_states.shape[-2]]
         else:


### PR DESCRIPTION
This PR fixes a silent numerical/logic bug that occurs when a boolean attention_mask is supplied to the eager attention path.
The current implementation simply adds the mask to the attention scores, which is correct for float masks that already contain −∞ values, but produces completely wrong logits when the mask is of type torch.bool.
The fix converts a boolean mask to float and fills the masked-out positions with −∞ before the addition, guaranteeing that softmax will assign them zero probability.
No breaking change.
 @vasqu @ArthurZucker  @Cyrilvallez 