### PR TITLE
Allow LayoutLMV3Processor to accept rescale_factor

### DIFF
--- a/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
@@ -188,10 +188,7 @@ class LayoutLMv3ImageProcessor(BaseImageProcessor):
         self.size = size
         self.resample = resample
         self.do_rescale = do_rescale
-        if "rescale_factor" in kwargs:
-            self.rescale_factor = kwargs["rescale_factor"]
-        else:
-            self.rescale_factor = rescale_value
+        self.rescale_factor = kwargs.get("rescale_factor", rescale_value)
         self.do_normalize = do_normalize
         self.image_mean = image_mean if image_mean is not None else IMAGENET_STANDARD_MEAN
         self.image_std = image_std if image_std is not None else IMAGENET_STANDARD_STD

--- a/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
@@ -188,7 +188,10 @@ class LayoutLMv3ImageProcessor(BaseImageProcessor):
         self.size = size
         self.resample = resample
         self.do_rescale = do_rescale
-        self.rescale_factor = rescale_value
+        if "rescale_factor" in kwargs:
+            self.rescale_factor = kwargs["rescale_factor"]
+        else:
+            self.rescale_factor = rescale_value
         self.do_normalize = do_normalize
         self.image_mean = image_mean if image_mean is not None else IMAGENET_STANDARD_MEAN
         self.image_std = image_std if image_std is not None else IMAGENET_STANDARD_STD

--- a/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/image_processing_layoutlmv3.py
@@ -171,7 +171,7 @@ class LayoutLMv3ImageProcessor(BaseImageProcessor):
         size: Optional[dict[str, int]] = None,
         resample: PILImageResampling = PILImageResampling.BILINEAR,
         do_rescale: bool = True,
-        rescale_value: float = 1 / 255,
+        rescale_factor: float = 1 / 255,
         do_normalize: bool = True,
         image_mean: Optional[Union[float, Iterable[float]]] = None,
         image_std: Optional[Union[float, Iterable[float]]] = None,
@@ -188,7 +188,9 @@ class LayoutLMv3ImageProcessor(BaseImageProcessor):
         self.size = size
         self.resample = resample
         self.do_rescale = do_rescale
-        self.rescale_factor = kwargs.get("rescale_factor", rescale_value)
+        # The standard name is rescale_factor, but this processor accepted rescale_value for a long time,
+        # so allow it as a kwarg for backward compatibility
+        self.rescale_factor = kwargs.get("rescale_value", rescale_factor)
         self.do_normalize = do_normalize
         self.image_mean = image_mean if image_mean is not None else IMAGENET_STANDARD_MEAN
         self.image_std = image_std if image_std is not None else IMAGENET_STANDARD_STD


### PR DESCRIPTION
`test_image_processor_defaults_preserved_by_image_kwargs` is flaky for models that use the `LayoutLMV3Processor`, which causes annoying intermittent CI failures, especially for `UDOP`. The cause is that `LayoutLMV3Processor` expects `rescale_value`, not the standard `rescale_factor`, but the test depends on `rescale_factor` being accepted. This PR allows `LayoutLMV3Processor` to accept `rescale_factor`, but I'm not sure if this is the optimal solution. cc @molbap @yonigozlan @zucchini-nlp 

Note that no other models use `rescale_value` - it's just LayoutLMV3! I suspect this issue was also the cause of several other flaky tests in `test_processing_common`