### PR TITLE
Issue 42197 resolve

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2642,9 +2642,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             if module.bias is not None:
                 module.bias.data.zero_()
         elif isinstance(module, nn.Embedding):
-            module.weight.data.normal_(mean=0.0, std=std)
-            if module.padding_idx is not None:
-                module.weight.data[module.padding_idx].zero_()
+            if module.weight.numel() > 0:
+                module.weight.data.normal_(mean=0.0, std=std)
+                if module.padding_idx is not None:
+                    if(hasattr(module,'padding_idx')
+                       and module.padding_idx is not None
+                       and 0<= module.padding_idx < module.weight.size(0)):
+                       module.weight.data[module.padding_idx].zero_()
         elif isinstance(module, nn.MultiheadAttention):
             # This uses torch's original init
             module._reset_parameters()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -48,7 +48,12 @@ from .configuration_utils import PreTrainedConfig
 from .distributed import DistributedConfig
 from .dynamic_module_utils import custom_object_save
 from .generation import CompileConfig, GenerationConfig
-from .integrations import PeftAdapterMixin, deepspeed_config, is_deepspeed_zero3_enabled, is_fsdp_enabled
+from .integrations import (
+    PeftAdapterMixin,
+    deepspeed_config,
+    is_deepspeed_zero3_enabled,
+    is_fsdp_enabled,
+)
 from .integrations.accelerate import (
     _get_device_map,
     accelerate_disk_offload,
@@ -115,7 +120,11 @@ from .utils import (
     logging,
 )
 from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder
-from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
+from .utils.hub import (
+    DownloadKwargs,
+    create_and_tag_model_card,
+    get_checkpoint_shard_files,
+)
 from .utils.import_utils import (
     ENV_VARS_TRUE_VALUES,
     is_huggingface_hub_greater_or_equal,
@@ -724,7 +733,10 @@ def load_shard_file(args):
     # If shard_file is "", we use the existing state_dict instead of loading it
     if shard_file != "":
         state_dict = load_state_dict(
-            shard_file, is_quantized=is_quantized, map_location=map_location, weights_only=weights_only
+            shard_file,
+            is_quantized=is_quantized,
+            map_location=map_location,
+            weights_only=weights_only,
         )
 
     # Fix the key names
@@ -854,36 +866,64 @@ def _get_resolved_checkpoint_files(
         if is_local:
             if transformers_explicit_filename is not None:
                 # If the filename is explicitly defined, load this by default.
-                archive_file = os.path.join(pretrained_model_name_or_path, subfolder, transformers_explicit_filename)
+                archive_file = os.path.join(
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    transformers_explicit_filename,
+                )
                 is_sharded = transformers_explicit_filename.endswith(".safetensors.index.json")
             elif use_safetensors is not False and os.path.isfile(
-                os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(SAFE_WEIGHTS_NAME, variant))
+                os.path.join(
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(SAFE_WEIGHTS_NAME, variant),
+                )
             ):
                 # Load from a safetensors checkpoint
                 archive_file = os.path.join(
-                    pretrained_model_name_or_path, subfolder, _add_variant(SAFE_WEIGHTS_NAME, variant)
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(SAFE_WEIGHTS_NAME, variant),
                 )
             elif use_safetensors is not False and os.path.isfile(
-                os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(SAFE_WEIGHTS_INDEX_NAME, variant))
+                os.path.join(
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(SAFE_WEIGHTS_INDEX_NAME, variant),
+                )
             ):
                 # Load from a sharded safetensors checkpoint
                 archive_file = os.path.join(
-                    pretrained_model_name_or_path, subfolder, _add_variant(SAFE_WEIGHTS_INDEX_NAME, variant)
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(SAFE_WEIGHTS_INDEX_NAME, variant),
                 )
                 is_sharded = True
             elif not use_safetensors and os.path.isfile(
-                os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant))
+                os.path.join(
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(WEIGHTS_NAME, variant),
+                )
             ):
                 # Load from a PyTorch checkpoint
                 archive_file = os.path.join(
-                    pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant)
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(WEIGHTS_NAME, variant),
                 )
             elif not use_safetensors and os.path.isfile(
-                os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_INDEX_NAME, variant))
+                os.path.join(
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(WEIGHTS_INDEX_NAME, variant),
+                )
             ):
                 # Load from a sharded PyTorch checkpoint
                 archive_file = os.path.join(
-                    pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_INDEX_NAME, variant)
+                    pretrained_model_name_or_path,
+                    subfolder,
+                    _add_variant(WEIGHTS_INDEX_NAME, variant),
                 )
                 is_sharded = True
             elif use_safetensors:
