### PR TITLE
AutoTokenizer: clear ImportError when loading Voxtral without mistral-common + unit test

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -1096,6 +1096,12 @@ class AutoTokenizer:
                 trust_remote_code, pretrained_model_name_or_path, has_local_code, has_remote_code, upstream_repo
             )
 
+        # Detect missing dependency for Voxtral early and provide a clear error message
+        if getattr(config, "model_type", None) == "voxtral" and not is_mistral_common_available():
+            raise ImportError(
+                "The Voxtral tokenizer requires the 'mistral-common' package. Please install it using `pip install mistral-common`."
+            )
+
         if has_remote_code and trust_remote_code:
             tokenizer_class = get_class_from_dynamic_module(class_ref, pretrained_model_name_or_path, **kwargs)
             _ = kwargs.pop("code_revision", None)

--- a/tests/models/voxtral/test_tokenization_voxtral.py
+++ b/tests/models/voxtral/test_tokenization_voxtral.py
@@ -1,0 +1,17 @@
+import pytest
+
+from transformers import AutoTokenizer
+from transformers.models.voxtral import VoxtralConfig
+import transformers.models.auto.tokenization_auto as ta
+
+
+def test_voxtral_tokenizer_requires_mistral_common(monkeypatch):
+    # Simulate that mistral_common is not available for the auto-tokenizer logic
+    monkeypatch.setattr(ta, "is_mistral_common_available", lambda: False)
+    # Avoid network access by short-circuiting tokenizer_config retrieval
+    monkeypatch.setattr(ta, "get_tokenizer_config", lambda *args, **kwargs: {})
+    with pytest.raises(ImportError, match="mistral-common"):
+        # Using a dummy path since the guard should raise before any file access
+        AutoTokenizer.from_pretrained("dummy", config=VoxtralConfig())
+
+


### PR DESCRIPTION
Summary: Fix confusing TypeError from SentencePiece when loading Voxtral tokenizer without mistral-common by raising a clear ImportError instead. Fixes #41553.
Rationale: Without mistral-common, loading via AutoTokenizer ends in a low-level TypeError inside sentencepiece. Users should see a direct, actionable message.
What’s changed
AutoTokenizer guard:
In AutoTokenizer.from_pretrained, after resolving config and before class selection, raise a clear error if config.model_type == "voxtral" and mistral-common is missing.
Message:
"The Voxtral tokenizer requires the 'mistral-common' package. Please install it using pip install mistral-common."
Tests:
Added tests/models/voxtral/test_tokenization_voxtral.py
Mocks is_mistral_common_available to False and get_tokenizer_config to avoid network, then asserts ImportError mentioning "mistral-common".
Why this approach
Keeps mapping logic intact; avoids unexpected fallbacks.
Ensures the user sees a clear, actionable message as early as possible in the loading path.
Testing
Targeted test: pytest tests/models/voxtral/test_tokenization_voxtral.py -q → passes.
No network calls thanks to test monkeypatching.
Backward compatibility
No behavior change when mistral-common is installed.
Only affects Voxtral when the dependency is missing.