### PR TITLE
Correctly return finish reason length when finished

### DIFF
--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -103,7 +103,7 @@ class RichInterface:
         self.model_id = model_id
         self.user_id = user_id
 
-    async def stream_output(self, stream: AsyncIterator[ChatCompletionStreamOutput]) -> tuple[str | Any, str | None]:
+    async def stream_output(self, stream: AsyncIterator[ChatCompletionStreamOutput]) -> tuple[str, str | Any | None]:
         self._console.print(f"[bold blue]<{self.model_id}>:")
         with Live(console=self._console, refresh_per_second=4) as live:
             text = ""

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -19,7 +19,7 @@ import re
 import string
 import time
 from collections.abc import AsyncIterator
-from typing import Annotated
+from typing import Annotated, Optional, Any, Coroutine
 
 import click
 import typer
@@ -103,15 +103,22 @@ class RichInterface:
         self.model_id = model_id
         self.user_id = user_id
 
-    async def stream_output(self, stream: AsyncIterator[ChatCompletionStreamOutput]) -> tuple[str, int]:
+    async def stream_output(
+        self, stream: AsyncIterator[ChatCompletionStreamOutput]
+    ) -> tuple[str | Any, str | None, list[int]]:
         self._console.print(f"[bold blue]<{self.model_id}>:")
         with Live(console=self._console, refresh_per_second=4) as live:
             text = ""
+            finish_reason: str | None = None
+            completion_tokens: int = 0
             async for token in await stream:
                 outputs = token.choices[0].delta.content
+                finish_reason = getattr(token.choices[0], "finish_reason", finish_reason)
 
                 if not outputs:
                     continue
+
+                completion_tokens += 1
 
                 # Escapes single words encased in <>, e.g. <think> -> \<think\>, for proper rendering in Markdown.
                 # It only escapes single words that may have `_`, optionally following a `/` (e.g. </think>)
@@ -147,7 +154,7 @@ class RichInterface:
 
         self._console.print()
 
-        return text
+        return text, finish_reason, completion_tokens
 
     def input(self) -> str:
         """Gets user input from the console."""
@@ -168,6 +175,18 @@ class RichInterface:
         """Prints text in a given color to the console."""
         self._console.print(f"[bold {color}]{text}")
         self._console.print()
+
+    def confirm(self, message: str, default: bool = False) -> bool:
+        """Displays a yes/no prompt to the user, returning True for confirmation."""
+        default_hint = "Y/n" if default else "y/N"
+        response = self._console.input(f"[bold yellow]{message} ({default_hint}): ")
+        self._console.print()
+
+        response = response.strip().lower()
+        if not response:
+            return default
+
+        return response in {"y", "yes"}
 
     def print_help(self, minimal: bool = False):
         """Prints the help message to the console."""
@@ -362,9 +381,15 @@ class Chat:
         config = self.config
 
         async with AsyncInferenceClient(base_url=self.base_url) as client:
+            pending_user_input: Optional[str] = None
             while True:
                 try:
-                    user_input = interface.input()
+                    if pending_user_input is not None:
+                        user_input = pending_user_input
+                        pending_user_input = None
+                        interface.print_user_message(user_input)
+                    else:
+                        user_input = interface.input()
 
                     # User commands
                     if user_input == "!exit":
@@ -448,9 +473,22 @@ class Chat:
                         },
                     )
 
-                    model_output = await interface.stream_output(stream)
+                    model_output, finish_reason, completion_tokens = await interface.stream_output(stream)
 
                     chat.append({"role": "assistant", "content": model_output})
+
+                    if finish_reason == "length":
+                        limit_hit = completion_tokens > config.max_new_tokens
+                        if limit_hit is not None:
+                            limit_message = f"Generation stopped after reaching the token limit ({limit_hit} tokens)."
+                        else:
+                            limit_message = "Generation stopped after reaching the token limit."
+
+                        interface.print_color(limit_message, "yellow")
+
+                        if interface.confirm("Continue generating?"):
+                            pending_user_input = "Please continue. Do not repeat text.”"
+                            continue
                 except KeyboardInterrupt:
                     break
 

--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -834,11 +834,18 @@ class Serve:
                 # they come from the assistant.
                 yield self.build_chat_completion_chunk(request_id, role="assistant", model=model_id_and_revision)
 
+                n_tokens_generated = 0
                 for result in self.running_continuous_batching_manager.request_id_iter(request_id):
+                    n_tokens_generated += 1
+
                     if result.status == RequestStatus.FINISHED:
