### PR TITLE
Remove outdated flags

### DIFF
--- a/tests/models/cwm/test_modeling_cwm.py
+++ b/tests/models/cwm/test_modeling_cwm.py
@@ -75,8 +75,6 @@ class CwmModelTest(CausalLMModelTest, unittest.TestCase):
         if is_torch_available()
         else {}
     )
-    test_headmasking = False
-    test_pruning = False
     fx_compatible = False
     model_tester_class = CwmModelTester
 

--- a/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
+++ b/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
@@ -62,8 +62,6 @@ class Lfm2MoeModelTest(CausalLMModelTest, unittest.TestCase):
         if is_torch_available()
         else {}
     )
-    test_headmasking = False
-    test_pruning = False
     fx_compatible = False
     model_tester_class = Lfm2MoeModelTester
     # used in `test_torch_compile_for_training`


### PR DESCRIPTION
# What does this PR do?

Those features disappeared recently, but those models were added in the middle so they still have the flags