### PR TITLE
feat: add benchmark v2 ci with results pushed to dataset

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
             commit_id=$GITHUB_SHA
           fi
           commit_msg=$(git show -s --format=%s | cut -c1-70)
-          python3 benchmark_v2/run_benchmarks.py -b 1 -w 1 -i 1 -s 32 -n 5 --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --push-result-to-dataset "$DATASET_ID"
+          python3 benchmark_v2/run_benchmarks.py -b 32 -s 128 -n 256 --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --push-result-to-dataset "$DATASET_ID"
         env:
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
           PUSH_TO_HUB_TOKEN: ${{ secrets.PUSH_TO_HUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,7 +1,10 @@
 name: Self-hosted runner (benchmark)
 
 on:
-  workflow_dispatch:
+  push:
+    branches: [main]
+  pull_request:
+    types: [ opened, labeled, reopened, synchronize ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -9,6 +12,8 @@ concurrency:
 
 env:
   HF_HOME: /mnt/cache
+  DATASET_ID: hf-benchmarks/transformers
+  MODEL_ID: meta-llama/Llama-3.1-8B-Instruct
 
 jobs:
   benchmark:
@@ -31,26 +36,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Install libpq-dev & psql
-        run: |
-          apt update
-          apt install -y libpq-dev postgresql-client
-
       - name: Install benchmark script dependencies
-        run: python3 -m pip install -r benchmark/requirements.txt
+        run: python3 -m pip install -r benchmark_v2/requirements.txt kernels
 
       - name: Reinstall transformers in edit mode (remove the one installed during docker image build)
         working-directory: /transformers
-        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e ".[torch]"
-
-      - name: Run database init script
-        run: |
-          psql -f benchmark/utils/init_db.sql
-        env:
-          PGDATABASE: metrics
-          PGHOST: ${{ secrets.TRANSFORMERS_BENCHMARKS_PGHOST }}
-          PGUSER: transformers_benchmarks
-          PGPASSWORD: ${{ secrets.TRANSFORMERS_BENCHMARKS_PGPASSWORD }}
+        run: python3 -m pip uninstall -y transformers && python3 -m pip install -e ".[torch]" && python3 -m pip uninstall -y torchvision # temp fix
 
       - name: Run benchmark
         run: |
@@ -61,13 +52,11 @@ jobs:
             commit_id=$GITHUB_SHA
           fi
           commit_msg=$(git show -s --format=%s | cut -c1-70)
-          python3 benchmark/benchmarks_entrypoint.py "huggingface/transformers" "$BRANCH_NAME" "$commit_id" "$commit_msg"
+          python3 benchmark_v2/run_benchmarks.py -b 1 -w 1 -i 1 -s 32 -n 5 --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --monitor-gpu --push-result-to-dataset "$DATASET_ID"
         env:
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+          PUSH_TO_HUB_TOKEN: ${{ secrets.PUSH_TO_HUB_TOKEN }}
           # Enable this to see debug logs
           # HF_HUB_VERBOSITY: debug
           # TRANSFORMERS_VERBOSITY: debug
-          PGHOST: ${{ secrets.TRANSFORMERS_BENCHMARKS_PGHOST }}
-          PGUSER: transformers_benchmarks
-          PGPASSWORD: ${{ secrets.TRANSFORMERS_BENCHMARKS_PGPASSWORD }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
             commit_id=$GITHUB_SHA
           fi
           commit_msg=$(git show -s --format=%s | cut -c1-70)
-          python3 benchmark_v2/run_benchmarks.py -b 1 -w 1 -i 1 -s 32 -n 5 --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --monitor-gpu --push-result-to-dataset "$DATASET_ID"
+          python3 benchmark_v2/run_benchmarks.py -b 1 -w 1 -i 1 -s 32 -n 5 --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --push-result-to-dataset "$DATASET_ID"
         env:
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
           PUSH_TO_HUB_TOKEN: ${{ secrets.PUSH_TO_HUB_TOKEN }}

--- a/benchmark_v2/framework/benchmark_config.py
+++ b/benchmark_v2/framework/benchmark_config.py
@@ -22,7 +22,7 @@ class BenchmarkConfig:
         self,
         warmup_iterations: int = 5,
         measurement_iterations: int = 20,
-        gpu_monitoring: bool = False,  # False by default because it slows down the benchmark by a lot
+        gpu_monitoring: bool = True,  # NOTE: you may want to disable this at times as we have obsvered it could heavily slow down benchmarks on AMD
         batch_size: int = 1,
         sequence_length: int = 128,
         num_tokens_to_generate: int = 128,
@@ -136,7 +136,7 @@ def cross_generate_configs(
     batch_size: int = 1,
     sequence_length: int = 128,
     num_tokens_to_generate: int = 128,
-    gpu_monitoring: bool = False,  # this slows down the benchmark by a lot so we disable it by default
+    gpu_monitoring: bool = True,
 ) -> list[BenchmarkConfig]:
     # Create kwargs common to all configs
     kwargs = {
@@ -169,7 +169,7 @@ def generate_all_configs(
     batch_size: int = 1,
     sequence_length: int = 128,
     num_tokens_to_generate: int = 128,
-    gpu_monitoring: bool = False,
+    gpu_monitoring: bool = True,
 ) -> list[BenchmarkConfig]:
     all_attn_implementations = [
         ("flash_attention_2", None),
@@ -197,7 +197,6 @@ def generate_main_configs(
     batch_size: int = 1,
     sequence_length: int = 128,
     num_tokens_to_generate: int = 128,
-    gpu_monitoring: bool = False,
 ) -> list[BenchmarkConfig]:
     # Create kwargs common to all configs
     kwargs = {
@@ -206,10 +205,10 @@ def generate_main_configs(
         "batch_size": batch_size,
         "sequence_length": sequence_length,
         "num_tokens_to_generate": num_tokens_to_generate,
-        "gpu_monitoring": gpu_monitoring,
     }
     return [  # TODO: test max-autotune instead of default
-        BenchmarkConfig(attn_implementation="flex_attention", compile_mode="default", **kwargs),
-        BenchmarkConfig(attn_implementation="eager", compile_mode="default", **kwargs),
-        BenchmarkConfig(attn_implementation="flash_attention_2", **kwargs),
+        BenchmarkConfig(attn_implementation="flex_attention", compile_mode="default", gpu_monitoring=False, **kwargs),
+        BenchmarkConfig(attn_implementation="flex_attention", compile_mode="default", gpu_monitoring=True, **kwargs),
+        BenchmarkConfig(attn_implementation="eager", compile_mode="default", gpu_monitoring=True, **kwargs),
+        BenchmarkConfig(attn_implementation="flash_attention_2", gpu_monitoring=True, **kwargs),
     ]

--- a/benchmark_v2/framework/benchmark_runner.py
+++ b/benchmark_v2/framework/benchmark_runner.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pathlib
 import re
+import tempfile
 import time
 from contextlib import nullcontext
 from datetime import datetime
@@ -49,6 +50,8 @@ DEFAULT_PROMPT = "\n".join([
     "Weakened by external threats and internal opposition, the Committee of Public Safety was replaced in November 1795 by the Directory.",
     "Its instability ended in the coup of 18 Brumaire and the establishment of the Consulate, with Napoleon Bonaparte as First Consul.",
 ])  # fmt: skip
+
+PUSH_TO_HUB_TOKEN = os.getenv("PUSH_TO_HUB_TOKEN", None)
 
 
 def compact_json_numeric_arrays(data: dict):
@@ -120,15 +123,19 @@ def flush_memory():
 
 class BenchmarkStreamer(BaseStreamer):
     def __init__(self, **kwargs) -> None:
+        self.timeout = kwargs.pop("timeout", 10)
         self.timestamps = []
         self.text_queue = Queue()
+        self.stop_signal = None
 
     def put(self, value):
         """Receives tokens and logs the timestamp of the generation."""
         self.timestamps.append(time.perf_counter())
+        self.text_queue.put(value)
 
     def end(self):
         self.timestamps.append(time.perf_counter())
+        self.text_queue.put(self.stop_signal)
 
     def __iter__(self):
         return self
@@ -144,13 +151,24 @@ class BenchmarkStreamer(BaseStreamer):
 class BenchmarkRunner:
     """Main benchmark runner that coordinates benchmark execution."""
 
-    def __init__(self, logger: logging.Logger, output_dir: str | None = None, commit_id: str | None = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger,
+        output_dir: str | None = None,
+        branch_name: str | None = None,
+        commit_id: str | None = None,
+        commit_message: str | None = None,
+        dataset_id: str | None = None,
+    ) -> None:
         # Those stay constant for the whole run
         self.logger = logger
         if output_dir is None:
             output_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), "benchmark_results")
         self.output_dir = output_dir
+        self.branch_name = branch_name
         self.commit_id = get_git_revision() if commit_id is None else commit_id
+        self.commit_message = commit_message
+        self.dataset_id = dataset_id
         os.makedirs(self.output_dir, exist_ok=True)
         self.profile_dir = None
         # Attributes that are reset for each model
@@ -163,7 +181,7 @@ class BenchmarkRunner:
         self.model = None
         flush_memory()
 
-    def setup_one_run(self, model_id: str, config: BenchmarkConfig) -> None:
+    def setup_benchmark(self, model_id: str, config: BenchmarkConfig) -> None:
         # Some attributes only need to be set once per model
         if self._setup_for != model_id:
             self.tokenizer = AutoTokenizer.from_pretrained(model_id)
@@ -200,10 +218,13 @@ class BenchmarkRunner:
         self.model = self.model.eval().to(config.device)
 
         # Kernelize the model if needed
-        if config.kernelize:
+        if config.kernelize and kernelize is not None and Mode is not None:
             self.model = kernelize(self.model, mode=Mode.INFERENCE)
 
-    def run_one_benchmark(self, model_id: str, config: BenchmarkConfig, num_tokens_to_profile: int = 0) -> None:
+    def run_benchmark(
+        self, model_id: str, config: BenchmarkConfig, num_tokens_to_profile: int = 0
+    ) -> dict[str, Any] | None:
+        """Run a single benchmark with the given model ID and config."""
         sdpa_ctx = nullcontext()
         if config.attn_implementation == "sdpa":
             sdpa_backend = get_sdpa_backend(config.sdpa_backend)
@@ -243,7 +264,12 @@ class BenchmarkRunner:
                 self.profile_generate(num_tokens_to_profile, config.name)
 
             return {
-                "metadata": BenchmarkMetadata(model_id=model_id, commit_id=self.commit_id),
+                "metadata": BenchmarkMetadata(
+                    model_id=model_id,
+                    branch_name=self.branch_name,
+                    commit_id=self.commit_id,
+                    commit_message=self.commit_message,
+                ),
                 "measurements": result,
                 "config": config,
             }
@@ -306,6 +332,7 @@ class BenchmarkRunner:
         num_tokens_to_profile: int = 0,
         pretty_print_summary: bool = True,
     ) -> dict[str, Any]:
+        """Run multiple benchmarks for the given model ID and list of benchmark configs."""
         all_results = {}
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         start_time = time.perf_counter()
@@ -324,14 +351,14 @@ class BenchmarkRunner:
                 continue
 
             # Otherwise, run the benchmark
-            self.setup_one_run(model_id, config)
+            self.setup_benchmark(model_id, config)
             self.logger.info(
                 f"Running benchmark of model {model_id} with scenario: {config.name} ({i + 1}/{n_configs})"
             )
 
             # Launch benchmark in a try/except block to avoid stopping the whole run if one benchmark fails
             try:
-                results = self.run_one_benchmark(model_id, config, num_tokens_to_profile)
+                results = self.run_benchmark(model_id, config, num_tokens_to_profile)
                 if results is not None:
                     all_results[config.hash] = results
 
@@ -357,6 +384,47 @@ class BenchmarkRunner:
                 print(f"Config: {result['config'].infer_name(compact=False)}\n")
                 result["measurements"].pprint(batch_size=result["config"].batch_size, tabs=1)
             print("=" * 100)
+
+        if PUSH_TO_HUB_TOKEN is None and self.dataset_id is not None:
+            raise ValueError(
+                "PUSH_TO_HUB_TOKEN is not set, cannot push results to the Hub. When setting dataset_id, please also set the PUSH_TO_HUB_TOKEN environment variable."
+            )
+
+        n_results = len(all_results)
+        if self.dataset_id is not None and n_results > 0:
+            from datasets import Dataset
+            from huggingface_hub import HfApi
+
+            self.logger.info(f"Pushing {n_results} results to: {self.dataset_id}")
+            rows = []
+            for cfg_hash, entry in all_results.items():
+                row = {
+                    "benchmark_config_hash": cfg_hash,
+                    "config": entry["config"].to_dict(),
+                    "measurements": entry["measurements"].to_dict(),
+                    "metadata": entry["metadata"].to_dict(),
+                }
+                rows.append(row)
+
+            ds = Dataset.from_list(rows)
+            with tempfile.TemporaryDirectory() as tmp:
+                jsonl_path = os.path.join(tmp, "data.jsonl")
+                with open(jsonl_path, "w") as f:
+                    for ex in ds:
+                        f.write(json.dumps(ex, ensure_ascii=False) + "\n")
+
+                api = HfApi()
+                # NOTE: we expect the repository to already exist
+                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S") if not timestamp else timestamp
+                file_name = f"benchmark_run_{timestamp}.jsonl"
+                api.upload_file(
+                    path_or_fileobj=jsonl_path,
+                    path_in_repo=file_name,
+                    repo_id=self.dataset_id,
+                    repo_type="dataset",
+                    token=PUSH_TO_HUB_TOKEN,
+                )
+            self.logger.info(f"Succesfully uploaded results to: {self.dataset_id}")
 
         return all_results
 

--- a/benchmark_v2/framework/benchmark_runner.py
+++ b/benchmark_v2/framework/benchmark_runner.py
@@ -12,6 +12,8 @@ from queue import Queue
 from typing import Any
 
 import torch
+from datasets import Dataset
+from huggingface_hub import HfApi
 from tqdm import trange
 
 from transformers import (
@@ -418,9 +420,6 @@ class BenchmarkRunner:
             raise ValueError(
                 "PUSH_TO_HUB_TOKEN is not set, cannot push results to the Hub. When setting dataset_id, please also set the PUSH_TO_HUB_TOKEN environment variable."
             )
-
-        from datasets import Dataset
-        from huggingface_hub import HfApi
 
         n_results = len(results)
         self.logger.info(f"Pushing {n_results} results to: {dataset_id}")

--- a/benchmark_v2/framework/data_classes.py
+++ b/benchmark_v2/framework/data_classes.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import numpy as np
@@ -59,19 +59,26 @@ class BenchmarkMetadata:
 
     model_id: str
     timestamp: str
+    branch_name: str
     commit_id: str
+    commit_message: str
     hardware_info: HardwareInfo
 
-    def __init__(self, model_id: str, commit_id: str):
+    def __init__(self, model_id: str, commit_id: str, branch_name: str = "main", commit_message: str = "") -> None:
         self.model_id = model_id
-        self.timestamp = datetime.utcnow().isoformat()
+        self.timestamp = datetime.now(timezone.utc).isoformat()
+        self.branch_name = branch_name
         self.commit_id = commit_id
+        self.commit_message = commit_message
         self.hardware_info = HardwareInfo()
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "model_id": self.model_id,
             "timestamp": self.timestamp,
+            "branch_name": self.branch_name,
             "commit_id": self.commit_id,
+            "commit_message": self.commit_message,
             "hardware_info": self.hardware_info.to_dict(),
         }
 

--- a/benchmark_v2/requirements.txt
+++ b/benchmark_v2/requirements.txt
@@ -4,4 +4,4 @@ gpustat>=1.0.0
 torch>=2.0.0
 transformers>=4.30.0
 datasets>=2.10.0
-huggingface_hub>=0.16.0 
+huggingface_hub>=0.16.0

--- a/benchmark_v2/run_benchmarks.py
+++ b/benchmark_v2/run_benchmarks.py
@@ -20,7 +20,6 @@ in the ./benches directory, organizing outputs into model-specific subfolders.
 
 import argparse
 import logging
-import os
 import sys
 import uuid
 
@@ -48,7 +47,9 @@ if __name__ == "__main__":
     parser.add_argument("--commit-id", type=str, help="Git commit ID (if not provided, will auto-detect from git)")
     parser.add_argument("--commit-message", type=str, help="Git commit message")
 
-    parser.add_argument("--monitor-gpu", action="store_true", help="Whether to monitor GPU usage during benchmarks")
+    parser.add_argument(
+        "--no-gpu-monitoring", action="store_true", help="Disables GPU monitoring during benchmark runs"
+    )
 
     parser.add_argument(
         "--push-result-to-dataset",
@@ -87,7 +88,7 @@ if __name__ == "__main__":
                 batch_size=args.batch_size[0],
                 sequence_length=args.sequence_length[0],
                 num_tokens_to_generate=args.num_tokens_to_generate[0],
-                gpu_monitoring=args.monitor_gpu,
+                gpu_monitoring=not args.no_gpu_monitoring,
             )
         else:
             benchmark_configs = generate_main_configs(
@@ -96,7 +97,6 @@ if __name__ == "__main__":
                 batch_size=args.batch_size[0],
                 sequence_length=args.sequence_length[0],
                 num_tokens_to_generate=args.num_tokens_to_generate[0],
-                gpu_monitoring=args.monitor_gpu,
             )
 
     # Otherwise, we benchmark across all combinations of dimensions
@@ -107,7 +107,6 @@ if __name__ == "__main__":
             batch_size=args.batch_size[0],
             sequence_length=args.sequence_length[0],
             num_tokens_to_generate=args.num_tokens_to_generate[0],
-            gpu_monitoring=args.monitor_gpu,
         )[0]
         benchmark_configs = []
         for num_tokens_to_generate in args.num_tokens_to_generate:

--- a/benchmark_v2/run_benchmarks.py
+++ b/benchmark_v2/run_benchmarks.py
@@ -125,12 +125,18 @@ if __name__ == "__main__":
         args.branch_name,
         args.commit_id,
         args.commit_message,
-        dataset_id=args.push_result_to_dataset,
     )
-    results = runner.run_benchmarks(
+    timestamp, results = runner.run_benchmarks(
         args.model_id,
         benchmark_configs,
         args.num_tokens_to_profile,
         pretty_print_summary=True,
     )
-    # runner.save_results(args.model_id, results)
+
+    dataset_id = args.push_result_to_dataset
+    if dataset_id is not None and len(results) > 0:
+        runner.push_results_to_hub(
+            dataset_id,
+            results,
+            timestamp,
+        )


### PR DESCRIPTION
Reusing the old `benchmark.yml` workflow for the benchmark v2, we'll eventually rename and clean up everything once we're confident it works nicely.

Benchmark results will be pushed to a dataset, for now located [here](https://huggingface.co/datasets/hf-benchmarks/transformers).

I chose JSONL for simplicity of parsing in the frontend space, and file name have the following format: `f"benchmark_run_{timestamp}.jsonl"`.

Also did a little naming refactoring and added extra metadata