### PR TITLE
Patch Mistral Common Tokenizer 2

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -149,7 +149,7 @@ class MistralTokenizerType(str, Enum):
     tekken = "tekken"
 
 
-def _get_validation_mode(mode: Union[str, ValidationMode]) -> ValidationMode:
+def _get_validation_mode(mode: Union[str, "ValidationMode"]) -> "ValidationMode":
     """Get the validation mode from a string or a ValidationMode."""
     _invalid_mode_msg = f"Invalid `mistral-common` tokenizer mode: {mode}. Possible values are 'finetuning' or 'test'."
     if isinstance(mode, str):

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -263,6 +263,7 @@ class MistralCommonBackend(PushToHubMixin):
         self.model_max_length = model_max_length
         self.cleanup_tokenization_spaces = clean_up_tokenization_spaces
         self.deprecation_warnings = {}  # Use to store when we have already noticed a deprecation warning (avoid overlogging).
+        self._all_special_tokens_ids = self._get_all_special_ids()
 
         if model_input_names is not None:
             if (
@@ -764,7 +765,7 @@ class MistralCommonBackend(PushToHubMixin):
 
         return BatchEncoding(batch_outputs)
 
-    def _all_special_ids(self) -> set[int]:
+    def _get_all_special_ids(self) -> set[int]:
         if self._tokenizer_type == MistralTokenizerType.tekken:
             return {t["rank"] for t in self.tokenizer.instruct_tokenizer.tokenizer._all_special_tokens}
         elif self._tokenizer_type == MistralTokenizerType.spm:
@@ -799,9 +800,7 @@ class MistralCommonBackend(PushToHubMixin):
                 "`already_has_special_tokens` is not supported by `MistralCommonBackend` and should be `False`."
             )
 
-        all_special_ids = self._all_special_ids()  # cache the ids
-
-        special_tokens_mask = [1 if token in all_special_ids else 0 for token in token_ids_0]
+        special_tokens_mask = [1 if token in self._all_special_tokens_ids else 0 for token in token_ids_0]
         return special_tokens_mask
 
     def _batch_prepare_for_model(

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -363,6 +363,20 @@ class MistralCommonBackend(PushToHubMixin):
         return self.convert_ids_to_tokens(self.pad_token_id)
 
     @property
+    def all_special_ids(self) -> list[int]:
+        """
+        `list[int]`: List the ids of the special tokens(`'<unk>'`, `'<cls>'`, etc.).
+        """
+        return sorted(self._all_special_tokens_ids)
+
+    @property
+    def all_special_tokens(self) -> list[str]:
+        """
+        `list[str]`: A list of all unique special tokens.
+        """
+        return self.convert_ids_to_tokens(self.all_special_ids)
+
+    @property
     def vocab_size(self) -> int:
         """
         Returns the size of the vocabulary.

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -496,6 +496,9 @@ class MistralCommonBackend(PushToHubMixin):
         clean_up_tokenization_spaces = clean_up_tokenization_spaces or self.cleanup_tokenization_spaces
 
         # Convert inputs to python lists
+        if isinstance(token_ids, int):
+            token_ids = [token_ids]
+
         token_ids = to_py_obj(token_ids)
 
         special_token_policy = SpecialTokenPolicy.IGNORE if skip_special_tokens else SpecialTokenPolicy.KEEP

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -61,7 +61,7 @@ ENCODE_KWARGS_DOCSTRING = r"""
                 Whether or not to add special tokens when encoding the sequences. This will use the underlying
                 `PretrainedTokenizerBase.build_inputs_with_special_tokens` function, which defines which tokens are
                 automatically added to the input ids. This is useful if you want to add `bos` or `eos` tokens
-                automatically. When Tokenizer is loadig with `finetuning` mode it adds both `bos` and `eos`. Else, for "test" mode it only add `bos`.
+                automatically. When Tokenizer is loading with `finetuning` mode it adds both `bos` and `eos`. Else, for "test" mode it only adds `bos`.
             padding (`bool`, `str` or [`~utils.PaddingStrategy`], *optional*, defaults to `False`):
                 Activates and controls padding. Accepts the following values:
 

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -2110,3 +2110,19 @@ class TestMistralCommonBackend(unittest.TestCase):
         for invalid_mode in [("serving", ValidationMode.serving, "invalid", 1)]:
             with self.assertRaises(ValueError):
                 MistralCommonBackend._get_validation_mode(invalid_mode)
+
+    def test_all_special_ids(self):
+        with patch.object(self.tokenizer, "_all_special_tokens_ids", {1, 0}):
+            self.assertEqual(self.tokenizer.all_special_ids, [0, 1])
+
+        spm_tokenizer = self._get_spm_tokenizer()
+        with patch.object(spm_tokenizer, "_all_special_tokens_ids", {1, 0}):
+            self.assertEqual(spm_tokenizer.all_special_ids, [0, 1])
+
+    def test_all_special_tokens(self):
+        with patch.object(self.tokenizer, "_all_special_tokens_ids", {1, 0}):
+            self.assertEqual(self.tokenizer.all_special_tokens, ["<unk>", "<s>"])
+
+        spm_tokenizer = self._get_spm_tokenizer()
+        with patch.object(spm_tokenizer, "_all_special_tokens_ids", {1, 0}):
+            self.assertEqual(spm_tokenizer.all_special_tokens, ["<unk>", "<s>"])

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -25,7 +25,7 @@ import torch
 from transformers.image_utils import load_image
 from transformers.models.auto.tokenization_auto import AutoTokenizer
 from transformers.testing_utils import require_mistral_common
-from transformers.tokenization_mistral_common import MistralCommonBackend, _get_validation_mode
+from transformers.tokenization_mistral_common import MistralCommonBackend
 from transformers.tokenization_utils_base import BatchEncoding, TruncationStrategy
 from transformers.utils import PaddingStrategy, is_mistral_common_available
 
@@ -1997,8 +1997,8 @@ class TestMistralCommonBackend(unittest.TestCase):
             ("finetuning", ValidationMode.finetuning),
             (ValidationMode.finetuning, ValidationMode.finetuning),
         ]:
