### PR TITLE
Add repro & preload-workaround scripts for torchcodec / transformers import-order issue

### DIFF
--- a/scripts/torchcodec_preload/README.md
+++ b/scripts/torchcodec_preload/README.md
@@ -1,0 +1,27 @@
+# TorchCodec / transformers import-order repro & workaround
+
+This small folder contains reproducible scripts demonstrating an import-order issue between
+`torchcodec` and `transformers` (AST audio feature modules), and a safe workaround that
+preloads the system `libavcodec` before loading `torchcodec`'s extension.
+
+Files
+- `repro_fail_order.py` — shows the failing import order (torchcodec first).
+- `repro_fix_ctypes_preload.py` — preloads `libavcodec` with `ctypes.CDLL(..., RTLD_GLOBAL)` before loading torchcodec.
+
+Usage
+1. Inspect which libavcodec is available:
+
+```bash
+ldconfig -p | grep avcodec
+python -c "import ctypes.util; print(ctypes.util.find_library('avcodec'))"
+```
+
+2. Run the example that preloads the library (recommended):
+
+```bash
+python scripts/torchcodec_preload/repro_fix_ctypes_preload.py
+```
+
+Notes
+- Replace the `ctypes.util.find_library('avcodec')` result with a full path if needed (e.g. `/usr/lib/.../libavcodec.so.58`).
+- If you cannot change import order in your app, the preload approach or LD_PRELOAD are the most reliable fixes.

--- a/scripts/torchcodec_preload/repro_fail_order.py
+++ b/scripts/torchcodec_preload/repro_fail_order.py
@@ -1,0 +1,20 @@
+"""
+Minimal repro: import torchcodec shared libs first, then transformers.
+This may raise an error like: "mpeg version 8: Could not load this library..."
+"""
+from __future__ import annotations
+
+from torchcodec._core.ops import load_torchcodec_shared_libraries
+
+
+def main() -> None:
+    load_torchcodec_shared_libraries()
+
+    # Import transformers modules that use audio processing
+    from transformers import ASTFeatureExtractor, ASTModel  # noqa: E402
+
+    print("Loaded torchcodec then transformers successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/torchcodec_preload/repro_fix_ctypes_preload.py
+++ b/scripts/torchcodec_preload/repro_fix_ctypes_preload.py
@@ -1,0 +1,42 @@
+"""
+Preload libavcodec via ctypes before loading torchcodec, then import transformers.
+
+This is a recommended workaround when third-party code calls
+`load_torchcodec_shared_libraries()` early and an incompatible libav* is already loaded.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.util
+import sys
+
+
+def preload_avcodec() -> None:
+    # Locate libavcodec
+    path = ctypes.util.find_library("avcodec")
+    if path is None:
+        # Give a helpful hint and exit non-zero
+        print("Could not find libavcodec via ctypes.util.find_library('avcodec').\n"
+              "Run `ldconfig -p | grep avcodec` to locate a system lib, or set LD_PRELOAD.")
+        sys.exit(2)
+
+    print("Preloading:", path)
+    # Load globally so subsequent C-extensions see its symbols
+    ctypes.CDLL(path, mode=ctypes.RTLD_GLOBAL)
+
+
+def main() -> None:
+    preload_avcodec()
+
+    from torchcodec._core.ops import load_torchcodec_shared_libraries  # noqa: E402
+
+    load_torchcodec_shared_libraries()
+
+    # Now safe to import transformers
+    from transformers import ASTFeatureExtractor, ASTModel  # noqa: E402
+
+    print("Preloaded avcodec, loaded torchcodec and transformers successfully")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds small reproducible scripts and documentation demonstrating an import-order issue between torchcodec and transformers' audio modules and a minimal runtime workaround that preloads the system libavcodec before loading torchcodec's extension.\n\nFiles added:\n- scripts/torchcodec_preload/repro_fail_order.py — repro that imports torchcodec first and may fail\n- scripts/torchcodec_preload/repro_fix_ctypes_preload.py — preloads libavcodec via ctypes then loads torchcodec and transformers\n- scripts/torchcodec_preload/README.md — instructions to inspect libavcodec and run examples\n\nTesting notes:\n- In some environments (including the container used to create this PR), ffmpeg/libavcodec may not be installed;  may return nothing. Run  locally to find a candidate path.\n- Recommended local test sequence:\n  1) \n  2) Could not find libavcodec via ctypes.util.find_library('avcodec').
Run `ldconfig -p | grep avcodec` to locate a system lib, or set LD_PRELOAD. — should preload and succeed\n  3)  — demonstrates the original failing order\n\nRationale and suggested next steps:\n- This PR intentionally adds only examples and docs to help reproduce and triage loader/symbol-version mismatches without modifying library code.\n- If maintainers prefer, we can follow up with either a small runtime helper in  to optionally preload ffmpeg libs, or open a reproducible issue on the torchcodec repo and collaborate on a longer-term fix.\n\nIf you want me to also add a small helper function and unit tests in this PR, say so and I will prepare the changes.