### PR TITLE
Fixed tiny incorrect imports in `glm4v`

### DIFF
--- a/src/transformers/models/glm4v/modular_glm4v.py
+++ b/src/transformers/models/glm4v/modular_glm4v.py
@@ -54,8 +54,8 @@ from ..qwen2_5_vl.modeling_qwen2_5_vl import (
     Qwen2_5_VLVisionBlock,
 )
 from ..qwen2_vl.processing_qwen2_vl import (
-    Qwen2_VLProcessor,
-    Qwen2_VLProcessorKwargs,
+    Qwen2VLProcessor,
+    Qwen2VLProcessorKwargs,
 )
 
 
@@ -1526,7 +1526,7 @@ class Glm4vForConditionalGeneration(Qwen2_5_VLForConditionalGeneration):
         return image_counts, video_counts
 
 
-class Glm4vProcessorKwargs(Qwen2_VLProcessorKwargs):
+class Glm4vProcessorKwargs(Qwen2VLProcessorKwargs):
     _defaults = {
         "text_kwargs": {
             "padding": False,
@@ -1537,7 +1537,7 @@ class Glm4vProcessorKwargs(Qwen2_VLProcessorKwargs):
     }
 
 
-class Glm4vProcessor(Qwen2_VLProcessor):
+class Glm4vProcessor(Qwen2VLProcessor):
     r"""
     Constructs a GLM-4V processor which wraps a GLM-4V image processor and a GLM-4 tokenizer into a single processor.
     [`~Glm4vProcessor.__call__`] and [`~Glm4vProcessor.decode`] for more information.


### PR DESCRIPTION
# What does this PR do?

Fixes tiny incorrect imports in `glm4v`. These are the correct classes

https://github.com/huggingface/transformers/blob/34b861abd11074fd32362b9a25c1cc582fa0b941/src/transformers/models/qwen2_vl/processing_qwen2_vl.py#L39

https://github.com/huggingface/transformers/blob/34b861abd11074fd32362b9a25c1cc582fa0b941/src/transformers/models/qwen2_vl/processing_qwen2_vl.py#L48



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
cc: @zucchini-nlp @gante @Cyrilvallez (Similar to https://github.com/huggingface/transformers/pull/41354)