### PR TITLE
Use indices as position_ids in modernebert

### DIFF
--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -916,7 +916,11 @@ class ModernBertModel(ModernBertPreTrainedModel):
         hidden_states = self.embeddings(input_ids=input_ids, inputs_embeds=inputs_embeds)
         position_embeddings = {}
         for layer_type in self.config.layer_types:
-            position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
+            position_embeddings[layer_type] = self.rotary_emb(
+                x=hidden_states,
+                position_ids=(indices.unsqueeze(0) if position_ids is None else position_ids),
+                layer_type=layer_type,
+            )
 
         for encoder_layer in self.layers:
             if output_hidden_states:

--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -905,6 +905,8 @@ class ModernBertModel(ModernBertPreTrainedModel):
                     inputs_embeds, indices, cu_seqlens, max_seqlen, *_ = _unpad_modernbert_input(
                         inputs=inputs_embeds, attention_mask=attention_mask
                     )
+            if position_ids is None:
+                position_ids = indices.unsqueeze(0)
         else:
             if position_ids is None:
                 position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
@@ -916,11 +918,7 @@ class ModernBertModel(ModernBertPreTrainedModel):
         hidden_states = self.embeddings(input_ids=input_ids, inputs_embeds=inputs_embeds)
         position_embeddings = {}
         for layer_type in self.config.layer_types:
-            position_embeddings[layer_type] = self.rotary_emb(
-                x=hidden_states,
-                position_ids=(indices.unsqueeze(0) if position_ids is None else position_ids),
-                layer_type=layer_type,
-            )
+            position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
 
         for encoder_layer in self.layers:
             if output_hidden_states:

--- a/src/transformers/models/modernbert/modular_modernbert.py
+++ b/src/transformers/models/modernbert/modular_modernbert.py
@@ -1014,6 +1014,8 @@ class ModernBertModel(ModernBertPreTrainedModel):
                     inputs_embeds, indices, cu_seqlens, max_seqlen, *_ = _unpad_modernbert_input(
                         inputs=inputs_embeds, attention_mask=attention_mask
                     )
+            if position_ids is None:
+                position_ids = indices.unsqueeze(0)
         else:
             if position_ids is None:
                 position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
@@ -1025,11 +1027,7 @@ class ModernBertModel(ModernBertPreTrainedModel):
         hidden_states = self.embeddings(input_ids=input_ids, inputs_embeds=inputs_embeds)
         position_embeddings = {}
         for layer_type in self.config.layer_types:
-            position_embeddings[layer_type] = self.rotary_emb(
-                x=hidden_states,
-                position_ids=(indices.unsqueeze(0) if position_ids is None else position_ids),
-                layer_type=layer_type,
-            )
+            position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
 
         for encoder_layer in self.layers:
             if output_hidden_states:

--- a/src/transformers/models/modernbert/modular_modernbert.py
+++ b/src/transformers/models/modernbert/modular_modernbert.py
@@ -1025,7 +1025,11 @@ class ModernBertModel(ModernBertPreTrainedModel):
         hidden_states = self.embeddings(input_ids=input_ids, inputs_embeds=inputs_embeds)
         position_embeddings = {}
         for layer_type in self.config.layer_types:
-            position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
+            position_embeddings[layer_type] = self.rotary_emb(
+                x=hidden_states,
+                position_ids=(indices.unsqueeze(0) if position_ids is None else position_ids),
+                layer_type=layer_type,
+            )
 
         for encoder_layer in self.layers:
             if output_hidden_states:


### PR DESCRIPTION
Currently there is an issue in `modernbert` stemming from #39847 : the `rotary_emb` always passes `position_ids` as if it were a tensor, but when the implementation is flash it can be `None`. To avoid the error `None has no attributes .shape` we use `indices` as the `positions_ids` in the rotary embedding. 
 