### PR TITLE
Fix `autoawq[kernels]` installation in quantization docker file

### DIFF
--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -50,7 +50,7 @@ RUN python3 -m pip install --no-cache-dir hqq
 RUN python3 -m pip install --no-cache-dir gguf
 
 # Add autoawq for quantization testing
-RUN python3 -m pip install --no-cache-dir autoawq[kernels]
+RUN python3 -m pip install --no-cache-dir --no-build-isolation autoawq[kernels]
 
 # Add quanto for quantization testing
 RUN python3 -m pip install --no-cache-dir optimum-quanto


### PR DESCRIPTION
# What does this PR do?

Same as #41975 but for `autoawq[kernels]`.

Merge directly.

The effect :

before this PR: https://github.com/huggingface/transformers/actions/runs/19015759405
after this PR: https://github.com/huggingface/transformers/actions/runs/19014860804

cc @MekkCyber 