### PR TITLE
docs: clarify recommended usage of max_new_tokens in generate()

### DIFF
--- a/docs/source/en/main_classes/text_generation.md
+++ b/docs/source/en/main_classes/text_generation.md
@@ -42,3 +42,8 @@ like token streaming.
 [[autodoc]] GenerationMixin
     - generate
     - compute_transition_scores
+
+
+> **Note**  
+> `max_new_tokens` is now the recommended argument to control how many tokens the model generates.  
+> `max_length` remains for backward compatibility because it includes the length of the input prompt, which can be less intuitive.


### PR DESCRIPTION
# What does this PR do?

This PR updates the documentation for the `generate()` method by clarifying that `max_new_tokens` is now the recommended argument for controlling output length, while `max_length` remains for backward compatibility.

## Before submitting
- [x] This PR fixes a typo or improves the docs

## Who can review?
@stevhliu