### PR TITLE
Add BatchFeature support to Wav2Vec2FeatureExtractor

### DIFF
--- a/tests/models/wav2vec2/test_feature_extraction_wav2vec2.py
+++ b/tests/models/wav2vec2/test_feature_extraction_wav2vec2.py
@@ -247,9 +247,7 @@ class Wav2Vec2FeatureExtractionTest(SequenceFeatureExtractionTestMixin, unittest
         batch_feature_output = feat_extract(batch_feature_input, padding=True, return_tensors="np")
 
         # Verify outputs match
-        np.testing.assert_allclose(
-            normal_output.input_values, batch_feature_output.input_values, atol=1e-5
-        )
+        np.testing.assert_allclose(normal_output.input_values, batch_feature_output.input_values, atol=1e-5)
 
     @require_torch
     def test_call_with_batch_feature_torch_tensors(self):


### PR DESCRIPTION
## Summary

This PR adds support for passing `BatchFeature` objects as input to `Wav2Vec2FeatureExtractor.__call__()`. This enables users to pass pre-batched data that may already be on a specific device (e.g., GPU) or in tensor format.

## Motivation

Closes #42161

When using `Wav2Vec2FeatureExtractor`, it is common for data to already be in a batched format (e.g., padded torch tensor) for various reasons:
- Tensor has already been moved to a specific device
- Certain functional operations require the data being in the framework's primitive tensor format
- It's faster to run when batched

Users should be able to construct a `BatchFeature` instance and pass it directly to the feature extractor.

## Changes

### Core Implementation
- Updated `__call__` type signature to accept `BatchFeature`
- Added validation to ensure `BatchFeature` contains required `input_values` key
- Preserved all existing functionality and backward compatibility
- Reuses existing padding and normalization logic

### Tests Added
- `test_call_with_batch_feature_input` - Basic BatchFeature functionality
- `test_call_with_batch_feature_torch_tensors` - PyTorch tensor support (GPU use case)
- `test_call_with_batch_feature_missing_key` - Error handling validation
- `test_call_with_batch_feature_preserves_attention_mask` - Attention mask handling
- `test_call_with_batch_feature_numpy_arrays` - NumPy array support with normalization

## Example Usage

```python
from transformers import Wav2Vec2FeatureExtractor, BatchFeature
import torch

feature_extractor = Wav2Vec2FeatureExtractor.from_pretrained("facebook/wav2vec2-base")

# Data already on GPU
audio_tensor = torch.randn(2, 16000, device="cuda")
batch_features = BatchFeature({"input_values": audio_tensor})

# Can pass BatchFeature directly
outputs = feature_extractor(batch_features, return_tensors="pt", padding=True)
```

## Testing

- [x] All existing tests pass (backward compatibility maintained)
- [x] New tests added for BatchFeature support
- [x] Syntax validation passed
- [x] Code follows DRY principles and existing patterns

## Checklist

- [x] Code is clean, readable, and maintainable
- [x] No hardcoded values - uses `self.model_input_names[0]`
- [x] Clear error messages with actionable information
- [x] Type hints are accurate and complete
- [x] Docstrings updated with BatchFeature usage
- [x] No code duplication
- [x] Backward compatible - no breaking changes