### PR TITLE
Change trigger time for AMD CI

### DIFF
--- a/.github/workflows/self-scheduled-amd-caller.yml
+++ b/.github/workflows/self-scheduled-amd-caller.yml
@@ -2,7 +2,7 @@ name: Self-hosted runner (AMD scheduled CI caller)
 
 on:
   schedule:
-    - cron: "17 2 * * *"
+    - cron: "17 5 * * *"
 
 jobs:
   run_scheduled_amd_ci:


### PR DESCRIPTION
# What does this PR do?

docker build starts at 12AM. UTC+0. AMD docker file build in 4 hours. Let's trigger AMD CI at 5AM 