### PR TITLE
[v5] Deprecate Text2Text and related pipelines

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -59,7 +59,7 @@ from .base import (
     get_default_model_and_revision,
     load_model,
 )
-from .deprecated.text2text_generation import SummarizationPipeline, Text2TextGenerationPipeline, TranslationPipeline
+from .deprecated import SummarizationPipeline, Text2TextGenerationPipeline, TranslationPipeline
 from .depth_estimation import DepthEstimationPipeline
 from .document_question_answering import DocumentQuestionAnsweringPipeline
 from .feature_extraction import FeatureExtractionPipeline

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -59,6 +59,7 @@ from .base import (
     get_default_model_and_revision,
     load_model,
 )
+from .deprecated.text2text_generation import SummarizationPipeline, Text2TextGenerationPipeline, TranslationPipeline
 from .depth_estimation import DepthEstimationPipeline
 from .document_question_answering import DocumentQuestionAnsweringPipeline
 from .feature_extraction import FeatureExtractionPipeline
@@ -74,7 +75,6 @@ from .mask_generation import MaskGenerationPipeline
 from .object_detection import ObjectDetectionPipeline
 from .question_answering import QuestionAnsweringArgumentHandler, QuestionAnsweringPipeline
 from .table_question_answering import TableQuestionAnsweringArgumentHandler, TableQuestionAnsweringPipeline
-from .text2text_generation import SummarizationPipeline, Text2TextGenerationPipeline, TranslationPipeline
 from .text_classification import TextClassificationPipeline
 from .text_generation import TextGenerationPipeline
 from .text_to_audio import TextToAudioPipeline

--- a/src/transformers/pipelines/deprecated/__init__.py
+++ b/src/transformers/pipelines/deprecated/__init__.py
@@ -1,0 +1,16 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .text2text_generation import Text2TextGenerationPipeline, SummarizationPipeline, TranslationPipeline

--- a/src/transformers/pipelines/deprecated/__init__.py
+++ b/src/transformers/pipelines/deprecated/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .text2text_generation import Text2TextGenerationPipeline, SummarizationPipeline, TranslationPipeline
+from .text2text_generation import SummarizationPipeline, Text2TextGenerationPipeline, TranslationPipeline

--- a/src/transformers/pipelines/deprecated/text2text_generation.py
+++ b/src/transformers/pipelines/deprecated/text2text_generation.py
@@ -78,7 +78,7 @@ class Text2TextGenerationPipeline(Pipeline):
 
     def __init__(self, *args, **kwargs):
         if self.return_name == "generated":  # Check this isn't summarization/translation instead
-            logging.warning_once(
+            logger.warning_once(
                 "The `Text2TextGenerationPipeline` is deprecated and no longer maintained. For most "
                 "purposes, we recommend using newer models with causal pipelines like "
                 "`TextGenerationPipeline` or `ImageTextToTextPipeline`."
@@ -261,7 +261,7 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
     return_name = "summary"
 
     def __init__(self, *args, **kwargs):
-        logging.warning_once(
+        logger.warning_once(
             "The `SummarizationPipeline` is deprecated and no longer maintained. For most "
             "summarization tasks, we recommend appropriately prompting modern general-purpose LLMs "
             "via pipelines like `TextGenerationPipeline` or `ImageTextToTextPipeline`."
@@ -338,7 +338,7 @@ class TranslationPipeline(Text2TextGenerationPipeline):
     return_name = "translation"
 
     def __init__(self, *args, **kwargs):
-        logging.warning_once(
+        logger.warning_once(
             "The `TranslationPipeline` is deprecated and no longer maintained. For most "
             "translation tasks, we recommend appropriately prompting modern general-purpose LLMs "
             "via pipelines like `TextGenerationPipeline` or `ImageTextToTextPipeline`."

--- a/src/transformers/pipelines/deprecated/text2text_generation.py
+++ b/src/transformers/pipelines/deprecated/text2text_generation.py
@@ -2,14 +2,14 @@ import enum
 import warnings
 from typing import Any
 
-from ..generation import GenerationConfig
-from ..tokenization_utils import TruncationStrategy
-from ..utils import add_end_docstrings, is_torch_available, logging
-from .base import Pipeline, build_pipeline_init_args
+from ...generation import GenerationConfig
+from ...tokenization_utils import TruncationStrategy
+from ...utils import add_end_docstrings, is_torch_available, logging
+from ..base import Pipeline, build_pipeline_init_args
 
 
 if is_torch_available():
-    from ..models.auto.modeling_auto import MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES
+    from ...models.auto.modeling_auto import MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES
 
 logger = logging.get_logger(__name__)
 
@@ -77,6 +77,12 @@ class Text2TextGenerationPipeline(Pipeline):
     return_name = "generated"
 
     def __init__(self, *args, **kwargs):
+        if self.return_name == "generated":  # Check this isn't summarization/translation instead
+            logging.warning_once(
+                "The `Text2TextGenerationPipeline` is deprecated and no longer maintained. For most "
+                "purposes, we recommend using newer models with causal pipelines like "
+                "`TextGenerationPipeline` or `ImageTextToTextPipeline`."
+            )
         super().__init__(*args, **kwargs)
 
         self.check_model_type(MODEL_FOR_SEQ_TO_SEQ_CAUSAL_LM_MAPPING_NAMES)
@@ -254,6 +260,14 @@ class SummarizationPipeline(Text2TextGenerationPipeline):
     # Used in the return key of the pipeline.
     return_name = "summary"
 
+    def __init__(self, *args, **kwargs):
+        logging.warning_once(
+            "The `SummarizationPipeline` is deprecated and no longer maintained. For most "
+            "summarization tasks, we recommend appropriately prompting modern general-purpose LLMs "
+            "via pipelines like `TextGenerationPipeline` or `ImageTextToTextPipeline`."
+        )
+        super().__init__(*args, **kwargs)
+
     def __call__(self, *args, **kwargs):
         r"""
         Summarize the text(s) given as inputs.
@@ -322,6 +336,14 @@ class TranslationPipeline(Text2TextGenerationPipeline):
 
     # Used in the return key of the pipeline.
     return_name = "translation"
+
+    def __init__(self, *args, **kwargs):
+        logging.warning_once(
+            "The `TranslationPipeline` is deprecated and no longer maintained. For most "
+            "translation tasks, we recommend appropriately prompting modern general-purpose LLMs "
+            "via pipelines like `TextGenerationPipeline` or `ImageTextToTextPipeline`."
+        )
+        super().__init__(*args, **kwargs)
 
     def check_inputs(self, input_length: int, min_length: int, max_new_tokens: int):
         """


### PR DESCRIPTION
Text2Text is mostly used only by older models, and via the Summarization/Translation pipelines. However, all of these tasks are now handled by general-purpose LLMs that provide much higher translation/summarization quality than older single-purpose models. This PR retains the pipelines, but deprecates them with a warning.