### PR TITLE
[torchao] fix safetensors and enable loading from sharded files 

### DIFF
--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -117,6 +117,7 @@ class HfQuantizer(ABC):
 
     def __init__(self, quantization_config: QuantizationConfigMixin, **kwargs):
         self.quantization_config = quantization_config
+        self.metadata = {}
 
         # -- Handle extra kwargs below --
         self.modules_to_not_convert = kwargs.pop("modules_to_not_convert", [])
@@ -391,10 +392,6 @@ class HfQuantizer(ABC):
     def get_state_dict_and_metadata(self, model, safe_serialization=False):
         """Get state dict and metadata. Useful when we need to modify a bit the state dict due to quantization"""
         return None, {}
-
-    def update_state_dict_with_metadata(self, state_dict, metadata):
-        """Update state dict with metadata. Default behaviour returns state_dict"""
-        return state_dict
 
     @abstractmethod
     def is_serializable(self, safe_serialization=None): ...


### PR DESCRIPTION
**Context**

This PR is a followup to #40735 and #41138. Previously, we enabled safetensors in torchao for one shard file. This PR fixes some errors introduced in #41138 and handles the case when checkpoints are sharded onto more than one file, including the edge case where a single quantized tensor (ie `Float8Tensor`) is sharded onto two different files (ie `qdata` on one and `scale` on another). 

**Summary**

If we are loading in a component of a tensor subclass in `create_quantized_param()` called by `_load_state_dict_into_meta_model()`, we add this as a new parameter into the model. Then after all parameters are loaded, we unflatten the `state_dict` and reassign the model parameters. 

**Testing**

Modified unit tests to test all tensor subclasses 
`python tests/quantization/torchao_integration/test_torchao.py -k TorchAoSafeSerializationTest`
