### PR TITLE
add back `logging_dir`

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -885,7 +885,12 @@ class TrainingArguments:
             )
         },
     )
-    logging_dir: Optional[str] = field(default=None, metadata={"help": "Deprecated and will be removed in v5.2. Set env var `TENSORBOARD_LOGGING_DIR` instead. TensorBoard log directory."})
+    logging_dir: Optional[str] = field(
+        default=None,
+        metadata={
+            "help": "Deprecated and will be removed in v5.2. Set env var `TENSORBOARD_LOGGING_DIR` instead. TensorBoard log directory."
+        },
+    )
     logging_strategy: Union[IntervalStrategy, str] = field(
         default="steps",
         metadata={"help": "The logging strategy to use."},
@@ -1700,6 +1705,7 @@ class TrainingArguments:
             logger.warning(
                 "`logging_dir` is deprecated and will be removed in v5.2. Please set `TENSORBOARD_LOGGING_DIR` instead."
             )
+
     def __str__(self):
         self_as_dict = asdict(self)
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -885,6 +885,7 @@ class TrainingArguments:
             )
         },
     )
+    logging_dir: Optional[str] = field(default=None, metadata={"help": "Deprecated and will be removed in v5.2. Set env var `TENSORBOARD_LOGGING_DIR` instead. TensorBoard log directory."})
     logging_strategy: Union[IntervalStrategy, str] = field(
         default="steps",
         metadata={"help": "The logging strategy to use."},
@@ -1695,6 +1696,10 @@ class TrainingArguments:
         if isinstance(self.include_num_input_tokens_seen, bool):
             self.include_num_input_tokens_seen = "all" if self.include_num_input_tokens_seen else "no"
 
+        if self.logging_dir is not None:
+            logger.warning(
+                "`logging_dir` is deprecated and will be removed in v5.2. Please set `TENSORBOARD_LOGGING_DIR` instead."
+            )
     def __str__(self):
         self_as_dict = asdict(self)
 


### PR DESCRIPTION
# What does this PR do?

This PR adds back `logging_dir` from @BenjaminBossan suggestion. It might be more used than I thought due to its generic name even though users might not be using tensorboard.