### PR TITLE
[docs] Attention backends + continuous batching

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -23,8 +23,6 @@
       title: Legacy model contribution
     - local: auto_docstring
       title: Documenting a model
-    - local: attention_interface
-      title: Customizing attention function
     title: Models
   - sections:
     - local: fast_tokenizers
@@ -61,11 +59,29 @@
     - local: llm_tutorial
       title: Text generation
     - local: generation_strategies
-      title: Generation strategies
+      title: Decoding methods
     - local: generation_features
       title: Generation features
     - local: tasks/prompting
       title: Prompt engineering
+    - local: perplexity
+      title: Perplexity of fixed-length models
+    title: Generate API
+  - sections:
+    - local: attention_interface
+      title: Attention backends
+    - local: continuous_batching
+      title: Continuous batching
+    - local: kernel_doc/overview
+      title: Kernels in transformers
+    - local: perf_torch_compile
+      title: torch.compile
+    - local: perf_infer_gpu_one
+      title: GPU
+    - local: perf_infer_gpu_multi
+      title: Distributed inference
+    - local: perf_infer_cpu
+      title: CPU
     - local: llm_optims
       title: Optimizing inference
     - local: cache_explanation
@@ -74,9 +90,7 @@
       title: KV cache strategies
     - local: llm_tutorial_optimization
       title: Getting the most out of LLMs
-    - local: perplexity
-      title: Perplexity of fixed-length models
-    title: LLMs
+    title: Optimization
   - sections:
     - local: conversations
       title: Chat basics
@@ -101,24 +115,12 @@
     - local: open_webui
       title: Open WebUI
     title: Serving
-  - sections:
-    - local: perf_torch_compile
-      title: torch.compile
-    - local: perf_infer_gpu_one
-      title: GPU
-    - local: perf_infer_gpu_multi
-      title: Distributed inference
-    - local: perf_infer_cpu
-      title: CPU
-    title: Optimization
   - local: agents
     title: Agents
   - local: tools
     title: Tools
   - local: transformers_as_backend
     title: Transformers as modeling backend
-  - local: continuous_batching
-    title: Continuous Batching
   title: Inference
 - isExpanded: false
   sections:
@@ -218,11 +220,6 @@
   - local: quantization/contribute
     title: Contribute
   title: Quantization
-- isExpanded: false
-  sections:
-  - local: kernel_doc/overview
-    title: Kernels in transformers
-  title: Kernels
 - isExpanded: false
   sections:
   - local: serialization

--- a/docs/source/en/attention_interface.md
+++ b/docs/source/en/attention_interface.md
@@ -13,37 +13,127 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Attention Interface
+# Attention backends
 
-This page describes how to use the `AttentionInterface` in order to register custom attention functions to use with
-supported models.
+Basic attention scales poorly. It compares every token in a sequence to *every other* token. These memory-bound computations create bottlenecks and slow down inference. Newer attention functions improve memory efficiency for faster, more affordable inference.
 
-## Customizing attention function
+[`AttentionInterface`] provides optimized attention functions. It decouples attention from model implementations to simplify experimentation with different functions. Add new backends easily with this consistent interface.
 
