### PR TITLE
Fix logic in setting self.fsdp when it is False

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2655,7 +2655,7 @@ class TrainingArguments:
         return self
 
     def _process_fsdp_args(self):
-        if self.fsdp is None:
+        if not self.fsdp:
             self.fsdp = []
         elif self.fsdp is True:
             self.fsdp = [FSDPOption.FULL_SHARD]


### PR DESCRIPTION
# What does this PR do?

This PR fixes the logic in setting `self.fsdp` in `_process_fsdp_args` in src/transformers/training_args.py. In the original logic, when `self.fsdp` is False, it will not be converted to list, and cause the later logic below failed because `self.fsdp` is a boolean (False).
```
FSDPOption.FULL_SHARD in self.fsdp and FSDPOption.SHARD_GRAD_OP in self.fsdp:
```

This diff fixes it by initializing it to list.

## Who can review?

@SunMarc 
