### PR TITLE
Add a safeguard around a flaky test in gemma2

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -669,7 +669,7 @@ def flex_attention_mask(
         Q_LEN=q_length,
         KV_LEN=kv_length,
         device=cache_position.device,
-        _compile=_is_torch_greater_or_equal_than_2_6,
+        _compile=not _is_torch_greater_or_equal_than_2_6,
     )
     return block_mask
 

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -669,7 +669,7 @@ def flex_attention_mask(
         Q_LEN=q_length,
         KV_LEN=kv_length,
         device=cache_position.device,
-        _compile=not _is_torch_greater_or_equal_than_2_6,
+        _compile=_is_torch_greater_or_equal_than_2_6,
     )
     return block_mask
 

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -151,6 +151,10 @@ class Gemma2IntegrationTest(unittest.TestCase):
                     "Hello I am doing a project on the 1960s and I am trying to find out what the average",
                     "Hi today I'm going to be talking about the 10 most powerful characters in the Naruto series.",
                 ],
+                ("cuda", (9, 0)): [
+                    "Hello I am doing a project on the 1960s and I am trying to find out what the average",
+                    "Hi today I'm going to be talking about the 10 best anime of all time.\n\n1",
+                ],
             }
         )
         EXPECTED_BATCH_TEXT = EXPECTED_BATCH_TEXTS.get_expectation()

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -34,6 +34,7 @@ from transformers.testing_utils import (
     require_torch_accelerator,
     require_torch_large_accelerator,
     require_torch_large_gpu,
+    run_test_using_subprocess,
     slow,
     torch_device,
 )
@@ -136,6 +137,9 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(output[0][0]["generated_text"], EXPECTED_TEXTS[0])
         self.assertEqual(output[1][0]["generated_text"], EXPECTED_TEXTS[1])
 
+    # TODO: run_test_using_subprocess was added because of an issue in torch 2.9, which is already fixed in nightly
+    # We can remove this once we upgrade to torch 2.10
+    @run_test_using_subprocess
     @require_read_token
     def test_model_2b_pipeline_bf16_flex_attention(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Gemma2 before this PR
@@ -150,10 +154,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
                 ("cuda", 8): [
                     "Hello I am doing a project on the 1960s and I am trying to find out what the average",
                     "Hi today I'm going to be talking about the 10 most powerful characters in the Naruto series.",
-                ],
-                ("cuda", (9, 0)): [
-                    "Hello I am doing a project on the 1960s and I am trying to find out what the average",
-                    "Hi today I'm going to be talking about the 10 best anime of all time.\n\n1",
                 ],
             }
         )


### PR DESCRIPTION
The test `tests/models/gemma2/test_modeling_gemma2.py::Gemma2IntegrationTest::test_model_2b_pipeline_bf16_flex_attention` is flaky because of the `_compile` flag at https://github.com/huggingface/transformers/blob/fe11cbb808b4301399240e40c5cb6cca9bb00d4d/src/transformers/masking_utils.py#L675
The issue is solved when upgrading torch to nightly 2.10, so it makes little sense to change the code.
But when the test causes an error, it causes all subsequent tests to fail. So this PR adds the `@run_test_using_subprocess` decorator around the test so this does not happen anymore. And a TODO to remove this once the fix is in the stable version of torch.