### PR TITLE
Fix chat schema tests

### DIFF
--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -55,7 +55,7 @@ def recursive_parse(
         return None
 
     # If not, we have to do a little parsing. First, set some vars and do basic validation
-    node_type = node_schema["type"]
+    node_type = node_schema.get("type")
     has_regex = "x-regex" in node_schema or "x-regex-iterator" in node_schema or "x-regex-key-value" in node_schema
     if has_regex and not isinstance(node_content, str):
         raise TypeError(
@@ -232,5 +232,7 @@ def recursive_parse(
         else:
             # String type
             return node_content
+    elif node_type is None:
+        return node_content  # Don't touch it
     else:
         raise TypeError(f"Unsupported schema type {node_type} for node: {node_content}")

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -15,7 +15,7 @@
 import tempfile
 import unittest
 
-from transformers import AutoProcessor, AutoTokenizer
+from transformers import AutoTokenizer
 from transformers.testing_utils import require_jmespath
 from transformers.utils.chat_parsing_utils import recursive_parse
 

--- a/tests/utils/test_chat_schema_utils.py
+++ b/tests/utils/test_chat_schema_utils.py
@@ -43,7 +43,7 @@ cohere_schema = {
                             "name": {"type": "string"},
                             "arguments": {
                                 "type": "object",
-                                "additionalProperties": {"type": "any"},
+                                "additionalProperties": {},
                             },
                         },
                     },
@@ -74,7 +74,7 @@ ernie_schema = {
                             "name": {"type": "string"},
                             "arguments": {
                                 "type": "object",
-                                "additionalProperties": {"type": "any"},
+                                "additionalProperties": {},
                             },
                         },
                     },
@@ -105,7 +105,7 @@ gpt_oss_schema = {
                                 "type": "object",
                                 "x-regex": r"<\|message\|>(.*)",
                                 "x-parser": "json",
-                                "additionalProperties": {"type": "any"},
+                                "additionalProperties": {},
                             },
                         },
                     },
@@ -136,7 +136,7 @@ smollm_schema = {
                             "name": {"type": "string"},
                             "arguments": {
                                 "type": "object",
-                                "additionalProperties": {"type": "any"},
+                                "additionalProperties": {},
                             },
                         },
                     },
@@ -191,14 +191,6 @@ class ChatSchemaParserTest(unittest.TestCase):
             tokenizer.save_pretrained(tmpdir)
             reloaded_tokenizer = AutoTokenizer.from_pretrained(tmpdir)
         self.assertEqual(reloaded_tokenizer.response_schema, ernie_schema)
-
-        # Has no schema by default
-        processor = AutoProcessor.from_pretrained("hf-internal-testing/tiny-random-Qwen2VLForConditionalGeneration")
-        processor.response_schema = ernie_schema
-        with tempfile.TemporaryDirectory() as tmpdir:
-            processor.save_pretrained(tmpdir)
-            reloaded_processor = AutoProcessor.from_pretrained(tmpdir)
-        self.assertEqual(reloaded_processor.response_schema, ernie_schema)
 
     def test_tokenizer_method(self):
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")


### PR DESCRIPTION
My bad - the [chat schema PR](https://github.com/huggingface/transformers/pull/40894) added some tests that were failing after my final commits, and I didn't realize because they weren't running in the CI for the PR.

The main problem was that I dropped support for `"type": "any"`, which is no longer part of the JSON schema standard, but left it in some tests, which caused errors. This PR changes the code to read a missing `type` annotation as implicitly allowing any type, which is compatible with the standard. It also removes a test for Processor schema save/loading, which was dropped from the PR (but will be added soon!)