### PR TITLE
Reduce warning noise caused by Tensor.new_tensor

### DIFF
--- a/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
+++ b/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py
@@ -450,7 +450,7 @@ class EncoderDecoderModel(PreTrainedModel, GenerationMixin):
                 labels, self.config.pad_token_id, self.config.decoder_start_token_id
             )
             if decoder_attention_mask is None:
-                decoder_attention_mask = decoder_input_ids.new_tensor(decoder_input_ids != self.config.pad_token_id)
+                decoder_attention_mask = (decoder_input_ids != self.config.pad_token_id).to(decoder_input_ids.dtype)
 
         # Decode
         decoder_outputs = self.decoder(


### PR DESCRIPTION
# What does this PR do?

This PR replaces `Tensor.new_tensor()` calls to suppress warning that users cannot address. This allows users to avoid being confused by warnings they cannot act on, making it easier for them to focus on meaningful warnings.

More specifically, when calling the `EncoderDecoderModel` forward method, users see warning like:

```py
from transformers import EncoderDecoderModel, AutoTokenizer

tok = AutoTokenizer.from_pretrained("bert-base-uncased")
model = EncoderDecoderModel.from_encoder_decoder_pretrained("bert-base-uncased", "bert-base-uncased")
model.config.decoder_start_token_id = tok.cls_token_id
model.config.pad_token_id = tok.pad_token_id

src = tok("hello world", return_tensors="pt")
tgt = tok("hi there", return_tensors="pt").input_ids
labels = tgt.clone()
labels[labels == tok.pad_token_id] = -100

out = model(
    input_ids=src["input_ids"],
    attention_mask=src["attention_mask"],
    labels=labels,
)
```

```sh
/home/shutotakahashi/projects/transformers-uv/transformers/src/transformers/models/encoder_decoder/modeling_encoder_decoder.py:453:
UserWarning: To copy construct from a tensor, it is recommended to use sourceTensor.detach().clone() or sourceTensor.detach().clone().requires_grad_(True), rather than tensor.new_tensor(sourceTensor).
  decoder_attention_mask = decoder_input_ids.new_tensor(decoder_input_ids != self.config.pad_token_id)
```

This warning is triggered by the use of `Tensor.new_tensor()` in the internal code and cannot be resolved by users.

The fix is functionally equivalent because `new_tensor()` creates a new tensor with the same dtype as the original tensor. Additionally, I think the fixed version is more semantically clear as it explicitly shows that `decoder_attention_mask` is created through tensor comparison followed by type casting.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- text models: @ArthurZucker @Cyrilvallez

