### PR TITLE
[quantization] Skip Fp8 tests when hardware capability < 8.9

### DIFF
--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -67,7 +67,7 @@ class FineGrainedFP8ConfigTest(unittest.TestCase):
 @unittest.skipIf(
     get_device_properties()[0] == "cuda"
     and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
-    "Skipping FP8QuantizerTest because it is not supported on GPU with capability < 9.0",
+    "Skipping FP8QuantizerTest because it is not supported on GPU with capability < 8.9",
 )
 class FP8QuantizerTest(unittest.TestCase):
     model_name = "meta-llama/Llama-3.2-1B"

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -65,8 +65,9 @@ class FineGrainedFP8ConfigTest(unittest.TestCase):
 @require_read_token
 @require_torch_accelerator
 @unittest.skipIf(
-        get_device_properties()[0] == "cuda" and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
-        "Skipping FP8QuantizerTest because it is not supported on GPU with capability < 9.0",
+    get_device_properties()[0] == "cuda"
+    and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
+    "Skipping FP8QuantizerTest because it is not supported on GPU with capability < 9.0",
 )
 class FP8QuantizerTest(unittest.TestCase):
     model_name = "meta-llama/Llama-3.2-1B"
@@ -256,7 +257,8 @@ class FP8QuantizerTest(unittest.TestCase):
 
 @require_torch_accelerator
 @unittest.skipIf(
-    get_device_properties()[0] == "cuda" and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
+    get_device_properties()[0] == "cuda"
+    and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
     "Skipping FP8LinearTest because it is not supported on GPU with capability < 8.9",
 )
 class FP8LinearTest(unittest.TestCase):

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -64,6 +64,10 @@ class FineGrainedFP8ConfigTest(unittest.TestCase):
 @require_accelerate
 @require_read_token
 @require_torch_accelerator
+@unittest.skipIf(
+        get_device_properties()[0] == "cuda" and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
+        "Skipping FP8QuantizerTest because it is not supported on GPU with capability < 9.0",
+)
 class FP8QuantizerTest(unittest.TestCase):
     model_name = "meta-llama/Llama-3.2-1B"
     input_text = "Once upon a time"
@@ -251,13 +255,13 @@ class FP8QuantizerTest(unittest.TestCase):
 
 
 @require_torch_accelerator
+@unittest.skipIf(
+    get_device_properties()[0] == "cuda" and (get_device_properties()[1] < 8 or (get_device_properties()[1] == 8 and get_device_properties()[2] < 9)),
+    "Skipping FP8LinearTest because it is not supported on GPU with capability < 8.9",
+)
 class FP8LinearTest(unittest.TestCase):
     device = torch_device
 
-    @unittest.skipIf(
-        get_device_properties()[0] == "cuda" and get_device_properties()[1] < 9,
-        "Skipping FP8LinearTest because it is not supported on GPU with capability < 9.0",
-    )
     def test_linear_preserves_shape(self):
         """
         Test that FP8Linear preserves shape when in_features == out_features.
@@ -270,10 +274,6 @@ class FP8LinearTest(unittest.TestCase):
         x_ = linear(x)
         self.assertEqual(x_.shape, x.shape)
 
-    @unittest.skipIf(
-        get_device_properties()[0] == "cuda" and get_device_properties()[1] < 9,
-        "Skipping FP8LinearTest because it is not supported on GPU with capability < 9.0",
-    )
     def test_linear_with_diff_feature_size_preserves_shape(self):
         """
         Test that FP8Linear generates the correct shape when in_features != out_features.


### PR DESCRIPTION
# What does this PR do?

Skips FP8 tests when hardware capability is < 8.9 (nvidia 4090)

It's erroring in the CI with gpus 8.6 : https://github.com/huggingface/transformers/actions/runs/18703774699/job/53337972742