### PR TITLE
Revert "Remove upper version bound of pandas"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ _deps = [
     "opencv-python",
     "optimum-benchmark>=0.3.0",
     "optuna",
-    "pandas!=2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
+    "pandas<2.3.0",  # `datasets` requires `pandas` while `pandas==2.3.0` has issues with CircleCI on 2025/06/05
     "packaging>=20.0",
     "parameterized>=0.9",  # older version of parameterized cause pytest collection to fail on .expand
     "phonemizer",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -38,7 +38,7 @@ deps = {
     "opencv-python": "opencv-python",
     "optimum-benchmark": "optimum-benchmark>=0.3.0",
     "optuna": "optuna",
-    "pandas": "pandas!=2.3.0",
+    "pandas": "pandas<2.3.0",
     "packaging": "packaging>=20.0",
     "parameterized": "parameterized>=0.9",
     "phonemizer": "phonemizer",


### PR DESCRIPTION
Reverts huggingface/transformers#41677

Unfortunately, when installed as `pip install -e .[dev]`, this unpin causes the installation fail

See [here](https://github.com/huggingface/transformers/actions/runs/18638585996/job/53133400345)

Let's revert this as at this moment there is also torch/trochcodec issue which is a priority to handle.

```
2025-10-20T00:43:42.6168504Z #11 16.22   Downloading pandas-2.0.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
2025-10-20T00:43:42.7684836Z #11 16.27   Downloading pandas-2.0.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
2025-10-20T00:43:42.7686067Z #11 16.31   Downloading pandas-2.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
2025-10-20T00:43:42.7687275Z #11 16.37   Downloading pandas-2.0.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (18 kB)
2025-10-20T00:43:42.8713511Z #11 16.41   Downloading pandas-1.5.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
2025-10-20T00:43:42.8714662Z #11 16.43   Downloading pandas-1.5.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
2025-10-20T00:43:42.8715862Z #11 16.45   Downloading pandas-1.5.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
2025-10-20T00:43:42.8717473Z #11 16.47   Downloading pandas-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
2025-10-20T00:43:42.9738014Z #11 16.49   Downloading pandas-1.4.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:42.9739213Z #11 16.51   Downloading pandas-1.4.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:42.9740359Z #11 16.53   Downloading pandas-1.4.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:42.9741802Z #11 16.55   Downloading pandas-1.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:42.9742942Z #11 16.58   Downloading pandas-1.4.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:43.0869588Z #11 16.60   Downloading pandas-1.3.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:43.0870327Z #11 16.63   Downloading pandas-1.3.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (12 kB)
2025-10-20T00:43:43.0870920Z #11 16.65   Downloading pandas-1.3.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)
2025-10-20T00:43:43.0871386Z #11 16.69   Downloading pandas-1.3.2.tar.gz (4.7 MB)
2025-10-20T00:43:43.2866880Z #11 16.74      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 4.7/4.7 MB 103.9 MB/s  0:00:00
2025-10-20T00:43:43.6341874Z #11 17.24   Installing build dependencies: started
2025-10-20T00:44:38.2660884Z #11 71.87   Installing build dependencies: finished with status 'error'
2025-10-20T00:44:38.4943389Z #11 71.90   error: subprocess-exited-with-error
2025-10-20T00:44:38.4943752Z #11 71.90   
2025-10-20T00:44:38.4944297Z #11 71.90   × pip subprocess to install build dependencies did not run successfully.
2025-10-20T00:44:38.4944687Z #11 71.90   │ exit code: 1
2025-10-20T00:44:38.4944958Z #11 71.90   ╰─> [966 lines of output]
2025-10-20T00:44:38.4945575Z #11 71.90       Ignoring numpy: markers 'python_version == "3.7" and (platform_machine != "arm64" or platform_system != "Darwin") and platform_machine != "aarch64"' don't match your environment
2025-10-20T00:44:38.4946813Z #11 71.90       Ignoring numpy: markers 'python_version == "3.8" and (platform_machine != "arm64" or platform_system != "Darwin") and platform_machine != "aarch64"' don't match your environment
2025-10-20T00:44:38.4947604Z #11 71.90       Ignoring numpy: markers 'python_version == "3.7" and platform_machine == "aarch64"' don't match your environment
2025-10-20T00:44:38.4948213Z #11 71.90       Ignoring numpy: markers 'python_version == "3.8" and platform_machine == "aarch64"' don't match your environment
2025-10-20T00:44:38.4948884Z #11 71.90       Ignoring numpy: markers 'python_version == "3.8" and platform_machine == "arm64" and platform_system == "Darwin"' don't match your environment
2025-10-20T00:44:38.4949634Z #11 71.90       Ignoring numpy: markers 'python_version == "3.9" and platform_machine == "arm64" and platform_system == "Darwin"' don't match your environment
2025-10-20T00:44:38.4950149Z #11 71.90       Collecting setuptools>=51.0.0
2025-10-20T00:44:38.4950527Z #11 71.90         Using cached setuptools-80.9.0-py3-none-any.whl.metadata (6.6 kB)
2025-10-20T00:44:38.4950873Z #11 71.90       Collecting wheel
2025-10-20T00:44:38.4951190Z #11 71.90         Using cached wheel-0.45.1-py3-none-any.whl.metadata (2.3 kB)
2025-10-20T00:44:38.4951525Z #11 71.90       Collecting Cython<3,>=0.29.21
2025-10-20T00:44:38.4952024Z #11 71.90         Downloading Cython-0.29.37-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl.metadata (3.1 kB)
2025-10-20T00:44:38.4952515Z #11 71.90       Collecting numpy==1.19.3
2025-10-20T00:44:38.4952787Z #11 71.90         Downloading numpy-1.19.3.zip (7.3 MB)
2025-10-20T00:44:38.4953181Z #11 71.90            ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 7.3/7.3 MB 177.3 MB/s  0:00:00
2025-10-20T00:44:38.4953493Z #11 71.90         Installing build dependencies: started
2025-10-20T00:44:38.4953938Z #11 71.90         Installing build dependencies: finished with status 'done'
2025-10-20T00:44:38.4954292Z #11 71.90         Getting requirements to build wheel: started
2025-10-20T00:44:38.4954655Z #11 71.90         Getting requirements to build wheel: finished with status 'done'
2025-10-20T00:44:38.4955020Z #11 71.90         Preparing metadata (pyproject.toml): started
2025-10-20T00:44:38.4955383Z #11 71.90         Preparing metadata (pyproject.toml): finished with status 'done'
2025-10-20T00:44:38.4955917Z #11 71.90       Using cached Cython-0.29.37-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl (1.9 MB)
2025-10-20T00:44:38.4956548Z #11 71.90       Using cached setuptools-80.9.0-py3-none-any.whl (1.2 MB)
2025-10-20T00:44:38.4956904Z #11 71.90       Using cached wheel-0.45.1-py3-none-any.whl (72 kB)
2025-10-20T00:44:38.4957236Z #11 71.90       Building wheels for collected packages: numpy
2025-10-20T00:44:38.4957566Z #11 71.90         Building wheel for numpy (pyproject.toml): started
2025-10-20T00:44:38.4957951Z #11 71.90         Building wheel for numpy (pyproject.toml): finished with status 'error'
2025-10-20T00:44:38.4958330Z #11 71.90         error: subprocess-exited-with-error
2025-10-20T00:44:38.4958578Z #11 71.90       
2025-10-20T00:44:38.4958927Z #11 71.90         × Building wheel for numpy (pyproject.toml) did not run successfully.
2025-10-20T00:44:38.4959294Z #11 71.90         │ exit code: 1
2025-10-20T00:44:38.4959573Z #11 71.90         ╰─> [925 lines of output]
2025-10-20T00:44:38.4959922Z #11 71.90             setup.py:67: RuntimeWarning: NumPy 1.19.3 may not yet support Python 3.10.
2025-10-20T00:44:38.4960268Z #11 71.90               warnings.warn(
2025-10-20T00:44:38.4960534Z #11 71.90             Running from numpy source directory.
2025-10-20T00:44:38.4961409Z #11 71.90             /tmp/pip-install-3iys8892/numpy_5d8c3d5f9dd14f69a67d14c539181119/tools/cythonize.py:67: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
```