### PR TITLE
Pickle - part 2

### DIFF
--- a/src/transformers/models/deprecated/mega/convert_mega_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/deprecated/mega/convert_mega_original_pytorch_checkpoint_to_pytorch.py
@@ -29,7 +29,7 @@ import argparse
 
 # utilities to import the model weights and config file
 import os
-import pickle as pickle
+import pickle
 
 # PyTorch + new model classes
 import torch

--- a/src/transformers/models/deprecated/mega/convert_mega_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/deprecated/mega/convert_mega_original_pytorch_checkpoint_to_pytorch.py
@@ -29,13 +29,15 @@ import argparse
 
 # utilities to import the model weights and config file
 import os
-import pickle as pkl
+import pickle as pickle
 
 # PyTorch + new model classes
 import torch
 from torch import nn
 
 from transformers import AutoTokenizer, MegaConfig, MegaForMaskedLM
+
+from ....utils import strtobool
 
 
 # import the EncoderLayer class used to pretrain
@@ -122,8 +124,15 @@ class OriginalMegaForMaskedLM(nn.Module):
 
 # code to convert the checkpoint located in the user-specified location
 def convert_checkpoint_to_huggingface(pretrained_checkpoint_path, output_path, includes_tokenizer):
+    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+        raise ValueError(
+            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+        )
     with open(os.path.join(pretrained_checkpoint_path, "model_args.pkl"), "rb") as f:
-        mega_original_args = pkl.load(f)
+        mega_original_args = pickle.load(f)
 
     # load the original encoder
     original_mlm = OriginalMegaForMaskedLM(**mega_original_args).eval()

--- a/src/transformers/models/glm4v/convert_glm4v_mgt_weights_to_hf.py
+++ b/src/transformers/models/glm4v/convert_glm4v_mgt_weights_to_hf.py
@@ -24,6 +24,8 @@ from typing import Callable, Optional
 import torch
 from safetensors.torch import save_file
 
+from ...utils import strtobool
+
 
 # Avoid Using Megatron Lib
 class UnpicklerWrapper(pickle.Unpickler):
@@ -248,6 +250,14 @@ def save_sharded_model(state_dict, output_path, max_shard_size_gb=5, num_layers=
 
 
 def merge_tp_weights(model_path, output_path, vllm_config_path=None):
+    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+        raise ValueError(
+            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+        )
+
     tp_size = 0
     for item in Path(model_path).iterdir():
         if item.is_dir():

--- a/src/transformers/models/maskformer/convert_maskformer_resnet_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_resnet_to_pytorch.py
@@ -17,6 +17,7 @@ https://github.com/facebookresearch/MaskFormer"""
 
 import argparse
 import json
+import os
 import pickle
 from pathlib import Path
 
@@ -27,6 +28,8 @@ from PIL import Image
 
 from transformers import MaskFormerConfig, MaskFormerForInstanceSegmentation, MaskFormerImageProcessor, ResNetConfig
 from transformers.utils import logging
+
+from ...utils import strtobool
 
 
 logging.set_verbosity_info()
@@ -266,6 +269,13 @@ def convert_maskformer_checkpoint(
     """
     config = get_maskformer_config(model_name)
 
+    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+        raise ValueError(
+            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+        )
     # load original state_dict
     with open(checkpoint_path, "rb") as f:
         data = pickle.load(f)

--- a/src/transformers/models/maskformer/convert_maskformer_swin_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_swin_to_pytorch.py
@@ -17,6 +17,7 @@ https://github.com/facebookresearch/MaskFormer"""
 
 import argparse
 import json
+import os
 import pickle
 from pathlib import Path
 
@@ -27,6 +28,8 @@ from PIL import Image
 
 from transformers import MaskFormerConfig, MaskFormerForInstanceSegmentation, MaskFormerImageProcessor, SwinConfig
 from transformers.utils import logging
+
+from ...utils import strtobool
 
 
 logging.set_verbosity_info()
@@ -235,6 +238,13 @@ def convert_maskformer_checkpoint(
     """
     config = get_maskformer_config(model_name)
 
+    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+        raise ValueError(
+            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+        )
     # load original state_dict
     with open(checkpoint_path, "rb") as f:
         data = pickle.load(f)

--- a/src/transformers/models/perceiver/convert_perceiver_haiku_to_pytorch.py
+++ b/src/transformers/models/perceiver/convert_perceiver_haiku_to_pytorch.py
@@ -16,6 +16,7 @@
 
 import argparse
 import json
+import os
 import pickle
 from pathlib import Path
 
@@ -38,6 +39,8 @@ from transformers import (
     PerceiverTokenizer,
 )
 from transformers.utils import logging
+
+from ...utils import strtobool
 
 
 logging.set_verbosity_info()
@@ -264,6 +267,13 @@ def convert_perceiver_checkpoint(pickle_file, pytorch_dump_folder_path, architec
     """
     Copy/paste/tweak model's weights to our Perceiver structure.
     """
+    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+        raise ValueError(
+            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+        )
 
     # load parameters as FlatMapping data structure
     with open(pickle_file, "rb") as f:

--- a/src/transformers/models/reformer/convert_reformer_trax_checkpoint_to_pytorch.py
+++ b/src/transformers/models/reformer/convert_reformer_trax_checkpoint_to_pytorch.py
@@ -15,6 +15,7 @@
 """Convert Reformer checkpoint."""
 
 import argparse
+import os
 import pickle
 
 import numpy as np
@@ -23,6 +24,8 @@ from torch import nn
 
 from transformers import ReformerConfig, ReformerModelWithLMHead
 from transformers.utils import logging
+
+from ...utils import strtobool
 
 
 logging.set_verbosity_info()
@@ -188,6 +191,13 @@ def convert_trax_checkpoint_to_pytorch(trax_model_pkl_path, config_file, pytorch
     print(f"Building PyTorch model from configuration: {config}")
     model = ReformerModelWithLMHead(config)
 
+    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
+        raise ValueError(
+            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
+            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
+            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
+            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
+        )
     with open(trax_model_pkl_path, "rb") as f:
         model_weights = pickle.load(f)["weights"]
 


### PR DESCRIPTION
# What does this PR do?

Require 
```
    if not strtobool(os.environ.get("TRUST_REMOTE_CODE", "False")):
        raise ValueError(
            "This part uses `pickle.load` which is insecure and will execute arbitrary code that is potentially "
            "malicious. It's recommended to never unpickle data that could have come from an untrusted source, or "
            "that could have been tampered with. If you already verified the pickle data and decided to use it, "
            "you can set the environment variable `TRUST_REMOTE_CODE` to `True` to allow it."
        )
```

I limit this PR to conversion scripts only. For other usage of pickle in our codebase, I will try to see if there is any alternative.
