### PR TITLE
Remove test inheritance for EfficientLoftr, rename KeypointMatchingOutput to model specific name

### DIFF
--- a/src/transformers/models/efficientloftr/image_processing_efficientloftr.py
+++ b/src/transformers/models/efficientloftr/image_processing_efficientloftr.py
@@ -45,7 +45,7 @@ if is_vision_available():
     import PIL
     from PIL import Image, ImageDraw
 
-    from .modeling_efficientloftr import KeypointMatchingOutput
+    from .modeling_efficientloftr import EfficientLoFTRKeypointMatchingOutput
 
 logger = logging.get_logger(__name__)
 
@@ -344,15 +344,15 @@ class EfficientLoFTRImageProcessor(BaseImageProcessor):
 
     def post_process_keypoint_matching(
         self,
-        outputs: "KeypointMatchingOutput",
+        outputs: "EfficientLoFTRKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`EfficientLoFTRKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`EfficientLoFTRKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `List[Tuple[Tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`Tuple[int, int]`) containing the

--- a/src/transformers/models/efficientloftr/image_processing_efficientloftr_fast.py
+++ b/src/transformers/models/efficientloftr/image_processing_efficientloftr_fast.py
@@ -24,7 +24,7 @@ from ...image_utils import (
 from ...processing_utils import Unpack
 from ...utils import TensorType, auto_docstring
 from .image_processing_efficientloftr import EfficientLoFTRImageProcessorKwargs
-from .modeling_efficientloftr import KeypointMatchingOutput
+from .modeling_efficientloftr import EfficientLoFTRKeypointMatchingOutput
 
 
 def _is_valid_image(image):
@@ -159,15 +159,15 @@ class EfficientLoFTRImageProcessorFast(BaseImageProcessorFast):
 
     def post_process_keypoint_matching(
         self,
-        outputs: "KeypointMatchingOutput",
+        outputs: "EfficientLoFTRKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`EfficientLoFTRKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`EfficientLoFTRKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `List[Tuple[Tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`Tuple[int, int]`) containing the

--- a/src/transformers/models/efficientloftr/modeling_efficientloftr.py
+++ b/src/transformers/models/efficientloftr/modeling_efficientloftr.py
@@ -1365,9 +1365,4 @@ class EfficientLoFTRForKeypointMatching(EfficientLoFTRPreTrainedModel):
         )
 
 
-__all__ = [
-    "EfficientLoFTRPreTrainedModel",
-    "EfficientLoFTRModel",
-    "EfficientLoFTRForKeypointMatching",
-    "EfficientLoFTRKeypointMatchingOutput",
-]
+__all__ = ["EfficientLoFTRPreTrainedModel", "EfficientLoFTRModel", "EfficientLoFTRForKeypointMatching"]

--- a/src/transformers/models/efficientloftr/modeling_efficientloftr.py
+++ b/src/transformers/models/efficientloftr/modeling_efficientloftr.py
@@ -40,15 +40,15 @@ from .configuration_efficientloftr import EfficientLoFTRConfig
 @dataclass
 @auto_docstring(
     custom_intro="""
-    Base class for outputs of keypoint matching models. Due to the nature of keypoint detection and matching, the number
+    Base class for outputs of EfficientLoFTR keypoint matching models. Due to the nature of keypoint detection and matching, the number
     of keypoints is not fixed and can vary from image to image, which makes batching non-trivial. In the batch of
-    images, the maximum number of matches is set as the dimension of the matches and matching scores. The mask tensor is
-    used to indicate which values in the keypoints, matches and matching_scores tensors are keypoint matching
-    information.
+    images, the maximum number of matches is set as the dimension of the matches and matching scores.
     """
 )
-class KeypointMatchingOutput(ModelOutput):
+class EfficientLoFTRKeypointMatchingOutput(ModelOutput):
     r"""
+    loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
+        Loss computed during training.
     matches (`torch.FloatTensor` of shape `(batch_size, 2, num_matches)`):
         Index of keypoint matched in the other image.
     matching_scores (`torch.FloatTensor` of shape `(batch_size, 2, num_matches)`):
@@ -64,6 +64,7 @@ class KeypointMatchingOutput(ModelOutput):
         num_keypoints)`, returned when `output_attentions=True` is passed or when `config.output_attentions=True`)
     """
 
+    loss: Optional[torch.FloatTensor] = None
     matches: Optional[torch.FloatTensor] = None
     matching_scores: Optional[torch.FloatTensor] = None
     keypoints: Optional[torch.FloatTensor] = None
@@ -1295,7 +1296,7 @@ class EfficientLoFTRForKeypointMatching(EfficientLoFTRPreTrainedModel):
         pixel_values: torch.FloatTensor,
         labels: Optional[torch.LongTensor] = None,
         **kwargs: Unpack[TransformersKwargs],
-    ) -> KeypointMatchingOutput:
+    ) -> EfficientLoFTRKeypointMatchingOutput:
         r"""
         Examples:
 
@@ -1353,7 +1354,9 @@ class EfficientLoFTRForKeypointMatching(EfficientLoFTRPreTrainedModel):
         matching_keypoints[:, :, :, 0] = matching_keypoints[:, :, :, 0] / width
         matching_keypoints[:, :, :, 1] = matching_keypoints[:, :, :, 1] / height
 
-        return KeypointMatchingOutput(
+        loss = None
+        return EfficientLoFTRKeypointMatchingOutput(
+            loss=loss,
             matches=coarse_matched_indices,
             matching_scores=coarse_matching_scores,
             keypoints=matching_keypoints,
@@ -1362,4 +1365,9 @@ class EfficientLoFTRForKeypointMatching(EfficientLoFTRPreTrainedModel):
         )
 
 
-__all__ = ["EfficientLoFTRPreTrainedModel", "EfficientLoFTRModel", "EfficientLoFTRForKeypointMatching"]
+__all__ = [
+    "EfficientLoFTRPreTrainedModel",
+    "EfficientLoFTRModel",
+    "EfficientLoFTRForKeypointMatching",
+    "EfficientLoFTRKeypointMatchingOutput",
+]

--- a/src/transformers/models/efficientloftr/modular_efficientloftr.py
+++ b/src/transformers/models/efficientloftr/modular_efficientloftr.py
@@ -4,21 +4,21 @@ import torch
 
 from ...utils import TensorType
 from ..superglue.image_processing_superglue_fast import SuperGlueImageProcessorFast
-from .modeling_efficientloftr import KeypointMatchingOutput
+from .modeling_efficientloftr import EfficientLoFTRKeypointMatchingOutput
 
 
 class EfficientLoFTRImageProcessorFast(SuperGlueImageProcessorFast):
     def post_process_keypoint_matching(
         self,
-        outputs: "KeypointMatchingOutput",
+        outputs: "EfficientLoFTRKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`EfficientLoFTRKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`EfficientLoFTRKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `List[Tuple[Tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`Tuple[int, int]`) containing the

--- a/src/transformers/models/lightglue/image_processing_lightglue.py
+++ b/src/transformers/models/lightglue/image_processing_lightglue.py
@@ -17,7 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import torch
@@ -42,8 +42,10 @@ from ...image_utils import (
 from ...processing_utils import ImagesKwargs
 from ...utils import TensorType, logging, requires_backends
 from ...utils.import_utils import requires
-from .modeling_lightglue import LightGlueKeypointMatchingOutput
 
+
+if TYPE_CHECKING:
+    from .modeling_lightglue import LightGlueKeypointMatchingOutput
 
 if is_vision_available():
     import PIL
@@ -341,15 +343,15 @@ class LightGlueImageProcessor(BaseImageProcessor):
 
     def post_process_keypoint_matching(
         self,
-        outputs: LightGlueKeypointMatchingOutput,
+        outputs: "LightGlueKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`LightGlueKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`LightGlueKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `list[tuple[tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`tuple[int, int]`) containing the

--- a/src/transformers/models/lightglue/image_processing_lightglue_fast.py
+++ b/src/transformers/models/lightglue/image_processing_lightglue_fast.py
@@ -17,7 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import torch
 from torchvision.transforms.v2 import functional as F
@@ -39,8 +39,10 @@ from ...image_utils import (
 from ...processing_utils import Unpack
 from ...utils import TensorType, auto_docstring
 from .image_processing_lightglue import LightGlueImageProcessorKwargs
-from .modeling_lightglue import LightGlueKeypointMatchingOutput
 
+
+if TYPE_CHECKING:
+    from .modeling_lightglue import LightGlueKeypointMatchingOutput
 
 if is_vision_available():
     from PIL import Image, ImageDraw
@@ -178,15 +180,15 @@ class LightGlueImageProcessorFast(BaseImageProcessorFast):
 
     def post_process_keypoint_matching(
         self,
-        outputs: LightGlueKeypointMatchingOutput,
+        outputs: "LightGlueKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`LightGlueKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`LightGlueKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `list[tuple[tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`tuple[int, int]`) containing the

--- a/src/transformers/models/lightglue/modeling_lightglue.py
+++ b/src/transformers/models/lightglue/modeling_lightglue.py
@@ -869,7 +869,7 @@ class LightGlueForKeypointMatching(LightGluePreTrainedModel):
         labels: Optional[torch.LongTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
-    ) -> Union[tuple, LightGlueKeypointMatchingOutput]:
+    ) -> Union[tuple, "LightGlueKeypointMatchingOutput"]:
         loss = None
         if labels is not None:
             raise ValueError("LightGlue is not trainable, no labels should be provided.")

--- a/src/transformers/models/lightglue/modular_lightglue.py
+++ b/src/transformers/models/lightglue/modular_lightglue.py
@@ -222,7 +222,7 @@ class LightGlueImageProcessorKwargs(SuperGlueImageProcessorKwargs):
 class LightGlueImageProcessor(SuperGlueImageProcessor):
     def post_process_keypoint_matching(
         self,
-        outputs: LightGlueKeypointMatchingOutput,
+        outputs: "LightGlueKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
@@ -232,7 +232,7 @@ class LightGlueImageProcessor(SuperGlueImageProcessor):
 class LightGlueImageProcessorFast(SuperGlueImageProcessorFast):
     def post_process_keypoint_matching(
         self,
-        outputs: LightGlueKeypointMatchingOutput,
+        outputs: "LightGlueKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
@@ -927,7 +927,7 @@ class LightGlueForKeypointMatching(LightGluePreTrainedModel):
         labels: Optional[torch.LongTensor] = None,
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
-    ) -> Union[tuple, LightGlueKeypointMatchingOutput]:
+    ) -> Union[tuple, "LightGlueKeypointMatchingOutput"]:
         loss = None
         if labels is not None:
             raise ValueError("LightGlue is not trainable, no labels should be provided.")

--- a/src/transformers/models/superglue/image_processing_superglue.py
+++ b/src/transformers/models/superglue/image_processing_superglue.py
@@ -44,7 +44,7 @@ if is_torch_available():
     import torch
 
 if TYPE_CHECKING:
-    from .modeling_superglue import KeypointMatchingOutput
+    from .modeling_superglue import SuperGlueKeypointMatchingOutput
 
 if is_vision_available():
     import PIL
@@ -345,15 +345,15 @@ class SuperGlueImageProcessor(BaseImageProcessor):
 
     def post_process_keypoint_matching(
         self,
-        outputs: "KeypointMatchingOutput",
+        outputs: "SuperGlueKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`SuperGlueKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`SuperGlueKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `list[tuple[tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`tuple[int, int]`) containing the

--- a/src/transformers/models/superglue/image_processing_superglue_fast.py
+++ b/src/transformers/models/superglue/image_processing_superglue_fast.py
@@ -32,7 +32,7 @@ from ...image_utils import (
 from ...processing_utils import Unpack
 from ...utils import TensorType, auto_docstring
 from .image_processing_superglue import SuperGlueImageProcessorKwargs
-from .modeling_superglue import KeypointMatchingOutput
+from .modeling_superglue import SuperGlueKeypointMatchingOutput
 
 
 def _is_valid_image(image):
@@ -167,15 +167,15 @@ class SuperGlueImageProcessorFast(BaseImageProcessorFast):
 
     def post_process_keypoint_matching(
         self,
-        outputs: "KeypointMatchingOutput",
+        outputs: "SuperGlueKeypointMatchingOutput",
         target_sizes: Union[TensorType, list[tuple]],
         threshold: float = 0.0,
     ) -> list[dict[str, torch.Tensor]]:
         """
