### PR TITLE
pin `pytest<9` for now

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,7 @@ _deps = [
     "psutil",
     "pyyaml>=5.1",
     "pydantic>=2",
-    "pytest>=7.2.0",
+    "pytest>=7.2.0,<9.0.0",
     "pytest-asyncio>=1.2.0",
     "pytest-rerunfailures<16.0",
     "pytest-timeout",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -47,7 +47,7 @@ deps = {
     "psutil": "psutil",
     "pyyaml": "pyyaml>=5.1",
     "pydantic": "pydantic>=2",
-    "pytest": "pytest>=7.2.0",
+    "pytest": "pytest>=7.2.0,<9.0.0",
     "pytest-asyncio": "pytest-asyncio>=1.2.0",
     "pytest-rerunfailures": "pytest-rerunfailures<16.0",
     "pytest-timeout": "pytest-timeout",


### PR DESCRIPTION
# What does this PR do?

`pytest 9.0.0` is released 4 days ago, causing some problems in our slack reporting. 

There is `9.0.1` just released, let's try it.