### PR TITLE
Add test coverage for ConvNextImageProcessorFast

### DIFF
--- a/tests/models/convnext/test_image_processing_convnext.py
+++ b/tests/models/convnext/test_image_processing_convnext.py
@@ -88,10 +88,12 @@ class ConvNextImageProcessingTester:
 class ConvNextImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
     image_processing_class = ConvNextImageProcessor if is_vision_available() else None
     fast_image_processing_class = ConvNextImageProcessorFast if is_torchvision_available() else None
+    image_processor_list = [image_processing_class, fast_image_processing_class]
 
     def setUp(self):
         super().setUp()
         self.image_processor_tester = ConvNextImageProcessingTester(self)
+
 
     @property
     def image_processor_dict(self):


### PR DESCRIPTION
# Add test coverage for ConvNextImageProcessorFast

## Description
Completes test coverage for the existing `ConvNextImageProcessorFast` implementation by adding `image_processor_list` to enable testing both slow and fast processors.

## Changes
- ✅ Added `image_processor_list = [image_processing_class, fast_image_processing_class]` to test class
- ✅ Enables all existing tests to run on both slow and fast processors
- ✅ All 19 tests passing

## Testing Results
```bash
RUN_SLOW=1 python -m pytest tests/models/convnext/test_image_processing_convnext.py -v