### PR TITLE
[loading] Fix device detection

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -610,7 +610,7 @@ def convert_and_load_state_dict_in_model(
     tp_plan = tp_plan or {}
     device_map = device_map or {"": "cpu"}
     device_map_regex = re.compile(
-        "|".join(rf"({k})" for k in sorted(device_map.keys(), key=lambda x: x.count("."), reverse=True))
+        "|".join(rf"({k})" for k in sorted(device_map.keys(), key=lambda x: (x.count("."), len(x)), reverse=True))
     )
     dtype_plan = dtype_plan or {}
     weight_mapping = weight_mapping or []


### PR DESCRIPTION
# What does this PR do?

As per the title. We need to sort first by modules, then length otherwise we may not detect the correct device. 
I first wanted to add it in https://github.com/huggingface/transformers/pull/42242, but upstreaming in the meantime as this is an important one (otherwise, param do not follow the device_map, leading to OOMs everywhere potentially etc)