### PR TITLE
Fix issue #41553: Improve error message for Voxtral tokenizer when mistral-common is missing

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -1138,6 +1138,12 @@ class AutoTokenizer:
 
         model_type = config_class_to_model_type(type(config).__name__)
         if model_type is not None:
+            # Check if Voxtral model requires mistral-common
+            if model_type == "voxtral" and not is_mistral_common_available():
+                raise ImportError(
+                    "The Voxtral tokenizer requires the `mistral-common` library to be installed. "
+                    "Please install it with: `pip install mistral-common` or `pip install transformers[mistral-common]`"
+                )
             tokenizer_class_py, tokenizer_class_fast = TOKENIZER_MAPPING[type(config)]
 
             if tokenizer_class_fast and (use_fast or tokenizer_class_py is None):

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -522,3 +522,27 @@ class NopConfig(PretrainedConfig):
                     pass
             finally:
                 os.chdir(prev_dir)
+
+    def test_voxtral_tokenizer_missing_mistral_common_error(self):
+        """Test that AutoTokenizer raises a clear error message when loading Voxtral without mistral-common."""
+        import unittest.mock as mock
+
+        try:
+            from transformers.models.voxtral.configuration_voxtral import VoxtralConfig
+        except ImportError:
+            self.skipTest("VoxtralConfig is not available")
+
+        # Create a VoxtralConfig instance
+        config = VoxtralConfig()
+
+        # Mock is_mistral_common_available to return False
+        with mock.patch(
+            "transformers.models.auto.tokenization_auto.is_mistral_common_available", return_value=False
+        ):
+            with self.assertRaises(ImportError) as cm:
+                AutoTokenizer.from_pretrained("mistralai/Voxtral-Mini-3B-2507", config=config)
+
+            error_message = str(cm.exception)
+            self.assertIn("mistral-common", error_message)
+            self.assertIn("pip install", error_message)
+            self.assertIn("Voxtral", error_message)


### PR DESCRIPTION
## Description

This PR fixes issue #41553 by providing a clear error message when trying to load Voxtral tokenizer without the `mistral-common` library installed.

## Problem

Currently, when users try to load a Voxtral tokenizer without `mistral-common` installed, they get a confusing error:
```
TypeError: not a string
```

This happens because the code falls back to `LlamaTokenizer` when `mistral-common` is not available, but Voxtral models don't have a compatible vocab file, causing `vocab_file` to be `None`.

## Solution

Added a check in `AutoTokenizer.from_pretrained()` that:
- Detects when a Voxtral model is being loaded
- Checks if `mistral-common` is available
- Raises a clear `ImportError` with installation instructions before attempting to use the fallback tokenizer

## Changes

- **File**: `src/transformers/models/auto/tokenization_auto.py`
  - Added check for Voxtral model type before accessing `TOKENIZER_MAPPING`
  - Raises `ImportError` with helpful message when `mistral-common` is missing

- **File**: `tests/models/auto/test_tokenization_auto.py`
  - Added test `test_voxtral_tokenizer_missing_mistral_common_error()` to verify the fix

## Error Message Improvement

**Before:**
```
TypeError: not a string
```

**After:**
```
ImportError: The Voxtral tokenizer requires the `mistral-common` library to be installed. 
Please install it with: `pip install mistral-common` or `pip install transformers[mistral-common]`
```

## Testing

- Added unit test that verifies the error message is raised correctly
- Test uses mocking to simulate missing `mistral-common` dependency
- Verifies error message contains required keywords

## Checklist

- [x] The code follows the code style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Fixes #41553