### PR TITLE
[loading] Use fewer threads by default for much better performances

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -359,7 +359,10 @@ class WeightConverter(WeightTransform):
         return collected_tensors, misc
 
 
-GLOBAL_WORKERS = min(16, (os.cpu_count() or 8) * 2)  # NVMe: 8-16; HDD/NFS: 2-4
+# For I/O bound operations (i.e. here reading files), it is better to have fewer threads, e.g. 4 is a good default.
+# Having too many is actually harming performances quite a lot, i.e. using 16 can sometimes lead to taking TWICE
+# as much time to load the same model
+GLOBAL_WORKERS = min(4, os.cpu_count() or 4)
 
 
 def _materialize_copy(tensor, device=None, dtype=None):


### PR DESCRIPTION
# What does this PR do?

As per the title.
After a lot of experimentation and reading on the subject, having fewer threads is much more performant than 16 for our loading pipeline (I/O bound operations). This is because otherwise they compete too much with each others.

For example, on a 45B parameters models, the following snippet:

```python
from transformers import AutoModelForCausalLM
import torch
import time

model_id = "mistralai/Mixtral-8x7B-v0.1"
device = "auto"

torch.cuda.synchronize()
t0 = time.time()
model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device, dtype=torch.float16)
torch.cuda.synchronize()
dt = time.time() - t0
print(f"Took {dt:.2f} s")
```

takes about `51.07 s` on `main` vs `20.98 s` on this branch, on our cluster (H100 gpus)

So having fewer threads actually goes more than 2x faster!! 
For completeness, if we try using `GLOBAL_WORKERS = 1` (i.e. no parallelism), then it takes about `30.02 s`. Using `8` is still too much and gives `27.58 s`.
So 4 seem to be the sweet spot.

NOTE FOR THE FUTURE:
The benchmark uses fp16, which is not the native dtype of the checkpoint (bf16), so an additional copy to cast is needed. When loading in bf16, using 4 or 16 threads leads to ~15s for both. So it seems that 4 is anyway the best default here, but the bottleneck is maybe not I/O bound -> depending on whether `tensor.to(dtype, device)` performs the dtype casting on cpu or on the device where it's sent (not sure of the operation order), it may be cpu-bound