### PR TITLE
Enable glm46v UTs on XPU

### DIFF
--- a/tests/models/glm46v/test_modeling_glm46v.py
+++ b/tests/models/glm46v/test_modeling_glm46v.py
@@ -29,7 +29,7 @@ from transformers.testing_utils import (
     require_deterministic_for_xpu,
     require_flash_attn,
     require_torch,
-    require_torch_gpu,
+    require_torch_accelerator,
     slow,
     torch_device,
 )
@@ -512,7 +512,7 @@ class Glm46VIntegrationTest(unittest.TestCase):
 
     @slow
     @require_flash_attn
-    @require_torch_gpu
+    @require_torch_accelerator
     def test_small_model_integration_test_batch_flashatt2(self):
         model = Glm46VForConditionalGeneration.from_pretrained(
             "THUDM/GLM-4.1V-9B-Thinking",
@@ -547,7 +547,7 @@ class Glm46VIntegrationTest(unittest.TestCase):
 
     @slow
     @require_flash_attn
-    @require_torch_gpu
+    @require_torch_accelerator
     def test_small_model_integration_test_batch_wo_image_flashatt2(self):
         model = Glm46VForConditionalGeneration.from_pretrained(
             "THUDM/GLM-4.1V-9B-Thinking",


### PR DESCRIPTION
# What does this PR do?

This PR enabled testing of `glm46v` on XPU.

**Notes:**

1. [General] Directly running `Glm46VIntegrationTest` currently fails with error: 
```
FAILED tests/models/glm46v/test_modeling_glm46v.py::Glm46VIntegrationTest::test_small_model_integration_test_batch_flashatt2 - RuntimeError: Expected tensor for argument #1 'indices' to have one of the following scalar types: Long, Int; but got XPUBFloat16Type instead (while checking argumen...
```
Need to wait for `zai-org/GLM-4.1V-9B-Thinking` PR [21](https://huggingface.co/zai-org/GLM-4.1V-9B-Thinking/discussions/21) to be merged, or use the workaround: change [here](https://github.com/huggingface/transformers/blob/a5c903f877fda21e739027eed133e03162eb7712/src/transformers/models/glm46v/modeling_glm46v.py#L90) to `self.visual = AutoModel.from_config(config.vision_config.vision_config)`.

2. [XPU] Tests related to `flash_attention_2` need to wait for PR [41956](https://github.com/huggingface/transformers/pull/41956) to be merged.