### PR TITLE
Fix const parsing for dict inputs in chat schemas

### DIFF
--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -173,12 +173,12 @@ def recursive_parse(
             return parsed_schema
         elif isinstance(node_content, dict):
             for key, child_node in node_schema.get("properties", {}).items():
-                if key in node_content:
+                if "const" in child_node:
+                    parsed_schema[key] = child_node["const"]
+                elif key in node_content:
                     parsed_schema[key] = recursive_parse(node_content[key], child_node)
                 elif "default" in child_node:
                     parsed_schema[key] = child_node["default"]
-                else:
-                    pass
             if "additionalProperties" in node_schema:
                 for key, value in node_content.items():
                     if key not in node_schema.get("properties", {}):

--- a/tests/utils/test_chat_parsing_utils.py
+++ b/tests/utils/test_chat_parsing_utils.py
@@ -306,7 +306,7 @@ class ChatSchemaParserTest(unittest.TestCase):
                 "role": "assistant",
                 "tool_calls": [
                     {"type": "function", "function": {"name": "get_weather", "arguments": {"city": "Paris"}}}
-                ]
+                ],
             },
         )
 
@@ -340,6 +340,6 @@ class ChatSchemaParserTest(unittest.TestCase):
                             },
                         },
                     }
-                ]
+                ],
             },
         )

--- a/tests/utils/test_chat_parsing_utils.py
+++ b/tests/utils/test_chat_parsing_utils.py
@@ -281,6 +281,7 @@ class ChatSchemaParserTest(unittest.TestCase):
         self.assertEqual(
             parsed_chat,
             {
+                "role": "assistant",
                 "thinking": 'Okay, the user said, "Hello! How are you?" I need to respond appropriately. Since this is the first message, I should greet them back and ask how I can assist. I should keep it friendly and open-ended. Let me make sure the response is welcoming and encourages them to share what they need help with. I\'ll avoid any technical jargon and keep it simple. Let me check for any typos and ensure the tone is positive.',
                 "tool_calls": [
                     {
@@ -302,6 +303,7 @@ class ChatSchemaParserTest(unittest.TestCase):
         self.assertEqual(
             parsed_chat,
             {
+                "role": "assistant",
                 "tool_calls": [
                     {"type": "function", "function": {"name": "get_weather", "arguments": {"city": "Paris"}}}
                 ]
@@ -314,6 +316,7 @@ class ChatSchemaParserTest(unittest.TestCase):
         self.assertEqual(
             parsed_chat,
             {
+                "role": "assistant",
                 "content": "Some content about gravity goes here but I'm cutting it off to make this shorter!",
                 "thinking": 'Okay, the user asked, "Hey! Can you tell me about gravity?" Let me start by breaking down what they might be looking for. They probably want a basic understanding of gravity, maybe for a school project or just personal curiosity. I should explain what gravity is, how it works, and maybe some examples.',
             },
@@ -325,6 +328,7 @@ class ChatSchemaParserTest(unittest.TestCase):
         self.assertEqual(
             parsed_chat,
             {
+                "role": "assistant",
                 "tool_calls": [
                     {
                         "type": "function",


### PR DESCRIPTION
Found one more bug in chat schemas and updated the tests to cover it! `const` nodes were not being handled correctly when the parent node had structured content.

This PR also moves `test_chat_schema_utils.py` to `test_chat_parsing_utils.py` to match the name of the actual file `utils/chat_parsing_utils.py`.

Tests may not be running in the CI yet but I ran them all locally and they're passing!