### PR TITLE
Fix EncoderDecoder cache

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -998,7 +998,7 @@ class DynamicCache(Cache):
 
     def __iter__(self):
         for layer in self.layers:
-            yield getattr(layer, "_sliding_window_tensor", None), layer.keys, layer.values
+            yield layer.keys, layer.values, getattr(layer, "_sliding_window_tensor", None)
 
 
 class StaticCache(Cache):

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1187,20 +1187,20 @@ class RagTokenForGeneration(RagPreTrainedModel, GenerationMixin):
         reordered_past = ()
         for idx in range(len(past_key_values)):
             if isinstance(past_key_values, EncoderDecoderCache):
-                self_attention_k, self_attention_v, cross_attention_k, cross_attention_v = map(
-                    fn=lambda x: _reorder_stacked(x, beam_idx.to(x.device)),
-                    iterable=(
+                self_attention_k, self_attention_v, cross_attention_k, cross_attention_v = (
+                    _reorder_stacked(x, beam_idx.to(x.device))
+                    for x in (
                         past_key_values.self_attention_cache.layers[idx].keys,
                         past_key_values.self_attention_cache.layers[idx].values,
                         past_key_values.cross_attention_cache.layers[idx].keys,
                         past_key_values.cross_attention_cache.layers[idx].values,
-                    ),
+                    )
                 )
                 new_tuple = ((self_attention_k, self_attention_v), (cross_attention_k, cross_attention_v))
             else:
-                self_attention_k, self_attention_v = map(
-                    fn=lambda x: _reorder_stacked(x, beam_idx.to(x.device)),
-                    iterable=(past_key_values.layers[idx].keys, past_key_values.layers[idx].values),
+                self_attention_k, self_attention_v = (
+                    _reorder_stacked(x, beam_idx.to(x.device))
+                    for x in (past_key_values.layers[idx].keys, past_key_values.layers[idx].values)
                 )
                 new_tuple = (self_attention_k, self_attention_v)
             reordered_past += (new_tuple,)

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1196,7 +1196,7 @@ class RagTokenForGeneration(RagPreTrainedModel, GenerationMixin):
                         past_key_values.cross_attention_cache.layers[idx].values,
                     )
                 )
-                new_tuple = ((self_attention_k, self_attention_v), (cross_attention_k, cross_attention_v))
+                new_tuple = (self_attention_k, self_attention_v, cross_attention_k, cross_attention_v)
             else:
                 self_attention_k, self_attention_v = (
                     _reorder_stacked(x, beam_idx.to(x.device))

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1187,22 +1187,24 @@ class RagTokenForGeneration(RagPreTrainedModel, GenerationMixin):
         reordered_past = ()
         for idx in range(len(past_key_values)):
             if isinstance(past_key_values, EncoderDecoderCache):
-                layer_past = (
-                    past_key_values.self_attention_cache.layers[idx].keys,
-                    past_key_values.self_attention_cache.layers[idx].values,
-                    past_key_values.cross_attention_cache.layers[idx].keys,
-                    past_key_values.cross_attention_cache.layers[idx].values,
+                self_attention_k, self_attention_v, cross_attention_k, cross_attention_v = map(
+                    fn=lambda x: _reorder_stacked(x, beam_idx.to(x.device)),
+                    iterable=(
+                        past_key_values.self_attention_cache.layers[idx].keys,
+                        past_key_values.self_attention_cache.layers[idx].values,
+                        past_key_values.cross_attention_cache.layers[idx].keys,
+                        past_key_values.cross_attention_cache.layers[idx].values,
+                    )
                 )
+                new_tuple = ((self_attention_k, self_attention_v), (cross_attention_k, cross_attention_v))
             else:
-                layer_past = (past_key_values.layers[idx].keys, past_key_values.layers[idx].values)
-            # get the correct batch idx from decoder layer's batch dim for cross and self-attn
-            reordered_past += (
-                tuple(_reorder_stacked(past_state, beam_idx.to(past_state.device)) for past_state in layer_past),
-            )
-
-        # Cast back to the correct cache class
-        reordered_cache = type(past_key_values)(reordered_past)
-        return reordered_cache
+                self_attention_k, self_attention_v = map(
+                    fn=lambda x: _reorder_stacked(x, beam_idx.to(x.device)),
+                    iterable=(past_key_values.layers[idx].keys, past_key_values.layers[idx].values),
+                )
+                new_tuple = (self_attention_k, self_attention_v)
+            reordered_past += (new_tuple,)
+        return type(past_key_values)(reordered_past)
 
     def marginalize(self, seq_logits, doc_scores, n_docs=None):
         n_docs = n_docs if n_docs is not None else self.config.n_docs

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1194,7 +1194,7 @@ class RagTokenForGeneration(RagPreTrainedModel, GenerationMixin):
                         past_key_values.self_attention_cache.layers[idx].values,
                         past_key_values.cross_attention_cache.layers[idx].keys,
                         past_key_values.cross_attention_cache.layers[idx].values,
-                    )
+                    ),
                 )
                 new_tuple = ((self_attention_k, self_attention_v), (cross_attention_k, cross_attention_v))
             else:

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1180,13 +1180,12 @@ class WhisperGenerationMixin(GenerationMixin):
                     return None
                 all_past_key_values = []
                 for layer_idx in range(self.config.decoder_layers):