-        Converts the raw output of [`KeypointMatchingOutput`] into lists of keypoints, scores and descriptors
+        Converts the raw output of [`SuperGlueKeypointMatchingOutput`] into lists of keypoints, scores and descriptors
         with coordinates absolute to the original image sizes.
         Args:
-            outputs ([`KeypointMatchingOutput`]):
+            outputs ([`SuperGlueKeypointMatchingOutput`]):
                 Raw outputs of the model.
             target_sizes (`torch.Tensor` or `list[tuple[tuple[int, int]]]`, *optional*):
                 Tensor of shape `(batch_size, 2, 2)` or list of tuples of tuples (`tuple[int, int]`) containing the

--- a/src/transformers/models/superglue/modeling_superglue.py
+++ b/src/transformers/models/superglue/modeling_superglue.py
@@ -149,14 +149,14 @@ def arange_like(x, dim: int) -> torch.Tensor:
 @dataclass
 @auto_docstring(
     custom_intro="""
-    Base class for outputs of keypoint matching models. Due to the nature of keypoint detection and matching, the number
+    Base class for outputs of SuperGlue keypoint matching models. Due to the nature of keypoint detection and matching, the number
     of keypoints is not fixed and can vary from image to image, which makes batching non-trivial. In the batch of
     images, the maximum number of matches is set as the dimension of the matches and matching scores. The mask tensor is
     used to indicate which values in the keypoints, matches and matching_scores tensors are keypoint matching
     information.
     """
 )
