### PR TITLE
Correctly create tied key mapping in post_init, and dynamic tie weight

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2350,9 +2350,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 if isinstance(submodule, PreTrainedModel):
                     # Will dynamically check the config if it has changed
                     submodel_tied_weights = submodule.get_expanded_tied_weights_keys(all_submodels=False)
-                    expanded_tied_weights.update(
-                        {f"{prefix}.{k}": f"{prefix}.{v}" for k, v in submodel_tied_weights.items()}
-                    )
+                    if prefix != "":
+                        submodel_tied_weights = {f"{prefix}.{k}": f"{prefix}.{v}" for k, v in submodel_tied_weights.items()}
+                    expanded_tied_weights.update(submodel_tied_weights)
             return expanded_tied_weights
 
         tied_mapping = self._tied_weights_keys

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2432,7 +2432,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 or len(target_params) % len(source_params) != 0
             ):
                 raise ValueError(
-                    f"There is an issue with your definition of `tie_weights_keys` for {source_name}:{target_name}. We found {source_params} to tie into {target_params}"
+                    f"There is an issue with your definition of `tie_weights_keys` for {source_name}:{target_name}. "
+                    f"We found {source_params} to tie into {target_params}"
                 )
             # we cycle source as it should be dispatch in many target if regex
             for target_n, source_n in zip(target_params, cycle(source_params)):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2363,8 +2363,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         elif tied_mapping is None:
             return {}
         # Short-cut for the most common cases: if the tied weights mapping only contains already expanded params,
-        # return it directly (the regex matches names containing only letters, numbers, dots, underscores, and finishing by
-        # "bias" or "weight")
+        # return it directly (the regex matches names containing only letters, numbers, dots, and underscores to make
+        # sure it does not contain a regex pattern, and finishing by "bias" or "weight" to make sure it's not a module)
         common_case_regex = re.compile(r"^[A-Za-z0-9_\.]+(weight)|(bias)$")
         if all(common_case_regex.match(k) for k in tied_mapping.keys() | tied_mapping.values()):
             return tied_mapping.copy()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2472,6 +2472,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             if missing_keys is not None:
                 source_is_there = source_param_name not in missing_keys
                 target_is_there = target_param_name not in missing_keys
+                # If we tied correctly, remove the target from the missing keys
                 if source_is_there:
                     missing_keys.discard(target_param_name)
                 # If the source is not present, but the target is, the checkpoint is corrupted

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2368,8 +2368,21 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             'bbox_embed.1.layers.2.weight': 'bbox_embed.0.layers.2.weight',
             'bbox_embed.2.layers.0.bias': 'bbox_embed.0.layers.0.bias',
             'bbox_embed.2.layers.0.weight': 'bbox_embed.0.layers.0.weight',
