### PR TITLE
Fix KeyError in _is_package_available for packages with dotted names

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -58,7 +58,7 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
             # pick the first item of the list as best guess (it's almost always a list of length 1 anyway)
             distribution_name = pkg_name if pkg_name in distributions else distributions[0]
             package_version = importlib.metadata.version(distribution_name)
-        except importlib.metadata.PackageNotFoundError:
+        except (importlib.metadata.PackageNotFoundError, KeyError):
             # If we cannot find the metadata (because of editable install for example), try to import directly.
             # Note that this branch will almost never be run, so we do not import packages for nothing here
             package = importlib.import_module(pkg_name)


### PR DESCRIPTION
# What does this PR do?

Fixes #41981

I ran into this issue while testing with `optimum.quanto`. The function was crashing with `KeyError` when checking for packages with dotted names.

The problem is in `import_utils.py` line 56 - when it tries to look up the package in `PACKAGE_DISTRIBUTION_MAPPING`, packages with dots in the name (like `optimum.quanto`) aren't always there. The mapping might only have `optimum` as a key, not `optimum.quanto`.

The function already has fallback logic to handle cases where package metadata can't be found - it imports the package directly and checks for `__version__`. But the exception handler only caught `PackageNotFoundError`, not `KeyError`.

I added `KeyError` to the exception handler so the fallback works for both cases. Now when a package name isn't in the mapping, it'll use the same fallback path instead of crashing.

This is a one-line change that handles the edge case without affecting normal operation. The existing tests should still pass since the behavior for normal packages is unchanged.
