### PR TITLE
Refines quantization method handling in model loading

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -616,9 +616,9 @@ def convert_and_load_state_dict_in_model(
                 if quantizer.__class__.__name__ == "FineGrainedFP8HfQuantizer":
                     from .integrations.finegrained_fp8 import Fp8Quantize
 
-                    converter.quantization_operation = Fp8Quantize()  # TODO support other methods
-                else:
-                    raise ValueError("This quantization method is gonna be supported SOOOON")
+                    converter.quantization_operation = Fp8Quantize()
+                # Other quantizers (BNB, HQQ, etc.) handle quantization when the parameter is set into the module,
+                # rather than as a conversion operation in the weight loading pipeline
             else:
                 _dtype = dtype
                 matched_dtype_pattern = match_glob(t, dtype_policy_alt, dtype_policy_by_group_name)


### PR DESCRIPTION
## What does this PR do?

Fixes a regression from #41580 where loading quantized models fails with `ValueError: This quantization method is gonna be supported SOOOON` for all quantizers except FP8 (e.g., BitsAndBytes 4-bit/8-bit, HQQ, EETQ, Quanto).

The issue: the refactored weight loading code only handled FineGrainedFP8HfQuantizer and raised an error for all other quantization methods. However, other quantizers don't need `quantization_operation` set during weight conversion—they handle quantization when parameters are assigned to modules.

The fix: Remove the error and add a clarifying comment explaining the difference between FP8 (quantizes during conversion) and other quantizers (quantize during parameter assignment).

Fixes #42215

## Review

@CyrilVallez (model loading) @SunMarc @MekkCyber (quantization)