### PR TITLE
Fix Auto classes to support dynamically registered processors

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -524,10 +524,9 @@ class AutoImageProcessor:
                 )
                 use_fast = False
             if use_fast:
-                for image_processors in IMAGE_PROCESSOR_MAPPING_NAMES.values():
-                    if image_processor_type in image_processors:
-                        break
-                else:
+                # Check if the fast image processor class exists
+                image_processor_class_fast = get_image_processor_class_from_name(image_processor_type)
+                if image_processor_class_fast is None:
                     image_processor_type = image_processor_type[:-4]
                     use_fast = False
                     logger.warning_once(

--- a/src/transformers/models/auto/video_processing_auto.py
+++ b/src/transformers/models/auto/video_processing_auto.py
@@ -291,7 +291,7 @@ class AutoVideoProcessor:
 
                 # Some models have different image processors, e.g. InternVL uses GotOCRImageProcessor
                 # We cannot use GotOCRVideoProcessor when falling back for BC and should try to infer from config later on
-                if video_processor_class_inferred in VIDEO_PROCESSOR_MAPPING_NAMES.values():
+                if video_processor_class_from_name(video_processor_class_inferred) is not None:
                     video_processor_class = video_processor_class_inferred
             if "AutoImageProcessor" in config_dict.get("auto_map", {}):
                 image_processor_auto_map = config_dict["auto_map"]["AutoImageProcessor"]


### PR DESCRIPTION
# What does this PR do?

This PR fixes Auto classes (`AutoImageProcessor` and `AutoVideoProcessor`) to properly support dynamically registered processors via the `.register()` method.

## Problem

When users call `AutoImageProcessor.register()` or `AutoVideoProcessor.register()`, the registration only updates the `*_MAPPING` objects (specifically their `_extra_content`), not the `*_MAPPING_NAMES` dictionaries. However, some code paths were checking `*_MAPPING_NAMES` instead of `*_MAPPING`, which meant registered processors would not be recognized in certain code paths.

## Changes

### `image_processing_auto.py`
- **Line 527-531**: Replaced a `for-else` loop that checked if `image_processor_type` exists in `IMAGE_PROCESSOR_MAPPING_NAMES.values()` with a direct call to `get_image_processor_class_from_name()`, which properly checks both the static mapping and registered items via `IMAGE_PROCESSOR_MAPPING._extra_content`

### `video_processing_auto.py`
- **Line 294**: Changed from checking `if video_processor_class_inferred in VIDEO_PROCESSOR_MAPPING_NAMES.values()` to using `video_processor_class_from_name(video_processor_class_inferred) is not None`, which properly checks both the static mapping and registered items

## Why This Matters

The helper functions like `get_image_processor_class_from_name()` and `video_processor_class_from_name()` are designed to check both:
1. The static `*_MAPPING_NAMES` dictionaries (for built-in processors)
2. The `*_MAPPING._extra_content` dictionaries (for dynamically registered processors)

By using these helper functions instead of directly checking `*_MAPPING_NAMES.values()`, we ensure that dynamically registered processors are properly recognized throughout the codebase.

## Testing

The changes maintain backward compatibility with existing code while adding support for registered processors. The helper functions already have the logic to handle both static and dynamic mappings.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @CyrilVallez (model loading)

