### PR TITLE
Revert back to use GitHub context 

### DIFF
--- a/.github/workflows/pr_slow_ci_suggestion.yml
+++ b/.github/workflows/pr_slow_ci_suggestion.yml
@@ -30,6 +30,8 @@ jobs:
 
       # We need to use `${{ ... }}` here to avoid `Argument list too long` error when a PR changes a lot of files.
       # (We could also try to use artifact approach, but it's more involved).
+      # `CodeQL` doesn't identify any security issue here. Also `PR_FILES` is from `get-pr-info.yml` by using an api
+      # `github.rest.pulls.listFiles`, which is fine.
       - name: Write pr_files file
         run: |
           cat > pr_files.txt << 'EOF'

--- a/.github/workflows/pr_slow_ci_suggestion.yml
+++ b/.github/workflows/pr_slow_ci_suggestion.yml
@@ -28,13 +28,13 @@ jobs:
         with:
           fetch-depth: "0"
 
+      # We need to use `${{ ... }}` here to avoid `Argument list too long` error when a PR changes a lot of files.
+      # (We could also try to use artifact approach, but it's more involved).
       - name: Write pr_files file
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('node:fs');
-            const prFilesJson = `${{ needs.get-pr-info.outputs.PR_FILES }}`;
-            fs.writeFileSync('pr_files.txt', prFilesJson);
+        run: |
+          cat > pr_files.txt << 'EOF'
+          ${{ needs.get-pr-info.outputs.PR_FILES }}
+          EOF
 
       - name: Get repository content
         id: repo_content


### PR DESCRIPTION
# What does this PR do?

Revert back to use GitHub context .

After the previous PR

Avoid explicit checkout in workflow (#42057), when a PR touched a lot of files, we get 

> Error: An error occurred trying to start process '/home/runner/actions-runner/cached/externals/node20/bin/node' with working directory '/home/runner/work/transformers/transformers'. Argument list too long