### PR TITLE
Mistral Tokenizer Converter Script - Initialization with Pattern Argument

### DIFF
--- a/src/transformers/integrations/mistral.py
+++ b/src/transformers/integrations/mistral.py
@@ -94,7 +94,7 @@ def convert_tekken_tokenizer(tokenizer_file: str):
 
     # Convert
     tokenizer = LlamaTokenizerFast(
-        tokenizer_object=MistralConverter(vocab=vocab, additional_special_tokens=all_special).converted(),
+        tokenizer_object=MistralConverter(vocab=vocab, pattern=mistral_tokenizer.instruct_tokenizer.tokenizer._model._pat_str, additional_special_tokens=all_special).converted(),
     )
 
     # Post-process


### PR DESCRIPTION
The current Mistral Tokenizer from Mistral Common to Transformers converter script uses a default regex pattern for the tokenizer, however Mistral models actually require a specific provided pattern.

More context can be found here: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84 

This PR will aim to fix this issue by intitializing the tokenizer with the correct pattern.

cc @ArthurZucker 