-Most recent models can now switch from one attention function used in the Attention layer to the other, thanks to a simple mapping.
-By default, we provide the implementation for [`sdpa`](https://pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html),
-[`flash_attention_2`](https://github.com/Dao-AILab/flash-attention) and [`flex_attention`](https://pytorch.org/docs/stable/nn.attention.flex_attention.html#module-torch.nn.attention.flex_attention)
-as well as `eager`, which is a simple matrix multiplication without any optimization on top.  
-This is the setting you can usually choose when instantiating a model:
+| attention backend | description |
+|---|---|
+| `"flash_attention_3"` | improves FlashAttention-2 by also overlapping operations and fusing forward and backward passes more tightly |
+| `"flash_attention_2"` | tiles computations into smaller blocks and uses fast on-chip memory |
+| `"flex_attention"` | framework for specifying custom attention patterns (sparse, block-local, sliding window) without writing low-level kernels by hand |
+| `"sdpa"` | built-in PyTorch implementation of [scaled dot product attention](https://docs.pytorch.org/docs/stable/generated/torch.nn.functional.scaled_dot_product_attention.html) |
+| <code>"paged&#124;flash_attention_2"</code> | Paged version of FlashAttention-2 |
+| <code>"paged&#124;sdpa"</code> | Paged version of SDPA |
+| <code>"paged&#124;eager"</code> | Paged version of eager |
 
-```python
+## Set an attention backend
+
+Use the `attn_implementation` argument in [`~PreTrainedModel.from_pretrained`] to instantiate a model with a specific attention function.
+
+```py
+import torch
 from transformers import AutoModelForCausalLM
 
-model_id = "meta-llama/Llama-3.2-1B"
-
-# Here, using flash attention as an example
-model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="flash_attention_2")
+model = AutoModelForCausalLM.from_pretrained(
+    "meta-llama/Llama-3.2-1B", attn_implementation="flash_attention_2"
+)
 ```
 
-But what if you wanted to create your own attention function? Or simply play around with existing ones, adding
-a few statements here and there? You can now do so with the `AttentionInterface`! Here is an example:
+Switch between attention backends at runtime without reloading the model using [`~PreTrainedModel.set_attn_implementation`].
+
+```py
+model.set_attn_implementation("sdpa")
+```
+
+### Kernels
+
+Download and load compiled compute kernels directly from the [Hub](https://huggingface.co/models?other=kernels) at runtime with the [Kernels](https://huggingface.co/docs/kernels/index) library. This avoids packaging issues from mismatched PyTorch or CUDA versions.
+
+Kernels automatically register to [`AttentionInterface`] upon detection. This eliminates the need to install the FlashAttention package explicitly.
+
+```py
+import torch
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained(
+    "meta-llama/Llama-3.2-1B", attn_implementation="kernels-community/flash-attn2"
+)
+```
+
+### SDPA context manager
+
+PyTorch's scaled dot product attention (SDPA) selects the fastest attention function for CUDA backends automatically. It defaults to the PyTorch C++ implementation for other backends.
+
+Force SDPA to use a specific implementation with the [torch.nn.attention.sdpa_kernel](https://pytorch.org/docs/stable/generated/torch.nn.attention.sdpa_kernel.html) context manager.
+
+```py
+import torch
+from torch.nn.attention import SDPBackend, sdpa_kernel
+from transformers import AutoModelForCausalLM
+
+model = AutoModelForCausalLM.from_pretrained(
+    "meta-llama/Llama-3.2-1B", attn_implementation="sdpa")
+
+with sdpa_kernel(SDPBackend.FLASH_ATTENTION):
+    outputs = model.generate(**inputs)
+```
+
+## Backbone-specific attention
+
+Multimodal models use different backbones for each modality. Optimize performance by assigning specific attention functions to each backbone. Some vision backbones perform better in fp32, for example, which FlashAttention does not support.
+
+Map vision backbones to different attention functions with a dict. The text backbone continues to use FlashAttention. Keys in the attention implementation must match sub-config names.
+
+```py
+from transformers import AutoModelForImageTextToText
+
+attention_implementation_per_backbone = {"vision_config": "sdpa", "text_config": "flash_attention_2"}
+
+for key in attention_implementation_per_backbone:
+    assert key in model.config.sub_configs, f"Invalid key in `attention_implementation`"
+
+model = AutoModelForImageTextToText.from_pretrained(
+    "facebook/chameleon-7b", attn_implementation=attention_implementation_per_backbone
+)
+```
+
+Omit certain backbones from the dict to use the default attention function (SDPA).
+
+```py
+model = AutoModelForImageTextToText.from_pretrained(
+    "facebook/chameleon-7b", attn_implementation={"text_config": "flash_attention_2"}
+)
+```
+
+Set the same attention function for all backbones with a single string.
+
+```py
+model = AutoModelForImageTextToText.from_pretrained(
+    "facebook/chameleon-7b", attn_implementation="eager"
+)
+```
+
+Set the attention function globally with an empty key.
+
+```py
+model = AutoModelForImageTextToText.from_pretrained(
+    "facebook/chameleon-7b", attn_implementation={"": "eager"}
+)
+```
+
+## Create a new attention function
+
+Customize or create new attention functions. Add them to the attention registry with [`AttentionInterface.register`]. Models use these functions through the `attn_implementation` argument.
+
+This example customizes the attention function to print a statement for each layer.
 
 ```python
+import torch
 from transformers import AutoModelForCausalLM, AttentionInterface
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
-import torch
-
-model_id = "meta-llama/Llama-3.2-1B"
 
 def my_new_sdpa(*args, **kwargs):
     print("I just entered the attention computation")
@@ -51,65 +141,16 @@ def my_new_sdpa(*args, **kwargs):
 
 AttentionInterface.register("my_new_sdpa", my_new_sdpa)
 
-model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="my_new_sdpa")
-# Try running the forward with the new attention function
+model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B", attn_implementation="my_new_sdpa")
 model(torch.ones(1, 5, dtype=int))
 ```
 
-You will see it prints "I just entered the attention computation" as many times as there are layers in the model (with this example, 16 times).
-
-## Dynamically switching attention function
-
-You could dynamically change the model's attention function as well:
+Add new arguments to the attention function. Models supporting [`AttentionInterface`] propagate kwargs to attention layers and the attention function. Pass arguments as kwargs in the model's forward function. Custom attention functions must follow this signature and return format.
 
 ```python
-# Back to use original sdpa implementation
-model.set_attn_implementation("sdpa")
-
-model(torch.ones(1, 5, dtype=int))
-```
-
-and it will stop printing the statements, as it now uses the `sdpa` attention.  
-This allows to quickly change an attention function, without needing to reload the model!
-
-## Different attention per backbone in multimodal models
-
-For multimodal models different attention functions may work better for each backbone module. For example, some vision backbones perform better in fp32, but are incompatible with FlashAttention. To continue using FlashAttention while keeping the vision encoder in fp32, create a dict and map each config to an attention implementation as shown below.
-
-```python
-from transformers import AutoModelForImageTextToText
-
-model_id = "facebook/chameleon-7b"
-
-attention_implementation_per_backbone = {"vision_config": "sdpa", "text_config": "flash_attention_2"}
-model = AutoModelForImageTextToText.from_pretrained(model_id, attn_implementation=attention_implementation_per_backbone)
-
-# NOTE: keys in the attention implementation have to be the same as the sub-config names
-for key in attention_implementation_per_backbone:
-    assert key in model.config.sub_configs, f"Invalid key in `attention_implementation`"
-
-# You can omit certain backbones - the default attention function (SDPA) will be used
-# This is equivalent to the previous example
-model = AutoModelForImageTextToText.from_pretrained(model_id, attn_implementation={"text_config": "flash_attention_2"})
-
-
-# Set the same attention implementation for all backbones with single string, same as in non-multimodal models
-model = AutoModelForImageTextToText.from_pretrained(model_id, attn_implementation="eager")
-
-# Alternatively use a dict with an empty key for global configuration
-model = AutoModelForImageTextToText.from_pretrained(model_id, attn_implementation={"": "eager"})
-```
-
-## What about new args needed in my custom attention function?
-
-But indeed, what if the new function requires a new arg to be properly used? It's no issue! Models supporting the
-`AttentionInterface` propagate kwargs all the way to the Attention layers, and to the used attention function. That way,
-you can simply pass the arg (as a kwargs, i.e. you need to qualify the name of the arg) in the model's forward, and it will be correctly used in the attention. However, custom attention functions have some limitations. In particular, it must follow the signature and return format of other attention functions, i.e.
-
-```python
+import torch
 from transformers import AutoModelForCausalLM, AttentionInterface
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
-import torch
 
 def custom_attention(
     module: torch.nn.Module,  # required arg
@@ -127,44 +168,19 @@ def custom_attention(
 AttentionInterface.register("custom", custom_attention)
 
 model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="custom")
-# Forward pass with the new kwargs
 model(torch.ones(1, 5, dtype=int), a_new_kwargs=..., another_new_kwargs=...)
 ```
 
-If in doubt about what args/kwargs a given model sends to the attention function, simply check that model's modeling code on [GitHub](https://github.com/huggingface/transformers/tree/main/src/transformers/models)!
+Check a model's [modeling code](https://github.com/huggingface/transformers/tree/main/src/transformers/models) to confirm what arguments and kwargs it sends to the attention function.
 
-## Accessing current available implementations
+### AttentionMaskInterface
 
-Most of the time, you will simply need to `register` a new function. If, however, you need to access an existing one,
-and/or perform a few checks, the preferred way is to use the global `ALL_ATTENTION_FUNCTIONS`. It behaves the same way you
-would expect from a usual Python dictionary:
+Configure which key and value tokens queries attend to with [`AttentionMaskInterface`]. Some attention functions require this configuration. Customize the attention mask function and add it to the registry with [`AttentionMaskInterface.register`].
 
 ```python
->>> from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
-
->>> list(ALL_ATTENTION_FUNCTIONS.keys())
->>> ['flash_attention_2', 'flex_attention', 'sdpa']
-
->>> ALL_ATTENTION_FUNCTIONS["sdpa"]
->>> <function transformers.integrations.sdpa_attention.sdpa_attention_forward>
-
->>> ALL_ATTENTION_FUNCTIONS.get("sdpa", None)
->>> <function transformers.integrations.sdpa_attention.sdpa_attention_forward>
-
-# You can also globally `register` a new function directly on it
->>> ALL_ATTENTION_FUNCTIONS.register("new_func", new_func)
-```
-
-## Attention Mask Interface
-
-Having a new attention function may mean that you need a new format of attention mask to decide what key and value tokens
-the query tokens should attend to. This is now possible with the `AttentionMaskInterface`! It works in the same way as
-the `AttentionInterface`:
-
-```python
+import torch
 from transformers import AttentionMaskInterface
 from transformers.masking_utils import sdpa_mask
-import torch
 
 def my_new_sdpa_mask(*args, **kwargs):
     print("I just entered the attention mask computation")
@@ -173,11 +189,9 @@ def my_new_sdpa_mask(*args, **kwargs):
 AttentionMaskInterface.register("my_new_sdpa_mask", my_new_sdpa_mask)
 ```
 
-The reason you have to register it is because we need to automatically correct your mask format based on the attention implementation (for example, flex attention uses a BlockMask format, while sdpa uses a 4D tensor).
-By default, if you do not register an attention mask function along with your attention function, mask creation will be skipped
-and `attention_mask=None` will be passed along to the Attention layers.
+Registered attention masks automatically correct the mask format for the attention implementation. FlexAttention uses a [BlockMask](https://docs.pytorch.org/docs/stable/nn.attention.flex_attention.html?utm_source=chatgpt.com#torch.nn.attention.flex_attention.BlockMask) format, while SDPA uses a 4D tensor. Failure to register an attention mask function skips mask creation and `attention_mask=None` is passed to the model's attention layers.
 
-The default signature of the attention mask functions is the following:
+This is the default signature for an attention mask function.
 
 ```python
 def custom_attention_mask(
@@ -191,6 +205,6 @@ def custom_attention_mask(
 ) -> Optional[torch.Tensor]:
 ```
 
-It mostly works thanks to the `mask_function`, which is a `Callable` in the form of [torch's mask_mod functions](https://pytorch.org/blog/flexattention/), taking 4 indices as input and returning a boolean to indicate if this position should take part in the attention computation.
+The `mask_function` argument is a `Callable` that mimics PyTorch's [mask_mod](https://pytorch.org/blog/flexattention/) functions. It takes 4 indices as input and returns a boolean. This boolean indicates if the position contributes to the attention computation.
 
-If you cannot use the `mask_function` to create your mask for some reason, you can try to work around it by doing something similar to our [torch export workaround](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/executorch.py).
+Use this [workaround](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/executorch.py) for torch export if `mask_function` fails to create a mask.

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -168,3 +168,7 @@ The [`ContinuousMixin`] class serves as the main interface for continuous batchi
 The [`Scheduler`] selects requests for processing at each step based on the token budget. [`FIFOScheduler`] is the default scheduler. It prioritizes decoding requests over prefilling requests, unlike [`PrefillFirstScheduler`], and assigns them to specific memory blocks.
 
 [`ContinuousBatchingManager`] runs the model forward pass for the scheduled requests. It then collects and returns the results.
+
+## Resources
+
+The [Continuous batching](https://huggingface.co/blog/continuous_batching) blog post explains KV caching, chunked prefill, and ragged batching with dynamic scheduling in more detail.

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -16,7 +16,7 @@ rendered properly in your Markdown viewer.
 
 # Continuous batching
 
-Continuous batching maximizes GPU utilization. It increases throughput and reduces latency. It uses dynamic scheduling to rearrange the batch at each step. Completed requests are removed, and new requests are added immediately to prevent GPU idling. Chunked prefill stops expensive prefill work from stalling the batch while still allowing new requests to join.
+Continuous batching maximizes GPU utilization. It increases throughput and reduces latency. It uses dynamic scheduling to rearrange the batch at each step. The system removes completed requests and adds new ones immediately to prevent GPU idling. Chunked prefill prevents expensive prefill work from stalling the batch while still allowing new requests to join.
 
 Continuous batching works with [transformers serve](./serving), a server for deploying local models, and [`~ContinuousMixin.generate_batch`].
 
@@ -146,7 +146,7 @@ Transformers models like Mistral and Gemma 2 natively support sliding window att
 from transformers import AutoConfig
 
 config = AutoConfig.from_pretrained("google/gemma-2-2b")
-config.sliding_window = 409
+config.sliding_window = 4096
 
 model = AutoModelForCausalLM.from_pretrained(
     "google/gemma-2-2b",
@@ -165,6 +165,6 @@ The [`ContinuousMixin`] class serves as the main interface for continuous batchi
 
 [`ContinuousBatchingManager`] manages requests by creating a background thread for the generation loop and adding requests to the queue. The manager is thread-safe, allowing asynchronous request addition while the model generates.
 
-The [`Scheduler`] selects requests for processing at each step based on the token budget, prioritizing decoding requests over prefilling requests and assigning specific memory blocks to them.
+The [`Scheduler`] selects requests for processing at each step based on the token budget. [`FIFOScheduler`] is the default scheduler. It prioritizes decoding requests over prefilling requests, unlike [`PrefillFirstScheduler`], and assigns them to specific memory blocks.
 
 [`ContinuousBatchingManager`] runs the model forward pass for the scheduled requests. It then collects and returns the results.

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -16,7 +16,7 @@ rendered properly in your Markdown viewer.
 
 # Continuous batching
 
-Continuous batching maximizes GPU utilization. It increases throughput and reduces latency. It uses dynamic scheduling to rearrange the batch at each step. The system removes completed requests and adds new ones immediately to prevent GPU idling. Chunked prefill prevents expensive prefill work from stalling the batch while still allowing new requests to join.
+Continuous batching maximizes GPU utilization. It increases throughput and reduces latency by using dynamic scheduling to rearrange the batch at each step. The system removes completed requests and adds new requests immediately to prevent GPU idling. Chunked prefill prevents expensive prefill work from stalling the batch while still allowing new requests still join.
 
 Continuous batching works with [transformers serve](./serving), a server for deploying local models, and [`~ContinuousMixin.generate_batch`].
 
@@ -75,7 +75,7 @@ manager = model.init_continuous_batching(generation_config=generation_config)
 manager.start()
 ```
 
-Use [`~ContinuousBatchingManager.add_requests`] to asynchronously submit individual requests. Provide a specific request id, or the manager generates one automatically.
+Use [`~ContinuousBatchingManager.add_request`] to asynchronously submit individual requests. Provide a specific request id or the manager wgenerates one automatically.
 
 ```py
 for i, input_ids in enumerate(simple_batch_inputs):
@@ -138,7 +138,7 @@ model = AutoModelForCausalLM.from_pretrained(
 
 ## Sliding window attention
 
-Sliding window attention limits the backward context of a token to save compute, keeping generation cost proportional to window size rather than total context. This reduces compute per step and simplifies continuous batching.
+Sliding window attention limits the backward context of a token to save compute. Generation cost stays proportional to window size. This reduces compute per step and simplifies continuous batching.
 
 Transformers models like Mistral and Gemma 2 natively support sliding window attention. Manually enable it in the model config if the architecture supports it. This helps with fine-tuning or running custom experiments.
 
@@ -163,9 +163,9 @@ Usage remains the same with [`~ContinuousMixin.generate_batch`].
 
 The [`ContinuousMixin`] class serves as the main interface for continuous batching through [`~ContinuousMixin.generate_batch`]. This method internally creates a [`ContinuousBatchingManager`].
 
-[`ContinuousBatchingManager`] manages requests by creating a background thread for the generation loop and adding requests to the queue. The manager is thread-safe, allowing asynchronous request addition while the model generates.
+[`ContinuousBatchingManager`] manages requests by creating a background thread for the generation loop and adding requests to the queue. The manager is thread-safe, allowing asynchronous request additions while the model generates.
 
-The [`Scheduler`] selects requests for processing at each step based on the token budget. [`FIFOScheduler`] is the default scheduler. It prioritizes decoding requests over prefilling requests, unlike [`PrefillFirstScheduler`], and assigns them to specific memory blocks.
+The [`Scheduler`] selects requests for processing at each step based on the token budget. [`FIFOScheduler`] is the default scheduler. It prioritizes decoding requests over prefilling requests and assigns them to specific memory blocks. [`PrefillFirstScheduler`] prioritizes prefill requests instead.
 
 [`ContinuousBatchingManager`] runs the model forward pass for the scheduled requests. It then collects and returns the results.
 

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -14,52 +14,30 @@ rendered properly in your Markdown viewer.
 
 -->
 
-# Continuous Batching
+# Continuous batching
 
-Continuous Batching (CB) is an advanced technique to optimize the inference of transformer models by dynamically grouping multiple requests into batches. This approach maximizes GPU utilization and throughput, specifically for workloads with many variable-length inputs.
+Continuous batching maximizes GPU utilization. It increases throughput and reduces latency. It uses dynamic scheduling to rearrange the batch at each step. Completed requests are removed, and new requests are added immediately to prevent GPU idling. Chunked prefill stops expensive prefill work from stalling the batch while still allowing new requests to join.
 
-We are particularly interested in having Continuous Batching in transformers for the following use cases:
-- Evaluation of models on large datasets with variable-length inputs
-- Generating outputs for multiple sequences for GRPO policies
+Continuous batching works with [transformers serve](./serving), a server for deploying local models, and [`~ContinuousMixin.generate_batch`].
 
-CB is what makes inference engines like vLLM or SGLang efficient. That being said, transformers does not aim to be a production-ready inference engine, but a complete framework for model development. For this reason, CB is available in `transformers serve`.
+## generate_batch
 
-If you are not familiar with some of the core concepts CB is built upon, we invite you to read the associated blog post: [Continuous Batching: Efficient Inference for Large Language Models](https://huggingface.co/blog/continuous-batching). _broken link for now_
-
-## API Reference
-
-## Usage Examples
-
-The main way to use CB in transformers is via the `generate_batch` method.
-
-Unlike `generate`, CB takes already tokenized inputs, known as input IDs. Each sequence of input IDs is represented as a list of integers, in python: `list[int]`. Since 
-
-For a more detailed example, please refer to: [examples/continuous_batching](./path/to/example)
-
-### `generate_batch` example
-
-We have created a `ContinuousMixin` that is inherited by the `GenerationMixin` so that all auto regressive text models support CB.
-
-This adds the `generate_batch` method to all models that inherit from `GenerationMixin`.
-
-You can use it as follows:
+The [`~ContinuousMixin.generate_batch`] method works with all autoregressive text models. It accepts a list of tokenized inputs and a [`GenerationConfig`] to configure generation settings.
 
 ```py
 import datasets
 import torch
-
 from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.generation import GenerationConfig
 
 model = AutoModelForCausalLM.from_pretrained(
     "Qwen/Qwen3-4B-Instruct-2507",
-    attn_implementation="spda_paged",
-    device_map="cuda",  # if you need cuda
+    attn_implementation="sdpa_paged",
+    device_map="cuda",
     dtype=torch.bfloat16,
 )
-tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, padding_side="left")
+tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507", padding_side="left")
 
-# prepare a batch of inputs
 dataset = datasets.load_dataset("openai/gsm8k", "socratic", split="test")
 dataset = dataset.select(range(args.samples))
 tokenized_datasets = dataset.map(lambda x: tokenizer(x["question"]), batched=True)
@@ -67,11 +45,11 @@ simple_batch_inputs = [item["input_ids"] for item in tokenized_datasets]
 
 generation_config = GenerationConfig(
     max_new_tokens=32,
-    use_cuda_graph=False,  # Not supported for simple version
+    use_cuda_graph=False,
     eos_token_id=tokenizer.eos_token_id,
     pad_token_id=tokenizer.pad_token_id,
     do_sample=False,
-    max_batch_tokens=512,  # max number of tokens in a batch, this is just a default value you should tune based on your hardware
+    max_batch_tokens=512,
 )
 
 batch_outputs = model.generate_batch(
@@ -84,59 +62,45 @@ for request_id, output in batch_outputs.items():
     print(f"Request {request_id} output: {generated_text}")
 ```
 
-### `ContinuousBatchingManager` example
+## ContinuousBatchingManager
 
-If you want more control w.r.t. how you want to schedule requests using CB, you can use the `ContinuousBatchingManager` class directly.
+The [`ContinuousBatchingManager`] orchestrates the background thread by pulling requests from the queue and filling the GPU to capacity. Every iteration checks for finished requests and schedules new ones to join the batch. Use this manager to customize request scheduling.
 
-This is what we use in `transformers serve` because requests arrive asynchronously and we can leverage the asynchronous nature of the CB process to make things more efficient.
-
-Under the hood, the `ContinuousBatchingManager` creates a background thread that receives inputs from a python `queue.Queue` which it uses to get requests to batch in each forward pass.
-
-Note that the manager is thread safe!
+Call [`~ContinuousMixin.init_continuous_batching`] to initialize the manager with a [`GenerationConfig`] and [`~ContinuousBatchingManager.start`] the background thread.
 
 ```py
-import datasets
-import torch
-
-from transformers import AutoModelForCausalLM, AutoTokenizer
-from transformers.generation import GenerationConfig
 from transformers.generation.continuous_batching import RequestStatus
 
-model = AutoModelForCausalLM.from_pretrained(
-    "Qwen/Qwen3-4B-Instruct-2507",
-    attn_implementation="spda_paged",
-    device_map="cuda",  # if you need cuda
-    dtype=torch.bfloat16,
-)
-tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, padding_side="left")
-
-# prepare a batch of inputs
-dataset = datasets.load_dataset("openai/gsm8k", "socratic", split="test")
-dataset = dataset.select(range(args.samples))
-tokenized_datasets = dataset.map(lambda x: tokenizer(x["question"]), batched=True)
-simple_batch_inputs = [item["input_ids"] for item in tokenized_datasets]
-
-# initialize the manager, available method thanks to the `ContinuousMixin`
 manager = model.init_continuous_batching(generation_config=generation_config)
-
-# start the background thread
 manager.start()
+```
 
-# this is for demonstration purposes only, in practice this is most useful to do concurrently
-for i, input in enumerate(simple_batch_inputs):
-    request_id = manager.add_request(input_ids=input, request_id=f"request_{i}")  # if you do not specify a request_id, one will be generated for you
+Use [`~ContinuousBatchingManager.add_requests`] to asynchronously submit individual requests. Provide a specific request id, or the manager generates one automatically.
 
-# Can be done in an other thread
-for id, request in manager.get_result():
+```py
+for i, input_ids in enumerate(simple_batch_inputs):
+    request_id = manager.add_request(input_ids=input_ids, request_id=f"request_{i}")
+```
+
+Retrieve *all* results as they arrive with [`~ContinuousBatchingManager.get_result`].
+
+```py
+for request_id, request in manager.get_result():
     generated_text = tokenizer.decode(request.generated_tokens, skip_special_tokens=True)
-    print(f"Request {id} output: {generated_text}")
+    print(f"Request {request_id} output: {generated_text}")
+```
 
-# you can also get results for a specific request id
-result = manager.get_result(request_id="request_5")  # this is blocking and will wait for the result to be ready
+Use the `request_id` of a specific request to get its results. This is a blocking operation that waits until the result is ready.
 
-# or get results for a request that is streaming
+```py
+result = manager.get_result(request_id="request_5")
+```
+
+Stream partial results for a specific request with [`~ContinuousBatchingManager.request_id_iter`].
+
+```py
 manager.add_request(
-    input_ids=input,
+    input_ids=input_ids,
     request_id="streaming_request",
     stream=True,
 )
@@ -146,49 +110,61 @@ for chunk in manager.request_id_iter(request_id="streaming_request"):
     # FIXME: stop iteration in `request_id_iter` when finished instead of doing it externally
     if chunk.status == RequestStatus.FINISHED:
         break
+```
 
-# stop the background thread before exiting the process
+Call [`~ContinuousBatchingManager.stop`] to terminate the manager.
+
+```py
 manager.stop()
 ```
 
-## Supported & Unsupported Features
+## PagedAttention
 
-### Supported Features
+PagedAttention breaks large key-value caches into smaller, non-contiguous fixed-size pages to avoid GPU memory fragmentation and support variable-length requests. Transformers automatically enables PagedAttention when using continuous batching.
 
-- Dynamic scheduling of variable-length requests
-- Chunked prefill
-- Paged Attention Cache
-- Sliding window attention
-- Chat templates
+You could explicitly enable PagedAttention when instantiating a model rather than waiting for [`~ContinuousMixin.generate_batch`] to dynamically enable it.
 
-### Unsupported Features
+```py
+import torch
+from transformers import AutoModelForCausalLM
 
-At the moment, the following features are not supported with CB. We plan to add support to the following:
-
-- Prefix caching
-- Beam search
-- tool calling
-
-The others are unplanned, but depending on community requests we might consider adding them:
-
-- MTP (multi token prediction)
-- Medusa
-
-## Performance Considerations
-
-
-## Integration with Serving
-
-You can use CB in `transformers serve` by passing the `--continuous-batching` flag when starting the server.
-
-## Monitoring
-
-We have added `opentelemetry` support to Continuous Batching to help you monitor its performance in production. To enable it, you need to install the `opentelemetry` extra when installing `transformers`:
-
-```sh
-# this installs `opentelemetry-api`, `opentelemetry-sdk` and `opentelemetry-exporter-otlp`
-pip install transformers[open-telemetry]
+model = AutoModelForCausalLM.from_pretrained(
+    "Qwen/Qwen3-4B-Instruct-2507",
+    attn_implementation="paged|flash_attention_2",
+    device_map="cuda",
+    torch_dtype=torch.bfloat16
+)
 ```
 
-This will enable traces and metrics collection in CB. You will then have to setup the backend to collect and visualize the traces and metrics.
+## Sliding window attention
 
+Sliding window attention limits the backward context of a token to save compute, keeping generation cost proportional to window size rather than total context. This reduces compute per step and simplifies continuous batching.
+
+Transformers models like Mistral and Gemma 2 natively support sliding window attention. Manually enable it in the model config if the architecture supports it. This helps with fine-tuning or running custom experiments.
+
+```py
+from transformers import AutoConfig
+
+config = AutoConfig.from_pretrained("google/gemma-2-2b")
+config.sliding_window = 409
+
+model = AutoModelForCausalLM.from_pretrained(
+    "google/gemma-2-2b",
+    config=config,
+    attn_implementation="paged|flash_attention_2",
+    device_map="cuda",
+    dtype=torch.bfloat16,
+)
+```
+
+Usage remains the same with [`~ContinuousMixin.generate_batch`].
+
+## How it works
+
+The [`ContinuousMixin`] class serves as the main interface for continuous batching through [`~ContinuousMixin.generate_batch`]. This method internally creates a [`ContinuousBatchingManager`].
+
+[`ContinuousBatchingManager`] manages requests by creating a background thread for the generation loop and adding requests to the queue. The manager is thread-safe, allowing asynchronous request addition while the model generates.
+
+The [`Scheduler`] selects requests for processing at each step based on the token budget, prioritizing decoding requests over prefilling requests and assigning specific memory blocks to them.
+
+[`ContinuousBatchingManager`] runs the model forward pass for the scheduled requests. It then collects and returns the results.

--- a/docs/source/en/main_classes/text_generation.md
+++ b/docs/source/en/main_classes/text_generation.md
@@ -42,3 +42,11 @@ like token streaming.
 [[autodoc]] GenerationMixin
     - generate
     - compute_transition_scores
+
+## ContinuousMixin
+
+[[autodoc]] generation.ContinuousMixin
+
+## ContinuousBatchingManager
+
+[[autodoc]] generation.ContinuousBatchingManager

--- a/docs/source/en/main_classes/text_generation.md
+++ b/docs/source/en/main_classes/text_generation.md
@@ -50,3 +50,15 @@ like token streaming.
 ## ContinuousBatchingManager
 
 [[autodoc]] generation.ContinuousBatchingManager
+
+## Scheduler
+
+[[autodoc]] generation.Scheduler
+
+## FIFOScheduler
+
+[[autodoc]] generation.FIFOScheduler
+
+## PrefillFirstScheduler
+
+[[autodoc]] generation.PrefillFirstScheduler

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -107,6 +107,8 @@ _import_structure = {
     "generation": [
         "AsyncTextIteratorStreamer",
         "CompileConfig",
+        "ContinuousBatchingManager",
+        "ContinuousMixin",
         "GenerationConfig",
         "TextIteratorStreamer",
         "TextStreamer",
@@ -536,6 +538,8 @@ if TYPE_CHECKING:
     from .generation import BayesianDetectorModel as BayesianDetectorModel
     from .generation import ClassifierFreeGuidanceLogitsProcessor as ClassifierFreeGuidanceLogitsProcessor
     from .generation import CompileConfig as CompileConfig
+    from .generation import ContinuousBatchingManager as ContinuousBatchingManager
+    from .generation import ContinuousMixin as ContinuousMixin
     from .generation import EncoderNoRepeatNGramLogitsProcessor as EncoderNoRepeatNGramLogitsProcessor
     from .generation import EncoderRepetitionPenaltyLogitsProcessor as EncoderRepetitionPenaltyLogitsProcessor
     from .generation import EosTokenCriteria as EosTokenCriteria

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -107,8 +107,6 @@ _import_structure = {
     "generation": [
         "AsyncTextIteratorStreamer",
         "CompileConfig",
-        "ContinuousBatchingManager",
-        "ContinuousMixin",
         "GenerationConfig",
         "TextIteratorStreamer",
         "TextStreamer",
@@ -385,6 +383,8 @@ else:
             "BayesianDetectorConfig",
             "BayesianDetectorModel",
             "ClassifierFreeGuidanceLogitsProcessor",
+            "ContinuousBatchingManager",
+            "ContinuousMixin",
             "EncoderNoRepeatNGramLogitsProcessor",
             "EncoderRepetitionPenaltyLogitsProcessor",
             "EosTokenCriteria",

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -88,6 +88,9 @@ else:
     _import_structure["continuous_batching"] = [
         "ContinuousBatchingManager",
         "ContinuousMixin",
+        "FIFOScheduler",
+        "PrefillFirstScheduler",
+        "Scheduler",
     ]
     _import_structure["utils"] = [
         "GenerationMixin",
@@ -128,7 +131,13 @@ if TYPE_CHECKING:
             EarlyExitCandidateGenerator,
             PromptLookupCandidateGenerator,
         )
-        from .continuous_batching import ContinuousBatchingManager, ContinuousMixin
+        from .continuous_batching import (
+            ContinuousBatchingManager,
+            ContinuousMixin,
+            FIFOScheduler,
+            PrefillFirstScheduler,
+            Scheduler,
+        )
         from .logits_process import (
             AlternatingCodebooksLogitsProcessor,
             ClassifierFreeGuidanceLogitsProcessor,

--- a/src/transformers/generation/__init__.py
+++ b/src/transformers/generation/__init__.py
@@ -86,6 +86,7 @@ else:
         "StopStringCriteria",
     ]
     _import_structure["continuous_batching"] = [
+        "ContinuousBatchingManager",
         "ContinuousMixin",
     ]
     _import_structure["utils"] = [
@@ -127,7 +128,7 @@ if TYPE_CHECKING:
             EarlyExitCandidateGenerator,
             PromptLookupCandidateGenerator,
         )
-        from .continuous_batching import ContinuousMixin
+        from .continuous_batching import ContinuousBatchingManager, ContinuousMixin
         from .logits_process import (
             AlternatingCodebooksLogitsProcessor,
             ClassifierFreeGuidanceLogitsProcessor,

--- a/src/transformers/generation/continuous_batching/__init__.py
+++ b/src/transformers/generation/continuous_batching/__init__.py
@@ -15,12 +15,16 @@
 from .cache import PagedAttentionCache
 from .continuous_api import ContinuousBatchingManager, ContinuousMixin
 from .requests import RequestState, RequestStatus
+from .scheduler import FIFOScheduler, PrefillFirstScheduler, Scheduler
 
 
 __all__ = [
     "ContinuousBatchingManager",
     "ContinuousMixin",
+    "FIFOScheduler",
     "PagedAttentionCache",
+    "PrefillFirstScheduler",
     "RequestState",
     "RequestStatus",
+    "Scheduler",
 ]


### PR DESCRIPTION
Refactors the optimization docs, starting with the attention backend and continuous batching docs (more updates to come in subsequent PRs!).

- reorg the `toctree` to create a clearer inference optimization section for inference (adds the `AttentionInterface`, continuous batching, and kernels guides)
- rename the "LLMs" section into a more generic "Generate API" section especially since we have VLMs now
- add `ContinuousMixin` and `ContinuousBatchingManager` to the API reference
- polish the Attention Interface doc (table describing the available backends, using kernels, etc.) - maybe you can review this section @Cyrilvallez 🙏
- polish the Continuous batching doc (break up the `ContinuousBatchingManager` example to better show the different options for using it, adds clearer PagedAttention and sliding window attention sections, high-level description of how the mixin, manager, and scheduler work together, move the monitoring section to the `transformers serve` docs) - maybe you can review this section @McPatate 🙏