### PR TITLE
Update a dataset reop link

### DIFF
--- a/tests/models/kosmos2_5/test_processor_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_processor_kosmos2_5.py
@@ -299,7 +299,7 @@ class Kosmos2_5ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
 
     @require_torch
     def test_full_processor(self):
-        url = url_to_local_path("https://huggingface.co/kirp/kosmos2_5/resolve/main/receipt_00008.png")
+        url = url_to_local_path("https://huggingface.co/microsoft/kosmos-2.5/resolve/main/receipt_00008.png")
         processor = AutoProcessor.from_pretrained("microsoft/kosmos-2.5")
         texts = ["<md>", "<ocr>"]
         expected_input_ids = [

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -29,7 +29,7 @@ URLS_FOR_TESTING_DATA = [
     "https://huggingface.co/datasets/raushan-testing-hf/images_test/resolve/main/picsum_237_200x300.jpg",
     "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/Big_Buck_Bunny_720_10s_10MB.mp4",
     "https://huggingface.co/datasets/raushan-testing-hf/videos-test/resolve/main/sample_demo_1.mp4",
-    "https://huggingface.co/kirp/kosmos2_5/resolve/main/receipt_00008.png",
+    "https://huggingface.co/microsoft/kosmos-2.5/resolve/main/receipt_00008.png",
     "https://huggingface.co/microsoft/kosmos-2-patch14-224/resolve/main/two_dogs.jpg",
     "https://llava-vl.github.io/static/images/view.jpg",
     "https://huggingface.co/datasets/hf-internal-testing/fixtures_videos/resolve/main/tennis.mp4",


### PR DESCRIPTION
# What does this PR do?

`https://huggingface.co/kirp/kosmos2_5/resolve/main/receipt_00008.png` is no longer available (likely the author deleted it).
That is used during the PR. Let's use the official repo. now

https://huggingface.co/microsoft/kosmos-2.5/resolve/main/receipt_00008.png

