### PR TITLE
Support .to(device) or Device Aware Handling for Segmentation Labels in EOMTImageProcessor #42205

### DIFF
--- a/src/transformers/models/eomt/modeling_eomt.py
+++ b/src/transformers/models/eomt/modeling_eomt.py
@@ -1104,6 +1104,14 @@ class EomtForUniversalSegmentation(EomtPreTrainedModel):
             list of tuples indicating the image index and start and end positions of patches for semantic segmentation.
         """
 
+        if mask_labels is not None:
+            target_device = pixel_values.device
+            mask_labels = [mask.to(target_device) for mask in mask_labels]
+
+        if class_labels is not None:
+            target_device = pixel_values.device
+            class_labels = [label.to(target_device) for label in class_labels]
+
         masks_queries_logits_per_layer, class_queries_logits_per_layer = (), ()
         attention_mask = None
 

--- a/src/transformers/models/eomt/modular_eomt.py
+++ b/src/transformers/models/eomt/modular_eomt.py
@@ -513,6 +513,14 @@ class EomtForUniversalSegmentation(Mask2FormerForUniversalSegmentation):
             list of tuples indicating the image index and start and end positions of patches for semantic segmentation.
         """
 
+        if mask_labels is not None:
+            target_device = pixel_values.device
+            mask_labels = [mask.to(target_device) for mask in mask_labels]
+
+        if class_labels is not None:
+            target_device = pixel_values.device
+            class_labels = [label.to(target_device) for label in class_labels]
+
         masks_queries_logits_per_layer, class_queries_logits_per_layer = (), ()
         attention_mask = None
 

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -2415,6 +2415,15 @@ class Mask2FormerForUniversalSegmentation(Mask2FormerPreTrainedModel):
         torch.Size([338, 676])
         ```
         """
+
+        if mask_labels is not None:
+            target_device = pixel_values.device
+            mask_labels = [mask.to(target_device) for mask in mask_labels]
+
+        if class_labels is not None:
+            target_device = pixel_values.device
+            class_labels = [label.to(target_device) for label in class_labels]
+        
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/mask2former/modeling_mask2former.py
+++ b/src/transformers/models/mask2former/modeling_mask2former.py
@@ -2423,7 +2423,7 @@ class Mask2FormerForUniversalSegmentation(Mask2FormerPreTrainedModel):
         if class_labels is not None:
             target_device = pixel_values.device
             class_labels = [label.to(target_device) for label in class_labels]
-        
+
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states

--- a/src/transformers/models/maskformer/modeling_maskformer.py
+++ b/src/transformers/models/maskformer/modeling_maskformer.py
@@ -1739,6 +1739,13 @@ class MaskFormerForInstanceSegmentation(MaskFormerPreTrainedModel):
         [480, 640]
         ```
         """
+        if mask_labels is not None:
+            target_device = pixel_values.device
+            mask_labels = [mask.to(target_device) for mask in mask_labels]
+
+        if class_labels is not None:
+            target_device = pixel_values.device
+            class_labels = [label.to(target_device) for label in class_labels]
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (

--- a/src/transformers/models/oneformer/modeling_oneformer.py
+++ b/src/transformers/models/oneformer/modeling_oneformer.py
@@ -3141,6 +3141,13 @@ class OneFormerForUniversalSegmentation(OneFormerPreTrainedModel):
         '👉 Panoptic Predictions Shape: [512, 683]'
         ```
         """
+        if mask_labels is not None:
+            target_device = pixel_values.device
+            mask_labels = [mask.to(target_device) for mask in mask_labels]
+
+        if class_labels is not None:
+            target_device = pixel_values.device
+            class_labels = [label.to(target_device) for label in class_labels]
 
         output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
         output_hidden_states = (


### PR DESCRIPTION
What does this PR do?
Fixes a RuntimeError: Expected all tensors to be on the same device... when training EomtForUniversalSegmentation.

The EomtImageProcessor returns labels (mask_labels, class_labels) as a list[torch.Tensor] because the number of masks per image varies. The standard BatchFeature.to(device) call in a training loop does not move tensors inside these lists, leaving them on the CPU.

This PR adds a robust check at the beginning of the EomtForUniversalSegmentation.forward() method. It automatically moves any provided mask_labels or class_labels to the same device as the pixel_values, ensuring all inputs are on the correct device before loss computation.

This fixes the device mismatch bug internally without requiring any changes from the user.

Fixes #42205

Before submitting
[x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

[x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

[x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. (Fixes #42205)

[x] Did you make sure to update the documentation with your changes? (N/A - Bugfix)

[x] Did you write any new necessary tests? (Verified with issue's code)

Who can review?
@NielsRogge @molbap @merveenoyan