### PR TITLE
Update `test_dynamic_cache_exportability_multiple_run` (failing on torch 2.10 nightly)

### DIFF
--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -628,7 +628,7 @@ class CacheExportIntegrationTest(unittest.TestCase):
         past_key_values = res.past_key_values
 
         shapes = torch.export.ShapesCollection()
-        dyn = torch.export.Dim("seq", max=512)
+        dyn = torch.export.Dim.DYNAMIC(max=512)
 
         for ix in range(len(past_key_values)):
             shapes[past_key_values.layers[ix].keys] = (None, None, dyn, None)


### PR DESCRIPTION
# What does this PR do?

See 

https://github.com/pytorch/pytorch/issues/167293#issuecomment-3529014252

The suggestion seems to reasonable since the test name is 

> test_dynamic_cache_exportability_multiple_run