### PR TITLE
Fix import error with huggingface_hub v1.0.0+

### DIFF
--- a/src/transformers/modelcard.py
+++ b/src/transformers/modelcard.py
@@ -24,8 +24,7 @@ from typing import Any, Optional, Union
 import httpx
 import yaml
 from huggingface_hub import model_info
-from huggingface_hub.errors import OfflineModeIsEnabled
-from huggingface_hub.utils import HFValidationError
+from huggingface_hub.errors import HFValidationError, OfflineModeIsEnabled
 
 from . import __version__
 from .models.auto.modeling_auto import (

--- a/src/transformers/models/oneformer/image_processing_oneformer.py
+++ b/src/transformers/models/oneformer/image_processing_oneformer.py
@@ -21,7 +21,7 @@ from typing import Any, Optional, Union
 
 import numpy as np
 from huggingface_hub import hf_hub_download
-from huggingface_hub.utils import RepositoryNotFoundError
+from huggingface_hub.errors import RepositoryNotFoundError
 
 from ...image_processing_utils import INIT_SERVICE_KWARGS, BaseImageProcessor, BatchFeature, get_size_dict
 from ...image_transforms import (

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -44,8 +44,7 @@ from huggingface_hub import (
     snapshot_download,
     try_to_load_from_cache,
 )
-from huggingface_hub.file_download import REGEX_COMMIT_HASH, http_get
-from huggingface_hub.utils import (
+from huggingface_hub.errors import (
     EntryNotFoundError,
     GatedRepoError,
     HfHubHTTPError,
@@ -53,6 +52,9 @@ from huggingface_hub.utils import (
     OfflineModeIsEnabled,
     RepositoryNotFoundError,
     RevisionNotFoundError,
+)
+from huggingface_hub.file_download import REGEX_COMMIT_HASH, http_get
+from huggingface_hub.utils import (
     build_hf_headers,
     get_session,
     hf_raise_for_status,


### PR DESCRIPTION
Update error class imports to use huggingface_hub.errors instead of huggingface_hub.utils to resolve ImportError with huggingface_hub versions 1.0.0 and above.

Fixes #41970