### PR TITLE
Fix inconsistency of commit sha during the workflow run

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -125,7 +125,7 @@ jobs:
             const { data: merge_commit }  = await github.rest.repos.getCommit({
               owner: pr.base.repo.owner.login,
               repo: pr.base.repo.name,
-              ref: pr.merge_commit_sha,
+              ref: '${{ inputs.commit_sha }}',
             });
 
             core.setOutput('merge_commit_base_sha', merge_commit.parents[0].sha);


### PR DESCRIPTION
# What does this PR do?

In `.github/workflows/check_failed_tests.yml`, we have (before this PR)

```
        uses: actions/github-script@v6
        with:
          script: |            
            const { data: pr } = await github.rest.pulls.get({
              owner: context.repo.owner,
              repo: context.repo.repo,
              pull_number: ${{ inputs.pr_number }}
            });

            const { data: merge_commit }  = await github.rest.repos.getCommit({
              owner: pr.base.repo.owner.login,
              repo: pr.base.repo.name,
              ref: pr.merge_commit_sha,
            });

            core.setOutput('merge_commit_base_sha', merge_commit.parents[0].sha);
```

We get the PR merge commit by fetching from github here. But if the `main` branch is updated during the workflow run, it may cause the situation where we use the old merge commit in an earlier job/step of the workflow run, but use the new merge commit here. 

We already had this happened and the job `check_failed_tests` fails, reporting no failure found for the PR.

This PR fixes this issue by using `${{ inputs.commit_sha }}` directly, which is the merge commit sha being passed if it is triggered from a PR. 