### PR TITLE
[`Executorch`] Simplify for encoder models

### DIFF
--- a/tests/models/albert/test_modeling_albert.py
+++ b/tests/models/albert/test_modeling_albert.py
@@ -337,8 +337,6 @@ class AlbertModelIntegrationTest(unittest.TestCase):
         if version.parse(torch.__version__) < version.parse("2.4.0"):
             self.skipTest(reason="This test requires torch >= 2.4 to run.")
 
-        from transformers.integrations.executorch import TorchExportableModuleForEncoderOnlyLM
-
         distilbert_model = "albert/albert-base-v2"
         device = "cpu"
         attn_implementation = "sdpa"
@@ -365,15 +363,13 @@ class AlbertModelIntegrationTest(unittest.TestCase):
             ["capital", "capitol", "comune", "arrondissement", "bastille"],
         )
 
-        exportable_module = TorchExportableModuleForEncoderOnlyLM(model)
-        exported_program = exportable_module.export(
-            input_ids=inputs["input_ids"],
-            attention_mask=inputs["attention_mask"],
+        exported_program = torch.export.export(
+            model,
+            args=(inputs["input_ids"],),
+            kwargs={"attention_mask": inputs["attention_mask"]},
             strict=True,
         )
 
-        result = exported_program.module().forward(
-            input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"]
-        )
+        result = exported_program.module().forward(inputs["input_ids"], inputs["attention_mask"])
         ep_predicted_mask = tokenizer.decode(result.logits[0, 4].topk(5).indices)
         self.assertEqual(eg_predicted_mask, ep_predicted_mask)

--- a/tests/models/bert/test_modeling_bert.py
+++ b/tests/models/bert/test_modeling_bert.py
@@ -709,8 +709,6 @@ class BertModelIntegrationTest(unittest.TestCase):
         if version.parse(torch.__version__) < version.parse("2.4.0"):
             self.skipTest(reason="This test requires torch >= 2.4 to run.")
 
-        from transformers.integrations.executorch import TorchExportableModuleForEncoderOnlyLM
-
         bert_model = "google-bert/bert-base-uncased"
         device = "cpu"
         attn_implementation = "sdpa"
@@ -735,15 +733,13 @@ class BertModelIntegrationTest(unittest.TestCase):
         eg_predicted_mask = tokenizer.decode(logits[0, 6].topk(5).indices)
         self.assertEqual(eg_predicted_mask.split(), ["carpenter", "waiter", "barber", "mechanic", "salesman"])
 
-        exportable_module = TorchExportableModuleForEncoderOnlyLM(model)
-        exported_program = exportable_module.export(
-            input_ids=inputs["input_ids"],
-            attention_mask=inputs["attention_mask"],
+        exported_program = torch.export.export(
+            model,
+            args=(inputs["input_ids"],),
+            kwargs={"attention_mask": inputs["attention_mask"]},
             strict=True,
         )
 
-        result = exported_program.module().forward(
-            input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"]
-        )
+        result = exported_program.module().forward(inputs["input_ids"], inputs["attention_mask"])
         ep_predicted_mask = tokenizer.decode(result.logits[0, 6].topk(5).indices)
         self.assertEqual(eg_predicted_mask, ep_predicted_mask)

--- a/tests/models/distilbert/test_modeling_distilbert.py
+++ b/tests/models/distilbert/test_modeling_distilbert.py
@@ -404,8 +404,6 @@ class DistilBertModelIntegrationTest(unittest.TestCase):
         if not is_torch_greater_or_equal_than_2_4:
             self.skipTest(reason="This test requires torch >= 2.4 to run.")
 
-        from transformers.integrations.executorch import TorchExportableModuleForEncoderOnlyLM
-
         distilbert_model = "distilbert-base-uncased"
         device = "cpu"
         attn_implementation = "sdpa"
@@ -432,15 +430,13 @@ class DistilBertModelIntegrationTest(unittest.TestCase):
             ["capital", "birthplace", "northernmost", "centre", "southernmost"],
         )
 
-        exportable_module = TorchExportableModuleForEncoderOnlyLM(model)
-        exported_program = exportable_module.export(
-            input_ids=inputs["input_ids"],
-            attention_mask=inputs["attention_mask"],
+        exported_program = torch.export.export(
+            model,
+            args=(inputs["input_ids"],),
+            kwargs={"attention_mask": inputs["attention_mask"]},
             strict=True,
         )
 
-        result = exported_program.module().forward(
-            input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"]
-        )
+        result = exported_program.module().forward(inputs["input_ids"], inputs["attention_mask"])
         exported_predicted_mask = tokenizer.decode(result.logits[0, 4].topk(5).indices)
         self.assertEqual(eager_predicted_mask, exported_predicted_mask)

--- a/tests/models/mobilebert/test_modeling_mobilebert.py
+++ b/tests/models/mobilebert/test_modeling_mobilebert.py
@@ -395,8 +395,6 @@ class MobileBertModelIntegrationTests(unittest.TestCase):
         if version.parse(torch.__version__) < version.parse("2.4.0"):
             self.skipTest(reason="This test requires torch >= 2.4 to run.")
 
-        from transformers.integrations.executorch import TorchExportableModuleForEncoderOnlyLM
-
         mobilebert_model = "google/mobilebert-uncased"
         device = "cpu"
         attn_implementation = "eager"
@@ -420,15 +418,13 @@ class MobileBertModelIntegrationTests(unittest.TestCase):
         eg_predicted_mask = tokenizer.decode(logits[0, 6].topk(5).indices)
         self.assertEqual(eg_predicted_mask.split(), ["carpenter", "waiter", "mechanic", "teacher", "clerk"])
 
-        exportable_module = TorchExportableModuleForEncoderOnlyLM(model)
-        exported_program = exportable_module.export(
-            input_ids=inputs["input_ids"],
-            attention_mask=inputs["attention_mask"],
+        exported_program = torch.export.export(
+            model,
+            args=(inputs["input_ids"],),
+            kwargs={"attention_mask": inputs["attention_mask"]},
             strict=True,
         )
 
-        result = exported_program.module().forward(
-            input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"]
-        )
+        result = exported_program.module().forward(inputs["input_ids"], inputs["attention_mask"])
         ep_predicted_mask = tokenizer.decode(result.logits[0, 6].topk(5).indices)
         self.assertEqual(eg_predicted_mask, ep_predicted_mask)

--- a/tests/models/roberta/test_modeling_roberta.py
+++ b/tests/models/roberta/test_modeling_roberta.py
@@ -691,8 +691,6 @@ class RobertaModelIntegrationTest(TestCasePlus):
         if not is_torch_greater_or_equal_than_2_4:
             self.skipTest(reason="This test requires torch >= 2.4 to run.")
 
-        from transformers.integrations.executorch import TorchExportableModuleForEncoderOnlyLM
-
         roberta_model = "FacebookAI/roberta-base"
         device = "cpu"
         attn_implementation = "sdpa"
@@ -717,15 +715,13 @@ class RobertaModelIntegrationTest(TestCasePlus):
         eager_predicted_mask = tokenizer.decode(logits[0, 6].topk(5).indices)
         self.assertEqual(eager_predicted_mask.split(), ["happiness", "love", "peace", "freedom", "simplicity"])
 
-        exportable_module = TorchExportableModuleForEncoderOnlyLM(model)
-        exported_program = exportable_module.export(
-            input_ids=inputs["input_ids"],
-            attention_mask=inputs["attention_mask"],
+        exported_program = torch.export.export(
+            model,
+            args=(inputs["input_ids"],),
+            kwargs={"attention_mask": inputs["attention_mask"]},
             strict=True,
         )
 
-        result = exported_program.module().forward(
-            input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"]
-        )
+        result = exported_program.module().forward(inputs["input_ids"], inputs["attention_mask"])
         exported_predicted_mask = tokenizer.decode(result.logits[0, 6].topk(5).indices)
         self.assertEqual(eager_predicted_mask, exported_predicted_mask)


### PR DESCRIPTION
Now that we include a fast path using no vmapping, we can revert the extra treatment. Followup to #41586