### PR TITLE
Fix an import error with PreTrainModel

### DIFF
--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -32,6 +32,9 @@ logger = logging.get_logger(__file__)
 
 
 def _assign_original_dtype(module, original_dtype):
+    # not very nice in a recursive function but it avoids a circular import
+    from ..modeling_utils import PreTrainedModel
+
     for child in module.children():
         if isinstance(child, PreTrainedModel):
             child.config._pre_quantization_dtype = original_dtype


### PR DESCRIPTION
This tiny tiny PR fixes an error introduced in #41445 which led to an import error.
For instance, `tests/models/gemma3/test_modeling_gemma3.py::Gemma3Vision2TextModelTest::test_flash_attn_2_fp32_ln` without this fix fails with 
```
NameError: name 'PreTrainedModel' is not defined
```
but after this fix passes