### PR TITLE
Improve package version check

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -52,7 +52,10 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> Union[
         try:
             # importlib.metadata works with the distribution package, which may be different from the import
             # name (e.g. `PIL` is the import name, but `pillow` is the distribution name)
-            distribution_name = PACKAGE_DISTRIBUTION_MAPPING[pkg_name][0]
+            distributions = PACKAGE_DISTRIBUTION_MAPPING[pkg_name]
+            # In most cases, the packages are well-behaved and both have the same name. If it's not the case, we
+            # pick the first item of the list as best guess (it's almost always a list of length 1 anyway)
+            distribution_name = pkg_name if pkg_name in distributions else distributions[0]
             package_version = importlib.metadata.version(distribution_name)
         except importlib.metadata.PackageNotFoundError:
             # If we cannot find the metadata (because of editable install for example), try to import directly.


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/41651. In very niche cases, a package may have several distributions, leading to potential issues in our current check (if the wrong one is first). This PR fixes it by checking if a distribution of the same name exists