### PR TITLE
QwenVL: add skipped keys in `setattr` as well

### DIFF
--- a/src/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
@@ -304,7 +304,7 @@ class Qwen2_5_VLConfig(PreTrainedConfig):
     def __setattr__(self, key, value):
         if (
             (text_config := super().__getattribute__("__dict__").get("text_config")) is not None
-            and key not in ["dtype", "_attn_implementation_internal"]
+            and key not in ["_name_or_path", "model_type", "dtype", "_attn_implementation_internal"]
             and key in text_config.__dict__
         ):
             setattr(text_config, key, value)

--- a/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -292,7 +292,7 @@ class Qwen2VLConfig(PreTrainedConfig):
     def __setattr__(self, key, value):
         if (
             (text_config := super().__getattribute__("__dict__").get("text_config")) is not None
-            and key not in ["dtype", "_attn_implementation_internal"]
+            and key not in ["_name_or_path", "model_type", "dtype", "_attn_implementation_internal"]
             and key in text_config.__dict__
         ):
             setattr(text_config, key, value)


### PR DESCRIPTION
# What does this PR do?

As per title, getattr and setattr skip different set of keys now 
