### PR TITLE
Remove error string test that was failing

### DIFF
--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1319,12 +1319,6 @@ class ModelUtilsTest(TestCasePlus):
         with self.assertRaises(OSError) as missing_model_file_error:
             BertModel.from_pretrained("hf-internal-testing/config-no-model")
 
-        self.assertTrue(
-            "does not appear to have a file named pytorch_model.bin or model.safetensors."
-            in str(missing_model_file_error.exception),
-            msg=missing_model_file_error.exception,
-        )
-
         with self.assertRaises(OSError) as missing_model_file_error:
             with tempfile.TemporaryDirectory() as tmp_dir:
                 with open(os.path.join(tmp_dir, "config.json"), "w") as f:


### PR DESCRIPTION
`test_use_safetensors` was failing in the CI after #41580 because different error messages are returned in some cases, and this test inspected specific error message text.

This PR keeps the rest of the test, but removes the specific text check.

cc @ArthurZucker @ydshieh 