-class KeypointMatchingOutput(ModelOutput):
+class SuperGlueKeypointMatchingOutput(ModelOutput):
     r"""
     loss (`torch.FloatTensor` of shape `(1,)`, *optional*):
         Loss computed during training.
@@ -670,7 +670,7 @@ class SuperGlueForKeypointMatching(SuperGluePreTrainedModel):
         output_attentions: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
-    ) -> Union[tuple, KeypointMatchingOutput]:
+    ) -> Union[tuple, SuperGlueKeypointMatchingOutput]:
         r"""
         Examples:
 
@@ -738,7 +738,7 @@ class SuperGlueForKeypointMatching(SuperGluePreTrainedModel):
                 if v is not None
             )
 
-        return KeypointMatchingOutput(
+        return SuperGlueKeypointMatchingOutput(
             loss=loss,
             matches=matches,
             matching_scores=matching_scores,

--- a/tests/models/efficientloftr/test_image_processing_efficientloftr.py
+++ b/tests/models/efficientloftr/test_image_processing_efficientloftr.py
@@ -15,22 +15,26 @@ import time
 import unittest
 
 import numpy as np
+import pytest
+from packaging import version
+from parameterized import parameterized
 
-from tests.models.superglue.test_image_processing_superglue import (
-    SuperGlueImageProcessingTest,
-    SuperGlueImageProcessingTester,
-)
 from transformers.testing_utils import (
     require_torch,
+    require_torch_accelerator,
     require_vision,
+    slow,
+    torch_device,
 )
 from transformers.utils import is_torch_available, is_torchvision_available, is_vision_available
+
+from ...test_image_processing_common import ImageProcessingTestMixin, prepare_image_inputs
 
 
 if is_torch_available():
     import torch
 
-    from transformers.models.efficientloftr.modeling_efficientloftr import KeypointMatchingOutput
+    from transformers.models.efficientloftr.modeling_efficientloftr import EfficientLoFTRKeypointMatchingOutput
 
 if is_vision_available():
     from transformers import EfficientLoFTRImageProcessor
@@ -47,7 +51,7 @@ def random_tensor(size):
     return torch.rand(size)
 
 
-class EfficientLoFTRImageProcessingTester(SuperGlueImageProcessingTester):
+class EfficientLoFTRImageProcessingTester:
     """Tester for EfficientLoFTRImageProcessor"""
 
     def __init__(
@@ -62,9 +66,41 @@ class EfficientLoFTRImageProcessingTester(SuperGlueImageProcessingTester):
         size=None,
         do_grayscale=True,
     ):
-        super().__init__(
-            parent, batch_size, num_channels, image_size, min_resolution, max_resolution, do_resize, size, do_grayscale
+        size = size if size is not None else {"height": 480, "width": 640}
+        self.parent = parent
+        self.batch_size = batch_size
+        self.num_channels = num_channels
+        self.image_size = image_size
+        self.min_resolution = min_resolution
+        self.max_resolution = max_resolution
+        self.do_resize = do_resize
+        self.size = size
+        self.do_grayscale = do_grayscale
+
+    def prepare_image_processor_dict(self):
+        return {
+            "do_resize": self.do_resize,
+            "size": self.size,
+            "do_grayscale": self.do_grayscale,
+        }
+
+    def expected_output_image_shape(self, images):
+        return 2, self.num_channels, self.size["height"], self.size["width"]
+
+    def prepare_image_inputs(self, equal_resolution=False, numpify=False, torchify=False, pairs=True, batch_size=None):
+        batch_size = batch_size if batch_size is not None else self.batch_size
+        image_inputs = prepare_image_inputs(
+            batch_size=batch_size,
+            num_channels=self.num_channels,
+            min_resolution=self.min_resolution,
+            max_resolution=self.max_resolution,
+            equal_resolution=equal_resolution,
+            numpify=numpify,
+            torchify=torchify,
         )
+        if pairs:
+            image_inputs = [image_inputs[i : i + 2] for i in range(0, len(image_inputs), 2)]
+        return image_inputs
 
     def prepare_keypoint_matching_output(self, pixel_values):
         """Prepare a fake output for the keypoint matching model with random matches between 50 keypoints per image."""
@@ -85,18 +121,292 @@ class EfficientLoFTRImageProcessingTester(SuperGlueImageProcessingTester):
             matches[i, 1, random_matches_indices0] = random_matches_indices1
             scores[i, 0, random_matches_indices1] = torch.rand((random_number_matches,))
             scores[i, 1, random_matches_indices0] = torch.rand((random_number_matches,))
-        return KeypointMatchingOutput(keypoints=keypoints, matches=matches, matching_scores=scores)
+        return EfficientLoFTRKeypointMatchingOutput(keypoints=keypoints, matches=matches, matching_scores=scores)
 
 
 @require_torch
 @require_vision
-class EfficientLoFTRImageProcessingTest(SuperGlueImageProcessingTest, unittest.TestCase):
+class EfficientLoFTRImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
     image_processing_class = EfficientLoFTRImageProcessor if is_vision_available() else None
     fast_image_processing_class = EfficientLoFTRImageProcessorFast if is_torchvision_available() else None
 
     def setUp(self) -> None:
         super().setUp()
         self.image_processor_tester = EfficientLoFTRImageProcessingTester(self)
+
+    @property
+    def image_processor_dict(self):
+        return self.image_processor_tester.prepare_image_processor_dict()
+
+    def test_image_processing(self):
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+            self.assertTrue(hasattr(image_processing, "do_resize"))
+            self.assertTrue(hasattr(image_processing, "size"))
+            self.assertTrue(hasattr(image_processing, "do_rescale"))
+            self.assertTrue(hasattr(image_processing, "rescale_factor"))
+            self.assertTrue(hasattr(image_processing, "do_grayscale"))
+
+    def test_image_processor_from_dict_with_kwargs(self):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            self.assertEqual(image_processor.size, {"height": 480, "width": 640})
+
+            image_processor = image_processing_class.from_dict(
+                self.image_processor_dict, size={"height": 42, "width": 42}
+            )
+            self.assertEqual(image_processor.size, {"height": 42, "width": 42})
+
+    @unittest.skip(reason="SuperPointImageProcessor is always supposed to return a grayscaled image")
+    def test_call_numpy_4_channels(self):
+        pass
+
+    def test_number_and_format_of_images_in_input(self):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+
+            # Cases where the number of images and the format of lists in the input is correct
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=False, batch_size=2)
+            image_processed = image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual((1, 2, 3, 480, 640), tuple(image_processed["pixel_values"].shape))
+
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=True, batch_size=2)
+            image_processed = image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual((1, 2, 3, 480, 640), tuple(image_processed["pixel_values"].shape))
+
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=True, batch_size=4)
+            image_processed = image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual((2, 2, 3, 480, 640), tuple(image_processed["pixel_values"].shape))
+
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=True, batch_size=6)
+            image_processed = image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual((3, 2, 3, 480, 640), tuple(image_processed["pixel_values"].shape))
+
+            # Cases where the number of images or the format of lists in the input is incorrect
+            ## List of 4 images
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=False, batch_size=4)
+            with self.assertRaises(ValueError) as cm:
+                image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual(ValueError, cm.exception.__class__)
+
+            ## List of 3 images
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=False, batch_size=3)
+            with self.assertRaises(ValueError) as cm:
+                image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual(ValueError, cm.exception.__class__)
+
+            ## List of 2 pairs and 1 image
+            image_input = self.image_processor_tester.prepare_image_inputs(pairs=True, batch_size=3)
+            with self.assertRaises(ValueError) as cm:
+                image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual(ValueError, cm.exception.__class__)
+
+    @parameterized.expand(
+        [
+            ([random_array((3, 100, 200)), random_array((3, 100, 200))], (1, 2, 3, 480, 640)),
+            ([[random_array((3, 100, 200)), random_array((3, 100, 200))]], (1, 2, 3, 480, 640)),
+            ([random_tensor((3, 100, 200)), random_tensor((3, 100, 200))], (1, 2, 3, 480, 640)),
+            ([random_tensor((3, 100, 200)), random_tensor((3, 100, 200))], (1, 2, 3, 480, 640)),
+        ],
+    )
+    def test_valid_image_shape_in_input(self, image_input, output):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            image_processed = image_processor.preprocess(image_input, return_tensors="pt")
+            self.assertEqual(output, tuple(image_processed["pixel_values"].shape))
+
+    @parameterized.expand(
+        [
+            (random_array((3, 100, 200)),),
+            ([random_array((3, 100, 200))],),
+            (random_array((1, 3, 100, 200)),),
+            ([[random_array((3, 100, 200))]],),
+            ([[random_array((3, 100, 200))], [random_array((3, 100, 200))]],),
+            ([random_array((1, 3, 100, 200)), random_array((1, 3, 100, 200))],),
+            (random_array((1, 1, 3, 100, 200)),),
+        ],
+    )
+    def test_invalid_image_shape_in_input(self, image_input):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            with self.assertRaises(ValueError) as cm:
+                image_processor(image_input, return_tensors="pt")
+            self.assertEqual(ValueError, cm.exception.__class__)
+
+    def test_input_images_properly_paired(self):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            image_inputs = self.image_processor_tester.prepare_image_inputs()
+            pre_processed_images = image_processor(image_inputs, return_tensors="pt")
+            self.assertEqual(len(pre_processed_images["pixel_values"].shape), 5)
+            self.assertEqual(pre_processed_images["pixel_values"].shape[1], 2)
+
+    def test_input_not_paired_images_raises_error(self):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            image_inputs = self.image_processor_tester.prepare_image_inputs(pairs=False)
+            with self.assertRaises(ValueError):
+                image_processor(image_inputs[0])
+
+    def test_input_image_properly_converted_to_grayscale(self):
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            image_inputs = self.image_processor_tester.prepare_image_inputs()
+            pre_processed_images = image_processor(image_inputs, return_tensors="pt")
+            for image_pair in pre_processed_images["pixel_values"]:
+                for image in image_pair:
+                    self.assertTrue(
+                        torch.all(image[0, ...] == image[1, ...]) and torch.all(image[1, ...] == image[2, ...])
+                    )
+
+    def test_call_numpy(self):
+        # Test overwritten because SuperGlueImageProcessor combines images by pair to feed it into SuperGlue
+
+        # Initialize image_processing
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+            # create random numpy tensors
+            image_pairs = self.image_processor_tester.prepare_image_inputs(equal_resolution=False, numpify=True)
+            for image_pair in image_pairs:
+                self.assertEqual(len(image_pair), 2)
+
+            expected_batch_size = int(self.image_processor_tester.batch_size / 2)
+
+            # Test with 2 images
+            encoded_images = image_processing(image_pairs[0], return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs[0])
+            self.assertEqual(tuple(encoded_images.shape), (1, *expected_output_image_shape))
+
+            # Test with list of pairs
+            encoded_images = image_processing(image_pairs, return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs)
+            self.assertEqual(tuple(encoded_images.shape), (expected_batch_size, *expected_output_image_shape))
+
+            # Test without paired images
+            image_pairs = self.image_processor_tester.prepare_image_inputs(
+                equal_resolution=False, numpify=True, pairs=False
+            )
+            with self.assertRaises(ValueError):
+                image_processing(image_pairs, return_tensors="pt").pixel_values
+
+    def test_call_pil(self):
+        # Test overwritten because SuperGlueImageProcessor combines images by pair to feed it into SuperGlue
+
+        # Initialize image_processing
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+            # create random PIL images
+            image_pairs = self.image_processor_tester.prepare_image_inputs(equal_resolution=False)
+            for image_pair in image_pairs:
+                self.assertEqual(len(image_pair), 2)
+
+            expected_batch_size = int(self.image_processor_tester.batch_size / 2)
+
+            # Test with 2 images
+            encoded_images = image_processing(image_pairs[0], return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs[0])
+            self.assertEqual(tuple(encoded_images.shape), (1, *expected_output_image_shape))
+
+            # Test with list of pairs
+            encoded_images = image_processing(image_pairs, return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs)
+            self.assertEqual(tuple(encoded_images.shape), (expected_batch_size, *expected_output_image_shape))
+
+            # Test without paired images
+            image_pairs = self.image_processor_tester.prepare_image_inputs(equal_resolution=False, pairs=False)
+            with self.assertRaises(ValueError):
+                image_processing(image_pairs, return_tensors="pt").pixel_values
+
+    def test_call_pytorch(self):
+        # Test overwritten because SuperGlueImageProcessor combines images by pair to feed it into SuperGlue
+
+        # Initialize image_processing
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+            # create random PyTorch tensors
+            image_pairs = self.image_processor_tester.prepare_image_inputs(equal_resolution=False, torchify=True)
+            for image_pair in image_pairs:
+                self.assertEqual(len(image_pair), 2)
+
+            expected_batch_size = int(self.image_processor_tester.batch_size / 2)
+
+            # Test with 2 images
+            encoded_images = image_processing(image_pairs[0], return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs[0])
+            self.assertEqual(tuple(encoded_images.shape), (1, *expected_output_image_shape))
+
+            # Test with list of pairs
+            encoded_images = image_processing(image_pairs, return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs)
+            self.assertEqual(tuple(encoded_images.shape), (expected_batch_size, *expected_output_image_shape))
+
+            # Test without paired images
+            image_pairs = self.image_processor_tester.prepare_image_inputs(
+                equal_resolution=False, torchify=True, pairs=False
+            )
+            with self.assertRaises(ValueError):
+                image_processing(image_pairs, return_tensors="pt").pixel_values
+
+    def test_image_processor_with_list_of_two_images(self):
+        for image_processing_class in self.image_processor_list:
+            image_processing = image_processing_class(**self.image_processor_dict)
+
+            image_pairs = self.image_processor_tester.prepare_image_inputs(
+                equal_resolution=False, numpify=True, batch_size=2, pairs=False
+            )
+            self.assertEqual(len(image_pairs), 2)
+            self.assertTrue(isinstance(image_pairs[0], np.ndarray))
+            self.assertTrue(isinstance(image_pairs[1], np.ndarray))
+
+            expected_batch_size = 1
+            encoded_images = image_processing(image_pairs, return_tensors="pt").pixel_values
+            expected_output_image_shape = self.image_processor_tester.expected_output_image_shape(image_pairs[0])
+            self.assertEqual(tuple(encoded_images.shape), (expected_batch_size, *expected_output_image_shape))
+
+    @require_torch
+    def test_post_processing_keypoint_matching(self):
+        def check_post_processed_output(post_processed_output, image_pair_size):
+            for post_processed_output, (image_size0, image_size1) in zip(post_processed_output, image_pair_size):
+                self.assertTrue("keypoints0" in post_processed_output)
+                self.assertTrue("keypoints1" in post_processed_output)
+                self.assertTrue("matching_scores" in post_processed_output)
+                keypoints0 = post_processed_output["keypoints0"]
+                keypoints1 = post_processed_output["keypoints1"]
+                all_below_image_size0 = torch.all(keypoints0[:, 0] <= image_size0[1]) and torch.all(
+                    keypoints0[:, 1] <= image_size0[0]
+                )
+                all_below_image_size1 = torch.all(keypoints1[:, 0] <= image_size1[1]) and torch.all(
+                    keypoints1[:, 1] <= image_size1[0]
+                )
+                all_above_zero0 = torch.all(keypoints0[:, 0] >= 0) and torch.all(keypoints0[:, 1] >= 0)
+                all_above_zero1 = torch.all(keypoints0[:, 0] >= 0) and torch.all(keypoints0[:, 1] >= 0)
+                self.assertTrue(all_below_image_size0)
+                self.assertTrue(all_below_image_size1)
+                self.assertTrue(all_above_zero0)
+                self.assertTrue(all_above_zero1)
+                all_scores_different_from_minus_one = torch.all(post_processed_output["matching_scores"] != -1)
+                self.assertTrue(all_scores_different_from_minus_one)
+
+        for image_processing_class in self.image_processor_list:
+            image_processor = image_processing_class.from_dict(self.image_processor_dict)
+            image_inputs = self.image_processor_tester.prepare_image_inputs()
+            pre_processed_images = image_processor.preprocess(image_inputs, return_tensors="pt")
+            outputs = self.image_processor_tester.prepare_keypoint_matching_output(**pre_processed_images)
+
+            tuple_image_sizes = [
+                ((image_pair[0].size[0], image_pair[0].size[1]), (image_pair[1].size[0], image_pair[1].size[1]))
+                for image_pair in image_inputs
+            ]
+            tuple_post_processed_outputs = image_processor.post_process_keypoint_matching(outputs, tuple_image_sizes)
+
+            check_post_processed_output(tuple_post_processed_outputs, tuple_image_sizes)
+
+            tensor_image_sizes = torch.tensor(
+                [(image_pair[0].size, image_pair[1].size) for image_pair in image_inputs]
+            ).flip(2)
+            tensor_post_processed_outputs = image_processor.post_process_keypoint_matching(outputs, tensor_image_sizes)
+
+            check_post_processed_output(tensor_post_processed_outputs, tensor_image_sizes)
 
     @unittest.skip(reason="Many failing cases. This test needs a more deep investigation.")
     def test_fast_is_faster_than_slow(self):
