### PR TITLE
Cleanup reference to TFBertTokenizer and TFGPT2Tokenizer

### DIFF
--- a/src/transformers/models/bert/__init__.py
+++ b/src/transformers/models/bert/__init__.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from .modeling_bert import *
     from .tokenization_bert import *
     from .tokenization_bert_fast import *
-    from .tokenization_bert_tf import *
 else:
     import sys
 

--- a/src/transformers/models/gpt2/__init__.py
+++ b/src/transformers/models/gpt2/__init__.py
@@ -22,7 +22,6 @@ if TYPE_CHECKING:
     from .modeling_gpt2 import *
     from .tokenization_gpt2 import *
     from .tokenization_gpt2_fast import *
-    from .tokenization_gpt2_tf import *
 else:
     import sys
 

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -111,7 +111,6 @@ OBJECTS_TO_IGNORE = {
     "InputFeatures",
     # Signature is *args/**kwargs
     "TFSequenceSummary",
-    "TFBertTokenizer",
     "TFGPT2Tokenizer",
     # Missing arguments in the docstring
     "ASTFeatureExtractor",

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -109,9 +109,6 @@ OBJECTS_TO_IGNORE = {
     # Deprecated
     "InputExample",
     "InputFeatures",
-    # Signature is *args/**kwargs
-    "TFSequenceSummary",
-    "TFGPT2Tokenizer",
     # Missing arguments in the docstring
     "ASTFeatureExtractor",
     "AlbertModel",


### PR DESCRIPTION
A reference to `TFBertTokenizer` was left behind after removing TF/JAX support, which caused some issues. This PR removes it!

Fixes #42175