### PR TITLE
restore dtype of `hidden_states` in modeling_t5.py

### DIFF
--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -395,7 +395,7 @@ class Kosmos2_5VisionEmbeddings(nn.Module):
 
 
 # Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5DenseGatedActDense->Pix2StructVisionMlp,T5Config->Pix2StructVisionConfig,config.d_model->config.hidden_size,dropout_rate->dropout_rate
-class Kosmos2_5VisionMlp(nn.Module):
+class Pix2StructVisionMlp(nn.Module):
     def __init__(self, config: Kosmos2_5VisionConfig):
         super().__init__()
         self.wi_0 = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)
@@ -416,6 +416,7 @@ class Kosmos2_5VisionMlp(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -424,7 +425,7 @@ class Kosmos2_5VisionMlp(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 def eager_attention_forward(

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -395,7 +395,7 @@ class Kosmos2_5VisionEmbeddings(nn.Module):
 
 
 # Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5DenseGatedActDense->Pix2StructVisionMlp,T5Config->Pix2StructVisionConfig,config.d_model->config.hidden_size,dropout_rate->dropout_rate
-class Pix2StructVisionMlp(nn.Module):
+class Kosmos2_5VisionMlp(nn.Module):
     def __init__(self, config: Kosmos2_5VisionConfig):
         super().__init__()
         self.wi_0 = nn.Linear(config.hidden_size, config.intermediate_size, bias=False)

--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -269,6 +269,7 @@ class LongT5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -276,7 +277,7 @@ class LongT5DenseActDense(nn.Module):
         ):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 class LongT5DenseGatedActDense(nn.Module):

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -95,6 +95,7 @@ class MT5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -102,7 +103,7 @@ class MT5DenseActDense(nn.Module):
         ):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5->MT5
@@ -124,6 +125,7 @@ class MT5DenseGatedActDense(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -132,7 +134,7 @@ class MT5DenseGatedActDense(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5LayerFF with T5->MT5

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -239,6 +239,7 @@ class Pix2StructVisionMlp(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -247,7 +248,7 @@ class Pix2StructVisionMlp(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 class Pix2StructVisionLayer(GradientCheckpointingLayer):
@@ -565,6 +566,7 @@ class Pix2StructTextDenseGatedActDense(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -573,7 +575,7 @@ class Pix2StructTextDenseGatedActDense(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 class Pix2StructTextLayerFF(nn.Module):

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -101,6 +101,7 @@ class Pop2PianoDenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -108,7 +109,7 @@ class Pop2PianoDenseActDense(nn.Module):
         ):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5->Pop2Piano
@@ -130,6 +131,7 @@ class Pop2PianoDenseGatedActDense(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -138,7 +140,7 @@ class Pop2PianoDenseGatedActDense(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5LayerFF with T5->Pop2Piano

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -181,7 +181,18 @@ class SwitchTransformersLayerNorm(T5LayerNorm):
 
 
 class SwitchTransformersDenseActDense(T5DenseActDense):
-    pass
+    def forward(self, hidden_states):
+        hidden_states = self.wi(hidden_states)
+        hidden_states = self.act(hidden_states)
+        hidden_states = self.dropout(hidden_states)
+        if (
+            isinstance(self.wo.weight, torch.Tensor)
+            and hidden_states.dtype != self.wo.weight.dtype
+            and self.wo.weight.dtype != torch.int8
+        ):
+            hidden_states = hidden_states.to(self.wo.weight.dtype)
+        hidden_states = self.wo(hidden_states)
+        return hidden_states
 
 
 class SwitchTransformersExperts(nn.ModuleDict):

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -107,6 +107,7 @@ class T5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -114,7 +115,7 @@ class T5DenseActDense(nn.Module):
         ):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 class T5DenseGatedActDense(nn.Module):
@@ -135,6 +136,7 @@ class T5DenseGatedActDense(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -143,7 +145,7 @@ class T5DenseGatedActDense(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 class T5LayerFF(nn.Module):

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -374,6 +374,7 @@ class UdopDenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -381,7 +382,7 @@ class UdopDenseActDense(nn.Module):
         ):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5->Udop
@@ -403,6 +404,7 @@ class UdopDenseGatedActDense(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -411,7 +413,7 @@ class UdopDenseGatedActDense(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5LayerFF with T5->Udop

--- a/src/transformers/models/umt5/modeling_umt5.py
+++ b/src/transformers/models/umt5/modeling_umt5.py
@@ -95,6 +95,7 @@ class UMT5DenseActDense(nn.Module):
         hidden_states = self.wi(hidden_states)
         hidden_states = self.act(hidden_states)
         hidden_states = self.dropout(hidden_states)
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -102,7 +103,7 @@ class UMT5DenseActDense(nn.Module):
         ):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5DenseGatedActDense with T5->UMT5
@@ -124,6 +125,7 @@ class UMT5DenseGatedActDense(nn.Module):
         # To make 8bit quantization work for google/flan-t5-xxl, self.wo is kept in float32.
         # See https://github.com/huggingface/transformers/issues/20287
         # we also make sure the weights are not in `int8` in case users will force `_keep_in_fp32_modules` to be `None``
+        dtype = hidden_states.dtype
         if (
             isinstance(self.wo.weight, torch.Tensor)
             and hidden_states.dtype != self.wo.weight.dtype
@@ -132,7 +134,7 @@ class UMT5DenseGatedActDense(nn.Module):
             hidden_states = hidden_states.to(self.wo.weight.dtype)
 
         hidden_states = self.wo(hidden_states)
-        return hidden_states
+        return hidden_states.to(dtype)
 
 
 # Copied from transformers.models.t5.modeling_t5.T5LayerFF with T5->UMT5


### PR DESCRIPTION
In t5 model, as dtype of `self.wo.weight` is kept fp32 in [L783](https://github.com/huggingface/transformers/blob/v4.57.1/src/transformers/models/t5/modeling_t5.py#L783), `hidden_states` need to be converted to fp32 in some cases, we should restore it back in scenerios we use model dtype like FP16.
@ArthurZucker @Cyrilvallez, pls help review, thx!