+                        generated_all_tokens = n_tokens_generated >= generation_config.max_new_tokens
+                        final_token_is_eos = result == tokenizer.eos_token
+                        reason = "length" if (generated_all_tokens and not final_token_is_eos) else "stop"
+
                         yield self.build_chat_completion_chunk(
                             request_id,
-                            finish_reason="stop",
+                            finish_reason=reason,
                             model=model_id_and_revision,
                         )
                         break
@@ -1079,8 +1086,13 @@ class Serve:
                 # they come from the assistant.
                 yield self.build_chat_completion_chunk(request_id, role="assistant", model=model_id_and_revision)
 
+                result = ""
+                n_tokens_generated = 0
+
                 for result in streamer:
-                    # Temporary hack for GPTOS 3: don't emit the final "<|return|>"
+                    n_tokens_generated += 1
+
+                    # Temporary hack for GPT-OSS 3: don't emit the final "<|return|>"
                     if "gptoss" in model.config.architectures[0].lower():
                         result = result.removesuffix("<|return|>")
                     results += result
@@ -1169,7 +1181,11 @@ class Serve:
                         yield self.build_chat_completion_chunk(
                             _request_id, content=result, model=model_id_and_revision
                         )
-                yield self.build_chat_completion_chunk(_request_id, finish_reason="stop", model=model_id_and_revision)
+
+                generated_all_tokens = n_tokens_generated >= generation_config.max_new_tokens
+                final_token_is_eos = result == streamer.tokenizer.eos_token
+                reason = "length" if (generated_all_tokens and not final_token_is_eos) else "stop"
+                yield self.build_chat_completion_chunk(_request_id, finish_reason=reason, model=model_id_and_revision)
 
                 thread.join()
             except Exception as e:

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -263,10 +263,9 @@ class ServeCompletionsMixin:
         # NOTE: the output of our server is wrapped by `InferenceClient`, which sends fields even when they
         # are empty.
 
-        # Finish reason: the last payload should have a finish reason of "stop", all others should be empty
-        # TODO: we may add other finish reasons in the future, and this may need more logic
+        # Finish reason: the last payload should have a finish reason of "length" or "stop", all others should be empty
         finish_reasons = [payload.choices[0].finish_reason for payload in all_payloads]
-        self.assertEqual(finish_reasons[-1], "stop")
+        self.assertTrue(finish_reasons[-1] in ["length", "stop"])
         self.assertTrue(all(reason is None for reason in finish_reasons[:-1]))
 
         # Role: the first payload should have a role of "assistant", all others should be empty
@@ -533,7 +532,7 @@ class ServeCompletionsGenerateIntegrationTest(ServeCompletionsMixin, unittest.Te
         # Finally, the last payload should contain a finish reason
         finish_reasons = [payload.choices[0].finish_reason for payload in all_payloads]
         # TODO: I think the finish reason for a tool call is different? double check this
-        self.assertEqual(finish_reasons[-1], "stop")
+        self.assertTrue(finish_reasons[-1] in ["stop", "length"])
         self.assertTrue(all(reason is None for reason in finish_reasons[:-1]))
 
 

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -300,6 +300,18 @@ class ServeCompletionsMixin:
         # sets `do_sample=True`
         self.assertEqual(output_text, '<think>\nOkay, the user just asked, "')
 
+    def test_early_return_due_to_length(self):
+        request = {
+            "model": "Qwen/Qwen3-0.6B",
+            "messages": [{"role": "user", "content": "Hello, how are you?"}],
+            "stream": True,
+            "max_tokens": 3,
+        }
+
+        all_payloads = self.run_server(request)
+        last_payload = all_payloads[-1]
+        self.assertTrue(last_payload.choices[0]["finish_reason"] == "length")
+
     # TODO: one test for each request flag, to confirm it is working as expected
     # TODO: speed-based test to confirm that KV cache is working across requests
 


### PR DESCRIPTION
This PR updates `transfsormers serve` so that it accurately returns the stop reason -> instead of only returning "stop" (stop token), it now accurately returns "length" as well, therefore indicating when the max new token limit has been reached.

Transformers chat is updated to check on this reason, and to offer to continue:

```
Generation stopped after reaching the token limit.

Continue generating? (y/N):
```

This results in chats like the following:
<img width="1256" height="626" alt="image" src="https://github.com/user-attachments/assets/863a0828-6f2d-43b0-a6d6-24cf47d6d070" />

Implemented for both continuous batching and generate.