### PR TITLE
add xpu to valid hardware for torch.compile

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2170,7 +2170,7 @@ class GenerationMixin(ContinuousMixin):
             return False
 
         # Base logic
-        valid_hardware = self.device.type == "cuda" or bool(
+        valid_hardware = self.device.type in ["cuda", "xpu"] or bool(
             generation_config.compile_config is not None and generation_config.compile_config._compile_all_devices
         )
         using_compilable_cache = (


### PR DESCRIPTION
@ydshieh @yao-matrix please help review
make pytest -rA tests/generation/test_utils.py::GenerationIntegrationTests::test_cpu_offload_doesnt_compile pass in xpu