### PR TITLE
update `huggingface_hub` dependency version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,6 @@ from pathlib import Path
 
 from setuptools import Command, find_packages, setup
 
-
 # Remove stale transformers.egg-info directory to avoid https://github.com/pypa/pip/issues/5466
 stale_egg_info = Path(__file__).parent / "transformers.egg-info"
 if stale_egg_info.exists():
@@ -113,7 +112,7 @@ _deps = [
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
     "hf_xet",
-    "huggingface-hub==1.0.0.rc6",
+    "huggingface-hub>=1.0.0,<2.0",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "jinja2>=3.1.0",

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ from pathlib import Path
 
 from setuptools import Command, find_packages, setup
 
+
 # Remove stale transformers.egg-info directory to avoid https://github.com/pypa/pip/issues/5466
 stale_egg_info = Path(__file__).parent / "transformers.egg-info"
 if stale_egg_info.exists():

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -23,7 +23,7 @@ deps = {
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
     "hf_xet": "hf_xet",
-    "huggingface-hub": "huggingface-hub==1.0.0.rc6",
+    "huggingface-hub": "huggingface-hub>=1.0.0,<2.0",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "jinja2": "jinja2>=3.1.0",


### PR DESCRIPTION
Now that `huggingface_hub` [v1.0](https://github.com/huggingface/huggingface_hub/releases/tag/v1.0.0) is released, Let's update the dependency to `>=1.0.0,<2.0`.

cc @Wauplin 