### PR TITLE
[device_map] Accelerate loading by computing device_map much faster

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -257,7 +257,7 @@ def check_and_set_device_map(device_map: "torch.device" | int | str | dict | Non
     return device_map
 
 
-def compute_module_sizes(model: "PreTrainedModel", hf_quantizer: "HfQuantizer" | None) -> dict[str, int]:
+def compute_module_sizes(model: "PreTrainedModel", hf_quantizer: "HfQuantizer | None") -> dict[str, int]:
     """
     Compute the size of each submodule of a given model (in bytes).
     """
@@ -279,7 +279,7 @@ def get_balanced_memory(
     model: "PreTrainedModel",
     max_memory: dict[int | str, int | str] | None = None,
     no_split_module_classes: list[str] | None = None,
-    hf_quantizer: "HfQuantizer" | None = None,
+    hf_quantizer: "HfQuantizer | None" = None,
     low_zero: bool = False,
 ):
     """
@@ -385,7 +385,7 @@ def _get_device_map(
     model: "PreTrainedModel",
     device_map: dict | str | None,
     max_memory: dict | None,
-    hf_quantizer: "HfQuantizer" | None,
+    hf_quantizer: "HfQuantizer | None",
     dtype: torch.dtype | None,
 ) -> dict:
     """Compute the final `device_map` to use if we passed a value in ['auto', 'balanced', 'balanced_low_0', 'sequential'].

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -263,8 +263,8 @@ def compute_module_sizes(model: "PreTrainedModel", hf_quantizer: "HfQuantizer" |
     """
     module_sizes = defaultdict(int)
     for name, param in model.state_dict():
-        if hf_quantizer is not None and hf_quantizer.param_needs_quantization(model, name):
-            dtype_size = hf_quantizer.dtype_byte_size(param.dtype)
+        if hf_quantizer is not None:
+            dtype_size = hf_quantizer.param_element_size(model, name)
         else:
             dtype_size = param.element_size()
         size = param.numel() * dtype_size

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -213,7 +213,7 @@ def find_tied_parameters(model: "nn.Module", **kwargs):
     return [sorted([weight] + list(set(tied))) for weight, tied in tied_param_groups.items()]
 
 
-def check_and_set_device_map(device_map: "torch.device" | int | str | dict | None):
+def check_and_set_device_map(device_map: "torch.device | int | str | dict | None") -> dict | str | None:
     from ..modeling_utils import get_torch_context_manager_or_global_device
 
     # Potentially detect context manager or global device, and use it (only if no device_map was provided)

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -404,7 +404,6 @@ def _get_device_map(
             special_dtypes = hf_quantizer.get_special_dtypes_update(model, dtype)
 
         target_dtype = dtype
-
         if hf_quantizer is not None:
             target_dtype = hf_quantizer.adjust_target_dtype(target_dtype)
 

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -257,7 +257,7 @@ def check_and_set_device_map(device_map: "torch.device" | int | str | dict | Non
     return device_map
 
 
-def compute_module_sizes(model: "PreTrainedModel", hf_quantizer: HfQuantizer | None) -> dict[str, int]:
+def compute_module_sizes(model: "PreTrainedModel", hf_quantizer: "HfQuantizer" | None) -> dict[str, int]:
     """
     Compute the size of each submodule of a given model (in bytes).
     """
@@ -279,7 +279,7 @@ def get_balanced_memory(
     model: "PreTrainedModel",
     max_memory: dict[int | str, int | str] | None = None,
     no_split_module_classes: list[str] | None = None,
-    hf_quantizer: HfQuantizer | None = None,
+    hf_quantizer: "HfQuantizer" | None = None,
     low_zero: bool = False,
 ):
     """
@@ -385,7 +385,7 @@ def _get_device_map(
     model: "PreTrainedModel",
     device_map: dict | str | None,
     max_memory: dict | None,
-    hf_quantizer: HfQuantizer | None,
+    hf_quantizer: "HfQuantizer" | None,
     dtype: torch.dtype | None,
 ) -> dict:
     """Compute the final `device_map` to use if we passed a value in ['auto', 'balanced', 'balanced_low_0', 'sequential'].

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -113,7 +113,7 @@ class HfQuantizer(ABC):
         """
         return device_map
 
-    def get_target_dtype(self, dtype: "torch.dtype") -> "torch.dtype":
+    def adjust_target_dtype(self, dtype: "torch.dtype") -> "torch.dtype":
         """
         Override this method if you want to adjust the `target_dtype` variable used in `from_pretrained`
         to compute the device_map in case the device_map is a `str`. E.g. for bitsandbytes we force-set `target_dtype`


### PR DESCRIPTION
# What does this PR do?

If a model has a lot of different parameters (which is the case for models with a lot of experts, such as Qwen3Next), the computation of the device_map itself (yes, just the mapping of modules to devices) is EXTREMELY slow when using `accelerate`.
This is because they traverse the model graph in a very non-optimized manner, resulting in quadratic complexity in the number of parameters and modules, when we could do it in linear time instead. For example, `Qwen/Qwen3-Next-80B-A3B-Instruct` has a total of `173529` parameters and intermediate modules, which is a a lot. So doing the following:

```python
from transformers import AutoConfig, Qwen3NextForCausalLM
from transformers.modeling_utils import _get_device_map
import torch
import time

model_name = "Qwen/Qwen3-Next-80B-A3B-Instruct"
config = AutoConfig.from_pretrained(model_name)

with torch.device("meta"):
    model = Qwen3NextForCausalLM(config)

t0 = time.time()
device_map = _get_device_map(model, device_map="auto", dtype=torch.bfloat16, max_memory=None, hf_quantizer=None, keep_in_fp32_regex=None)
dt = time.time() - t0
print(f"Time needed: {dt:.2f} s")

>>> Time needed: 60.02 s
```

takes un UNBEARABLE `60.02` s on my Macbook Pro M3. And this is only for the device_map computation, the loading has not even started yet...

This PR fixes the issue by rewriting the needed functions from `accelerate` with much better complexity and operations directly in Transformers, leading to linear time and the following:

```python
>>> Time needed: 1.33 s
```

So effectively going 60x faster from 1min to 1s

The device_map created are the exact same.