### PR TITLE
[`Docs`] Fix changed references

### DIFF
--- a/docs/source/en/models.md
+++ b/docs/source/en/models.md
@@ -139,7 +139,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     new_model = AutoModel.from_pretrained(tmp_dir)
 ```
 
-Sharded checkpoints can also be directly loaded with [`~transformers.modeling_utils.load_sharded_checkpoint`].
+Sharded checkpoints can also be directly loaded with [`~transformers.trainer_utils.load_sharded_checkpoint`].
 
 ```py
 from transformers.modeling_utils import load_sharded_checkpoint

--- a/docs/source/en/models.md
+++ b/docs/source/en/models.md
@@ -142,7 +142,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
 Sharded checkpoints can also be directly loaded with [`~transformers.trainer_utils.load_sharded_checkpoint`].
 
 ```py
-from transformers.modeling_utils import load_sharded_checkpoint
+from transformers.trainer_utils import load_sharded_checkpoint
 
 with tempfile.TemporaryDirectory() as tmp_dir:
     model.save_pretrained(tmp_dir, max_shard_size="5GB")

--- a/docs/source/it/big_models.md
+++ b/docs/source/it/big_models.md
@@ -106,7 +106,7 @@ La mappa dei pesi è la parte principale di questo indice, che mappa ogni nome d
  ...
 ```
 
-Se vuoi caricare direttamente un checkpoint frammentato in un modello senza usare [`~PreTrainedModel.from_pretrained`] (come si farebbe con `model.load_state_dict()` per un checkpoint completo) devi usare [`~modeling_utils.load_sharded_checkpoint`]:
+Se vuoi caricare direttamente un checkpoint frammentato in un modello senza usare [`~PreTrainedModel.from_pretrained`] (come si farebbe con `model.load_state_dict()` per un checkpoint completo) devi usare [`~trainer_utils.load_sharded_checkpoint`]:
 
 ```py
 >>> from transformers.modeling_utils import load_sharded_checkpoint

--- a/docs/source/it/big_models.md
+++ b/docs/source/it/big_models.md
@@ -109,7 +109,7 @@ La mappa dei pesi è la parte principale di questo indice, che mappa ogni nome d
 Se vuoi caricare direttamente un checkpoint frammentato in un modello senza usare [`~PreTrainedModel.from_pretrained`] (come si farebbe con `model.load_state_dict()` per un checkpoint completo) devi usare [`~trainer_utils.load_sharded_checkpoint`]:
 
 ```py
->>> from transformers.modeling_utils import load_sharded_checkpoint
+>>> from transformers.trainer_utils import load_sharded_checkpoint
 
 >>> with tempfile.TemporaryDirectory() as tmp_dir:
 ...     model.save_pretrained(tmp_dir, max_shard_size="200MB")

--- a/docs/source/ja/big_models.md
+++ b/docs/source/ja/big_models.md
@@ -114,7 +114,7 @@ dict_keys(['metadata', 'weight_map'])
 
 
 ```py
->>> from transformers.modeling_utils import load_sharded_checkpoint
+>>> from transformers.trainer_utils import load_sharded_checkpoint
 
 >>> with tempfile.TemporaryDirectory() as tmp_dir:
 ...     model.save_pretrained(tmp_dir, max_shard_size="200MB")

--- a/docs/source/ja/big_models.md
+++ b/docs/source/ja/big_models.md
@@ -110,7 +110,7 @@ dict_keys(['metadata', 'weight_map'])
 ```
 
 直接モデル内で[`~PreTrainedModel.from_pretrained`]を使用せずに、
