### PR TITLE
Fix gpt2 modeling tests

### DIFF
--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -438,16 +438,18 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         output_fa_2 = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_fa_2 = tokenizer.batch_decode(output_fa_2)
 
-        expected_output = Expectations({
-            ("cuda", (8, 6)): [
-                "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was born in the city of Kolkata, was a member of the Kolkata",
-                "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
-            ],
-            ("rocm", (9, 4)): [
-                '<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was also a member of the group, said: "We are very happy to have been',
-                "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
-            ]
-        }).get_expectation()
+        expected_output = Expectations(
+            {
+                ("cuda", (8, 6)): [
+                    "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was born in the city of Kolkata, was a member of the Kolkata",
+                    "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
+                ],
+                ("rocm", (9, 4)): [
+                    '<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was also a member of the group, said: "We are very happy to have been',
+                    "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
+                ],
+            }
+        ).get_expectation()
 
         self.assertListEqual(output_native, output_fa_2)
         self.assertListEqual(output_native, expected_output)

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -171,6 +171,7 @@ class GPT2ModelTest(CausalLMModelTest, unittest.TestCase):
     )
     test_missing_keys = False
     model_tester_class = GPT2ModelTester
+    model_split_percents = [0.5, 0.6, 0.7]
 
     def _prepare_for_class(self, inputs_dict, model_class, return_labels=False):
         # Overwritten: special case for DoubleHeads model
@@ -438,7 +439,7 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         output_fa_2 = tokenizer.batch_decode(output_fa_2)
 
         expected_output = [
-            "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was born in the city of Kolkata, was a member of the Kolkata",
+            '<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was also a member of the group, said: "We are very happy to have been',
             "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
         ]
 
@@ -491,7 +492,9 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
 
         num_paddings = inputs_non_padded.shape[-1] - inputs["attention_mask"][-1].long().sum().item()
         inputs_padded = tokenizer(sentences[1], return_tensors="pt").input_ids.to(torch_device)
-        output_padded = model.generate(input_ids=inputs_padded, max_length=model.config.max_length - num_paddings)
+        output_padded = model.generate(
+            input_ids=inputs_padded, max_length=model.generation_config.max_length - num_paddings
+        )
 
         batch_out_sentence = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         batch_out_sentence_tt = tokenizer.batch_decode(outputs_tt, skip_special_tokens=True)
@@ -553,7 +556,9 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
 
         num_paddings = inputs_non_padded.shape[-1] - inputs["attention_mask"][-1].long().sum().item()
         inputs_padded = tokenizer(sentences[1], return_tensors="pt").input_ids.to(torch_device)
-        output_padded = model.generate(input_ids=inputs_padded, max_length=model.config.max_length - num_paddings)
+        output_padded = model.generate(
+            input_ids=inputs_padded, max_length=model.generation_config.max_length - num_paddings
+        )
 
         batch_out_sentence = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         batch_out_sentence_tt = tokenizer.batch_decode(outputs_tt, skip_special_tokens=True)

--- a/tests/models/gpt2/test_modeling_gpt2.py
+++ b/tests/models/gpt2/test_modeling_gpt2.py
@@ -438,10 +438,16 @@ class GPT2ModelLanguageGenerationTest(unittest.TestCase):
         output_fa_2 = model.generate(**inputs, max_new_tokens=20, do_sample=False)
         output_fa_2 = tokenizer.batch_decode(output_fa_2)
 
-        expected_output = [
-            '<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was also a member of the group, said: "We are very happy to have been',
-            "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
-        ]
+        expected_output = Expectations({
+            ("cuda", (8, 6)): [
+                "<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was born in the city of Kolkata, was a member of the Kolkata",
+                "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
+            ],
+            ("rocm", (9, 4)): [
+                '<|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|><|endoftext|>hi, who was also a member of the group, said: "We are very happy to have been',
+                "Hello this is a very long sentence. I'm sorry. I'm sorry. I'm sorry. I'm sorry. I'm sorry",
+            ]
+        }).get_expectation()
 
         self.assertListEqual(output_native, output_fa_2)
         self.assertListEqual(output_native, expected_output)


### PR DESCRIPTION
Fixing gpt2 modeling tests : 

1. `test_batch_generation` & `test_batch_generation_2heads`:
Changed model.config.max_length → model.generation_config.max_length (GPT2Config doesn't have max_length)
2. `test_model_parallelism`:
Added `model_split_percents = [0.5, 0.6, 0.7]` to force model splitting across GPUs (default `[0.5,0.7, 0.9]` was too large). The model doesn’t split starting from 0.8.
3. `test_flash_attn_2_generate_padding_left`:
Updated expected output to match actual generation result
