### PR TITLE
Add AutoTokenizer mapping for mistral3 and ministral

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -452,6 +452,15 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, tuple[Optional[str], Optional[str]]](
             ),
         ),
         (
+            "mistral3",
+            (
+                "MistralCommonTokenizer"
+                if is_mistral_common_available()
+                else ("LlamaTokenizer" if is_sentencepiece_available() else None),
+                "LlamaTokenizerFast" if is_tokenizers_available() and not is_mistral_common_available() else None,
+            ),
+        ),
+        (
             "mixtral",
             (
                 "MistralCommonTokenizer"

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -443,6 +443,15 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, tuple[Optional[str], Optional[str]]](
             ),
         ),
         (
+            "ministral",
+            (
+                "MistralCommonTokenizer"
+                if is_mistral_common_available()
+                else ("LlamaTokenizer" if is_sentencepiece_available() else None),
+                "LlamaTokenizerFast" if is_tokenizers_available() and not is_mistral_common_available() else None,
+            ),
+        ),
+        (
             "mistral",
             (
                 "MistralCommonTokenizer"


### PR DESCRIPTION
# What does this PR do?

This PR makes sure that:

```py
from transformers import AutoTokenizer

tok = AutoTokenizer.from_pretrained("mistralai/Mistral-Small-3.2-24B-Instruct-2506")
tok = AutoTokenizer.from_pretrained("mistralai/Ministral-8B-Instruct-2410")
```

works correctly