### PR TITLE
Simplify pipeline padding logic

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -103,9 +103,9 @@ def _pad(items, key, padding_value, padding_side):
 
         for i, item in enumerate(items):
             if padding_side == "left":
-                tensor[i, -len(item[key][0]) :] = item[key][0].clone()
+                tensor[i, -len(item[key][0]) :] = item[key][0]
             else:
-                tensor[i, : len(item[key][0])] = item[key][0].clone()
+                tensor[i, : len(item[key][0])] = item[key][0]
 
         return tensor
     else:

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -79,7 +79,7 @@ def _pad(items, key, padding_value, padding_side):
     if isinstance(items[0][key], torch.Tensor):
         # Others include `attention_mask` etc...
         shape = items[0][key].shape
-        dim = len(shape)
+        dim = items[0][key].ndim
         if dim == 1:
             # We have a list of 1-dim torch tensors, which can be stacked without padding
             return torch.cat([item[key] for item in items], dim=0)
@@ -94,37 +94,18 @@ def _pad(items, key, padding_value, padding_side):
         min_length = min(item[key].shape[1] for item in items)
         dtype = items[0][key].dtype
 
-        tensor = None
-        if dim == 2:
-            if max_length == min_length:
-                # Bypass for `ImageGPT` which doesn't provide a padding value, yet
-                # we can consistently pad since the size should be matching
-                return torch.cat([item[key] for item in items], dim=0)
-            tensor = torch.zeros((batch_size, max_length), dtype=dtype) + padding_value
-        elif dim == 3:
-            tensor = torch.zeros((batch_size, max_length, shape[-1]), dtype=dtype) + padding_value
-        elif dim == 4:
-            tensor = torch.zeros((batch_size, max_length, shape[-2], shape[-1]), dtype=dtype) + padding_value
-
-        if tensor is None:
-            raise ValueError(f"Unable to create tensor for padding from {key} with dimension {dim}")
+        if dim == 2 and max_length == min_length:
+            # Bypass for `ImageGPT` which doesn't provide a padding value, yet
+            # we can consistently pad since the size should be matching
+            return torch.cat([item[key] for item in items], dim=0)
+        else:
+            tensor = torch.zeros([batch_size, max_length] + list(shape[2:]), dtype=dtype) + padding_value
 
         for i, item in enumerate(items):
-            if dim == 2:
-                if padding_side == "left":
-                    tensor[i, -len(item[key][0]) :] = item[key][0].clone()
-                else:
-                    tensor[i, : len(item[key][0])] = item[key][0].clone()
-            elif dim == 3:
-                if padding_side == "left":
-                    tensor[i, -len(item[key][0]) :, :] = item[key][0].clone()
-                else:
-                    tensor[i, : len(item[key][0]), :] = item[key][0].clone()
-            elif dim == 4:
-                if padding_side == "left":
-                    tensor[i, -len(item[key][0]) :, :, :] = item[key][0].clone()
-                else:
-                    tensor[i, : len(item[key][0]), :, :] = item[key][0].clone()
+            if padding_side == "left":
+                tensor[i, -len(item[key][0]) :] = item[key][0].clone()
+            else:
+                tensor[i, : len(item[key][0])] = item[key][0].clone()
 
         return tensor
     else:

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -99,7 +99,7 @@ def _pad(items, key, padding_value, padding_side):
             # we can consistently pad since the size should be matching
             return torch.cat([item[key] for item in items], dim=0)
         else:
-            tensor = torch.zeros([batch_size, max_length] + list(shape[2:]), dtype=dtype) + padding_value
+            tensor = torch.full([batch_size, max_length] + list(shape[2:]), fill_value=padding_value, dtype=dtype)
 
         for i, item in enumerate(items):
             if padding_side == "left":


### PR DESCRIPTION
Follow-up to #41636 

When reviewing that PR I noticed the padding logic was cluttered and much more complex than it needed to be. We can eliminate a lot of code by just constructing shapes as lists and trusting in implicit slice dimensions