### PR TITLE
fix bnb model loading

### DIFF
--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -126,6 +126,12 @@ class AutoQuantizationConfig:
                 "The model's quantization config from the arguments has no `quant_method` attribute. Make sure that the model has been correctly quantized"
             )
 
+        if quant_method == QuantizationMethod.BITS_AND_BYTES:
+            if quantization_config_dict.get("load_in_8bit"):
+                quant_method += "_8bit"
+            else:
+                quant_method += "_4bit"
+
         if quant_method not in AUTO_QUANTIZATION_CONFIG_MAPPING:
             raise ValueError(
                 f"Unknown quantization type, got {quant_method} - supported types are:"


### PR DESCRIPTION
```python
from transformers import pipeline

pipe = pipeline("text-generation", model="hugging-quants/Meta-Llama-3.1-8B-Instruct-BNB-NF4")
```

Before this PR:
```
Traceback (most recent call last):
  File "/home/jiqing/transformers/src/transformers/pipelines/base.py", line 262, in load_model
    model = model_class.from_pretrained(model, **fp32_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/modeling_utils.py", line 272, in _wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/modeling_utils.py", line 4669, in from_pretrained
    hf_quantizer, config, dtype, device_map = get_hf_quantizer(
                                              ^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/quantizers/auto.py", line 301, in get_hf_quantizer
    config.quantization_config = AutoHfQuantizer.merge_quantization_configs(
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/quantizers/auto.py", line 210, in merge_quantization_configs
    quantization_config = AutoQuantizationConfig.from_dict(quantization_config)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/quantizers/auto.py", line 130, in from_dict
    raise ValueError(
ValueError: Unknown quantization type, got bitsandbytes - supported types are: ['awq', 'bitsandbytes_4bit', 'bitsandbytes_8bit', 'gptq
', 'aqlm', 'quanto', 'quark', 'fp_quant', 'eetq', 'higgs', 'hqq', 'compressed-tensors', 'fbgemm_fp8', 'torchao', 'bitnet', 'vptq', 'sp
qr', 'fp8', 'auto-round', 'mxfp4']
```

After this PR, it works.


Hi @SunMarc . Please review this PR. Thanks!