### PR TITLE
Fix GPT-2 Flash Attention 2 generation with left-padding

### DIFF
--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -251,7 +251,6 @@ class DecisionTransformerGPT2Attention(nn.Module):
                 value_states,
                 attention_mask,
                 dropout=self.attn_dropout.p if self.training else 0.0,
-                is_causal=self.is_causal,
                 **kwargs,
             )
 

--- a/src/transformers/models/decision_transformer/modeling_decision_transformer.py
+++ b/src/transformers/models/decision_transformer/modeling_decision_transformer.py
@@ -236,6 +236,11 @@ class DecisionTransformerGPT2Attention(nn.Module):
 
         is_causal = attention_mask is None and query_states.shape[-2] > 1 and not is_cross_attention
 
+        # For flash attention backends, we must keep causal behavior even when a 2D padding mask is provided
+        # (flash attention uses `is_causal` for the triangular mask and expects an optional 2D key padding mask)
+        if self.config._attn_implementation in {"flash_attention_2", "flash_attention_3"} and not is_cross_attention:
+            is_causal = query_states.shape[-2] > 1
+
         using_eager = self.config._attn_implementation == "eager"
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -260,7 +260,6 @@ class GPT2Attention(nn.Module):
                 value_states,
                 attention_mask,
                 dropout=self.attn_dropout.p if self.training else 0.0,
-                is_causal=self.is_causal,
                 **kwargs,
             )
 

--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -130,7 +130,7 @@ class GPT2Attention(nn.Module):
 
         self.attn_dropout = nn.Dropout(config.attn_pdrop)
         self.resid_dropout = nn.Dropout(config.resid_pdrop)
-        self.is_causal = True
+        self.is_causal = not is_cross_attention
 
     def _upcast_and_reordered_attn(self, query, key, value, attention_mask=None):
         # Use `torch.baddbmm` (a bit more efficient w/ alpha param for scaling -- from Megatron-LM)
@@ -243,13 +243,6 @@ class GPT2Attention(nn.Module):
             if is_cross_attention:
                 past_key_values.is_updated[self.layer_idx] = True
 
-        is_causal = attention_mask is None and query_states.shape[-2] > 1 and not is_cross_attention
-
-        # For flash attention backends, we must keep causal behavior even when a 2D padding mask is provided
-        # (flash attention uses `is_causal` for the triangular mask and expects an optional 2D key padding mask)
-        if self.config._attn_implementation in {"flash_attention_2", "flash_attention_3"} and not is_cross_attention:
-            is_causal = query_states.shape[-2] > 1
-
         using_eager = self.config._attn_implementation == "eager"
         attention_interface: Callable = eager_attention_forward
         if self.config._attn_implementation != "eager":
@@ -267,7 +260,7 @@ class GPT2Attention(nn.Module):
                 value_states,
                 attention_mask,
                 dropout=self.attn_dropout.p if self.training else 0.0,
-                is_causal=is_causal,
+                is_causal=self.is_causal,
                 **kwargs,
             )
 


### PR DESCRIPTION
# What does this PR do?

Fixes Flash Attention 2 generation with left-padding in GPT-2 by ensuring `is_causal=True` is set even when padding masks are provided.

Flash Attention 2 handles causal masking and padding independently, but the original code incorrectly disabled causal masking when any attention mask was present.

Fixes: `test_flash_attn_2_generate_padding_left`