### PR TITLE
Disable loss rounding in training stats log

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3004,7 +3004,7 @@ class Trainer:
             # reset tr_loss to zero
             tr_loss -= tr_loss
 
-            logs["loss"] = round(tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged), 4)
+            logs["loss"] = tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged)
             if grad_norm is not None:
                 logs["grad_norm"] = grad_norm.item() if isinstance(grad_norm, torch.Tensor) else grad_norm
             if learning_rate is not None:

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -665,12 +665,12 @@ class ProgressCallback(TrainerCallback):
                         f"[String too long to display, length: {len(v)} > {self.max_str_len}. "
                         "Consider increasing `max_str_len` if needed.]"
                     )
+                if isinstance(v, float):
+                    # Format floats for better readability
+                    shallow_logs[k] = f"{v:.4g}"
                 else:
                     shallow_logs[k] = v
             _ = shallow_logs.pop("total_flos", None)
-            # round numbers so that it looks better in console
-            if "epoch" in shallow_logs:
-                shallow_logs["epoch"] = round(shallow_logs["epoch"], 2)
             self.training_bar.write(str(shallow_logs))
 
     def on_train_end(self, args, state, control, **kwargs):
@@ -687,6 +687,8 @@ class PrinterCallback(TrainerCallback):
     def on_log(self, args, state, control, logs=None, **kwargs):
         _ = logs.pop("total_flos", None)
         if state.is_local_process_zero:
+            if logs is not None:
+                logs = {k: (f"{v:.4g}" if isinstance(v, float) else v) for k, v in logs.items()}
             print(logs)
 
 


### PR DESCRIPTION
This PR disables unconditional rounding of the loss value to 4 digits in logged values. Effectively reverting part of https://github.com/huggingface/transformers/pull/9491.

Closes https://github.com/huggingface/transformers/issues/38032 (stale)

Motivation:
- Loss value may have very low absolute magnitude depending on model/data/objective function.
- No other values are rounded (e.g. eval/loss or grad_norm) which may result in confusion.
- Rounding is a display/formatting detail in this case and should not be done silently in non-UI code

### Examples of undesired behavior that would be fixed with this PR:
Notebook outputs: 
<img width="282" height="281" alt="Screenshot 2025-11-07 at 16 06 21" src="https://github.com/user-attachments/assets/adcd0245-d097-44d6-8582-8372f83634b8" />

Wandb loss chart:
<img width="405" height="241" alt="Screenshot 2025-11-07 at 15 42 45" src="https://github.com/user-attachments/assets/e15103a2-935e-4885-a61f-843e309b1c00" />

