### PR TITLE
evaluate>=0.4.6 is needed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ _deps = [
     "deepspeed>=0.9.3",
     "diffusers",
     "dill<0.3.5",
-    "evaluate>=0.2.0",
+    "evaluate>=0.4.6",
     "faiss-cpu",
     "fastapi",
     "filelock",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -14,7 +14,7 @@ deps = {
     "deepspeed": "deepspeed>=0.9.3",
     "diffusers": "diffusers",
     "dill": "dill<0.3.5",
-    "evaluate": "evaluate>=0.2.0",
+    "evaluate": "evaluate>=0.4.6",
     "faiss-cpu": "faiss-cpu",
     "fastapi": "fastapi",
     "filelock": "filelock",


### PR DESCRIPTION
Some HF Transformers tests/examples fail with main and `evaluate < 0.4.6`

Fixing:
```
stderr: [rank0]: Traceback (most recent call last):
stderr: [rank0]:   File "/code/users/stas/github/transformers-alst-integration/examples/pytorch/question-answering/run_qa.py", line 692, in <module>
stderr: [rank0]:     main()
stderr: [rank0]:   File "/code/users/stas/github/transformers-alst-integration/examples/pytorch/question-answering/run_qa.py", line 608, in main
stderr: [rank0]:     metric = evaluate.load(
stderr: [rank0]:              ^^^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/loading.py", line 748, in load
stderr: [rank0]:     evaluation_module = evaluation_module_factory(
stderr: [rank0]:                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/loading.py", line 680, in evaluation_module_factory
stderr: [rank0]:     raise e1 from None
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/loading.py", line 639, in evaluation_module_factory
stderr: [rank0]:     ).get_module()
stderr: [rank0]:       ^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/loading.py", line 479, in get_module
stderr: [rank0]:     local_path = self.download_loading_script(revision)
stderr: [rank0]:                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/loading.py", line 469, in download_loading_script
stderr: [rank0]:     return cached_path(file_path, download_config=download_config)
stderr: [rank0]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/utils/file_utils.py", line 175, in cached_path
stderr: [rank0]:     output_path = get_from_cache(
stderr: [rank0]:                   ^^^^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/utils/file_utils.py", line 448, in get_from_cache
stderr: [rank0]:     headers = get_authentication_headers_for_url(url, token=token)
stderr: [rank0]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
stderr: [rank0]:   File "/home/yak/miniconda3/envs/dev/lib/python3.12/site-packages/evaluate/utils/file_utils.py", line 236, in get_authentication_headers_for_url
stderr: [rank0]:     token = hf_api.HfFolder.get_token()
stderr: [rank0]:             ^^^^^^^^^^^^^^^
stderr: [rank0]: AttributeError: module 'huggingface_hub.hf_api' has no attribute 'HfFolder'
```

`evaluate>=0.4.6` is needed to fix this.