### PR TITLE
Fix looping in torch guard decorator

### DIFF
--- a/src/transformers/initialization.py
+++ b/src/transformers/initialization.py
@@ -165,7 +165,7 @@ def copy_(tensor: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
 # Here, we need to check several modules imported, and hot patch all of them, as sometimes torch does
 # something like `from torch.nn.init import xavier_uniform_` in their internals (e.g in torch.nn.modules.activations,
 # where MultiHeadAttention lives), so the function name is binded at import time and just doing
-# `setattr(torch.nn.init, name, gloabls()[name])` is thus not enough
+# `setattr(torch.nn.init, name, globals()[name])` is thus not enough
 # The following list should be enough for all torch versions we work with
 TORCH_MODULES_TO_PATCH = (
     "torch.nn.init",

--- a/src/transformers/initialization.py
+++ b/src/transformers/initialization.py
@@ -168,6 +168,7 @@ def copy_(tensor: torch.Tensor, other: torch.Tensor) -> torch.Tensor:
 TORCH_MODULES_TO_PATCH = (
     torch.nn.init,
     torch.nn.modules.activation,
+    torch.nn.modules.transformer,
 )
 
 

--- a/src/transformers/initialization.py
+++ b/src/transformers/initialization.py
@@ -193,10 +193,10 @@ def guard_torch_init_functions():
     originals = defaultdict(dict)
     try:
         # Replace all torch funcs by the ones in this file
-        for func_name in TORCH_INIT_FUNCTIONS.keys():
-            for module_name in TORCH_MODULES_TO_PATCH:
-                if module_name in sys.modules:
-                    module = sys.modules[module_name]
+        for module_name in TORCH_MODULES_TO_PATCH:
+            if module_name in sys.modules:
+                module = sys.modules[module_name]
+                for func_name in TORCH_INIT_FUNCTIONS.keys():
                     if hasattr(module, func_name):
                         originals[module][func_name] = getattr(module, func_name)
                         setattr(module, func_name, globals()[func_name])


### PR DESCRIPTION
# What does this PR do?

`sys.modules` can end-up being quite large, especially when using `pytest`. This avoids the loop while keeping the benefits