### PR TITLE
[Bugfix] Fix quantizer import

### DIFF
--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -18,7 +18,6 @@ from ..utils import is_torch_available, logging
 from ..utils.quantization_config import QuantizationConfigMixin, QuantizationMethod
 from .quantizers_utils import get_module_from_name
 
-
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 
@@ -32,6 +31,8 @@ logger = logging.get_logger(__file__)
 
 
 def _assign_original_dtype(module, original_dtype):
+    from ..modeling_utils import PreTrainedModel
+
     for child in module.children():
         if isinstance(child, PreTrainedModel):
             child.config._pre_quantization_dtype = original_dtype

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -18,6 +18,7 @@ from ..utils import is_torch_available, logging
 from ..utils.quantization_config import QuantizationConfigMixin, QuantizationMethod
 from .quantizers_utils import get_module_from_name
 
+
 if TYPE_CHECKING:
     from ..modeling_utils import PreTrainedModel
 


### PR DESCRIPTION
## Purpose ##
* Fix bad import in `src/transformers/quantizers/base.py`

## Changes ##
* Import `PreTrainedModel` dynamically, rather than only importing when type checking
  * The class is needed for an `isinstance` check

## Testing ##
* Code which calls `_assign_original_dtype` which was previously failing is now passing
  * Can provide a minimum example if required