-            'bbox_embed.2.layers.1.bias': 'bbox_embed.0.layers.1.bias',
-            'bbox_embed.2.layers.1.weight': 'bbox_embed.0.layers.1.weight',
+            ...
+            'class_embed.1.bias': 'class_embed.0.bias',
+            'class_embed.1.weight': 'class_embed.0.weight',
+            'class_embed.2.bias': 'class_embed.0.bias',
+            'class_embed.2.weight': 'class_embed.0.weight',
+            ...
+            'model.decoder.class_embed.0.bias': 'class_embed.0.bias',
+            'model.decoder.class_embed.0.weight': 'class_embed.0.weight',
+            'model.decoder.class_embed.1.bias': 'class_embed.0.bias',
+            'model.decoder.class_embed.1.weight': 'class_embed.0.weight',
+            ...
+            'model.decoder.bbox_embed.0.layers.0.bias': 'bbox_embed.0.layers.0.bias',
+            'model.decoder.bbox_embed.0.layers.0.weight': 'bbox_embed.0.layers.0.weight',
+            'model.decoder.bbox_embed.0.layers.1.bias': 'bbox_embed.0.layers.1.bias',
+            'model.decoder.bbox_embed.0.layers.1.weight': 'bbox_embed.0.layers.1.weight',
             ...
         }
         ```
@@ -2377,7 +2390,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """
         if all_submodels:
             expanded_tied_weights = {}
-            for prefix, submodule in self.named_modules():
+            for prefix, submodule in self.named_modules(remove_duplicate=False):
                 if isinstance(submodule, PreTrainedModel):
                     # Will dynamically check the config if it has changed
                     submodel_tied_weights = submodule.get_expanded_tied_weights_keys(all_submodels=False)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2474,13 +2474,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 target_is_there = target_param_name not in missing_keys
                 if source_is_there:
                     missing_keys.discard(target_param_name)
-                # If the source is not present, the checkpoint is corrupted
-                else:
-                    target_present = "not present either" if not target_is_there else "present"
+                # If the source is not present, but the target is, the checkpoint is corrupted
+                # TODO: maybe we could simply tie in the opposite direction here instead of error?
+                elif target_is_there:
                     raise ValueError(
                         f"This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie "
                         f"{source_param_name} (which should be present and is not), to {target_param_name} (which is "
-                        f"{target_present})"
+                        f"present)."
                     )
 
     def _adjust_bias(self, output_embeddings, input_embeddings):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2453,7 +2453,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         Tie the model weights. If `recompute_mapping=False` (default when called internally), it will rely on the
         `model.all_tied_weights_keys` attribute, containing the `{target: source}` mapping for the tied params.
         If `recompute_mapping=True`, it will re-check all internal submodels and their config to determine the params
-        that need to be tied.
+        that need to be tied. This is the default when `model.tie_weights()` is called on its own, outside of
+        `__init__`, and `from_pretrained`, in case the config values were changed somewhere.
         """
         # In this case, the keys stored in `all_tied_weights_keys` are already correct
         if not recompute_mapping:

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -732,8 +732,6 @@ class EsmForMaskedLM(EsmPreTrainedModel):
         self.esm = EsmModel(config, add_pooling_layer=False)
         self.lm_head = EsmLMHead(config)
 
-        self.init_weights()
-
         self.post_init()
 
     def get_output_embeddings(self):

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -826,8 +826,6 @@ class EsmForSequenceClassification(EsmPreTrainedModel):
         self.esm = EsmModel(config, add_pooling_layer=False)
         self.classifier = EsmClassificationHead(config)
 
-        self.init_weights()
-
         self.post_init()
 
     @can_return_tuple
@@ -900,8 +898,6 @@ class EsmForTokenClassification(EsmPreTrainedModel):
         self.esm = EsmModel(config, add_pooling_layer=False)
         self.dropout = nn.Dropout(config.hidden_dropout_prob)
         self.classifier = nn.Linear(config.hidden_size, config.num_labels)
-
-        self.init_weights()
 
         self.post_init()
 

--- a/src/transformers/models/hubert/modeling_hubert.py
+++ b/src/transformers/models/hubert/modeling_hubert.py
@@ -993,7 +993,7 @@ class HubertForCTC(HubertPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -1111,7 +1111,7 @@ class IdeficsForVisionText2Text(IdeficsPreTrainedModel, GenerationMixin):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         Overwrite `transformers.modeling_utils.PreTrainedModel.tie_weights` to handle the case of
         IdeficsDecoupledLinear and IdeficsDecoupledEmbedding.

--- a/src/transformers/models/sew/modeling_sew.py
+++ b/src/transformers/models/sew/modeling_sew.py
@@ -857,7 +857,7 @@ class SEWForCTC(SEWPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -1400,7 +1400,7 @@ class SEWDForCTC(SEWDPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/src/transformers/models/unispeech/modeling_unispeech.py
+++ b/src/transformers/models/unispeech/modeling_unispeech.py
@@ -1210,7 +1210,7 @@ class UniSpeechForCTC(UniSpeechPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
+++ b/src/transformers/models/unispeech_sat/modeling_unispeech_sat.py
@@ -1206,7 +1206,7 @@ class UniSpeechSatForCTC(UniSpeechSatPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/src/transformers/models/wav2vec2/modeling_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/modeling_wav2vec2.py
@@ -1684,7 +1684,7 @@ class Wav2Vec2ForCTC(Wav2Vec2PreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/src/transformers/models/wavlm/modeling_wavlm.py
+++ b/src/transformers/models/wavlm/modeling_wavlm.py
@@ -1135,7 +1135,7 @@ class WavLMForCTC(WavLMPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys=None):
+    def tie_weights(self, **kwargs):
         """
         This method overwrites [`~PreTrainedModel.tie_weights`] so that adapter weights can be correctly loaded when
         passing `target_lang=...` to `from_pretrained(...)`.

--- a/tests/models/openai/test_modeling_openai.py
+++ b/tests/models/openai/test_modeling_openai.py
@@ -269,6 +269,13 @@ class OpenAIGPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         model = OpenAIGPTModel.from_pretrained(model_name)
         self.assertIsNotNone(model)
 
+    @unittest.skip("Tied weights mapping is reversed, so this is supposed to error out")
+    def test_correct_missing_keys(self):
+        # openai defines `_tied_weights_keys = {"transformer.tokens_embed.weight": "lm_head.weight"}` instead
+        # of the usual `_tied_weights_keys = {"lm_head.weight": "transformer.tokens_embed.weight"}`, so removing
+        # the head parameters actually removes the source weight, so this test is supposed to fail
+        pass
+
 
 @require_torch
 class OPENAIGPTModelLanguageGenerationTest(unittest.TestCase):

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -180,7 +180,7 @@ if is_torch_available():
         def forward(self, x):
             return self.linear_2(self.linear(x))
 
-        def tie_weights(self, missing_keys=None):
+        def tie_weights(self, missing_keys=None, **kwargs):
             self.linear_2.weight = self.linear.weight
             if missing_keys is not None:
                 missing_keys.discard("linear_2.weight")
@@ -254,7 +254,7 @@ if is_torch_available():
         def forward(self, x):
             return self.decoder(self.base(x))
 
-        def tie_weights(self, missing_keys=None):
+        def tie_weights(self, missing_keys=None, **kwargs):
             self.decoder.weight = self.base.linear.weight
             if missing_keys is not None:
                 missing_keys.discard("decoder.weight")


### PR DESCRIPTION
As we rely more and more in `self.all_tied_weight_keys` everywhere (i.e. the list of tied keys obtained during `post_init`) for multiple manipulations (device_map computation, cuda warmup, post-processing of `from_pretrained`...), it becomes very important that the (few) models containing regex patterns for their `_tied_weights_keys` mapping have the patterns expanded to fit in `all_tied_weight_keys` as well, instead of containing simple patterns that are skipped in different ways for all downstream application.
This PR fixes that, by expanding correctly at `post_init` time, so the mapping are correct params everywhere.
Also allows for recomputing this mapping in `tie_weights` dynamically, so that it is correct if calling `tie_weights` after having modified the config