### PR TITLE
Fix inaccurate eval and train loss computation with variable batch sizes

### DIFF
--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -616,6 +616,7 @@ def main():
         model.train()
         if args.with_tracking:
             total_loss = 0
+            total_samples = 0
         if args.resume_from_checkpoint and epoch == starting_epoch and resume_step is not None:
             # We skip the first `n` batches in the dataloader when resuming from a checkpoint
             active_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
@@ -627,7 +628,9 @@ def main():
                 loss = outputs.loss
                 # We keep track of the loss at each epoch
                 if args.with_tracking:
-                    total_loss += loss.detach().float()
+                    batch_size = batch["input_ids"].shape[0]
+                    total_loss += loss.detach().float() * batch_size
+                    total_samples += batch_size
                 accelerator.backward(loss)
                 optimizer.step()
                 lr_scheduler.step()
@@ -654,7 +657,8 @@ def main():
                 outputs = model(**batch)
 
             loss = outputs.loss
-            losses.append(accelerator.gather_for_metrics(loss.repeat(args.per_device_eval_batch_size)))
+            batch_size = batch["input_ids"].shape[0]
+            losses.append(accelerator.gather_for_metrics(loss.repeat(batch_size)))
 
         losses = torch.cat(losses)
         try:
@@ -670,7 +674,7 @@ def main():
                 {
                     "perplexity": perplexity,
                     "eval_loss": eval_loss,
-                    "train_loss": total_loss.item() / len(train_dataloader),
+                    "train_loss": total_loss.item() / total_samples,
                     "epoch": epoch,
                     "step": completed_steps,
                 },

--- a/examples/pytorch/language-modeling/run_mlm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_mlm_no_trainer.py
@@ -653,6 +653,7 @@ def main():
         model.train()
         if args.with_tracking:
             total_loss = 0
+            total_samples = 0
         if args.resume_from_checkpoint and epoch == starting_epoch and resume_step is not None:
             # We skip the first `n` batches in the dataloader when resuming from a checkpoint
             active_dataloader = accelerator.skip_first_batches(train_dataloader, resume_step)
@@ -664,7 +665,9 @@ def main():
                 loss = outputs.loss
                 # We keep track of the loss at each epoch
                 if args.with_tracking:
-                    total_loss += loss.detach().float()
+                    batch_size = batch["input_ids"].shape[0]
+                    total_loss += loss.detach().float() * batch_size
+                    total_samples += batch_size
                 accelerator.backward(loss)
                 optimizer.step()
                 lr_scheduler.step()
@@ -692,7 +695,8 @@ def main():
                 outputs = model(**batch)
 
             loss = outputs.loss
-            losses.append(accelerator.gather_for_metrics(loss.repeat(args.per_device_eval_batch_size)))
+            batch_size = batch["input_ids"].shape[0]
+            losses.append(accelerator.gather_for_metrics(loss.repeat(batch_size)))
 
         losses = torch.cat(losses)
         try:
@@ -708,7 +712,7 @@ def main():
                 {
                     "perplexity": perplexity,
                     "eval_loss": eval_loss,
-                    "train_loss": total_loss.item() / len(train_dataloader),
+                    "train_loss": total_loss.item() / total_samples,
                     "epoch": epoch,
                     "step": completed_steps,
                 },

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4400,7 +4400,7 @@ class Trainer:
 
             # Update containers
             if losses is not None:
-                losses = self.gather_function(losses.repeat(batch_size))
+                losses = self.gather_function(losses.repeat(observed_batch_size))
                 all_losses.add(losses)
             if inputs_decode is not None:
                 inputs_decode = self.accelerator.pad_across_processes(inputs_decode, dim=1, pad_index=-100)


### PR DESCRIPTION
Fixes #41898

When drop_last=False (default), the last batch may contain fewer samples than per_device_eval_batch_size. Using a fixed batch_size to repeat the scalar loss causes the last batch to be over-represented in the final average loss calculation.

Changes:
- Trainer: Use observed_batch_size instead of fixed batch_size when repeating eval loss for gather_for_metrics
- no_trainer examples: Use actual batch size from input_ids.shape[0] for both eval and train loss computation
- Train loss: Weight by actual batch size and divide by total samples instead of number of batches

This ensures accurate loss computation regardless of batch size variability while maintaining backward compatibility (identical behavior when all batches are uniform size).

