### PR TITLE
speed up loading checkpoints for zero stage 3

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -314,13 +314,14 @@ def _load_state_dict_into_zero3_model(model_to_load, state_dict):
         args = (state_dict, prefix, local_metadata, True, [], [], error_msgs)
         # Parameters of module and children will start with prefix. We can exit early if there are none in this
         # state_dict
-        if is_deepspeed_zero3_enabled() and len([key for key in state_dict if key.startswith(prefix)]) > 0:
+        if is_deepspeed_zero3_enabled():
             import deepspeed
 
             # In sharded models, each shard has only part of the full state_dict, so only gather
             # parameters that are in the current state_dict.
             named_parameters = dict(module.named_parameters(prefix=prefix[:-1], recurse=False))
-            params_to_gather = [named_parameters[k] for k in state_dict if k in named_parameters]
+            params_to_gather = [named_parameters[k] for k in named_parameters if k in state_dict]
+
             if len(params_to_gather) > 0:
                 # because zero3 puts placeholders in model params, this context
                 # manager gathers (unpartitions) the params of the current layer, then loads from

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -218,13 +218,10 @@ class PeftAdapterMixin:
             token = adapter_kwargs.pop("token")
 
         if peft_config is None:
-            new_args = adapter_kwargs.copy()
-            if 'token' in new_args:
-                new_args.pop('token')
             adapter_config_file = find_adapter_config_file(
                 peft_model_id,
                 token=token,
-                **new_args,
+                **adapter_kwargs,
             )
 
             if adapter_config_file is None:
@@ -655,10 +652,6 @@ def maybe_load_adapters(
     _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None)
 
     if _adapter_model_path is None:
-        new_args = adapter_kwargs.copy()
-        if 'token' in new_args:
-            new_args.pop('token')
-
         _adapter_model_path = find_adapter_config_file(
             pretrained_model_name_or_path,
             cache_dir=download_kwargs.get("cache_dir"),
@@ -669,7 +662,7 @@ def maybe_load_adapters(
             local_files_only=bool(download_kwargs.get("local_files_only", False)),
             subfolder=download_kwargs.get("subfolder", ""),
             _commit_hash=download_kwargs.get("commit_hash"),
-            **new_args,
+            **adapter_kwargs,
         )
 
     if _adapter_model_path is not None and os.path.isfile(_adapter_model_path):

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -218,10 +218,13 @@ class PeftAdapterMixin:
             token = adapter_kwargs.pop("token")
 
         if peft_config is None:
+            new_args = adapter_kwargs.copy()
+            if 'token' in new_args:
+                new_args.pop('token')
             adapter_config_file = find_adapter_config_file(
                 peft_model_id,
                 token=token,
-                **adapter_kwargs,
+                **new_args,
             )
 
             if adapter_config_file is None:
@@ -652,6 +655,10 @@ def maybe_load_adapters(
     _adapter_model_path = adapter_kwargs.pop("_adapter_model_path", None)
 
     if _adapter_model_path is None:
+        new_args = adapter_kwargs.copy()
+        if 'token' in new_args:
+            new_args.pop('token')
+
         _adapter_model_path = find_adapter_config_file(
             pretrained_model_name_or_path,
             cache_dir=download_kwargs.get("cache_dir"),
@@ -662,7 +669,7 @@ def maybe_load_adapters(
             local_files_only=bool(download_kwargs.get("local_files_only", False)),
             subfolder=download_kwargs.get("subfolder", ""),
             _commit_hash=download_kwargs.get("commit_hash"),
-            **adapter_kwargs,
+            **new_args,
         )
 
     if _adapter_model_path is not None and os.path.isfile(_adapter_model_path):


### PR DESCRIPTION

Loading checkpoints for model Qwen/Qwen3-Next-80B-A3B-Instruct was very slow

this change brought down checkpoint loading times from 10mins+ to about 1.5mins

the load method is called over 4 million times (123,799 per layer and there are 41 layers). Looping through the state dict (size ~1500) was therefore very slow. This change speed the loading method by avoiding looping through the state dict.

Flagged for review
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- Big Model Inference: @SunMarc