### PR TITLE
Fix: prevent .gitignore truncation in run_clm_no_trainer.py

### DIFF
--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -321,7 +321,6 @@ def main():
                     f.write("step_*\n")
                 if "epoch_*" not in content:
                     f.write("epoch_*\n")
-            
         elif args.output_dir is not None:
             os.makedirs(args.output_dir, exist_ok=True)
     accelerator.wait_for_everyone()

--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -308,11 +308,20 @@ def main():
             api = HfApi()
             repo_id = api.create_repo(repo_name, exist_ok=True, token=args.hub_token).repo_id
 
-            with open(os.path.join(args.output_dir, ".gitignore"), "w+") as gitignore:
-                if "step_*" not in gitignore:
-                    gitignore.write("step_*\n")
-                if "epoch_*" not in gitignore:
-                    gitignore.write("epoch_*\n")
+            os.makedirs(args.output_dir, exist_ok=True)
+            gitignore_path = os.path.join(args.output_dir, ".gitignore")
+            content = ""
+            if os.path.exists(gitignore_path):
+                with open(gitignore_path, "r") as f:
+                    content = f.read()
+            with open(gitignore_path, "a") as f:
+                if content and not content.endswith("\n"):
+                    f.write("\n")
+                if "step_*" not in content:
+                    f.write("step_*\n")
+                if "epoch_*" not in content:
+                    f.write("epoch_*\n")
+            
         elif args.output_dir is not None:
             os.makedirs(args.output_dir, exist_ok=True)
     accelerator.wait_for_everyone()


### PR DESCRIPTION
# What does this PR do?

This PR fixes an issue in `run_clm_no_trainer.py` where the `.gitignore` file was being truncated due to the use of `"w+"` mode when writing.  
Now, the script preserves existing `.gitignore` content, avoids duplicates, and safely appends the required ignore patterns for model outputs (`step_*` and `epoch_*`).


I have tested with:

1. no gitignore: file was created and populated with step_* and epoch_*
2. gitignore with additional content: step_* and epoch_* were added after previous content
3. blank gitignore: step_* and epoch_* were added to the file

Fixes #41896


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

wdyt @Rocketknight1?