### PR TITLE
Fix model_input_names singleton issue causing shared state

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1414,7 +1414,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 f"Truncation side should be selected between 'right' and 'left', current value: {self.truncation_side}"
             )
 
-        self.model_input_names = kwargs.pop("model_input_names", self.model_input_names)
+        self.model_input_names = list(kwargs.pop("model_input_names", self.model_input_names))
 
         # By default, cleaning tokenization spaces for both fast and slow tokenizers
         self.clean_up_tokenization_spaces = kwargs.pop("clean_up_tokenization_spaces", False)


### PR DESCRIPTION
# What does this PR do?

Fixes #42024

I found this while testing tokenizers - when you modify `model_input_names` on one tokenizer instance, it was affecting all other instances of the same tokenizer class.

The problem is that `model_input_names` is defined as a class-level list, and in the `__init__` method (line 1417), when no custom `model_input_names` is provided, it was just referencing the class attribute directly instead of making a copy.

So all instances were sharing the same list object. This is a classic Python gotcha with mutable class attributes.

The fix is simple - wrap it in `list()` to create a new list for each instance:

**Before:**
```python
self.model_input_names = kwargs.pop("model_input_names", self.model_input_names)
```

**After:**
```python
self.model_input_names = list(kwargs.pop("model_input_names", self.model_input_names))
```

This ensures each tokenizer instance gets its own independent copy of the list. Now modifications to one instance won't affect others.

The reproduction from the issue shows the problem clearly - with the fix, the second tokenizer instance will have the original list values instead of inheriting the modifications from the first instance.
