### PR TITLE
Reduce the number of benchmark in the CI

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -52,7 +52,7 @@ jobs:
             commit_id=$GITHUB_SHA
           fi
           commit_msg=$(git show -s --format=%s | cut -c1-70)
-          python3 benchmark_v2/run_benchmarks.py -b 32 -s 128 -n 256 --cross-generate --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --push-result-to-dataset "$DATASET_ID"
+          python3 benchmark_v2/run_benchmarks.py -b 32 -s 128 -n 256 --level 2 --branch-name "$BRANCH_NAME" --commit-id "$commit_id" --commit-message "$commit_msg" --model-id "$MODEL_ID" --log-level INFO --push-result-to-dataset "$DATASET_ID"
         env:
           HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
           PUSH_TO_HUB_TOKEN: ${{ secrets.PUSH_TO_HUB_TOKEN }}


### PR DESCRIPTION
In recent changes, we increased the number of benchmarks being run in the benchmarking CI. This has led to a relatively long CI runtime ~1hr on A10 runners. This might be wasteful. 
This PR changes how the `run_benchmark.py` generates the benchmark configs, favoring a benchmarking "level" system instead of ad hoc heuristic. The system has 5 levels of coverage:

0. Only one cfg is benchmarked, the most efficient until now for generate
1. A few well-performing config are benchmarked. Default option
2. For each attention implementation, we benhcmark one config, and we add 2 more on top to test `kernelize`. This leads to a total of 6 configs, and it is the option used in the CI.
3. We benchmark all possible config, but the compile mode is either `None` (no compile) or `default`
4. Same but with all possible compile modes.

This simplifies the script and makes it usable for both CI and users that want to run a fast benchmark suite as well as those who want more coverage.