### PR TITLE
fix: Gemma 3 weights conversion vision and multimodal projector paths

### DIFF
--- a/src/transformers/models/gemma3/convert_gemma3_weights.py
+++ b/src/transformers/models/gemma3/convert_gemma3_weights.py
@@ -447,7 +447,7 @@ def convert_transformer_weights(
             return zip([], [])
         else:
             raise ValueError(f"Unexpected member, {prop}, in Embedder.")
-    elif path.startswith(f"{_TRANSFORMER_EMBEDDER}/mm"):
+    elif f"{_TRANSFORMER_EMBEDDER}/mm_" in path:
         if not _INCLUDE_VISION_ENCODER.value:
             return zip([], [])
 
@@ -553,7 +553,7 @@ def convert(
                 continue
 
             path, weights = convert_siglip_weight(config=config.vision_config, paths=paths, weights=value)
-            update_tree(path, weights, config.vision_config.dtype)
+            update_tree(f"model.{path}", weights, config.vision_config.dtype)
         else:
             for path, weights in convert_transformer_weights(config=config.text_config, paths=paths, weights=value):
                 if not _INCLUDE_VISION_ENCODER.value:


### PR DESCRIPTION
# What does this PR do?

Fixes bugs in the Gemma 3 weights conversion script:

* Looking for multi-modal projector weights at the wrong location
* Had the wrong prefix on the vision model weights


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@zucchini-nlp
