### PR TITLE
fix(benchmarks): correct sdpa_backend inconsistency and attn_implementation for continuous batching

### DIFF
--- a/benchmark_v2/framework/benchmark_config.py
+++ b/benchmark_v2/framework/benchmark_config.py
@@ -102,7 +102,7 @@ class BenchmarkConfig:
                 logger.warning(
                     "when continuous batching is enabled, sdpa_backend must be None because of the attention mask, setting it to None"
                 )
-                self.sdpa_backend = "math"
+                self.sdpa_backend = None
 
     @property
     def hash(self) -> str:
@@ -240,5 +240,5 @@ def get_config_by_level(level: int) -> list[BenchmarkConfig]:
         configs.append(BenchmarkConfig(attn_implementation="sdpa", compile_mode="default"))
         configs.append(BenchmarkConfig(attn_implementation="flex_attention", compile_mode="default", kernelize=True))
         configs.append(BenchmarkConfig(attn_implementation="flash_attention_2", kernelize=True))
-        configs.append(BenchmarkConfig(attn_implementation="paged|sdpa", continuous_batching=True))
+        configs.append(BenchmarkConfig(attn_implementation="sdpa", continuous_batching=True))
     return configs


### PR DESCRIPTION
## Summary

This PR fixes two bugs in `BenchmarkConfig` reported in issue #42211:

1. **sdpa_backend inconsistency (line 105)**: The warning message states "sdpa_backend must be None" but the code was setting it to "math". Changed to None to match the warning message.

2. **Invalid attn_implementation (line 243)**: Changed from "paged|sdpa" to "sdpa". Using "paged|sdpa" directly bypassed the validation logic since it only checks for exactly "sdpa". The "paged|" prefix is automatically added by `init_continuous_batching()`.

## Technical Details

**Bug 1 - sdpa_backend inconsistency:**
- Location: `benchmark_v2/framework/benchmark_config.py:105`
- Issue: Warning says "setting it to None" but code sets to "math"
- Fix: Changed `self.sdpa_backend = "math"` to `self.sdpa_backend = None`
- Reasoning: Setting to None allows PyTorch to auto-select the appropriate SDPA backend for continuous batching scenarios with custom attention masks

**Bug 2 - attn_implementation bypass:**
- Location: `benchmark_v2/framework/benchmark_config.py:243`
- Issue: Using "paged|sdpa" bypasses validation at lines 91-105
- Fix: Changed from `attn_implementation="paged|sdpa"` to `attn_implementation="sdpa"`
- Reasoning: The "paged|" prefix is automatically added by `init_continuous_batching()` in `continuous_api.py` (lines 744-756), so configs should use plain implementation names

Both bugs were introduced in commit 069684ef87 (PR #41916).

Fixes #42211