### PR TITLE
Remove unnecessary tied weights for Seamless M4T?

### DIFF
--- a/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
@@ -1981,7 +1981,6 @@ class SeamlessM4TTextToUnitForConditionalGeneration(SeamlessM4TPreTrainedModel, 
         "text_encoder",
         "text_decoder",
     ]
-    _tied_weights_keys = {"lm_head.weight": "model.decoder.embed_tokens.weight"}
 
     def __init__(
         self,


### PR DESCRIPTION
# What does this PR do?

The tied weights refactoring from https://github.com/huggingface/transformers/pull/41580 may have introduced an error for the Seamless M4T model? Opening this PR to not lose track.

Perhaps https://github.com/huggingface/transformers/pull/42362 will address?

Modeling tests before fix (11 errors)
```
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelWithSpeechInputTest::test_model_from_pretrained - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelWithTextInputTest::test_model_from_pretrained - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelWithTextInputTest::test_resize_embeddings_untied_with_deepspeed - ImportError: libmpi.so.40: cannot open shared object file: No such file or directory
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelWithTextInputTest::test_resize_tokens_embeddings_with_deepspeed - ImportError: libmpi.so.40: cannot open shared object file: No such file or directory
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_speech_to_speech_model - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_speech_to_text_model - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_text_to_speech_model - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_text_to_text_model - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_to_eng_text - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_to_rus_speech - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_to_swh_text - ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_mo... 
========== 11 failed, 79 passed, 193 skipped, 5 warnings in 116.67s (0:01:56) ====
```

Modeling tests after fix (7 errors)
```
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelWithTextInputTest::test_resize_embeddings_untied_with_deepspeed - ImportError: libmpi.so.40: cannot open shared object file: No such file or directory
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelWithTextInputTest::test_resize_tokens_embeddings_with_deepspeed - ImportError: libmpi.so.40: cannot open shared object file: No such file or directory
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_speech_to_speech_model - AssertionError: 86400 != 86080
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_text_to_speech_model - AssertionError: 90560 != 86720
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_to_eng_text - AssertionError: Lists differ: [2, 10051, 8980, 8212, 949, 1270, 4311, 1123, 5918, 2333] != [2, 10051, 9253, 9253, 9253, 9253, 3765, 3765, 3765, 3765]
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_to_rus_speech - AssertionError: Lists differ: [2, 10067, 5729, 4798, 9631, 8378, 4446, 2393, 6901, 5983] != [2, 10067, 5560, 5560, 5560, 5560, 5560, 5560, 5560, 5560]
FAILED tests/models/seamless_m4t/test_modeling_seamless_m4t.py::SeamlessM4TModelIntegrationTest::test_to_swh_text - AssertionError: Lists differ: [2, 10071, 5729, 9995, 3089, 7546, 1204, 1721, 2532, 4340] != [2, 10071, 2679, 2679, 2679, 2679, 2679, 2679, 9178, 9178]
=============== 7 failed, 89 passed, 187 skipped, 5 warnings in 171.26s (0:02:51) =========
```

Essentially such errors are resolved:
```
ValueError: This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie t2u_model.model.decoder.embed_tokens.weight (which should be present and is not), to t2u_model.lm_head.weight (which is present).
```
But integration tests are failing which is probably better for another PR?

cc: @vasqu, @ArthurZucker