@@ -957,7 +997,9 @@ def _get_resolved_checkpoint_files(
                         # This repo has no safetensors file of any kind, we switch to PyTorch.
                         filename = _add_variant(WEIGHTS_NAME, variant)
                         resolved_archive_file = cached_file(
-                            pretrained_model_name_or_path, filename, **cached_file_kwargs
+                            pretrained_model_name_or_path,
+                            filename,
+                            **cached_file_kwargs,
                         )
                 if resolved_archive_file is None and filename == _add_variant(WEIGHTS_NAME, variant):
                     # Maybe the checkpoint is sharded, we try to grab the index name in this case.
@@ -998,13 +1040,20 @@ def _get_resolved_checkpoint_files(
                                 **has_file_kwargs,
                             }
                             if (
-                                not has_file(pretrained_model_name_or_path, safe_weights_name, **has_file_kwargs)
+                                not has_file(
+                                    pretrained_model_name_or_path,
+                                    safe_weights_name,
+                                    **has_file_kwargs,
+                                )
                                 and not is_remote_code
                             ):
                                 Thread(
                                     target=auto_conversion,
                                     args=(pretrained_model_name_or_path,),
-                                    kwargs={"ignore_errors_during_conversion": True, **cached_file_kwargs},
+                                    kwargs={
+                                        "ignore_errors_during_conversion": True,
+                                        **cached_file_kwargs,
+                                    },
                                     name="Thread-auto_conversion",
                                 ).start()
                     else:
@@ -1017,7 +1066,9 @@ def _get_resolved_checkpoint_files(
                             "local_files_only": local_files_only,
                         }
                         if variant is not None and has_file(
-                            pretrained_model_name_or_path, WEIGHTS_NAME, **has_file_kwargs
+                            pretrained_model_name_or_path,
+                            WEIGHTS_NAME,
+                            **has_file_kwargs,
                         ):
                             raise OSError(
                                 f"{pretrained_model_name_or_path} does not appear to have a file named"
@@ -1126,7 +1177,9 @@ def _get_dtype(
                         dtype = get_state_dict_dtype(state_dict)
                     else:
                         state_dict = load_state_dict(
-                            checkpoint_files[0], map_location="meta", weights_only=weights_only
+                            checkpoint_files[0],
+                            map_location="meta",
+                            weights_only=weights_only,
                         )
                         dtype = get_state_dict_dtype(state_dict)
                     logger.info(
@@ -1253,7 +1306,10 @@ def _find_mismatched_keys(
         # If shard_file is "", we use the existing state_dict instead of loading it
         if shard_file != "":
             state_dict = load_state_dict(
-                shard_file, is_quantized=is_quantized, map_location="meta", weights_only=weights_only
+                shard_file,
+                is_quantized=is_quantized,
+                map_location="meta",
+                weights_only=weights_only,
             )
 
         # Fix the key names
@@ -1370,7 +1426,8 @@ class ModuleUtilsMixin:
     def create_extended_attention_mask_for_decoder(input_shape, attention_mask, device=None):
         if device is not None:
             warnings.warn(
-                "The `device` argument is deprecated and will be removed in v5 of Transformers.", FutureWarning
+                "The `device` argument is deprecated and will be removed in v5 of Transformers.",
+                FutureWarning,
             )
         else:
             device = attention_mask.device
@@ -1384,7 +1441,11 @@ class ModuleUtilsMixin:
             prefix_seq_len = attention_mask.shape[1] - causal_mask.shape[1]
             causal_mask = torch.cat(
                 [
-                    torch.ones((batch_size, seq_length, prefix_seq_len), device=device, dtype=causal_mask.dtype),
+                    torch.ones(
+                        (batch_size, seq_length, prefix_seq_len),
+                        device=device,
+                        dtype=causal_mask.dtype,
+                    ),
                     causal_mask,
                 ],
                 axis=-1,
@@ -1419,7 +1480,8 @@ class ModuleUtilsMixin:
             # show warning only if it won't be shown in `create_extended_attention_mask_for_decoder`
             if device is not None:
                 warnings.warn(
-                    "The `device` argument is deprecated and will be removed in v5 of Transformers.", FutureWarning
+                    "The `device` argument is deprecated and will be removed in v5 of Transformers.",
+                    FutureWarning,
                 )
         # We can provide a self-attention mask of dimensions [batch_size, from_seq_length, to_seq_length]
         # ourselves in which case we just need to make it broadcastable to all heads.
@@ -1525,7 +1587,9 @@ class ModuleUtilsMixin:
         return 0
 
     def floating_point_ops(
-        self, input_dict: dict[str, Union[torch.Tensor, Any]], exclude_embeddings: bool = True
+        self,
+        input_dict: dict[str, Union[torch.Tensor, Any]],
+        exclude_embeddings: bool = True,
     ) -> int:
         """
         Get number of (optionally, non-embeddings) floating-point operations for the forward and backward passes of a
@@ -2041,7 +2105,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # and memory copying it on CPU or each GPU first
             import deepspeed
 
-            init_contexts = [deepspeed.zero.Init(config_dict_or_path=deepspeed_config()), set_zero3_state()]
+            init_contexts = [
+                deepspeed.zero.Init(config_dict_or_path=deepspeed_config()),
+                set_zero3_state(),
+            ]
             with ContextManagers(init_contexts):
                 model = cls(config, **kwargs)
 
@@ -2637,7 +2704,17 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # 0.02 is the standard default value across the library
             std = getattr(self.config.get_text_config(), "initializer_range", 0.02)
 
-        if isinstance(module, (nn.Linear, nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.ConvTranspose1d, nn.ConvTranspose2d)):
+        if isinstance(
+            module,
+            (
+                nn.Linear,
+                nn.Conv1d,
+                nn.Conv2d,
+                nn.Conv3d,
+                nn.ConvTranspose1d,
+                nn.ConvTranspose2d,
+            ),
+        ):
             module.weight.data.normal_(mean=0.0, std=std)
             if module.bias is not None:
                 module.bias.data.zero_()
@@ -2645,10 +2722,12 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             if module.weight.numel() > 0:
                 module.weight.data.normal_(mean=0.0, std=std)
                 if module.padding_idx is not None:
-                    if(hasattr(module,'padding_idx')
-                       and module.padding_idx is not None
-                       and 0<= module.padding_idx < module.weight.size(0)):
-                       module.weight.data[module.padding_idx].zero_()
+                    if (
+                        hasattr(module, "padding_idx")
+                        and module.padding_idx is not None
+                        and 0 <= module.padding_idx < module.weight.size(0)
+                    ):
+                        module.weight.data[module.padding_idx].zero_()
         elif isinstance(module, nn.MultiheadAttention):
             # This uses torch's original init
             module._reset_parameters()
@@ -2741,7 +2820,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
     @staticmethod
     def _tie_encoder_decoder_weights(
-        encoder: nn.Module, decoder: nn.Module, base_model_prefix: str, base_encoder_name: str
+        encoder: nn.Module,
+        decoder: nn.Module,
+        base_model_prefix: str,
+        base_encoder_name: str,
     ):
         uninitialized_encoder_weights: list[str] = []
         tied_weights: list[str] = []
@@ -2787,9 +2869,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                     if name.isdigit():
                         encoder_name = str(int(name) + encoder_layer_pos)
                         decoder_name = name
-                        if not isinstance(decoder_modules[decoder_name], type(encoder_modules[encoder_name])) and len(
-                            encoder_modules
-                        ) != len(decoder_modules):
+                        if not isinstance(
+                            decoder_modules[decoder_name],
+                            type(encoder_modules[encoder_name]),
+                        ) and len(encoder_modules) != len(decoder_modules):
                             # this can happen if the name corresponds to the position in a list module list of layers
                             # in this case the decoder has added a cross-attention that the encoder does not have
                             # thus skip this step and subtract one layer pos from encoder
@@ -2820,7 +2903,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         # tie weights recursively
         tie_encoder_to_decoder_recursively(
-            decoder, encoder, base_model_prefix, base_encoder_name, uninitialized_encoder_weights
+            decoder,
+            encoder,
+            base_model_prefix,
+            base_encoder_name,
+            uninitialized_encoder_weights,
         )
 
         if len(uninitialized_encoder_weights) > 0:
@@ -2847,7 +2934,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if getattr(output_embeddings, "bias", None) is not None:
             output_embeddings.bias.data = nn.functional.pad(
                 output_embeddings.bias.data,
-                (0, output_embeddings.weight.shape[0] - output_embeddings.bias.shape[0]),
+                (
+                    0,
+                    output_embeddings.weight.shape[0] - output_embeddings.bias.shape[0],
+                ),
                 "constant",
                 0,
             )
@@ -3242,14 +3332,24 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                     params += [old_lm_head.bias]
                 with deepspeed.zero.GatheredParameters(params, modifier_rank=None):
                     self._init_added_lm_head_weights_with_mean(
-                        old_lm_head, new_lm_head, old_lm_head_dim, old_num_tokens, added_num_tokens, transposed
+                        old_lm_head,
+                        new_lm_head,
+                        old_lm_head_dim,
+                        old_num_tokens,
+                        added_num_tokens,
+                        transposed,
                     )
                     if has_new_lm_head_bias:
                         self._init_added_lm_head_bias_with_mean(old_lm_head, new_lm_head, added_num_tokens)
 
             else:
                 self._init_added_lm_head_weights_with_mean(
-                    old_lm_head, new_lm_head, old_lm_head_dim, old_num_tokens, added_num_tokens, transposed
+                    old_lm_head,
+                    new_lm_head,
+                    old_lm_head_dim,
+                    old_num_tokens,
+                    added_num_tokens,
+                    transposed,
                 )
                 if has_new_lm_head_bias:
                     self._init_added_lm_head_bias_with_mean(old_lm_head, new_lm_head, added_num_tokens)
@@ -3259,14 +3359,27 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if is_deepspeed_zero3_enabled() and not is_quantized:
             import deepspeed
 
-            params = [old_lm_head.weight, old_lm_head.bias, new_lm_head.weight, new_lm_head.bias]
+            params = [
+                old_lm_head.weight,
+                old_lm_head.bias,
+                new_lm_head.weight,
+                new_lm_head.bias,
+            ]
             with deepspeed.zero.GatheredParameters(params, modifier_rank=0):
                 self._copy_lm_head_original_to_resized(
-                    new_lm_head, old_lm_head, num_tokens_to_copy, transposed, has_new_lm_head_bias
+                    new_lm_head,
+                    old_lm_head,
+                    num_tokens_to_copy,
+                    transposed,
+                    has_new_lm_head_bias,
                 )
         else:
             self._copy_lm_head_original_to_resized(
-                new_lm_head, old_lm_head, num_tokens_to_copy, transposed, has_new_lm_head_bias
+                new_lm_head,
+                old_lm_head,
+                num_tokens_to_copy,
+                transposed,
+                has_new_lm_head_bias,
             )
 
         return new_lm_head
@@ -3324,7 +3437,12 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         new_lm_head.bias.data[-1 * added_num_tokens :].normal_(mean=bias_mean, std=1e-9 * bias_std)
 
     def _copy_lm_head_original_to_resized(
-        self, new_lm_head, old_lm_head, num_tokens_to_copy, transposed, has_new_lm_head_bias
+        self,
+        new_lm_head,
+        old_lm_head,
+        num_tokens_to_copy,
+        transposed,
+        has_new_lm_head_bias,
     ):
         # Copy old lm head weights to new lm head
         if not transposed:
@@ -3590,7 +3708,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                         "generation parameters in the model config, as opposed to in the generation config.",
                         UserWarning,
                     )
-                    for param_name, param_value in misplaced_generation_parameters.items():
+                    for (
+                        param_name,
+                        param_value,
+                    ) in misplaced_generation_parameters.items():
                         setattr(model_to_save.generation_config, param_name, param_value)
                         setattr(model_to_save.config, param_name, None)
 
@@ -3772,7 +3893,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         index = None
         if state_dict_split.is_sharded:
             index = {
-                "metadata": {"total_parameters": self.num_parameters(), **state_dict_split.metadata},
+                "metadata": {
+                    "total_parameters": self.num_parameters(),
+                    **state_dict_split.metadata,
+                },
                 "weight_map": state_dict_split.tensor_to_filename,
             }
 
@@ -3859,7 +3983,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if push_to_hub:
             # Eventually create an empty model card
             model_card = create_and_tag_model_card(
-                repo_id, self.model_tags, token=token, ignore_metadata_errors=ignore_metadata_errors
+                repo_id,
+                self.model_tags,
+                token=token,
+                ignore_metadata_errors=ignore_metadata_errors,
             )
 
             # Update model card if needed:
@@ -4025,7 +4152,12 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # We cannot initialize the model on meta device with deepspeed when not quantized
             if not is_quantized and not _is_ds_init_called:
                 logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
-                init_contexts.extend([deepspeed.zero.Init(config_dict_or_path=deepspeed_config()), set_zero3_state()])
+                init_contexts.extend(
+                    [
+                        deepspeed.zero.Init(config_dict_or_path=deepspeed_config()),
+                        set_zero3_state(),
+                    ]
+                )
             elif is_quantized:
                 init_contexts.extend([init_empty_weights(), set_quantized_state()])
         else:
@@ -4313,7 +4445,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             tp_plan = "auto"
 
         # Not used anymore -- remove them from the kwargs
-        for name in ["mirror", "_fast_init", "low_cpu_mem_usage", "from_tf", "from_flax", "offload_state_dict"]:
+        for name in [
+            "mirror",
+            "_fast_init",
+            "low_cpu_mem_usage",
+            "from_tf",
+            "from_flax",
+            "offload_state_dict",
+        ]:
             _ = kwargs.pop(name, None)
 
         # For BC on torch_dtype argument
@@ -4364,7 +4503,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         )
         device_map = check_and_set_device_map(device_map)  # warn, error and fix the device map
 
-        user_agent = {"file_type": "model", "framework": "pytorch", "from_auto_class": from_auto_class}
+        user_agent = {
+            "file_type": "model",
+            "framework": "pytorch",
+            "from_auto_class": from_auto_class,
+        }
         if from_pipeline is not None:
             user_agent["using_pipeline"] = from_pipeline
 
@@ -4444,7 +4587,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         # Find the correct dtype based on current state
         config, dtype, dtype_orig = _get_dtype(
-            cls, dtype, checkpoint_files, config, sharded_metadata, state_dict, weights_only
+            cls,
+            dtype,
+            checkpoint_files,
+            config,
+            sharded_metadata,
+            state_dict,
+            weights_only,
         )
 
         config.name_or_path = pretrained_model_name_or_path
@@ -4484,7 +4633,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             torch.set_default_dtype(dtype_orig)
 
         # Finalize model weight initialization
-        model, missing_keys, unexpected_keys, mismatched_keys, offload_index, error_msgs = cls._load_pretrained_model(
+        (
+            model,
+            missing_keys,
+            unexpected_keys,
+            mismatched_keys,
+            offload_index,
+            error_msgs,
+        ) = cls._load_pretrained_model(
             model,
             state_dict,
             checkpoint_files,
@@ -4520,7 +4676,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         # for device_map="auto" : dispatch model with hooks on all devices if necessary (not needed with a tp_plan, so we skip it as it slightly
         # harm performances).
         if device_map is not None and device_mesh is None:
-            accelerate_dispatch(model, hf_quantizer, device_map, offload_folder, offload_index, offload_buffers)
+            accelerate_dispatch(
+                model,
+                hf_quantizer,
+                device_map,
+                offload_folder,
+                offload_index,
+                offload_buffers,
+            )
 
         if hf_quantizer is not None:
             model.hf_quantizer = hf_quantizer
@@ -4560,14 +4723,26 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         # This rename is not logged.
         if hasattr(nn.utils.parametrizations, "weight_norm"):
             if key.endswith("weight_g"):
-                return key.replace("weight_g", "parametrizations.weight.original0"), True
+                return (
+                    key.replace("weight_g", "parametrizations.weight.original0"),
+                    True,
+                )
             if key.endswith("weight_v"):
-                return key.replace("weight_v", "parametrizations.weight.original1"), True
+                return (
+                    key.replace("weight_v", "parametrizations.weight.original1"),
+                    True,
+                )
         else:
             if key.endswith("parametrizations.weight.original0"):
-                return key.replace("parametrizations.weight.original0", "weight_g"), True
+                return (
+                    key.replace("parametrizations.weight.original0", "weight_g"),
+                    True,
+                )
             if key.endswith("parametrizations.weight.original1"):
-                return key.replace("parametrizations.weight.original1", "weight_v"), True
+                return (
+                    key.replace("parametrizations.weight.original1", "weight_v"),
+                    True,
+                )
 
         return key, False
 
@@ -4713,7 +4888,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         # Find missing and unexpected keys from the state dict
         missing_keys, unexpected_keys = _find_missing_and_unexpected_keys(
-            model, original_checkpoint_keys, checkpoint_keys, loading_base_model_from_task_state_dict, hf_quantizer
+            model,
+            original_checkpoint_keys,
+            checkpoint_keys,
+            loading_base_model_from_task_state_dict,
+            hf_quantizer,
         )
         # Find all the keys with shape mismatch (if we ignore the mismatch, the weights need to be newly initialized the
         # same way as missing keys)
@@ -4896,7 +5075,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 " to use it for predictions and inference."
             )
 
-        return model, missing_keys, unexpected_keys, mismatched_keys, disk_offload_index, error_msgs
+        return (
+            model,
+            missing_keys,
+            unexpected_keys,
+            mismatched_keys,
+            disk_offload_index,
+            error_msgs,
+        )
 
     def retrieve_modules_from_names(self, names, add_prefix=False, remove_prefix=False):
         module_keys = {".".join(key.split(".")[:-1]) for key in names}
@@ -5081,7 +5267,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         return cls._supports_attention_backend
 
     def _move_missing_keys_from_meta_to_cpu(
-        self, missing_keys: list[str], dtype: torch.dtype, hf_quantizer: Optional[HfQuantizer]
+        self,
+        missing_keys: list[str],
+        dtype: torch.dtype,
+        hf_quantizer: Optional[HfQuantizer],
     ) -> None:
         """Move the missing keys (keys that are part of the model parameters, but were NOT found in the loaded state dicts) back
         from meta device to cpu.
@@ -5155,7 +5344,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             self.initialize_weights()
 
     def _adjust_missing_and_unexpected_keys(
-        self, missing_keys: list[str], unexpected_keys: list[str], loading_task_model_from_base_state_dict: bool
+        self,
+        missing_keys: list[str],
+        unexpected_keys: list[str],
+        loading_task_model_from_base_state_dict: bool,
     ) -> tuple[list[str], list[str]]:
         """Adjust the `missing_keys` and `unexpected_keys` based on current model's exception rules, to avoid
         raising unneeded warnings/errors.
@@ -5295,7 +5487,11 @@ def is_accelerator_device(device: Union[str, int, torch.device]) -> bool:
         return torch.device(device).type not in ["meta", "cpu"]
 
 
-def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: dict, hf_quantizer: Optional[HfQuantizer]):
+def caching_allocator_warmup(
+    model: PreTrainedModel,
+    expanded_device_map: dict,
+    hf_quantizer: Optional[HfQuantizer],
+):
     """This function warm-ups the caching allocator based on the size of the model tensors that will reside on each
     device. It allows to have one large call to Malloc, instead of recursively calling it later when loading
     the model, which is actually the loading speed bottleneck.
@@ -5375,7 +5571,12 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: dict, 
             ) - torch_accelerator_module.memory_allocated(index)
             byte_count = max(0, byte_count - unused_memory)
         # Allocate memory
-        _ = torch.empty(byte_count // factor, dtype=torch.float16, device=device, requires_grad=False)
+        _ = torch.empty(
+            byte_count // factor,
+            dtype=torch.float16,
+            device=device,
+            requires_grad=False,
+        )
 
 
 class AttentionInterface(GeneralInterface):

--- a/test_gemma3_deepspeed.py
+++ b/test_gemma3_deepspeed.py
@@ -1,0 +1,71 @@
+# test_gemma3_deepspeed.py
+import torch
+from transformers import (
+    Gemma3ForConditionalGeneration,
+    Gemma3Config,
+    Trainer,
+    TrainingArguments,
+)
+import deepspeed
+import json
+
+# Create minimal config
+config = Gemma3Config(
+    vocab_size=1000,
+    hidden_size=512,
+    intermediate_size=1024,
+    num_hidden_layers=2,
+    num_attention_heads=8,
+    num_key_value_heads=4,
+    max_position_embeddings=1024,
+    pad_token_id=0,
+)
+
+# DeepSpeed ZeRO-3 config
+deepspeed_config = {
+    "train_batch_size": 4,
+    "gradient_accumulation_steps": 1,
+    "optimizer": {"type": "AdamW", "params": {"lr": 5e-5}},
+    "zero_optimization": {
+        "stage": 3,
+        "offload_optimizer": {"device": "cpu"},
+        "offload_param": {"device": "cpu"},
+    },
+    "fp16": {"enabled": True},
+}
+
+# Save config
+with open("deepspeed_config.json", "w") as f:
+    json.dump(deepspeed_config, f)
+
+
+def main():
+    model = Gemma3ForConditionalGeneration(config)
+    training_args = TrainingArguments(
+        output_dir="./test_output",
+        per_device_train_batch_size=1,
+        num_train_epochs=1,
+        deepspeed="deepspeed_config.json",
+        logging_steps=1,
+    )
+    dummy_data = [
+        {
+            "input_ids": torch.randint(0, 1000, (512,)),
+            "labels": torch.randint(0, 1000, (512,)),
+        }
+        for _ in range(4)
+    ]
+
+    # Initialize trainer
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=dummy_data,
+    )
+
+    print("Model initialized successfully with DeepSpeed ZeRO-3!")
+    return trainer
+
+
+if __name__ == "__main__":
+    trainer = main()

--- a/tests/test_gemma3_deepspeed.py
+++ b/tests/test_gemma3_deepspeed.py
@@ -1,22 +1,22 @@
-import pytest
-import torch
-import json
-import tempfile
 import os
+import tempfile
+
+import torch
+
 from transformers import (
-    Gemma3ForConditionalGeneration,
     Gemma3Config,
+    Gemma3ForConditionalGeneration,
     Trainer,
     TrainingArguments,
 )
-from transformers.testing_utils import (
-    require_deepspeed,
-    require_torch_accelerator,
-    TestCasePlus,
-    mockenv_context,
-)
 from transformers.integrations.deepspeed import (
     unset_hf_deepspeed_config,
+)
+from transformers.testing_utils import (
+    TestCasePlus,
+    mockenv_context,
+    require_deepspeed,
+    require_torch_accelerator,
 )
 
 
@@ -155,7 +155,12 @@ class TestGemma3DeepSpeed(TestCasePlus):  # Inherit from TestCasePlus
                     report_to=[],
                 )
 
-                dummy_dataset = [{"input_ids": torch.randint(0, 1000, (64,)), "labels": torch.randint(0, 1000, (64,))}]
+                dummy_dataset = [
+                    {
+                        "input_ids": torch.randint(0, 1000, (64,)),
+                        "labels": torch.randint(0, 1000, (64,)),
+                    }
+                ]
 
                 trainer = Trainer(
                     model=model,

--- a/tests/test_gemma3_deepspeed.py
+++ b/tests/test_gemma3_deepspeed.py
@@ -19,6 +19,7 @@ from transformers.integrations.deepspeed import (
     unset_hf_deepspeed_config,
 )
 
+
 # Use consistent naming and structure like existing tests
 @require_deepspeed
 @require_torch_accelerator  # Add this decorator
@@ -121,7 +122,7 @@ class TestGemma3DeepSpeed(TestCasePlus):  # Inherit from TestCasePlus
 
                 # Assertions following existing pattern
                 self.assertIsNotNone(trainer)
-                self.assertTrue(hasattr(trainer.model, 'config'))
+                self.assertTrue(hasattr(trainer.model, "config"))
                 self.assertEqual(trainer.model.config.vocab_size, 1000)
 
     def test_gemma3_basic_config_creation(self):

--- a/tests/test_gemma3_deepspeed.py
+++ b/tests/test_gemma3_deepspeed.py
@@ -1,0 +1,166 @@
+import pytest
+import torch
+import json
+import tempfile
+import os
+from transformers import (
+    Gemma3ForConditionalGeneration,
+    Gemma3Config,
+    Trainer,
+    TrainingArguments,
+)
+from transformers.testing_utils import (
+    require_deepspeed,
+    require_torch_accelerator,
+    TestCasePlus,
+    mockenv_context,
+)
+from transformers.integrations.deepspeed import (
+    unset_hf_deepspeed_config,
+)
+
+# Use consistent naming and structure like existing tests
+@require_deepspeed
+@require_torch_accelerator  # Add this decorator
+class TestGemma3DeepSpeed(TestCasePlus):  # Inherit from TestCasePlus
+    """Test DeepSpeed integration with Gemma3 models"""
+
+    def setUp(self):
+        """Setup method following existing pattern"""
+        super().setUp()
+
+        # Follow the existing pattern for distributed environment
+        master_port = self.get_master_port(real_launcher=False)
+        self.dist_env_1_gpu = {
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": master_port,
+            "RANK": "0",
+            "LOCAL_RANK": "0",
+            "WORLD_SIZE": "1",
+        }
+
+    def tearDown(self):
+        """Cleanup following existing pattern"""
+        super().tearDown()
+
+        # Reset deepspeed config global state
+        unset_hf_deepspeed_config()
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def get_master_port(self, real_launcher=False):
+        """Helper method from existing tests"""
+        master_port_base = os.environ.get("DS_TEST_PORT", "10999")
+        if not real_launcher:
+            master_port_base = str(int(master_port_base) + 1)
+        return master_port_base
+
+    def get_config_dict(self):
+        """Create deepspeed config following existing pattern"""
+        return {
+            "train_batch_size": 4,
+            "gradient_accumulation_steps": 1,
+            "optimizer": {"type": "AdamW", "params": {"lr": 5e-5}},
+            "zero_optimization": {
+                "stage": 3,
+                "offload_optimizer": {"device": "cpu"},
+                "offload_param": {"device": "cpu"},
+            },
+            "fp16": {"enabled": True},
+        }
+
+    def get_model_config(self):
+        """Create model config"""
+        return Gemma3Config(
+            vocab_size=1000,
+            hidden_size=512,
+            intermediate_size=1024,
+            num_hidden_layers=2,
+            num_attention_heads=8,
+            num_key_value_heads=4,
+            max_position_embeddings=1024,
+            pad_token_id=0,
+        )
+
+    def test_gemma3_deepspeed_zero3_initialization(self):
+        """Test DeepSpeed ZeRO-3 initialization with Gemma3"""
+        # Use mockenv_context like existing tests
+        with mockenv_context(**self.dist_env_1_gpu):
+            ds_config = self.get_config_dict()
+            model_config = self.get_model_config()
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model = Gemma3ForConditionalGeneration(model_config)
+
+                training_args = TrainingArguments(
+                    output_dir=tmp_dir,
+                    per_device_train_batch_size=1,
+                    num_train_epochs=1,
+                    deepspeed=ds_config,
+                    logging_steps=1,
+                    save_steps=999999,
+                    report_to=[],
+                    dataloader_num_workers=0,  # Avoid multiprocessing issues
+                )
+
+                # Create dummy dataset like existing tests
+                dummy_dataset = [
+                    {
+                        "input_ids": torch.randint(0, 1000, (128,)),  # Smaller size
+                        "labels": torch.randint(0, 1000, (128,)),
+                    }
+                    for _ in range(2)  # Fewer samples
+                ]
+
+                trainer = Trainer(
+                    model=model,
+                    args=training_args,
+                    train_dataset=dummy_dataset,
+                )
+
+                # Assertions following existing pattern
+                self.assertIsNotNone(trainer)
+                self.assertTrue(hasattr(trainer.model, 'config'))
+                self.assertEqual(trainer.model.config.vocab_size, 1000)
+
+    def test_gemma3_basic_config_creation(self):
+        """Test basic model configuration without DeepSpeed"""
+        model_config = self.get_model_config()
+        model = Gemma3ForConditionalGeneration(model_config)
+
+        self.assertEqual(model.config.vocab_size, 1000)
+        self.assertEqual(model.config.hidden_size, 512)
+        self.assertEqual(model.config.num_hidden_layers, 2)
+        self.assertEqual(model.config.num_attention_heads, 8)
+
+    @require_deepspeed
+    def test_gemma3_deepspeed_stage2(self):
+        """Test with DeepSpeed ZeRO Stage 2"""
+        with mockenv_context(**self.dist_env_1_gpu):
+            ds_config = self.get_config_dict()
+            ds_config["zero_optimization"]["stage"] = 2  # Change to stage 2
+
+            model_config = self.get_model_config()
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                model = Gemma3ForConditionalGeneration(model_config)
+
+                training_args = TrainingArguments(
+                    output_dir=tmp_dir,
+                    per_device_train_batch_size=1,
+                    max_steps=1,  # Just one step for testing
+                    deepspeed=ds_config,
+                    report_to=[],
+                )
+
+                dummy_dataset = [{"input_ids": torch.randint(0, 1000, (64,)), "labels": torch.randint(0, 1000, (64,))}]
+
+                trainer = Trainer(
+                    model=model,
+                    args=training_args,
+                    train_dataset=dummy_dataset,
+                )
+
+                # Just test initialization, not training
+                self.assertIsNotNone(trainer)


### PR DESCRIPTION
Fix offline model loading with subprocess cache warming

Improve cache resolution in cached_files() to properly locate models
downloaded in subprocess when loading offline. 

Changes:
- Enhanced cache directory lookup to check HF_HOME, TRANSFORMERS_CACHE, and HF_HUB_CACHE
- Added logic to search through snapshot directories when ref file is missing
- Return cached files early to avoid unnecessary download attempts

Tests:
- Test AutoModel/AutoTokenizer offline loading after subprocess download
- Test pipeline API offline loading with socket blocking
- Verify no network access attempts when cache is warm

