### PR TITLE
Correct type hint in config models

### DIFF
--- a/examples/modular-transformers/configuration_duplicated_method.py
+++ b/examples/modular-transformers/configuration_duplicated_method.py
@@ -122,7 +122,7 @@ class DuplicatedMethodConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -127,7 +127,7 @@ class AriaTextConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id=2,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -148,7 +148,7 @@ class DeepseekV2Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/deepseek_v2/modular_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/modular_deepseek_v2.py
@@ -161,7 +161,7 @@ class DeepseekV2Config(LlamaConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
@@ -179,7 +179,7 @@ class DeepseekV3Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 4096,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 0,

--- a/src/transformers/models/dots1/configuration_dots1.py
+++ b/src/transformers/models/dots1/configuration_dots1.py
@@ -156,7 +156,7 @@ class Dots1Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/gemma/configuration_gemma.py
+++ b/src/transformers/models/gemma/configuration_gemma.py
@@ -125,7 +125,7 @@ class GemmaConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/gemma/modular_gemma.py
+++ b/src/transformers/models/gemma/modular_gemma.py
@@ -152,7 +152,7 @@ class GemmaConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/gemma2/configuration_gemma2.py
+++ b/src/transformers/models/gemma2/configuration_gemma2.py
@@ -136,7 +136,7 @@ class Gemma2Config(PreTrainedConfig):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/gemma2/modular_gemma2.py
+++ b/src/transformers/models/gemma2/modular_gemma2.py
@@ -165,7 +165,7 @@ class Gemma2Config(PreTrainedConfig):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/gemma3/configuration_gemma3.py
+++ b/src/transformers/models/gemma3/configuration_gemma3.py
@@ -143,7 +143,7 @@ class Gemma3TextConfig(PreTrainedConfig):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 131_072,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -158,7 +158,7 @@ class Gemma3TextConfig(Gemma2Config, PreTrainedConfig):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 131_072,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/granite/configuration_granite.py
+++ b/src/transformers/models/granite/configuration_granite.py
@@ -135,7 +135,7 @@ class GraniteConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/granitemoe/configuration_granitemoe.py
+++ b/src/transformers/models/granitemoe/configuration_granitemoe.py
@@ -124,7 +124,7 @@ class GraniteMoeConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/configuration_granitemoehybrid.py
@@ -141,7 +141,7 @@ class GraniteMoeHybridConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/granitemoeshared/configuration_granitemoeshared.py
+++ b/src/transformers/models/granitemoeshared/configuration_granitemoeshared.py
@@ -126,7 +126,7 @@ class GraniteMoeSharedConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/jetmoe/configuration_jetmoe.py
+++ b/src/transformers/models/jetmoe/configuration_jetmoe.py
@@ -120,7 +120,7 @@ class JetMoeConfig(PreTrainedConfig):
         eos_token_id: Optional[int] = 2,
         tie_word_embeddings: Optional[bool] = True,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         initializer_range: Optional[float] = 0.01,
         attention_dropout: Optional[float] = 0.0,
         **kwargs,

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -136,7 +136,7 @@ class LlamaConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 2048,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/mistral/configuration_mistral.py
+++ b/src/transformers/models/mistral/configuration_mistral.py
@@ -130,7 +130,7 @@ class MistralConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 4096 * 32,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = None,
         bos_token_id: Optional[int] = 1,

--- a/src/transformers/models/qwen2/configuration_qwen2.py
+++ b/src/transformers/models/qwen2/configuration_qwen2.py
@@ -126,7 +126,7 @@ class Qwen2Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
@@ -319,7 +319,7 @@ class Qwen2_5OmniTextConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -352,7 +352,7 @@ class Qwen2_5OmniTextConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/qwen2_moe/configuration_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/configuration_qwen2_moe.py
@@ -147,7 +147,7 @@ class Qwen2MoeConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/qwen3/configuration_qwen3.py
+++ b/src/transformers/models/qwen3/configuration_qwen3.py
@@ -131,7 +131,7 @@ class Qwen3Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py
@@ -145,7 +145,7 @@ class Qwen3MoeConfig(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         tie_word_embeddings: Optional[bool] = False,
         rope_parameters: Optional[RopeParameters | dict[RopeParameters]] = None,

--- a/src/transformers/models/recurrent_gemma/configuration_recurrent_gemma.py
+++ b/src/transformers/models/recurrent_gemma/configuration_recurrent_gemma.py
@@ -113,7 +113,7 @@ class RecurrentGemmaConfig(PreTrainedConfig):
         attention_window_size: Optional[int] = 2048,
         conv1d_width: Optional[int] = 4,
         logits_soft_cap: Optional[float] = 30.0,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/smollm3/configuration_smollm3.py
+++ b/src/transformers/models/smollm3/configuration_smollm3.py
@@ -135,7 +135,7 @@ class SmolLM3Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 128004,
         bos_token_id: Optional[int] = 128000,

--- a/src/transformers/models/smollm3/modular_smollm3.py
+++ b/src/transformers/models/smollm3/modular_smollm3.py
@@ -152,7 +152,7 @@ class SmolLM3Config(PreTrainedConfig):
         hidden_act: Optional[str] = "silu",
         max_position_embeddings: Optional[int] = 32768,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 128004,
         bos_token_id: Optional[int] = 128000,

--- a/src/transformers/models/t5gemma/configuration_t5gemma.py
+++ b/src/transformers/models/t5gemma/configuration_t5gemma.py
@@ -134,7 +134,7 @@ class T5GemmaModuleConfig(PreTrainedConfig):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/t5gemma/modular_t5gemma.py
+++ b/src/transformers/models/t5gemma/modular_t5gemma.py
@@ -153,7 +153,7 @@ class T5GemmaModuleConfig(Gemma2Config):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/vaultgemma/configuration_vaultgemma.py
+++ b/src/transformers/models/vaultgemma/configuration_vaultgemma.py
@@ -134,7 +134,7 @@ class VaultGemmaConfig(PreTrainedConfig):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,

--- a/src/transformers/models/vaultgemma/modular_vaultgemma.py
+++ b/src/transformers/models/vaultgemma/modular_vaultgemma.py
@@ -115,7 +115,7 @@ class VaultGemmaConfig(Gemma2Config):
         hidden_activation: Optional[str] = "gelu_pytorch_tanh",
         max_position_embeddings: Optional[int] = 8192,
         initializer_range: Optional[float] = 0.02,
-        rms_norm_eps: Optional[int] = 1e-6,
+        rms_norm_eps: Optional[float] = 1e-6,
         use_cache: Optional[bool] = True,
         pad_token_id: Optional[int] = 0,
         eos_token_id: Optional[int] = 1,


### PR DESCRIPTION


# What does this PR do?
Most models are using a config with `rms_norm_eps: Optional[int] = 1e-6`: I modified it to an optional float.
This update configs that use a type of optional int instead of optional float for the epsilon value for their RMS norm.
You can clearly see that the epsilon has a default value of 10e-6 (float), the hint should therefore be adjusted.

FIx no issue.


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?

Let me know if you want any changes,  @ArthurZucker @Cyrilvallez @stevhliu, I tried to find all occurence of it, but some might have slipped through.

