### PR TITLE
Fix helper fn for new processor config format

### DIFF
--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -437,7 +437,7 @@ class FeatureExtractionMixin(PushToHubMixin):
                 # Load from local folder or from cache or download from model Hub and cache
                 resolved_feature_extractor_files = [
                     resolved_file
-                    for filename in [feature_extractor_file, PROCESSOR_NAME]
+                    for filename in [PROCESSOR_NAME, feature_extractor_file]
                     if (
                         resolved_file := cached_file(
                             pretrained_model_name_or_path,

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -427,35 +427,42 @@ class FeatureExtractionMixin(PushToHubMixin):
             feature_extractor_file = os.path.join(pretrained_model_name_or_path, FEATURE_EXTRACTOR_NAME)
         if os.path.isfile(pretrained_model_name_or_path):
             resolved_feature_extractor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
             is_local = True
         elif is_remote_url(pretrained_model_name_or_path):
             feature_extractor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
             resolved_feature_extractor_file = download_url(pretrained_model_name_or_path)
         else:
             feature_extractor_file = FEATURE_EXTRACTOR_NAME
             try:
                 # Load from local folder or from cache or download from model Hub and cache
-                resolved_feature_extractor_files = [
-                    resolved_file
-                    for filename in [PROCESSOR_NAME, feature_extractor_file]
-                    if (
-                        resolved_file := cached_file(
-                            pretrained_model_name_or_path,
-                            filename=filename,
-                            cache_dir=cache_dir,
-                            force_download=force_download,
-                            proxies=proxies,
-                            local_files_only=local_files_only,
-                            subfolder=subfolder,
-                            token=token,
-                            user_agent=user_agent,
-                            revision=revision,
-                            _raise_exceptions_for_missing_entries=False,
-                        )
-                    )
-                    is not None
-                ]
-                resolved_feature_extractor_file = resolved_feature_extractor_files[0]
+                resolved_processor_file = cached_file(
+                    pretrained_model_name_or_path,
+                    filename=PROCESSOR_NAME,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    local_files_only=local_files_only,
+                    token=token,
+                    user_agent=user_agent,
+                    revision=revision,
+                    subfolder=subfolder,
+                    _raise_exceptions_for_missing_entries=False,
+                )
+                resolved_feature_extractor_file = cached_file(
+                    pretrained_model_name_or_path,
+                    filename=feature_extractor_file,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    local_files_only=local_files_only,
+                    token=token,
+                    user_agent=user_agent,
+                    revision=revision,
+                    subfolder=subfolder,
+                    _raise_exceptions_for_missing_entries=False,
+                )
             except OSError:
                 # Raise any environment error raise by `cached_file`. It will have a helpful error message adapted to
                 # the original exception.
@@ -469,19 +476,38 @@ class FeatureExtractionMixin(PushToHubMixin):
                     f" directory containing a {FEATURE_EXTRACTOR_NAME} file"
                 )
 
-        try:
-            # Load feature_extractor dict
-            with open(resolved_feature_extractor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            feature_extractor_dict = json.loads(text)
-            if "audio_processor" in feature_extractor_dict:
-                feature_extractor_dict = feature_extractor_dict["audio_processor"]
-            else:
-                feature_extractor_dict = feature_extractor_dict.get("feature_extractor", feature_extractor_dict)
+        # Load feature_extractor dict. Priority goes as (nested config if found -> image processor config)
+        # We are downloading both configs because almost all models have a `processor_config.json` but
+        # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
+        feature_extractor_dict = None
+        if resolved_processor_file is not None:
+            try:
+                with open(resolved_processor_file, encoding="utf-8") as reader:
+                    text = reader.read()
+                processor_dict = json.loads(text)
+            except json.JSONDecodeError:
+                raise OSError(
+                    f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file."
+                )
+            if "feature_extractor" in processor_dict or "audio_processor" in processor_dict:
+                feature_extractor_dict = processor_dict.get("feature_extractor", processor_dict.get("audio_processor"))
 
-        except json.JSONDecodeError:
+        if resolved_feature_extractor_file is not None and feature_extractor_dict is None:
+            try:
+                with open(resolved_feature_extractor_file, encoding="utf-8") as reader:
+                    text = reader.read()
+                feature_extractor_dict = json.loads(text)
+            except json.JSONDecodeError:
+                raise OSError(
+                    f"It looks like the config file at '{resolved_feature_extractor_file}' is not a valid JSON file."
+                )
+
+        if feature_extractor_dict is None:
             raise OSError(
-                f"It looks like the config file at '{resolved_feature_extractor_file}' is not a valid JSON file."
+                f"Can't load feature extractor for '{pretrained_model_name_or_path}'. If you were trying to load"
+                " it from 'https://huggingface.co/models', make sure you don't have a local directory with the"
+                f" same name. Otherwise, make sure '{pretrained_model_name_or_path}' is the correct path to a"
+                f" directory containing a {feature_extractor_file} file"
             )
 
         if is_local:

--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -39,6 +39,7 @@ from .utils import (
     is_torch_dtype,
     logging,
     requires_backends,
+    safe_load_json_file,
 )
 from .utils.hub import cached_file
 
@@ -481,26 +482,12 @@ class FeatureExtractionMixin(PushToHubMixin):
         # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
         feature_extractor_dict = None
         if resolved_processor_file is not None:
-            try:
-                with open(resolved_processor_file, encoding="utf-8") as reader:
-                    text = reader.read()
-                processor_dict = json.loads(text)
-            except json.JSONDecodeError:
-                raise OSError(
-                    f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file."
-                )
+            processor_dict = safe_load_json_file(resolved_processor_file)
             if "feature_extractor" in processor_dict or "audio_processor" in processor_dict:
                 feature_extractor_dict = processor_dict.get("feature_extractor", processor_dict.get("audio_processor"))
 
         if resolved_feature_extractor_file is not None and feature_extractor_dict is None:
-            try:
-                with open(resolved_feature_extractor_file, encoding="utf-8") as reader:
-                    text = reader.read()
-                feature_extractor_dict = json.loads(text)
-            except json.JSONDecodeError:
-                raise OSError(
-                    f"It looks like the config file at '{resolved_feature_extractor_file}' is not a valid JSON file."
-                )
+            feature_extractor_dict = safe_load_json_file(resolved_feature_extractor_file)
 
         if feature_extractor_dict is None:
             raise OSError(

--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -290,7 +290,7 @@ class ImageProcessingMixin(PushToHubMixin):
                 # Load from local folder or from cache or download from model Hub and cache
                 resolved_image_processor_files = [
                     resolved_file
-                    for filename in [image_processor_file, PROCESSOR_NAME]
+                    for filename in [PROCESSOR_NAME, image_processor_file]
                     if (
                         resolved_file := cached_file(
                             pretrained_model_name_or_path,

--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -32,6 +32,7 @@ from .utils import (
     is_offline_mode,
     is_remote_url,
     logging,
+    safe_load_json_file,
 )
 from .utils.hub import cached_file
 
@@ -333,26 +334,12 @@ class ImageProcessingMixin(PushToHubMixin):
         # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
         image_processor_dict = None
         if resolved_processor_file is not None:
-            try:
-                with open(resolved_processor_file, encoding="utf-8") as reader:
-                    text = reader.read()
-                processor_dict = json.loads(text)
-            except json.JSONDecodeError:
-                raise OSError(
-                    f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file."
-                )
+            processor_dict = safe_load_json_file(resolved_processor_file)
             if "image_processor" in processor_dict:
                 image_processor_dict = processor_dict["image_processor"]
 
         if resolved_image_processor_file is not None and image_processor_dict is None:
-            try:
-                with open(resolved_image_processor_file, encoding="utf-8") as reader:
-                    text = reader.read()
-                image_processor_dict = json.loads(text)
-            except json.JSONDecodeError:
-                raise OSError(
-                    f"It looks like the config file at '{resolved_image_processor_file}' is not a valid JSON file."
-                )
+            image_processor_dict = safe_load_json_file(resolved_image_processor_file)
 
         if image_processor_dict is None:
             raise OSError(

--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -280,35 +280,41 @@ class ImageProcessingMixin(PushToHubMixin):
             image_processor_file = os.path.join(pretrained_model_name_or_path, image_processor_filename)
         if os.path.isfile(pretrained_model_name_or_path):
             resolved_image_processor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
             is_local = True
         elif is_remote_url(pretrained_model_name_or_path):
             image_processor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
             resolved_image_processor_file = download_url(pretrained_model_name_or_path)
         else:
             image_processor_file = image_processor_filename
             try:
-                # Load from local folder or from cache or download from model Hub and cache
-                resolved_image_processor_files = [
-                    resolved_file
-                    for filename in [PROCESSOR_NAME, image_processor_file]
-                    if (
-                        resolved_file := cached_file(
-                            pretrained_model_name_or_path,
-                            filename=filename,
-                            cache_dir=cache_dir,
-                            force_download=force_download,
-                            proxies=proxies,
-                            local_files_only=local_files_only,
-                            token=token,
-                            user_agent=user_agent,
-                            revision=revision,
-                            subfolder=subfolder,
-                            _raise_exceptions_for_missing_entries=False,
-                        )
-                    )
-                    is not None
-                ]
-                resolved_image_processor_file = resolved_image_processor_files[0]
+                resolved_processor_file = cached_file(
+                    pretrained_model_name_or_path,
+                    filename=PROCESSOR_NAME,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    local_files_only=local_files_only,
+                    token=token,
+                    user_agent=user_agent,
+                    revision=revision,
+                    subfolder=subfolder,
+                    _raise_exceptions_for_missing_entries=False,
+                )
+                resolved_image_processor_file = cached_file(
+                    pretrained_model_name_or_path,
+                    filename=image_processor_file,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    local_files_only=local_files_only,
+                    token=token,
+                    user_agent=user_agent,
+                    revision=revision,
+                    subfolder=subfolder,
+                    _raise_exceptions_for_missing_entries=False,
+                )
             except OSError:
                 # Raise any environment error raise by `cached_file`. It will have a helpful error message adapted to
                 # the original exception.
@@ -322,16 +328,38 @@ class ImageProcessingMixin(PushToHubMixin):
                     f" directory containing a {image_processor_filename} file"
                 )
 
-        try:
-            # Load image_processor dict
-            with open(resolved_image_processor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            image_processor_dict = json.loads(text)
-            image_processor_dict = image_processor_dict.get("image_processor", image_processor_dict)
+        # Load image_processor dict. Priority goes as (nested config if found -> image processor config)
+        # We are downloading both configs because almost all models have a `processor_config.json` but
+        # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
+        image_processor_dict = None
+        if resolved_processor_file is not None:
+            try:
+                with open(resolved_processor_file, encoding="utf-8") as reader:
+                    text = reader.read()
+                processor_dict = json.loads(text)
+            except json.JSONDecodeError:
+                raise OSError(
+                    f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file."
+                )
+            if "image_processor" in processor_dict:
+                image_processor_dict = processor_dict["image_processor"]
 
-        except json.JSONDecodeError:
+        if resolved_image_processor_file is not None and image_processor_dict is None:
+            try:
+                with open(resolved_image_processor_file, encoding="utf-8") as reader:
+                    text = reader.read()
+                image_processor_dict = json.loads(text)
+            except json.JSONDecodeError:
+                raise OSError(
+                    f"It looks like the config file at '{resolved_image_processor_file}' is not a valid JSON file."
+                )
+
+        if image_processor_dict is None:
             raise OSError(
-                f"It looks like the config file at '{resolved_image_processor_file}' is not a valid JSON file."
+                f"Can't load image processor for '{pretrained_model_name_or_path}'. If you were trying to load"
+                " it from 'https://huggingface.co/models', make sure you don't have a local directory with the"
+                f" same name. Otherwise, make sure '{pretrained_model_name_or_path}' is the correct path to a"
+                f" directory containing a {image_processor_filename} file"
             )
 
         if is_local:

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -15,7 +15,6 @@
 """AutoFeatureExtractor class."""
 
 import importlib
-import json
 import os
 from collections import OrderedDict
 from typing import Optional, Union
@@ -24,7 +23,7 @@ from typing import Optional, Union
 from ...configuration_utils import PreTrainedConfig
 from ...dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
 from ...feature_extraction_utils import FeatureExtractionMixin
-from ...utils import CONFIG_NAME, FEATURE_EXTRACTOR_NAME, PROCESSOR_NAME, cached_file, logging
+from ...utils import CONFIG_NAME, FEATURE_EXTRACTOR_NAME, PROCESSOR_NAME, cached_file, logging, safe_load_json_file
 from .auto_factory import _LazyAutoMapping
 from .configuration_auto import (
     CONFIG_MAPPING_NAMES,
@@ -203,25 +202,12 @@ def get_feature_extractor_config(
     # not all of these are nested. We need to check if it was saved recently as nested or if it is legacy style
     feature_extractor_dict = {}
     if resolved_processor_file is not None:
-        try:
-            with open(resolved_processor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            processor_dict = json.loads(text)
-        except json.JSONDecodeError:
-            raise OSError(f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file.")
+        processor_dict = safe_load_json_file(resolved_processor_file)
         if "feature_extractor" in processor_dict:
             feature_extractor_dict = processor_dict["feature_extractor"]
 
     if resolved_feature_extractor_file is not None and feature_extractor_dict is None:
-        try:
-            with open(resolved_feature_extractor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            feature_extractor_dict = json.loads(text)
-        except json.JSONDecodeError:
-            raise OSError(
-                f"It looks like the config file at '{resolved_feature_extractor_file}' is not a valid JSON file."
-            )
-
+        feature_extractor_dict = safe_load_json_file(resolved_feature_extractor_file)
     return feature_extractor_dict
 
 

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -167,9 +167,10 @@ def get_feature_extractor_config(
     feature_extractor.save_pretrained("feature-extractor-test")
     feature_extractor_config = get_feature_extractor_config("feature-extractor-test")
     ```"""
+    # Load with a priority given to the nested processor config, if available in repo
     resolved_config_files = [
         resolved_file
-        for filename in [FEATURE_EXTRACTOR_NAME, PROCESSOR_NAME]
+        for filename in [PROCESSOR_NAME, FEATURE_EXTRACTOR_NAME]
         if (
             resolved_file := cached_file(
                 pretrained_model_name_or_path,

--- a/src/transformers/models/auto/feature_extraction_auto.py
+++ b/src/transformers/models/auto/feature_extraction_auto.py
@@ -200,7 +200,7 @@ def get_feature_extractor_config(
 
     # Load feature_extractor dict. Priority goes as (nested config if found -> feature extractor config)
     # We are downloading both configs because almost all models have a `processor_config.json` but
-    # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
+    # not all of these are nested. We need to check if it was saved recently as nested or if it is legacy style
     feature_extractor_dict = {}
     if resolved_processor_file is not None:
         try:

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -15,7 +15,6 @@
 """AutoImageProcessor class."""
 
 import importlib
-import json
 import os
 import warnings
 from collections import OrderedDict
@@ -36,6 +35,7 @@ from ...utils import (
     is_torchvision_available,
     is_vision_available,
     logging,
+    safe_load_json_file,
 )
 from ...utils.import_utils import requires
 from .auto_factory import _LazyAutoMapping
@@ -342,24 +342,12 @@ def get_image_processor_config(
     # not all of these are nested. We need to check if it was saved recently as nested or if it is legacy style
     image_processor_dict = {}
     if resolved_processor_file is not None:
-        try:
-            with open(resolved_processor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            processor_dict = json.loads(text)
-        except json.JSONDecodeError:
-            raise OSError(f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file.")
+        processor_dict = safe_load_json_file(resolved_processor_file)
         if "image_processor" in processor_dict:
             image_processor_dict = processor_dict["image_processor"]
 
     if resolved_image_processor_file is not None and image_processor_dict is None:
-        try:
-            with open(resolved_image_processor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            image_processor_dict = json.loads(text)
-        except json.JSONDecodeError:
-            raise OSError(
-                f"It looks like the config file at '{resolved_image_processor_file}' is not a valid JSON file."
-            )
+        image_processor_dict = safe_load_json_file(resolved_image_processor_file)
 
     return image_processor_dict
 

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -339,7 +339,7 @@ def get_image_processor_config(
 
     # Load image_processor dict. Priority goes as (nested config if found -> image processor config)
     # We are downloading both configs because almost all models have a `processor_config.json` but
-    # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
+    # not all of these are nested. We need to check if it was saved recently as nested or if it is legacy style
     image_processor_dict = {}
     if resolved_processor_file is not None:
         try:

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -306,9 +306,10 @@ def get_image_processor_config(
     image_processor.save_pretrained("image-processor-test")
     image_processor_config = get_image_processor_config("image-processor-test")
     ```"""
+    # Load with a priority given to the nested processor config, if available in repo
     resolved_config_files = [
         resolved_file
-        for filename in [IMAGE_PROCESSOR_NAME, PROCESSOR_NAME]
+        for filename in [PROCESSOR_NAME, IMAGE_PROCESSOR_NAME]
         if (
             resolved_file := cached_file(
                 pretrained_model_name_or_path,

--- a/src/transformers/models/auto/video_processing_auto.py
+++ b/src/transformers/models/auto/video_processing_auto.py
@@ -23,7 +23,15 @@ from typing import TYPE_CHECKING, Optional, Union
 # Build the list of all video processors
 from ...configuration_utils import PreTrainedConfig
 from ...dynamic_module_utils import get_class_from_dynamic_module, resolve_trust_remote_code
-from ...utils import CONFIG_NAME, PROCESSOR_NAME, VIDEO_PROCESSOR_NAME, cached_file, is_torchvision_available, logging
+from ...utils import (
+    CONFIG_NAME,
+    IMAGE_PROCESSOR_NAME,
+    PROCESSOR_NAME,
+    VIDEO_PROCESSOR_NAME,
+    cached_file,
+    is_torchvision_available,
+    logging,
+)
 from ...utils.import_utils import requires
 from ...video_processing_utils import BaseVideoProcessor
 from .auto_factory import _LazyAutoMapping
@@ -167,9 +175,10 @@ def get_video_processor_config(
     video_processor.save_pretrained("video-processor-test")
     video_processor = get_video_processor_config("video-processor-test")
     ```"""
+    # Load with a priority given to the nested processor config, if available in repo
     resolved_config_files = [
         resolved_file
-        for filename in [VIDEO_PROCESSOR_NAME, PROCESSOR_NAME]
+        for filename in [PROCESSOR_NAME, VIDEO_PROCESSOR_NAME, IMAGE_PROCESSOR_NAME]
         if (
             resolved_file := cached_file(
                 pretrained_model_name_or_path,

--- a/src/transformers/models/auto/video_processing_auto.py
+++ b/src/transformers/models/auto/video_processing_auto.py
@@ -15,7 +15,6 @@
 """AutoVideoProcessor class."""
 
 import importlib
-import json
 import os
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Optional, Union
@@ -31,6 +30,7 @@ from ...utils import (
     cached_file,
     is_torchvision_available,
     logging,
+    safe_load_json_file,
 )
 from ...utils.import_utils import requires
 from ...video_processing_utils import BaseVideoProcessor
@@ -220,24 +220,12 @@ def get_video_processor_config(
     # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
     video_processor_dict = {}
     if resolved_processor_file is not None:
-        try:
-            with open(resolved_processor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            processor_dict = json.loads(text)
-        except json.JSONDecodeError:
-            raise OSError(f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file.")
+        processor_dict = safe_load_json_file(resolved_processor_file)
         if "video_processor" in processor_dict:
             video_processor_dict = processor_dict["video_processor"]
 
     if resolved_video_processor_file is not None and video_processor_dict is None:
-        try:
-            with open(resolved_video_processor_file, encoding="utf-8") as reader:
-                text = reader.read()
-            video_processor_dict = json.loads(text)
-        except json.JSONDecodeError:
-            raise OSError(
-                f"It looks like the config file at '{resolved_video_processor_file}' is not a valid JSON file."
-            )
+        video_processor_dict = safe_load_json_file(resolved_video_processor_file)
 
     return video_processor_dict
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -63,6 +63,7 @@ from .generic import (
     is_torch_dtype,
     is_torch_tensor,
     reshape,
+    safe_load_json_file,
     squeeze,
     strtobool,
     tensor_size,

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -221,6 +221,17 @@ def to_numpy(obj):
     return obj
 
 
+def safe_load_json_file(json_file: str):
+    "A helper to load safe config files and raise a proper error message if it wasn't serialized correctly"
+    try:
+        with open(json_file, encoding="utf-8") as reader:
+            text = reader.read()
+        config_dict = json.loads(text)
+    except json.JSONDecodeError:
+        raise OSError(f"It looks like the config file at '{json_file}' is not a valid JSON file.")
+    return config_dict
+
+
 class ModelOutput(OrderedDict):
     """
     Base class for all model outputs as dataclass. Has a `__getitem__` that allows indexing by integer or slice (like a

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -643,10 +643,10 @@ class BaseVideoProcessor(BaseImageProcessorFast):
             video_processor_file = VIDEO_PROCESSOR_NAME
             try:
                 # Try to load with a new config name first and if not successful try with the old file name
-                # NOTE: we will gradually change to saving all processor configs as nested dict in PROCESSOR_NAME
+                # NOTE: we save all processor configs as nested dict in PROCESSOR_NAME from v5, which is the standard
                 resolved_video_processor_files = [
                     resolved_file
-                    for filename in [VIDEO_PROCESSOR_NAME, IMAGE_PROCESSOR_NAME, PROCESSOR_NAME]
+                    for filename in [PROCESSOR_NAME, VIDEO_PROCESSOR_NAME, IMAGE_PROCESSOR_NAME]
                     if (
                         resolved_file := cached_file(
                             pretrained_model_name_or_path,

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -635,18 +635,33 @@ class BaseVideoProcessor(BaseImageProcessorFast):
         is_local = os.path.isdir(pretrained_model_name_or_path)
         if os.path.isfile(pretrained_model_name_or_path):
             resolved_video_processor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
             is_local = True
         elif is_remote_url(pretrained_model_name_or_path):
             video_processor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
             resolved_video_processor_file = download_url(pretrained_model_name_or_path)
         else:
             video_processor_file = VIDEO_PROCESSOR_NAME
             try:
                 # Try to load with a new config name first and if not successful try with the old file name
                 # NOTE: we save all processor configs as nested dict in PROCESSOR_NAME from v5, which is the standard
+                resolved_processor_file = cached_file(
+                    pretrained_model_name_or_path,
+                    filename=PROCESSOR_NAME,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    local_files_only=local_files_only,
+                    token=token,
+                    user_agent=user_agent,
+                    revision=revision,
+                    subfolder=subfolder,
+                    _raise_exceptions_for_missing_entries=False,
+                )
                 resolved_video_processor_files = [
                     resolved_file
-                    for filename in [PROCESSOR_NAME, VIDEO_PROCESSOR_NAME, IMAGE_PROCESSOR_NAME]
+                    for filename in [video_processor_file, IMAGE_PROCESSOR_NAME]
                     if (
                         resolved_file := cached_file(
                             pretrained_model_name_or_path,
@@ -664,7 +679,9 @@ class BaseVideoProcessor(BaseImageProcessorFast):
                     )
                     is not None
                 ]
-                resolved_video_processor_file = resolved_video_processor_files[0]
+                resolved_video_processor_file = (
+                    resolved_video_processor_files[0] if resolved_video_processor_files else None
+                )
             except OSError:
                 # Raise any OS error raise by `cached_file`. It will have a helpful error message adapted to
                 # the original exception.
@@ -675,19 +692,41 @@ class BaseVideoProcessor(BaseImageProcessorFast):
                     f"Can't load video processor for '{pretrained_model_name_or_path}'. If you were trying to load"
                     " it from 'https://huggingface.co/models', make sure you don't have a local directory with the"
                     f" same name. Otherwise, make sure '{pretrained_model_name_or_path}' is the correct path to a"
-                    f" directory containing a {VIDEO_PROCESSOR_NAME} file"
+                    f" directory containing a {video_processor_file} file"
                 )
 
-        try:
-            # Load video_processor dict
-            with open(resolved_video_processor_file, "r", encoding="utf-8") as reader:
-                text = reader.read()
-            video_processor_dict = json.loads(text)
-            video_processor_dict = video_processor_dict.get("video_processor", video_processor_dict)
+        # Load video_processor dict. Priority goes as (nested config if found -> video processor config -> image processor config)
+        # We are downloading both configs because almost all models have a `processor_config.json` but
+        # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
+        video_processor_dict = None
+        if resolved_processor_file is not None:
+            try:
+                with open(resolved_processor_file, encoding="utf-8") as reader:
+                    text = reader.read()
+                processor_dict = json.loads(text)
+            except json.JSONDecodeError:
+                raise OSError(
+                    f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file."
+                )
+            if "video_processor" in processor_dict:
+                video_processor_dict = processor_dict["video_processor"]
 
-        except json.JSONDecodeError:
+        if resolved_video_processor_file is not None and video_processor_dict is None:
+            try:
+                with open(resolved_video_processor_file, encoding="utf-8") as reader:
+                    text = reader.read()
+                video_processor_dict = json.loads(text)
+            except json.JSONDecodeError:
+                raise OSError(
+                    f"It looks like the config file at '{resolved_video_processor_file}' is not a valid JSON file."
+                )
+
+        if video_processor_dict is None:
             raise OSError(
-                f"It looks like the config file at '{resolved_video_processor_file}' is not a valid JSON file."
+                f"Can't load video processor for '{pretrained_model_name_or_path}'. If you were trying to load"
+                " it from 'https://huggingface.co/models', make sure you don't have a local directory with the"
+                f" same name. Otherwise, make sure '{pretrained_model_name_or_path}' is the correct path to a"
+                f" directory containing a {video_processor_file} file"
             )
 
         if is_local:

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -50,6 +50,7 @@ from .utils import (
     is_torchcodec_available,
     is_torchvision_v2_available,
     logging,
+    safe_load_json_file,
 )
 from .utils.hub import cached_file
 from .utils.import_utils import requires
@@ -700,26 +701,12 @@ class BaseVideoProcessor(BaseImageProcessorFast):
         # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
         video_processor_dict = None
         if resolved_processor_file is not None:
-            try:
-                with open(resolved_processor_file, encoding="utf-8") as reader:
-                    text = reader.read()
-                processor_dict = json.loads(text)
-            except json.JSONDecodeError:
-                raise OSError(
-                    f"It looks like the config file at '{resolved_processor_file}' is not a valid JSON file."
-                )
+            processor_dict = safe_load_json_file(resolved_processor_file)
             if "video_processor" in processor_dict:
                 video_processor_dict = processor_dict["video_processor"]
 
         if resolved_video_processor_file is not None and video_processor_dict is None:
-            try:
-                with open(resolved_video_processor_file, encoding="utf-8") as reader:
-                    text = reader.read()
-                video_processor_dict = json.loads(text)
-            except json.JSONDecodeError:
-                raise OSError(
-                    f"It looks like the config file at '{resolved_video_processor_file}' is not a valid JSON file."
-                )
+            video_processor_dict = safe_load_json_file(resolved_video_processor_file)
 
         if video_processor_dict is None:
             raise OSError(

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -33,8 +33,12 @@ from transformers import (
     AutoFeatureExtractor,
     AutoProcessor,
     AutoTokenizer,
+    BaseVideoProcessor,
     BertTokenizer,
+    FeatureExtractionMixin,
+    ImageProcessingMixin,
     LlamaTokenizer,
+    LlavaOnevisionVideoProcessor,
     LlavaProcessor,
     ProcessorMixin,
     SiglipImageProcessor,
@@ -42,6 +46,9 @@ from transformers import (
     Wav2Vec2FeatureExtractor,
     Wav2Vec2Processor,
 )
+from transformers.models.auto.feature_extraction_auto import get_feature_extractor_config
+from transformers.models.auto.image_processing_auto import get_image_processor_config
+from transformers.models.auto.video_processing_auto import get_video_processor_config
 from transformers.testing_utils import TOKEN, TemporaryHubRepo, get_tests_dir, is_staging_test
 from transformers.tokenization_utils import TOKENIZER_CONFIG_FILE
 from transformers.utils import (
@@ -106,6 +113,48 @@ class AutoFeatureExtractorTest(unittest.TestCase):
             processor = AutoProcessor.from_pretrained(tmpdirname)
 
         self.assertIsInstance(processor, Wav2Vec2Processor)
+
+    def test_subcomponent_get_config_dict__saved_as_nested_config(self):
+        """
+        Tests that we can get config dict of a subcomponents of a processor,
+        even if they were saved as nested dict in `processor_config.json`
+        """
+        # Test feature extractor first
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor = AutoProcessor.from_pretrained("facebook/wav2vec2-base-960h")
+            processor.save_pretrained(tmpdirname)
+
+            config_dict_1 = get_feature_extractor_config(tmpdirname)
+            feature_extractor_1 = Wav2Vec2FeatureExtractor(**config_dict_1)
+            self.assertIsInstance(feature_extractor_1, Wav2Vec2FeatureExtractor)
+
+            config_dict_2, _ = FeatureExtractionMixin.get_feature_extractor_dict(tmpdirname)
+            feature_extractor_2 = Wav2Vec2FeatureExtractor(**config_dict_2)
+            self.assertIsInstance(feature_extractor_2, Wav2Vec2FeatureExtractor)
+            self.assertEqual(config_dict_1, config_dict_2)
+
+        # Test image and video processors next
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            processor = AutoProcessor.from_pretrained("llava-hf/llava-onevision-qwen2-0.5b-ov-hf")
+            processor.save_pretrained(tmpdirname)
+
+            config_dict_1 = get_image_processor_config(tmpdirname)
+            image_processor_1 = SiglipImageProcessor(**config_dict_1)
+            self.assertIsInstance(image_processor_1, SiglipImageProcessor)
+
+            config_dict_2, _ = ImageProcessingMixin.get_image_processor_dict(tmpdirname)
+            image_processor_2 = SiglipImageProcessor(**config_dict_2)
+            self.assertIsInstance(image_processor_2, SiglipImageProcessor)
+            self.assertEqual(config_dict_1, config_dict_2)
+
+            config_dict_1 = get_video_processor_config(tmpdirname)
+            video_processor_1 = LlavaOnevisionVideoProcessor(**config_dict_1)
+            self.assertIsInstance(video_processor_1, LlavaOnevisionVideoProcessor)
+
+            config_dict_2, _ = BaseVideoProcessor.get_video_processor_dict(tmpdirname)
+            video_processor_2 = LlavaOnevisionVideoProcessor(**config_dict_2)
+            self.assertIsInstance(video_processor_2, LlavaOnevisionVideoProcessor)
+            self.assertEqual(config_dict_1, config_dict_2)
 
     def test_processor_from_processor_class(self):
         with tempfile.TemporaryDirectory() as tmpdirname:

--- a/tests/models/auto/test_processor_auto.py
+++ b/tests/models/auto/test_processor_auto.py
@@ -114,7 +114,7 @@ class AutoFeatureExtractorTest(unittest.TestCase):
 
         self.assertIsInstance(processor, Wav2Vec2Processor)
 
-    def test_subcomponent_get_config_dict__saved_as_nested_config(self):
+    def test_subcomponent_get_config_dict_saved_as_nested_config(self):
         """
         Tests that we can get config dict of a subcomponents of a processor,
         even if they were saved as nested dict in `processor_config.json`


### PR DESCRIPTION
# What does this PR do?

As per title, these helpers are used in vLLM and don't work if we save a processor after v5. Now all processor's subcomponents are saved in one single place in `processor_config.json`, so we need to check it as well when trying to locate the config file

fyi @hmellor 