### PR TITLE
Fix FSDPv2 checkpoint saving on TPU by using recursive unwrap

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3995,17 +3995,18 @@ class Trainer:
                     logger.info("Trainer.model is not a `PreTrainedModel`, only saving its state dict.")
                     xm.save(full_state_dict, os.path.join(output_dir, WEIGHTS_NAME))
         elif not isinstance(model, supported_classes):
-            if isinstance(self.accelerator.unwrap_model(model), supported_classes):
-                self.accelerator.unwrap_model(model).save_pretrained(
+            unwrapped_model = unwrap_model(model, recursive=self.is_fsdp_xla_v2_enabled)
+            if isinstance(unwrapped_model, supported_classes):
+                unwrapped_model.save_pretrained(
                     output_dir,
                     is_main_process=self.args.should_save,
-                    state_dict=xm._maybe_convert_to_cpu(model.state_dict()),
+                    state_dict=xm._maybe_convert_to_cpu(unwrapped_model.state_dict()),
                     save_function=xm.save,
                     safe_serialization=self.args.save_safetensors,
                 )
             else:
                 logger.info("Trainer.model is not a `PreTrainedModel`, only saving its state dict.")
-                state_dict = xm._maybe_convert_to_cpu(model.state_dict())
+                state_dict = xm._maybe_convert_to_cpu(unwrapped_model.state_dict())
                 xm.save(state_dict, os.path.join(output_dir, WEIGHTS_NAME))
         else:
             model.save_pretrained(


### PR DESCRIPTION
# What does this PR do?

This PR fixes checkpoint saving for FSDPv2 (SPMD) on TPU by properly unwrapping nested FSDP wrappers before extracting the model state dict.

When using FSDPv2 on TPU, models have nested FSDP wrappers around each transformer layer. The previous implementation only unwrapped the top-level wrapper, causing the saved checkpoint to contain wrapped state dict keys instead of the actual model parameters. This resulted in:
- PEFT adapters not being saved in the correct format
- Model weights appearing unchanged after training
- Missing adapter keys when loading checkpoints

The fix uses `unwrap_model` with `recursive=True` specifically for FSDPv2 to unwrap all nested wrappers, then extracts the state dict from the fully unwrapped model. This ensures clean parameter keys in saved checkpoints while maintaining backward compatibility with FSDPv1 and other training configurations.
https://github.com/huggingface/transformers/issues/36004
Fixes #36004

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc @muellerzr