### PR TITLE
[quantization] fix torchao tests after 0.14.0 release

### DIFF
--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -48,10 +48,10 @@ if is_torchao_available():
     from torchao.quantization import (
         Float8Tensor,
         Float8WeightOnlyConfig,
-        Int8WeightOnlyConfig,
-        IntxWeightOnlyConfig,
         Int4WeightOnlyConfig,
         Int8DynamicActivationInt8WeightConfig,
+        Int8WeightOnlyConfig,
+        IntxWeightOnlyConfig,
         MappingType,
         ModuleFqnToConfig,
         PerAxis,

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -48,7 +48,6 @@ if is_torchao_available():
     from torchao.quantization import (
         Float8Tensor,
         Float8WeightOnlyConfig,
-        Int4WeightOnlyConfig,
         Int8DynamicActivationInt8WeightConfig,
         Int8WeightOnlyConfig,
         IntxWeightOnlyConfig,
@@ -62,7 +61,8 @@ if is_torchao_available():
         from torchao.dtypes import Int4CPULayout
     if version.parse(importlib.metadata.version("torchao")) >= version.parse("0.11.0"):
         from torchao.dtypes import Int4XPULayout
-
+    if version.parse(importlib.metadata.version("torchao")) >= version.parse("0.14.0"):
+        from torchao.quantization import Int4WeightOnlyConfig
 
 def check_torchao_int4_wo_quantized(test_module, qlayer):
     weight = qlayer.weight

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -650,6 +650,7 @@ class TorchAoSerializationW8CPUTest(TorchAoSerializationTest):
 
 
 @require_torch_accelerator
+@require_torchao
 class TorchAoSerializationAcceleratorTest(TorchAoSerializationTest):
     quant_scheme, quant_scheme_kwargs = Int4WeightOnlyConfig(**{"group_size": 32, "version": 1}), {}
     device = f"{torch_device}:0"

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -526,7 +526,8 @@ class TorchAoSerializationTest(unittest.TestCase):
     def setUpClass(cls):
         cls.quant_scheme_kwargs = (
             {"group_size": 32, "layout": Int4CPULayout(), "version": 1}
-            if is_torchao_available() and version.parse(importlib.metadata.version("torchao")) >= version.parse("0.8.0")
+            if is_torchao_available()
+            and version.parse(importlib.metadata.version("torchao")) >= version.parse("0.8.0")
             else {"group_size": 32}
         )
         cls.quant_scheme = Int4WeightOnlyConfig(**cls.quant_scheme_kwargs)
@@ -614,7 +615,6 @@ class TorchAoSafeSerializationTest(TorchAoSerializationTest):
 
 
 class TorchAoSerializationW8A8CPUTest(TorchAoSerializationTest):
-
     # called only once for all test in this class
     @classmethod
     def setUpClass(cls):
@@ -632,7 +632,6 @@ class TorchAoSerializationW8A8CPUTest(TorchAoSerializationTest):
 
 
 class TorchAoSerializationW8CPUTest(TorchAoSerializationTest):
-
     # called only once for all test in this class
     @classmethod
     def setUpClass(cls):

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -50,6 +50,7 @@ if is_torchao_available():
         Float8WeightOnlyConfig,
         Int8WeightOnlyConfig,
         IntxWeightOnlyConfig,
+        Int4WeightOnlyConfig,
         MappingType,
         ModuleFqnToConfig,
         PerAxis,
@@ -181,7 +182,8 @@ class TorchAoTest(unittest.TestCase):
         """
         Testing the dtype of model will be modified to be bfloat16 for int4 weight only quantization
         """
-        quant_config = TorchAoConfig("int4_weight_only", **self.quant_scheme_kwargs)
+        config = Int4WeightOnlyConfig(**self.quant_scheme_kwargs)
+        quant_config = TorchAoConfig(config)
 
         # Note: we quantize the bfloat16 model on the fly to int4
         quantized_model = AutoModelForCausalLM.from_pretrained(

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -64,6 +64,7 @@ if is_torchao_available():
     if version.parse(importlib.metadata.version("torchao")) >= version.parse("0.14.0"):
         from torchao.quantization import Int4WeightOnlyConfig
 
+
 def check_torchao_int4_wo_quantized(test_module, qlayer):
     weight = qlayer.weight
     test_module.assertEqual(weight.quant_min, 0)


### PR DESCRIPTION
# What does this PR do?

Fixes the deprecation of `int4_weight_only` deprecation in torchao>=0.14.0 https://github.com/pytorch/ao/pull/2994