### PR TITLE
Fix mel length computation in Qwen2-Audio

### DIFF
--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -347,9 +347,15 @@ class Qwen2AudioEncoder(Qwen2AudioPreTrainedModel):
     ):
         r"""
         Args:
-            attention_mask (`torch.Tensor`)`, *optional*):
-                Qwen2Audio does not support masking of the `input_features`, this argument is preserved for compatibility,
-                but it is not used. By default the silence in the input log mel spectrogram are ignored.
+            input_features (`torch.LongTensor` of shape `(batch_size, feature_size, sequence_length)`):
+                Float values of mel features extracted from the raw speech waveform. Raw speech waveform can be
+                obtained by loading a `.flac` or `.wav` audio file into an array of type `list[float]`, a
+                `numpy.ndarray` or a `torch.Tensor`, *e.g.* via the torchcodec library (`pip install torchcodec`) or
+                the soundfile library (`pip install soundfile`). To prepare the array into
+                `input_features`, the [`AutoFeatureExtractor`] should be used for extracting the mel features, padding
+                and conversion into a tensor of type `torch.FloatTensor`. See [`~WhisperFeatureExtractor.__call__`]
+            attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`), *optional*):
+                attention mask used in the encoder stack (after the convolutional layers).
             output_attentions (`bool`, *optional*):
                 Whether or not to return the attentions tensors of all attention layers. See `attentions` under
                 returned tensors for more detail.
@@ -765,7 +771,7 @@ class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMi
                     feature_attention_mask.sum(-1)
                 )
                 batch_size, _, max_mel_seq_len = input_features.shape
-                max_seq_len = (max_mel_seq_len - 2) // 2 + 1
+                max_seq_len = (max_mel_seq_len - 1) // 2 + 1
                 # Create a sequence tensor of shape (batch_size, max_seq_len)
                 seq_range = (
                     torch.arange(0, max_seq_len, dtype=audio_feat_lengths.dtype, device=audio_feat_lengths.device)


### PR DESCRIPTION
# What does this PR do?

1. Updates the misleading docstring in `Qwen2AudioEncoder.forward` stating that _"Qwen2Audio does not support masking of the `input_features`"_, while in fact it _does_ make use of it. This is likely a mistake made while copying the docstring over from Whisper
2. Fixes a bug that causes the last "valid" (i.e. not masked) frame of the sequence coming out of the first two convolutional layers to be masked incorrectly when `max_mel_seq_len` is an odd number

Here's a more elaborate explanation for point 2:
`max_seq_len` represents the maximum sequence length after the first 2 convolutional layers, of which only the first one compresses the input sequences (due to `stride=2`). The compression applied by the first convolutional layer can be computed using this expression (cf. [torch.nn.Conv1d](https://docs.pytorch.org/docs/stable/generated/torch.nn.Conv1d.html)): 
```
output_length = (input_length + 2*padding - dilation * (kernel_size - 1) - 1) // stride + 1
```
which, given that:
- `padding` = 1
- `dilation` = 1
- `kernel_size` = 3
- `stride` = 2

can be simplified to:

```
output_length = (input_length - 1) // 2 + 1
```

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@ylacombe @amyeroberts @faychu 
