### PR TITLE
Enable flake8-pie rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ line-length = 119
 ignore = ["C901", "E501", "E741", "F402", "F823", "SIM1", "SIM300", "SIM212", "SIM905", "UP009", "UP015", "UP031", "UP028", "UP004", "UP045", "UP007"]
 # RUF013: Checks for the use of implicit Optional
 #  in type annotations when the default parameter value is None.
-select = ["C", "E", "F", "I", "W", "RUF013", "PERF102", "PLC1802", "PLC0208", "SIM", "UP", "PIE794", "FURB"]
+select = ["C", "E", "F", "I", "W", "RUF013", "PERF102", "PLC1802", "PLC0208", "SIM", "UP", "PIE", "FURB"]
 extend-safe-fixes = ["UP006"]
 
 # Ignore import violations in all `__init__.py` files.

--- a/src/transformers/audio_utils.py
+++ b/src/transformers/audio_utils.py
@@ -131,7 +131,7 @@ def load_audio_librosa(audio: Union[str, np.ndarray], sampling_rate=16000, timeo
     requires_backends(load_audio_librosa, ["librosa"])
 
     # Load audio from URL (e.g https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen2-Audio/audio/translate_to_chinese.wav)
-    if audio.startswith("http://") or audio.startswith("https://"):
+    if audio.startswith(("http://", "https://")):
         audio = librosa.load(
             BytesIO(httpx.get(audio, follow_redirects=True, timeout=timeout).content), sr=sampling_rate
         )[0]

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -843,8 +843,6 @@ class SkipParameters(Exception):
     """Control-flow sentinel: abort processing of the current parameters only (that were supposed to be created
     by a WeightConverter)."""
 
-    pass
-
 
 def rename_source_key(
     source_key: str,

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -456,7 +456,7 @@ def load_image(image: Union[str, "PIL.Image.Image"], timeout: Optional[float] = 
     """
     requires_backends(load_image, ["vision"])
     if isinstance(image, str):
-        if image.startswith("http://") or image.startswith("https://"):
+        if image.startswith(("http://", "https://")):
             # We need to actually check for a real protocol, otherwise it's impossible to use a local file
             # like http_huggingface_co.png
             image = PIL.Image.open(BytesIO(httpx.get(image, timeout=timeout, follow_redirects=True).content))

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -200,7 +200,7 @@ def _w8a8_block_fp8_matmul_per_tensor(
     scale_a = tl.load(As)
     scale_b = tl.load(Bs)
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+    for k in range(tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
         b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -122,7 +122,7 @@ def _w8a8_block_fp8_matmul(
     Bs_ptrs = Bs + offs_bsn * stride_Bs_n
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+    for k in range(tl.cdiv(K, BLOCK_SIZE_K)):
         a = tl.load(a_ptrs, mask=offs_k[None, :] < K - k * BLOCK_SIZE_K, other=0.0)
         b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
 

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -292,7 +292,7 @@ class PeftAdapterMixin:
 
             # For hotswapping, we need the adapter name to be present in the state dict keys
             if hotswap:
-                if key.endswith("lora_A.weight") or key.endswith("lora_B.weight"):
+                if key.endswith(("lora_A.weight", "lora_B.weight")):
                     new_key = new_key[: -len(".weight")] + f".{adapter_name}.weight"
                 elif key.endswith("lora_B.bias"):  # lora_bias=True option
                     new_key = new_key[: -len(".bias")] + f".{adapter_name}.bias"

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -382,7 +382,7 @@ def get_gguf_hf_weights_map(
         hf_name = processor.preprocess_name(hf_name)
 
         name, suffix = hf_name, ""
-        if hf_name.endswith(".weight") or hf_name.endswith(".bias"):
+        if hf_name.endswith((".weight", ".bias")):
             name, suffix = hf_name.rsplit(".", 1)
             suffix = "." + suffix
 

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -79,7 +79,6 @@ class TensorProcessor:
         This is particularly useful to resolve one-to-many
         HF-GGUF mappings sometimes appear in some MoE models.
         """
-        pass
 
     def process(self, weights, name, **kwargs):
         return GGUFTensor(weights, name, {})

--- a/src/transformers/models/bert/convert_bert_token_dropping_original_tf2_checkpoint_to_pytorch.py
+++ b/src/transformers/models/bert/convert_bert_token_dropping_original_tf2_checkpoint_to_pytorch.py
@@ -82,7 +82,7 @@ def convert_checkpoint_to_pytorch(tf_checkpoint_path: str, config_path: str, pyt
     model = BertForMaskedLM(config)
 
     # Layers
-    for layer_index in range(0, config.num_hidden_layers):
+    for layer_index in range(config.num_hidden_layers):
         layer: BertLayer = model.bert.encoder.layer[layer_index]
 
         # Self-attention

--- a/src/transformers/models/bertweet/tokenization_bertweet.py
+++ b/src/transformers/models/bertweet/tokenization_bertweet.py
@@ -270,7 +270,7 @@ class BertweetTokenizer(PreTrainedTokenizer):
         lowercased_token = token.lower()
         if token.startswith("@"):
             return "@USER"
-        elif lowercased_token.startswith("http") or lowercased_token.startswith("www"):
+        elif lowercased_token.startswith(("http", "www")):
             return "HTTPURL"
         elif len(token) == 1:
             if token in self.special_puncts:

--- a/src/transformers/models/big_bird/convert_bigbird_original_tf_checkpoint_to_pytorch.py
+++ b/src/transformers/models/big_bird/convert_bigbird_original_tf_checkpoint_to_pytorch.py
@@ -177,10 +177,8 @@ def load_tf_weights_in_big_bird(model, tf_checkpoint_path, is_trivia_qa=False):
         try:
             if len(array.shape) > len(pointer.shape) and math.prod(array.shape) == math.prod(pointer.shape):
                 # print(txt_name, array.shape)
-                if (
-                    txt_name.endswith("attention/self/key/kernel")
-                    or txt_name.endswith("attention/self/query/kernel")
-                    or txt_name.endswith("attention/self/value/kernel")
+                if txt_name.endswith(
+                    ("attention/self/key/kernel", "attention/self/query/kernel", "attention/self/value/kernel")
                 ):
                     array = array.transpose(1, 0, 2).reshape(pointer.shape)
                 elif txt_name.endswith("attention/output/dense/kernel"):

--- a/src/transformers/models/clap/feature_extraction_clap.py
+++ b/src/transformers/models/clap/feature_extraction_clap.py
@@ -175,7 +175,7 @@ class ClapFeatureExtractor(SequenceFeatureExtractor):
         return log_mel_spectrogram.T
 
     def _random_mel_fusion(self, mel, total_frames, chunk_frames):
-        ranges = np.array_split(list(range(0, total_frames - chunk_frames + 1)), 3)
+        ranges = np.array_split(list(range(total_frames - chunk_frames + 1)), 3)
         if len(ranges[1]) == 0:
             # if the audio is too short, we just use the first chunk
             ranges[1] = [0]

--- a/src/transformers/models/conditional_detr/convert_conditional_detr_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/conditional_detr/convert_conditional_detr_original_pytorch_checkpoint_to_pytorch.py
@@ -279,7 +279,7 @@ def convert_conditional_detr_checkpoint(model_name, pytorch_dump_folder_path):
             elif "class_labels_classifier" in key or "bbox_predictor" in key:
                 val = state_dict.pop(key)
                 state_dict["conditional_detr." + key] = val
-            elif key.startswith("bbox_attention") or key.startswith("mask_head"):
+            elif key.startswith(("bbox_attention", "mask_head")):
                 continue
             else:
                 val = state_dict.pop(key)

--- a/src/transformers/models/convbert/tokenization_convbert.py
+++ b/src/transformers/models/convbert/tokenization_convbert.py
@@ -26,5 +26,4 @@ class ConvBertTokenizer(BertTokenizer):
     """
 
 
-
 __all__ = ["ConvBertTokenizer"]

--- a/src/transformers/models/convbert/tokenization_convbert.py
+++ b/src/transformers/models/convbert/tokenization_convbert.py
@@ -25,7 +25,6 @@ class ConvBertTokenizer(BertTokenizer):
     refer to this superclass for more information regarding those methods.
     """
 
-    pass
 
 
 __all__ = ["ConvBertTokenizer"]

--- a/src/transformers/models/detr/convert_detr_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/detr/convert_detr_original_pytorch_checkpoint_to_pytorch.py
@@ -236,7 +236,7 @@ def convert_detr_checkpoint(model_name, pytorch_dump_folder_path):
             elif "class_labels_classifier" in key or "bbox_predictor" in key:
                 val = state_dict.pop(key)
                 state_dict["detr." + key] = val
-            elif key.startswith("bbox_attention") or key.startswith("mask_head"):
+            elif key.startswith(("bbox_attention", "mask_head")):
                 continue
             else:
                 val = state_dict.pop(key)

--- a/src/transformers/models/detr/convert_detr_to_pytorch.py
+++ b/src/transformers/models/detr/convert_detr_to_pytorch.py
@@ -322,7 +322,7 @@ def convert_detr_checkpoint(model_name, pytorch_dump_folder_path=None, push_to_h
             elif "class_labels_classifier" in key or "bbox_predictor" in key:
                 val = state_dict.pop(key)
                 state_dict["detr." + key] = val
-            elif key.startswith("bbox_attention") or key.startswith("mask_head"):
+            elif key.startswith(("bbox_attention", "mask_head")):
                 continue
             else:
                 val = state_dict.pop(key)

--- a/src/transformers/models/funnel/modeling_funnel.py
+++ b/src/transformers/models/funnel/modeling_funnel.py
@@ -153,7 +153,7 @@ class FunnelAttentionStructure(nn.Module):
             pos = torch.arange(0, seq_len, dtype=torch.int64, device=device).to(dtype)
             pooled_pos = pos
             position_embeds_list = []
-            for block_index in range(0, self.config.num_blocks):
+            for block_index in range(self.config.num_blocks):
                 # For each block with block_index > 0, we need two types position embeddings:
                 #   - Attention(pooled-q, unpooled-kv)
                 #   - Attention(pooled-q, pooled-kv)

--- a/src/transformers/models/glm46v/processing_glm46v.py
+++ b/src/transformers/models/glm46v/processing_glm46v.py
@@ -172,7 +172,7 @@ class Glm46VProcessor(ProcessorMixin):
                     timestamps = metadata.timestamps[::2]  # mrope
 
                     unique_timestamps = []
-                    for idx in range(0, len(timestamps)):
+                    for idx in range(len(timestamps)):
                         unique_timestamps.append(timestamps[idx])
 
                     selected_timestamps = unique_timestamps[:num_frames]

--- a/src/transformers/models/glm4v/convert_glm4v_mgt_weights_to_hf.py
+++ b/src/transformers/models/glm4v/convert_glm4v_mgt_weights_to_hf.py
@@ -31,7 +31,7 @@ class UnpicklerWrapper(pickle.Unpickler):
             def __init__(self, *args, **kwargs):
                 pass
 
-        if mod_name.startswith("megatron") or mod_name.startswith("glm") or mod_name.startswith("__main__"):
+        if mod_name.startswith(("megatron", "glm", "__main__")):
             return DummyClass
         return super().find_class(mod_name, name)
 

--- a/src/transformers/models/glm4v/modular_glm4v.py
+++ b/src/transformers/models/glm4v/modular_glm4v.py
@@ -1635,7 +1635,7 @@ class Glm4vProcessor(Qwen2VLProcessor):
                     timestamps = metadata.timestamps[::2]  # mrope
 
                     unique_timestamps = []
-                    for idx in range(0, len(timestamps)):
+                    for idx in range(len(timestamps)):
                         unique_timestamps.append(timestamps[idx])
 
                     selected_timestamps = unique_timestamps[:num_frames]

--- a/src/transformers/models/glm4v/processing_glm4v.py
+++ b/src/transformers/models/glm4v/processing_glm4v.py
@@ -171,7 +171,7 @@ class Glm4vProcessor(ProcessorMixin):
                     timestamps = metadata.timestamps[::2]  # mrope
 
                     unique_timestamps = []
-                    for idx in range(0, len(timestamps)):
+                    for idx in range(len(timestamps)):
                         unique_timestamps.append(timestamps[idx])
 
                     selected_timestamps = unique_timestamps[:num_frames]

--- a/src/transformers/models/glm4v_moe/convert_glm4v_moe_mgt_weights_to_hf.py
+++ b/src/transformers/models/glm4v_moe/convert_glm4v_moe_mgt_weights_to_hf.py
@@ -31,7 +31,7 @@ class UnpicklerWrapper(pickle.Unpickler):
             def __init__(self, *args, **kwargs):
                 pass
 
-        if mod_name.startswith("megatron") or mod_name.startswith("glm") or mod_name.startswith("__main__"):
+        if mod_name.startswith(("megatron", "glm", "__main__")):
             return DummyClass
         return super().find_class(mod_name, name)
 

--- a/src/transformers/models/gpt_neo/configuration_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/configuration_gpt_neo.py
@@ -178,7 +178,7 @@ def custom_unfold(input, dimension, size, step):
     s[dimension] = indices
     sliced = input[s]
 
-    perm = list(range(0, rank + 1))
+    perm = list(range(rank + 1))
     perm.append(perm.pop(dimension + 1))
 
     return sliced.permute(perm)

--- a/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
+++ b/src/transformers/models/gpt_sw3/tokenization_gpt_sw3.py
@@ -126,7 +126,7 @@ class GPTSw3Tokenizer(SentencePieceBackend):
 
         # Regular expression to remove non-printing characters (e.g. some unicode control chars) in preprocessing
         self.non_printing_characters_re = re.compile(
-            f"[{''.join(map(chr, list(range(0, 9)) + list(range(11, 32)) + list(range(127, 160)) + [160, 173, 8203]))}]"
+            f"[{''.join(map(chr, list(range(9)) + list(range(11, 32)) + list(range(127, 160)) + [160, 173, 8203]))}]"
         )
 
         # Ensure sp_model_kwargs is in kwargs for proper signature storage

--- a/src/transformers/models/instructblipvideo/modeling_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/modeling_instructblipvideo.py
@@ -1218,7 +1218,6 @@ class InstructBlipVideoForConditionalGeneration(InstructBlipVideoPreTrainedModel
             pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, image_size, image_size)`):
                 The tensors corresponding to the input images.
         """
-        pass
 
     def get_placeholder_mask(self, input_ids: torch.LongTensor, inputs_embeds: torch.FloatTensor):
         """

--- a/src/transformers/models/internvl/convert_internvl_weights_to_hf.py
+++ b/src/transformers/models/internvl/convert_internvl_weights_to_hf.py
@@ -169,11 +169,7 @@ def convert_old_keys_to_new_keys(state_dict_keys: Optional[dict] = None, path: O
                 new_text = re.sub(pattern, replacement, new_text)
         output_dict.update(dict(zip(old_text_language.split("\n"), new_text.split("\n"))))
         old_text_multi = "\n".join(
-            [
-                key
-                for key in state_dict_keys
-                if not (key.startswith("language_model") or key.startswith("vision_model"))
-            ]
+            [key for key in state_dict_keys if not (key.startswith(("language_model", "vision_model")))]
         )
         new_text = old_text_multi
         for pattern, replacement in ORIGINAL_TO_CONVERTED_KEY_MAPPING_MULTI.items():

--- a/src/transformers/models/layoutxlm/modular_layoutxlm.py
+++ b/src/transformers/models/layoutxlm/modular_layoutxlm.py
@@ -104,5 +104,4 @@ class LayoutXLMConfig(LayoutLMv2Config):
     ```"""
 
 
-
 __all__ = ["LayoutXLMConfig"]

--- a/src/transformers/models/layoutxlm/modular_layoutxlm.py
+++ b/src/transformers/models/layoutxlm/modular_layoutxlm.py
@@ -103,7 +103,6 @@ class LayoutXLMConfig(LayoutLMv2Config):
     >>> configuration = model.config
     ```"""
 
-    pass
 
 
 __all__ = ["LayoutXLMConfig"]

--- a/src/transformers/models/luke/convert_luke_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/luke/convert_luke_original_pytorch_checkpoint_to_pytorch.py
@@ -75,10 +75,10 @@ def convert_luke_checkpoint(checkpoint_path, metadata_path, entity_vocab_path, p
     missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
     if not (len(missing_keys) == 1 and missing_keys[0] == "embeddings.position_ids"):
         raise ValueError(f"Missing keys {', '.join(missing_keys)}. Expected only missing embeddings.position_ids")
-    if not (all(key.startswith("entity_predictions") or key.startswith("lm_head") for key in unexpected_keys)):
+    if not (all(key.startswith(("entity_predictions", "lm_head")) for key in unexpected_keys)):
         raise ValueError(
             "Unexpected keys"
-            f" {', '.join([key for key in unexpected_keys if not (key.startswith('entity_predictions') or key.startswith('lm_head'))])}"
+            f" {', '.join([key for key in unexpected_keys if not (key.startswith(('entity_predictions', 'lm_head')))])}"
         )
 
     # Check outputs

--- a/src/transformers/models/marian/convert_marian_to_pytorch.py
+++ b/src/transformers/models/marian/convert_marian_to_pytorch.py
@@ -574,11 +574,14 @@ class OpusState:
     def extra_keys(self):
         extra = []
         for k in self.state_keys:
-            if (
-                k.startswith("encoder_l")
-                or k.startswith("decoder_l")
-                or k in [CONFIG_KEY, "Wemb", "encoder_Wemb", "decoder_Wemb", "Wpos", "decoder_ff_logit_out_b"]
-            ):
+            if k.startswith(("encoder_l", "decoder_l")) or k in [
+                CONFIG_KEY,
+                "Wemb",
+                "encoder_Wemb",
+                "decoder_Wemb",
+                "Wpos",
+                "decoder_ff_logit_out_b",
+            ]:
                 continue
             else:
                 extra.append(k)

--- a/src/transformers/models/maskformer/convert_maskformer_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_original_pytorch_checkpoint_to_pytorch.py
@@ -371,7 +371,7 @@ class OriginalMaskFormerCheckpointToOursConverter:
         renamed_keys.extend(rename_keys_for_conv(f"{src_prefix}.layer_4", f"{dst_prefix}.fpn.stem"))
 
         # add all the fpn layers (here we need some config parameters to know the size in advance)
-        for src_i, dst_i in zip(range(3, 0, -1), range(0, 3)):
+        for src_i, dst_i in zip(range(3, 0, -1), range(3)):
             renamed_keys.extend(
                 rename_keys_for_conv(f"{src_prefix}.adapter_{src_i}", f"{dst_prefix}.fpn.layers.{dst_i}.proj")
             )

--- a/src/transformers/models/maskformer/convert_maskformer_resnet_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_resnet_to_pytorch.py
@@ -162,7 +162,7 @@ def create_rename_keys(config):
     rename_keys.append(("sem_seg_head.layer_4.weight", "model.pixel_level_module.decoder.fpn.stem.0.weight"))
     rename_keys.append(("sem_seg_head.layer_4.norm.weight", "model.pixel_level_module.decoder.fpn.stem.1.weight"))
     rename_keys.append(("sem_seg_head.layer_4.norm.bias", "model.pixel_level_module.decoder.fpn.stem.1.bias"))
-    for source_index, target_index in zip(range(3, 0, -1), range(0, 3)):
+    for source_index, target_index in zip(range(3, 0, -1), range(3)):
         rename_keys.append((f"sem_seg_head.adapter_{source_index}.weight", f"model.pixel_level_module.decoder.fpn.layers.{target_index}.proj.0.weight"))
         rename_keys.append((f"sem_seg_head.adapter_{source_index}.norm.weight", f"model.pixel_level_module.decoder.fpn.layers.{target_index}.proj.1.weight"))
         rename_keys.append((f"sem_seg_head.adapter_{source_index}.norm.bias", f"model.pixel_level_module.decoder.fpn.layers.{target_index}.proj.1.bias"))

--- a/src/transformers/models/maskformer/convert_maskformer_swin_to_pytorch.py
+++ b/src/transformers/models/maskformer/convert_maskformer_swin_to_pytorch.py
@@ -109,7 +109,7 @@ def create_rename_keys(config):
     rename_keys.append(("sem_seg_head.layer_4.weight", "model.pixel_level_module.decoder.fpn.stem.0.weight"))
     rename_keys.append(("sem_seg_head.layer_4.norm.weight", "model.pixel_level_module.decoder.fpn.stem.1.weight"))
     rename_keys.append(("sem_seg_head.layer_4.norm.bias", "model.pixel_level_module.decoder.fpn.stem.1.bias"))
-    for source_index, target_index in zip(range(3, 0, -1), range(0, 3)):
+    for source_index, target_index in zip(range(3, 0, -1), range(3)):
         rename_keys.append((f"sem_seg_head.adapter_{source_index}.weight", f"model.pixel_level_module.decoder.fpn.layers.{target_index}.proj.0.weight"))
         rename_keys.append((f"sem_seg_head.adapter_{source_index}.norm.weight", f"model.pixel_level_module.decoder.fpn.layers.{target_index}.proj.1.weight"))
         rename_keys.append((f"sem_seg_head.adapter_{source_index}.norm.bias", f"model.pixel_level_module.decoder.fpn.layers.{target_index}.proj.1.bias"))

--- a/src/transformers/models/mluke/convert_mluke_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/mluke/convert_mluke_original_pytorch_checkpoint_to_pytorch.py
@@ -101,7 +101,7 @@ def convert_luke_checkpoint(checkpoint_path, metadata_path, entity_vocab_path, p
     state_dict.pop("lm_head.decoder.bias")
     state_dict_for_hugging_face = OrderedDict()
     for key in state_dict:
-        if not (key.startswith("lm_head") or key.startswith("entity_predictions")):
+        if not (key.startswith(("lm_head", "entity_predictions"))):
             state_dict_for_hugging_face[f"luke.{key}"] = state_dict[key]
         else:
             state_dict_for_hugging_face[key] = state_dict[key]

--- a/src/transformers/models/mm_grounding_dino/convert_mm_grounding_dino_to_hf.py
+++ b/src/transformers/models/mm_grounding_dino/convert_mm_grounding_dino_to_hf.py
@@ -377,10 +377,7 @@ def preprocess_old_state(state_dict: dict, config: MMGroundingDinoConfig) -> dic
             k == "dn_query_generator.label_embedding.weight"
             or k == "language_model.language_backbone.body.model.embeddings.position_ids"
             or k == "image_seperate.weight"
-            or k.startswith("lmm")
-            or k.startswith("connector")
-            or k.startswith("region_connector")
-            or k.startswith("ref_point_head")
+            or k.startswith(("lmm", "connector", "region_connector", "ref_point_head"))
         ):
             new_state_dict.pop(k)
 

--- a/src/transformers/models/mobilevit/convert_mlcvnets_to_pytorch.py
+++ b/src/transformers/models/mobilevit/convert_mlcvnets_to_pytorch.py
@@ -95,13 +95,13 @@ def rename_key(name, base_model=False):
     if ".conv_proj." in name:
         name = name.replace(".conv_proj.", ".conv_projection.")
 
-    for i in range(0, 2):
-        for j in range(0, 4):
+    for i in range(2):
+        for j in range(4):
             if f".{i}.{j}." in name:
                 name = name.replace(f".{i}.{j}.", f".{i}.layer.{j}.")
 
     for i in range(2, 6):
-        for j in range(0, 4):
+        for j in range(4):
             if f".{i}.{j}." in name:
                 name = name.replace(f".{i}.{j}.", f".{i}.")
                 if "expand_1x1" in name:

--- a/src/transformers/models/mobilevitv2/convert_mlcvnets_to_pytorch.py
+++ b/src/transformers/models/mobilevitv2/convert_mlcvnets_to_pytorch.py
@@ -242,7 +242,7 @@ def convert_mobilevitv2_checkpoint(task_name, checkpoint_path, orig_config_path,
     checkpoint = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
 
     # load huggingface model
-    if task_name.startswith("ade20k_") or task_name.startswith("voc_"):
+    if task_name.startswith(("ade20k_", "voc_")):
         model = MobileViTV2ForSemanticSegmentation(config).eval()
         base_model = False
     else:

--- a/src/transformers/models/nougat/tokenization_nougat.py
+++ b/src/transformers/models/nougat/tokenization_nougat.py
@@ -179,7 +179,7 @@ def truncate_repetitions(text: str, min_len: int = 30) -> str:
     for repetition_length in range(min_len, int(text_length / 2)):
         # check if there is a repetition at the end
         same = True
-        for i in range(0, repetition_length):
+        for i in range(repetition_length):
             if text_lower[text_length - repetition_length - i - 1] != text_lower[text_length - i - 1]:
                 same = False
                 break

--- a/src/transformers/models/owlvit/convert_owlvit_original_flax_to_hf.py
+++ b/src/transformers/models/owlvit/convert_owlvit_original_flax_to_hf.py
@@ -285,11 +285,8 @@ def convert_clip_backbone(flax_params, torch_config):
         torch_key = flax_key.replace("/", ".")
         torch_key = torch_key.replace("text.token_embedding.embedding", "token_embedding.kernel")
 
-        if (
-            torch_key.startswith("text.transformer")
-            or torch_key.startswith("text.text_projection")
-            or torch_key.startswith("text.ln_final")
-            or torch_key.startswith("text.positional_embedding")
+        if torch_key.startswith(
+            ("text.transformer", "text.text_projection", "text.ln_final", "text.positional_embedding")
         ):
             torch_key = torch_key[5:]
 

--- a/src/transformers/models/parakeet/convert_nemo_to_hf.py
+++ b/src/transformers/models/parakeet/convert_nemo_to_hf.py
@@ -90,10 +90,7 @@ def extract_nemo_archive(nemo_file_path: str, extract_dir: str) -> dict[str, str
 
             # Look for model weights with various common names
             if (
-                file.endswith(".pt")
-                or file.endswith(".pth")
-                or file.endswith(".ckpt")
-                or file.endswith(".bin")
+                file.endswith((".pt", ".pth", ".ckpt", ".bin"))
                 or "model" in file_lower
                 and ("weight" in file_lower or "state" in file_lower)
                 or file_lower == "model.pt"
@@ -117,10 +114,9 @@ def extract_nemo_archive(nemo_file_path: str, extract_dir: str) -> dict[str, str
 
             # Look for vocabulary files
             elif (
-                file.endswith(".vocab")
-                or file.endswith(".model")
-                or file.endswith(".txt")
-                or ("tokenizer" in file_lower and (file.endswith(".vocab") or file.endswith(".model")))
+                file.endswith((".vocab", ".model", ".txt"))
+                or "tokenizer" in file_lower
+                and (file.endswith((".vocab", ".model")))
             ):
                 # Prefer .vocab files over others
                 if "tokenizer_model_file" not in model_files or file.endswith(".model"):
@@ -264,7 +260,7 @@ def load_and_convert_state_dict(model_files):
     converted_state_dict = {}
     for key, value in state_dict.items():
         # Skip preprocessing weights (featurizer components)
-        if key.endswith("featurizer.window") or key.endswith("featurizer.fb"):
+        if key.endswith(("featurizer.window", "featurizer.fb")):
             print(f"Skipping preprocessing weight: {key}")
             continue
         converted_key = convert_key(key, NEMO_TO_HF_WEIGHT_MAPPING)

--- a/src/transformers/models/pix2struct/image_processing_pix2struct_fast.py
+++ b/src/transformers/models/pix2struct/image_processing_pix2struct_fast.py
@@ -83,7 +83,6 @@ class Pix2StructImageProcessorFast(BaseImageProcessorFast):
         """
         # Pix2Struct doesn't use standard resize/rescale/normalize parameters
         # so we skip the default validation
-        pass
 
     def render_header(
         self,

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -527,7 +527,7 @@ def torch_chunk_gated_delta_rule(
     mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
 
     # for each chunk
-    for i in range(0, total_sequence_length // chunk_size):
+    for i in range(total_sequence_length // chunk_size):
         q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
         attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
         v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -363,7 +363,7 @@ def torch_chunk_gated_delta_rule(
     mask = torch.triu(torch.ones(chunk_size, chunk_size, dtype=torch.bool, device=query.device), diagonal=1)
 
     # for each chunk
-    for i in range(0, total_sequence_length // chunk_size):
+    for i in range(total_sequence_length // chunk_size):
         q_i, k_i, v_i = query[:, :, i], key[:, :, i], value[:, :, i]
         attn = (q_i @ k_i.transpose(-1, -2) * decay_mask[:, :, i]).masked_fill_(mask, 0)
         v_prime = (k_cumdecay[:, :, i]) @ last_recurrent_state

--- a/src/transformers/models/roberta_prelayernorm/convert_roberta_prelayernorm_original_pytorch_checkpoint_to_pytorch.py
+++ b/src/transformers/models/roberta_prelayernorm/convert_roberta_prelayernorm_original_pytorch_checkpoint_to_pytorch.py
@@ -47,7 +47,7 @@ def convert_roberta_prelayernorm_checkpoint_to_pytorch(checkpoint_repo: str, pyt
             tensor_key = "roberta_prelayernorm." + tensor_key[len("roberta.") :]
 
         # The original implementation contains weights which are not used, remove them from the state_dict
-        if tensor_key.endswith(".self.LayerNorm.weight") or tensor_key.endswith(".self.LayerNorm.bias"):
+        if tensor_key.endswith((".self.LayerNorm.weight", ".self.LayerNorm.bias")):
             continue
 
         state_dict[tensor_key] = tensor_value

--- a/src/transformers/models/rt_detr/convert_rt_detr_original_pytorch_checkpoint_to_hf.py
+++ b/src/transformers/models/rt_detr/convert_rt_detr_original_pytorch_checkpoint_to_hf.py
@@ -232,7 +232,7 @@ def create_rename_keys(config):
             )
         )
 
-    for j in range(0, 3):
+    for j in range(3):
         rename_keys.append((f"encoder.input_proj.{j}.0.weight", f"model.encoder_input_proj.{j}.0.weight"))
         for last in last_key:
             rename_keys.append((f"encoder.input_proj.{j}.1.{last}", f"model.encoder_input_proj.{j}.1.{last}"))

--- a/src/transformers/models/speecht5/number_normalizer.py
+++ b/src/transformers/models/speecht5/number_normalizer.py
@@ -78,7 +78,7 @@ class EnglishNumberNormalizer:
             return "zero"
 
         parts = []
-        for i in range(0, len(self.thousands)):
+        for i in range(len(self.thousands)):
             if num % 1000 != 0:
                 part = ""
                 hundreds = num % 1000 // 100

--- a/src/transformers/models/t5gemma2/modeling_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modeling_t5gemma2.py
@@ -1370,10 +1370,7 @@ class T5Gemma2ForConditionalGeneration(T5Gemma2PreTrainedModel, GenerationMixin)
             # Initialize new cache.
             model_kwargs["past_key_values"] = EncoderDecoderCache(
                 DynamicCache(
-                    **{
-                        "config": self.config.get_text_config(decoder=True),
-                        "offloading": offload_cache,
-                    }
+                    config=self.config.get_text_config(decoder=True), offloading=offload_cache
                 ),  # self-attention cache
                 DynamicCache(),  # cross-attention cache
             )

--- a/src/transformers/models/t5gemma2/modular_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modular_t5gemma2.py
@@ -1412,10 +1412,7 @@ class T5Gemma2ForConditionalGeneration(T5Gemma2PreTrainedModel, GenerationMixin)
             # Initialize new cache.
             model_kwargs["past_key_values"] = EncoderDecoderCache(
                 DynamicCache(
-                    **{
-                        "config": self.config.get_text_config(decoder=True),
-                        "offloading": offload_cache,
-                    }
+                    config=self.config.get_text_config(decoder=True), offloading=offload_cache
                 ),  # self-attention cache
                 DynamicCache(),  # cross-attention cache
             )

--- a/src/transformers/models/vits/convert_original_checkpoint.py
+++ b/src/transformers/models/vits/convert_original_checkpoint.py
@@ -163,7 +163,7 @@ def set_recursively(hf_pointer, key, value, full_name, weight_type):
         hf_shape = hf_pointer.shape
 
     # strip off the kernel dimension at the end (original weights are Conv1d)
-    if key.endswith(".k_proj") or key.endswith(".v_proj") or key.endswith(".q_proj") or key.endswith(".out_proj"):
+    if key.endswith((".k_proj", ".v_proj", ".q_proj", ".out_proj")):
         value = value.squeeze(-1)
 
     if hf_shape != value.shape:

--- a/src/transformers/models/xlstm/modeling_xlstm.py
+++ b/src/transformers/models/xlstm/modeling_xlstm.py
@@ -119,7 +119,7 @@ else:
 
         scaM_inter_k = scaM_inter_k.squeeze(-1)
 
-        for key in range(0, num_chunks):
+        for key in range(num_chunks):
             # store the states from the previous iteration before updating them
             # in the first iteration, these are the initial states
             matC_states[:, :, key * dhqk : (key + 1) * dhqk, :] = matC_k

--- a/src/transformers/pipelines/audio_classification.py
+++ b/src/transformers/pipelines/audio_classification.py
@@ -165,7 +165,7 @@ class AudioClassificationPipeline(Pipeline):
 
     def preprocess(self, inputs):
         if isinstance(inputs, str):
-            if inputs.startswith("http://") or inputs.startswith("https://"):
+            if inputs.startswith(("http://", "https://")):
                 # We need to actually check for a real protocol, otherwise it's impossible to use a local file
                 # like http_huggingface_co.png
                 inputs = httpx.get(inputs, follow_redirects=True).content

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -362,7 +362,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
 
     def preprocess(self, inputs, chunk_length_s=0, stride_length_s=None):
         if isinstance(inputs, str):
-            if inputs.startswith("http://") or inputs.startswith("https://"):
+            if inputs.startswith(("http://", "https://")):
                 # We need to actually check for a real protocol, otherwise it's impossible to use a local file
                 # like http_huggingface_co.png
                 inputs = httpx.get(inputs, follow_redirects=True).content

--- a/src/transformers/pipelines/video_classification.py
+++ b/src/transformers/pipelines/video_classification.py
@@ -141,7 +141,7 @@ class VideoClassificationPipeline(Pipeline):
         if num_frames is None:
             num_frames = self.model.config.num_frames
 
-        if video.startswith("http://") or video.startswith("https://"):
+        if video.startswith(("http://", "https://")):
             video = BytesIO(httpx.get(video, follow_redirects=True).content)
 
         container = av.open(video)

--- a/src/transformers/pipelines/zero_shot_audio_classification.py
+++ b/src/transformers/pipelines/zero_shot_audio_classification.py
@@ -104,7 +104,7 @@ class ZeroShotAudioClassificationPipeline(Pipeline):
 
     def preprocess(self, audio, candidate_labels=None, hypothesis_template="This is a sound of {}."):
         if isinstance(audio, str):
-            if audio.startswith("http://") or audio.startswith("https://"):
+            if audio.startswith(("http://", "https://")):
                 # We need to actually check for a real protocol, otherwise it's impossible to use a local file
                 # like http_huggingface_co.png
                 audio = httpx.get(audio, follow_redirects=True).content

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1257,7 +1257,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
     def __setattr__(self, key, value):
         key_without_id = key
-        key_is_special_id = key.endswith("_id") or key.endswith("_ids")
+        key_is_special_id = key.endswith(("_id", "_ids"))
         if key_is_special_id:
             key_without_id = key[:-3] if not key.endswith("_ids") else key[:-4]
 
@@ -1296,7 +1296,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
     def __getattr__(self, key):
         key_without_id = key
-        key_is_special_id = key.endswith("_id") or key.endswith("_ids")
+        key_is_special_id = key.endswith(("_id", "_ids"))
         if key_is_special_id:
             key_without_id = key[:-3] if not key.endswith("_ids") else key[:-4]
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -275,7 +275,7 @@ def default_compute_objective(metrics: dict[str, float]) -> float:
     loss = metrics.pop("eval_loss", None)
     _ = metrics.pop("epoch", None)
     # Remove speed metrics
-    speed_metrics = [m for m in metrics if m.endswith("_runtime") or m.endswith("_per_second")]
+    speed_metrics = [m for m in metrics if m.endswith(("_runtime", "_per_second"))]
     for sm in speed_metrics:
         _ = metrics.pop(sm, None)
     return loss if len(metrics) == 0 else sum(metrics.values())

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -2143,7 +2143,7 @@ class _LazyModule(ModuleType):
             # V5: If a tokenizer class doesn't exist, check if it should alias to another tokenizer
             # via the converter mapping (e.g., FNetTokenizer -> AlbertTokenizer via AlbertConverter)
             value = None
-            if name.endswith("Tokenizer") or name.endswith("TokenizerFast"):
+            if name.endswith(("Tokenizer", "TokenizerFast")):
                 # Strip "Fast" suffix for converter lookup if present
                 lookup_name = name[:-4] if name.endswith("TokenizerFast") else name
 

--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -699,7 +699,7 @@ def load_video(
             f.download([video])
         bytes_obj = buffer.getvalue()
         file_obj = BytesIO(bytes_obj)
-    elif video.startswith("http://") or video.startswith("https://"):
+    elif video.startswith(("http://", "https://")):
         file_obj = BytesIO(httpx.get(video, follow_redirects=True).content)
     elif os.path.isfile(video):
         file_obj = video
@@ -708,7 +708,7 @@ def load_video(
 
     # can also load with decord, but not cv2/torchvision
     # both will fail in case of url links
-    video_is_url = video.startswith("http://") or video.startswith("https://")
+    video_is_url = video.startswith(("http://", "https://"))
     if video_is_url and backend == "opencv":
         raise ValueError("If you are trying to load a video from URL, you cannot use 'opencv' as backend")
 

--- a/tests/models/beit/test_modeling_beit.py
+++ b/tests/models/beit/test_modeling_beit.py
@@ -535,7 +535,7 @@ class BeitModelIntegrationTest(unittest.TestCase):
     @slow
     def test_inference_interpolate_pos_encoding(self):
         model_name = "microsoft/beit-base-patch16-224-pt22k"
-        model = BeitModel.from_pretrained(model_name, **{"use_absolute_position_embeddings": True}).to(torch_device)
+        model = BeitModel.from_pretrained(model_name, use_absolute_position_embeddings=True).to(torch_device)
 
         image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
         processor = BeitImageProcessor.from_pretrained(model_name)

--- a/tests/models/data2vec/test_modeling_data2vec_vision.py
+++ b/tests/models/data2vec/test_modeling_data2vec_vision.py
@@ -345,9 +345,7 @@ class Data2VecVisionModelIntegrationTest(unittest.TestCase):
     @slow
     def test_inference_interpolate_pos_encoding(self):
         model_name = "facebook/data2vec-vision-base-ft1k"
-        model = Data2VecVisionModel.from_pretrained(model_name, **{"use_absolute_position_embeddings": True}).to(
-            torch_device
-        )
+        model = Data2VecVisionModel.from_pretrained(model_name, use_absolute_position_embeddings=True).to(torch_device)
 
         image = Image.open("./tests/fixtures/tests_samples/COCO/000000039769.png")
         processor = BeitImageProcessor.from_pretrained("facebook/data2vec-vision-base-ft1k")

--- a/tests/models/detr/test_image_processing_detr.py
+++ b/tests/models/detr/test_image_processing_detr.py
@@ -186,7 +186,7 @@ class DetrImageProcessingTest(AnnotationFormatTestMixin, ImageProcessingTestMixi
             "return_tensors": "pt",
         }
 
-        image_processor_params = {**image_processor_dict, **{"format": "_INVALID_FORMAT_"}}
+        image_processor_params = {**image_processor_dict, "format": "_INVALID_FORMAT_"}
         for image_processing_class in self.image_processor_list:
             image_processor = image_processing_class(**image_processor_params)
 

--- a/tests/models/idefics/test_modeling_idefics.py
+++ b/tests/models/idefics/test_modeling_idefics.py
@@ -833,7 +833,6 @@ class IdeficsForVisionText2TextTest(IdeficsModelTest, GenerationTesterMixin, uni
         Overwrite from generation tests because Idefics has only SDPA layers.
         Do not skip because we still want generation tests to run. Rather we can remove checks for shape.
         """
-        pass
 
     @unittest.skip(reason="We only test the model that takes in multiple images")
     def test_custom_4d_attention_mask(self):

--- a/tests/models/mask2former/test_image_processing_mask2former.py
+++ b/tests/models/mask2former/test_image_processing_mask2former.py
@@ -236,7 +236,7 @@ class Mask2FormerImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase
         weird_input_sizes = [(407, 802), (582, 1094)]
         for image_processing_class in self.image_processor_list:
             for size_divisor in size_divisors:
-                image_processor_dict = {**self.image_processor_dict, **{"size_divisor": size_divisor}}
+                image_processor_dict = {**self.image_processor_dict, "size_divisor": size_divisor}
                 image_processing = image_processing_class(**image_processor_dict)
                 for weird_input_size in weird_input_sizes:
                     inputs = image_processing([np.ones((3, *weird_input_size))], return_tensors="pt")

--- a/tests/models/maskformer/test_image_processing_maskformer.py
+++ b/tests/models/maskformer/test_image_processing_maskformer.py
@@ -221,7 +221,7 @@ class MaskFormerImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase)
         weird_input_sizes = [(407, 802), (582, 1094)]
         for image_processing_class in self.image_processor_list:
             for size_divisor in size_divisors:
-                image_processor_dict = {**self.image_processor_dict, **{"size_divisor": size_divisor}}
+                image_processor_dict = {**self.image_processor_dict, "size_divisor": size_divisor}
                 image_processing = image_processing_class(**image_processor_dict)
                 for weird_input_size in weird_input_sizes:
                     inputs = image_processing([np.ones((3, *weird_input_size))], return_tensors="pt")

--- a/tests/models/parakeet/test_tokenization_parakeet.py
+++ b/tests/models/parakeet/test_tokenization_parakeet.py
@@ -42,7 +42,6 @@ class ParakeetTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         Precompiled normalization from sentencepiece is `nmt_nfkc_cf` that includes lowercasing. Yet, ParakeetTokenizerFast does not have a do_lower_case attribute.
         This result in the test failing.
         """
-        pass
 
     @unittest.skip(reason="This needs a slow tokenizer. Parakeet does not have one!")
     def test_encode_decode_with_spaces(self):

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -1577,7 +1577,7 @@ class T5ModelIntegrationTests(unittest.TestCase):
         cache_buffers = [
             (name, buffer)
             for name, buffer in exported_program.named_buffers()
-            if name.startswith("key_cache_") or name.startswith("value_cache_")
+            if name.startswith(("key_cache_", "value_cache_"))
         ]
 
         # Verify cache buffers

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -889,7 +889,7 @@ class TorchAoSerializationAcceleratorTest(TorchAoSerializationTest):
     def setUpClass(cls):
         super().setUpClass()
         # fmt: off
-        cls.quant_scheme = Int4WeightOnlyConfig(**{"group_size": 32, "version": 1})
+        cls.quant_scheme = Int4WeightOnlyConfig(group_size=32, version=1)
         cls.quant_scheme_kwargs = {}
         EXPECTED_OUTPUTS = Expectations(
             {

--- a/tests/test_image_processing_common.py
+++ b/tests/test_image_processing_common.py
@@ -786,7 +786,7 @@ class AnnotationFormatTestMixin:
 
         for annotation_format, params in test_cases:
             with self.subTest(annotation_format):
-                image_processor_params = {**image_processor_dict, **{"format": annotation_format}}
+                image_processor_params = {**image_processor_dict, "format": annotation_format}
                 image_processor_first = self.image_processing_class(**image_processor_params)
 
                 with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/test_pipeline_mixin.py
+++ b/tests/test_pipeline_mixin.py
@@ -946,13 +946,9 @@ def compare_pipeline_args_to_hub_spec(pipeline_class, hub_spec):
     hub_args = set(get_arg_names_from_hub_spec(hub_spec))
 
     # Special casing: We allow the name of this arg to differ
-    hub_generate_args = [
-        hub_arg for hub_arg in hub_args if hub_arg.startswith("generate") or hub_arg.startswith("generation")
-    ]
+    hub_generate_args = [hub_arg for hub_arg in hub_args if hub_arg.startswith(("generate", "generation"))]
     docstring_generate_args = [
-        docstring_arg
-        for docstring_arg in docstring_args
-        if docstring_arg.startswith("generate") or docstring_arg.startswith("generation")
+        docstring_arg for docstring_arg in docstring_args if docstring_arg.startswith(("generate", "generation"))
     ]
     if (
         len(hub_generate_args) == 1

--- a/tests/test_training_mixin.py
+++ b/tests/test_training_mixin.py
@@ -100,7 +100,6 @@ class TrainingTesterMixin(ABC):
         width: int,
     ) -> dict[str, torch.Tensor]:
         """Create fixed batch for image models using a deterministic pattern."""
-        pass
 
     def _create_audio_training_batch(
         self,
@@ -109,7 +108,6 @@ class TrainingTesterMixin(ABC):
         feature_size: Optional[int] = None,
     ) -> dict[str, torch.Tensor]:
         """Create fixed batch for audio models using a deterministic waveform."""
-        pass
 
     def _decode_text_tokens(self, tokens: list[int], max_display: int = 40) -> str:
         """Decode tokens to readable string (maps token IDs to letters: 1->a, 2->b, etc.)."""

--- a/tests/test_video_processing_common.py
+++ b/tests/test_video_processing_common.py
@@ -357,7 +357,7 @@ class VideoProcessingTestMixin:
 
             # Sample with `fps` requires metadata to infer number of frames from total duration
             with self.assertRaises(ValueError):
-                metadata = VideoMetadata(**{"total_num_frames": 8})
+                metadata = VideoMetadata(total_num_frames=8)
                 video_processing.sample_frames(metadata=metadata, fps=3)
 
             metadata = [[{"duration": 2.0, "total_num_frames": 8, "fps": 4}]]

--- a/tests/trainer/test_trainer_utils.py
+++ b/tests/trainer/test_trainer_utils.py
@@ -304,7 +304,7 @@ class TrainerUtilsTest(unittest.TestCase):
         ]
         # When drop_last=False, we get two last full batches by looping back to the beginning.
         expected_shards[0].extend(list(range(96, 100)))
-        expected_shards[1].extend(list(range(0, 4)))
+        expected_shards[1].extend(list(range(4)))
 
         self.assertListEqual([list(shard) for shard in sampler_shards], expected_shards)
         self.assertListEqual([len(shard) for shard in sampler_shards], [len(shard) for shard in expected_shards])

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -441,7 +441,6 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
             Returns:
                 God knows what
             """
-            pass
 
         schema = get_json_schema(fn)
         expected_schema = {
@@ -470,7 +469,6 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
             Args:
                 x: The first input
             """
-            pass
 
         schema = get_json_schema(fn)
         expected_schema = {
@@ -505,7 +503,6 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
                 The output. The return description is also a big multiline
                 description that spans multiple lines.
             """
-            pass
 
         schema = get_json_schema(fn)
         expected_schema = {

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -3301,8 +3301,6 @@ class TestGetDecoder(unittest.TestCase):
         class MockInnerModel:
             """Mock model without get_decoder method."""
 
-            pass
-
         class MockWrapperModel:
             """Mock wrapper with model attribute but inner has no get_decoder."""
 
@@ -3505,8 +3503,6 @@ class TestGetEncoder(unittest.TestCase):
 
         class MockInnerModel:
             """Mock model without get_encoder method."""
-
-            pass
 
         class MockWrapperModel:
             """Mock wrapper with model attribute but inner has no get_encoder."""

--- a/utils/add_dates.py
+++ b/utils/add_dates.py
@@ -181,7 +181,7 @@ def get_release_date(link: str) -> str:
         except Exception as e:
             print(f"Error fetching release date for the paper https://huggingface.co/papers/{link}: {e}")
 
-    elif link.startswith("https://arxiv.org/abs/") or link.startswith("https://arxiv.org/pdf/"):
+    elif link.startswith(("https://arxiv.org/abs/", "https://arxiv.org/pdf/")):
         print(f"This paper {link} is not yet available in Hugging Face papers, skipping the release date attachment.")
         return r"{release_date}"
 

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -1062,14 +1062,7 @@ def ignore_undocumented(name: str) -> bool:
     if name.isupper():
         return True
     # PreTrainedModels / Encoders / Decoders / Layers / Embeddings / Attention are not documented.
-    if (
-        name.endswith("PreTrainedModel")
-        or name.endswith("Decoder")
-        or name.endswith("Encoder")
-        or name.endswith("Layer")
-        or name.endswith("Embeddings")
-        or name.endswith("Attention")
-    ):
+    if name.endswith(("PreTrainedModel", "Decoder", "Encoder", "Layer", "Embeddings", "Attention")):
         return True
     # Submodules are not documented.
     if os.path.isdir(os.path.join(PATH_TO_TRANSFORMERS, name)) or os.path.isfile(

--- a/utils/compare_test_runs.py
+++ b/utils/compare_test_runs.py
@@ -25,7 +25,7 @@ def normalize_test_line(line):
         return f"{status} {location}"
 
     # Normalize ERROR/FAILED lines with optional message
-    if line.startswith("ERROR") or line.startswith("FAILED"):
+    if line.startswith(("ERROR", "FAILED")):
         return re.split(r"\s+-\s+", line)[0].strip()
 
     return line

--- a/utils/create_dummy_models.py
+++ b/utils/create_dummy_models.py
@@ -1194,7 +1194,7 @@ def build_tiny_model_summary(results, organization=None, token=None):
     tiny_model_summary = {}
     for config_name in results:
         processors = [key for key, value in results[config_name]["processor"].items()]
-        tokenizer_classes = sorted([x for x in processors if x.endswith("TokenizerFast") or x.endswith("Tokenizer")])
+        tokenizer_classes = sorted([x for x in processors if x.endswith(("TokenizerFast", "Tokenizer"))])
         processor_classes = sorted([x for x in processors if x not in tokenizer_classes])
 
         if "pytorch" not in results[config_name]:

--- a/utils/modular_integrations.py
+++ b/utils/modular_integrations.py
@@ -118,7 +118,7 @@ def convert_to_relative_import(import_node: cst.ImportFrom, file_path: str, pack
 
     # Check if it's from the target package
     if (
-        not (module_name.startswith(package_name + ".") or module_name.startswith("optimum." + package_name + "."))
+        not (module_name.startswith((package_name + ".", "optimum." + package_name + ".")))
         and module_name != package_name
     ):
         return import_node  # Not from target package


### PR DESCRIPTION
# What does this PR do?

This PR enables all [flake8-pie](https://docs.astral.sh/ruff/rules/#flake8-pie-pie) rules in ruff. These rules are:
```
PIE790   Unnecessary pass statement
PIE794   Class field {name} is defined multiple times 
PIE796   Enum contains duplicate value: {value}  
PIE800   Unnecessary spread ** 
PIE804   Unnecessary dict kwargs  
PIE807   Prefer {container} over useless lambda 
PIE808   Unnecessary start argument in range  
PIE810   Call {attr} once with a tuple   
```