### PR TITLE
fix: fix IsADirectoryError in NotebookProgressBar by explicitly passi…

### DIFF
--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -197,9 +197,9 @@ class NotebookProgressBar:
             self.parent.display()
             return
         if self.output is None:
-            self.output = disp.display(disp.HTML(self.html_code), display_id=True)
+            self.output = disp.display(disp.HTML(data=self.html_code), display_id=True)
         else:
-            self.output.update(disp.HTML(self.html_code))
+            self.output.update(disp.HTML(data=self.html_code))
 
     def close(self):
         "Closes the progress bar."
@@ -229,9 +229,9 @@ class NotebookTrainingTracker(NotebookProgressBar):
         if self.child_bar is not None:
             self.html_code += self.child_bar.html_code
         if self.output is None:
-            self.output = disp.display(disp.HTML(self.html_code), display_id=True)
+            self.output = disp.display(disp.HTML(data=self.html_code), display_id=True)
         else:
-            self.output.update(disp.HTML(self.html_code))
+            self.output.update(disp.HTML(data=self.html_code))
 
     def write_line(self, values):
         """


### PR DESCRIPTION
…ng HTML data parameter

Fixes #34766

## Problem
When training with tqdm progress bars enabled in Jupyter/Azure ML environments, the display() method encounters an IsADirectoryError. The issue occurs because IPython's HTML() constructor is being called without explicitly specifying the `data=` parameter, causing some versions to misinterpret the HTML string as a filename path.

## Solution
Explicitly pass the HTML content using the `data=` keyword argument in all disp.HTML() calls within:
- NotebookProgressBar.display() method
- NotebookTrainingTracker.display() method

This ensures consistent behavior across different IPython/Jupyter versions by explicitly marking the argument as data content rather than a file path.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
