### PR TITLE
fix qwen2vl/qwen3vl video processor temporal padding when num_frames%temporal_patch_size!=1

### DIFF
--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -232,9 +232,10 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
             patches = stacked_videos
 
             # Check that videos have `num_frames` divisible by `temporal_patch_size`
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, self.temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
+            T = patches.shape[1]
+            if pad := -T % temporal_patch_size:
+                repeats = patches[:, -1:].expand(-1, pad, -1, -1, -1)
+                patches = torch.cat((patches, repeats), dim=1)
 
             batch_size, grid_t, channel = patches.shape[:3]
             grid_t = grid_t // temporal_patch_size

--- a/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
@@ -196,10 +196,6 @@ class Qwen3VLVideoProcessor(BaseVideoProcessor):
 
         for shape, stacked_videos in grouped_videos.items():
             if do_resize:
-                T = stacked_videos.shape[1]
-                if pad := -T % temporal_patch_size:
-                    repeats = stacked_videos[:, -1:].expand(-1, pad, -1, -1, -1)
-                    stacked_videos = torch.cat((stacked_videos, repeats), dim=1)
                 B, T, C, H, W = stacked_videos.shape
                 num_frames, height, width = T, H, W
                 resized_height, resized_width = smart_resize(

--- a/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
@@ -40,8 +40,6 @@ def smart_resize(
     min_pixels: int = 128 * 128,
     max_pixels: int = 16 * 16 * 2 * 2 * 2 * 6144,
 ):
-    if num_frames < temporal_factor:
-        raise ValueError(f"t:{num_frames} must be larger than temporal_factor:{temporal_factor}")
     if height < factor or width < factor:
         raise ValueError(f"height:{height} or width:{width} must be larger than factor:{factor}")
     elif max(height, width) / min(height, width) > 200:
@@ -50,7 +48,7 @@ def smart_resize(
         )
     h_bar = round(height / factor) * factor
     w_bar = round(width / factor) * factor
-    t_bar = round(num_frames / temporal_factor) * temporal_factor
+    t_bar = math.ceil(num_frames / temporal_factor) * temporal_factor
 
     if t_bar * h_bar * w_bar > max_pixels:
         beta = math.sqrt((num_frames * height * width) / max_pixels)

--- a/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
@@ -195,9 +195,9 @@ class Qwen3VLVideoProcessor(BaseVideoProcessor):
         resized_videos_grouped = {}
 
         for shape, stacked_videos in grouped_videos.items():
+            B, T, C, H, W = stacked_videos.shape
+            num_frames, height, width = T, H, W
             if do_resize:
-                B, T, C, H, W = stacked_videos.shape
-                num_frames, height, width = T, H, W
                 resized_height, resized_width = smart_resize(
                     num_frames=num_frames,
                     height=height,

--- a/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
@@ -352,7 +352,8 @@ class Qwen3VLVideoProcessingTest(VideoProcessingTestMixin, unittest.TestCase):
             video_processor_dict = self.video_processor_dict.copy()
             video_processor_dict["size"] = {"longest_edge": 5 * 32 * 32, "shortest_edge": 32 * 32}
             video_processor_dict["do_sample_frames"] = False
-            video_processor_dict["temporal_patch_size"] = 3
+            temporal_patch_size = 3
+            video_processor_dict["temporal_patch_size"] = temporal_patch_size
             video_processing = video_processing_class(**video_processor_dict)
 
             n, w, h = 5, 32, 32
@@ -360,7 +361,7 @@ class Qwen3VLVideoProcessingTest(VideoProcessingTestMixin, unittest.TestCase):
 
             video_processed = video_processing(video_inputs, return_tensors="pt")
             encoded_videos = video_processed[self.input_name]
-            self.assertEqual(list(encoded_videos.shape), [8, 2304])
+            self.assertEqual(list(encoded_videos.shape), [8, temporal_patch_size * 3 * 16 * 16])
 
             video_grid_thw = video_processed["video_grid_thw"]
             self.assertEqual(video_grid_thw.tolist(), [[2, 2, 2]])

--- a/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
@@ -41,7 +41,7 @@ class Qwen3VLVideoProcessingTester:
         num_channels=3,
         min_resolution=32,
         max_resolution=80,
-        temporal_patch_size=3,
+        temporal_patch_size=2,
         patch_size=16,
         merge_size=2,
         do_resize=True,

--- a/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
@@ -329,24 +329,6 @@ class Qwen3VLVideoProcessingTest(VideoProcessingTestMixin, unittest.TestCase):
             if prev_max_resolution is not None:
                 self.video_processor_tester.max_resolution = prev_max_resolution
 
-    def test_only_one_image_input(self):
-        for video_processing_class in self.video_processor_list:
-            video_processor_dict = self.video_processor_dict.copy()
-            video_processor_dict["size"] = {"longest_edge": 1 * 32 * 32, "shortest_edge": 32 * 32}
-            video_processor_dict["do_sample_frames"] = False
-            video_processor_dict["temporal_patch_size"] = 3
-            video_processing = video_processing_class(**video_processor_dict)
-
-            n, w, h = 1, 32, 32
-            video_inputs = [(np.random.randint(0, 256, (h, w, 3), dtype=np.uint8)) for _ in range(n)]
-
-            video_processed = video_processing(video_inputs, return_tensors="pt")
-            encoded_videos = video_processed[self.input_name]
-            self.assertEqual(list(encoded_videos.shape), [4, 2304])
-
-            video_grid_thw = video_processed["video_grid_thw"]
-            self.assertEqual(video_grid_thw.tolist(), [[1, 2, 2]])
-
     def test_num_frames_equal_temporal_patch_size_plus_two(self):
         for video_processing_class in self.video_processor_list:
             video_processor_dict = self.video_processor_dict.copy()

--- a/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_video_processing_qwen3_vl.py
@@ -329,38 +329,38 @@ class Qwen3VLVideoProcessingTest(VideoProcessingTestMixin, unittest.TestCase):
             if prev_max_resolution is not None:
                 self.video_processor_tester.max_resolution = prev_max_resolution
 
-    def test_image_input(self):
+    def test_only_one_image_input(self):
         for video_processing_class in self.video_processor_list:
             video_processor_dict = self.video_processor_dict.copy()
-            video_processor_dict["size"] = {"longest_edge": 40960, "shortest_edge": 4096}
+            video_processor_dict["size"] = {"longest_edge": 1 * 32 * 32, "shortest_edge": 32 * 32}
             video_processor_dict["do_sample_frames"] = False
             video_processor_dict["temporal_patch_size"] = 3
             video_processing = video_processing_class(**video_processor_dict)
 
-            n, w, h = 1, 64, 64
+            n, w, h = 1, 32, 32
             video_inputs = [(np.random.randint(0, 256, (h, w, 3), dtype=np.uint8)) for _ in range(n)]
 
             video_processed = video_processing(video_inputs, return_tensors="pt")
             encoded_videos = video_processed[self.input_name]
-            self.assertEqual(list(encoded_videos.shape), [16, 2304])
+            self.assertEqual(list(encoded_videos.shape), [4, 2304])
 
             video_grid_thw = video_processed["video_grid_thw"]
-            self.assertEqual(video_grid_thw.tolist(), [[1, 4, 4]])
+            self.assertEqual(video_grid_thw.tolist(), [[1, 2, 2]])
 
     def test_num_frames_equal_temporal_patch_size_plus_two(self):
         for video_processing_class in self.video_processor_list:
             video_processor_dict = self.video_processor_dict.copy()
-            video_processor_dict["size"] = {"longest_edge": 40960, "shortest_edge": 4096}
+            video_processor_dict["size"] = {"longest_edge": 5 * 32 * 32, "shortest_edge": 32 * 32}
             video_processor_dict["do_sample_frames"] = False
             video_processor_dict["temporal_patch_size"] = 3
             video_processing = video_processing_class(**video_processor_dict)
 
-            n, w, h = 5, 64, 64
+            n, w, h = 5, 32, 32
             video_inputs = [(np.random.randint(0, 256, (h, w, 3), dtype=np.uint8)) for _ in range(n)]
 
             video_processed = video_processing(video_inputs, return_tensors="pt")
             encoded_videos = video_processed[self.input_name]
-            self.assertEqual(list(encoded_videos.shape), [32, 2304])
+            self.assertEqual(list(encoded_videos.shape), [8, 2304])
 
             video_grid_thw = video_processed["video_grid_thw"]
-            self.assertEqual(video_grid_thw.tolist(), [[2, 4, 4]])
+            self.assertEqual(video_grid_thw.tolist(), [[2, 2, 2]])


### PR DESCRIPTION
# What does this PR do?
expect qwen3vl video processor can process these two cases:
1. num_frames is 1, and sample_frames is false.
2. num_frames > temporal_patch_size and num_frames % temporal_patch_size != 1

Fixes # (issue)
https://github.com/QwenLM/Qwen3-VL/issues/1689

