### PR TITLE
Fix UnboundLocalError in RT-DETR loss when auxiliary_loss is False

### DIFF
--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -447,6 +447,7 @@ def RTDetrForObjectDetectionLoss(
     outputs_loss = {}
     outputs_loss["logits"] = logits
     outputs_loss["pred_boxes"] = pred_boxes
+    auxiliary_outputs = None
     if config.auxiliary_loss:
         if denoising_meta_values is not None:
             dn_out_coord, outputs_coord = torch.split(outputs_coord, denoising_meta_values["dn_num_split"], dim=2)


### PR DESCRIPTION
## What does this PR do?

Fixes #42219 

This PR fixes an `UnboundLocalError` that occurs in `RTDetrForObjectDetectionLoss` when `config.auxiliary_loss` is set to `False`.

## Problem

The function `RTDetrForObjectDetectionLoss` in `src/transformers/loss/loss_rt_detr.py` always returns `auxiliary_outputs` at line 468, but this variable is only initialized inside the `if config.auxiliary_loss:` block (line 451). When `auxiliary_loss=False`, the variable is never initialized, causing:

```python
UnboundLocalError: variable 'auxiliary_outputs' referenced before assignment
```

## Solution

Initialize `auxiliary_outputs = None` before the conditional block (line 450) to ensure it always has a value when returned.

**Changes:**
- Added `auxiliary_outputs = None` initialization at line 450

This is a minimal, defensive fix that ensures the function works correctly regardless of the `auxiliary_loss` configuration.

## Testing

The fix ensures that:
- When `auxiliary_loss=True`: `auxiliary_outputs` is set to the computed values (existing behavior)
- When `auxiliary_loss=False`: `auxiliary_outputs` is `None` (fixed behavior)

## Additional context

The `auxiliary_loss` parameter defaults to `True` in `RTDetrConfig`, which is why this bug may not have been caught in standard testing scenarios. The bug only manifests when users explicitly set `auxiliary_loss=False`.