### PR TITLE
Corrected line 2471 from _config.model_type to _config["model_type"]

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2468,7 +2468,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     transformers_version = _config.get("transformers_version")
 
                     if transformers_version and version.parse(transformers_version) <= version.parse("4.57.2"):
-                        if _is_local and _config.model_type not in [
+                        if _is_local and _config["model_type"] not in [
                             "mistral",
                             "mistral3",
                             "voxstral",


### PR DESCRIPTION
As per line 2467: _config = json.load(f)
In python, since config.json file read is usually a json, it is returned in dictionary format. thus the output of 'json.load(f)' is a <class: dict> object

However line 2471 tries to access the key "model_type" in a wrong manner. _config.model_type throws an error since _config is a 'dict' object. Hence corrected to _config["model_type"]

# What does this PR do?
This pr fixes the incorrect use of _config variable

Fixes # (issue)
As per line 2467: 
```
_config = json.load(f)
```
In python, since config.json file read is usually a json, it is returned in dictionary format. thus the output of 'json.load(f)' is a <class: dict> object

However line 2471 tries to access the key "model_type" in a wrong manner.
Hence _config.model_type will throw an error that
```
AttributeError: 'dict' object has no attribute 'model_type'
```

Thus in line 2471, changed _config.model_type to _config["model_type"]