@@ -129,7 +439,44 @@ class EfficientLoFTRImageProcessingTest(SuperGlueImageProcessingTest, unittest.T
             fast_time, slow_time * 1.2, "Fast processor should not be significantly slower than slow processor"
         )
 
-    # TODO: FIXME @yonigozlan
-    @unittest.skip(reason="failing after #42018")
-    def test_post_processing_keypoint_matching_with_padded_match_indices(self):
-        pass
+    @require_vision
+    @require_torch
+    def test_slow_fast_equivalence(self):
+        if not self.test_slow_image_processor or not self.test_fast_image_processor:
+            self.skipTest(reason="Skipping slow/fast equivalence test")
+
+        if self.image_processing_class is None or self.fast_image_processing_class is None:
+            self.skipTest(reason="Skipping slow/fast equivalence test as one of the image processors is not defined")
+
+        dummy_image = self.image_processor_tester.prepare_image_inputs(
+            equal_resolution=False, numpify=True, batch_size=2, pairs=False
+        )
+        image_processor_slow = self.image_processing_class(**self.image_processor_dict)
+        image_processor_fast = self.fast_image_processing_class(**self.image_processor_dict)
+
+        encoding_slow = image_processor_slow(dummy_image, return_tensors="pt")
+        encoding_fast = image_processor_fast(dummy_image, return_tensors="pt")
+
+        self._assert_slow_fast_tensors_equivalence(encoding_slow.pixel_values, encoding_fast.pixel_values)
+
+    @slow
+    @require_torch_accelerator
+    @require_vision
+    @pytest.mark.torch_compile_test
+    def test_can_compile_fast_image_processor(self):
+        """Override the generic test since EfficientLoFTR requires image pairs."""
+        if self.fast_image_processing_class is None:
+            self.skipTest("Skipping compilation test as fast image processor is not defined")
+        if version.parse(torch.__version__) < version.parse("2.3"):
+            self.skipTest(reason="This test requires torch >= 2.3 to run.")
+
+        torch.compiler.reset()
+        input_image = self.image_processor_tester.prepare_image_inputs(equal_resolution=True, torchify=False)
+        image_processor = self.fast_image_processing_class(**self.image_processor_dict)
+        output_eager = image_processor(input_image, device=torch_device, return_tensors="pt")
+
+        image_processor = torch.compile(image_processor, mode="reduce-overhead")
+        output_compiled = image_processor(input_image, device=torch_device, return_tensors="pt")
+        self._assert_slow_fast_tensors_equivalence(
+            output_eager.pixel_values, output_compiled.pixel_values, atol=1e-4, rtol=1e-4, mean_atol=1e-5
+        )

