### PR TITLE
Fix code examples to load gpt 1 openai community model

### DIFF
--- a/docs/source/en/model_doc/openai-gpt.md
+++ b/docs/source/en/model_doc/openai-gpt.md
@@ -43,7 +43,7 @@ The example below demonstrates how to generate text with [`Pipeline`], [`AutoMod
 import torch
 from transformers import pipeline
 
-generator = pipeline(task="text-generation", model="openai-community/openai-gpt", dtype=torch.float16, device=0)
+generator = pipeline(task="text-generation", model="openai-community/openai-gpt", device=0)
 output = generator("The future of AI is", max_length=50, do_sample=True)
 print(output[0]["generated_text"])
 ```
@@ -55,7 +55,7 @@ print(output[0]["generated_text"])
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 tokenizer = AutoTokenizer.from_pretrained("openai-community/openai-gpt")
-model = AutoModelForCausalLM.from_pretrained("openai-community/openai-gpt", dtype=torch.float16)
+model = AutoModelForCausalLM.from_pretrained("openai-community/openai-gpt")
 
 inputs = tokenizer("The future of AI is", return_tensors="pt")
 outputs = model.generate(**inputs, max_length=50)

--- a/docs/source/en/model_doc/openai-gpt.md
+++ b/docs/source/en/model_doc/openai-gpt.md
@@ -43,7 +43,7 @@ The example below demonstrates how to generate text with [`Pipeline`], [`AutoMod
 import torch
 from transformers import pipeline
 
-generator = pipeline(task="text-generation", model="openai-community/gpt", dtype=torch.float16, device=0)
+generator = pipeline(task="text-generation", model="openai-community/openai-gpt", dtype=torch.float16, device=0)
 output = generator("The future of AI is", max_length=50, do_sample=True)
 print(output[0]["generated_text"])
 ```
@@ -54,7 +54,7 @@ print(output[0]["generated_text"])
 ```python
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
-tokenizer = AutoTokenizer.from_pretrained("openai-community/gpt")
+tokenizer = AutoTokenizer.from_pretrained("openai-community/openai-gpt")
 model = AutoModelForCausalLM.from_pretrained("openai-community/openai-gpt", dtype=torch.float16)
 
 inputs = tokenizer("The future of AI is", return_tensors="pt")


### PR DESCRIPTION
# What does this PR do?

Fixes the reference to the model `openai-gpt` that seems to have changed its name from `gpt` to `openai-gpt`


## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker
- vision models: @amyeroberts
- speech models: @sanchit-gandhi
- graph models: @clefourrier

Library:

- flax: @sanchit-gandhi
- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- pipelines: @Narsil
- tensorflow: @gante and @Rocketknight1
- tokenizers: @ArthurZucker
- trainer: @muellerzr and @SunMarc

Integrations:

- deepspeed: HF Trainer/Accelerate: @muellerzr
- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization (bitsandbytes, autogpt): @SunMarc

Documentation: @stevhliu

HF projects:

- accelerate: [different repo](https://github.com/huggingface/accelerate)
- datasets: [different repo](https://github.com/huggingface/datasets)
- diffusers: [different repo](https://github.com/huggingface/diffusers)
- rust tokenizers: [different repo](https://github.com/huggingface/tokenizers)

Maintained examples (not research project or legacy):

- Flax: @sanchit-gandhi
- PyTorch: See Models above and tag the person corresponding to the modality of the example.
- TensorFlow: @Rocketknight1

 -->

Documentation: @stevhliu