### PR TITLE
add new model internvl-3_5-Flash

### DIFF
--- a/src/transformers/models/internvl/modeling_internvl.py
+++ b/src/transformers/models/internvl/modeling_internvl.py
@@ -27,6 +27,7 @@ from typing import Optional, Union
 
 import torch
 import torch.nn as nn
+import torch.utils.checkpoint as cp
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache
@@ -40,6 +41,92 @@ from ...utils import ModelOutput, TransformersKwargs, auto_docstring, can_return
 from ...utils.generic import check_model_inputs
 from ..auto import AutoModel
 from .configuration_internvl import InternVLConfig, InternVLVisionConfig
+
+
+class Gating(nn.Module):
+    def __init__(self, hidden_size=2048, expansion_factor=4, dropout=0.1, use_checkpoint=True):
+        super().__init__()
+        self.use_checkpoint = use_checkpoint
+        mid_dim = hidden_size * expansion_factor
+
+        def mlp_block(in_dim, out_dim):
+            return nn.Sequential(
+                nn.Linear(in_dim, out_dim),
+                nn.GELU(),
+                nn.Dropout(dropout),
+                nn.Linear(out_dim, in_dim),
+                nn.Dropout(dropout),
+                nn.LayerNorm(in_dim),
+            )
+
+        self.block1 = mlp_block(hidden_size, mid_dim)
+        self.block2 = mlp_block(hidden_size, mid_dim)
+        self.block3 = mlp_block(hidden_size, mid_dim)
+        self.block4 = mlp_block(hidden_size, mid_dim)
+        self.gate = nn.Sequential(nn.LayerNorm(hidden_size), nn.Linear(hidden_size, 2))  # 2 experts
+
+    def forward(self, x):
+        if self.use_checkpoint:
+            x = x + cp.checkpoint(self.block1, x)
+            x = x + cp.checkpoint(self.block2, x)
+            x = x + cp.checkpoint(self.block3, x)
+            x = x + cp.checkpoint(self.block4, x)
+        else:
+            x = x + self.block1(x)
+            x = x + self.block2(x)
+            x = x + self.block3(x)
+            x = x + self.block4(x)
+        logits = self.gate(x)  # shape: [B, 2]
+        probs = torch.softmax(logits, dim=-1)  # 每个 token 的 expert 选择概率
+        return probs
+
+
+class CrossAttentionPooling(nn.Module):
+    def __init__(self, dim, num_heads=16):
+        super().__init__()
+        self.query_token = nn.Parameter(torch.randn(1, dim))  # [1, D]
+        self.attn1 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn2 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm2 = nn.LayerNorm(dim)
+        self.attn3 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm3 = nn.LayerNorm(dim)
+        self.attn4 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm4 = nn.LayerNorm(dim)
+
+    def forward(self, batched_tokens: list[torch.Tensor]):
+        """
+        batched_tokens: List of Tensors of shape [Ti, D], length = B
+        """
+        B = len(batched_tokens)
+        if B == 0:
+            return torch.empty(
+                0, self.query_token.shape[-1], device=self.query_token.device, dtype=self.query_token.dtype
+            )
+
+        D = batched_tokens[0].shape[-1]
+        device = batched_tokens[0].device
+        # 1. Padding
+        max_len = max(t.shape[0] for t in batched_tokens)
+        dtype = self.query_token.dtype
+        padded = torch.zeros(B, max_len, D, dtype=dtype, device=device)
+        padding_mask = torch.ones(B, max_len, dtype=torch.bool, device=device)
+        for i, t in enumerate(batched_tokens):
+            L = t.shape[0]
+            padded[i, :L] = t
+            padding_mask[i, :L] = False
+        # 2. Query token: [B, 1, D]
+        query = self.query_token.unsqueeze(0).expand(B, -1, -1)  # learnable token for each sample
+        # 3. Attention layers
+        out1, _ = self.attn1(query, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out1 = self.norm1(out1)
+        out2, _ = self.attn2(out1, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out2 = self.norm2(out2)
+        out3, _ = self.attn3(out2, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out3 = self.norm3(out3)
+        out4, _ = self.attn4(out3, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out4 = self.norm4(out4)
+        return out4.squeeze(1)
 
 
 @use_kernel_forward_from_hub("RMSNorm")
@@ -537,6 +624,31 @@ class InternVLModel(InternVLPreTrainedModel):
 
         self.multi_modal_projector = InternVLMultiModalProjector(config)
         self.language_model = AutoModel.from_config(config.text_config)
+
+        if getattr(config, "is_flash_model", False):
+            vit_hidden_size = config.vision_config.hidden_size
+            self.pooling_before_gating = CrossAttentionPooling(dim=vit_hidden_size)
+            self.gating = Gating(hidden_size=vit_hidden_size)
+
+            llm_hidden_size = config.text_config.hidden_size
+            self.multi_modal_projector = InternVLMultiModalProjector(config)
+            self.mlp2 = nn.Sequential(
+                nn.LayerNorm(vit_hidden_size * int(1 / config.downsample_ratio) ** 4),
+                nn.Linear(vit_hidden_size * int(1 / config.downsample_ratio) ** 4, llm_hidden_size * 2),
+                nn.GELU(),
+                nn.Dropout(0.1),
+                nn.Linear(llm_hidden_size * 2, llm_hidden_size * 2),
+                nn.GELU(),
+                nn.Dropout(0.1),
+                nn.Linear(llm_hidden_size * 2, llm_hidden_size),
+            )
+
+            self.flash_relative_threshold = config.flash_relative_threshold
+            self.flash_absolute_threshold = config.flash_absolute_threshold
+
+        else:
+            if not getattr(config, "is_flash_model", False):
+                self.multi_modal_projector = InternVLMultiModalProjector(config)
         self.post_init()
 
     def get_input_embeddings(self):
@@ -562,12 +674,17 @@ class InternVLModel(InternVLPreTrainedModel):
         Obtains image last hidden states from the vision tower and apply multimodal projection.
 
         Args:
-            pixel_values (`torch.FloatTensor]` of shape `(batch_size, channels, height, width)`)
+            pixel_values (`torch.FloatTensor]` of shape `(batch_size, channels, height, width)`):
                The tensors corresponding to the input images.
-            vision_feature_layer (`int` or `list[int]`):
-                Layer index or list of layer indices to extract features from.
+            vision_feature_layer (`Union[int, list[int]]`, *optional*):
+                The index of the layer to select the vision feature. If multiple indices are provided,
+                the vision feature of the corresponding indices will be concatenated to form the
+                vision features.
+            vision_feature_select_strategy (`str`, *optional*):
+                The feature selection strategy used to select the vision feature from the vision backbone.
+                Can be one of `"default"` or `"full"`
         Returns:
-            vision_features (`torch.Tensor`): Image feature tensor of shape `(num_images, image_length, embed_dim)`.
+            image_features (`torch.Tensor`): Image feature tensor of shape `(num_images, image_length, embed_dim)`).
         """
         vision_feature_layer = (
             vision_feature_layer if vision_feature_layer is not None else self.config.vision_feature_layer
@@ -644,49 +761,210 @@ class InternVLModel(InternVLPreTrainedModel):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> Union[tuple, InternVLModelOutputWithPast]:
-        vision_feature_layer = (
-            vision_feature_layer if vision_feature_layer is not None else self.config.vision_feature_layer
-        )
-        vision_feature_select_strategy = (
-            vision_feature_select_strategy
-            if vision_feature_select_strategy is not None
-            else self.config.vision_feature_select_strategy
-        )
+        if getattr(self.config, "is_flash_model", False):
+            if (input_ids is None) ^ (inputs_embeds is not None):
+                raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+            # image feature is vit embeds
+            if inputs_embeds is None:
+                inputs_embeds = self.get_input_embeddings()(input_ids)
 
-        if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+            if pixel_values is not None:
+                lengths = self.get_image_num_per_sample(input_ids) / 256
 
-        if inputs_embeds is None:
-            inputs_embeds = self.get_input_embeddings()(input_ids)
+                lengths_sum = torch.ones(int(lengths.sum().item()), dtype=torch.int64)
+                lengths = lengths_sum.repeat_interleave(1)
+                vit_embeds_64, vit_embeds_256, gate_result = self.get_image_features_flash(pixel_values, lengths)
 
-        if pixel_values is not None:
-            image_features = self.get_image_features(
-                pixel_values=pixel_values,
-                vision_feature_layer=vision_feature_layer,
-                vision_feature_select_strategy=vision_feature_select_strategy,
+                B, N, C = inputs_embeds.shape
+                inputs_embeds = inputs_embeds.reshape(B * N, C)
+
+                input_ids = input_ids.reshape(B * N)
+
+                relative_threshold_value = torch.quantile(
+                    gate_result[:, 0].to(torch.float32), self.flash_relative_threshold
+                )
+                gate_result = (gate_result[:, 0] > relative_threshold_value) & (
+                    gate_result[:, 0] >= self.flash_absolute_threshold
+                )
+
+                selected_embeds = []
+                for i in range(gate_result.size(0)):
+                    if gate_result[i]:
+                        selected_embeds.append(vit_embeds_64[i])
+                    else:
+                        selected_embeds.append(vit_embeds_256[i])
+
+                vit_embeds = torch.cat(selected_embeds, dim=0)
+
+                assert torch.all(attention_mask == 1)
+                inputs_embeds, input_ids, attention_mask, keep_mask = self.compress_visual_tokens_in_sentence(
+                    input_embeds=inputs_embeds,
+                    input_ids=input_ids,
+                    mask_idx=attention_mask,
+                    img_context_token_id=self.config.image_token_id,
+                    gate_result=gate_result,
+                )
+
+                attention_mask = torch.ones(1, inputs_embeds.shape[0]).to(inputs_embeds.device)
+
+                selected = input_ids == self.config.image_token_id
+                assert selected.sum() != 0
+                inputs_embeds[selected] = vit_embeds.to(inputs_embeds.device)
+
+                inputs_embeds = inputs_embeds.reshape(B, -1, C)
+
+            outputs = self.language_model(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                cache_position=cache_position,
+                **kwargs,
             )
-            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
-            special_image_mask = self.get_placeholder_mask(
-                input_ids, inputs_embeds=inputs_embeds, image_features=image_features
+
+            return InternVLModelOutputWithPast(
+                last_hidden_state=outputs.last_hidden_state,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+                image_hidden_states=inputs_embeds if pixel_values is not None else None,
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
 
-        outputs = self.language_model(
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            inputs_embeds=inputs_embeds,
-            cache_position=cache_position,
-            **kwargs,
-        )
+        else:
+            vision_feature_layer = (
+                vision_feature_layer if vision_feature_layer is not None else self.config.vision_feature_layer
+            )
+            vision_feature_select_strategy = (
+                vision_feature_select_strategy
+                if vision_feature_select_strategy is not None
+                else self.config.vision_feature_select_strategy
+            )
 
-        return InternVLModelOutputWithPast(
-            last_hidden_state=outputs.last_hidden_state,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-            image_hidden_states=image_features if pixel_values is not None else None,
+            if (input_ids is None) ^ (inputs_embeds is not None):
+                raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+            if inputs_embeds is None:
+                inputs_embeds = self.get_input_embeddings()(input_ids)
+
+            if pixel_values is not None:
+                image_features = self.get_image_features(
+                    pixel_values=pixel_values,
+                    vision_feature_layer=vision_feature_layer,
+                    vision_feature_select_strategy=vision_feature_select_strategy,
+                )
+                image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+                special_image_mask = self.get_placeholder_mask(
+                    input_ids, inputs_embeds=inputs_embeds, image_features=image_features
+                )
+                inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+
+            outputs = self.language_model(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                cache_position=cache_position,
+                **kwargs,
+            )
+
+            return InternVLModelOutputWithPast(
+                last_hidden_state=outputs.last_hidden_state,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+                image_hidden_states=image_features if pixel_values is not None else None,
+            )
+
+    def compress_visual_tokens_in_sentence(
+        self,
+        input_embeds: torch.Tensor,
+        input_ids: torch.Tensor,
+        mask_idx: torch.Tensor,
+        img_context_token_id: int,
+        gate_result,
+    ) -> tuple:
+        N, C = input_embeds.shape
+
+        input_ids = input_ids.squeeze(0)  # (N,)
+        selected = input_ids == img_context_token_id
+        padded = torch.cat(
+            [torch.tensor([0], device=selected.device), selected.int(), torch.tensor([0], device=selected.device)]
         )
+        diff = torch.diff(padded)
+
+        starts = (diff == 1).nonzero(as_tuple=True)[0]
+        ends = (diff == -1).nonzero(as_tuple=True)[0]
+        lengths = ends - starts
+
+        keep_mask = torch.ones(N, dtype=torch.bool, device=input_embeds.device)
+
+        delete_flags = torch.zeros(N, dtype=torch.int32, device=input_embeds.device)
+
+        total_blocks = 0
+        block_counts = []
+        for l in lengths.tolist():
+            if l % 256 != 0:
+                raise ValueError(f"l % 256 != 0, l = {l}")
+            num_blocks = l // 256
+            block_counts.append(num_blocks)
+            total_blocks += num_blocks
+
+        flag_idx = 0
+        for s, e, l, num_blocks in zip(starts.tolist(), ends.tolist(), lengths.tolist(), block_counts):
+            for i in range(num_blocks):
+                block_start = s + i * 256
+                block_end = block_start + 256
+
+                compress = gate_result[flag_idx]
+                flag_idx += 1
+
+                if compress:
+                    keep_mask[block_start + 64 : block_end] = False
+                    delete_flags[block_start + 64 : block_end] = 1
+
+        cumulative_deletes = torch.cumsum(delete_flags, dim=0)
+        cumulative_deletes = torch.cat([cumulative_deletes, cumulative_deletes[-1:].clone()], dim=0)
+
+        mask_idx = mask_idx.squeeze(0)
+        updated_mask_idx = mask_idx - cumulative_deletes[mask_idx.to(cumulative_deletes.device)].to(mask_idx.device)
+        updated_mask_idx = updated_mask_idx.unsqueeze(0)
+
+        new_input_embeds = input_embeds[keep_mask.to(input_embeds.device), :]
+        new_input_ids = input_ids[keep_mask.to(input_ids.device)]
+
+        return new_input_embeds, new_input_ids, updated_mask_idx, keep_mask
+
+    def get_image_num_per_sample(
+        self,
+        input_ids: torch.Tensor,
+    ):
+        input_ids = input_ids.squeeze(0)  # (N,)
+        selected = input_ids == self.config.image_token_id
+        padded = torch.cat(
+            [torch.tensor([0], device=selected.device), selected.int(), torch.tensor([0], device=selected.device)]
+        )
+        diff = torch.diff(padded)
+
+        starts = (diff == 1).nonzero(as_tuple=True)[0]
+        ends = (diff == -1).nonzero(as_tuple=True)[0]
+        lengths = ends - starts
+
+        return lengths
+
+    def split_and_merge(self, features: torch.Tensor, split_sizes: torch.Tensor):
+        """
+        features: Tensor of shape [T, 1024, 1024]
+        split_sizes: 1D Tensor like [3, 3, 4] — 每个样本 tile 数
+
+        returns: List of Tensors of shape [tile_i * 1024, 1024]
+        """
+        # 拆分 features → 每个样本一个 tile list
+        tile_splits = torch.split(features, split_sizes, dim=0)
+
+        # 合并前两维：tile * 1024 × 1024
+        merged = [x.reshape(-1, x.shape[-1]) for x in tile_splits]
+
+        return merged
 
     def pixel_shuffle(self, vision_features: torch.Tensor, scale_factor: float = 0.5):
         """Perform pixel shuffle downsampling on vision features.
@@ -722,6 +1000,52 @@ class InternVLModel(InternVLPreTrainedModel):
         vision_features = vision_features.permute(0, 2, 1, 3).contiguous()
 
         return vision_features
+
+    def get_image_features_flash(
+        self,
+        pixel_values: torch.FloatTensor,
+        lengths: torch.Tensor,
+        vision_feature_layer: Optional[Union[int, list[int]]] = None,
+        vision_feature_select_strategy: Optional[str] = None,
+        **kwargs,
+    ):
+        """
+        Obtains image last hidden states from the vision tower and apply multimodal projection.
+
+        Args:
+            pixel_values (`torch.FloatTensor]` of shape `(batch_size, channels, height, width)`)
+               The tensors corresponding to the input images.
+            vision_feature_layer (`int` or `list[int]`):
+                Layer index or list of layer indices to extract features from.
+        Returns:
+            vision_features (`torch.Tensor`): Image feature tensor of shape `(num_images, image_length, embed_dim)`.
+        """
+        with torch.no_grad():
+            vit_embeds_1024 = self.vision_tower(pixel_values=pixel_values.to(self.dtype)).last_hidden_state
+
+        vit_embeds_1024 = vit_embeds_1024[:, 1:, :]
+        h = w = int(vit_embeds_1024.shape[1] ** 0.5)
+        vit_embeds_1024 = vit_embeds_1024.reshape(vit_embeds_1024.shape[0], h, w, -1)
+
+        # begin moe
+        lengths = [int(x) for x in lengths.tolist()]
+        vit_embeds_1024_split_and_merge = self.split_and_merge(vit_embeds_1024, lengths)
+
+        gate = self.pooling_before_gating(vit_embeds_1024_split_and_merge)
+        gate = self.gating(gate)
+
+        vit_embeds_256 = vit_embeds_1024.clone()
+
+        with torch.no_grad():
+            vit_embeds_64 = self.pixel_shuffle(vit_embeds_1024, scale_factor=self.config.downsample_ratio**2)
+            vit_embeds_64 = vit_embeds_64.reshape(vit_embeds_64.shape[0], -1, vit_embeds_64.shape[-1])
+            vit_embeds_64 = self.mlp2(vit_embeds_64)
+
+            vit_embeds_256 = self.pixel_shuffle(vit_embeds_256, scale_factor=self.config.downsample_ratio)
+            vit_embeds_256 = vit_embeds_256.reshape(vit_embeds_256.shape[0], -1, vit_embeds_256.shape[-1])
+            vit_embeds_256 = self.multi_modal_projector(vit_embeds_256)
+
+        return vit_embeds_64, vit_embeds_256, gate
 
 
 @dataclass

--- a/src/transformers/models/internvl/modular_internvl.py
+++ b/src/transformers/models/internvl/modular_internvl.py
@@ -21,6 +21,7 @@ from typing import Optional, Union
 
 import torch
 import torch.nn as nn
+import torch.utils.checkpoint as cp
 
 from ...activations import ACT2FN
 from ...cache_utils import Cache
@@ -71,6 +72,92 @@ def eager_attention_forward(
     attn_output = attn_output.transpose(1, 2).contiguous()
 
     return attn_output, attn_weights
+
+
+class Gating(nn.Module):
+    def __init__(self, hidden_size=2048, expansion_factor=4, dropout=0.1, use_checkpoint=True):
+        super().__init__()
+        self.use_checkpoint = use_checkpoint
+        mid_dim = hidden_size * expansion_factor
+
+        def mlp_block(in_dim, out_dim):
+            return nn.Sequential(
+                nn.Linear(in_dim, out_dim),
+                nn.GELU(),
+                nn.Dropout(dropout),
+                nn.Linear(out_dim, in_dim),
+                nn.Dropout(dropout),
+                nn.LayerNorm(in_dim),
+            )
+
+        self.block1 = mlp_block(hidden_size, mid_dim)
+        self.block2 = mlp_block(hidden_size, mid_dim)
+        self.block3 = mlp_block(hidden_size, mid_dim)
+        self.block4 = mlp_block(hidden_size, mid_dim)
+        self.gate = nn.Sequential(nn.LayerNorm(hidden_size), nn.Linear(hidden_size, 2))  # 2 experts
+
+    def forward(self, x):
+        if self.use_checkpoint:
+            x = x + cp.checkpoint(self.block1, x)
+            x = x + cp.checkpoint(self.block2, x)
+            x = x + cp.checkpoint(self.block3, x)
+            x = x + cp.checkpoint(self.block4, x)
+        else:
+            x = x + self.block1(x)
+            x = x + self.block2(x)
+            x = x + self.block3(x)
+            x = x + self.block4(x)
+        logits = self.gate(x)  # shape: [B, 2]
+        probs = torch.softmax(logits, dim=-1)  # 每个 token 的 expert 选择概率
+        return probs
+
+
+class CrossAttentionPooling(nn.Module):
+    def __init__(self, dim, num_heads=16):
+        super().__init__()
+        self.query_token = nn.Parameter(torch.randn(1, dim))  # [1, D]
+        self.attn1 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm1 = nn.LayerNorm(dim)
+        self.attn2 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm2 = nn.LayerNorm(dim)
+        self.attn3 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm3 = nn.LayerNorm(dim)
+        self.attn4 = nn.MultiheadAttention(embed_dim=dim, num_heads=num_heads, batch_first=True)
+        self.norm4 = nn.LayerNorm(dim)
+
+    def forward(self, batched_tokens: list[torch.Tensor]):
+        """
+        batched_tokens: List of Tensors of shape [Ti, D], length = B
+        """
+        B = len(batched_tokens)
+        if B == 0:
+            return torch.empty(
+                0, self.query_token.shape[-1], device=self.query_token.device, dtype=self.query_token.dtype
+            )
+
+        D = batched_tokens[0].shape[-1]
+        device = batched_tokens[0].device
+        # 1. Padding
+        max_len = max(t.shape[0] for t in batched_tokens)
+        dtype = self.query_token.dtype
+        padded = torch.zeros(B, max_len, D, dtype=dtype, device=device)
+        padding_mask = torch.ones(B, max_len, dtype=torch.bool, device=device)
+        for i, t in enumerate(batched_tokens):
+            L = t.shape[0]
+            padded[i, :L] = t
+            padding_mask[i, :L] = False
+        # 2. Query token: [B, 1, D]
+        query = self.query_token.unsqueeze(0).expand(B, -1, -1)  # learnable token for each sample
+        # 3. Attention layers
+        out1, _ = self.attn1(query, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out1 = self.norm1(out1)
+        out2, _ = self.attn2(out1, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out2 = self.norm2(out2)
+        out3, _ = self.attn3(out2, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out3 = self.norm3(out3)
+        out4, _ = self.attn4(out3, padded, padded, key_padding_mask=padding_mask)  # [B, 1, D]
+        out4 = self.norm4(out4)
+        return out4.squeeze(1)
 
 
 class InternVLVisionRMSNorm(LlamaRMSNorm):
@@ -455,6 +542,125 @@ class InternVLModelOutputWithPast(LlavaModelOutputWithPast):
 
 
 class InternVLModel(LlavaModel):
+    def __init__(self, config: InternVLConfig):
+        super().__init__(config)
+
+        if getattr(config, "is_flash_model", False):
+            vit_hidden_size = config.vision_config.hidden_size
+            self.pooling_before_gating = CrossAttentionPooling(dim=vit_hidden_size)
+            self.gating = Gating(hidden_size=vit_hidden_size)
+
+            llm_hidden_size = config.text_config.hidden_size
+            self.multi_modal_projector = InternVLMultiModalProjector(config)
+            self.mlp2 = nn.Sequential(
+                nn.LayerNorm(vit_hidden_size * int(1 / config.downsample_ratio) ** 4),
+                nn.Linear(vit_hidden_size * int(1 / config.downsample_ratio) ** 4, llm_hidden_size * 2),
+                nn.GELU(),
+                nn.Dropout(0.1),
+                nn.Linear(llm_hidden_size * 2, llm_hidden_size * 2),
+                nn.GELU(),
+                nn.Dropout(0.1),
+                nn.Linear(llm_hidden_size * 2, llm_hidden_size),
+            )
+
+            self.flash_relative_threshold = config.flash_relative_threshold
+            self.flash_absolute_threshold = config.flash_absolute_threshold
+
+        else:
+            if not getattr(config, "is_flash_model", False):
+                self.multi_modal_projector = InternVLMultiModalProjector(config)
+
+    def compress_visual_tokens_in_sentence(
+        self,
+        input_embeds: torch.Tensor,
+        input_ids: torch.Tensor,
+        mask_idx: torch.Tensor,
+        img_context_token_id: int,
+        gate_result,
+    ) -> tuple:
+        N, C = input_embeds.shape
+
+        input_ids = input_ids.squeeze(0)  # (N,)
+        selected = input_ids == img_context_token_id
+        padded = torch.cat(
+            [torch.tensor([0], device=selected.device), selected.int(), torch.tensor([0], device=selected.device)]
+        )
+        diff = torch.diff(padded)
+
+        starts = (diff == 1).nonzero(as_tuple=True)[0]
+        ends = (diff == -1).nonzero(as_tuple=True)[0]
+        lengths = ends - starts
+
+        keep_mask = torch.ones(N, dtype=torch.bool, device=input_embeds.device)
+
+        delete_flags = torch.zeros(N, dtype=torch.int32, device=input_embeds.device)
+
+        total_blocks = 0
+        block_counts = []
+        for l in lengths.tolist():
+            if l % 256 != 0:
+                raise ValueError(f"l % 256 != 0, l = {l}")
+            num_blocks = l // 256
+            block_counts.append(num_blocks)
+            total_blocks += num_blocks
+
+        flag_idx = 0
+        for s, e, l, num_blocks in zip(starts.tolist(), ends.tolist(), lengths.tolist(), block_counts):
+            for i in range(num_blocks):
+                block_start = s + i * 256
+                block_end = block_start + 256
+
+                compress = gate_result[flag_idx]
+                flag_idx += 1
+
+                if compress:
+                    keep_mask[block_start + 64 : block_end] = False
+                    delete_flags[block_start + 64 : block_end] = 1
+
+        cumulative_deletes = torch.cumsum(delete_flags, dim=0)
+        cumulative_deletes = torch.cat([cumulative_deletes, cumulative_deletes[-1:].clone()], dim=0)
+
+        mask_idx = mask_idx.squeeze(0)
+        updated_mask_idx = mask_idx - cumulative_deletes[mask_idx.to(cumulative_deletes.device)].to(mask_idx.device)
+        updated_mask_idx = updated_mask_idx.unsqueeze(0)
+
+        new_input_embeds = input_embeds[keep_mask.to(input_embeds.device), :]
+        new_input_ids = input_ids[keep_mask.to(input_ids.device)]
+
+        return new_input_embeds, new_input_ids, updated_mask_idx, keep_mask
+
+    def get_image_num_per_sample(
+        self,
+        input_ids: torch.Tensor,
+    ):
+        input_ids = input_ids.squeeze(0)  # (N,)
+        selected = input_ids == self.config.image_token_id
+        padded = torch.cat(
+            [torch.tensor([0], device=selected.device), selected.int(), torch.tensor([0], device=selected.device)]
+        )
+        diff = torch.diff(padded)
+
+        starts = (diff == 1).nonzero(as_tuple=True)[0]
+        ends = (diff == -1).nonzero(as_tuple=True)[0]
+        lengths = ends - starts
+
+        return lengths
+
+    def split_and_merge(self, features: torch.Tensor, split_sizes: torch.Tensor):
+        """
+        features: Tensor of shape [T, 1024, 1024]
+        split_sizes: 1D Tensor like [3, 3, 4] — 每个样本 tile 数
+
+        returns: List of Tensors of shape [tile_i * 1024, 1024]
+        """
+        # 拆分 features → 每个样本一个 tile list
+        tile_splits = torch.split(features, split_sizes, dim=0)
+
+        # 合并前两维：tile * 1024 × 1024
+        merged = [x.reshape(-1, x.shape[-1]) for x in tile_splits]
+
+        return merged
+
     def pixel_shuffle(self, vision_features: torch.Tensor, scale_factor: float = 0.5):
         """Perform pixel shuffle downsampling on vision features.
 
@@ -490,9 +696,10 @@ class InternVLModel(LlavaModel):
 
         return vision_features
 
-    def get_image_features(
+    def get_image_features_flash(
         self,
         pixel_values: torch.FloatTensor,
+        lengths: torch.Tensor,
         vision_feature_layer: Optional[Union[int, list[int]]] = None,
         vision_feature_select_strategy: Optional[str] = None,
         **kwargs,
@@ -508,6 +715,40 @@ class InternVLModel(LlavaModel):
         Returns:
             vision_features (`torch.Tensor`): Image feature tensor of shape `(num_images, image_length, embed_dim)`.
         """
+        with torch.no_grad():
+            vit_embeds_1024 = self.vision_tower(pixel_values=pixel_values.to(self.dtype)).last_hidden_state
+
+        vit_embeds_1024 = vit_embeds_1024[:, 1:, :]
+        h = w = int(vit_embeds_1024.shape[1] ** 0.5)
+        vit_embeds_1024 = vit_embeds_1024.reshape(vit_embeds_1024.shape[0], h, w, -1)
+
+        # begin moe
+        lengths = [int(x) for x in lengths.tolist()]
+        vit_embeds_1024_split_and_merge = self.split_and_merge(vit_embeds_1024, lengths)
+
+        gate = self.pooling_before_gating(vit_embeds_1024_split_and_merge)
+        gate = self.gating(gate)
+
+        vit_embeds_256 = vit_embeds_1024.clone()
+
+        with torch.no_grad():
+            vit_embeds_64 = self.pixel_shuffle(vit_embeds_1024, scale_factor=self.config.downsample_ratio**2)
+            vit_embeds_64 = vit_embeds_64.reshape(vit_embeds_64.shape[0], -1, vit_embeds_64.shape[-1])
+            vit_embeds_64 = self.mlp2(vit_embeds_64)
+
+            vit_embeds_256 = self.pixel_shuffle(vit_embeds_256, scale_factor=self.config.downsample_ratio)
+            vit_embeds_256 = vit_embeds_256.reshape(vit_embeds_256.shape[0], -1, vit_embeds_256.shape[-1])
+            vit_embeds_256 = self.multi_modal_projector(vit_embeds_256)
+
+        return vit_embeds_64, vit_embeds_256, gate
+
+    def get_image_features(
+        self,
+        pixel_values: torch.FloatTensor,
+        vision_feature_layer: Optional[Union[int, list[int]]] = None,
+        vision_feature_select_strategy: Optional[str] = None,
+        **kwargs,
+    ):
         vision_feature_layer = (
             vision_feature_layer if vision_feature_layer is not None else self.config.vision_feature_layer
         )
@@ -559,49 +800,119 @@ class InternVLModel(LlavaModel):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> Union[tuple, InternVLModelOutputWithPast]:
-        vision_feature_layer = (
-            vision_feature_layer if vision_feature_layer is not None else self.config.vision_feature_layer
-        )
-        vision_feature_select_strategy = (
-            vision_feature_select_strategy
-            if vision_feature_select_strategy is not None
-            else self.config.vision_feature_select_strategy
-        )
+        if getattr(self.config, "is_flash_model", False):
+            if (input_ids is None) ^ (inputs_embeds is not None):
+                raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+            # image feature is vit embeds
+            if inputs_embeds is None:
+                inputs_embeds = self.get_input_embeddings()(input_ids)
 
-        if (input_ids is None) ^ (inputs_embeds is not None):
-            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+            if pixel_values is not None:
+                lengths = self.get_image_num_per_sample(input_ids) / 256
 
-        if inputs_embeds is None:
-            inputs_embeds = self.get_input_embeddings()(input_ids)
+                lengths_sum = torch.ones(int(lengths.sum().item()), dtype=torch.int64)
+                lengths = lengths_sum.repeat_interleave(1)
+                vit_embeds_64, vit_embeds_256, gate_result = self.get_image_features_flash(pixel_values, lengths)
 
-        if pixel_values is not None:
-            image_features = self.get_image_features(
-                pixel_values=pixel_values,
-                vision_feature_layer=vision_feature_layer,
-                vision_feature_select_strategy=vision_feature_select_strategy,
+                B, N, C = inputs_embeds.shape
+                inputs_embeds = inputs_embeds.reshape(B * N, C)
+
+                input_ids = input_ids.reshape(B * N)
+
+                relative_threshold_value = torch.quantile(
+                    gate_result[:, 0].to(torch.float32), self.flash_relative_threshold
+                )
+                gate_result = (gate_result[:, 0] > relative_threshold_value) & (
+                    gate_result[:, 0] >= self.flash_absolute_threshold
+                )
+
+                selected_embeds = []
+                for i in range(gate_result.size(0)):
+                    if gate_result[i]:
+                        selected_embeds.append(vit_embeds_64[i])
+                    else:
+                        selected_embeds.append(vit_embeds_256[i])
+
+                vit_embeds = torch.cat(selected_embeds, dim=0)
+
+                assert torch.all(attention_mask == 1)
+                inputs_embeds, input_ids, attention_mask, keep_mask = self.compress_visual_tokens_in_sentence(
+                    input_embeds=inputs_embeds,
+                    input_ids=input_ids,
+                    mask_idx=attention_mask,
+                    img_context_token_id=self.config.image_token_id,
+                    gate_result=gate_result,
+                )
+
+                attention_mask = torch.ones(1, inputs_embeds.shape[0]).to(inputs_embeds.device)
+
+                selected = input_ids == self.config.image_token_id
+                assert selected.sum() != 0
+                inputs_embeds[selected] = vit_embeds.to(inputs_embeds.device)
+
+                inputs_embeds = inputs_embeds.reshape(B, -1, C)
+
+            outputs = self.language_model(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                cache_position=cache_position,
+                **kwargs,
             )
-            image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
-            special_image_mask = self.get_placeholder_mask(
-                input_ids, inputs_embeds=inputs_embeds, image_features=image_features
+
+            return InternVLModelOutputWithPast(
+                last_hidden_state=outputs.last_hidden_state,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+                image_hidden_states=inputs_embeds if pixel_values is not None else None,
             )
-            inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
 
-        outputs = self.language_model(
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            inputs_embeds=inputs_embeds,
-            cache_position=cache_position,
-            **kwargs,
-        )
+        else:
+            vision_feature_layer = (
+                vision_feature_layer if vision_feature_layer is not None else self.config.vision_feature_layer
+            )
+            vision_feature_select_strategy = (
+                vision_feature_select_strategy
+                if vision_feature_select_strategy is not None
+                else self.config.vision_feature_select_strategy
+            )
 
-        return InternVLModelOutputWithPast(
-            last_hidden_state=outputs.last_hidden_state,
-            past_key_values=outputs.past_key_values,
-            hidden_states=outputs.hidden_states,
-            attentions=outputs.attentions,
-            image_hidden_states=image_features if pixel_values is not None else None,
-        )
+            if (input_ids is None) ^ (inputs_embeds is not None):
+                raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+            if inputs_embeds is None:
+                inputs_embeds = self.get_input_embeddings()(input_ids)
+
+            if pixel_values is not None:
+                image_features = self.get_image_features(
+                    pixel_values=pixel_values,
+                    vision_feature_layer=vision_feature_layer,
+                    vision_feature_select_strategy=vision_feature_select_strategy,
+                )
+                image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+                special_image_mask = self.get_placeholder_mask(
+                    input_ids, inputs_embeds=inputs_embeds, image_features=image_features
+                )
+                inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+
+            outputs = self.language_model(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                cache_position=cache_position,
+                **kwargs,
+            )
+
+            return InternVLModelOutputWithPast(
+                last_hidden_state=outputs.last_hidden_state,
+                past_key_values=outputs.past_key_values,
+                hidden_states=outputs.hidden_states,
+                attentions=outputs.attentions,
+                image_hidden_states=image_features if pixel_values is not None else None,
+            )
 
 
 class InternVLCausalLMOutputWithPast(LlavaCausalLMOutputWithPast):
@@ -609,6 +920,12 @@ class InternVLCausalLMOutputWithPast(LlavaCausalLMOutputWithPast):
 
 
 class InternVLForConditionalGeneration(LlavaForConditionalGeneration):
+    def __init__(self, config: InternVLConfig):
+        super(LlavaForConditionalGeneration, self).__init__(config)
+        self.model = InternVLModel(config)
+        self.lm_head = nn.Linear(config.text_config.hidden_size, config.text_config.vocab_size, bias=False)
+        self.post_init()
+
     def forward(**super_kwargs):
         r"""
         Example:


### PR DESCRIPTION

Resolves #41862

Hi @Rocketknight1,

Following our discussion in the issue, this PR adds support for the InternVL-Flash model variant.

As noted, the Flash variant uses a dynamic resolution router and a different image feature processing path, which was not compatible with the existing InternVLForConditionalGeneration.

Implementation Details
To solve this while following the modular style, I've implemented the following:

Added an is_flash_model: bool = False flag to the InternVLConfig.

Updated InternVLModel and InternVLForConditionalGeneration to use this flag (getattr(config, "is_flash_model", False)) to branch their logic for the __init__, get_image_features, and forward methods.

This implementation allows the same modeling_internvl.py file to support both the Base and Flash models, keeping the PR concise as you suggested.

Testing
All local tests are passing:

make style (style checks pass)

pytest  

Thank you for the guidance!

Before submitting
[ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

[x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

[x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. (Link: #41862)

[x] Did you make sure to update the documentation with your changes? No documentation changes needed.
[x] Did you write any new necessary tests? (Added tests/models/internvl/test_modeling_internvl.py and InternVLFlashModelTest)

Who can review?
@Rocketknight1 (handled the original issue) @zucchini-nlp (multimodal models)