### PR TITLE
[WIP] Add moondream3 model

### DIFF
--- a/src/transformers/models/moondream3/configuration_moondream3.py
+++ b/src/transformers/models/moondream3/configuration_moondream3.py
@@ -1,0 +1,326 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional, List
+
+from transformers.configuration_utils import PretrainedConfig
+from transformers.modeling_rope_utils import RopeParameters, rope_config_validation, standardize_rope_params
+
+
+class Moondream3TextConfig(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`Moondream3TextModel`]. It is used to instantiate a
+    Moondream3 model according to the specified arguments, defining the model architecture.
+
+    Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PreTrainedConfig`] for more information.
+
+    Args:
+        vocab_size (`int`, *optional*, defaults to 51200):
+            Vocabulary size of the Moondream3 model.
+        hidden_size (`int`, *optional*, defaults to 2048):
+            Dimension of the hidden representations.
+        intermediate_size (`int`, *optional*, defaults to 8192):
+            Dimension of the MLP representations.
+        num_hidden_layers (`int`, *optional*, defaults to 24):
+            Number of hidden layers in the Transformer encoder.
+        num_attention_heads (`int`, *optional*, defaults to 32):
+            Number of attention heads for each attention layer in the Transformer encoder.
+        num_key_value_heads (`int`, *optional*, defaults to 32):
+            This is the number of key_value heads that should be used to implement Grouped Query Attention.
+        max_position_embeddings (`int`, *optional*, defaults to 4096):
+            The maximum sequence length that this model might ever be used with.
+        num_experts (`int`, *optional*, defaults to 64):
+            Number of experts for MoE layers.
+        num_experts_per_tok (`int`, *optional*, defaults to 8):
+            Number of selected experts per token.
+        moe_intermediate_size (`int`, *optional*, defaults to 1024):
+            Intermediate size of the routed expert.
+        moe_start_layer (`int`, *optional*, defaults to 4):
+            The layer index where MoE layers start.
+        bos_token_id (`int`, *optional*, defaults to 0):
+            The id of the beginning-of-sequence token.
+        eos_token_id (`int`, *optional*, defaults to 0):
+            The id of the end-of-sequence token.
+        coord_token_id (`int`, *optional*, defaults to 5):
+            The id of the coordinate token used for region detection.
+        hidden_act (`str` or `function`, *optional*, defaults to `"gelu_pytorch_tanh"`):
+            The non-linear activation function.
+        moe_hidden_act (`str` or `function`, *optional*, defaults to `"gelu"`):
+            The non-linear activation function used inside MoE experts.
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer.
+        rms_norm_eps (`float`, *optional*, defaults to 1e-5):
+            The epsilon used by the rms normalization layers.
+        use_cache (`bool`, *optional*, defaults to `True`):
+            Whether or not the model should return the last key/values attentions.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether the model's input and output word embeddings should be tied.
+        attention_bias (`bool`, *optional*, defaults to `False`):
+            Whether to use a bias in the query, key, value and output projection layers.
+        rope_parameters (`dict`, *optional*):
+            The dictionary containing parameters for RoPE (Rotary Positional Embeddings), such as `rope_theta` and `rope_type`.
+        head_dim (`int`, *optional*):
+            The dimension of the head. If not specified, will default to `hidden_size // num_attention_heads`.
+    """
+
+    model_type = "moondream3_text"
+    base_config_key = "text_config"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        vocab_size: int = 51200,
+        hidden_size: int = 2048,
+        intermediate_size: int = 8192,
+        num_hidden_layers: int = 24,
+        num_attention_heads: int = 32,
+        num_key_value_heads: int = 32,
+        max_position_embeddings: int = 4096,
+        num_experts: int = 64,
+        num_experts_per_tok: int = 8,
+        moe_intermediate_size: int = 1024,
+        moe_start_layer: int = 4,
+        bos_token_id: int = 0,
+        eos_token_id: int = 0,
+        coord_token_id: int = 5,
+        hidden_act: str = "gelu_pytorch_tanh",
+        moe_hidden_act: str = "gelu",
+        initializer_range: float = 0.02,
+        rms_norm_eps: float = 1e-5,
+        use_cache: bool = True,
+        tie_word_embeddings: bool = False,
+        attention_bias: bool = True,
+        rope_parameters: Optional[RopeParameters | dict[str, RopeParameters]] = None,
+        head_dim: Optional[int] = None,
+        **kwargs,
+    ):
+        self.vocab_size = vocab_size
+        self.max_position_embeddings = max_position_embeddings
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.num_key_value_heads = num_key_value_heads
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.rms_norm_eps = rms_norm_eps
+        self.use_cache = use_cache
+        self.attention_bias = attention_bias
+        self.head_dim = head_dim or hidden_size // num_attention_heads
+        self.bos_token_id = bos_token_id
+        self.coord_token_id = coord_token_id
+        self.eos_token_id = eos_token_id
+
+        # MoE parameters (merged from TextMoeConfig)
+        self.num_experts = num_experts
+        self.num_experts_per_tok = num_experts_per_tok
+        self.moe_intermediate_size = moe_intermediate_size
+        self.moe_start_layer = moe_start_layer
+        self.moe_hidden_act = moe_hidden_act
+
+        # Try to set `rope_scaling` if available, otherwise use `rope_parameters`
+        rope_scaling = kwargs.pop("rope_scaling", None)
+        self.rope_parameters = rope_scaling or rope_parameters
+
+        # Validate the correctness of rotary position embeddings parameters
+        rope_theta = kwargs.get("rope_theta", 1500000.0)
+        standardize_rope_params(self, rope_theta=rope_theta)
+        rope_config_validation(self)
+
+        # HF compatibility attributes
+        self.output_router_logits = False
+        self.output_attentions = False
+        self.output_hidden_states = False
+        self.attention_dropout = 0.0
+
+        super().__init__(tie_word_embeddings=tie_word_embeddings, **kwargs)
+
+
+class Moondream3VisionConfig(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of the Moondream3 vision encoder.
+
+    Args:
+        hidden_size (`int`, *optional*, defaults to 1152):
+            Dimension of the encoder's hidden states.
+        intermediate_size (`int`, *optional*, defaults to 4304):
+            Dimension of the encoder's MLP representations.
+        num_hidden_layers (`int`, *optional*, defaults to 27):
+            Number of hidden layers in the vision encoder.
+        num_attention_heads (`int`, *optional*, defaults to 16):
+            Number of attention heads in the vision encoder.
+        patch_size (`int`, *optional*, defaults to 14):
+            The size of each patch in the vision encoder.
+        in_channels (`int`, *optional*, defaults to 3):
+            Number of input channels.
+        proj_out_dim (`int`, *optional*, defaults to 2048):
+            Output dimension of the projection layer.
+        crop_size (`int`, *optional*, defaults to 378):
+            Size of image crops.
+        max_crops (`int`, *optional*, defaults to 12):
+            Maximum number of crops.
+        overlap_margin (`int`, *optional*, defaults to 4):
+            Overlap margin for crops.
+        proj_inner_dim (`int`, *optional*, defaults to 8192):
+            Inner dimension of the projection MLP.
+        prefix_len (`int`, *optional*, defaults to 730):
+            The number of tokens used to represent the visual input (prefix length).
+        hidden_act (`str`, *optional*, defaults to `"gelu_pytorch_tanh"`):
+            The non-linear activation function.
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            The standard deviation of the truncated_normal_initializer.
+        attention_bias (`bool`, *optional*, defaults to `True`):
+            Whether to use a bias in the query, key, value and output projection layers.
+    """
+
+    model_type = "moondream3_vision"
+    base_config_key = "vision_config"
+
+    def __init__(
+        self,
+        hidden_size: int = 1152,
+        intermediate_size: int = 4304,
+        num_hidden_layers: int = 27,
+        num_attention_heads: int = 16,
+        patch_size: int = 14,
+        in_channels: int = 3,
+        proj_out_dim: int = 2048,
+        crop_size: int = 378,
+        max_crops: int = 12,
+        overlap_margin: int = 4,
+        proj_inner_dim: int = 8192,
+        prefix_len: int = 730,
+        hidden_act: str = "gelu_pytorch_tanh",
+        initializer_range: float = 0.02,
+        attention_bias: bool = True,
+        **kwargs,
+    ):
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.num_hidden_layers = num_hidden_layers
+        self.num_attention_heads = num_attention_heads
+        self.patch_size = patch_size
+        self.in_channels = in_channels
+        self.proj_out_dim = proj_out_dim
+        self.crop_size = crop_size
+        self.max_crops = max_crops
+        self.prefix_len = prefix_len
+        self.overlap_margin = overlap_margin
+        self.proj_inner_dim = proj_inner_dim
+        self.hidden_act = hidden_act
+        self.initializer_range = initializer_range
+        self.attention_dropout = 0.0
+        self.attention_bias = attention_bias
+
+        super().__init__(**kwargs)
+
+
+class Moondream3RegionConfig(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of the Moondream3 region encoder for object detection and grounding.
+
+    Args:
+        hidden_size (`int`, *optional*, defaults to 2048):
+            Dimension of the hidden representations for region features.
+        coord_feat_dim (`int`, *optional*, defaults to 256):
+            Dimension of coordinate feature embeddings.
+        coord_out_dim (`int`, *optional*, defaults to 1024):
+            Output dimension for coordinate features.
+        size_feat_dim (`int`, *optional*, defaults to 512):
+            Dimension of size feature embeddings.
+        size_out_dim (`int`, *optional*, defaults to 2048):
+            Output dimension for size features.
+    """
+
+    model_type = "moondream3_region"
+    base_config_key = "region_config"
+
+    def __init__(
+        self,
+        hidden_size: int = 2048,
+        coord_feat_dim: int = 256,
+        coord_out_dim: int = 1024,
+        size_feat_dim: int = 512,
+        size_out_dim: int = 2048,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        self.hidden_size = hidden_size
+        self.coord_feat_dim = coord_feat_dim
+        self.coord_out_dim = coord_out_dim
+        self.size_feat_dim = size_feat_dim
+        self.size_out_dim = size_out_dim
+
+
+class Moondream3Config(PretrainedConfig):
+    r"""
+    This is the configuration class to store the configuration of a [`Moondream3Model`].
+
+    Args:
+        text_config (`Union[PreTrainedConfig, dict]`, *optional*, defaults to `Moondream3TextConfig`):
+            The config object or dictionary of the text backbone.
+        vision_config (`Union[PreTrainedConfig, dict]`, *optional*, defaults to `Moondream3VisionConfig`):
+            The config object or dictionary of the vision backbone.
+        region_config (`Union[PreTrainedConfig, dict]`, *optional*, defaults to `Moondream3RegionConfig`):
+            The config object or dictionary of the region backbone for object detection and grounding.
+        bos_token_id (`int`, *optional*, defaults to 0):
+            The id of the beginning-of-sequence token.
+        tie_word_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether to tie the word embeddings.
+    """
+
+    model_type = "moondream3"
+    sub_configs = {
+        "vision_config": Moondream3VisionConfig,
+        "text_config": Moondream3TextConfig,
+        "region_config": Moondream3RegionConfig,
+    }
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        text_config=None,
+        vision_config=None,
+        region_config=None,
+        bos_token_id=0,
+        tie_word_embeddings: bool = False,
+        **kwargs,
+    ):
+        if isinstance(vision_config, dict):
+            self.vision_config = self.sub_configs["vision_config"](**vision_config)
+        elif vision_config is None:
+            self.vision_config = self.sub_configs["vision_config"]()
+
+        if isinstance(text_config, dict):
+            self.text_config = self.sub_configs["text_config"](**text_config)
+        elif text_config is None:
+            self.text_config = self.sub_configs["text_config"]()
+
+        if isinstance(region_config, dict):
+            self.region_config = self.sub_configs["region_config"](**region_config)
+        elif region_config is None:
+            self.region_config = self.sub_configs["region_config"]()
+
+        super().__init__(**kwargs, tie_word_embeddings=tie_word_embeddings)
+
+
+__all__ = [
+    "Moondream3Config",
+    "Moondream3TextConfig",
+    "Moondream3VisionConfig",
+    "Moondream3RegionConfig",
+]

--- a/src/transformers/models/moondream3/convert_moondream_weights_to_hf.py
+++ b/src/transformers/models/moondream3/convert_moondream_weights_to_hf.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Dict
+
+from safetensors.torch import load_file
+from safetensors.torch import save_file
+
+
+# Key mapping from original Moondream to HF Moondream3
+OLD_KEY_TO_NEW_KEY_MAPPING = [
+    # Text model
+    (r"model\.text\.wte", "model.text_model.embed_tokens.weight"),
+    (r"model\.text\.post_ln\.(weight|bias)", r"model.text_model.norm.\1"),
+    (r"model\.text\.lm_head\.(weight|bias)", r"lm_head.\1"),
+    (
+        r"model\.text\.blocks\.(\d+)\.attn\.qkv\.(weight|bias)",
+        r"model.text_model.layers.\1.self_attn.qkv.\2",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.attn\.proj\.(weight|bias)",
+        r"model.text_model.layers.\1.self_attn.o_proj.\2",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.attn\.tau\.wq",
+        r"model.text_model.layers.\1.self_attn.tau_wq.weight",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.attn\.tau\.wv",
+        r"model.text_model.layers.\1.self_attn.tau_wv.weight",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.attn\.tau\.alpha",
+        r"model.text_model.layers.\1.self_attn.tau_alpha",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.ln\.(weight|bias)",
+        r"model.text_model.layers.\1.input_layernorm.\2",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.mlp\.fc1\.(weight|bias)",
+        r"model.text_model.layers.\1.mlp.up_proj.\2",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.mlp\.fc2\.(weight|bias)",
+        r"model.text_model.layers.\1.mlp.down_proj.\2",
+    ),
+    (
+        r"model\.text\.blocks\.(\d+)\.mlp\.router\.(weight|bias)",
+        r"model.text_model.layers.\1.mlp.gate.\2",
+    ),
+    # Vision model
+    (
+        r"model\.vision\.patch_emb\.(weight|bias)",
+        r"model.vision_model.embeddings.projection.\1",
+    ),
+    (r"model\.vision\.pos_emb", "model.vision_model.embeddings.position_embeddings"),
+    (r"model\.vision\.post_ln\.(weight|bias)", r"model.vision_model.post_layernorm.\1"),
+    (
+        r"model\.vision\.blocks\.(\d+)\.attn\.qkv\.(weight|bias)",
+        r"model.vision_model.layers.\1.self_attn.qkv.\2",
+    ),
+    (
+        r"model\.vision\.blocks\.(\d+)\.attn\.proj\.(weight|bias)",
+        r"model.vision_model.layers.\1.self_attn.o_proj.\2",
+    ),
+    (
+        r"model\.vision\.blocks\.(\d+)\.ln1\.(weight|bias)",
+        r"model.vision_model.layers.\1.input_layernorm.\2",
+    ),
+    (
+        r"model\.vision\.blocks\.(\d+)\.ln2\.(weight|bias)",
+        r"model.vision_model.layers.\1.post_attention_layernorm.\2",
+    ),
+    (
+        r"model\.vision\.blocks\.(\d+)\.mlp\.fc1\.(weight|bias)",
+        r"model.vision_model.layers.\1.mlp.up_proj.\2",
+    ),
+    (
+        r"model\.vision\.blocks\.(\d+)\.mlp\.fc2\.(weight|bias)",
+        r"model.vision_model.layers.\1.mlp.down_proj.\2",
+    ),
+    # Vision projection
+    (
+        r"model\.vision\.proj_mlp\.fc1\.(weight|bias)",
+        r"model.vision_model.vision_projection.up_proj.\1",
+    ),
+    (
+        r"model\.vision\.proj_mlp\.fc2\.(weight|bias)",
+        r"model.vision_model.vision_projection.down_proj.\1",
+    ),
+    # Region model
+    (
+        r"model\.region\.coord_encoder\.(weight|bias)",
+        r"model.region_encoder.coord_encoder.\1",
+    ),
+    (
+        r"model\.region\.coord_decoder\.(weight|bias)",
+        r"model.region_decoder.coord_decoder.\1",
+    ),
+    (
+        r"model\.region\.size_encoder\.(weight|bias)",
+        r"model.region_encoder.size_encoder.\1",
+    ),
+    (
+        r"model\.region\.size_decoder\.(weight|bias)",
+        r"model.region_decoder.size_decoder.\1",
+    ),
+    (r"model\.region\.coord_features", "model.region_encoder.coord_freq"),
+    (r"model\.region\.size_features", "model.region_encoder.size_freq"),
+]
+
+
+def rename_key(old_key: str) -> str:
+    """Convert original key name to HF key name."""
+    for pattern, new_key in OLD_KEY_TO_NEW_KEY_MAPPING:
+        if re.match(pattern, old_key):
+            return re.sub(pattern, new_key, old_key)
+    return old_key
+
+
+def convert_state_dict(original_state_dict: Dict) -> Dict:
+    """Convert original state dict to HF format."""
+    converted_state_dict = {}
+    converted_keys = []
+    for old_key, tensor in original_state_dict.items():
+        new_key = rename_key(old_key)
+
+        # Handle QKV weight splitting for attention
+        if "attn.qkv.weight" in old_key or "attn.qkv.bias" in old_key:
+            # Split QKV into separate Q, K, V matrices
+            layer_match = re.search(r"blocks\.(\d+)", old_key)
+            if layer_match:
+                layer_idx = int(layer_match.group(1))
+
+                # Determine if this is text or vision model
+                if "model.text.blocks" in old_key:
+                    n_heads = 32
+                    n_kv_heads = 32
+                    head_dim = 64  # 2048 / 32
+                    base_key = f"model.text_model.layers.{layer_idx}.self_attn"
+                else:  # vision
+                    n_heads = 16
+                    n_kv_heads = 16
+                    head_dim = 72  # 1152 / 16
+                    base_key = f"model.vision_model.layers.{layer_idx}.self_attn"
+
+                # Split tensor
+                q_dim = n_heads * head_dim
+                kv_dim = n_kv_heads * head_dim
+
+                if "weight" in old_key:
+                    q_weight = tensor[:q_dim]
+                    k_weight = tensor[q_dim : q_dim + kv_dim]
+                    v_weight = tensor[q_dim + kv_dim :]
+
+                    converted_state_dict[f"{base_key}.q_proj.weight"] = q_weight
+                    converted_state_dict[f"{base_key}.k_proj.weight"] = k_weight
+                    converted_state_dict[f"{base_key}.v_proj.weight"] = v_weight
+                    converted_keys.append(old_key)
+                else:  # bias
+                    q_bias = tensor[:q_dim]
+                    k_bias = tensor[q_dim : q_dim + kv_dim]
+                    v_bias = tensor[q_dim + kv_dim :]
+
+                    converted_state_dict[f"{base_key}.q_proj.bias"] = q_bias
+                    converted_state_dict[f"{base_key}.k_proj.bias"] = k_bias
+                    converted_state_dict[f"{base_key}.v_proj.bias"] = v_bias
+                    converted_keys.append(old_key)
+        # Handle MoE expert weight splitting
+        elif (
+            "mlp.fc1.weight" in old_key or "mlp.fc2.weight" in old_key
+        ) and not "proj_mlp" in old_key:
+            layer_match = re.search(r"blocks\.(\d+)", old_key)
+            if layer_match:
+                layer_idx = int(layer_match.group(1))
+                # Only process MoE layers (4+ in this model)
+                if layer_idx >= 4 and "model.text." in old_key:
+                    n_experts = 64  # From config
+
+                    if "fc1.weight" in old_key:
+                        # Shape: (n_experts, 2 * d_ffn, d_model) → split into individual experts
+                        for expert_idx in range(n_experts):
+                            expert_weight = tensor[
+                                expert_idx
+                            ]  # Shape: (2 * d_ffn, d_model)
+                            # For GeGLU, split into gate and up projections
+                            up_weight = expert_weight[
+                                : expert_weight.shape[0] // 2
+                            ]  # First half
+                            gate_weight = expert_weight[
+                                expert_weight.shape[0] // 2 :
+                            ]  # Second half
+
+                            converted_state_dict[
+                                f"model.text_model.layers.{layer_idx}.mlp.experts.{expert_idx}.gate_proj.weight"
+                            ] = gate_weight
+                            converted_state_dict[
+                                f"model.text_model.layers.{layer_idx}.mlp.experts.{expert_idx}.up_proj.weight"
+                            ] = up_weight
+                    elif "fc2.weight" in old_key:
+                        # Shape: (n_experts, d_model, d_ffn) → split into individual experts
+                        for expert_idx in range(n_experts):
+                            expert_weight = tensor[
+                                expert_idx
+                            ]  # Shape: (d_model, d_ffn)
+                            converted_state_dict[
+                                f"model.text_model.layers.{layer_idx}.mlp.experts.{expert_idx}.down_proj.weight"
+                            ] = expert_weight
+                else:
+                    # Dense MLP for layers < 4
+                    converted_state_dict[new_key] = tensor
+        else:
+            converted_state_dict[new_key] = tensor
+    return converted_state_dict
+
+
+def convert_moondream_weights_to_hf(
+    original_model_path: str,
+    output_file: str,
+):
+    """Convert Moondream weights to HuggingFace format."""
+
+    # Load original state dict
+    print(f"Loading original model from {original_model_path}")
+
+    # Find safetensors files
+    model_path = Path(original_model_path)
+    if model_path.is_file() and model_path.suffix == ".safetensors":
+        # Single file
+        original_state_dict = load_file(str(model_path))
+    elif model_path.is_dir():
+        # Directory - look for index file or single model file
+        index_path = model_path / "model.safetensors.index.json"
+        single_file_path = model_path / "model.safetensors"
+
+        if index_path.exists():
+            with open(index_path) as f:
+                index = json.load(f)
+
+            original_state_dict = {}
+            for filename in set(index["weight_map"].values()):
+                file_path = model_path / filename
+                if file_path.exists():
+                    state_dict = load_file(str(file_path))
+                    for k, v in state_dict.items():
+                        original_state_dict[k] = v
+                else:
+                    print(f"Warning: {file_path} not found")
+        elif single_file_path.exists():
+            original_state_dict = load_file(str(single_file_path))
+        else:
+            raise FileNotFoundError(
+                f"Could not find model files in {original_model_path}"
+            )
+    else:
+        raise FileNotFoundError(f"Could not find model files in {original_model_path}")
+
+    print(f"Loaded {len(original_state_dict)} tensors")
+
+    # Convert state dict
+    print("Converting state dict...")
+    converted_state_dict = convert_state_dict(original_state_dict)
+
+    print(f"Converted {len(converted_state_dict)} tensors")
+
+    # Save converted weights
+    output_path = Path(output_file)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"Saving converted weights to {output_path}")
+    save_file(converted_state_dict, str(output_path))
+
+    print(f"Converted weights saved to {output_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Moondream weights to HuggingFace format"
+    )
+    parser.add_argument(
+        "--input_path",
+        type=str,
+        required=True,
+        help="Path to original Moondream model directory or safetensors file",
+    )
+    parser.add_argument(
+        "--output_file",
+        type=str,
+        required=True,
+        help="Path to save converted HuggingFace safetensors file",
+    )
+
+    args = parser.parse_args()
+
+    convert_moondream_weights_to_hf(
+        args.input_path,
+        args.output_file,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/transformers/models/moondream3/image_processing_moondream3.py
+++ b/src/transformers/models/moondream3/image_processing_moondream3.py
@@ -1,0 +1,282 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Image processor class for Moondream3."""
+
+import math
+from typing import Optional, Union
+
+import torch
+import numpy as np
+
+from transformers.image_processing_utils import (
+    BaseImageProcessor,
+    BatchFeature,
+    get_size_dict,
+)
+from transformers.image_utils import (
+    ImageInput,
+    make_flat_list_of_images,
+    valid_images,
+    validate_kwargs,
+)
+from transformers.processing_utils import ImagesKwargs
+from transformers.utils import TensorType, logging
+from transformers.utils.import_utils import requires_backends
+
+
+logger = logging.get_logger(__name__)
+
+
+import PIL
+
+
+class Moondream3ImageProcessorKwargs(ImagesKwargs, total=False):
+    """
+    patch_size (`Union[dict[str, int], int]` *optional*, defaults to `{"height": 16, "width": 16}`):
+        Size of the patches in the model, used to calculate the output image size. Can be overridden by `patch_size` in the `preprocess` method.
+    """
+
+    pass
+
+
+def select_tiling(
+    height: int, width: int, crop_size: int, max_crops: int
+) -> tuple[int, int]:
+    """
+    Determine the optimal number of tiles to cover an image with overlapping crops.
+    """
+    if height <= crop_size or width <= crop_size:
+        return (1, 1)
+
+    # Minimum required tiles in each dimension
+    min_h = math.ceil(height / crop_size)
+    min_w = math.ceil(width / crop_size)
+
+    # If minimum required tiles exceed max_crops, return proportional distribution
+    if min_h * min_w > max_crops:
+        ratio = math.sqrt(max_crops / (min_h * min_w))
+        return (max(1, math.floor(min_h * ratio)), max(1, math.floor(min_w * ratio)))
+
+    # Perfect aspect-ratio tiles that satisfy max_crops
+    h_tiles = math.floor(math.sqrt(max_crops * height / width))
+    w_tiles = math.floor(math.sqrt(max_crops * width / height))
+
+    # Ensure we meet minimum tile requirements
+    h_tiles = max(h_tiles, min_h)
+    w_tiles = max(w_tiles, min_w)
+
+    # If we exceeded max_crops, scale down the larger dimension
+    if h_tiles * w_tiles > max_crops:
+        if w_tiles > h_tiles:
+            w_tiles = math.floor(max_crops / h_tiles)
+        else:
+            h_tiles = math.floor(max_crops / w_tiles)
+
+    return (max(1, h_tiles), max(1, w_tiles))
+
+
+def overlap_crop_image(
+    image: np.ndarray,
+    overlap_margin: int,
+    max_crops: int,
+    base_size: tuple[int, int] = (378, 378),
+    patch_size: int = 14,
+):
+    """
+    Process an image using an overlap-and-resize cropping strategy with margin handling.
+
+    This function takes an input image and creates multiple overlapping crops with
+    consistent margins. It produces:
+    1. A single global crop resized to base_size
+    2. Multiple overlapping local crops that maintain high resolution details
+    3. A patch ordering matrix that tracks correspondence between crops
+
+    The overlap strategy ensures:
+    - Smooth transitions between adjacent crops
+    - No loss of information at crop boundaries
+    - Proper handling of features that cross crop boundaries
+    - Consistent patch indexing across the full image
+
+    Args:
+        image (np.ndarray): Input image as numpy array with shape (H,W,C)
+        base_size (tuple[int,int]): Target size for crops, default (378,378)
+        patch_size (int): Size of patches in pixels, default 14
+        overlap_margin (int): Margin size in patch units, default 4
+        max_crops (int): Maximum number of crops allowed, default 12
+
+    Returns:
+        OverlapCropOutput: Dictionary containing:
+            - crops: A numpy array containing the global crop of the full image (index 0)
+                followed by the overlapping cropped regions (indices 1+)
+            - tiling: Tuple of (height,width) tile counts
+    """
+    original_h, original_w = image.shape[:2]
+
+    # Convert margin from patch units to pixels
+    margin_pixels = patch_size * overlap_margin
+    total_margin_pixels = margin_pixels * 2  # Both sides
+
+    # Calculate crop parameters
+    crop_patches = base_size[0] // patch_size  # patches per crop dimension
+    crop_window_patches = crop_patches - (2 * overlap_margin)  # usable patches
+    crop_window_size = crop_window_patches * patch_size  # usable size in pixels
+
+    # Determine tiling
+    tiling = select_tiling(
+        original_h - total_margin_pixels,
+        original_w - total_margin_pixels,
+        crop_window_size,
+        max_crops,
+    )
+
+    # Pre-allocate crops.
+    n_crops = tiling[0] * tiling[1] + 1  # 1 = global crop
+    crops = np.zeros(
+        (n_crops, base_size[0], base_size[1], image.shape[2]), dtype=np.uint8
+    )
+
+    # Resize image to fit tiling
+    target_size = (
+        tiling[0] * crop_window_size + total_margin_pixels,
+        tiling[1] * crop_window_size + total_margin_pixels,
+    )
+
+    pil_img = PIL.Image.fromarray(image)
+    resized = pil_img.resize(
+        (int(target_size[1]), int(target_size[0])),
+        resample=PIL.Image.Resampling.LANCZOS,
+    )
+    image = np.asarray(resized)
+
+    # Create global crop
+    global_pil = pil_img.resize(
+        (int(base_size[1]), int(base_size[0])), resample=PIL.Image.Resampling.LANCZOS
+    )
+    crops[0] = np.asarray(global_pil)
+
+    for i in range(tiling[0]):
+        for j in range(tiling[1]):
+            # Calculate crop coordinates
+            y0 = i * crop_window_size
+            x0 = j * crop_window_size
+
+            # Extract crop with padding if needed
+            y_end = min(y0 + base_size[0], image.shape[0])
+            x_end = min(x0 + base_size[1], image.shape[1])
+
+            crop_region = image[y0:y_end, x0:x_end]
+            crops[
+                1 + i * tiling[1] + j, : crop_region.shape[0], : crop_region.shape[1]
+            ] = crop_region
+
+    return {"crops": crops, "tiling": tiling}
+
+
+def prepare_crops(image, max_crops=12, overlap_margin=4):
+    if isinstance(image, PIL.Image.Image):
+        np_image = np.array(image.convert("RGB"))
+    elif isinstance(image, torch.Tensor):
+        np_image = image.cpu().detach().numpy()
+    else:
+        np_image = image
+    overlap_crops = overlap_crop_image(
+        np_image, max_crops=max_crops, overlap_margin=overlap_margin
+    )
+    all_crops = overlap_crops["crops"]
+    all_crops = np.transpose(all_crops, (0, 3, 1, 2))
+    all_crops = all_crops = (
+        torch.from_numpy(all_crops)
+        .to(device="cpu", dtype=torch.bfloat16)
+        .div_(255.0)
+        .sub_(0.5)
+        .div_(0.5)
+    )
+    return all_crops.tolist(), overlap_crops["tiling"]
+
+
+class Moondream3ImageProcessor(BaseImageProcessor):
+    r"""
+    Constructs a Moondream3 image processor.
+    """
+
+    model_input_names = ["pixel_values", "image_sizes"]
+    valid_kwargs = Moondream3ImageProcessorKwargs
+
+    def __init__(
+        self,
+        max_crops: int = 12,
+        overlap_margin: int = 4,
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.max_crops = max_crops
+        self.overlap_margin = overlap_margin
+        self._valid_processor_keys = [
+            "max_crops",
+            "overlap_margin",
+        ]
+
+    def preprocess(
+        self,
+        images: ImageInput,
+        max_crops: Optional[int] = None,
+        overlap_margin: Optional[int] = None,
+        return_tensors: Optional[Union[str, TensorType]] = None,
+        **kwargs,
+    ) -> PIL.Image.Image:
+        """
+        Preprocess an image or batch of images.
+
+        Args:
+            images (`ImageInput`):
+                Image to preprocess. Expects a single or batch of images with pixel values ranging from 0 to 255. If
+                passing in images with pixel values between 0 and 1, set `do_rescale=False`.
+            max_crops (`bool`, *optional*, defaults to `self.max_crops`):
+            overlap_margin (`dict[str, int]`, *optional*, defaults to `self.overlap_margin`):
+        """
+        overlap_margin = (
+            overlap_margin if overlap_margin is not None else self.overlap_margin
+        )
+        max_crops = max_crops if max_crops is not None else self.max_crops
+
+        validate_kwargs(
+            captured_kwargs=kwargs.keys(),
+            valid_processor_keys=self._valid_processor_keys,
+        )
+
+        images = self.fetch_images(images)
+        images = make_flat_list_of_images(images)
+
+        if not valid_images(images[0]):
+            raise ValueError(
+                "Invalid image type. Must be of type PIL.Image.Image, numpy.ndarray, or torch.Tensor"
+            )
+
+        batch_images = []
+        batch_tiling = []
+        for image in images:
+            pixel_values, tiling = prepare_crops(
+                image, max_crops=max_crops, overlap_margin=overlap_margin
+            )
+            batch_images.append(pixel_values)
+            batch_tiling.append(tiling)
+
+        return BatchFeature(
+            data={"pixel_values": batch_images, "tiling": batch_tiling},
+            tensor_type=return_tensors,
+        )
+
+
+__all__ = ["Moondream3ImageProcessor"]

--- a/src/transformers/models/moondream3/modeling_moondream3.py
+++ b/src/transformers/models/moondream3/modeling_moondream3.py
@@ -1,0 +1,1435 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Callable, Optional, Tuple, Union
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache
+from transformers.masking_utils import create_causal_mask
+from dataclasses import dataclass
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.processing_utils import Unpack
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
+from transformers.generation import GenerationMixin
+from transformers.generation.utils import GenerateDecoderOnlyOutput
+from transformers.utils import logging, TransformersKwargs
+from .configuration_moondream3 import (
+    Moondream3Config,
+    Moondream3TextConfig,
+    Moondream3VisionConfig,
+    Moondream3RegionConfig,
+)
+
+logger = logging.get_logger(__name__)
+
+_CONFIG_FOR_DOC = "Moondream3Config"
+
+
+def apply_rotary_pos_emb(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    cos: torch.Tensor,
+    sin: torch.Tensor,
+    rot_dim: int = 32,
+):
+    """
+    Apply rotary position embeddings to query and key tensors.
+
+    Args:
+        q: Query tensor [batch, num_heads, seq_len, head_dim]
+        k: Key tensor [batch, num_heads, seq_len, head_dim]
+        cos: Cosine frequencies [batch, seq_len, rot_dim]
+        sin: Sine frequencies [batch, seq_len, rot_dim]
+        rot_dim: Number of dimensions to apply rotation to (default: 32)
+
+    Returns:
+        Tuple of (rotated_q, rotated_k)
+    """
+
+    def apply_rope(x):
+        dtype = x.dtype
+        x = x.to(torch.float64)
+        x_rot, x_pass = x[..., :rot_dim], x[..., rot_dim:]
+
+        d_q = x_rot.shape[-1] // 2
+        xq_r, xq_i = x_rot[..., :d_q], x_rot[..., d_q:]
+
+        xq_out_r = xq_r * cos - xq_i * sin
+        xq_out_i = xq_r * sin + xq_i * cos
+
+        xq_out = torch.stack((xq_out_r, xq_out_i), dim=-1).flatten(-2)
+
+        return torch.cat([xq_out, x_pass], dim=-1)
+
+    return apply_rope(q), apply_rope(k)
+
+
+class Moondream3RotaryEmbedding(nn.Module):
+    inv_freq: torch.Tensor
+
+    def __init__(self, config: Moondream3Config, device=None):
+        super().__init__()
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+
+        self.rope_type = self.config.rope_parameters["rope_type"]
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, device)
+
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = inv_freq
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: Optional[Moondream3Config] = None,
+        device: Optional["torch.device"] = None,
+        seq_len: Optional[int] = None,
+    ) -> tuple["torch.Tensor", float]:
+        """
+        Computes the inverse frequencies according to the original RoPE implementation
+        """
+        base = config.rope_parameters["rope_theta"]
+        dim = (
+            getattr(config, "head_dim", None)
+            or config.hidden_size // config.num_attention_heads
+        )
+        dim //= 2
+
+        attention_factor = 1.0
+
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.float32)[: (dim // 2)] / dim)
+        )
+        if device is not None:
+            inv_freq = inv_freq.to(device=device)
+        return inv_freq, attention_factor
+
+    @torch.no_grad()
+    @dynamic_rope_update
+    def forward(self, x, position_ids):
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None]
+            .to(torch.float32)
+            .expand(position_ids.shape[0], -1, 1)
+            .to(x.device)
+        )
+        position_ids_expanded = position_ids[:, None, :].to(torch.float32)
+
+        freqs = (
+            inv_freq_expanded.to(torch.float32)
+            @ position_ids_expanded.to(torch.float32)
+        ).transpose(1, 2)
+        cfreqs = (
+            torch.exp(1j * freqs)
+            .unsqueeze(1)
+            .expand(-1, self.config.num_attention_heads, -1, -1)
+        )
+
+        return cfreqs.real, cfreqs.imag
+
+
+class Moondream3Attention(nn.Module):
+    def __init__(
+        self,
+        config: Moondream3TextConfig | Moondream3VisionConfig,
+        layer_idx: Optional[int] = None,
+        use_tau: bool = True,
+    ):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = getattr(config, "head_dim", self.hidden_size // self.num_heads)
+        self.num_key_value_heads = getattr(
+            config, "num_key_value_heads", self.num_heads
+        )
+        attention_bias = config.attention_bias
+        self.attention_dropout = config.attention_dropout
+
+        if isinstance(config, Moondream3TextConfig):
+            self.is_causal = True
+        elif isinstance(config, Moondream3VisionConfig):
+            self.is_causal = False
+        else:
+            raise TypeError(f"Unsupported config type: {type(config)}")
+
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.use_tau = use_tau
+
+        if (self.head_dim * self.num_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {self.num_heads})."
+            )
+
+        self.q_proj = nn.Linear(
+            self.hidden_size, self.num_heads * self.head_dim, bias=attention_bias
+        )
+        self.k_proj = nn.Linear(
+            self.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            self.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, self.hidden_size, bias=attention_bias
+        )
+
+        if self.use_tau:
+            # In original, tau weights are (n_heads, qkv_dim) where qkv_dim is the combined QKV dimension
+            qkv_dim = (
+                self.num_heads * self.head_dim
+                + 2 * self.num_key_value_heads * self.head_dim
+            )
+            self.tau_wq = nn.Linear(qkv_dim, self.num_heads, bias=False)
+            self.tau_wv = nn.Linear(qkv_dim, self.num_heads, bias=False)
+            self.tau_alpha = nn.Parameter(torch.empty(self.num_heads))
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        **kwargs,
+    ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Cache]]:
+        input_shape = hidden_states.shape[:-1]
+
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+        if self.use_tau:
+            qkv_out = torch.cat([query_states, key_states, value_states], dim=-1)
+            tok_feat = F.gelu(qkv_out)
+            tok_q = torch.tanh(self.tau_wq(tok_feat)).permute(0, 2, 1)
+            tok_v = torch.tanh(self.tau_wv(tok_feat)).permute(0, 2, 1)
+
+            pos = position_ids.to(tok_q.dtype) + 1
+            alpha = self.tau_alpha.to(tok_q.dtype)
+            tau_pos = 1 + (
+                torch.sigmoid(alpha[None, :, None] * pos[:, None, :].log()) - 0.5
+            )
+            tau_q = (tok_q + tau_pos).unsqueeze(-1)
+            tau_v = (tok_v + tau_pos).unsqueeze(-1)
+
+        query_states = query_states.view(
+            bsz, q_len, self.num_heads, self.head_dim
+        ).transpose(1, 2)
+        key_states = key_states.view(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+        value_states = value_states.view(
+            bsz, q_len, self.num_key_value_heads, self.head_dim
+        ).transpose(1, 2)
+
+        if self.use_tau:
+            query_states = query_states * tau_q
+
+            if self.num_key_value_groups > 1:
+                tau_v_repeated = tau_v.repeat(1, self.num_key_value_groups, 1, 1)[
+                    :, : self.num_key_value_heads, :, :
+                ]
+            else:
+                tau_v_repeated = tau_v
+            value_states = value_states * tau_v_repeated
+
+        cos, sin = None, None
+        if position_embeddings is not None:
+            cos, sin = position_embeddings
+
+            query_states, key_states = apply_rotary_pos_emb(
+                query_states, key_states, cos, sin
+            )
+
+        query_states, key_states = (
+            query_states.to(value_states.dtype),
+            key_states.to(value_states.dtype),
+        )
+
+        if past_key_values is not None:
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            key_states, value_states = past_key_values.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        query_states = query_states.contiguous()
+        key_states = key_states.contiguous()
+        value_states = value_states.contiguous()
+
+        attn_output, attn_weights = ALL_ATTENTION_FUNCTIONS["sdpa"](
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+
+        return attn_output, attn_weights
+
+
+class Moondream3MLP(nn.Module):
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        hidden_act: str = "gelu_pytorch_tanh",
+        out_size: int | None = None,
+        gated: bool = False,
+        bias: bool = True,
+    ):
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.out_size = self.hidden_size if out_size is None else out_size
+        self.hidden_act = hidden_act
+        self.gated = gated
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=bias)
+        self.down_proj = nn.Linear(self.intermediate_size, self.out_size, bias=bias)
+        self.gate_proj = None
+        if self.gated:
+            self.gate_proj = nn.Linear(
+                self.hidden_size, self.intermediate_size, bias=bias
+            )
+        self.act_fn = ACT2FN[self.hidden_act]
+
+    def forward(self, x) -> torch.Tensor:
+        if self.gated:
+            h = self.up_proj(x)
+            g = self.gate_proj(x)
+            x = self.act_fn(h) * (g + 1)
+        else:
+            x = self.act_fn(self.up_proj(x))
+        return self.down_proj(x)
+
+
+class Moondream3SparseMoeBlock(nn.Module):
+    def __init__(self, config: Moondream3TextConfig, layer_idx=None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.moe_intermediate_size = config.moe_intermediate_size
+        self.num_experts = config.num_experts
+        self.top_k = config.num_experts_per_tok
+
+        self.gate = nn.Linear(self.hidden_size, self.num_experts, bias=True)
+        self.experts = nn.ModuleList(
+            [
+                Moondream3MLP(
+                    hidden_size=self.hidden_size,
+                    intermediate_size=self.moe_intermediate_size,
+                    # hidden_act=self.config.moe_hidden_act,
+                    gated=True,
+                    bias=False,
+                    hidden_act="gelu",
+                )
+                for _ in range(self.num_experts)
+            ]
+        )
+
+    def forward(
+        self, hidden_states: torch.Tensor, cache_position=None
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size, sequence_length, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+        router_logits: torch.Tensor = self.gate(hidden_states)
+        routing_weights, selected_experts = torch.topk(
+            router_logits, self.top_k, dim=-1
+        )
+        routing_weights = F.softmax(routing_weights, dim=-1, dtype=torch.float32)
+        routing_weights = routing_weights.to(hidden_states.dtype)
+
+        final_hidden_states = torch.zeros(
+            (batch_size * sequence_length, hidden_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
+
+        for expert_idx in range(self.num_experts):
+            expert_layer = self.experts[expert_idx]
+            top_x, idx = (selected_experts == expert_idx).nonzero(as_tuple=True)
+
+            if top_x.shape[0] == 0:
+                continue
+
+            current_state = hidden_states[None, top_x].reshape(-1, hidden_dim)
+            current_hidden_states = (
+                expert_layer(current_state) * routing_weights[top_x, idx, None]
+            )
+            final_hidden_states.index_add_(
+                0, top_x, current_hidden_states.to(hidden_states.dtype)
+            )
+
+        final_hidden_states = final_hidden_states.reshape(
+            batch_size, sequence_length, hidden_dim
+        )
+        return final_hidden_states, router_logits
+
+
+class Moondream3DecoderLayer(nn.Module):
+    def __init__(self, config: Moondream3TextConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.self_attn = Moondream3Attention(config, layer_idx, use_tau=True)
+        self.input_layernorm = nn.LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        self.is_moe_layer = layer_idx >= config.moe_start_layer
+        if self.is_moe_layer:
+            self.mlp = Moondream3SparseMoeBlock(config, layer_idx=layer_idx)
+        else:
+            self.mlp = Moondream3MLP(
+                self.hidden_size,
+                self.intermediate_size,
+                # hidden_act=self.config.hidden_act,
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        output_attentions: bool = False,
+        output_router_logits: bool = False,
+        use_cache: bool = False,
+        cache_position: Optional[torch.LongTensor] = None,
+        position_embeddings: Optional[tuple[torch.Tensor, torch.Tensor]] = None,
+        **kwargs,
+    ) -> Tuple:
+        hidden_states_ln = self.input_layernorm(hidden_states)
+
+        hidden_states_attn, self_attn_weights = self.self_attn(
+            hidden_states=hidden_states_ln,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            output_attentions=output_attentions,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+            **kwargs,
+        )
+
+        if self.is_moe_layer:
+            hidden_states_mlp, router_logits = self.mlp(
+                hidden_states_ln, cache_position=cache_position
+            )
+        else:
+            hidden_states_mlp = self.mlp(hidden_states_ln)
+            router_logits = None
+
+        # Add both attention and MLP to residual like original
+        hidden_states = hidden_states + hidden_states_attn + hidden_states_mlp
+
+        outputs = (hidden_states,)
+
+        if output_attentions:
+            outputs += (self_attn_weights,)
+
+        if output_router_logits:
+            outputs += (router_logits,)
+
+        return outputs
+
+
+class Moondream3PreTrainedModel(PreTrainedModel):
+    config_class = Moondream3Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Moondream3DecoderLayer", "Moondream3SparseMoeBlock"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn_2 = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+
+    _can_compile_fullgraph = True
+    _supports_attention_backend = True
+    _can_record_outputs = {
+        "hidden_states": Moondream3DecoderLayer,
+        "attentions": Moondream3Attention,
+    }
+
+class Moondream3TextModel(Moondream3PreTrainedModel):
+    config_class = Moondream3TextConfig
+
+    def __init__(self, config: Moondream3TextConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id if hasattr(config, "pad_token_id") else 0
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(
+            config.vocab_size, config.hidden_size, self.padding_idx
+        )
+        self.layers = nn.ModuleList(
+            [
+                Moondream3DecoderLayer(config, layer_idx)
+                for layer_idx in range(config.num_hidden_layers)
+            ]
+        )
+        self.norm = nn.LayerNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Moondream3RotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+
+        self.post_init()
+
+    def forward(
+        self,
+        input_ids: Optional[torch.LongTensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        output_router_logits: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_router_logits = (
+            output_router_logits
+            if output_router_logits is not None
+            else self.config.output_router_logits
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError(
+                "You cannot specify both input_ids and inputs_embeds at the same time, and must specify either one"
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        hidden_states = inputs_embeds
+        batch_size = hidden_states.shape[0]
+
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                logger.warning(
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+                )
+                use_cache = False
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache()
+
+        if cache_position is None:
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+        all_router_logits = () if output_router_logits else None
+
+        for decoder_layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    decoder_layer.__call__,
+                    hidden_states,
+                    attention_mask,
+                    position_ids,
+                    past_key_values,
+                    output_attentions,
+                    output_router_logits,
+                    use_cache,
+                    cache_position,
+                    position_embeddings,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    past_key_values=past_key_values,
+                    output_attentions=output_attentions,
+                    output_router_logits=output_router_logits,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    position_embeddings=position_embeddings,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+
+            if output_router_logits and layer_outputs[-1] is not None:
+                all_router_logits += (layer_outputs[-1],)
+
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        next_cache = None
+        if use_cache:
+            next_cache = past_key_values
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [
+                    hidden_states,
+                    next_cache,
+                    all_hidden_states,
+                    all_self_attns,
+                    all_router_logits,
+                ]
+                if v is not None
+            )
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=next_cache,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+        )
+
+
+class Moondream3VisionPatchEmbeddings(nn.Module):
+    def __init__(self, config: Moondream3VisionConfig):
+        super().__init__()
+        self.patch_size = config.patch_size
+        self.num_channels = config.in_channels
+        self.hidden_size = config.hidden_size
+        self.crop_size = config.crop_size
+        self.patch_size = config.patch_size
+        self.grid_size = self.crop_size // self.patch_size
+        self.num_patches = self.grid_size * self.grid_size
+
+        self.projection = nn.Linear(
+            self.patch_size * self.patch_size * self.num_channels,
+            self.hidden_size,
+            bias=True,
+        )
+        self.position_embeddings = nn.Parameter(
+            torch.zeros(1, self.num_patches, config.hidden_size)
+        )
+
+    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+        B, C, H, W = pixel_values.shape
+        P1 = P2 = self.patch_size
+
+        x = pixel_values.reshape(B, C, H // P1, P1, W // P2, P2)
+
+        x = x.permute(0, 2, 4, 1, 3, 5)
+
+        x = x.reshape(B, (H // P1) * (W // P2), C * P1 * P2)
+
+        x = self.projection(x)
+        return x + self.position_embeddings
+
+
+class Moondream3VisionEncoderLayer(nn.Module):
+    def __init__(self, config: Moondream3VisionConfig, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.layer_idx = layer_idx
+
+        self.self_attn = Moondream3Attention(
+            config, layer_idx=self.layer_idx, use_tau=False
+        )
+        self.input_layernorm = nn.LayerNorm(config.hidden_size, eps=1e-5)
+        self.post_attention_layernorm = nn.LayerNorm(config.hidden_size, eps=1e-5)
+        self.mlp = Moondream3MLP(
+            hidden_size=self.hidden_size,
+            intermediate_size=self.intermediate_size,
+            # hidden_act=self.config.hidden_act,
+        )
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        residual = hidden_states
+        hidden_states = self.input_layernorm(hidden_states)
+        hidden_states, _ = self.self_attn(hidden_states=hidden_states)
+        hidden_states = residual + hidden_states
+
+        residual = hidden_states
+        hidden_states = self.post_attention_layernorm(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        return hidden_states
+
+
+class Moondream3VisionModel(Moondream3PreTrainedModel):
+    config_class = Moondream3VisionConfig
+    main_input_name = "pixel_values"
+    _no_split_modules = ["Moondream3VisionEncoderLayer"]
+
+    def __init__(self, config: Moondream3VisionConfig):
+        super().__init__(config)
+        self.config = config
+        self.hidden_size = self.config.hidden_size
+        self.num_hidden_layers = self.config.num_hidden_layers
+        self.proj_inner_dim = self.config.proj_inner_dim
+        self.proj_out_dim = self.config.proj_out_dim
+
+        self.embeddings = Moondream3VisionPatchEmbeddings(config)
+        self.layers = nn.ModuleList(
+            [
+                Moondream3VisionEncoderLayer(config, layer_idx)
+                for layer_idx in range(self.num_hidden_layers)
+            ]
+        )
+        self.post_layernorm = nn.LayerNorm(self.hidden_size, eps=1e-5)
+        self.vision_projection = Moondream3MLP(
+            hidden_size=self.hidden_size * 2,
+            intermediate_size=self.proj_inner_dim,
+            out_size=self.proj_out_dim,
+        )
+        self.gradient_checkpointing = False
+        self.post_init()
+
+    def _reconstruct_from_crops(
+        self,
+        crops: torch.Tensor,
+        tiling: tuple[int, int],
+        overlap_margin: int = 4,
+        patch_size: int = 14,
+    ) -> torch.Tensor:
+        """
+        Reconstruct the original image from overlapping crops into a single seamless image.
+
+        Takes a list of overlapping image crops along with their positional metadata and
+        reconstructs them into a single coherent image by carefully stitching together
+        non-overlapping regions. Handles both numpy arrays and PyTorch tensors.
+
+        Args:
+            crops: List of image crops as numpy arrays or PyTorch tensors with shape
+                (H,W,C)
+            tiling: Tuple of (height,width) indicating crop grid layout
+            patch_size: Size in pixels of each patch, default 14
+            overlap_margin: Number of overlapping patches on each edge, default 4
+
+        Returns:
+            Reconstructed image as numpy array or PyTorch tensor matching input type,
+            with shape (H,W,C) where H,W are the original image dimensions
+        """
+        if isinstance(tiling, torch.Tensor):
+            tiling_h, tiling_w = tiling[0].item(), tiling[1].item()
+        else:
+            tiling_h, tiling_w = tiling
+        tiling_h, tiling_w = int(tiling_h), int(tiling_w)
+        crop_height, crop_width = crops[0].shape[:2]
+        margin_pixels = overlap_margin * patch_size
+
+        output_h = (crop_height - 2 * margin_pixels) * tiling_h + 2 * margin_pixels
+        output_w = (crop_width - 2 * margin_pixels) * tiling_w + 2 * margin_pixels
+        reconstructed = torch.zeros(
+            (output_h, output_w, crops[0].shape[2]),
+            device=crops[0].device,
+            dtype=crops[0].dtype,
+        )
+
+        for i, crop in enumerate(crops):
+            tile_y = i // tiling_w
+            tile_x = i % tiling_w
+
+            x_start = 0 if tile_x == 0 else margin_pixels
+            x_end = crop_width if tile_x == tiling_w - 1 else crop_width - margin_pixels
+            y_start = 0 if tile_y == 0 else margin_pixels
+            y_end = (
+                crop_height if tile_y == tiling_h - 1 else crop_height - margin_pixels
+            )
+
+            out_x = tile_x * (crop_width - 2 * margin_pixels)
+            out_y = tile_y * (crop_height - 2 * margin_pixels)
+
+            reconstructed[
+                out_y + y_start : out_y + y_end, out_x + x_start : out_x + x_end
+            ] = crop[y_start:y_end, x_start:x_end]
+
+        return reconstructed
+
+    def forward(
+        self,
+        pixel_values: torch.FloatTensor,
+        tiling: Tuple[int, int],
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        batch_size, num_crops = pixel_values.shape[:2]
+        # flatten batch_size and num_crops into same dim
+        pixel_values = pixel_values.view(-1, *pixel_values.shape[2:])
+        hidden_states: torch.Tensor = self.embeddings(pixel_values)
+
+        all_hidden_states = () if output_hidden_states else None
+        all_attentions = () if output_attentions else None
+
+        for encoder_layer in self.layers:
+            if output_hidden_states and all_hidden_states is not None:
+                all_hidden_states += (hidden_states,)
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    encoder_layer.__call__, hidden_states
+                )
+            else:
+                layer_outputs = encoder_layer(hidden_states)
+
+            hidden_states = layer_outputs
+
+        hidden_states = self.post_layernorm(hidden_states)
+
+        hidden_states = hidden_states.view(
+            batch_size, num_crops, *hidden_states.shape[1:]
+        )
+        outputs = []
+        for b in range(batch_size):
+            hs = hidden_states[b]
+            t = tiling[b]
+
+            global_features = hs[0]
+            local_features = hs[1:].view(
+                -1,
+                self.num_hidden_layers,
+                self.num_hidden_layers,
+                self.hidden_size,
+            )
+
+            reconstructed = self._reconstruct_from_crops(
+                local_features,
+                t,
+                patch_size=1,
+                overlap_margin=self.config.overlap_margin,
+            )
+
+            reconstructed = reconstructed.permute(2, 0, 1)
+            reconstructed = F.adaptive_avg_pool2d(
+                reconstructed,
+                output_size=(self.num_hidden_layers, self.num_hidden_layers),
+            )
+            reconstructed = reconstructed.permute(1, 2, 0).view(
+                self.num_hidden_layers * self.num_hidden_layers, self.hidden_size
+            )
+            final_features = torch.cat([global_features, reconstructed], dim=-1)
+            outputs.append(final_features)
+        output = torch.stack(outputs, 0)
+
+        hidden_states = self.vision_projection(output)
+
+        if output_hidden_states and all_hidden_states is not None:
+            all_hidden_states += (hidden_states,)
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [hidden_states, all_hidden_states, all_attentions]
+                if v is not None
+            )
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            hidden_states=all_hidden_states,
+            attentions=all_attentions,
+        )
+
+
+class Moondream3RegionEncoder(nn.Module):
+    def __init__(self, config: Moondream3RegionConfig):
+        super().__init__()
+        self.coord_encoder = nn.Linear(config.coord_feat_dim, config.hidden_size)
+        self.size_encoder = nn.Linear(config.size_feat_dim, config.hidden_size)
+
+        coord_freq = torch.randn(config.coord_feat_dim // 2, 1) * 10.0
+        size_freq = torch.randn(config.size_feat_dim // 2, 2) * 10.0
+        self.register_buffer("coord_freq", coord_freq.T)
+        self.register_buffer("size_freq", size_freq.T)
+
+    def fourier_features(self, x: torch.Tensor, w: torch.Tensor) -> torch.Tensor:
+        x_proj = 2 * torch.pi * x @ w
+        return torch.cat([x_proj.cos(), x_proj.sin()], dim=-1)
+
+    def encode_coordinate(self, coord: torch.Tensor) -> torch.Tensor:
+        fourier_features = self.fourier_features(coord, self.coord_freq)
+        return self.coord_encoder(fourier_features)
+
+    def encode_size(self, size: torch.Tensor) -> torch.Tensor:
+        fourier_features = self.fourier_features(size, self.size_freq)
+        return self.size_encoder(fourier_features)
+
+
+class Moondream3RegionDecoder(nn.Module):
+    def __init__(self, config: Moondream3RegionConfig):
+        super().__init__()
+        self.coord_decoder = nn.Linear(config.hidden_size, config.coord_out_dim)
+        self.size_decoder = nn.Linear(config.hidden_size, config.size_out_dim)
+
+    def decode_coordinate(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.coord_decoder(hidden_state)
+
+    def decode_size(self, hidden_state: torch.Tensor) -> torch.Tensor:
+        return self.size_decoder(hidden_state).view(hidden_state.shape[0], 2, -1)
+
+
+class Moondream3Model(Moondream3PreTrainedModel):
+    def __init__(self, config: Moondream3Config):
+        super().__init__(config)
+        self.config = config
+        self.text_model = Moondream3TextModel(config.text_config)
+        self.vision_model = Moondream3VisionModel(config.vision_config)
+        self.vocab_size = config.text_config.vocab_size
+
+        self.region_encoder = Moondream3RegionEncoder(config.region_config)
+        self.region_decoder = Moondream3RegionDecoder(config.region_config)
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.text_model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.text_model.embed_tokens = value
+
+    def set_decoder(self, decoder):
+        self.text_model = decoder
+
+    def get_decoder(self):
+        return self.text_model
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        pixel_values: torch.FloatTensor = None,
+        tiling: Tuple[int, int] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: int = 0,
+    ) -> Union[Tuple, BaseModelOutputWithPast]:
+        output_attentions = (
+            output_attentions
+            if output_attentions is not None
+            else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states
+            if output_hidden_states is not None
+            else self.config.output_hidden_states
+        )
+        return_dict = (
+            return_dict if return_dict is not None else self.config.use_return_dict
+        )
+
+        if (input_ids is not None) == (inputs_embeds is not None):
+            raise ValueError("Provide exactly one of input_ids or inputs_embeds.")
+
+        if not ((pixel_values is not None) ^ (tiling is None)):
+            raise ValueError("You must specify both pixel_values and tiling")
+
+        if inputs_embeds is not None and (
+            pixel_values is not None or tiling is not None
+        ):
+            raise ValueError(
+                "When inputs_embeds is provided, do not pass pixel_values/tiling; "
+                "inputs_embeds must already include BOS+image(+text)."
+            )
+
+        if inputs_embeds is None:
+            inputs_embeds: torch.Tensor = self.text_model.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
+        if cache_position is None:
+            past_seen_tokens = (
+                past_key_values.get_seq_length() if past_key_values is not None else 0
+            )
+            cache_position: torch.Tensor = torch.arange(
+                past_seen_tokens, past_seen_tokens, device=inputs_embeds.device
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        if pixel_values is not None:
+            pixel_values = pixel_values.to(
+                dtype=self.vision_model.embeddings.projection.weight.dtype
+            )
+            image_embeds = self.vision_model(pixel_values, tiling=tiling)[
+                "last_hidden_state"
+            ]
+            prefix = self.text_model.embed_tokens(
+                torch.full(
+                    (input_ids.shape[0], 1),
+                    # self.config.text_config.bos_token_id is None, unsure, so for now just use 0 directly.
+                    0,
+                    dtype=input_ids.dtype,
+                    device=input_ids.device,
+                )
+            )
+            embeds = torch.cat([prefix, image_embeds], dim=1)
+            cache_pos = torch.arange(embeds.shape[-2], device=embeds.device)
+            pos = cache_pos.unsqueeze(0).expand(embeds.shape[0], -1)
+            attn_mask = torch.full(
+                (embeds.shape[0], 1, embeds.shape[-2], pos.shape[-1]),
+                True,
+                dtype=torch.bool,
+                device=embeds.device,
+            )
+
+            outputs = self.text_model(
+                input_ids=None,
+                attention_mask=attn_mask,
+                position_ids=pos,
+                past_key_values=past_key_values,
+                inputs_embeds=embeds,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=True,
+                cache_position=cache_pos,
+            )
+
+        attn_mask = create_causal_mask(
+            config=self.config,
+            input_embeds=inputs_embeds,
+            attention_mask=torch.cat(
+                [
+                    torch.ones(
+                        attention_mask.shape[0],
+                        cache_position[-1] + 1 - attention_mask.shape[-1],
+                        device=attention_mask.device,
+                        dtype=attention_mask.dtype,
+                    ),
+                    attention_mask,
+                ],
+                dim=-1,
+            ),
+            cache_position=cache_position,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+
+        outputs = self.text_model(
+            input_ids=None,
+            attention_mask=attn_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            cache_position=cache_position,
+        )
+
+        if not return_dict:
+            return tuple(
+                v
+                for v in [
+                    outputs.last_hidden_state,
+                    getattr(outputs, "past_key_values", None),
+                    getattr(outputs, "hidden_states", None),
+                    getattr(outputs, "attentions", None),
+                ]
+                if v is not None
+            )
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=outputs.last_hidden_state,
+            past_key_values=getattr(outputs, "past_key_values", None),
+            hidden_states=getattr(outputs, "hidden_states", None),
+            attentions=getattr(outputs, "attentions", None),
+        )
+
+
+@dataclass
+class Moondream3GenerateOutput(GenerateDecoderOnlyOutput):
+    objects: Optional[list[dict[str, float]]] = None
+
+
+class Moondream3ForConditionalGeneration(Moondream3PreTrainedModel, GenerationMixin):
+    _tied_weights_keys = ["lm_head.weight"]
+
+    def __init__(self, config: Moondream3Config):
+        super().__init__(config)
+        self.objects = None
+        self.model = Moondream3Model(config)
+        self.vocab_size = config.text_config.vocab_size
+        self.lm_head = nn.Linear(
+            config.text_config.hidden_size, config.text_config.vocab_size, bias=True
+        )
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.text_model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.text_model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model.text_model = decoder
+
+    def get_decoder(self):
+        return self.model.text_model
+
+    def _prepare_generated_length(
+        self,
+        generation_config,
+        **kwargs,
+    ):
+        generation_config = super()._prepare_generated_length(
+            generation_config, **kwargs
+        )
+        generation_config.max_length += self.config.vision_config.prefix_len
+        return generation_config
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        pixel_values: torch.FloatTensor = None,
+        tiling: torch.LongTensor = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        position_ids: Optional[torch.LongTensor] = None,
+        past_key_values: Optional[Cache] = None,
+        inputs_embeds: Optional[torch.FloatTensor] = None,
+        labels: Optional[torch.LongTensor] = None,
+        use_cache: Optional[bool] = None,
+        output_attentions: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+        cache_position: Optional[torch.LongTensor] = None,
+        logits_to_keep: int = 0,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> Union[Tuple, CausalLMOutputWithPast]:
+        if pixel_values is not None and inputs_embeds is None:
+            position_ids += self.config.vision_config.prefix_len
+            cache_position += self.config.vision_config.prefix_len
+
+        model_outputs = self.model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            tiling=tiling,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            labels=None,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            cache_position=cache_position,
+            logits_to_keep=logits_to_keep,
+        )
+        hidden_states = model_outputs.last_hidden_state
+
+        if isinstance(logits_to_keep, int) and logits_to_keep > 0:
+            hs = hidden_states[:, -logits_to_keep:, :]
+        elif isinstance(logits_to_keep, slice):
+            hs = hidden_states[:, logits_to_keep, :]
+        else:
+            hs = hidden_states
+
+        hs = self.model.text_model.norm(hs)
+        logits = self.lm_head(hs)
+
+        pred = torch.argmax(logits, dim=-1)
+        print(pred)
+
+        pos_ids = position_ids[:, -1:] + 1
+        cache_pos = cache_position[-1:] + 1
+        mask = torch.ones(
+            hidden_states.shape[0], 1, device=self.device, dtype=torch.long
+        )
+        is_processing_point = torch.any(pred == 5)
+        while is_processing_point:
+            batch_mask = pred[:, -1] == 5
+            hidden_states = hidden_states[:, -1:, :]
+            x_logits = self.model.region_decoder.decode_coordinate(hidden_states)
+            x_center = torch.argmax(x_logits, dim=-1) / x_logits.size(-1)
+            next_embeds = self.model.region_encoder.encode_coordinate(
+                x_center.to(x_logits.dtype)
+            ).unsqueeze(1)
+            model_outputs = self.model(
+                input_ids=None,
+                pixel_values=None,
+                tiling=None,
+                attention_mask=mask,
+                position_ids=pos_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=next_embeds,
+                labels=None,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=True,
+                cache_position=cache_pos,
+                logits_to_keep=logits_to_keep,
+            )
+            hidden_states = model_outputs.last_hidden_state
+            y_logits = self.model.region_decoder.decode_coordinate(hidden_states)
+            y_center = torch.argmax(y_logits, dim=-1) / y_logits.size(-1)
+            next_embeds = self.model.region_encoder.encode_coordinate(
+                y_center.to(y_logits.dtype)
+            ).unsqueeze(1)
+            coords = torch.cat([x_center, y_center], dim=1)
+            coords = coords * (batch_mask).unsqueeze(1)
+            pos_ids += 1
+            cache_pos = cache_pos + 1
+            bbox = None
+            if input_ids.shape[-1] > 1 and input_ids[0, 1] == 7235:
+                model_outputs = self.model(
+                    input_ids=None,
+                    pixel_values=None,
+                    tiling=None,
+                    attention_mask=mask,
+                    position_ids=pos_ids,
+                    past_key_values=past_key_values,
+                    inputs_embeds=next_embeds,
+                    labels=None,
+                    use_cache=use_cache,
+                    output_attentions=output_attentions,
+                    output_hidden_states=output_hidden_states,
+                    return_dict=True,
+                    cache_position=cache_pos,
+                    logits_to_keep=logits_to_keep,
+                )
+                hidden_states = model_outputs.last_hidden_state
+                size_logits = self.model.region_decoder.decode_size(hidden_states)
+                bins = torch.argmax(size_logits, dim=-1)
+                w_bin = bins[:, 0]
+                h_bin = bins[:, 1]
+
+                w = torch.pow(2.0, (w_bin.float() / 1023.0) * 10.0 - 10.0)
+                h = torch.pow(2.0, (h_bin.float() / 1023.0) * 10.0 - 10.0)
+
+                next_embeds = (
+                    self.model.region_encoder.encode_size(
+                        torch.stack([w, h], dim=-1).to(size_logits.dtype)
+                    )
+                ).unsqueeze(1)
+                bbox = [
+                    x_center.item() - w.item() / 2,
+                    y_center.item() - h.item() / 2,
+                    x_center.item() + w.item() / 2,
+                    y_center.item() + h.item() / 2,
+                ]
+                bbox = bbox * (batch_mask).unsqueeze(1)
+                pos_ids += 1
+                cache_pos = cache_pos + 1
+
+            new = coords.unsqueeze(1) if bbox is None else bbox.unsqueeze(1)
+            if self.objects is None:
+                self.objects = new
+            else:
+                self.objects = torch.cat([self.objects, new], dim=1)
+            model_outputs = self.model(
+                input_ids=None,
+                pixel_values=None,
+                tiling=None,
+                attention_mask=mask,
+                position_ids=pos_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=next_embeds,
+                labels=None,
+                use_cache=use_cache,
+                output_attentions=output_attentions,
+                output_hidden_states=output_hidden_states,
+                return_dict=True,
+                cache_position=cache_pos,
+                logits_to_keep=logits_to_keep,
+            )
+            pos_ids += 1
+            cache_pos = cache_pos + 1
+            hidden_states = model_outputs.last_hidden_state
+
+            indices = torch.tensor(
+                [
+                    self.config.text_config.coord_token_id,
+                    0, # self.config.text_config.eos_token_id,
+                ],
+                device=self.device,
+            )
+
+            hidden_states = self.model.text_model.norm(hidden_states)
+            logits = (
+                hidden_states @ self.lm_head.weight[indices].T
+                + self.lm_head.bias[indices]
+            )
+
+            logits_full = torch.full(
+                (logits.shape[0], logits.shape[1], self.config.text_config.vocab_size),
+                float("-inf"),
+                device=logits.device,
+                dtype=logits.dtype,
+            )
+            logits_full[:, :, torch.tensor([5, 0])] = logits
+            logits = logits_full
+            pred[batch_mask] = torch.argmax(logits, dim=-1)[batch_mask]
+            print(pred)
+            is_processing_point = torch.any(pred == 5)
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.vocab_size
+            )
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=getattr(model_outputs, "past_key_values", None),
+            hidden_states=getattr(model_outputs, "hidden_states", None),
+            attentions=getattr(model_outputs, "attentions", None),
+        )
+
+    def generate(self, **kwargs) -> Union[Moondream3GenerateOutput, torch.LongTensor]:
+        outputs = super().generate(**kwargs)
+        if self.objects is not None and len(self.objects) > 0:
+            if isinstance(outputs, torch.Tensor):
+                outputs = self.objects
+                self.objects = []
+            else:
+                outputs = Moondream3GenerateOutput(**outputs, objects=self.objects)
+                self.objects = []
+        return outputs
+
+    def prepare_inputs_for_generation(self, input_ids, **model_kwargs):
+        model_inputs = super().prepare_inputs_for_generation(input_ids, **model_kwargs)
+        model_inputs["position_ids"] += (
+            model_inputs["cache_position"].unsqueeze(0) - model_inputs["position_ids"]
+        )
+        return model_inputs
+
+    def _update_model_kwargs_for_generation(
+        self,
+        outputs,
+        model_kwargs,
+        is_encoder_decoder,
+        num_new_tokens: int = 1,
+    ):
+        model_kwargs = super()._update_model_kwargs_for_generation(
+            outputs,
+            model_kwargs,
+            is_encoder_decoder=is_encoder_decoder,
+            num_new_tokens=num_new_tokens,
+        )
+        if model_kwargs["use_cache"] == True:
+            model_kwargs["pixel_values"] = None
+            model_kwargs["tiling"] = None
+        return model_kwargs
+
+    @staticmethod
+    def _reorder_cache(past_key_values, beam_idx):
+        reordered_past = ()
+        for layer_past in past_key_values:
+            reordered_past += (
+                tuple(
+                    past_state.index_select(0, beam_idx.to(past_state.device))
+                    for past_state in layer_past
+                ),
+            )
+        return reordered_past
+
+
+__all__ = [
+    "Moondream3Config",
+    "Moondream3TextConfig",
+    "Moondream3VisionConfig",
+    "Moondream3RegionConfig",
+    "Moondream3PreTrainedModel",
+    "Moondream3Model",
+    "Moondream3TextModel",
+    "Moondream3VisionModel",
+    "Moondream3ForConditionalGeneration",
+]

--- a/src/transformers/models/moondream3/processing_moondream3.py
+++ b/src/transformers/models/moondream3/processing_moondream3.py
@@ -1,0 +1,174 @@
+# coding=utf-8
+# Copyright 2024 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Processor class for Moondream3.
+"""
+
+from typing import Optional, Union
+
+import numpy as np
+
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_utils import ImageInput, is_valid_image
+from transformers.processing_utils import (
+    MultiModalData,
+    ProcessingKwargs,
+    ProcessorMixin,
+    Unpack,
+)
+from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
+from transformers.utils import is_vision_available, logging
+
+
+logger = logging.get_logger(__name__)
+
+
+class Moondream3ProcessorKwargs(ProcessingKwargs, total=False):
+    _defaults = {
+        "text_kwargs": {"padding": False, "return_token_type_ids": False},
+        "common_kwargs": {
+            "return_tensors": "pt",
+        },
+    }
+
+
+# Copied from transformers.models.idefics2.processing_idefics2.is_url
+def is_url(val) -> bool:
+    return isinstance(val, str) and val.startswith("http")
+
+
+# Copied from transformers.models.idefics2.processing_idefics2.is_image_or_image_url
+def is_image_or_image_url(elem):
+    return is_url(elem) or is_valid_image(elem)
+
+
+class Moondream3Processor(ProcessorMixin):
+    r"""
+    Constructs a Moondream3 processor which wraps a Moondream3 image processor and a Moondream3 tokenizer into a single processor.
+
+    [`Moondream3Processor`] offers all the functionalities of [`CLIPImageProcessor`] and [`LlamaTokenizerFast`]. See the
+    [`~Moondream3Processor.__call__`] and [`~Moondream3Processor.decode`] for more information.
+
+    Args:
+        image_processor ([`Moondream3ImageProcessor`], *optional*):
+            The image processor is a required input.
+        tokenizer ([`LlamaTokenizerFast`], *optional*):
+            The tokenizer is a required input.
+        patch_size (`int`, *optional*, defaults to 16):
+            Patch size from the vision tower.
+        spatial_merge_size (`int`, *optional*, defaults to 1):
+            The downsampling factor for the spatial merge operation.
+        chat_template (`str`, *optional*): A Jinja template which will be used to convert lists of messages
+            in a chat into a tokenizable string.
+        image_token (`str`, *optional*, defaults to `"[IMG]"`):
+            Special token used to denote image location.
+        image_break_token (`str`, *optional*, defaults to `"[IMG_BREAK]"`):
+            Special token used to denote the end of a line of pixels in an image.
+        image_end_token (`str`, *optional*, defaults to `"[IMG_END]"`):
+            Special token used to denote the end of an image input.
+    """
+
+    attributes = ["image_processor", "tokenizer"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        **kwargs,
+    ):
+        super().__init__(image_processor, tokenizer, chat_template=chat_template)
+
+    def __call__(
+        self,
+        images: Optional[ImageInput] = None,
+        text: Union[
+            TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]
+        ] = None,
+        **kwargs: Unpack[Moondream3ProcessorKwargs],
+    ) -> BatchFeature:
+        """
+        Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
+        and `kwargs` arguments to LlamaTokenizerFast's [`~LlamaTokenizerFast.__call__`] if `text` is not `None` to encode
+        the text. To prepare the image(s), this method forwards the `images` and `kwargs` arguments to
+        CLIPImageProcessor's [`~CLIPImageProcessor.__call__`] if `images` is not `None`. Please refer to the docstring
+        of the above two methods for more information.
+
+        Args:
+            images (`PIL.Image.Image`, `np.ndarray`, `torch.Tensor`, `list[PIL.Image.Image]`, `list[np.ndarray]`, `list[torch.Tensor]`):
+                The image or batch of images to be prepared. Each image can be a PIL image, NumPy array or PyTorch
+                tensor. Both channels-first and channels-last formats are supported.
+            text (`str`, `list[str]`, `list[list[str]]`):
+                The sequence or batch of sequences to be encoded. Each sequence can be a string or a list of strings
+                (pretokenized string). If the sequences are provided as list of strings (pretokenized), you must set
+                `is_split_into_words=True` (to lift the ambiguity with a batch of sequences).
+            return_tensors (`str` or [`~utils.TensorType`], *optional*):
+                If set, will return tensors of a particular framework. Acceptable values are:
+
+                - `'pt'`: Return PyTorch `torch.Tensor` objects.
+                - `'np'`: Return NumPy `np.ndarray` objects.
+
+        Returns:
+            [`BatchFeature`]: A [`BatchFeature`] with the following fields:
+
+            - **input_ids** -- List of token ids to be fed to a model. Returned when `text` is not `None`.
+            - **attention_mask** -- List of indices specifying which tokens should be attended to by the model (when
+              `return_attention_mask=True` or if *"attention_mask"* is in `self.model_input_names` and if `text` is not
+            `None`).
+            - **pixel_values** -- Pixel values to be fed to a model. Returned when `images` is not `None`.
+        """
+
+        output_kwargs = self._merge_kwargs(
+            Moondream3ProcessorKwargs,
+            tokenizer_init_kwargs=self.tokenizer.init_kwargs,
+            **kwargs,
+        )
+
+        if images is not None:
+            image_inputs = self.image_processor(
+                images, **output_kwargs["images_kwargs"]
+            )
+        else:
+            image_inputs = {}
+
+        if isinstance(text, str):
+            text = [text]
+        elif not isinstance(text, list) and not isinstance(text[0], str):
+            raise TypeError(
+                "Invalid input text. Please provide a string, or a list of strings"
+            )
+
+        # try to expand inputs in processing if we have the necessary parts
+        prompt_strings = text
+
+        return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+        text_inputs = self.tokenizer(
+            prompt_strings, **output_kwargs["text_kwargs"], return_tensors=None
+        )
+
+        return BatchFeature(
+            data={**text_inputs, **image_inputs}, tensor_type=return_tensors
+        )
+
+    @property
+    def model_input_names(self):
+        tokenizer_input_names = self.tokenizer.model_input_names
+        image_processor_input_names = self.image_processor.model_input_names
+        return tokenizer_input_names + image_processor_input_names + ["image_sizes"]
+
+
+__all__ = ["Moondream3Processor"]


### PR DESCRIPTION
Taken from my first attempt at [NyxKrage/moondream3-preview-hf](https://huggingface.co/NyxKrage/moondream3-preview-hf), however it needed some changes to work properly with the latest transformers from git, and so the model with the proper config json files can be found at [NyxKrage/moondream3-preview-hf-git](https://huggingface.co/NyxKrage/moondream3-preview-hf-git), though the weights stay the same.

[Moondream3](moondream/moondream3-preview) modeling code ported over to follow more proper HuggingFace conventions, code is mostly functional, though there are currently some pretty glaring issues.  

1. The whole loop to decode points/regions in the forward pass is obviously not something that should be stay, but I wanted to get the functionality in correctly, so that the flow of how points/bounding boxes are calculated are there as a reference point at least.  
2. The code as is currently does not work without caching being enabled (due to simply running the image embeds through the model separately and relying on the kv cache to "store them").  
3. Batching with differently sized images does not work, batching with different objectives (query/point/detect) does not work.  
4. I was pretty unsure in general on how to properly handle the processor, should it prepend some bogus token to make space for the image embeddings (even though the tokenizer used does not have a dedicated image placeholder token).  

Opening this as a draft PR to get some initial feedback on the proper way to handle a most of these as I'm generally unfamiliar with the specifics in terms of how image models should be implemented.  
Also the code has the full modeling code rather than using the modular setup for now, because I felt that it would be easier to "fix" the issues, and then identify which parts can be modularized afterwards.  

For point 1, from what I couldn't tell if the proper way would be to override the generate method and handle it there, or just have the model handle generation and let the end user worry about the point/bounding box functionality?  
For point 2, I think the main pain point, comes from the fact that I ended up handling the image embeddings and shifting around stuff in the modeling code, rather than adding padding for the space the image embeddings should take up in full input embeddings in the processor, but I ended up going for this way just because I was unsure what the correct approach was with the lack of an image token, and so if point 4 gets solved by moving that to the processor, this should come for free I believe.  
For point 3, the batching of differently sized images, should just require a bit of tweaking in the reconstruction path for the image projection to handle padding the number of crops, and for the query/point problem, that should hopefully be fixed by the way of solving point 1.  