-シャーディングされたチェックポイントをロードしたい場合（フルチェックポイントの場合に`model.load_state_dict()`を使用するように行う方法）、[`~modeling_utils.load_sharded_checkpoint`]を使用する必要があります：
+シャーディングされたチェックポイントをロードしたい場合（フルチェックポイントの場合に`model.load_state_dict()`を使用するように行う方法）、[`~trainer_utils.load_sharded_checkpoint`]を使用する必要があります：
 
 
 ```py

--- a/docs/source/ja/main_classes/model.md
+++ b/docs/source/ja/main_classes/model.md
@@ -127,7 +127,3 @@ Pytorch の設計により、この機能は浮動小数点 dtype でのみ使�
 ## Pushing to the Hub
 
 [[autodoc]] utils.PushToHubMixin
-
-## Sharded checkpoints
-
-[[autodoc]] modeling_utils.load_sharded_checkpoint

--- a/docs/source/ko/main_classes/model.md
+++ b/docs/source/ko/main_classes/model.md
@@ -46,7 +46,3 @@ rendered properly in your Markdown viewer.
 ## 허브에 저장하기
 
 [[autodoc]] utils.PushToHubMixin
-
-## 공유된 체크포인트
-
-[[autodoc]] modeling_utils.load_sharded_checkpoint

--- a/docs/source/ko/models.md
+++ b/docs/source/ko/models.md
@@ -178,7 +178,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
     new_model = AutoModel.from_pretrained(tmp_dir)
 ```
 
-분할된 체크포인트는 [`~transformers.modeling_utils.load_sharded_checkpoint`]로도 직접 불러올 수 있습니다.
+분할된 체크포인트는 [`~transformers.trainer_utils.load_sharded_checkpoint`]로도 직접 불러올 수 있습니다.
 
 ```py
 from transformers.modeling_utils import load_sharded_checkpoint

--- a/docs/source/ko/models.md
+++ b/docs/source/ko/models.md
@@ -181,7 +181,7 @@ with tempfile.TemporaryDirectory() as tmp_dir:
 분할된 체크포인트는 [`~transformers.trainer_utils.load_sharded_checkpoint`]로도 직접 불러올 수 있습니다.
 
 ```py
-from transformers.modeling_utils import load_sharded_checkpoint
+from transformers.trainer_utils import load_sharded_checkpoint
 
 with tempfile.TemporaryDirectory() as tmp_dir:
     model.save_pretrained(tmp_dir, max_shard_size="5GB")

--- a/docs/source/zh/big_models.md
+++ b/docs/source/zh/big_models.md
@@ -105,7 +105,7 @@ dict_keys(['metadata', 'weight_map'])
  ...
 ```
 
-如果您想直接在模型内部加载这样的分片`checkpoint`，而不使用 [`PreTrainedModel.from_pretrained`](就像您会为完整`checkpoint`执行 `model.load_state_dict()` 一样)，您应该使用 [`modeling_utils.load_sharded_checkpoint`]：
+如果您想直接在模型内部加载这样的分片`checkpoint`，而不使用 [`PreTrainedModel.from_pretrained`](就像您会为完整`checkpoint`执行 `model.load_state_dict()` 一样)，您应该使用 [`trainer_utils.load_sharded_checkpoint`]：
 
 
 ```py

--- a/docs/source/zh/big_models.md
+++ b/docs/source/zh/big_models.md
@@ -109,7 +109,7 @@ dict_keys(['metadata', 'weight_map'])
 
 
 ```py
->>> from transformers.modeling_utils import load_sharded_checkpoint
+>>> from transformers.trainer_utils import load_sharded_checkpoint
 
 >>> with tempfile.TemporaryDirectory() as tmp_dir:
 ...     model.save_pretrained(tmp_dir, max_shard_size="200MB")

--- a/docs/source/zh/main_classes/model.md
+++ b/docs/source/zh/main_classes/model.md
@@ -109,6 +109,3 @@ model = AutoModel.from_config(config)
 
 ## 推送到 Hub
 [[autodoc]] utils.PushToHubMixin
-
-## 分片检查点
-[[autodoc]] modeling_utils.load_sharded_checkpoint


### PR DESCRIPTION
#41445 moved `load_sharded_checkpoint` to the trainer utils instead of the modeling utils. This PR changes the remaining references and (hopefully) fixes the CI on main with the doc builder