### PR TITLE
Remove invalid `@staticmethod` from module-level get_device_and_memory_breakdown

### DIFF
--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -27,7 +27,6 @@ from ...utils.metrics import traced
 logger = logging.getLogger("ContinuousBatchingLogger")
 
 
-@staticmethod
 def get_device_and_memory_breakdown() -> tuple[torch.device, int, int, int]:
     if torch.cuda.is_available():
         device = torch.device("cuda")


### PR DESCRIPTION
Remove invalid staticmethod decorator from module-level function `get_device_and_memory_breakdown`.

This PR removes an incorrect @staticmethod decorator applied to the module-level function `get_device_and_memory_breakdown`.

The decorator caused a runtime error on Python 3.9, even though it appeared to work fine on newer Python versions.

See `trl` stacktrace for Python 3.9: https://github.com/huggingface/trl/actions/runs/18605452485/job/53053774127
```python
ERROR    ContinuousBatchingLogger:continuous_api.py:879 Error in generation loop: 'staticmethod' object is not callable
Traceback (most recent call last):
  File "/__w/trl/trl/.venv/lib/python3.9/site-packages/transformers/generation/continuous_batching/continuous_api.py", line 837, in _run_generation_loop
    paged_attention_cache = PagedAttentionCache(
  File "/__w/trl/trl/.venv/lib/python3.9/site-packages/transformers/generation/continuous_batching/cache.py", line 191, in __init__
    num_blocks, max_batch_tokens = memory_handler.infer_num_blocks_and_max_batch_tokens(
  File "/__w/trl/trl/.venv/lib/python3.9/site-packages/transformers/generation/continuous_batching/cache.py", line 437, in infer_num_blocks_and_max_batch_tokens
    num_blocks, max_batch_tokens = self.compute_num_blocks_and_max_batch_tokens(
  File "/__w/trl/trl/.venv/lib/python3.9/site-packages/transformers/generation/continuous_batching/cache.py", line 476, in compute_num_blocks_and_max_batch_tokens
    cache_memory = self.get_available_memory(max_memory_percent)
  File "/__w/trl/trl/.venv/lib/python3.9/site-packages/transformers/generation/continuous_batching/cache.py", line 411, in get_available_memory
    _, total, reserved, allocated = get_device_and_memory_breakdown()
TypeError: 'staticmethod' object is not callable
```

### Root cause
In Python 3.9 and earlier, `@staticmethod` produces a descriptor object that is not directly callable when defined outside a class.

Starting with Python 3.10, CPython changed the behavior of `staticmethod`: staticmethod objects gained a `__call__` method that delegates to the wrapped function, making them callable even outside a class context. However, this masked the underlying issue in newer Python versions.

### Fix
Remove the invalid decorator and leave the function as a normal callable at module scope.

This PR will fix https://github.com/huggingface/trl/issues/4308

CC: @remi-or, who created the original PR:
- https://github.com/huggingface/transformers/pull/40426