### PR TITLE
Fix `torchcodec` version in quantization docker file

### DIFF
--- a/docker/transformers-quantization-latest-gpu/Dockerfile
+++ b/docker/transformers-quantization-latest-gpu/Dockerfile
@@ -24,7 +24,7 @@ RUN [ ${#PYTORCH} -gt 0 ] && VERSION='torch=='$PYTORCH'.*' ||  VERSION='torch'; 
 RUN echo torch=$VERSION
 # `torchvision` and `torchaudio` should be installed along with `torch`, especially for nightly build.
 # Currently, let's just use their latest releases (when `torch` is installed with a release version)
-RUN python3 -m pip install --no-cache-dir -U $VERSION torchvision torchaudio torchcodec --extra-index-url https://download.pytorch.org/whl/$CUDA
+RUN python3 -m pip install --no-cache-dir -U $VERSION torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/$CUDA
 
 RUN python3 -m pip install --no-cache-dir git+https://github.com/huggingface/accelerate@main#egg=accelerate
 


### PR DESCRIPTION
# What does this PR do?

The `torchcodec` version is not bind automatically to `torch` version during the installation. Currently we get `torch 2.8` (as we pin it) and `torchcodec 0.8.1` (which is for `torch 2.9`).

This PR follows #41892 to allow specifying `torchcodec` version.

Previously, the quantization jobs fails 

https://github.com/huggingface/transformers/actions/runs/18862400780/job/53850645716