### PR TITLE
[docs] Duplicate entry

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -544,8 +544,6 @@
         title: Helium
       - local: model_doc/herbert
         title: HerBERT
-      - local: model_doc/hgnet_v2
-        title: HGNet-V2
       - local: model_doc/hunyuan_v1_dense
         title: HunYuanDenseV1
       - local: model_doc/hunyuan_v1_moe


### PR DESCRIPTION
Fixes duplicate entry in the `toctree` that may be breaking the `custom-doc-build` job for translations (https://github.com/huggingface/transformers/actions/runs/18381182160/job/52725830409)