### PR TITLE
[`Pop2Piano`] Fix tied weights

### DIFF
--- a/src/transformers/models/pop2piano/configuration_pop2piano.py
+++ b/src/transformers/models/pop2piano/configuration_pop2piano.py
@@ -122,6 +122,7 @@ class Pop2PianoConfig(PreTrainedConfig):
             is_encoder_decoder=is_encoder_decoder,
             **kwargs,
         )
+        self.tie_encoder_decoder = True  # forcing it
 
 
 __all__ = ["Pop2PianoConfig"]

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -583,6 +583,8 @@ class Pop2PianoPreTrainedModel(PreTrainedModel):
             module.o.weight.normal_(mean=0.0, std=factor * ((n_heads * key_value_proj_dim) ** -0.5))
             if module.has_relative_attention_bias:
                 module.relative_attention_bias.weight.normal_(mean=0.0, std=factor * ((d_model) ** -0.5))
+        elif isinstance(module, nn.Linear):
+            module.weight.normal_(mean=0.0, std=factor)
 
     def _shift_right(self, input_ids):
         decoder_start_token_id = self.config.decoder_start_token_id

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -554,7 +554,7 @@ class Pop2PianoPreTrainedModel(PreTrainedModel):
             module.embedding.weight.normal_(mean=0.0, std=factor * 1.0)
         elif isinstance(module, Pop2PianoForConditionalGeneration):
             module.shared.weight.normal_(mean=0.0, std=factor * 1.0)
-            if hasattr(module, "lm_head") and not self.config.tie_word_embeddings:
+            if hasattr(module, "lm_head"):
                 module.lm_head.weight.normal_(mean=0.0, std=factor * 1.0)
         elif isinstance(module, Pop2PianoDenseActDense):
             module.wi.weight.normal_(mean=0.0, std=factor * ((self.config.d_model) ** -0.5))
@@ -583,8 +583,6 @@ class Pop2PianoPreTrainedModel(PreTrainedModel):
             module.o.weight.normal_(mean=0.0, std=factor * ((n_heads * key_value_proj_dim) ** -0.5))
             if module.has_relative_attention_bias:
                 module.relative_attention_bias.weight.normal_(mean=0.0, std=factor * ((d_model) ** -0.5))
-        elif isinstance(module, nn.Linear):
-            module.weight.normal_(mean=0.0, std=factor)
 
     def _shift_right(self, input_ids):
         decoder_start_token_id = self.config.decoder_start_token_id

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -948,7 +948,6 @@ class Pop2PianoForConditionalGeneration(Pop2PianoPreTrainedModel, GenerationMixi
     _tied_weights_keys = {
         "encoder.embed_tokens.weight": "shared.weight",
         "decoder.embed_tokens.weight": "shared.weight",
-        "lm_head.weight": "shared.weight",
     }
 
     def __init__(self, config: Pop2PianoConfig):
@@ -963,13 +962,11 @@ class Pop2PianoForConditionalGeneration(Pop2PianoPreTrainedModel, GenerationMixi
         encoder_config = copy.deepcopy(config)
         encoder_config.is_decoder = False
         encoder_config.use_cache = False
-        encoder_config.tie_encoder_decoder = False
 
         self.encoder = Pop2PianoStack(encoder_config)
 
         decoder_config = copy.deepcopy(config)
         decoder_config.is_decoder = True
-        decoder_config.tie_encoder_decoder = False
         decoder_config.num_layers = config.num_decoder_layers
         self.decoder = Pop2PianoStack(decoder_config)
 

--- a/tests/models/pop2piano/test_modeling_pop2piano.py
+++ b/tests/models/pop2piano/test_modeling_pop2piano.py
@@ -574,7 +574,7 @@ class Pop2PianoModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
     @slow
     def test_model_from_pretrained(self):
         model_name = "sweetcocoa/pop2piano"
-        model = Pop2PianoForConditionalGeneration.from_pretrained(model_name, trust_remote_code=True)
+        model = Pop2PianoForConditionalGeneration.from_pretrained(model_name)
         self.assertIsNotNone(model)
 
     def test_pass_with_input_features(self):
@@ -585,7 +585,7 @@ class Pop2PianoModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
                 "extrapolated_beatstep": torch.randint(size=(1, 900), low=0, high=100).type(torch.float32),
             }
         )
-        model = Pop2PianoForConditionalGeneration.from_pretrained("sweetcocoa/pop2piano", trust_remote_code=True)
+        model = Pop2PianoForConditionalGeneration.from_pretrained("sweetcocoa/pop2piano")
         model_opts = model.generate(input_features=input_features["input_features"], return_dict_in_generate=True)
 
         self.assertEqual(model_opts.sequences.ndim, 2)
@@ -611,7 +611,7 @@ class Pop2PianoModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCas
                 "attention_mask_extrapolated_beatstep": torch.ones((5, 900)).type(torch.int32),
             }
         )
-        model = Pop2PianoForConditionalGeneration.from_pretrained("sweetcocoa/pop2piano", trust_remote_code=True)
+        model = Pop2PianoForConditionalGeneration.from_pretrained("sweetcocoa/pop2piano")
         model_opts = model.generate(
             input_features=input_features["input_features"],
             attention_mask=input_features["attention_mask"],


### PR DESCRIPTION
Turns out that the weights were a 2way tie and not 3way as indicated by the original key:
- Only encoder + decoder --> the lm heads are separate

My investigation came originally from the increased runtime in a test, turns out it is due to different weights and hence generation ran longer (longer sequence generated). And the profiler showed the most time was spent on the cache, which is kinda expected as we have to constantly torch cat during the rollout generation.

Fixed by correctly specifying the key and forcing tied weights keys as in bart. I checked with the first 2 integration tests that now pass (the last head version issues and I'm too lazy to resolve them)

NOTE:
It is likely that some other models are also affected by this as it's a mixture of what ties were really expected.