### PR TITLE
Fix UnboundLocalError in RT-DETR loss computation

### DIFF
--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -447,7 +447,7 @@ def RTDetrForObjectDetectionLoss(
     outputs_loss = {}
     outputs_loss["logits"] = logits
     outputs_loss["pred_boxes"] = pred_boxes
-    auxiliary_outputs = None  # Initialize to prevent UnboundLocalError when auxiliary_loss is False
+    auxiliary_outputs = None
     if config.auxiliary_loss:
         if denoising_meta_values is not None:
             dn_out_coord, outputs_coord = torch.split(outputs_coord, denoising_meta_values["dn_num_split"], dim=2)

--- a/src/transformers/loss/loss_rt_detr.py
+++ b/src/transformers/loss/loss_rt_detr.py
@@ -447,6 +447,7 @@ def RTDetrForObjectDetectionLoss(
     outputs_loss = {}
     outputs_loss["logits"] = logits
     outputs_loss["pred_boxes"] = pred_boxes
+    auxiliary_outputs = None  # Initialize to prevent UnboundLocalError when auxiliary_loss is False
     if config.auxiliary_loss:
         if denoising_meta_values is not None:
             dn_out_coord, outputs_coord = torch.split(outputs_coord, denoising_meta_values["dn_num_split"], dim=2)


### PR DESCRIPTION
## Summary

Fixes an `UnboundLocalError` that occurs in the RT-DETR loss computation when `config.auxiliary_loss` is `False`.

## Problem

The variable `auxiliary_outputs` is conditionally assigned inside an `if config.auxiliary_loss:` block, but it's referenced later in the function regardless of whether the condition was true. When `auxiliary_loss` is disabled, this causes:

```
UnboundLocalError: local variable 'auxiliary_outputs' referenced before assignment
```

## Solution

Initialize `auxiliary_outputs = None` before the conditional block to ensure it's always defined before use.

## Changes

- Added `auxiliary_outputs = None` initialization in `src/transformers/loss/loss_rt_detr.py:450`

## Testing

This fix ensures the function works correctly whether `config.auxiliary_loss` is `True` or `False`.