### PR TITLE
Fix epoch logging for iterable dataloaders

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2593,7 +2593,7 @@ class Trainer:
 
                         model.zero_grad()
                         self.state.global_step += 1
-                        self.state.epoch = epoch + (step + 1) / steps_in_epoch
+                        self.state.epoch = epoch if len_dataloader is None else epoch + (step + 1) / steps_in_epoch
                         self.control = self.callback_handler.on_step_end(args, self.state, self.control)
                         self._maybe_log_save_evaluate(
                             tr_loss,


### PR DESCRIPTION
**What does this PR do?**
- Fixes incorrect fractional `epoch` progress logging when training with iterable dataloaders that do not provide a length (`__len__`). When the dataloader length is unknown, the previous logic divided by the total training plan (`max_steps * gradient_accumulation_steps`), producing misleading values like `0.05 → 0.5 → 1.05`. This PR makes `epoch` an integer counter in such cases, while preserving the existing fractional progress for dataloaders with a known length.
- Fixes #41913

**Motivation and Context**
- With iterable datasets without `__len__`, `steps_in_epoch` is set to `args.max_steps * args.gradient_accumulation_steps`, which is the global training plan, not the number of steps in the current epoch. As a result, logs show fractional `epoch` increments that do not reflect the actual pass over the dataset, confusing users and tooling that rely on `epoch` semantics.
- This change aligns the `epoch` field with its core meaning when the true epoch length is unknown: a pass counter (integer), while keeping the original fractional behavior when the epoch length is known.

**Changes**
- One-line change in the trainer to gate fractional epoch calculation on the presence of a dataloader length:
  - `src/transformers/trainer.py:2596`
  - Before: `self.state.epoch = epoch + (step + 1) / steps_in_epoch`
  - After: `self.state.epoch = epoch if len_dataloader is None else epoch + (step + 1) / steps_in_epoch`

**Before vs After**
- Before (iterable dataloader without `__len__`):
  - Logs: `epoch=0.05, 0.10, …, 0.50` then `1.05, 1.10, …, 1.50`
  - Fractional progress derived from global `max_steps`, not real per-epoch steps
- After:
  - Iterable dataloader without `__len__`: `epoch` is an integer (0 for first pass, 1 for second, etc.)
  - Dataloader with `__len__`: unchanged; `epoch` shows fractional progress with correct per-epoch denominator

**Backward Compatibility**
- No change for standard dataloaders with `__len__`; fractional logging remains as-is
- Callbacks or dashboards that expect fractional `epoch` values with unknown-length dataloaders will now see integers; these should rely on `global_step` for fine-grained progress in such scenarios
- `global_step`, optimizer scheduling, and LR schedulers are unaffected

**Dependencies**
- None

**Before submitting**
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request, Pull Request section?
- [x] Was this discussed/approved via a Github issue or the https://discuss.huggingface.co/? Please add a link to it if that's the case. Fixes #41913
- [ ] Did you make sure to update the documentation with your changes? Here are the https://github.com/huggingface/transformers/tree/main/docs, and https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation.
- [ ] Did you write any new necessary tests?

**Who can review?**
- Trainer: @SunMarc