### PR TITLE
Remove upper version bound of pandas

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ _deps = [
     "opencv-python",
     "optimum-benchmark>=0.3.0",
     "optuna",
-    "pandas<2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
+    "pandas!=2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
     "packaging>=20.0",
     "parameterized>=0.9",  # older version of parameterized cause pytest collection to fail on .expand
     "phonemizer",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -38,7 +38,7 @@ deps = {
     "opencv-python": "opencv-python",
     "optimum-benchmark": "optimum-benchmark>=0.3.0",
     "optuna": "optuna",
-    "pandas": "pandas<2.3.0",
+    "pandas": "pandas!=2.3.0",
     "packaging": "packaging>=20.0",
     "parameterized": "parameterized>=0.9",
     "phonemizer": "phonemizer",


### PR DESCRIPTION
# What does this PR do?

Let's skip pandas 2.3.0 and allow users to install newer versions.
