### PR TITLE
Add conditional checks to _check_and_adjust_attn_implementation()

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2541,6 +2541,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             and self._supports_flash_attn
             and not (is_flash_attn_2_available() or is_flash_attn_3_available())
             and is_kernels_available()
+            and not is_torch_npu_available()
         ):
             if attn_implementation.endswith("2"):
                 applicable_attn_implementation = "kernels-community/flash-attn"


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

To prevent unnecessary downloads by kernels, avoid installing kernels-community/flash-attn and kernels-community/vllm-flash-attn3 when attn_implementation=flash_attention_2 is specified for NPU.


## test 

### script
```
from transformers import AutoModelForCausalLM, AutoTokenizer

model = AutoModelForCausalLM.from_pretrained(
    "Qwen/Qwen3-0.6B",
    device_map="auto",
    torch_dtype="auto",
    attn_implementation="flash_attention_2",
).eval()
print("Operation successful")
```

### Before
```
`torch_dtype` is deprecated! Use `dtype` instead!
Fetching 0 files: 0it [00:00, ?it/s]
Traceback (most recent call last):
  File "/root/kernels-main/src/kernels/utils.py", line 144, in install_kernel
    return _load_kernel_from_path(repo_path, package_name, variant_locks)
  File "/root/kernels-main/src/kernels/utils.py", line 177, in _load_kernel_from_path
    raise FileNotFoundError(
FileNotFoundError: Kernel at path `/root/.cache/huggingface/hub/models--kernels-community--flash-attn/snapshots/90b3e941627659b28ff001c08b218315e1b7183b` does not have build: torch27-cxx11-cann81-aarch64-linux
```

### After
```
`torch_dtype` is deprecated! Use `dtype` instead!
Operation successful
```
