### PR TITLE
[loading] Re-add and improve disk offloading support

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -756,7 +756,7 @@ def convert_and_load_state_dict_in_model(
             except SkipLayer:
                 continue
     thread_pool.shutdown(wait=False)
-    return missing_keys, unexpected_keys, mismatch_keys, misc
+    return missing_keys, unexpected_keys, mismatch_keys, disk_offload_index, misc
 
 
 # TODO this is not done yet!

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -398,7 +398,7 @@ def dot_natural_key(s: str):
 
 @contextmanager
 def log_to_misc(
-    full_param_name: str,
+    all_target_keys: str,
     misc: MutableMapping[str, str],
     extras: Any = None,
     op: Union[list[ConversionOps], ConversionOps, None] = None,
@@ -422,16 +422,16 @@ def log_to_misc(
         if isinstance(extras, tuple) and len(extras) == 2:
             values, target_keys = extras
             descriptor = f"{op_name} " if op_name else ""
-            misc[full_param_name] = (
+            misc[all_target_keys] = (
                 f"{e}\nError: {descriptor}on tensors destined for {target_keys}. Ckpt contains: {len(values)}"
             )
         elif isinstance(extras, str):
             suffix = f" via {op_name}" if op_name else ""
-            misc[full_param_name] = f"{e}\nError{suffix} when processing parameter {extras}"
+            misc[all_target_keys] = f"{e}\nError{suffix} when processing parameter {extras}"
         elif extras is None and op_name:
-            misc[full_param_name] = f"{op_name}: {e}"
+            misc[all_target_keys] = f"{op_name}: {e}"
         else:
-            misc[full_param_name] = f"{extras} |Error: {e}"
+            misc[all_target_keys] = f"{extras} |Error: {e}"
         raise SkipLayer()
 
 

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -611,6 +611,7 @@ def convert_and_load_state_dict_in_model(
     prefix = model.base_model_prefix
     tp_plan = tp_plan or {}
     device_map = device_map or {"": "cpu"}
+    # Here, we first sort by number of submodules, then length of the full string, to make sure to match correctly
     device_map_regex = re.compile(
         "|".join(rf"({k})" for k in sorted(device_map.keys(), key=lambda x: (x.count("."), len(x)), reverse=True))
     )

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -730,9 +730,9 @@ def convert_and_load_state_dict_in_model(
                 realized_value, misc = mapping.convert(
                     full_param_name, config=model.config, quantizer=hf_quantizer, missing_keys=missing_keys
                 )
-                for k, output_value in realized_value.items():
-                    output_value = output_value[0] if isinstance(output_value, list) else output_value
-                    device_match = device_map_regex.match(k)
+                for target_name, param in realized_value.items():
+                    param = param[0] if isinstance(param, list) else param
+                    device_match = device_map_regex.match(target_name)
                     param_device = (
                         device_map[device_match.group()] if device_match else device_map.get("", "cpu")
                     )
@@ -742,13 +742,13 @@ def convert_and_load_state_dict_in_model(
                         # If not already offloaded, or if we applied any special Operation, we need to re-save
                         if k not in disk_offload_index or len(operations) > 0:
                             disk_offload_index = offload_weight(
-                                output_value, k, disk_offload_folder, disk_offload_index
+                                param, target_name, disk_offload_folder, disk_offload_index
                             )
                     else:
                         set_param_for_module(
                             model,
-                            k,
-                            output_value,
+                            target_name,
+                            param,
                             mismatch_keys,
                             missing_keys,
                             misc,

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -732,7 +732,10 @@ def convert_and_load_state_dict_in_model(
                 )
                 for k, output_value in realized_value.items():
                     output_value = output_value[0] if isinstance(output_value, list) else output_value
-                    param_device = device_map[re.search(device_map_regex, k).group()]
+                    device_match = device_map_regex.match(k)
+                    param_device = (
+                        device_map[device_match.group()] if device_match else device_map.get("", "cpu")
+                    )
                     # Offloading support
                     if param_device == "disk":
                         missing_keys.discard(k)

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -739,9 +739,9 @@ def convert_and_load_state_dict_in_model(
                     )
                     # Offloading support
                     if param_device == "disk":
-                        missing_keys.discard(k)
-                        # If not already offloaded, or if we applied any special Operation, we need to re-save
-                        if k not in disk_offload_index or len(operations) > 0:
+                        missing_keys.discard(target_name)
+                        # If not already offloaded, or if we applied any special Operation except Renaming, we need to re-save
+                        if target_name not in disk_offload_index or isinstance(mapping, WeightConverter):
                             disk_offload_index = offload_weight(
                                 param, target_name, disk_offload_folder, disk_offload_index
                             )
@@ -759,6 +759,7 @@ def convert_and_load_state_dict_in_model(
                         )
             except SkipLayer:
                 continue
+
     thread_pool.shutdown(wait=False)
     return missing_keys, unexpected_keys, mismatch_keys, disk_offload_index, misc
 

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -503,9 +503,10 @@ def offload_weight(weight: torch.Tensor, weight_name: str, offload_folder: str |
 
     if offload_folder is None:
         raise ValueError(
-            "The current `device_map` had weights offloaded to the disk, which needed to be re-saved. This is likely "
-            "because the model uses an internal weight format different than the one saved (i.e. most MoE models). "
-            "Please provide an `offload_folder`for them in `from_pretrained`."
+            "The current `device_map` had weights offloaded to the disk, which needed to be re-saved. This is either "
+            "because the weights are not in `safetensors` format, or because the model uses an internal weight format "
+            "different than the one saved (i.e. most MoE models). Please provide an `offload_folder`for them in "
+            "`from_pretrained`."
         )
     # Write the weight to disk
     safetensor_file = os.path.join(offload_folder, f"{weight_name}.safetensors")

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -502,7 +502,7 @@ def accelerate_disk_offload(
             weight_map = dict.fromkeys(safe_open(checkpoint_files[0], framework="pt").keys(), checkpoint_files[0])
         else:
             folder = os.path.sep.join(checkpoint_files[0].split(os.path.sep)[:-1])
-            weight_map = {k: os.path.join(folder, v) for k, v in weight_map.items()}
+            weight_map = {k: os.path.join(folder, v) for k, v in sharded_metadata["weight_map"].items()}
 
         # Update the weight names according to the `weight_mapping`
         weight_renaming_map = {

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -406,6 +406,10 @@ def _get_device_map(
             if max_memory is not None and device_name in max_memory:
                 inferred_max_memory[device_name] = min(inferred_max_memory[device_name], max_memory[device_name])
 
+        # Here we need to retie the weights before the call even if they are all on meta device, otherwise accelerate
+        # mess up the device_map computation
+        # TODO Cyril: replace this function to avoid re-tying uselessly
+        model.tie_weights()
         device_map = infer_auto_device_map(
             model,
             max_memory=inferred_max_memory,

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -470,7 +470,11 @@ def expand_device_map(device_map, param_names):
     return new_device_map
 
 
-def update_param_name(param_name: str, weight_pattern_alt, weight_pattern_by_group_name, source_to_target):
+def update_param_name(param_name: str, weight_pattern_alt, weight_pattern_by_group_name, source_to_target) -> str:
+    """Update a source `param_name` in a checkpoint into the target name that the model expects, if different.
+    This uses the same logic as `core_model_loading.py`."""
+    # TODO Cyril: This function would not even need to exist if the Converter entries already contained the
+    # full expanded source and target names
     from ..core_model_loading import match_glob
 
     if weight_pattern_alt is None:

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -505,7 +505,7 @@ def offload_weight(weight: torch.Tensor, weight_name: str, offload_folder: str |
         raise ValueError(
             "The current `device_map` had weights offloaded to the disk, which needed to be re-saved. This is either "
             "because the weights are not in `safetensors` format, or because the model uses an internal weight format "
-            "different than the one saved (i.e. most MoE models). Please provide an `offload_folder`for them in "
+            "different than the one saved (i.e. most MoE models). Please provide an `offload_folder` for them in "
             "`from_pretrained`."
         )
     # Write the weight to disk

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -474,6 +474,12 @@ def accelerate_disk_offload(
     dtype: torch.dtype | None,
     weight_mapping=None,
 ):
+    """
+    Prepare the `disk_offload_index` that will be used for reading offloaded parameters. If reading from a safetensors
+    file, parameters which do not need any special WeightConverter operation during loading (i.e. they are used as-is, or only
+    renamed) will be mapped to where they already reside on disk. Otherwise, the parameters will be resaved inside
+    `disk_offload_folder` during loading.
+    """
     from ..core_model_loading import WeightRenaming, build_glob_alternation, repl
 
     if disk_offload_folder is not None:

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -409,10 +409,6 @@ def _get_device_map(
             if max_memory is not None and device_name in max_memory:
                 inferred_max_memory[device_name] = min(inferred_max_memory[device_name], max_memory[device_name])
 
-        # Here we need to retie the weights before the call even if they are all on meta device, otherwise accelerate
-        # mess up the device_map computation
-        # TODO Cyril: replace this function to avoid re-tying uselessly (and the function is very inefficient)
-        model.tie_weights()
         device_map = infer_auto_device_map(
             model,
             max_memory=inferred_max_memory,

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -408,7 +408,7 @@ def _get_device_map(
 
         # Here we need to retie the weights before the call even if they are all on meta device, otherwise accelerate
         # mess up the device_map computation
-        # TODO Cyril: replace this function to avoid re-tying uselessly
+        # TODO Cyril: replace this function to avoid re-tying uselessly (and the function is very inefficient)
         model.tie_weights()
         device_map = infer_auto_device_map(
             model,

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -518,7 +518,8 @@ def accelerate_disk_offload(
                 "dtype": str_dtype,
             }
             for target_name, source_name in weight_renaming_map.items()
-            if param_device_map[target_name] == "disk"
+            # Need to check if it's in the mapping in case of unexpected keys that would result in KeyError (we skip them)
+            if target_name in param_device_map and param_device_map[target_name] == "disk"
         }
     # In this case we will resave every offloaded weight
     else:

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -471,7 +471,7 @@ def accelerate_disk_offload(
         os.makedirs(disk_offload_folder, exist_ok=True)
     is_offloaded_safetensors = checkpoint_files is not None and checkpoint_files[0].endswith(".safetensors")
 
-    # In this cause, the offload index is simply the existing safetensors (except if using custom weight loading
+    # In this case, the offload index is simply the existing safetensors (except if using custom weight loading
     # Operation, e.g. the MoE models, where we need to resave the weights that were changed at loading time)
     if is_offloaded_safetensors:
         param_device_map = expand_device_map(device_map, expected_keys)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4075,6 +4075,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 expected_keys,
                 sharded_metadata,
                 dtype,
+                weight_mapping,
             )
 
         # Warmup cuda to load the weights much faster on devices

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -64,6 +64,7 @@ from .integrations.accelerate import (
     check_and_set_device_map,
     expand_device_map,
     init_empty_weights,
+    offload_weight,
 )
 from .integrations.deepspeed import _load_state_dict_into_zero3_model
 from .integrations.eager_paged import eager_paged_attention_forward
@@ -132,7 +133,7 @@ from .utils.quantization_config import QuantizationMethod
 
 if is_accelerate_available():
     from accelerate.hooks import add_hook_to_module
-    from accelerate.utils import extract_model_from_parallel, offload_weight
+    from accelerate.utils import extract_model_from_parallel
     from accelerate.utils.modeling import get_state_dict_from_offload
 
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4115,18 +4115,20 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             else:
                 raise ValueError("Neither a state dict nor checkpoint files were found.")
 
-            missing_keys, unexpected_keys, mismatched_keys, misc = convert_and_load_state_dict_in_model(
-                model,
-                merged_state_dict,
-                weight_mapping,
-                tp_plan,
-                hf_quantizer,
-                dtype,
-                device_map,
-                model.dtype_plan,
-                device_mesh,
-                disk_offload_index,
-                disk_offload_folder,
+            missing_keys, unexpected_keys, mismatched_keys, disk_offload_index, misc = (
+                convert_and_load_state_dict_in_model(
+                    model,
+                    merged_state_dict,
+                    weight_mapping,
+                    tp_plan,
+                    hf_quantizer,
+                    dtype,
+                    device_map,
+                    model.dtype_plan,
+                    device_mesh,
+                    disk_offload_index,
+                    disk_offload_folder,
+                )
             )
 
             # finally close all opened file pointers

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4196,7 +4196,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             misc=misc,
             ignore_mismatched_sizes=ignore_mismatched_sizes,
         )
-        disk_offload_index = None
+
         return model, missing_keys, unexpected_keys, mismatched_keys, disk_offload_index, error_msgs
 
     def retrieve_modules_from_names(self, names, add_prefix=False, remove_prefix=False):

--- a/tests/models/deepseek_vl_hybrid/test_modeling_deepseek_vl_hybrid.py
+++ b/tests/models/deepseek_vl_hybrid/test_modeling_deepseek_vl_hybrid.py
@@ -167,6 +167,7 @@ class DeepseekVLHybridModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
         else {}
     )
     _is_composite = True
+    model_split_percents = [0.5, 0.85, 0.9]  # it tries to offload everything with the default value
 
     def setUp(self):
         self.model_tester = DeepseekVLHybridModelTester(self)

--- a/tests/models/glm4_moe/test_modeling_glm4_moe.py
+++ b/tests/models/glm4_moe/test_modeling_glm4_moe.py
@@ -61,6 +61,7 @@ class Glm4MoeModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = Glm4MoeModelTester
     # used in `test_torch_compile_for_training`. Skip as "Dynamic control flow in MoE"
     _torch_compile_train_cls = None
+    model_split_percents = [0.5, 0.85, 0.9]  # it tries to offload everything with the default value
 
 
 @require_torch_accelerator

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2385,7 +2385,7 @@ class ModelTesterMixin:
                 max_size = int(self.model_split_percents[1] * model_size)
                 max_memory = {0: max_size, "cpu": max_size}
                 new_model = model_class.from_pretrained(
-                    tmp_dir, device_map="auto", max_memory=max_memory, offload_folder=tmp_dir
+                    tmp_dir, device_map="auto", max_memory=max_memory, offload_folder=tmp_dir, use_safetensors=False
                 )
 
                 self.check_device_map_is_respected(new_model, new_model.hf_device_map)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2378,7 +2378,9 @@ class ModelTesterMixin:
                     max_size = int(self.model_split_percents[0] * model_size)
                     max_memory = {0: max_size, "cpu": max_size}
                     # This errors out cause it's missing an offload folder
-                    new_model = model_class.from_pretrained(tmp_dir, device_map="auto", max_memory=max_memory)
+                    new_model = model_class.from_pretrained(
+                        tmp_dir, device_map="auto", max_memory=max_memory, use_safetensors=False
+                    )
 
                 max_size = int(self.model_split_percents[1] * model_size)
                 max_memory = {0: max_size, "cpu": max_size}

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2357,7 +2357,6 @@ class ModelTesterMixin:
     @require_accelerate
     @mark.accelerate_tests
     @require_torch_accelerator
-    @unittest.skip("# TODO @CyrilVallez fix this in the other PR")
     def test_disk_offload_bin(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -2402,7 +2401,6 @@ class ModelTesterMixin:
     @require_accelerate
     @mark.accelerate_tests
     @require_torch_accelerator
-    @unittest.skip("# TODO @CyrilVallez fix this in the other PR")
     def test_disk_offload_safetensors(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -2441,7 +2439,6 @@ class ModelTesterMixin:
     @require_accelerate
     @mark.accelerate_tests
     @require_torch_accelerator
-    @unittest.skip("# TODO @CyrilVallez fix this in the other PR")
     def test_cpu_offload(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -105,16 +105,11 @@ from transformers.utils import (
     CONFIG_NAME,
     GENERATION_CONFIG_NAME,
     SAFE_WEIGHTS_NAME,
-    is_accelerate_available,
     is_torch_bf16_available_on_device,
     is_torch_fp16_available_on_device,
 )
 
 from .generation.test_utils import GenerationTesterMixin
-
-
-if is_accelerate_available():
-    from accelerate.utils import compute_module_sizes
 
 
 if is_torch_available():
@@ -125,6 +120,7 @@ if is_torch_available():
     from torch import nn
 
     from transformers import MODEL_MAPPING
+    from transformers.integrations.accelerate import compute_module_sizes
     from transformers.integrations.tensor_parallel import _get_parameter_tp_plan
     from transformers.modeling_utils import load_state_dict
     from transformers.pytorch_utils import id_tensor_storage
@@ -2370,7 +2366,7 @@ class ModelTesterMixin:
             torch.manual_seed(0)
             base_output = model(**inputs_dict_class)
 
-            model_size = compute_module_sizes(model)[""]
+            model_size = compute_module_sizes(model)[0][""]
             with tempfile.TemporaryDirectory() as tmp_dir:
                 model.cpu().save_pretrained(tmp_dir, safe_serialization=False)
 
@@ -2416,7 +2412,7 @@ class ModelTesterMixin:
             torch.manual_seed(0)
             base_output = model(**inputs_dict_class)
 
-            model_size = compute_module_sizes(model)[""]
+            model_size = compute_module_sizes(model)[0][""]
             with tempfile.TemporaryDirectory() as tmp_dir:
                 model.cpu().save_pretrained(tmp_dir)
 
@@ -2455,7 +2451,7 @@ class ModelTesterMixin:
             torch.manual_seed(0)
             base_output = model(**inputs_dict_class)
 
-            model_size = compute_module_sizes(model)[""]
+            model_size = compute_module_sizes(model)[0][""]
             # We test several splits of sizes to make sure it works.
             max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents[1:]]
             with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2498,7 +2494,7 @@ class ModelTesterMixin:
             torch.manual_seed(0)
             base_output = model(**inputs_dict_class)
 
-            model_size = compute_module_sizes(model)[""]
+            model_size = compute_module_sizes(model)[0][""]
             # We test several splits of sizes to make sure it works.
             max_gpu_sizes = [int(p * model_size) for p in self.model_split_percents[1:]]
             with tempfile.TemporaryDirectory() as tmp_dir:

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -250,7 +250,7 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
             ),
             WeightRenaming("mlp.w2.weight", "mlp.down_proj.weight"),
         ]
-        missing, unexpected, mismatch, misc = convert_and_load_state_dict_in_model(
+        missing, unexpected, mismatch, _, misc = convert_and_load_state_dict_in_model(
             model, state_dict, weight_mapping, tp_plan=None, hf_quantizer=None
         )
 
@@ -400,7 +400,7 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
             )
         ]
 
-        missing, unexpected, mismatch, misc = convert_and_load_state_dict_in_model(
+        missing, unexpected, mismatch, _, misc = convert_and_load_state_dict_in_model(
             model, state_dict, weight_mapping, tp_plan=None, hf_quantizer=quantizer
         )
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1208,7 +1208,6 @@ class ModelUtilsTest(TestCasePlus):
     @require_accelerate
     @mark.accelerate_tests
     @require_torch_accelerator
-    @unittest.skip("TODO @cyrilvallez when saving")
     def test_save_offloaded_model(self):
         device_map = {
             "transformer.wte": f"{torch_device}:0",

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1246,7 +1246,6 @@ class ModelUtilsTest(TestCasePlus):
     @require_accelerate
     @mark.accelerate_tests
     @require_torch_accelerator
-    @unittest.skip("TODO @cyrilvallez when saving")
     def test_save_offloaded_model_with_direct_params(self):
         from accelerate import dispatch_model
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2055,7 +2055,6 @@ class ModelUtilsTest(TestCasePlus):
         for k, v in model.state_dict().items():
             self.assertTrue(v.device.type == "cpu", f"{k} is not on cpu!")
 
-    @unittest.skip("TODO fix offloaded in another PR @CyrilVallez")
     def test_device_map_works_with_unexpected_keys(self):
         """Test that if a parameter is specified in `_keys_to_ignore_on_load_unexpected` and is actually
         present in the checkpoint, it will correctly be removed from the weights we load, especially those
@@ -2079,7 +2078,6 @@ class ModelUtilsTest(TestCasePlus):
         # Unexpected keys (mtp) should be removed from the state dict, therefore this should not error out.
         BaseModelWithUnexpectedKeys.from_pretrained(temp.name, device_map={"linear": "cpu", "linear_2": "disk"})
 
-    @unittest.skip("TODO fix offloaded in another PR @CyrilVallez")
     def test_device_map_works_with_unexpected_keys_sharded(self):
         """Test that if a parameter is specified in `_keys_to_ignore_on_load_unexpected` and is actually
         present in the checkpoint, it will correctly be removed from the weights we load, especially those


### PR DESCRIPTION
# What does this PR do?

This PR re-add support for weight offloading to disk using the `device_map`, which was temporarily dropped in https://github.com/huggingface/transformers/pull/41580 to simplify the PR (because weights need to be resaved correctly after performing custom Ops during dynamic loading).

It further improve the offloading mechanism as everything is now offloaded in `safetensors` format, vs `numpy` format originally when using `accelerate`. This is much easier and efficient.

Slow tests are exactly similar to before the big weight loading refactor (10 failing over all models)