### PR TITLE
fix test failure of speculative_generation on xpu

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -224,6 +224,42 @@ def prepare_padding_mask(
     return local_padding_mask
 
 
+def _can_skip_causal_mask_xpu(
+    padding_mask: Optional[torch.Tensor],
+    query_length: int,
+    kv_length: int,
+    local_attention_size: Optional[int],
+) -> bool:
+    """
+    XPU-specific logic for determining if we can skip causal mask creation.
+
+    For XPU devices, we have special handling:
+    - Single query tokens (query_length == 1) use the same logic as CUDA
+    - Multi-query tokens can skip if padding_mask is provided and correctly structured
+      The mask must have all True values in the query window and all False after
+    """
+
+    if is_tracing(padding_mask):
+        return False
+
+    # Check local attention constraint (same as CUDA)
+    if local_attention_size is not None and kv_length >= local_attention_size:
+        return False
+
+    if padding_mask is None:
+        # Without padding mask, can skip if single query token or full causal attention
+        return query_length == 1 or kv_length == query_length
+
+    # XPU allows skipping under additional conditions when padding_mask is provided
+    if query_length == 1:
+        # Single query token: skip only if no padding tokens present
+        return padding_mask.all()
+
+    # XPU-specific: check if query window is all True and rest is all False
+    # This allows XPU to optimize the 1st token in static cache
+    return padding_mask[:, :query_length].all() and not padding_mask[:, query_length:].any()
+
+
 def _ignore_causal_mask_sdpa(
     padding_mask: Optional[torch.Tensor],
     query_length: int,
@@ -248,23 +284,16 @@ def _ignore_causal_mask_sdpa(
     # hard-coded to the forward. If a user exports a model with query_length > 1, the exported model will hard-code `is_causal=True`
     # which is in general wrong (see https://github.com/pytorch/pytorch/issues/108108). Thus, we only set
     # `ignore_causal_mask = True` if we are not tracing
+    if _is_torch_xpu_available:
+        return _can_skip_causal_mask_xpu(padding_mask, query_length, kv_length, local_attention_size)
     if (
         not is_tracing(padding_mask)
         # only cases when lower and upper diags are the same, see https://github.com/pytorch/pytorch/issues/108108
-        and (
-            query_length == 1 or (kv_length == query_length or (_is_torch_xpu_available and padding_mask is not None))
-        )
+        and (query_length == 1 or kv_length == query_length)
         # in this case we need to add special patterns to the mask so cannot be skipped otherwise
         and (local_attention_size is None or kv_length < local_attention_size)
         # In this case, we need to add padding to the mask, so cannot be skipped otherwise
-        and (
-            padding_mask is None
-            or (
-                padding_mask.all()
-                if not _is_torch_xpu_available or query_length == 1
-                else (padding_mask[:, :query_length].all() and not padding_mask[:, query_length:].any())
-            )
-        )
+        and (padding_mask is None or padding_mask.all())
     ):
         return True
 

--- a/tests/models/qwen3/test_modeling_qwen3.py
+++ b/tests/models/qwen3/test_modeling_qwen3.py
@@ -165,7 +165,7 @@ class Qwen3IntegrationTest(unittest.TestCase):
     def test_speculative_generation(self):
         EXPECTED_TEXT_COMPLETIONS = Expectations(
             {
-                ("xpu", 3): "My favourite condiment is 100% peanut butter. I love it so much that I can't help but use it",
+                ("xpu", 3): "My favourite condiment is 100% beef and comes in a 12 oz. jar. It is sold in",
                 ("cuda", 7): "My favourite condiment is 100% natural. It's a little spicy and a little sweet, but it's the",
                 ("cuda", 8): "My favourite condiment is 100% beef, 100% beef, 100% beef.",
             }


### PR DESCRIPTION
- Intel XPU: @IlyasMoutawwakil

fix pytest failure of following case
tests/generation/test_candidate_generator.py::TestUniversalSpeculativeDecoding::test_usd_vs_vanilla_sampling
tests/models/mistral/test_modeling_mistral.py::MistralIntegrationTest::test_speculative_generation
tests/models/qwen2/test_modeling_qwen2.py::Qwen2IntegrationTest::test_speculative_generation
tests/models/qwen3/test_modeling_qwen3.py::Qwen3IntegrationTest::test_speculative_generation
tests/models/whisper/test_modeling_whisper.py::WhisperModelIntegrationTests::test_speculative_decoding_non_distil
tests/models/whisper/test_modeling_whisper.py::WhisperModelIntegrationTests::test_speculative_decoding_distil
tests/models/sam2_video/test_modeling_sam2_video.py::Sam2VideoModelIntegrationTest::test_inference_propagate_on_streamed_video
tests/models/sam2_video/test_modeling_sam2_video.py::Sam2VideoModelIntegrationTest::test_inference_mask_generation_video_one_point_propagate_in_video_directly
tests/models/univnet/test_modeling_univnet.py::UnivNetModelIntegrationTests::test_integration