-            self.assertEqual(_get_validation_mode(mode), expected)
+            self.assertEqual(MistralCommonTokenizer._get_validation_mode(mode), expected)
 
         for invalid_mode in [("serving", ValidationMode.serving, "invalid", 1)]:
             with self.assertRaises(ValueError):
-                _get_validation_mode(invalid_mode)
+                MistralCommonTokenizer._get_validation_mode(invalid_mode)

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -313,6 +313,14 @@ class TestMistralCommonBackend(unittest.TestCase):
         )
 
         # Test 3:
+        # decode one token
+        self.assertEqual(self.tokenizer.decode(tokens_ids[0], skip_special_tokens=False), "<s>")
+
+        # Test 4:
+        # decode numpy
+        self.assertEqual(self.tokenizer.decode(np.array(tokens_ids), skip_special_tokens=True), string)
+
+        # Test 5:
         # decode with unsupported kwargs
         with self.assertRaises(
             ValueError, msg="Kwargs [unk_args] are not supported by `MistralCommonBackend.decode`."
@@ -365,6 +373,15 @@ class TestMistralCommonBackend(unittest.TestCase):
         )
         self.assertEqual(
             self.tokenizer.batch_decode(batch_tokens_ids, skip_special_tokens=True, clean_up_tokenization_spaces=True),
+            ["Hello, world!", "Hello, world!"],
+        )
+
+        # Test 3:
+        # decode numpy
+        self.assertEqual(
+            self.tokenizer.batch_decode(
+                np.array(batch_tokens_ids), skip_special_tokens=True, clean_up_tokenization_spaces=True
+            ),
             ["Hello, world!", "Hello, world!"],
         )
 

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -2072,8 +2072,8 @@ class TestMistralCommonBackend(unittest.TestCase):
             ("finetuning", ValidationMode.finetuning),
             (ValidationMode.finetuning, ValidationMode.finetuning),
         ]:
-            self.assertEqual(MistralCommonTokenizer._get_validation_mode(mode), expected)
+            self.assertEqual(MistralCommonBackend._get_validation_mode(mode), expected)
 
         for invalid_mode in [("serving", ValidationMode.serving, "invalid", 1)]:
             with self.assertRaises(ValueError):
-                MistralCommonTokenizer._get_validation_mode(invalid_mode)
+                MistralCommonBackend._get_validation_mode(invalid_mode)

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -367,11 +367,6 @@ class TestMistralCommonBackend(unittest.TestCase):
             ["Hello, world!", "Hello, world!"],
         )
 
-        # Test 4:
-        # decode empty list
-        self.assertEqual(self.tokenizer.decode([], skip_special_tokens=True), [])
-        self.assertEqual(self.tokenizer.decode([batch_tokens_ids[0], []], skip_special_tokens=True), [string, ""])
-
     def test_decode_transcription_mode(self):
         # in the specific case of Voxtral, the added f"lang:xx" (always a two char language code since it follows ISO 639-1 alpha-2 format)
         # is not considered as a special token by mistral-common and is encoded/ decoded as normal text.


### PR DESCRIPTION
# What does this PR do?

1. Fixes the behavior of add_special_tokens to match PretrainedTokenizer goals:
- if mode is finetuning: add both bos and eos tokens
- if mode is test: add only bos tokens so that the model can generate freely.

2. Add `ValidationMode` as a string support to avoid import from mistral-common for the user.

3. Fix decode when user passes an int instead of a sequence of ints

4. Add support to batch for `decode`.

5. Add special tokens properties to list ids and tokens string representation.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

cc @patrickvonplaten for viz

@ArthurZucker and @itazap
