### PR TITLE
[kernels] update flash-attn kernel name to flash-attn2

### DIFF
--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -44,7 +44,7 @@ def generate_simple(
         "eager": "eager",
         "paged_attention": "eager",  # TODO: this does not work on AMD docker
         "flash_paged": "flash_attention_2",  # TODO: this does not work on AMD docker
-        "kernels-community/flash-attn": "eager",
+        "kernels-community/flash-attn2": "eager",
     }[attn_impl]
 
     model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16, attn_implementation=attn_impl)
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-blocks", "-n", type=int, default=None)
     parser.add_argument("--max-batch-tokens", "-b", type=int, default=None)
 
-    parser.add_argument("--attn", type=str, default="kernels-community/flash-attn", help="Attention implementation")
+    parser.add_argument("--attn", type=str, default="kernels-community/flash-attn2", help="Attention implementation")
     parser.add_argument("--matmul-precision", "-mp", type=str, default="high")  # set to "none" to disable
     parser.add_argument("--cuda-graph", "-cg", help="Use cuda graphs", type=str, default=None)
     parser.add_argument("--compile", action="store_true", help="Compile the model using torch.compile")

--- a/examples/pytorch/continuous_batching_simple.py
+++ b/examples/pytorch/continuous_batching_simple.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--num-blocks", "-n", type=int, default=None)
     parser.add_argument("--max-batch-tokens", "-b", type=int, default=None)
-    parser.add_argument("--attn", type=str, default="kernels-community/flash-attn", help="Attention implementation")
+    parser.add_argument("--attn", type=str, default="kernels-community/flash-attn2", help="Attention implementation")
     parser.add_argument("--samples", type=int, default=500)
     parser.add_argument("--max-new-tokens", type=int, default=32)
 

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -97,7 +97,7 @@ def _lazy_imports(implementation: Optional[str]):
             if flash_attn_varlen_func is None or flash_attn_func is None:
                 raise ValueError(
                     f"Could not find the currently requested flash attention implementation at `{implementation}`."
-                    f"Make sure that you request a valid kernel from the hub, e.g. `kernels-community/flash-attn`."
+                    f"Make sure that you request a valid kernel from the hub, e.g. `kernels-community/flash-attn2`."
                 )
 
     return flash_attn_func, flash_attn_varlen_func, pad_input, unpad_input

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2381,7 +2381,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             and not is_torch_npu_available()
         ):
             if attn_implementation.endswith("2"):
-                applicable_attn_implementation = "kernels-community/flash-attn"
+                applicable_attn_implementation = "kernels-community/flash-attn2"
             else:
                 applicable_attn_implementation = "kernels-community/vllm-flash-attn3"
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -592,7 +592,7 @@ def require_flash_attn(test_case):
     try:
         from kernels import get_kernel
 
-        get_kernel("kernels-community/flash-attn")
+        get_kernel("kernels-community/flash-attn2")
     except Exception as _:
         kernels_available = False
 

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -160,7 +160,7 @@ class ContinuousBatchingTest(unittest.TestCase):
             non_cb_attn_implementation = "sdpa"
         elif attn_implementation == "eager_paged":
             non_cb_attn_implementation = "eager"
-        elif attn_implementation == "paged_attention|kernels-community/flash-attn":
+        elif attn_implementation == "paged_attention|kernels-community/flash-attn2":
             non_cb_attn_implementation = "eager"
         else:
             raise ValueError(f"Invalid attention implementation: {attn_implementation}")
@@ -293,7 +293,7 @@ class ContinuousBatchingTest(unittest.TestCase):
             }
         }).get_expectation()  # fmt: skip
         self._continuous_batching_parity(
-            "meta-llama/Llama-3.1-8B", "paged_attention|kernels-community/flash-attn", expected_outputs
+            "meta-llama/Llama-3.1-8B", "paged_attention|kernels-community/flash-attn2", expected_outputs
         )
 
     @require_torch_gpu
@@ -306,7 +306,7 @@ class ContinuousBatchingTest(unittest.TestCase):
             }
         }).get_expectation()  # fmt: skip
         self._continuous_batching_parity(
-            "google/gemma-2-2b-it", "paged_attention|kernels-community/flash-attn", expected_outputs
+            "google/gemma-2-2b-it", "paged_attention|kernels-community/flash-attn2", expected_outputs
         )
 
     @require_torch_gpu
@@ -315,7 +315,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     def test_continuous_batching_parity_qwen_flash(self) -> None:
         expected_outputs = {}
         self._continuous_batching_parity(
-            "Qwen/Qwen3-4B-Instruct-2507", "paged_attention|kernels-community/flash-attn", expected_outputs
+            "Qwen/Qwen3-4B-Instruct-2507", "paged_attention|kernels-community/flash-attn2", expected_outputs
         )
 
     @require_torch_gpu
@@ -324,7 +324,7 @@ class ContinuousBatchingTest(unittest.TestCase):
     def test_continuous_batching_parity_gpt_oss_flash(self) -> None:
         expected_outputs = {}
         self._continuous_batching_parity(
-            "openai/gpt-oss-20b", "paged_attention|kernels-community/flash-attn", expected_outputs
+            "openai/gpt-oss-20b", "paged_attention|kernels-community/flash-attn2", expected_outputs
         )
 
     def test_attn_implementation(self) -> None:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2902,7 +2902,7 @@ class TestAttentionImplementation(unittest.TestCase):
                 )
 
         self.assertTrue(
-            "You do not have `flash_attn` installed, using `kernels-community/flash-attn` from the `kernels` library instead!"
+            "You do not have `flash_attn` installed, using `kernels-community/flash-attn2` from the `kernels` library instead!"
             in cl.out
         )
 
@@ -2912,7 +2912,7 @@ class TestAttentionImplementation(unittest.TestCase):
 
         with self.assertRaises(ImportError) as cm:
             _ = AutoModel.from_pretrained(
-                "hf-tiny-model-private/tiny-random-MCTCTModel", attn_implementation="kernels-community/flash-attn"
+                "hf-tiny-model-private/tiny-random-MCTCTModel", attn_implementation="kernels-community/flash-attn2"
             )
 
         self.assertTrue("`kernels` is either not installed or uses an incompatible version." in str(cm.exception))


### PR DESCRIPTION
# What does this PR do?

Simply updates all occurences of the kernel `kernels-community/flash-attn` with `kernels-community/flash-attn2`