### PR TITLE
Switch to CB if cache_implementation == paged

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -44,7 +44,7 @@ if TYPE_CHECKING:
 
 logger = logging.get_logger(__name__)
 METADATA_FIELDS = ("_from_model_config", "_commit_hash", "_original_object_hash", "transformers_version")
-STATIC_CACHE_IMPLEMENTATIONS = ("static", "offloaded_static")
+STATIC_CACHE_IMPLEMENTATIONS = ("static", "offloaded_static", "paged")
 DYNAMIC_CACHE_IMPLEMENTATIONS = ("dynamic", "dynamic_full", "offloaded", "quantized")
 # All the following are redundant and deprecated, but kept for BC
 DEPRECATED_STATIC_CACHE_IMPLEMENTATIONS = (

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2394,6 +2394,11 @@ class GenerationMixin(ContinuousMixin):
 
         # 0.b. If requested, switched to continuous batching generation
         if kwargs.get("cache_implementation") == "paged":
+            logger.warning(
+                "Detected cache_implementation=paged: switching to continuous batching. You should consider using "
+                "generate_batch directly instead."
+            )
+
             # generate_batch expects a list of lists of ints, so we create it from the inputs or input_ids
             inputs = inputs if inputs is not None else kwargs.get("input_ids")
             if inputs is None:
@@ -2435,17 +2440,13 @@ class GenerationMixin(ContinuousMixin):
                 logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
             num_return_sequences = kwargs.get("num_return_sequences", 1)
             num_beams = kwargs.get("num_beams", 1)
-            if num_return_sequences > 1 or num_beams > 1:  # FIXME: remove this once CB supports this (which is planned)
+            if num_return_sequences > 1 or num_beams > 1:  # FIXME: remove this once CB supports it (which is planned)
                 logger.warning(
                     f"num_return_sequences and num_beams are not supported for continuous batching yet. "
                     f"Got {num_return_sequences = } and {num_beams = }. "
                 )
 
-            # switch to CB and signal it
-            logger.warning(
-                "Detected cache_implementation=paged: switching to continuous batching. You should consider using "
-                "generate_batch directly instead."
-            )
+            # switch to CB
             outputs = self.generate_batch(
                 inputs=inputs,
                 generation_config=self._prepare_generation_config(generation_config, use_model_defaults, **kwargs)[0],

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2370,7 +2370,7 @@ class GenerationMixin(ContinuousMixin):
                     - [`~generation.GenerateEncoderDecoderOutput`],
                     - [`~generation.GenerateBeamEncoderDecoderOutput`]
         """
-        # 0. If requested, load an arbitrary generation recipe from the Hub and run it instead
+        # 0.a. If requested, load an arbitrary generation recipe from the Hub and run it instead
         trust_remote_code = kwargs.pop("trust_remote_code", None)
 
         if custom_generate is not None and isinstance(custom_generate, str):
@@ -2391,6 +2391,52 @@ class GenerationMixin(ContinuousMixin):
                 custom_generate, trust_remote_code=trust_remote_code, **kwargs
             )
             return custom_generate_function(model=self, **generate_arguments)
+
+        # 0.b. If requested, switched to continuous batching generation
+        if kwargs.get("cache_implementation") == "paged_cache":
+            # generate_batch expects a list of lists of ints
+            if inputs.dim() == 1:
+                inputs = inputs.unsqueeze(0).tolist()
+            elif inputs.dim() == 2:
+                inputs = inputs.tolist()
+            else:
+                raise ValueError(f"inputs must be a 1D or 2D tensor, got {inputs.dim() = }")
+
+            # some arguments are not supported for continuous batching
+            if stopping_criteria is not None:
+                raise NotImplementedError(
+                    f"stopping_criteria is not supported for continuous batching. Got {stopping_criteria = }"
+                )
+            if prefix_allowed_tokens_fn is not None:
+                raise NotImplementedError(
+                    f"prefix_allowed_tokens_fn is not supported for continuous batching. Got {prefix_allowed_tokens_fn = }"
+                )
+            if assistant_model is not None:
+                raise NotImplementedError(
+                    f"assistant_model is not supported for continuous batching. Got {assistant_model = }"
+                )
+            if streamer is not None:  # TODO: actualy this could be supported
+                raise NotImplementedError(f"streaming is not supported for continuous batching. Got {streamer = }")
+            if negative_prompt_ids is not None:
+                raise NotImplementedError(
+                    f"negative_prompt_ids is not supported for continuous batching. Got {negative_prompt_ids = }"
+                )
+            if negative_prompt_attention_mask is not None:
+                raise NotImplementedError(
+                    f"negative_prompt_attention_mask is not supported for continuous batching. Got {negative_prompt_attention_mask = }"
+                )
+
+            # others are ignored
+            if synced_gpus is not None:
+                logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
+
+            # switch to CB and signal it
+            logger.warning("Detected cache_implementation=paged_cache, switching to continuous batching.")
+            return self.generate_batch(
+                inputs=inputs,
+                generation_config=self._prepare_generation_config(generation_config, use_model_defaults, **kwargs)[0],
+                **kwargs,
+            )
 
         # 1. Handle kwargs, `generation_config`, validate them and obtain generation mode
         generation_mode_kwargs = self._extract_generation_mode_kwargs(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2433,6 +2433,13 @@ class GenerationMixin(ContinuousMixin):
             # others are ignored
             if synced_gpus is not None:
                 logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
+            num_return_sequences = kwargs.get("num_return_sequences", 1)
+            num_beams = kwargs.get("num_beams", 1)
+            if num_return_sequences > 1 or num_beams > 1:  # FIXME: remove this once CB supports this (which is planned)
+                logger.warning(
+                    f"num_return_sequences and num_beams are not supported for continuous batching yet. "
+                    f"Got {num_return_sequences = } and {num_beams = }. "
+                )
 
             # switch to CB and signal it
             logger.warning(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2394,7 +2394,12 @@ class GenerationMixin(ContinuousMixin):
 
         # 0.b. If requested, switched to continuous batching generation
         if kwargs.get("cache_implementation") == "paged_cache":
-            # generate_batch expects a list of lists of ints
+
+            # generate_batch expects a list of lists of ints, so we create it from the inputs or input_ids
+            inputs = inputs if inputs is not None else kwargs.get("input_ids")
+            if inputs is None:
+                raise ValueError("inputs or input_ids must be provided for CB generation.")
+
             if inputs.dim() == 1:
                 inputs = inputs.unsqueeze(0).tolist()
             elif inputs.dim() == 2:


### PR DESCRIPTION
This PR fixes one of the issues raised in #41501

This PR adds `paged` as a static cache implementation and switches from `generate` to `generate_batch` if it's the chosen implementation. It also raises errors if an argument for `generate` is passed to `generate_batch` but is not supported, and warn the user that `generate_batch` is used. 
The interface for the user stays the same, as the sample script below shows:
```
import os
import torch

from transformers import AutoModelForCausalLM, AutoTokenizer, GenerationConfig


if __name__ == '__main__':
    model_path = "Qwen/Qwen3-0.6B"

    tokenizer = AutoTokenizer.from_pretrained(
        model_path,
        trust_remote_code=True,
        add_bos_token=False,
        add_eos_token=False,
    )

    model = AutoModelForCausalLM.from_pretrained(
        model_path,
        dtype=torch.bfloat16,
        trust_remote_code=True,
        device_map="cuda",
    ).eval()

    prompt="How are you today?"
    chat_prompt=tokenizer.apply_chat_template(
        [{"role" : "user", "content" : prompt}],
        tokenize=False,
        add_generation_prompt=True,
        enable_thinking=False,
    )

    generation_config=GenerationConfig(
        do_sample=True,
        temperature=1.0,
        top_p=1.0,
        # num_return_sequences=8,
        max_new_tokens=100,
        eos_token_id=tokenizer.eos_token_id,
        pad_token_id=tokenizer.pad_token_id,
        use_cache=True,
        return_dict_in_generate=True,
        output_logits=True,
    )

    chat_prompt_ids = tokenizer(chat_prompt, return_tensors="pt")["input_ids"].to(model.device)

    print("Classic generate")
    output = model.generate(input_ids=chat_prompt_ids, generation_config=generation_config)[0]
    output_text = tokenizer.batch_decode(output[:, chat_prompt_ids.shape[1]:], skip_special_tokens=True)
    print(output_text)

    print("\nWith paged cache")
    output = model.generate(input_ids=chat_prompt_ids, generation_config=generation_config, cache_implementation="paged")[0]
    output_text = tokenizer.batch_decode(output[:, chat_prompt_ids.shape[1]:], skip_special_tokens=True)
    print(output_text)

```
which outputs
```
Classic generate
`generation_config` default values have been modified to match model-specific defaults: {'temperature': 0.6, 'top_k': 20, 'top_p': 0.95, 'bos_token_id': 151643}. If this is not desired, please set these values explicitly.
["Hello! I'm here to help you with anything you need. How can I assist you today?"]

With paged cache
Detected cache_implementation=paged: switching to continuous batching. You should consider using generate_batch directly instead.
No behavior specified for use_cuda_graph, defaulting to self.use_cuda_graph = False because self.model.config._attn_implementation = 'paged|sdpa'. If you want to save memory, turn off cuda graphs, but they can improve performances.
Solving 1 requests: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  2.16request/s]
["Hello! I'm here to help you with anything you need. How can I assist you today? 😊"]
```