### PR TITLE
Fix graphormer model compilation with Cython 3.1.4

### DIFF
--- a/src/transformers/models/deprecated/graphormer/algos_graphormer.pyx
+++ b/src/transformers/models/deprecated/graphormer/algos_graphormer.pyx
@@ -85,8 +85,8 @@ def gen_edge_input(max_dist, path, edge_feat):
     cdef unsigned int n = nrows
     cdef unsigned int max_dist_copy = max_dist
 
-    path_copy = path.astype(long, order='C', casting='safe', copy=True)
-    edge_feat_copy = edge_feat.astype(long, order='C', casting='safe', copy=True)
+    path_copy = path.astype(int, order='C', casting='safe', copy=True)
+    edge_feat_copy = edge_feat.astype(int, order='C', casting='safe', copy=True)
     assert path_copy.flags['C_CONTIGUOUS']
     assert edge_feat_copy.flags['C_CONTIGUOUS']
 


### PR DESCRIPTION
Hitting this kind of error when running:

```
cython src/transformers/models/deprecated/graphormer/algos_graphormer.pyx
```

```
Error compiling Cython file:
------------------------------------------------------------
...
    (nrows, ncols) = path.shape
    assert nrows == ncols
    cdef unsigned int n = nrows
    cdef unsigned int max_dist_copy = max_dist

    path_copy = path.astype(long, order='C', casting='safe', copy=True)
                            ^
------------------------------------------------------------
src/transformers/models/deprecated/graphormer/algos_graphormer.pyx:88:28: undeclared name not builtin: long
```

This appears to have changed between cython==3.0 and cython==3.1.  AFAICT the correct type to use here would be `int`.  Switching to it makes the command succeed and generate an algos_graphormer.c file.