### PR TITLE
Fixes wrong epoch count in trainer under some conditions

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2390,18 +2390,17 @@ class Trainer:
 
         if args.eval_on_start:
             self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
-
+        _steps_in_current_epoch = 0
         for epoch in range(epochs_trained, num_train_epochs):
             epoch_dataloader = train_dataloader
             epoch_iterator = iter(epoch_dataloader)
-    
+
             if len_dataloader is None and epoch > epochs_trained and _steps_in_current_epoch > 0:
                 steps_in_epoch = _steps_in_current_epoch
                 _steps_in_current_epoch = 0
             if hasattr(epoch_dataloader, "set_epoch"):
                 epoch_dataloader.set_epoch(epoch)
 
-           
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
 
             step = -1
@@ -2423,7 +2422,7 @@ class Trainer:
                 # For iterable datasets without __len__
                 steps_in_epoch = args.max_steps * args.gradient_accumulation_steps
             # We chunkify the epoch iterator into gradient accumulation steps `n` batches
-            _steps_in_current_epoch = 0
+
             remainder = steps_in_epoch % args.gradient_accumulation_steps
             if remainder == 0:
                 remainder = args.gradient_accumulation_steps

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2391,9 +2391,8 @@ class Trainer:
             self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
         _steps_in_current_epoch = 0
         epoch_dataloader = train_dataloader
-        epoch_iterator = iter(epoch_dataloader)
         if len_dataloader is not None:
-            steps_in_epoch = len(epoch_iterator)
+            steps_in_epoch = len_dataloader
         else:
             steps_in_epoch = args.max_steps * args.gradient_accumulation_steps
         # We chunkify the epoch iterator into gradient accumulation steps `n` batches

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2393,14 +2393,15 @@ class Trainer:
 
         for epoch in range(epochs_trained, num_train_epochs):
             epoch_dataloader = train_dataloader
+            epoch_iterator = iter(epoch_dataloader)
+    
+            if len_dataloader is None and epoch > epochs_trained and _steps_in_current_epoch > 0:
+                steps_in_epoch = _steps_in_current_epoch
+                _steps_in_current_epoch = 0
             if hasattr(epoch_dataloader, "set_epoch"):
                 epoch_dataloader.set_epoch(epoch)
 
-            steps_in_epoch = (
-                len(epoch_dataloader)
-                if len_dataloader is not None
-                else args.max_steps * args.gradient_accumulation_steps
-            )
+           
             self.control = self.callback_handler.on_epoch_begin(args, self.state, self.control)
 
             step = -1
@@ -2416,7 +2417,13 @@ class Trainer:
                     self._load_rng_state(resume_from_checkpoint)
 
             epoch_iterator = iter(epoch_dataloader)
+            if len_dataloader is not None:
+                steps_in_epoch = len(epoch_iterator)
+            else:
+                # For iterable datasets without __len__
+                steps_in_epoch = args.max_steps * args.gradient_accumulation_steps
             # We chunkify the epoch iterator into gradient accumulation steps `n` batches
+            _steps_in_current_epoch = 0
             remainder = steps_in_epoch % args.gradient_accumulation_steps
             if remainder == 0:
                 remainder = args.gradient_accumulation_steps
@@ -2552,7 +2559,10 @@ class Trainer:
 
                         model.zero_grad()
                         self.state.global_step += 1
-                        self.state.epoch = epoch + (step + 1) / steps_in_epoch
+                        if len_dataloader is None:
+                            _steps_in_current_epoch += 1
+
+                        self.state.epoch = epoch + (step + 1 + _steps_in_current_epoch) / steps_in_epoch
                         self.control = self.callback_handler.on_step_end(args, self.state, self.control)
                         self._maybe_log_save_evaluate(
                             tr_loss,


### PR DESCRIPTION
# What does this PR do?
When using an iterable dataset, the Trainer incorrectly calculates `steps_in_epoch` as `max_steps`, 
causing epoch values to be 2x smaller than expected.


Fixes #41913 



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/huggingface/transformers/issues/41913
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@Rocketknight1  @SunMarc @nzw0301 

members/contributors who may be interested in your PR.

