### PR TITLE
Remove import to deperated file

### DIFF
--- a/src/transformers/models/bert/__init__.py
+++ b/src/transformers/models/bert/__init__.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from .modeling_bert import *
     from .tokenization_bert import *
     from .tokenization_bert_fast import *
-    from .tokenization_bert_tf import *
 else:
     import sys
 


### PR DESCRIPTION

the `tokenization_bert_tf.py` file is already removed, while the import in TYPE_CHECKING is still remain.
