### PR TITLE
Use `yaml.safe_load`

### DIFF
--- a/src/transformers/models/marian/convert_marian_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_to_pytorch.py
@@ -105,7 +105,7 @@ def load_config_from_state_dict(opus_dict):
     import yaml
 
     cfg_str = "".join([chr(x) for x in opus_dict[CONFIG_KEY]])
-    yaml_cfg = yaml.load(cfg_str[:-1], Loader=yaml.BaseLoader)
+    yaml_cfg = yaml.safe_load(cfg_str[:-1], Loader=yaml.BaseLoader)
     return cast_marian_config(yaml_cfg)
 
 
@@ -682,7 +682,7 @@ def load_yaml(path):
     import yaml
 
     with open(path, encoding="utf-8") as f:
-        return yaml.load(f, Loader=yaml.BaseLoader)
+        return yaml.safe_load(f, Loader=yaml.BaseLoader)
 
 
 def save_json(content: Union[dict, list], path: str) -> None:

--- a/src/transformers/models/mobilevitv2/convert_mlcvnets_to_pytorch.py
+++ b/src/transformers/models/mobilevitv2/convert_mlcvnets_to_pytorch.py
@@ -54,7 +54,7 @@ def load_orig_config_file(orig_cfg_file):
     config = argparse.Namespace()
     with open(orig_cfg_file, "r") as yaml_file:
         try:
-            cfg = yaml.load(yaml_file, Loader=yaml.FullLoader)
+            cfg = yaml.safe_load(yaml_file, Loader=yaml.FullLoader)
 
             flat_cfg = flatten_yaml_as_dict(cfg)
             for k, v in flat_cfg.items():

--- a/src/transformers/models/parakeet/convert_nemo_to_hf.py
+++ b/src/transformers/models/parakeet/convert_nemo_to_hf.py
@@ -294,7 +294,7 @@ def main(
     filepath = cached_file(hf_repo_id, nemo_filename)
 
     model_files = extract_nemo_archive(filepath, os.path.dirname(filepath))
-    nemo_config = yaml.load(open(model_files["model_config"], "r"), Loader=yaml.FullLoader)
+    nemo_config = yaml.safe_load(open(model_files["model_config"], "r"), Loader=yaml.FullLoader)
 
     write_processor(nemo_config, model_files, output_dir, push_to_repo_id)
     write_model(nemo_config, model_files, model_type, output_dir, push_to_repo_id)


### PR DESCRIPTION
# What does this PR do?

Use `yaml.safe_load` instead of `yaml.load` to avoid potential security issue, and to close the security report we received.

https://pyyaml.org/wiki/PyYAMLDocumentation

> Warning: It is not safe to call yaml.load with any data received from an untrusted source! yaml.load is as powerful as pickle.load and so may call any Python function. Check the yaml.safe_load function though.