### PR TITLE
Fix Qwen3Next dtype API usage

### DIFF
--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -637,7 +637,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 eps=self.layer_norm_epsilon,
                 activation=self.activation,
                 device=torch.cuda.current_device(),
-                dtype=config.dtype if config.dtype is not None else torch.get_current_dtype(),
+                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -473,7 +473,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
                 eps=self.layer_norm_epsilon,
                 activation=self.activation,
                 device=torch.cuda.current_device(),
-                dtype=config.dtype if config.dtype is not None else torch.get_current_dtype(),
+                dtype=config.dtype if config.dtype is not None else torch.get_default_dtype(),
             )
         )
 


### PR DESCRIPTION
This PR fixes an invalid PyTorch API usage in the Qwen3Next model.

### Changes
- Replaced `torch.get_current_dtype()` with `torch.get_default_dtype()` in both modular and modeling files
- This change fixes FLA (Flash Linear Attention) compatibility when using different dtypes like float32/float16

### Technical Details
- The original code was using a non-existent PyTorch API `get_current_dtype()`
- The correct API is `get_default_dtype()` which returns the global default dtype setting
- This change ensures proper dtype handling in the Qwen3Next GatedDeltaNet normalization layer

### Testing
The changes have been tested with `make fixup` and pass the repository consistency checks.

Fix #41732 