### PR TITLE
Incorrect access of dataset field fixed

### DIFF
--- a/scripts/check_tokenizers.py
+++ b/scripts/check_tokenizers.py
@@ -155,12 +155,10 @@ def test_tokenizer(slow: PreTrainedTokenizerBase, fast: PreTrainedTokenizerBase)
     global batch_total
     for i in range(len(dataset)):
         # premise, all languages
-        for text in dataset[i]["premise"].values():
-            test_string(slow, fast, text)
+        test_string(slow, fast, dataset[i]["premise"])
 
         # hypothesis, all languages
-        for text in dataset[i]["hypothesis"]["translation"]:
-            test_string(slow, fast, text)
+        test_string(slow, fast, dataset[i]["hypothesis"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In `test_tokenizer`:

`for text in dataset[i]["premise"].values():
    test_string(slow, fast, text)

# hypothesis, all languages
for text in dataset[i]["hypothesis"]["translation"]:
    test_string(slow, fast, text)`

The "premise" field in the XNLI dataset is a string, not a dictionary**. Calling .values() on a string will raise an error. Similarly, "hypothesis" is also a string (not a dictionary), so "hypothesis"]["translation" will fail.