### PR TITLE
Fix forced_bos_token_id not set in generation_config

### DIFF
--- a/examples/pytorch/translation/run_translation.py
+++ b/examples/pytorch/translation/run_translation.py
@@ -444,6 +444,9 @@ def main():
         )
         model.config.forced_bos_token_id = forced_bos_token_id
 
+        if hasattr(model, "generation_config") and model.generation_config is not None:
+            model.generation_config.forced_bos_token_id = forced_bos_token_id
+
     # Get the language codes for input/target.
     source_lang = data_args.source_lang.split("_")[0]
     target_lang = data_args.target_lang.split("_")[0]


### PR DESCRIPTION
# What does this PR do?

Fixes #41492

Fixes incorrect target language generation during evaluation/validation in run_translation.py for multilingual translation models (mBART , M2M100).

### Problem 

When fine-tuning multilingual models, forced_bos_token_id was only set in model.config but not in model.generation_config. During evaluation, model.generate() reads from generation_config, causing generation in wrong language and artificially low BLEU scores.Previously would be ~2-5 (wrong language)

### Solution 

Set forced_bos_token_id in both model.config and model.generation_config.

Results:

<img width="275" height="112" alt="eval_metrics" src="https://github.com/user-attachments/assets/5b499354-bdbc-4eb0-b07a-fcb75cc2690f" />

- ✅ this generated correct language token id with correct target language.
- ✅ This warning appears if you modify model.config directly for generation. Using model.generation_config removes this warning and ensures Transformers v5+ uses the setting correctly.
- ✅ All evaluations complete without errors
- ✅ Using decoder_start_token_id only/both causes empty outputs.
- ✅ With this fix, the target language ID is automatically handled during generation.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@zach-huggingface @CyrilVallez
