### PR TITLE
Fix Qwen2Audio flash attention mask format for generation

### DIFF
--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -777,8 +777,9 @@ class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMi
                 padding_mask = seq_range >= lengths_expand
                 audio_attention_mask_2d = (~padding_mask).to(dtype=torch.long, device=audio_feat_lengths.device)
 
+                # Dummy embeddings for mask creation (only shape, dtype, and device are used)
                 dummy_embeds = torch.zeros(
-                    (batch_size, max_seq_len, self.audio_tower.config.d_model),
+                    (batch_size, max_seq_len, 1),
                     dtype=self.audio_tower.conv1.weight.dtype,
                     device=self.audio_tower.conv1.weight.device,
                 )

--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -779,8 +779,8 @@ class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMi
 
                 dummy_embeds = torch.zeros(
                     (batch_size, max_seq_len, 1),
-                    dtype=self.audio_tower.conv1.weight.dtype,
-                    device=self.audio_tower.conv1.weight.device,
+                    dtype=inputs_embeds.dtype,
+                    device=inputs_embeds.device,
                 )
 
                 audio_attention_mask = create_bidirectional_mask(

--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -25,6 +25,7 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache
 from ...generation import GenerationMixin
+from ...masking_utils import create_bidirectional_mask
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutput, ModelOutput
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
@@ -774,23 +775,19 @@ class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMi
                 lengths_expand = audio_feat_lengths.unsqueeze(1).expand(batch_size, max_seq_len)
                 # Create mask
                 padding_mask = seq_range >= lengths_expand
+                audio_attention_mask_2d = (~padding_mask).to(dtype=torch.long, device=audio_feat_lengths.device)
 
-                # Flash attention requires a 2D boolean mask (batch_size, seq_len) where 1 means valid and 0 means padding
-                # Eager/SDPA attention requires a 4D mask with -inf for padding
-                if self.audio_tower.config._attn_implementation in ["flash_attention_2", "flash_attention_3"]:
-                    # For flash attention: 2D mask with 1 for valid tokens, 0 for padding
-                    audio_attention_mask = (~padding_mask).to(
-                        dtype=torch.int32, device=self.audio_tower.conv1.weight.device
-                    )
-                else:
-                    # For eager/SDPA: 4D mask with -inf for padding
-                    audio_attention_mask_ = padding_mask.view(batch_size, 1, 1, max_seq_len).expand(
-                        batch_size, 1, max_seq_len, max_seq_len
-                    )
-                    audio_attention_mask = audio_attention_mask_.to(
-                        dtype=self.audio_tower.conv1.weight.dtype, device=self.audio_tower.conv1.weight.device
-                    )
-                    audio_attention_mask[audio_attention_mask_] = float("-inf")
+                dummy_embeds = torch.zeros(
+                    (batch_size, max_seq_len, self.audio_tower.config.d_model),
+                    dtype=self.audio_tower.conv1.weight.dtype,
+                    device=self.audio_tower.conv1.weight.device,
+                )
+
+                audio_attention_mask = create_bidirectional_mask(
+                    config=self.audio_tower.config,
+                    input_embeds=dummy_embeds,
+                    attention_mask=audio_attention_mask_2d,
+                )
 
                 audio_outputs = self.audio_tower(input_features, attention_mask=audio_attention_mask)
                 selected_audio_feature = audio_outputs.last_hidden_state

--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -777,7 +777,6 @@ class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMi
                 padding_mask = seq_range >= lengths_expand
                 audio_attention_mask_2d = (~padding_mask).to(dtype=torch.long, device=audio_feat_lengths.device)
 
-                # Dummy embeddings for mask creation (only shape, dtype, and device are used)
                 dummy_embeds = torch.zeros(
                     (batch_size, max_seq_len, 1),
                     dtype=self.audio_tower.conv1.weight.dtype,


### PR DESCRIPTION
## What does this PR fix?

This PR fixes the `test_eager_matches_fa2_generate` test failure for Qwen2Audio by using the `create_bidirectional_mask` utility function to properly handle attention masks across different attention implementations.

The Qwen2Audio model was manually creating a 4D attention mask with `-inf` values for the audio encoder, regardless of the attention implementation being used. This caused issues with Flash Attention 2/3, which requires a 2D boolean mask (shape `(batch_size, seq_len)`) with `1` for valid tokens and `0` for padding.