-                    layer_cache = [
-                        (
-                            cache_cls.layers[layer_idx].keys[batch_idx][None].cpu(),
-                            cache_cls.layers[layer_idx].values[batch_idx][None].cpu(),
-                        )
-                        for cache_cls in [values.self_attention_cache, values.cross_attention_cache]
-                    ]
+                    layer_cache = (
+                        values.self_attention_cache.layers[layer_idx].keys[batch_idx][None].cpu(),
+                        values.self_attention_cache.layers[layer_idx].values[batch_idx][None].cpu(),
+                        values.cross_attention_cache.layers[layer_idx].keys[batch_idx][None].cpu(),
+                        values.cross_attention_cache.layers[layer_idx].values[batch_idx][None].cpu(),
+                    )
                     all_past_key_values.append(layer_cache)
                 return EncoderDecoderCache(all_past_key_values)
 
@@ -1240,7 +1239,7 @@ class WhisperGenerationMixin(GenerationMixin):
                             for sub_key in ["keys", "values"]
                         )
                         all_past_key_values.append(
-                            ((self_attention_k, self_attention_v), (cross_attention_k, cross_attention_v))
+                            (self_attention_k, self_attention_v, cross_attention_k, cross_attention_v)
                         )
                     outputs[key] = EncoderDecoderCache(tuple(all_past_key_values))
                 else:

--- a/src/transformers/models/whisper/generation_whisper.py
+++ b/src/transformers/models/whisper/generation_whisper.py
@@ -1180,12 +1180,15 @@ class WhisperGenerationMixin(GenerationMixin):
                     return None
                 all_past_key_values = []
                 for layer_idx in range(self.config.decoder_layers):
-                    layer_past_key_values = []
-                    for cache_cls in [values.self_attention_cache, values.cross_attention_cache]:
-                        for v in [cache_cls.layers[layer_idx].keys, cache_cls.layers[layer_idx].values]:
-                            layer_past_key_values.append(v[batch_idx][None].cpu())
-                    all_past_key_values.append(tuple(layer_past_key_values))
-                return EncoderDecoderCache(tuple(all_past_key_values))
+                    layer_cache = [
+                        (
+                            cache_cls.layers[layer_idx].keys[batch_idx][None].cpu(),
+                            cache_cls.layers[layer_idx].values[batch_idx][None].cpu(),
+                        )
+                        for cache_cls in [values.self_attention_cache, values.cross_attention_cache]
+                    ]
+                    all_past_key_values.append(layer_cache)
+                return EncoderDecoderCache(all_past_key_values)
 
             return values[batch_idx].cpu()
 
@@ -1224,7 +1227,7 @@ class WhisperGenerationMixin(GenerationMixin):
                 if seek_outputs[0][key] is not None:
                     all_past_key_values = []
                     for layer_idx in range(len(seek_outputs[0][key])):
-                        layer_past_key_values = tuple(
+                        self_attention_k, self_attention_v, cross_attention_k, cross_attention_v = (
                             torch.stack(
                                 [
                                     getattr(getattr(sub_output[key], sub_cache).layers[layer_idx], sub_key)
@@ -1236,7 +1239,9 @@ class WhisperGenerationMixin(GenerationMixin):
                             for sub_cache in ["self_attention_cache", "cross_attention_cache"]
                             for sub_key in ["keys", "values"]
                         )
-                        all_past_key_values.append(layer_past_key_values)
+                        all_past_key_values.append(
+                            ((self_attention_k, self_attention_v), (cross_attention_k, cross_attention_v))
+                        )
                     outputs[key] = EncoderDecoderCache(tuple(all_past_key_values))
                 else:
                     outputs[key] = None

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1807,8 +1807,8 @@ class ModelUtilsTest(TestCasePlus):
         # simulate injecting virtual tokens like in prefix tuning
         num_virtual_tokens = 3
         past_key_values = [
-            (torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8), None),
-            (torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8), None),
+            (torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8)),
+            (torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8)),
         ]
         past_key_values = DynamicCache(past_key_values)
         model_inputs["attention_mask"] = torch.cat(

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1807,8 +1807,8 @@ class ModelUtilsTest(TestCasePlus):
         # simulate injecting virtual tokens like in prefix tuning
         num_virtual_tokens = 3
         past_key_values = [
-            (None, torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8)),
-            (None, torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8)),
+            (torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8), None),
+            (torch.randn(1, 2, num_virtual_tokens, 8), torch.randn(1, 2, num_virtual_tokens, 8), None),
         ]
         past_key_values = DynamicCache(past_key_values)
         model_inputs["attention_mask"] = torch.cat(


### PR DESCRIPTION
In #41569 we restored thr `__iter__` method to `DynamicCache` but I missed the fact that it was also removed from `EncoderDecoderCache`. This PR fixes that and modifies the `__init__` of `EncoderDecoderCache` in the case of DDP, so it is compatible with the new system.