--- a/tests/models/superglue/test_image_processing_superglue.py
+++ b/tests/models/superglue/test_image_processing_superglue.py
@@ -28,17 +28,14 @@ from transformers.testing_utils import (
 )
 from transformers.utils import is_torch_available, is_torchvision_available, is_vision_available
 
-from ...test_image_processing_common import (
-    ImageProcessingTestMixin,
-    prepare_image_inputs,
-)
+from ...test_image_processing_common import ImageProcessingTestMixin, prepare_image_inputs
 
 
 if is_torch_available():
     import numpy as np
     import torch
 
-    from transformers.models.superglue.modeling_superglue import KeypointMatchingOutput
+    from transformers.models.superglue.modeling_superglue import SuperGlueKeypointMatchingOutput
 
 if is_vision_available():
     from transformers import SuperGlueImageProcessor
@@ -125,7 +122,7 @@ class SuperGlueImageProcessingTester:
             matches[i, 1, random_matches_indices0] = random_matches_indices1
             scores[i, 0, random_matches_indices1] = torch.rand((random_number_matches,))
             scores[i, 1, random_matches_indices0] = torch.rand((random_number_matches,))
-        return KeypointMatchingOutput(mask=mask, keypoints=keypoints, matches=matches, matching_scores=scores)
+        return SuperGlueKeypointMatchingOutput(mask=mask, keypoints=keypoints, matches=matches, matching_scores=scores)
 
 
 @require_torch
@@ -450,7 +447,9 @@ class SuperGlueImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             matches[0, 0, 1] = 2  # Points to index 2, which is valid
             scores[0, 0, 1] = 0.8
 
-            outputs = KeypointMatchingOutput(mask=mask, keypoints=keypoints, matches=matches, matching_scores=scores)
+            outputs = SuperGlueKeypointMatchingOutput(
+                mask=mask, keypoints=keypoints, matches=matches, matching_scores=scores
+            )
 
             image_sizes = [((480, 640), (480, 640))]
 


### PR DESCRIPTION
# What does this PR do?

Remove inheritance in efficient loftr tests (following https://github.com/huggingface/transformers/pull/42327). Also fix source of the issue, KeypointMatchingOutput is different for each keypoint matching model, so rename it to model-specific names.