### PR TITLE
Fix qwen3_vl mix precision dtype

### DIFF
--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1172,10 +1172,11 @@ class Qwen3OmniMoeVisionEncoder(Qwen3OmniMoePreTrainedModel):
         Returns:
             `torch.Tensor`: hidden_states.
         """
+        input_dtype = hidden_states.dtype
         hidden_states = self.patch_embed(hidden_states)
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
-        hidden_states = hidden_states + pos_embeds
+        hidden_states = (hidden_states + pos_embeds).to(input_dtype)
 
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -740,10 +740,11 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         Returns:
             `torch.Tensor`: hidden_states.
         """
+        input_dtype = hidden_states.dtype
         hidden_states = self.patch_embed(hidden_states)
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
-        hidden_states = hidden_states + pos_embeds
+        hidden_states = (hidden_states + pos_embeds).to(input_dtype)
 
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -640,10 +640,11 @@ class Qwen3VLVisionModel(Qwen3VLPreTrainedModel):
         Returns:
             `torch.Tensor`: hidden_states.
         """
+        input_dtype = hidden_states.dtype
         hidden_states = self.patch_embed(hidden_states)
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
-        hidden_states = hidden_states + pos_embeds
+        hidden_states = (hidden_states + pos_embeds).to(input_dtype)
 
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -731,10 +731,11 @@ class Qwen3VLMoeVisionModel(Qwen3VLMoePreTrainedModel):
         Returns:
             `torch.Tensor`: hidden_states.
         """
+        input_dtype = hidden_states.dtype
         hidden_states = self.patch_embed(hidden_states)
 
         pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
-        hidden_states = hidden_states + pos_embeds
+        hidden_states = (hidden_states + pos_embeds).to(input_dtype)
 
         rotary_pos_emb = self.rot_pos_emb(grid_thw)
 


### PR DESCRIPTION
`fast_pos_embed_interpolate` returns `pos_embeds` in the same dtype as the master weights.

Therefore, when the master weights are in FP32 but the forward pass runs in BF16, `hidden_states` will be upcast to FP32, causing dtype mismatches with other activations.

CC @yonigozlan @molbap @zucchini-nlp