### PR TITLE
Fix initialization guard for pytest

### DIFF
--- a/src/transformers/initialization.py
+++ b/src/transformers/initialization.py
@@ -179,7 +179,7 @@ def guard_torch_init_functions():
             # something like `from torch.nn.init import xavier_uniform_` in their internals (e.g in torch.nn.modules,
             # where MultiHeadAttention lives), so the function name is binded at import time and just doing
             # `setattr(torch.nn.init, name, gloabls()[name])` is thus not enough
-            for module in sys.modules.values():
+            for module in sys.modules.copy().values():
                 if module and hasattr(module, name):
                     originals[module][name] = getattr(module, name)
                     setattr(module, name, globals()[name])


### PR DESCRIPTION
# What does this PR do?

As per the title. Otherwise, when running multiple tests at once with `pytest`, we sometimes hit the following error: `RuntimeError: dictionary changed size during iteration` due to how multiple tests are handled with `pytest`.