### PR TITLE
revert changes in _is_package_available

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -48,7 +48,7 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
     """Check if `pkg_name` exist, and optionally try to get its version"""
     spec = importlib.util.find_spec(pkg_name)
     # the spec might be not None but not importable
-    package_exists = spec is not None and spec.loader is not None
+    package_exists = spec is not None
     package_version = "N/A"
     if package_exists and return_version:
         try:

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -47,7 +47,6 @@ PACKAGE_DISTRIBUTION_MAPPING = importlib.metadata.packages_distributions()
 def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[bool, str] | bool:
     """Check if `pkg_name` exist, and optionally try to get its version"""
     spec = importlib.util.find_spec(pkg_name)
-    # the spec might be not None but not importable
     package_exists = spec is not None
     package_version = "N/A"
     if package_exists and return_version:


### PR DESCRIPTION
# What does this PR do?

Reverts https://github.com/huggingface/transformers/pull/41411, because for some packages like `optimum` we don't have loaders as expected from most packages.