### PR TITLE
Fix processor saving with multiple tokenizers

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -796,8 +796,8 @@ class ProcessorMixin(PushToHubMixin):
             if attribute_name == "tokenizer":
                 # Create a subdirectory for this attribute to avoid filename conflicts
                 attribute_save_directory = os.path.join(save_directory, attribute_name)
-                attribute.save_pretrained(attribute_save_directory)            elif attribute._auto_class is not None:
-                custom_object_save(attribute, save_directory, config=attribute)
+                attribute.save_pretrained(attribute_save_directory)
+                elif attribute._auto_class is not None:                custom_object_save(attribute, save_directory, config=attribute)
 
         if self._auto_class is not None:
             # We added an attribute to the init_kwargs of the tokenizers, which needs to be cleaned up.

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -797,8 +797,8 @@ class ProcessorMixin(PushToHubMixin):
                 # Create a subdirectory for this attribute to avoid filename conflicts
                 attribute_save_directory = os.path.join(save_directory, attribute_name)
                 attribute.save_pretrained(attribute_save_directory)
-                elif attribute._auto_class is not None:                custom_object_save(attribute, save_directory, config=attribute)
-
+                elif attribute._auto_class is not None:
+                    custom_object_save(attribute, save_directory, config=attribute)
         if self._auto_class is not None:
             # We added an attribute to the init_kwargs of the tokenizers, which needs to be cleaned up.
             for attribute_name in self.attributes:


### PR DESCRIPTION
Resolves issue #41816

When a processor contains multiple tokenizers (or other sub-processors of the same type), they were overwriting each other during save due to using the same file names. This fix:

1. Saves each attribute in its own subdirectory named after the attribute name
2. Updates loading logic to check for subdirectories first (new format), then falls back to main directory (legacy format) for backward compatibility

This maintains backward compatibility while allowing processors with multiple tokenizers to save and load correctly.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
