### PR TITLE
Fix `run slow v2`: empty report when there is only one model

### DIFF
--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -102,8 +102,10 @@ jobs:
         working-directory: /transformers/tests
         run: |
           if [ "${{ inputs.job }}" = "run_models_gpu" ]; then
-            echo "folder_slices=$(python3 ../utils/split_model_tests.py --subdirs '${{ inputs.subdirs }}' --num_splits ${{ env.NUM_SLICES }})" >> $GITHUB_OUTPUT
-            echo "slice_ids=$(python3 -c 'd = list(range(${{ env.NUM_SLICES }})); print(d)')" >> $GITHUB_OUTPUT
+            python3 ../utils/split_model_tests.py --subdirs '${{ inputs.subdirs }}' --num_splits ${{ env.NUM_SLICES }} > folder_slices.txt
+            echo "folder_slices=$(cat folder_slices.txt)" >> $GITHUB_OUTPUT
+            python3 -c "import ast; folder_slices = ast.literal_eval(open('folder_slices.txt').read()); open('slice_ids.txt', 'w').write(str(list(range(len(folder_slices)))))"
+            echo "slice_ids=$(cat slice_ids.txt)" >> $GITHUB_OUTPUT
           elif [ "${{ inputs.job }}" = "run_trainer_and_fsdp_gpu" ]; then
             echo "folder_slices=[['trainer'], ['fsdp']]" >> $GITHUB_OUTPUT
             echo "slice_ids=[0, 1]" >> $GITHUB_OUTPUT

--- a/utils/split_model_tests.py
+++ b/utils/split_model_tests.py
@@ -81,6 +81,8 @@ if __name__ == "__main__":
     for idx in range(args.num_splits):
         start = end
         end = start + num_jobs_per_splits + (1 if idx < num_jobs % args.num_splits else 0)
-        model_splits.append(d[start:end])
+        # Only add the slice if it is not an empty list
+        if len(d[start:end]) > 0:
+            model_splits.append(d[start:end])
 
     print(model_splits)


### PR DESCRIPTION
# What does this PR do?

Fix Run slow v2 (#41914):

when there is only one model specified (in particular, new model addition PR), the `setup` job's step in `.github/workflows/self-scheduled.yml`:

> echo "slice_ids=$(python3 -c 'd = list(range(${{ env.NUM_SLICES }})); print(d)')" >> $GITHUB_OUTPUT

will still generate a list `[0,1]` (because `NUM_SLICES: 2`) and the `run_models_gpu` will have a matrix `slice_id: [0, 1]` but one of it would get an empty list of models to run.

The workflow still runs without problem, but this causes `${{ needs.model-ci.outputs.report }}` in `.github/workflows/self-comment-ci.yml` being empty , see [this run](https://github.com/huggingface/transformers/actions/runs/19057114226/job/54430404760).
We got `Annotations 3 errors` if we click any job which shows

> Error when evaluating 'strategy' for job 'run_models_gpu'. huggingface/transformers/.github/workflows/model_jobs.yml@f6837a4cf5b173c38c992531685a4a9c2fe43259 (Line: 54, Col: 18): Matrix vector 'folders' does not contain any values


This PR fixes this issue by using the actual length of `folder_slices` instead.