### PR TITLE
Fixed incorrect model_type for qwen2vl and qwen2.5vl when config is saved and loaded again

### DIFF
--- a/src/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
@@ -313,6 +313,8 @@ class Qwen2_5_VLConfig(PreTrainedConfig):
 
     def __getattribute__(self, key):
         if "text_config" in super().__getattribute__("__dict__") and key not in [
+            "_name_or_path",
+            "model_type",
             "dtype",
             "_attn_implementation_internal",
         ]:

--- a/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -301,6 +301,8 @@ class Qwen2VLConfig(PreTrainedConfig):
 
     def __getattribute__(self, key):
         if "text_config" in super().__getattribute__("__dict__") and key not in [
+            "_name_or_path",
+            "model_type",
             "dtype",
             "_attn_implementation_internal",
         ]:

--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -235,6 +235,17 @@ class Qwen2_5_VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
         self.assertEqual(base_config.patch_size, 8)
         self.assertNotEqual(base_config.vision_config.patch_size, 8)
 
+        # Test for making sure config save and load preserves correct model type
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+        self.assertEqual(config.model_type, "qwen2_5_vl")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config.save_pretrained(tmp_dir)
+
+            loaded_config = Qwen2_5_VLConfig.from_pretrained(tmp_dir)
+            self.assertEqual(loaded_config.model_type, "qwen2_5_vl")
+
     def test_mismatching_num_image_tokens(self):
         """
         Tests that VLMs through an error with explicit message saying what is wrong

--- a/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
@@ -215,6 +215,17 @@ class Qwen2VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
         self.assertEqual(base_config.patch_size, 8)
         self.assertNotEqual(base_config.vision_config.patch_size, 8)
 
+        # Test for making sure config save and load preserves correct model type
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+        self.assertEqual(config.model_type, "qwen2_vl")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            config.save_pretrained(tmp_dir)
+
+            loaded_config = Qwen2VLConfig.from_pretrained(tmp_dir)
+            self.assertEqual(loaded_config.model_type, "qwen2_vl")
+
     def test_mismatching_num_image_tokens(self):
         """
         Tests that VLMs through an error with explicit message saying what is wrong


### PR DESCRIPTION
# What does this PR do?
Fixes the issue where if you save the config and load it again it would return the incorrect model_type . 
Minor fix in __getattribute__ method of the config class for both models .


Fixes # 41746


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.  - https://github.com/huggingface/transformers/issues/41746
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@zucchini-nlp 
Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

