### PR TITLE
Replace Optional and Union typing with | in some source files

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -22,7 +22,7 @@ import os
 import re
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from safetensors import safe_open
 from safetensors.torch import save_file
@@ -550,14 +550,14 @@ def offload_weight(weight: torch.Tensor, weight_name: str, offload_folder: str |
 
 def _init_infer_auto_device_map(
     model: nn.Module,
-    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
-    no_split_module_classes: Optional[list[str]] = None,
-    tied_parameters: Optional[list[list[str]]] = None,
+    max_memory: dict[int | str, int | str] | None = None,
+    no_split_module_classes: list[str] | None = None,
+    tied_parameters: list[list[str]] | None = None,
     hf_quantizer: "HfQuantizer | None" = None,
 ) -> tuple[
-    list[Union[int, str]],
-    dict[Union[int, str], Union[int, str]],
-    list[Union[int, str]],
+    list[int | str],
+    dict[int | str, int | str],
+    list[int | str],
     list[int],
     dict[str, int],
     list[list[str]],
@@ -620,12 +620,12 @@ def _init_infer_auto_device_map(
 
 def infer_auto_device_map(
     model: nn.Module,
-    max_memory: Optional[dict[Union[int, str], Union[int, str]]] = None,
-    no_split_module_classes: Optional[list[str]] = None,
+    max_memory: dict[int | str, int | str] | None = None,
+    no_split_module_classes: list[str] | None = None,
     verbose: bool = False,
     clean_result: bool = True,
     offload_buffers: bool = False,
-    tied_parameters: Optional[list[list[str]]] = None,
+    tied_parameters: list[list[str]] | None = None,
     hf_quantizer: "HfQuantizer | None" = None,
 ):
     """

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -1,7 +1,6 @@
 import inspect
 from collections import defaultdict
 from inspect import signature
-from typing import Optional
 
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import get_module_from_name
@@ -36,7 +35,7 @@ class Bnb4bitQuantize(ConversionOps):
         self.hf_quantizer = hf_quantizer
 
     def convert(
-        self, input_dict: torch.Tensor, model: Optional[torch.nn.Module] = None, missing_keys=None, **kwargs
+        self, input_dict: torch.Tensor, model: torch.nn.Module | None = None, missing_keys=None, **kwargs
     ) -> dict[str, torch.Tensor]:
         """
         we need to store some parameters to create the quantized weight. For example, bnb requires 6 values that are stored in the checkpoint to recover the quantized weight. So we store them in a dict that it stored in hf_quantizer for now as we can't save it in the op since we create an op per tensor.
@@ -87,7 +86,7 @@ class Bnb8bitQuantize(ConversionOps):
         self.hf_quantizer = hf_quantizer
 
     def convert(
-        self, input_dict: torch.Tensor, model: Optional[torch.nn.Module] = None, missing_keys=None, **kwargs
+        self, input_dict: torch.Tensor, model: torch.nn.Module | None = None, missing_keys=None, **kwargs
     ) -> dict[str, torch.Tensor]:
         target_key, value = tuple(input_dict.items())[0]
         value = value[0] if isinstance(value, list) else value

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -15,7 +15,7 @@
 
 import re
 from collections.abc import Sequence
-from typing import Any, Optional, Union
+from typing import Any
 
 from ..core_model_loading import ConversionOps
 from ..utils import is_accelerate_available, is_torch_accelerator_available, is_torch_available, logging
@@ -655,13 +655,13 @@ class Fp8Quantize(ConversionOps):
 class Fp8Dequantize(ConversionOps):
     """Inverse operation of :class:`Fp8Quantize`. Takes a pair (weight, scale) and reconstructs the fp32 tensor."""
 
-    def __init__(self, block_size: Optional[tuple[int, int]] = None):
+    def __init__(self, block_size: tuple[int, int] | None = None):
         self.block_size = block_size
         self.reverse_op = Fp8Quantize
 
     def convert(
         self,
-        value: Union[Sequence[torch.Tensor], dict[str, torch.Tensor]],
+        value: Sequence[torch.Tensor] | dict[str, torch.Tensor],
         *,
         context: dict[str, Any],
     ) -> torch.Tensor:

--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -18,7 +18,6 @@ import operator
 import os
 import re
 from functools import partial, reduce
-from typing import Optional
 
 import torch
 import torch.distributed as dist
@@ -317,7 +316,7 @@ def repack_weights(
     return final_ordered_tensor
 
 
-def get_tensor_shard(param, empty_param, device_mesh, rank, dim, tensor_idx: Optional[int] = None):
+def get_tensor_shard(param, empty_param, device_mesh, rank, dim, tensor_idx: int | None = None):
     """
     Generalized tensor sharding across a multi-dimensional device mesh.
     Extract only the fraction of the parameter owned by the given `rank` when the parameter would have gone sharding at provided `dim`.

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -16,7 +16,6 @@
 import math
 import warnings
 from functools import partial
-from typing import Optional, Union
 
 import torch
 from torch.optim import Optimizer
@@ -283,7 +282,7 @@ def get_polynomial_decay_schedule_with_warmup(
     return LambdaLR(optimizer, lr_lambda, last_epoch)
 
 
-def _get_inverse_sqrt_schedule_lr_lambda(current_step: int, *, num_warmup_steps: int, timescale: Optional[int] = None):
+def _get_inverse_sqrt_schedule_lr_lambda(current_step: int, *, num_warmup_steps: int, timescale: int | None = None):
     if current_step < num_warmup_steps:
         return float(current_step) / float(max(1, num_warmup_steps))
     shift = timescale - num_warmup_steps
@@ -292,7 +291,7 @@ def _get_inverse_sqrt_schedule_lr_lambda(current_step: int, *, num_warmup_steps:
 
 
 def get_inverse_sqrt_schedule(
-    optimizer: Optimizer, num_warmup_steps: int, timescale: Optional[int] = None, last_epoch: int = -1
+    optimizer: Optimizer, num_warmup_steps: int, timescale: int | None = None, last_epoch: int = -1
 ):
     """
     Create a schedule with an inverse square-root learning rate, from the initial lr set in the optimizer, after a
@@ -338,8 +337,8 @@ def get_cosine_with_min_lr_schedule_with_warmup(
     num_training_steps: int,
     num_cycles: float = 0.5,
     last_epoch: int = -1,
-    min_lr: Optional[float] = None,
-    min_lr_rate: Optional[float] = None,
+    min_lr: float | None = None,
+    min_lr_rate: float | None = None,
 ):
     """
     Create a schedule with a learning rate that decreases following the values of the cosine function between the
@@ -391,7 +390,7 @@ def _get_cosine_with_min_lr_schedule_with_warmup_lr_rate_lambda(
     num_training_steps: int,
     num_cycles: float,
     min_lr_rate: float = 0.0,
-    warmup_lr_rate: Optional[float] = None,
+    warmup_lr_rate: float | None = None,
 ):
     current_step = float(current_step)
     num_warmup_steps = float(num_warmup_steps)
@@ -415,9 +414,9 @@ def get_cosine_with_min_lr_schedule_with_warmup_lr_rate(
     num_training_steps: int,
     num_cycles: float = 0.5,
     last_epoch: int = -1,
-    min_lr: Optional[float] = None,
-    min_lr_rate: Optional[float] = None,
-    warmup_lr_rate: Optional[float] = None,
+    min_lr: float | None = None,
+    min_lr_rate: float | None = None,
+    warmup_lr_rate: float | None = None,
 ):
     """
     Create a schedule with a learning rate that decreases following the values of the cosine function between the
@@ -507,8 +506,8 @@ def get_wsd_schedule(
     optimizer: Optimizer,
     num_warmup_steps: int,
     num_decay_steps: int,
-    num_training_steps: Optional[int] = None,
-    num_stable_steps: Optional[int] = None,
+    num_training_steps: int | None = None,
+    num_stable_steps: int | None = None,
     warmup_type: str = "linear",
     decay_type: str = "cosine",
     min_lr_ratio: float = 0,
@@ -592,11 +591,11 @@ TYPE_TO_SCHEDULER_FUNCTION = {
 
 
 def get_scheduler(
-    name: Union[str, SchedulerType],
+    name: str | SchedulerType,
     optimizer: Optimizer,
-    num_warmup_steps: Optional[int] = None,
-    num_training_steps: Optional[int] = None,
-    scheduler_specific_kwargs: Optional[dict] = None,
+    num_warmup_steps: int | None = None,
+    num_training_steps: int | None = None,
+    scheduler_specific_kwargs: dict | None = None,
 ):
     """
     Unified API to get any scheduler from its name.

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -177,8 +177,8 @@ def pad_collate_fn(tokenizer, feature_extractor):
 def load_model(
     model,
     config: AutoConfig,
-    model_classes: Optional[tuple[type, ...]] = None,
-    task: Optional[str] = None,
+    model_classes: tuple[type, ...] | None = None,
+    task: str | None = None,
     **model_kwargs,
 ):
     """
@@ -270,7 +270,7 @@ def load_model(
     return model
 
 
-def get_default_model_and_revision(targeted_task: dict, task_options: Optional[Any]) -> tuple[str, str]:
+def get_default_model_and_revision(targeted_task: dict, task_options: Any | None) -> tuple[str, str]:
     """
     Select a default model to use for a given task.
 
@@ -305,9 +305,9 @@ def get_default_model_and_revision(targeted_task: dict, task_options: Optional[A
 
 def load_assistant_model(
     model: "PreTrainedModel",
-    assistant_model: Optional[Union[str, "PreTrainedModel"]],
-    assistant_tokenizer: Optional[PreTrainedTokenizer],
-) -> tuple[Optional["PreTrainedModel"], Optional[PreTrainedTokenizer]]:
+    assistant_model: Union[str, "PreTrainedModel"] | None,
+    assistant_tokenizer: PreTrainedTokenizer | None,
+) -> tuple[Optional["PreTrainedModel"], PreTrainedTokenizer | None]:
     """
     Prepares the assistant model and the assistant tokenizer for a pipeline whose model that can call `generate`.
 
@@ -404,9 +404,9 @@ class PipelineDataFormat:
 
     def __init__(
         self,
-        output_path: Optional[str],
-        input_path: Optional[str],
-        column: Optional[str],
+        output_path: str | None,
+        input_path: str | None,
+        column: str | None,
         overwrite: bool = False,
     ):
         self.output_path = output_path
@@ -430,7 +430,7 @@ class PipelineDataFormat:
         raise NotImplementedError()
 
     @abstractmethod
-    def save(self, data: Union[dict, list[dict]]):
+    def save(self, data: dict | list[dict]):
         """
         Save the provided data object with the representation for the current [`~pipelines.PipelineDataFormat`].
 
@@ -439,7 +439,7 @@ class PipelineDataFormat:
         """
         raise NotImplementedError()
 
-    def save_binary(self, data: Union[dict, list[dict]]) -> str:
+    def save_binary(self, data: dict | list[dict]) -> str:
         """
         Save the provided data object as a pickle-formatted binary data on the disk.
 
@@ -460,9 +460,9 @@ class PipelineDataFormat:
     @staticmethod
     def from_str(
         format: str,
-        output_path: Optional[str],
-        input_path: Optional[str],
-        column: Optional[str],
+        output_path: str | None,
+        input_path: str | None,
+        column: str | None,
         overwrite=False,
     ) -> "PipelineDataFormat":
         """
@@ -507,9 +507,9 @@ class CsvPipelineDataFormat(PipelineDataFormat):
 
     def __init__(
         self,
-        output_path: Optional[str],
-        input_path: Optional[str],
-        column: Optional[str],
+        output_path: str | None,
+        input_path: str | None,
+        column: str | None,
         overwrite=False,
     ):
         super().__init__(output_path, input_path, column, overwrite=overwrite)
@@ -551,9 +551,9 @@ class JsonPipelineDataFormat(PipelineDataFormat):
 
     def __init__(
         self,
-        output_path: Optional[str],
-        input_path: Optional[str],
-        column: Optional[str],
+        output_path: str | None,
+        input_path: str | None,
+        column: str | None,
         overwrite=False,
     ):
         super().__init__(output_path, input_path, column, overwrite=overwrite)
@@ -617,7 +617,7 @@ class PipedPipelineDataFormat(PipelineDataFormat):
         """
         print(data)
 
-    def save_binary(self, data: Union[dict, list[dict]]) -> str:
+    def save_binary(self, data: dict | list[dict]) -> str:
         if self.output_path is None:
             raise KeyError(
                 "When using piped input on pipeline outputting large object requires an output file path. "
@@ -776,13 +776,13 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
     def __init__(
         self,
         model: "PreTrainedModel",
-        tokenizer: Optional[PreTrainedTokenizer] = None,
+        tokenizer: PreTrainedTokenizer | None = None,
         feature_extractor: Optional[PreTrainedFeatureExtractor] = None,
-        image_processor: Optional[BaseImageProcessor] = None,
-        processor: Optional[ProcessorMixin] = None,
-        modelcard: Optional[ModelCard] = None,
+        image_processor: BaseImageProcessor | None = None,
+        processor: ProcessorMixin | None = None,
+        modelcard: ModelCard | None = None,
         task: str = "",
-        device: Optional[Union[int, "torch.device"]] = None,
+        device: Union[int, "torch.device"] | None = None,
         binary_output: bool = False,
         **kwargs,
     ):
@@ -939,7 +939,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
 
     def save_pretrained(
         self,
-        save_directory: Union[str, os.PathLike],
+        save_directory: str | os.PathLike,
         safe_serialization: bool = True,
         **kwargs: Any,
     ):
@@ -1085,7 +1085,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         else:
             return inputs
 
-    def check_model_type(self, supported_models: Union[list[str], dict]):
+    def check_model_type(self, supported_models: list[str] | dict):
         """
         Check if the model class is in supported by the pipeline.
 
@@ -1348,9 +1348,9 @@ class PipelineRegistry:
         self,
         task: str,
         pipeline_class: type,
-        pt_model: Optional[Union[type, tuple[type]]] = None,
-        default: Optional[dict] = None,
-        type: Optional[str] = None,
+        pt_model: type | tuple[type] | None = None,
+        default: dict | None = None,
+        type: str | None = None,
     ) -> None:
         if task in self.supported_tasks:
             logger.warning(f"{task} is already registered. Overwriting pipeline for task {task}...")

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -42,7 +42,7 @@ from dataclasses import MISSING, fields
 from functools import cache, wraps
 from io import StringIO
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
@@ -1809,7 +1809,7 @@ class TemporaryHubRepo:
     ```
     """
 
-    def __init__(self, namespace: Optional[str] = None, token: Optional[str] = None) -> None:
+    def __init__(self, namespace: str | None = None, token: str | None = None) -> None:
         self.token = token
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_id = Path(tmp_dir).name
@@ -1826,7 +1826,7 @@ class TemporaryHubRepo:
 
 @contextlib.contextmanager
 # adapted from https://stackoverflow.com/a/64789046/9201239
-def ExtendSysPath(path: Union[str, os.PathLike]) -> Iterator[None]:
+def ExtendSysPath(path: str | os.PathLike) -> Iterator[None]:
     """
     Temporary add given path to `sys.path`.
 
@@ -2566,7 +2566,7 @@ class RequestCounter:
         return sum(self._counter.values())
 
 
-def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None, description: Optional[str] = None):
+def is_flaky(max_attempts: int = 5, wait_before_retry: float | None = None, description: str | None = None):
     """
     To decorate flaky tests. They will be retried on failures.
 
@@ -2607,7 +2607,7 @@ def is_flaky(max_attempts: int = 5, wait_before_retry: Optional[float] = None, d
     return decorator
 
 
-def hub_retry(max_attempts: int = 5, wait_before_retry: Optional[float] = 2):
+def hub_retry(max_attempts: int = 5, wait_before_retry: float | None = 2):
     """
     To decorate tests that download from the Hub. They can fail due to a
     variety of network issues such as timeouts, connection resets, etc.
@@ -3161,9 +3161,9 @@ def cleanup(device: str, gc_collect=False):
 
 
 # Type definition of key used in `Expectations` class.
-DeviceProperties = tuple[Optional[str], Optional[int], Optional[int]]
+DeviceProperties = tuple[str | None, int | None, int | None]
 # Helper type. Makes creating instances of `Expectations` smoother.
-PackedDeviceProperties = tuple[Optional[str], Union[None, int, tuple[int, int]]]
+PackedDeviceProperties = tuple[str | None, None | int | tuple[int, int]]
 
 
 @cache
@@ -3192,7 +3192,7 @@ def get_device_properties() -> DeviceProperties:
 
 
 def unpack_device_properties(
-    properties: Optional[PackedDeviceProperties] = None,
+    properties: PackedDeviceProperties | None = None,
 ) -> DeviceProperties:
     """
     Unpack a `PackedDeviceProperties` tuple into consistently formatted `DeviceProperties` tuple. If properties is None, it is fetched.
@@ -3749,7 +3749,7 @@ def patch_testing_methods_to_collect_info():
     _patch_with_call_info(unittest.case.TestCase, "assertGreaterEqual", _parse_call_info, target_args=("a", "b"))
 
 
-def torchrun(script: str, nproc_per_node: int, is_torchrun: bool = True, env: Optional[dict] = None):
+def torchrun(script: str, nproc_per_node: int, is_torchrun: bool = True, env: dict | None = None):
     """Run the `script` using `torchrun` command for multi-processing in a subprocess. Captures errors as necessary."""
     with tempfile.NamedTemporaryFile(mode="w+", suffix=".py") as tmp:
         tmp.write(script)

--- a/src/transformers/time_series_utils.py
+++ b/src/transformers/time_series_utils.py
@@ -17,7 +17,6 @@ Time series distributional output classes and utilities.
 """
 
 from collections.abc import Callable
-from typing import Optional
 
 import torch
 from torch import nn
@@ -103,8 +102,8 @@ class DistributionOutput:
     def distribution(
         self,
         distr_args,
-        loc: Optional[torch.Tensor] = None,
-        scale: Optional[torch.Tensor] = None,
+        loc: torch.Tensor | None = None,
+        scale: torch.Tensor | None = None,
     ) -> Distribution:
         distr = self._base_distribution(distr_args)
         if loc is None and scale is None:
@@ -215,7 +214,7 @@ class NegativeBinomialOutput(DistributionOutput):
     # transformation since negative binomial should return integers. Instead
     # we scale the parameters.
     def distribution(
-        self, distr_args, loc: Optional[torch.Tensor] = None, scale: Optional[torch.Tensor] = None
+        self, distr_args, loc: torch.Tensor | None = None, scale: torch.Tensor | None = None
     ) -> Distribution:
         total_count, logits = distr_args
 

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -19,7 +19,7 @@ import warnings
 from collections.abc import Callable, Mapping, Sized
 from enum import Enum
 from pathlib import Path
-from typing import Any, Optional, Union, overload
+from typing import Any, Union, overload
 
 import numpy as np
 
@@ -204,12 +204,12 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def __init__(
         self,
-        tokenizer_path: Union[str, os.PathLike, Path],
+        tokenizer_path: str | os.PathLike | Path,
         mode: ValidationMode = ValidationMode.test,
         model_max_length: int = VERY_LARGE_INTEGER,
         padding_side: str = "left",
         truncation_side: str = "right",
-        model_input_names: Optional[list[str]] = None,
+        model_input_names: list[str] | None = None,
         clean_up_tokenization_spaces: bool = False,
         **kwargs,
     ):
@@ -272,7 +272,7 @@ class MistralCommonTokenizer(PushToHubMixin):
                 )
             self.model_input_names = model_input_names
 
-        self._cache_get_vocab: Optional[dict[str, int]] = None
+        self._cache_get_vocab: dict[str, int] | None = None
 
     @property
     def bos_token_id(self) -> int:
@@ -378,16 +378,16 @@ class MistralCommonTokenizer(PushToHubMixin):
     )
     def encode(
         self,
-        text: Union[TextInput, EncodedInput],
+        text: TextInput | EncodedInput,
         text_pair: None = None,
         add_special_tokens: bool = True,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy, None] = None,
-        max_length: Optional[int] = None,
+        padding: bool | str | PaddingStrategy = False,
+        truncation: bool | str | TruncationStrategy | None = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
         verbose: bool = True,
         **kwargs,
     ) -> list[int]:
@@ -436,7 +436,7 @@ class MistralCommonTokenizer(PushToHubMixin):
         self,
         token_ids: Union[int, list[int], np.ndarray, "torch.Tensor"],
         skip_special_tokens: bool = False,
-        clean_up_tokenization_spaces: Optional[bool] = None,
+        clean_up_tokenization_spaces: bool | None = None,
         **kwargs,
     ) -> str:
         """
@@ -484,7 +484,7 @@ class MistralCommonTokenizer(PushToHubMixin):
         self,
         sequences: Union[list[int], list[list[int]], np.ndarray, "torch.Tensor"],
         skip_special_tokens: bool = False,
-        clean_up_tokenization_spaces: Optional[bool] = None,
+        clean_up_tokenization_spaces: bool | None = None,
         **kwargs,
     ) -> list[str]:
         """
@@ -527,9 +527,7 @@ class MistralCommonTokenizer(PushToHubMixin):
     def convert_ids_to_tokens(self, ids: int, skip_special_tokens: bool = False) -> str: ...
     @overload
     def convert_ids_to_tokens(self, ids: list[int], skip_special_tokens: bool = False) -> list[str]: ...
-    def convert_ids_to_tokens(
-        self, ids: Union[int, list[int]], skip_special_tokens: bool = False
-    ) -> Union[str, list[str]]:
+    def convert_ids_to_tokens(self, ids: int | list[int], skip_special_tokens: bool = False) -> str | list[str]:
         """
         Converts a single index or a sequence of indices in a token or a sequence of tokens, using the vocabulary and
         added tokens.
@@ -587,7 +585,7 @@ class MistralCommonTokenizer(PushToHubMixin):
         else:
             raise ValueError(f"Unknown tokenizer type: {self._tokenizer_type}")
 
-    def convert_tokens_to_ids(self, tokens: Union[str, list[str]]) -> Union[int, list[int]]:
+    def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
         """
         Converts a token string (or a sequence of tokens) in a single integer id (or a sequence of ids), using the
         vocabulary.
@@ -645,16 +643,16 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def _encode_plus(
         self,
-        text: Union[TextInput, EncodedInput],
+        text: TextInput | EncodedInput,
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
@@ -690,19 +688,16 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def _batch_encode_plus(
         self,
-        batch_text: Union[
-            list[TextInput],
-            list[EncodedInput],
-        ],
+        batch_text: list[TextInput] | list[EncodedInput],
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
@@ -781,16 +776,16 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def _batch_prepare_for_model(
         self,
-        batch_ids: list[Union[PreTokenizedInput, list[int]]],
+        batch_ids: list[PreTokenizedInput | list[int]],
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[str] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
@@ -849,14 +844,14 @@ class MistralCommonTokenizer(PushToHubMixin):
         ids: list[int],
         pair_ids: None = None,
         add_special_tokens: bool = True,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy, None] = None,
-        max_length: Optional[int] = None,
+        padding: bool | str | PaddingStrategy = False,
+        truncation: bool | str | TruncationStrategy | None = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
@@ -944,10 +939,10 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def _get_padding_truncation_strategies(
         self,
-        padding: Union[str, PaddingStrategy, bool] = False,
-        truncation: Optional[Union[str, TruncationStrategy, bool]] = None,
-        max_length: Optional[int] = None,
-        pad_to_multiple_of: Optional[int] = None,
+        padding: str | PaddingStrategy | bool = False,
+        truncation: str | TruncationStrategy | bool | None = None,
+        max_length: int | None = None,
+        pad_to_multiple_of: int | None = None,
         verbose: bool = True,
         **kwargs,
     ):
@@ -1057,12 +1052,12 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def _pad(
         self,
-        encoded_inputs: Union[dict[str, EncodedInput], BatchEncoding],
-        max_length: Optional[int] = None,
+        encoded_inputs: dict[str, EncodedInput] | BatchEncoding,
+        max_length: int | None = None,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_attention_mask: bool | None = None,
     ) -> dict:
         """
         Pad encoded inputs (on left/right and up to predefined length or max length in the batch)
@@ -1131,19 +1126,17 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def pad(
         self,
-        encoded_inputs: Union[
-            BatchEncoding,
-            list[BatchEncoding],
-            dict[str, EncodedInput],
-            dict[str, list[EncodedInput]],
-            list[dict[str, EncodedInput]],
-        ],
-        padding: Union[bool, str, PaddingStrategy] = True,
-        max_length: Optional[int] = None,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_attention_mask: Optional[bool] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        encoded_inputs: BatchEncoding
+        | list[BatchEncoding]
+        | dict[str, EncodedInput]
+        | dict[str, list[EncodedInput]]
+        | list[dict[str, EncodedInput]],
+        padding: bool | str | PaddingStrategy = True,
+        max_length: int | None = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_attention_mask: bool | None = None,
+        return_tensors: str | TensorType | None = None,
         verbose: bool = True,
     ) -> BatchEncoding:
         """
@@ -1297,7 +1290,7 @@ class MistralCommonTokenizer(PushToHubMixin):
         ids: list[int],
         pair_ids: None = None,
         num_tokens_to_remove: int = 0,
-        truncation_strategy: Union[str, TruncationStrategy] = "longest_first",
+        truncation_strategy: str | TruncationStrategy = "longest_first",
         stride: int = 0,
         **kwargs,
     ) -> tuple[list[int], None, list[int]]:
@@ -1369,18 +1362,18 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def apply_chat_template(
         self,
-        conversation: Union[list[dict[str, str]], list[list[dict[str, str]]]],
-        tools: Optional[list[Union[dict, Callable]]] = None,
+        conversation: list[dict[str, str]] | list[list[dict[str, str]]],
+        tools: list[dict | Callable] | None = None,
         add_generation_prompt: bool = False,
         continue_final_message: bool = False,
         tokenize: bool = True,
-        padding: Union[bool, str, PaddingStrategy] = False,
+        padding: bool | str | PaddingStrategy = False,
         truncation: bool = False,
-        max_length: Optional[int] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
+        max_length: int | None = None,
+        return_tensors: str | TensorType | None = None,
         return_dict: bool = True,
         **kwargs,
-    ) -> Union[str, list[int], list[str], list[list[int]], BatchEncoding]:
+    ) -> str | list[int] | list[str] | list[list[int]] | BatchEncoding:
         """
         Converts a list of dictionaries with `"role"` and `"content"` keys to a list of token
         ids.
@@ -1465,21 +1458,19 @@ class MistralCommonTokenizer(PushToHubMixin):
             """Adapt message to `mistral-common` format and leave validation to `mistral-common`."""
             if not isinstance(message, dict):
                 return
-            maybe_list_content: Optional[Union[str, list[dict[str, Union[str, dict[str, Any]]]]]] = message.get(
-                "content"
-            )
+            maybe_list_content: str | list[dict[str, str | dict[str, Any]]] | None = message.get("content")
             if not maybe_list_content or isinstance(maybe_list_content, str):
                 return
 
-            normalized_content: list[dict[str, Union[str, dict[str, Any]]]] = []
+            normalized_content: list[dict[str, str | dict[str, Any]]] = []
             for content in maybe_list_content:
                 content_type = content.get("type", None)
                 if not content_type:
                     continue
                 elif content_type == "image":
-                    maybe_url: Optional[str] = content.get("url")
-                    maybe_path: Optional[str] = content.get("path")
-                    maybe_base64: Optional[str] = content.get("base64")
+                    maybe_url: str | None = content.get("url")
+                    maybe_path: str | None = content.get("path")
+                    maybe_base64: str | None = content.get("base64")
                     if maybe_url:
                         image_content = maybe_url
                     elif maybe_path:
@@ -1494,9 +1485,9 @@ class MistralCommonTokenizer(PushToHubMixin):
                         raise ValueError("Image content must be specified.")
                     normalized_content.append({"type": "image_url", "image_url": {"url": image_content}})
                 elif content_type == "audio":
-                    maybe_url: Optional[str] = content.get("url")
-                    maybe_path: Optional[str] = content.get("path")
-                    maybe_base64: Optional[str] = content.get("base64")
+                    maybe_url: str | None = content.get("url")
+                    maybe_path: str | None = content.get("path")
+                    maybe_base64: str | None = content.get("base64")
                     if maybe_url or maybe_path:
                         audio_data = load_audio_as(maybe_url or maybe_path, return_format="dict", force_mono=True)
                         normalized_content.append({"type": "input_audio", "input_audio": audio_data})
@@ -1513,7 +1504,7 @@ class MistralCommonTokenizer(PushToHubMixin):
         audios: list[np.ndarray] = []
 
         for conversation in conversations:
-            messages: list[dict[str, Union[str, list[dict[str, Union[str, dict[str, Any]]]]]]] = []
+            messages: list[dict[str, str | list[dict[str, str | dict[str, Any]]]]] = []
             for message in conversation:
                 _maybe_adapt_message(message)
                 messages.append(message)
@@ -1546,7 +1537,7 @@ class MistralCommonTokenizer(PushToHubMixin):
             )
             if return_dict:
                 if images:
-                    pixel_values: Union[list[np.ndarray], np.ndarray, torch.Tensor]
+                    pixel_values: list[np.ndarray] | np.ndarray | torch.Tensor
                     if return_tensors == "pt":
                         if not is_torch_available():
                             raise ImportError(
@@ -1582,19 +1573,19 @@ class MistralCommonTokenizer(PushToHubMixin):
     @add_end_docstrings(ENCODE_KWARGS_DOCSTRING, ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING)
     def __call__(
         self,
-        text: Union[TextInput, EncodedInput, list[TextInput], list[EncodedInput], None] = None,
+        text: TextInput | EncodedInput | list[TextInput] | list[EncodedInput] | None = None,
         text_pair: None = None,
         text_target: None = None,
         text_pair_target: None = None,
         add_special_tokens: bool = True,
-        padding: Union[bool, str, PaddingStrategy] = False,
-        truncation: Union[bool, str, TruncationStrategy, None] = None,
-        max_length: Optional[int] = None,
+        padding: bool | str | PaddingStrategy = False,
+        truncation: bool | str | TruncationStrategy | None = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
@@ -1699,18 +1690,18 @@ class MistralCommonTokenizer(PushToHubMixin):
     @classmethod
     def from_pretrained(
         cls,
-        pretrained_model_name_or_path: Union[str, os.PathLike],
+        pretrained_model_name_or_path: str | os.PathLike,
         *init_inputs,
         mode: ValidationMode = ValidationMode.test,
-        cache_dir: Optional[Union[str, os.PathLike]] = None,
+        cache_dir: str | os.PathLike | None = None,
         force_download: bool = False,
         local_files_only: bool = False,
-        token: Optional[Union[str, bool]] = None,
+        token: str | bool | None = None,
         revision: str = "main",
         model_max_length: int = VERY_LARGE_INTEGER,
         padding_side: str = "left",
         truncation_side: str = "right",
-        model_input_names: Optional[list[str]] = None,
+        model_input_names: list[str] | None = None,
         clean_up_tokenization_spaces: bool = False,
         **kwargs,
     ):
@@ -1826,14 +1817,14 @@ class MistralCommonTokenizer(PushToHubMixin):
 
     def save_pretrained(
         self,
-        save_directory: Union[str, os.PathLike, Path],
+        save_directory: str | os.PathLike | Path,
         push_to_hub: bool = False,
-        token: Optional[Union[str, bool]] = None,
-        commit_message: Optional[str] = None,
-        repo_id: Optional[str] = None,
-        private: Optional[bool] = None,
-        repo_url: Optional[str] = None,
-        organization: Optional[str] = None,
+        token: str | bool | None = None,
+        commit_message: str | None = None,
+        repo_id: str | None = None,
+        private: bool | None = None,
+        repo_url: str | None = None,
+        organization: str | None = None,
         **kwargs,
     ) -> tuple[str, ...]:
         """

--- a/src/transformers/tokenization_utils.py
+++ b/src/transformers/tokenization_utils.py
@@ -21,7 +21,7 @@ import itertools
 import re
 import unicodedata
 from collections import OrderedDict
-from typing import Any, Optional, Union, overload
+from typing import Any, overload
 
 from .tokenization_utils_base import (
     ENCODE_KWARGS_DOCSTRING,
@@ -587,7 +587,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         self._update_total_vocab_size()
         return added_tokens
 
-    def _update_trie(self, unique_no_split_tokens: Optional[list[str]] = None):
+    def _update_trie(self, unique_no_split_tokens: list[str] | None = None):
         for token in self._added_tokens_decoder.values():
             if token.content not in self.tokens_trie._tokens:
                 self.tokens_trie.add(token.content)
@@ -742,19 +742,19 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
 
     def _encode_plus(
         self,
-        text: Union[TextInput, PreTokenizedInput, EncodedInput],
-        text_pair: Optional[Union[TextInput, PreTokenizedInput, EncodedInput]] = None,
+        text: TextInput | PreTokenizedInput | EncodedInput,
+        text_pair: TextInput | PreTokenizedInput | EncodedInput | None = None,
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
         is_split_into_words: bool = False,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
+        return_token_type_ids: bool | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_offsets_mapping: bool = False,
@@ -822,25 +822,23 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
 
     def _batch_encode_plus(
         self,
-        batch_text_or_text_pairs: Union[
-            list[TextInput],
-            list[TextInputPair],
-            list[PreTokenizedInput],
-            list[PreTokenizedInputPair],
-            list[EncodedInput],
-            list[EncodedInputPair],
-        ],
+        batch_text_or_text_pairs: list[TextInput]
+        | list[TextInputPair]
+        | list[PreTokenizedInput]
+        | list[PreTokenizedInputPair]
+        | list[EncodedInput]
+        | list[EncodedInputPair],
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
         is_split_into_words: bool = False,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[Union[str, TensorType]] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | TensorType | None = None,
+        return_token_type_ids: bool | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_offsets_mapping: bool = False,
@@ -914,17 +912,17 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
     @add_end_docstrings(ENCODE_KWARGS_DOCSTRING, ENCODE_PLUS_ADDITIONAL_KWARGS_DOCSTRING)
     def _batch_prepare_for_model(
         self,
-        batch_ids_pairs: list[Union[PreTokenizedInputPair, tuple[list[int], None]]],
+        batch_ids_pairs: list[PreTokenizedInputPair | tuple[list[int], None]],
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[str] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | None = None,
+        return_token_type_ids: bool | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
@@ -1006,7 +1004,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
         return (text, kwargs)
 
     def get_special_tokens_mask(
-        self, token_ids_0: list, token_ids_1: Optional[list] = None, already_has_special_tokens: bool = False
+        self, token_ids_0: list, token_ids_1: list | None = None, already_has_special_tokens: bool = False
     ) -> list[int]:
         """
         Retrieves sequence ids from a token list that has no special tokens added. This method is called when adding
@@ -1041,9 +1039,7 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
     @overload
     def convert_ids_to_tokens(self, ids: list[int], skip_special_tokens: bool = False) -> list[str]: ...
 
-    def convert_ids_to_tokens(
-        self, ids: Union[int, list[int]], skip_special_tokens: bool = False
-    ) -> Union[str, list[str]]:
+    def convert_ids_to_tokens(self, ids: int | list[int], skip_special_tokens: bool = False) -> str | list[str]:
         """
         Converts a single index or a sequence of indices in a token or a sequence of tokens, using the vocabulary and
         added tokens.
@@ -1081,9 +1077,9 @@ class PreTrainedTokenizer(PreTrainedTokenizerBase):
 
     def _decode(
         self,
-        token_ids: Union[int, list[int]],
+        token_ids: int | list[int],
         skip_special_tokens: bool = False,
-        clean_up_tokenization_spaces: Optional[bool] = None,
+        clean_up_tokenization_spaces: bool | None = None,
         spaces_between_special_tokens: bool = True,
         **kwargs,
     ) -> str:

--- a/src/transformers/tokenization_utils_fast.py
+++ b/src/transformers/tokenization_utils_fast.py
@@ -21,7 +21,7 @@ import json
 import os
 from collections import defaultdict
 from collections.abc import Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 import tokenizers.pre_tokenizers as pre_tokenizers_fast
 from tokenizers import Encoding as EncodingFast
@@ -93,7 +93,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
     """
 
     vocab_files_names = VOCAB_FILES_NAMES
-    slow_tokenizer_class: Optional[type[PreTrainedTokenizer]] = None
+    slow_tokenizer_class: type[PreTrainedTokenizer] | None = None
 
     def __init__(self, *args, **kwargs):
         tokenizer_object = kwargs.pop("tokenizer_object", None)
@@ -307,8 +307,8 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
     def _convert_encoding(
         self,
         encoding: EncodingFast,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
+        return_token_type_ids: bool | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_offsets_mapping: bool = False,
@@ -351,7 +351,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
         return encoding_dict, encodings
 
-    def convert_tokens_to_ids(self, tokens: Union[str, Iterable[str]]) -> Union[int, list[int]]:
+    def convert_tokens_to_ids(self, tokens: str | Iterable[str]) -> int | list[int]:
         """
         Converts a token string (or a sequence of tokens) in a single integer id (or a Iterable of ids), using the
         vocabulary.
@@ -373,10 +373,10 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             return self.unk_token_id
         return index
 
-    def _convert_id_to_token(self, index: int) -> Optional[str]:
+    def _convert_id_to_token(self, index: int) -> str | None:
         return self._tokenizer.id_to_token(int(index))
 
-    def _add_tokens(self, new_tokens: list[Union[str, AddedToken]], special_tokens=False) -> int:
+    def _add_tokens(self, new_tokens: list[str | AddedToken], special_tokens=False) -> int:
         if special_tokens:
             return self._tokenizer.add_special_tokens(new_tokens)
 
@@ -403,9 +403,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         """
         return self._tokenizer.num_special_tokens_to_add(pair)
 
-    def convert_ids_to_tokens(
-        self, ids: Union[int, list[int]], skip_special_tokens: bool = False
-    ) -> Union[str, list[str]]:
+    def convert_ids_to_tokens(self, ids: int | list[int], skip_special_tokens: bool = False) -> str | list[str]:
         """
         Converts a single index or a sequence of indices in a token or a sequence of tokens, using the vocabulary and
         added tokens.
@@ -431,7 +429,7 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
             tokens.append(self._tokenizer.id_to_token(index))
         return tokens
 
-    def tokenize(self, text: str, pair: Optional[str] = None, add_special_tokens: bool = False, **kwargs) -> list[str]:
+    def tokenize(self, text: str, pair: str | None = None, add_special_tokens: bool = False, **kwargs) -> list[str]:
         return self.encode_plus(text=text, text_pair=pair, add_special_tokens=add_special_tokens, **kwargs).tokens()
 
     def set_truncation_and_padding(
@@ -440,8 +438,8 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
         truncation_strategy: TruncationStrategy,
         max_length: int,
         stride: int,
-        pad_to_multiple_of: Optional[int],
-        padding_side: Optional[str],
+        pad_to_multiple_of: int | None,
+        padding_side: str | None,
     ):
         """
         Define the truncation and the padding strategies for fast tokenizers (provided by HuggingFace tokenizers
@@ -511,20 +509,21 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
     def _batch_encode_plus(
         self,
-        batch_text_or_text_pairs: Union[
-            list[TextInput], list[TextInputPair], list[PreTokenizedInput], list[PreTokenizedInputPair]
-        ],
+        batch_text_or_text_pairs: list[TextInput]
+        | list[TextInputPair]
+        | list[PreTokenizedInput]
+        | list[PreTokenizedInputPair],
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
         is_split_into_words: bool = False,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[str] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: str | None = None,
+        return_token_type_ids: bool | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_offsets_mapping: bool = False,
@@ -602,19 +601,19 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
     def _encode_plus(
         self,
-        text: Union[TextInput, PreTokenizedInput],
-        text_pair: Optional[Union[TextInput, PreTokenizedInput]] = None,
+        text: TextInput | PreTokenizedInput,
+        text_pair: TextInput | PreTokenizedInput | None = None,
         add_special_tokens: bool = True,
         padding_strategy: PaddingStrategy = PaddingStrategy.DO_NOT_PAD,
         truncation_strategy: TruncationStrategy = TruncationStrategy.DO_NOT_TRUNCATE,
-        max_length: Optional[int] = None,
+        max_length: int | None = None,
         stride: int = 0,
         is_split_into_words: bool = False,
-        pad_to_multiple_of: Optional[int] = None,
-        padding_side: Optional[str] = None,
-        return_tensors: Optional[bool] = None,
-        return_token_type_ids: Optional[bool] = None,
-        return_attention_mask: Optional[bool] = None,
+        pad_to_multiple_of: int | None = None,
+        padding_side: str | None = None,
+        return_tensors: bool | None = None,
+        return_token_type_ids: bool | None = None,
+        return_attention_mask: bool | None = None,
         return_overflowing_tokens: bool = False,
         return_special_tokens_mask: bool = False,
         return_offsets_mapping: bool = False,
@@ -670,9 +669,9 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
     def _decode(
         self,
-        token_ids: Union[int, list[int]],
+        token_ids: int | list[int],
         skip_special_tokens: bool = False,
-        clean_up_tokenization_spaces: Optional[bool] = None,
+        clean_up_tokenization_spaces: bool | None = None,
         **kwargs,
     ) -> str:
         self._decode_use_source_tokenizer = kwargs.pop("use_source_tokenizer", False)
@@ -694,10 +693,10 @@ class PreTrainedTokenizerFast(PreTrainedTokenizerBase):
 
     def _save_pretrained(
         self,
-        save_directory: Union[str, os.PathLike],
+        save_directory: str | os.PathLike,
         file_names: tuple[str, ...],
-        legacy_format: Optional[bool] = None,
-        filename_prefix: Optional[str] = None,
+        legacy_format: bool | None = None,
+        filename_prefix: str | None = None,
     ) -> tuple[str, ...]:
         """
         Save a tokenizer using the slow-tokenizer/legacy format: vocabulary + added tokens as well as in a unique JSON

--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -19,7 +19,6 @@ import dataclasses
 import json
 import math
 from dataclasses import dataclass
-from typing import Optional, Union
 
 import numpy as np
 from tqdm.auto import tqdm
@@ -93,26 +92,26 @@ class TrainerState:
             Relevant callbacks should implement a `state` and `from_state` function.
     """
 
-    epoch: Optional[float] = None
+    epoch: float | None = None
     global_step: int = 0
     max_steps: int = 0
     logging_steps: int = 500
     eval_steps: int = 500
     save_steps: int = 500
-    train_batch_size: Optional[int] = None
+    train_batch_size: int | None = None
     num_train_epochs: int = 0
     num_input_tokens_seen: int = 0
     total_flos: float = 0
     log_history: list[dict[str, float]] = None
-    best_metric: Optional[float] = None
-    best_global_step: Optional[int] = None
-    best_model_checkpoint: Optional[str] = None
+    best_metric: float | None = None
+    best_global_step: int | None = None
+    best_model_checkpoint: str | None = None
     is_local_process_zero: bool = True
     is_world_process_zero: bool = True
     is_hyper_param_search: bool = False
-    trial_name: Optional[str] = None
-    trial_params: Optional[dict[str, Union[str, float, int, bool]]] = None
-    stateful_callbacks: Optional[list["TrainerCallback"]] = None
+    trial_name: str | None = None
+    trial_params: dict[str, str | float | int | bool] | None = None
+    stateful_callbacks: list["TrainerCallback"] | None = None
 
     def __post_init__(self):
         if self.log_history is None:
@@ -708,7 +707,7 @@ class EarlyStoppingCallback(TrainerCallback, ExportableState):
     early stopping will not occur until the next save step.
     """
 
-    def __init__(self, early_stopping_patience: int = 1, early_stopping_threshold: Optional[float] = 0.0):
+    def __init__(self, early_stopping_patience: int = 1, early_stopping_threshold: float | None = 0.0):
         self.early_stopping_patience = early_stopping_patience
         self.early_stopping_threshold = early_stopping_threshold
         # early_stopping_patience_counter denotes the number of times validation metrics failed to improve.

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -29,7 +29,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from itertools import chain
 from logging import StreamHandler
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 import torch
@@ -69,7 +69,7 @@ def get_dataloader_sampler(dataloader):
         return dataloader.sampler
 
 
-def atleast_1d(tensor_or_array: Union[torch.Tensor, np.ndarray]):
+def atleast_1d(tensor_or_array: torch.Tensor | np.ndarray):
     if isinstance(tensor_or_array, torch.Tensor):
         if hasattr(torch, "atleast_1d"):
             tensor_or_array = torch.atleast_1d(tensor_or_array)
@@ -199,7 +199,7 @@ def nested_xla_mesh_reduce(tensors, name):
         raise ImportError("Torch xla must be installed to use `nested_xla_mesh_reduce`")
 
 
-def distributed_concat(tensor: Any, num_total_examples: Optional[int] = None) -> Any:
+def distributed_concat(tensor: Any, num_total_examples: int | None = None) -> Any:
     try:
         if isinstance(tensor, (tuple, list)):
             return type(tensor)(distributed_concat(t, num_total_examples) for t in tensor)
@@ -219,9 +219,9 @@ def distributed_concat(tensor: Any, num_total_examples: Optional[int] = None) ->
 
 
 def distributed_broadcast_scalars(
-    scalars: list[Union[int, float]],
-    num_total_examples: Optional[int] = None,
-    device: Optional[torch.device] = torch.device("cuda"),
+    scalars: list[int | float],
+    num_total_examples: int | None = None,
+    device: torch.device | None = torch.device("cuda"),
 ) -> torch.Tensor:
     try:
         tensorized_scalar = torch.tensor(scalars, device=device)
@@ -457,9 +457,9 @@ class LengthGroupedSampler(Sampler):
     def __init__(
         self,
         batch_size: int,
-        dataset: Optional[Dataset] = None,
-        lengths: Optional[list[int]] = None,
-        model_input_name: Optional[str] = None,
+        dataset: Dataset | None = None,
+        lengths: list[int] | None = None,
+        model_input_name: str | None = None,
         generator=None,
     ):
         if dataset is None and lengths is None:
@@ -501,13 +501,13 @@ class DistributedLengthGroupedSampler(DistributedSampler):
     def __init__(
         self,
         batch_size: int,
-        dataset: Optional[Dataset] = None,
-        num_replicas: Optional[int] = None,
-        rank: Optional[int] = None,
+        dataset: Dataset | None = None,
+        num_replicas: int | None = None,
+        rank: int | None = None,
         seed: int = 0,
         drop_last: bool = False,
-        lengths: Optional[list[int]] = None,
-        model_input_name: Optional[str] = None,
+        lengths: list[int] | None = None,
+        model_input_name: str | None = None,
     ):
         if dataset is None and lengths is None:
             raise ValueError("One of dataset and lengths must be provided.")
@@ -1095,7 +1095,7 @@ class AcceleratorConfig:
             " in your script multiplied by the number of processes."
         },
     )
-    dispatch_batches: Optional[bool] = field(
+    dispatch_batches: bool | None = field(
         default=None,
         metadata={
             "help": "If set to `True`, the dataloader prepared by the Accelerator is only iterated through on the main process"
@@ -1131,7 +1131,7 @@ class AcceleratorConfig:
         },
     )
 
-    gradient_accumulation_kwargs: Optional[dict] = field(
+    gradient_accumulation_kwargs: dict | None = field(
         default=None,
         metadata={
             "help": "Additional kwargs to configure gradient accumulation, see [`accelerate.utils.GradientAccumulationPlugin`]. "
@@ -1193,7 +1193,7 @@ class LayerWiseDummyOptimizer(torch.optim.Optimizer):
     def zero_grad(self, set_to_none: bool = True) -> None:
         pass
 
-    def step(self, closure=None) -> Optional[float]:
+    def step(self, closure=None) -> float | None:
         pass
 
 

--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -53,20 +53,21 @@ logger = logging.get_logger(__name__)
 class Seq2SeqTrainer(Trainer):
     def __init__(
         self,
-        model: Optional[Union["PreTrainedModel", nn.Module]] = None,
+        model: Union["PreTrainedModel", nn.Module] | None = None,
         args: Optional["TrainingArguments"] = None,
         data_collator: Optional["DataCollator"] = None,
-        train_dataset: Optional[Union[Dataset, "IterableDataset", "datasets.Dataset"]] = None,
-        eval_dataset: Optional[Union[Dataset, dict[str, Dataset]]] = None,
-        processing_class: Optional[
-            Union["PreTrainedTokenizerBase", "BaseImageProcessor", "FeatureExtractionMixin", "ProcessorMixin"]
-        ] = None,
-        model_init: Optional[Callable[[], "PreTrainedModel"]] = None,
-        compute_loss_func: Optional[Callable] = None,
-        compute_metrics: Optional[Callable[["EvalPrediction"], dict]] = None,
-        callbacks: Optional[list["TrainerCallback"]] = None,
-        optimizers: tuple[Optional[torch.optim.Optimizer], Optional[torch.optim.lr_scheduler.LambdaLR]] = (None, None),
-        preprocess_logits_for_metrics: Optional[Callable[[torch.Tensor, torch.Tensor], torch.Tensor]] = None,
+        train_dataset: Union[Dataset, "IterableDataset", "datasets.Dataset"] | None = None,
+        eval_dataset: Dataset | dict[str, Dataset] | None = None,
+        processing_class: Union[
+            "PreTrainedTokenizerBase", "BaseImageProcessor", "FeatureExtractionMixin", "ProcessorMixin"
+        ]
+        | None = None,
+        model_init: Callable[[], "PreTrainedModel"] | None = None,
+        compute_loss_func: Callable | None = None,
+        compute_metrics: Callable[["EvalPrediction"], dict] | None = None,
+        callbacks: list["TrainerCallback"] | None = None,
+        optimizers: tuple[torch.optim.Optimizer | None, torch.optim.lr_scheduler.LambdaLR | None] = (None, None),
+        preprocess_logits_for_metrics: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
     ):
         super().__init__(
             model=model,
@@ -90,7 +91,7 @@ class Seq2SeqTrainer(Trainer):
             self.model.generation_config = gen_config
 
     @staticmethod
-    def load_generation_config(gen_config_arg: Union[str, GenerationConfig]) -> GenerationConfig:
+    def load_generation_config(gen_config_arg: str | GenerationConfig) -> GenerationConfig:
         """
         Loads a `~generation.GenerationConfig` from the `Seq2SeqTrainingArguments.generation_config` arguments.
 
@@ -135,8 +136,8 @@ class Seq2SeqTrainer(Trainer):
 
     def evaluate(
         self,
-        eval_dataset: Optional[Dataset] = None,
-        ignore_keys: Optional[list[str]] = None,
+        eval_dataset: Dataset | None = None,
+        ignore_keys: list[str] | None = None,
         metric_key_prefix: str = "eval",
         **gen_kwargs,
     ) -> dict[str, float]:
@@ -192,7 +193,7 @@ class Seq2SeqTrainer(Trainer):
     def predict(
         self,
         test_dataset: Dataset,
-        ignore_keys: Optional[list[str]] = None,
+        ignore_keys: list[str] | None = None,
         metric_key_prefix: str = "test",
         **gen_kwargs,
     ) -> "PredictionOutput":
@@ -256,11 +257,11 @@ class Seq2SeqTrainer(Trainer):
     def prediction_step(
         self,
         model: nn.Module,
-        inputs: dict[str, Union[torch.Tensor, Any]],
+        inputs: dict[str, torch.Tensor | Any],
         prediction_loss_only: bool,
-        ignore_keys: Optional[list[str]] = None,
+        ignore_keys: list[str] | None = None,
         **gen_kwargs,
-    ) -> tuple[Optional[float], Optional[torch.Tensor], Optional[torch.Tensor]]:
+    ) -> tuple[float | None, torch.Tensor | None, torch.Tensor | None]:
         """
         Perform an evaluation step on `model` using `inputs`.
 

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -27,7 +27,7 @@ import threading
 import time
 from collections.abc import Callable
 from functools import partial
-from typing import Any, NamedTuple, Optional, Union
+from typing import Any, NamedTuple
 
 import numpy as np
 
@@ -159,10 +159,10 @@ class EvalPrediction:
 
     def __init__(
         self,
-        predictions: Union[np.ndarray, tuple[np.ndarray]],
-        label_ids: Union[np.ndarray, tuple[np.ndarray]],
-        inputs: Optional[Union[np.ndarray, tuple[np.ndarray]]] = None,
-        losses: Optional[Union[np.ndarray, tuple[np.ndarray]]] = None,
+        predictions: np.ndarray | tuple[np.ndarray],
+        label_ids: np.ndarray | tuple[np.ndarray],
+        inputs: np.ndarray | tuple[np.ndarray] | None = None,
+        losses: np.ndarray | tuple[np.ndarray] | None = None,
     ):
         self.predictions = predictions
         self.label_ids = label_ids
@@ -184,16 +184,16 @@ class EvalPrediction:
 
 
 class EvalLoopOutput(NamedTuple):
-    predictions: Union[np.ndarray, tuple[np.ndarray]]
-    label_ids: Optional[Union[np.ndarray, tuple[np.ndarray]]]
-    metrics: Optional[dict[str, float]]
-    num_samples: Optional[int]
+    predictions: np.ndarray | tuple[np.ndarray]
+    label_ids: np.ndarray | tuple[np.ndarray] | None
+    metrics: dict[str, float] | None
+    num_samples: int | None
 
 
 class PredictionOutput(NamedTuple):
-    predictions: Union[np.ndarray, tuple[np.ndarray]]
-    label_ids: Optional[Union[np.ndarray, tuple[np.ndarray]]]
-    metrics: Optional[dict[str, float]]
+    predictions: np.ndarray | tuple[np.ndarray]
+    label_ids: np.ndarray | tuple[np.ndarray] | None
+    metrics: dict[str, float] | None
 
 
 class TrainOutput(NamedTuple):
@@ -255,9 +255,9 @@ class BestRun(NamedTuple):
     """
 
     run_id: str
-    objective: Union[float, list[float]]
+    objective: float | list[float]
     hyperparameters: dict[str, Any]
-    run_summary: Optional[Any] = None
+    run_summary: Any | None = None
 
 
 def default_compute_objective(metrics: dict[str, float]) -> float:
@@ -763,7 +763,7 @@ def number_of_arguments(func):
 
 
 def find_executable_batch_size(
-    function: Optional[Callable] = None, starting_batch_size: int = 128, auto_find_batch_size: bool = False
+    function: Callable | None = None, starting_batch_size: int = 128, auto_find_batch_size: bool = False
 ):
     """
     Args:
@@ -811,8 +811,8 @@ class RemoveColumnsCollator:
         data_collator,
         signature_columns,
         logger=None,
-        model_name: Optional[str] = None,
-        description: Optional[str] = None,
+        model_name: str | None = None,
+        description: str | None = None,
     ):
         self.data_collator = data_collator
         self.signature_columns = signature_columns

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -21,7 +21,7 @@ from dataclasses import asdict, dataclass, field, fields
 from datetime import timedelta
 from enum import Enum
 from functools import cached_property
-from typing import Any, Optional, Union
+from typing import Any
 
 from .debug_utils import DebugOption
 from .trainer_utils import (
@@ -116,7 +116,7 @@ def get_int_from_env(env_keys, default):
     return default
 
 
-def get_xla_device_type(device: "torch.device") -> Optional[str]:
+def get_xla_device_type(device: "torch.device") -> str | None:
     """
     Returns the xla device type (CPU|GPU|TPU) or None if the device is a non-xla device.
     """
@@ -771,7 +771,7 @@ class TrainingArguments:
         "lr_scheduler_kwargs",
     ]
 
-    output_dir: Optional[str] = field(
+    output_dir: str | None = field(
         default=None,
         metadata={
             "help": "The output directory where the model predictions and checkpoints will be written. Defaults to 'trainer_output' if not provided."
@@ -781,7 +781,7 @@ class TrainingArguments:
     do_train: bool = field(default=False, metadata={"help": "Whether to run training."})
     do_eval: bool = field(default=False, metadata={"help": "Whether to run eval on the dev set."})
     do_predict: bool = field(default=False, metadata={"help": "Whether to run predictions on the test set."})
-    eval_strategy: Union[IntervalStrategy, str] = field(
+    eval_strategy: IntervalStrategy | str = field(
         default="no",
         metadata={"help": "The evaluation strategy to use."},
     )
@@ -801,7 +801,7 @@ class TrainingArguments:
         default=1,
         metadata={"help": "Number of updates steps to accumulate before performing a backward/update pass."},
     )
-    eval_accumulation_steps: Optional[int] = field(
+    eval_accumulation_steps: int | None = field(
         default=None,
         metadata={"help": "Number of predictions steps to accumulate before moving the tensors to the CPU."},
     )
@@ -816,7 +816,7 @@ class TrainingArguments:
         },
     )
 
-    torch_empty_cache_steps: Optional[int] = field(
+    torch_empty_cache_steps: int | None = field(
         default=None,
         metadata={
             "help": "Number of steps to wait before calling `torch.<device>.empty_cache()`."
@@ -837,11 +837,11 @@ class TrainingArguments:
         default=-1,
         metadata={"help": "If > 0: set total number of training steps to perform. Override num_train_epochs."},
     )
-    lr_scheduler_type: Union[SchedulerType, str] = field(
+    lr_scheduler_type: SchedulerType | str = field(
         default="linear",
         metadata={"help": "The scheduler type to use."},
     )
-    lr_scheduler_kwargs: Optional[Union[dict, str]] = field(
+    lr_scheduler_kwargs: dict | str | None = field(
         default=None,
         metadata={
             "help": (
@@ -849,7 +849,7 @@ class TrainingArguments:
             )
         },
     )
-    warmup_ratio: Optional[float] = field(
+    warmup_ratio: float | None = field(
         default=None,
         metadata={
             "help": "This argument is deprecated and will be removed in v5. Use `warmup_steps` instead as it also works with float values."
@@ -885,13 +885,13 @@ class TrainingArguments:
             )
         },
     )
-    logging_dir: Optional[str] = field(
+    logging_dir: str | None = field(
         default=None,
         metadata={
             "help": "Deprecated and will be removed in v5.2. Set env var `TENSORBOARD_LOGGING_DIR` instead. TensorBoard log directory."
         },
     )
-    logging_strategy: Union[IntervalStrategy, str] = field(
+    logging_strategy: IntervalStrategy | str = field(
         default="steps",
         metadata={"help": "The logging strategy to use."},
     )
@@ -906,7 +906,7 @@ class TrainingArguments:
         },
     )
     logging_nan_inf_filter: bool = field(default=True, metadata={"help": "Filter nan and inf losses for logging."})
-    save_strategy: Union[SaveStrategy, str] = field(
+    save_strategy: SaveStrategy | str = field(
         default="steps",
         metadata={"help": "The checkpoint save strategy to use."},
     )
@@ -919,7 +919,7 @@ class TrainingArguments:
             )
         },
     )
-    save_total_limit: Optional[int] = field(
+    save_total_limit: int | None = field(
         default=None,
         metadata={
             "help": (
@@ -972,7 +972,7 @@ class TrainingArguments:
         },
     )
     seed: int = field(default=42, metadata={"help": "Random seed that will be set at the beginning of training."})
-    data_seed: Optional[int] = field(default=None, metadata={"help": "Random seed to be used with data samplers."})
+    data_seed: int | None = field(default=None, metadata={"help": "Random seed to be used with data samplers."})
     bf16: bool = field(
         default=False,
         metadata={
@@ -1000,7 +1000,7 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Whether to use full float16 evaluation instead of 32-bit"},
     )
-    tf32: Optional[bool] = field(
+    tf32: bool | None = field(
         default=None,
         metadata={
             "help": (
@@ -1015,14 +1015,14 @@ class TrainingArguments:
             "help": "When using torch.distributed.launch (Deprecated), it will pass `local_rank` in the script, so we need this for the parser. To get the local rank, prefer using the property `local_process_index`"
         },
     )
-    ddp_backend: Optional[str] = field(
+    ddp_backend: str | None = field(
         default=None,
         metadata={
             "help": "The backend to be used for distributed training",
             "choices": ["nccl", "gloo", "mpi", "ccl", "hccl", "cncl", "mccl"],
         },
     )
-    debug: Union[str, list[DebugOption]] = field(
+    debug: str | list[DebugOption] = field(
         default="",
         metadata={
             "help": (
@@ -1036,7 +1036,7 @@ class TrainingArguments:
     dataloader_drop_last: bool = field(
         default=False, metadata={"help": "Drop the last incomplete batch if it is not divisible by the batch size."}
     )
-    eval_steps: Optional[float] = field(
+    eval_steps: float | None = field(
         default=None,
         metadata={
             "help": (
@@ -1054,7 +1054,7 @@ class TrainingArguments:
             )
         },
     )
-    dataloader_prefetch_factor: Optional[int] = field(
+    dataloader_prefetch_factor: int | None = field(
         default=None,
         metadata={
             "help": (
@@ -1064,7 +1064,7 @@ class TrainingArguments:
         },
     )
 
-    run_name: Optional[str] = field(
+    run_name: str | None = field(
         default=None,
         metadata={
             "help": (
@@ -1073,14 +1073,14 @@ class TrainingArguments:
             )
         },
     )
-    disable_tqdm: Optional[bool] = field(
+    disable_tqdm: bool | None = field(
         default=None, metadata={"help": "Whether or not to disable the tqdm progress bars."}
     )
 
     remove_unused_columns: bool = field(
         default=True, metadata={"help": "Remove columns not required by the model when using an nlp.Dataset."}
     )
-    label_names: Optional[list[str]] = field(
+    label_names: list[str] | None = field(
         default=None, metadata={"help": "The list of keys in your dictionary of inputs that correspond to the labels."}
     )
     load_best_model_at_end: bool = field(
@@ -1092,10 +1092,10 @@ class TrainingArguments:
             )
         },
     )
-    metric_for_best_model: Optional[str] = field(
+    metric_for_best_model: str | None = field(
         default=None, metadata={"help": "The metric to use to compare two different models."}
     )
-    greater_is_better: Optional[bool] = field(
+    greater_is_better: bool | None = field(
         default=None, metadata={"help": "Whether the `metric_for_best_model` should be maximized or not."}
     )
     ignore_data_skip: bool = field(
@@ -1107,7 +1107,7 @@ class TrainingArguments:
             )
         },
     )
-    fsdp: Optional[Union[list[FSDPOption], str]] = field(
+    fsdp: list[FSDPOption] | str | None = field(
         default=None,
         metadata={
             "help": (
@@ -1119,7 +1119,7 @@ class TrainingArguments:
             ),
         },
     )
-    fsdp_config: Optional[Union[dict[str, Any], str]] = field(
+    fsdp_config: dict[str, Any] | str | None = field(
         default=None,
         metadata={
             "help": (
@@ -1128,7 +1128,7 @@ class TrainingArguments:
             )
         },
     )
-    accelerator_config: Optional[Union[dict, str]] = field(
+    accelerator_config: dict | str | None = field(
         default=None,
         metadata={
             "help": (
@@ -1137,11 +1137,11 @@ class TrainingArguments:
             )
         },
     )
-    parallelism_config: Optional[ParallelismConfig] = field(
+    parallelism_config: ParallelismConfig | None = field(
         default=None,
         metadata={"help": ("Parallelism configuration for the training run. Requires Accelerate `1.12.0`")},
     )
-    deepspeed: Optional[Union[dict, str]] = field(
+    deepspeed: dict | str | None = field(
         default=None,
         metadata={
             "help": (
@@ -1160,11 +1160,11 @@ class TrainingArguments:
 
         if is_torch_greater_or_equal_than_2_8:
             default_optim = "adamw_torch_fused"
-    optim: Union[OptimizerNames, str] = field(
+    optim: OptimizerNames | str = field(
         default=default_optim,
         metadata={"help": "The optimizer to use."},
     )
-    optim_args: Optional[str] = field(default=None, metadata={"help": "Optional arguments to supply to optimizer."})
+    optim_args: str | None = field(default=None, metadata={"help": "Optional arguments to supply to optimizer."})
     group_by_length: bool = field(
         default=False,
         metadata={"help": "Whether or not to group samples of roughly the same length together when batching."},
@@ -1173,14 +1173,14 @@ class TrainingArguments:
         default="length",
         metadata={"help": "Column name with precomputed lengths to use when grouping by length."},
     )
-    report_to: Union[None, str, list[str]] = field(
+    report_to: None | str | list[str] = field(
         default="none", metadata={"help": "The list of integrations to report the results and logs to."}
     )
     project: str = field(
         default="huggingface",
         metadata={"help": "The name of the project to use for logging. Currenly, only used by Trackio."},
     )
-    trackio_space_id: Optional[str] = field(
+    trackio_space_id: str | None = field(
         default="trackio",
         metadata={
             "help": "The Hugging Face Space ID to deploy to when using Trackio. Should be a complete Space name like "
@@ -1190,7 +1190,7 @@ class TrainingArguments:
             "default is to create private Spaces."
         },
     )
-    ddp_find_unused_parameters: Optional[bool] = field(
+    ddp_find_unused_parameters: bool | None = field(
         default=None,
         metadata={
             "help": (
@@ -1199,7 +1199,7 @@ class TrainingArguments:
             )
         },
     )
-    ddp_bucket_cap_mb: Optional[int] = field(
+    ddp_bucket_cap_mb: int | None = field(
         default=None,
         metadata={
             "help": (
@@ -1208,7 +1208,7 @@ class TrainingArguments:
             )
         },
     )
-    ddp_broadcast_buffers: Optional[bool] = field(
+    ddp_broadcast_buffers: bool | None = field(
         default=None,
         metadata={
             "help": (
@@ -1232,19 +1232,19 @@ class TrainingArguments:
     push_to_hub: bool = field(
         default=False, metadata={"help": "Whether or not to upload the trained model to the model hub after training."}
     )
-    resume_from_checkpoint: Optional[str] = field(
+    resume_from_checkpoint: str | None = field(
         default=None,
         metadata={"help": "The path to a folder with a valid checkpoint for your model."},
     )
-    hub_model_id: Optional[str] = field(
+    hub_model_id: str | None = field(
         default=None, metadata={"help": "The name of the repository to keep in sync with the local `output_dir`."}
     )
-    hub_strategy: Union[HubStrategy, str] = field(
+    hub_strategy: HubStrategy | str = field(
         default="every_save",
         metadata={"help": "The hub strategy to use when `--push_to_hub` is activated."},
     )
-    hub_token: Optional[str] = field(default=None, metadata={"help": "The token to use to push to the Model Hub."})
-    hub_private_repo: Optional[bool] = field(
+    hub_token: str | None = field(default=None, metadata={"help": "The token to use to push to the Model Hub."})
+    hub_private_repo: bool | None = field(
         default=None,
         metadata={
             "help": "Whether to make the repo private. If `None` (default), the repo will be public unless the "
@@ -1257,7 +1257,7 @@ class TrainingArguments:
         default=False,
         metadata={"help": "Unless `True`, the Trainer will skip pushes if the previous one wasn't finished yet."},
     )
-    hub_revision: Optional[str] = field(
+    hub_revision: str | None = field(
         default=None,
         metadata={
             "help": "The revision to use when pushing to the Hub. Can be a branch name, a tag, or a commit hash."
@@ -1269,7 +1269,7 @@ class TrainingArguments:
             "help": "If True, use gradient checkpointing to save memory at the expense of slower backward pass."
         },
     )
-    gradient_checkpointing_kwargs: Optional[Union[dict[str, Any], str]] = field(
+    gradient_checkpointing_kwargs: dict[str, Any] | str | None = field(
         default=None,
         metadata={
             "help": "Gradient checkpointing key word arguments such as `use_reentrant`. Will be passed to `torch.utils.checkpoint.checkpoint` through `model.gradient_checkpointing_enable`."
@@ -1315,19 +1315,19 @@ class TrainingArguments:
     torch_compile: bool = field(
         default=False, metadata={"help": "If set to `True`, the model will be wrapped in `torch.compile`."}
     )
-    torch_compile_backend: Optional[str] = field(
+    torch_compile_backend: str | None = field(
         default=None,
         metadata={
             "help": "Which backend to use with `torch.compile`, passing one will trigger a model compilation.",
         },
     )
-    torch_compile_mode: Optional[str] = field(
+    torch_compile_mode: str | None = field(
         default=None,
         metadata={
             "help": "Which mode to use with `torch.compile`, passing one will trigger a model compilation.",
         },
     )
-    include_num_input_tokens_seen: Union[str, bool] = field(
+    include_num_input_tokens_seen: str | bool = field(
         default="no",
         metadata={
             "help": (
@@ -1337,14 +1337,14 @@ class TrainingArguments:
         },
     )
 
-    neftune_noise_alpha: Optional[float] = field(
+    neftune_noise_alpha: float | None = field(
         default=None,
         metadata={
             "help": "Activates neftune noise embeddings into the model. NEFTune has been proven to drastically improve model performances for instruction fine-tuning. Check out the original paper here: https://huggingface.co/papers/2310.05914 and the original code here: https://github.com/neelsjain/NEFTune. Only supported for `PreTrainedModel` and `PeftModel` classes."
         },
     )
 
-    optim_target_modules: Union[None, str, list[str]] = field(
+    optim_target_modules: None | str | list[str] = field(
         default=None,
         metadata={
             "help": "Target modules for the optimizer defined in the `optim` argument. Only used for the GaLore optimizer at the moment."
@@ -1368,7 +1368,7 @@ class TrainingArguments:
         metadata={"help": "Whether or not to enable the Liger Kernel for model training."},
     )
 
-    liger_kernel_config: Optional[dict[str, bool]] = field(
+    liger_kernel_config: dict[str, bool] | None = field(
         default=None,
         metadata={
             "help": (
@@ -2200,11 +2200,11 @@ class TrainingArguments:
 
     def set_evaluate(
         self,
-        strategy: Union[str, IntervalStrategy] = "no",
+        strategy: str | IntervalStrategy = "no",
         steps: int = 500,
         batch_size: int = 8,
-        accumulation_steps: Optional[int] = None,
-        delay: Optional[float] = None,
+        accumulation_steps: int | None = None,
+        delay: float | None = None,
         loss_only: bool = False,
     ):
         """
@@ -2293,9 +2293,9 @@ class TrainingArguments:
 
     def set_save(
         self,
-        strategy: Union[str, IntervalStrategy] = "steps",
+        strategy: str | IntervalStrategy = "steps",
         steps: int = 500,
-        total_limit: Optional[int] = None,
+        total_limit: int | None = None,
         on_each_node: bool = False,
     ):
         """
@@ -2342,9 +2342,9 @@ class TrainingArguments:
 
     def set_logging(
         self,
-        strategy: Union[str, IntervalStrategy] = "steps",
+        strategy: str | IntervalStrategy = "steps",
         steps: int = 500,
-        report_to: Union[str, list[str]] = "none",
+        report_to: str | list[str] = "none",
         level: str = "passive",
         first_step: bool = False,
         nan_inf_filter: bool = False,
@@ -2418,11 +2418,11 @@ class TrainingArguments:
     def set_push_to_hub(
         self,
         model_id: str,
-        strategy: Union[str, HubStrategy] = "every_save",
-        token: Optional[str] = None,
-        private_repo: Optional[bool] = None,
+        strategy: str | HubStrategy = "every_save",
+        token: str | None = None,
+        private_repo: bool | None = None,
         always_push: bool = False,
-        revision: Optional[str] = None,
+        revision: str | None = None,
     ):
         """
         A method that regroups all arguments linked to synchronizing checkpoints with the Hub.
@@ -2491,13 +2491,13 @@ class TrainingArguments:
 
     def set_optimizer(
         self,
-        name: Union[str, OptimizerNames] = "adamw_torch",
+        name: str | OptimizerNames = "adamw_torch",
         learning_rate: float = 5e-5,
         weight_decay: float = 0,
         beta1: float = 0.9,
         beta2: float = 0.999,
         epsilon: float = 1e-8,
-        args: Optional[str] = None,
+        args: str | None = None,
     ):
         """
         A method that regroups all arguments linked to the optimizer and its hyperparameters.
@@ -2542,11 +2542,11 @@ class TrainingArguments:
 
     def set_lr_scheduler(
         self,
-        name: Union[str, SchedulerType] = "linear",
+        name: str | SchedulerType = "linear",
         num_epochs: float = 3.0,
         max_steps: int = -1,
         warmup_steps: float = 0,
-        warmup_ratio: Optional[float] = None,
+        warmup_ratio: float | None = None,
     ):
         """
         A method that regroups all arguments linked to the learning rate scheduler and its hyperparameters.
@@ -2594,10 +2594,10 @@ class TrainingArguments:
         num_workers: int = 0,
         pin_memory: bool = True,
         persistent_workers: bool = False,
-        prefetch_factor: Optional[int] = None,
+        prefetch_factor: int | None = None,
         auto_find_batch_size: bool = False,
         ignore_data_skip: bool = False,
-        sampler_seed: Optional[int] = None,
+        sampler_seed: int | None = None,
     ):
         """
         A method that regroups all arguments linked to the dataloaders creation.

--- a/src/transformers/training_args_seq2seq.py
+++ b/src/transformers/training_args_seq2seq.py
@@ -15,7 +15,6 @@
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional, Union
 
 from .generation.configuration_utils import GenerationConfig
 from .training_args import TrainingArguments
@@ -52,7 +51,7 @@ class Seq2SeqTrainingArguments(TrainingArguments):
     predict_with_generate: bool = field(
         default=False, metadata={"help": "Whether to use generate to calculate generative metrics (ROUGE, BLEU)."}
     )
-    generation_max_length: Optional[int] = field(
+    generation_max_length: int | None = field(
         default=None,
         metadata={
             "help": (
@@ -61,7 +60,7 @@ class Seq2SeqTrainingArguments(TrainingArguments):
             )
         },
     )
-    generation_num_beams: Optional[int] = field(
+    generation_num_beams: int | None = field(
         default=None,
         metadata={
             "help": (
@@ -70,7 +69,7 @@ class Seq2SeqTrainingArguments(TrainingArguments):
             )
         },
     )
-    generation_config: Optional[Union[str, Path, GenerationConfig]] = field(
+    generation_config: str | Path | GenerationConfig | None = field(
         default=None,
         metadata={
             "help": "Model id, file path or url pointing to a GenerationConfig json file, to use during prediction."

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import unittest
-from typing import Literal, Optional, Union
+from typing import Literal
 
 from transformers.utils import DocstringParsingException, TypeHintParsingException, get_json_schema
 
@@ -57,7 +57,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         self.assertEqual(schema["function"], expected_schema)
 
     def test_union(self):
-        def fn(x: Union[int, float]):
+        def fn(x: int | float):
             """
             Test function
 
@@ -79,7 +79,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         self.assertEqual(schema["function"], expected_schema)
 
     def test_optional(self):
-        def fn(x: Optional[int]):
+        def fn(x: int | None):
             """
             Test function
 
@@ -119,7 +119,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         self.assertEqual(schema["function"], expected_schema)
 
     def test_nested_list(self):
-        def fn(x: list[list[Union[str, int]]]):
+        def fn(x: list[list[str | int]]):
             """
             Test function
 
@@ -173,7 +173,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         self.assertEqual(schema["function"], expected_schema)
 
     def test_multiple_complex_arguments(self):
-        def fn(x: list[Union[int, float]], y: Optional[Union[int, str]] = None):
+        def fn(x: list[int | float], y: int | str | None = None):
             """
             Test function
 
@@ -488,9 +488,7 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         self.assertEqual(schema["function"], expected_schema)
 
     def test_everything_all_at_once(self):
-        def fn(
-            x: str, y: Optional[list[Union[str, int]]], z: tuple[Union[str, int], str] = (42, "hello")
-        ) -> tuple[int, str]:
+        def fn(x: str, y: list[str | int] | None, z: tuple[str | int, str] = (42, "hello")) -> tuple[int, str]:
             """
             Test function with multiple args, and docstring args that we have to strip out.
 

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -44,7 +44,7 @@ import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 from check_repo import ignore_undocumented
 from git import Repo
@@ -71,11 +71,11 @@ class DecoratedItem:
         int  # 1-based line number where body starts (for functions) or __init__ body start (for classes with __init__)
     )
     args: list[str]  # List of argument names (excluding self, *args, **kwargs) - for classes, these are __init__ args
-    custom_args_text: Optional[str] = None  # custom_args string if provided in decorator
+    custom_args_text: str | None = None  # custom_args string if provided in decorator
 
     # Class-specific fields (only populated when kind == 'class')
     has_init: bool = False  # Whether the class has an __init__ method
-    init_def_line: Optional[int] = None  # 1-based line number of __init__ def (if has_init)
+    init_def_line: int | None = None  # 1-based line number of __init__ def (if has_init)
     is_model_output: bool = False  # Whether the class inherits from ModelOutput
 
 
@@ -913,7 +913,7 @@ def _is_auto_docstring_decorator(dec):
     return isinstance(target, ast.Name) and target.id == "auto_docstring"
 
 
-def _extract_function_args(func_node: Union[ast.FunctionDef, ast.AsyncFunctionDef]) -> list[str]:
+def _extract_function_args(func_node: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
     """Extract argument names from a function node, excluding 'self', *args, **kwargs."""
     all_args = (func_node.args.posonlyargs or []) + func_node.args.args + func_node.args.kwonlyargs
     return [a.arg for a in all_args if a.arg != "self"]


### PR DESCRIPTION
# What does this PR do?

This PR uses Python 3.10 typing for `Optional` and `Union` types.