### PR TITLE
Fix TypeError when loading adapter models with _adapter_model_path

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -217,6 +217,9 @@ class PeftAdapterMixin:
         if "token" in adapter_kwargs:
             token = adapter_kwargs.pop("token")
 
+        # Remove _adapter_model_path if present, as it's not a parameter of find_adapter_config_file
+        adapter_kwargs.pop("_adapter_model_path", None)
+
         if peft_config is None:
             adapter_config_file = find_adapter_config_file(
                 peft_model_id,


### PR DESCRIPTION
# What does this PR do?

This PR resolves a TypeError that occurs when loading models with LoRA adapters (like ibm-granite/granite-speech-3.3-2b).

## Issue
When calling `AutoModelForSpeechSeq2Seq.from_pretrained()` on models with LoRA adapters, the following error occurs:
TypeError: find_adapter_config_file() got an unexpected keyword argument '_adapter_model_path'

## Root Cause
In `auto_factory.py` line 302, `_adapter_model_path` is added to `adapter_kwargs`. Later, in `peft.py` line 221, these `adapter_kwargs` are passed to `find_adapter_config_file()` via `**adapter_kwargs`, but `find_adapter_config_file()` doesn't accept `_adapter_model_path` as a parameter.

## Solution
Remove `_adapter_model_path` from `adapter_kwargs` in `peft.py` before passing it to `find_adapter_config_file()`.

## Testing
Verified the fix resolves the TypeError when loading `ibm-granite/granite-speech-3.3-2b`.

Fixes #41760

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@BenjaminBossan @Cyrilvallez @ArthurZucker