### PR TITLE
Remove KERAS_NLP_IMPORT_ERROR

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1512,12 +1512,6 @@ SCIPY_IMPORT_ERROR = """
 """
 
 # docstyle-ignore
-KERAS_NLP_IMPORT_ERROR = """
-{0} requires the keras_nlp library but it was not found in your environment. You can install it with pip.
-Please note that you may need to restart your runtime after installation.
-"""
-
-# docstyle-ignore
 SPEECH_IMPORT_ERROR = """
 {0} requires the torchaudio library but it was not found in your environment. You can install it with pip:
 `pip install torchaudio`. Please note that you may need to restart your runtime after installation.


### PR DESCRIPTION
# What does this PR do?

Because `KERAS_NLP_IMPORT_ERROR` is not used.