### PR TITLE
Transformers serve -> list all generative models from the cache 

### DIFF
--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -11,14 +11,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import datetime
+import json
 import os
+import tempfile
 import time
 import unittest
+from pathlib import PosixPath
 from threading import Thread
 from unittest.mock import Mock, patch
 
 import httpx
 from huggingface_hub import ChatCompletionStreamOutput, InferenceClient
+from huggingface_hub.utils._cache_manager import (
+    REPO_TYPE_T,
+    CachedFileInfo,
+    CachedRepoInfo,
+    CachedRevisionInfo,
+    HFCacheInfo,
+)
 from parameterized import parameterized
 
 from transformers import GenerationConfig
@@ -151,6 +162,120 @@ def test_build_chat_completion_chunk():
         '\\"foo2\\": \\"bar2\\"}","name":"foo_bar"},"type":"function"}]},"index":0}]'
     )
     assert expected_choices_content in chunk
+
+
+@require_openai
+def test_generative_model_list():
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as generative_model_config_file:
+        json.dump({"architectures": ["LlamaForCausalLM"]}, generative_model_config_file)
+        generative_model_config_file.flush()
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as non_generative_model_config_file:
+        json.dump({"architectures": ["BertForPreTraining"]}, non_generative_model_config_file)
+        non_generative_model_config_file.flush()
+
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".json", delete=False) as broken_config_file:
+        json.dump({}, broken_config_file)
+        broken_config_file.flush()
+
+    def cached_repo_factory(
+        repo_author: str,
+        repo_name: str,
+        repo_type: REPO_TYPE_T,
+        config_file_path: PosixPath,
+        git_ref: str,
+        git_blob: str,
+        refs: list[str],
+    ):
+        return CachedRepoInfo(
+            repo_id=f"{repo_author}/{repo_name}",
+            repo_type=repo_type,
+            repo_path=PosixPath(f"/.cache/huggingface/hub/models--{repo_author}--{repo_name}"),
+            size_on_disk=100_000,
+            last_accessed=datetime.datetime.now().timestamp(),
+            last_modified=datetime.datetime.now().timestamp(),
+            nb_files=2,
+            revisions=frozenset(
+                [
+                    CachedRevisionInfo(
+                        commit_hash=f"{git_ref}",
+                        snapshot_path=PosixPath(
+                            f"/.cache/huggingface/hub/models--{repo_author}--{repo_name}/snapshots/{git_ref}"
+                        ),
+                        size_on_disk=706,
+                        files=frozenset(
+                            {
+                                CachedFileInfo(
+                                    file_name="model.safetensors",
+                                    file_path=PosixPath(
+                                        f"/.cache/huggingface/hub/models--{repo_author}--{repo_name}/snapshots/{git_ref}/model.safetensors"
+                                    ),
+                                    blob_path=PosixPath(
+                                        f"/.cache/huggingface/hub/models--{repo_author}--{repo_name}/blobs/{git_blob}"
+                                    ),
+                                    size_on_disk=298,
+                                    blob_last_accessed=datetime.datetime.now().timestamp(),
+                                    blob_last_modified=datetime.datetime.now().timestamp(),
+                                ),
+                                CachedFileInfo(
+                                    file_name="config.json",
+                                    file_path=config_file_path,
+                                    blob_path=PosixPath(
+                                        f"/.cache/huggingface/hub/models--{repo_author}--{repo_name}/blobs/{git_blob}"
+                                    ),
+                                    size_on_disk=408,
+                                    blob_last_accessed=datetime.datetime.now().timestamp(),
+                                    blob_last_modified=datetime.datetime.now().timestamp(),
+                                ),
+                            }
+                        ),
+                        refs=frozenset(refs),
+                        last_modified=1739366513.8599825,
+                    )
+                ]
+            ),
+        )
+
+    repos = frozenset(
+        [
+            # Correct repo, should be returned
+            cached_repo_factory(
+                "author0", "repo0", "model", PosixPath(generative_model_config_file.name), "aaa", "bbb", ["main"]
+            ),
+            # Incorrect repo, is a dataset
+            cached_repo_factory(
+                "author0", "repo1", "dataset", PosixPath(generative_model_config_file.name), "aaa", "bbb", ["main"]
+            ),
+            # Correct repo with two refs; both refs should be returned
+            cached_repo_factory(
+                "author0",
+                "repo2",
+                "model",
+                PosixPath(generative_model_config_file.name),
+                "aaa",
+                "bbb",
+                ["main", "refs/pr/2"],
+            ),
+            # Incorrect repo, the architectures field is not a generative model
+            cached_repo_factory(
+                "author0", "repo3", "model", PosixPath(non_generative_model_config_file.name), "aaa", "bbb", ["main"]
+            ),
+            # Incorrect repo, the config is just an empty JSON
+            cached_repo_factory(
+                "author0", "repo4", "model", PosixPath(broken_config_file.name), "aaa", "bbb", ["main"]
+            ),
+        ]
+    )
+    fake_cache = HFCacheInfo(size_on_disk=100_000, repos=repos, warnings=[])
+
+    with patch("transformers.cli.serve.scan_cache_dir", return_value=fake_cache):
+        result = Serve.get_gen_models()
+        repo_id_to_result = {r["id"]: r for r in result}
+
+    assert "author0/repo0" in repo_id_to_result
+    assert "author0/repo2" in repo_id_to_result
+    assert "author0/repo2@refs/pr/2" in repo_id_to_result
+    assert len(repo_id_to_result) == 3
 
 
 @require_openai


### PR DESCRIPTION
Instead of relying on an inadequate list, look for generative models within the cache. Generative models are identified by taking checking in their config whether the architecture defined is in the `MODEL_FOR_CAUSAL_LM_MAPPING_NAMES` mapping.