### PR TITLE
[CI] Build translated docs

### DIFF
--- a/.github/workflows/pr_build_doc_with_comment.yml
+++ b/.github/workflows/pr_build_doc_with_comment.yml
@@ -98,7 +98,7 @@ jobs:
       commit_sha: ${{ needs.get-pr-info.outputs.PR_HEAD_SHA }}
       pr_number: ${{ needs.get-pr-number.outputs.PR_NUMBER }}
       package: transformers
-      languages: ar de en es fr hi it ko pt tr zh ja te
+      languages: ar de en es fr hi it ja ko pt zh
 
   update_run_status:
     name: Update Check Run Status

--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,6 @@ tags
 
 # modular conversion
 *.modular_backup
+
+# Cursor IDE files
+.cursor/


### PR DESCRIPTION
Actually, this might be the reason why the translated docs aren't building when commenting `build-doc`. The `tr` and `te` language codes don't exist 😅 