### PR TITLE
Add __iter__ to DynamicCache

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1598,6 +1598,7 @@ class ModelTesterMixin:
                         cache_shape = (batch_size, num_heads, cache_length, head_dim)
                         non_empty_pkv = tuple(
                             (
+                                None,
                                 torch.rand(cache_shape, dtype=torch.float, device=torch_device),
                                 torch.rand(cache_shape, dtype=torch.float, device=torch_device),
                             )

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1806,7 +1806,10 @@ class ModelUtilsTest(TestCasePlus):
 
         # simulate injecting virtual tokens like in prefix tuning
         num_virtual_tokens = 3
-        past_key_values = [torch.randn(2, 1, 2, num_virtual_tokens, 8)] * 2
+        past_key_values = [
+            (None, torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8)),
+            (None, torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8)),
+        ]
         past_key_values = DynamicCache(past_key_values)
         model_inputs["attention_mask"] = torch.cat(
             (


### PR DESCRIPTION
Currently, DDP is broken when there is a `DynamicCache` because it has no `__iter___` method and so it cannot be concatenated after the distributed forward. This PR adds back and `__iter__` and adapts the way ddp data is consumed to properly initialize sliding windows.