### PR TITLE
[`Mistral Tokenizers`] Fix tokenizer detection

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2472,13 +2472,18 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     #   a) having a non-mistral tokenizer
                     #   b) fixed version of transformers
                     if transformers_version and version.parse(transformers_version) <= version.parse("4.57.2"):
-                        if _is_local and transformers_model_type is not None and transformers_model_type not in [
-                            "mistral",
-                            "mistral3",
-                            "voxtral",
-                            "ministral",
-                            "pixtral",
-                        ]:
+                        if (
+                            _is_local
+                            and transformers_model_type is not None
+                            and transformers_model_type
+                            not in [
+                                "mistral",
+                                "mistral3",
+                                "voxtral",
+                                "ministral",
+                                "pixtral",
+                            ]
+                        ):
                             return tokenizer
                     elif transformers_version and version.parse(transformers_version) > version.parse("4.57.2"):
                         return tokenizer

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2437,87 +2437,121 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         except NotImplementedError:
             vocab_size = 0
 
+        # Optionally patches mistral tokenizers with wrong regex
         if (
             vocab_size > 100000
             and hasattr(tokenizer, "_tokenizer")
             and getattr(tokenizer._tokenizer, "pre_tokenizer", None) is not None
         ):
-            from huggingface_hub import model_info
+            tokenizer = cls._patch_mistral_regex(
+                tokenizer,
+                pretrained_model_name_or_path,
+                token=token,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                _commit_hash=_commit_hash,
+                _is_local=_is_local,
+                init_kwargs=init_kwargs,
+                **kwargs,
+            )
 
-            def is_base_mistral(model_id: str) -> bool:
-                model = model_info(model_id)
-                if model.tags is not None:
-                    if re.search("base_model:.*mistralai", "".join(model.tags)):
-                        return True
-                return False
+        return tokenizer
 
-            if _is_local or is_base_mistral(pretrained_model_name_or_path):
-                _config_file = cached_file(
-                    pretrained_model_name_or_path,
-                    "config.json",
-                    cache_dir=cache_dir,
-                    token=token,
-                    local_files_only=local_files_only,
-                    _raise_exceptions_for_missing_entries=False,
-                    _raise_exceptions_for_connection_errors=False,
-                    _commit_hash=_commit_hash,
-                )
+    @classmethod
+    def _patch_mistral_regex(
+        cls,
+        tokenizer,
+        pretrained_model_name_or_path,
+        token=None,
+        cache_dir=None,
+        local_files_only=False,
+        _commit_hash=None,
+        _is_local=False,
+        init_kwargs=None,
+        **kwargs,
+    ):
+        """
+        Patches mistral related tokenizers with incorrect regex if detected
+            1) Local file with an associated config saved next to it
+                >> Model type one of the mistral models (on older versions)
+            2) Remote models on the hub from official mistral models
+                >> Tags including `base_model:.*mistralai`
+        """
+        from huggingface_hub import model_info
 
-                # detected using a (local) mistral tokenizer
-                fix_mistral_regex = False
-                if _config_file is not None:
-                    with open(_config_file, encoding="utf-8") as f:
-                        _config = json.load(f)
-                    transformers_version = _config.get("transformers_version")
-                    transformers_model_type = _config.get("model_type")
+        def is_base_mistral(model_id: str) -> bool:
+            model = model_info(model_id)
+            if model.tags is not None:
+                if re.search("base_model:.*mistralai", "".join(model.tags)):
+                    return True
+            return False
 
-                    # Detect if we can skip the mistral fix by
-                    #   a) having a non-mistral tokenizer
-                    #   b) fixed version of transformers
-                    if transformers_version and version.parse(transformers_version) <= version.parse("4.57.2"):
-                        if (
-                            _is_local
-                            and transformers_model_type is not None
-                            and transformers_model_type
-                            not in [
-                                "mistral",
-                                "mistral3",
-                                "voxtral",
-                                "ministral",
-                                "pixtral",
-                            ]
-                        ):
-                            return tokenizer
-                    elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
+        if _is_local or is_base_mistral(pretrained_model_name_or_path):
+            _config_file = cached_file(
+                pretrained_model_name_or_path,
+                "config.json",
+                cache_dir=cache_dir,
+                token=token,
+                local_files_only=local_files_only,
+                _raise_exceptions_for_missing_entries=False,
+                _raise_exceptions_for_connection_errors=False,
+                _commit_hash=_commit_hash,
+            )
+
+            # Detected using a (local) mistral tokenizer
+            fix_mistral_regex = False
+            if _config_file is not None:
+                with open(_config_file, encoding="utf-8") as f:
+                    _config = json.load(f)
+                transformers_version = _config.get("transformers_version")
+                transformers_model_type = _config.get("model_type")
+
+                # Detect if we can skip the mistral fix by
+                #   a) having a non-mistral tokenizer
+                #   b) fixed version of transformers
+                if transformers_version and version.parse(transformers_version) <= version.parse("4.57.2"):
+                    if (
+                        _is_local
+                        and transformers_model_type is not None
+                        and transformers_model_type
+                        not in [
+                            "mistral",
+                            "mistral3",
+                            "voxtral",
+                            "ministral",
+                            "pixtral",
+                        ]
+                    ):
                         return tokenizer
+                elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
+                    return tokenizer
 
-                    fix_mistral_regex = True
+                fix_mistral_regex = True
 
-                if fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
-                    # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
-                    if "fix_mistral_regex" in init_kwargs:
-                        setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])
+            if fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
+                # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
+                if "fix_mistral_regex" in init_kwargs:
+                    setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])
 
-                    fix_mistral_regex = kwargs.get("fix_mistral_regex")  # not init kwargs
-                    # only warn if its not explicitly passed
-                    if fix_mistral_regex is None and not getattr(tokenizer, "fix_mistral_regex", False):
-                        setattr(tokenizer, "fix_mistral_regex", False)
-                        logger.warning(
-                            f"The tokenizer you are loading from '{pretrained_model_name_or_path}'"
-                            f" with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e."
-                            " This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue."
-                        )
-                    elif fix_mistral_regex is True or getattr(tokenizer, "fix_mistral_regex", False):
-                        setattr(tokenizer, "fix_mistral_regex", True)
-                        import tokenizers
+                fix_mistral_regex = kwargs.get("fix_mistral_regex")  # not init kwargs
+                # only warn if its not explicitly passed
+                if fix_mistral_regex is None and not getattr(tokenizer, "fix_mistral_regex", False):
+                    setattr(tokenizer, "fix_mistral_regex", False)
+                    logger.warning(
+                        f"The tokenizer you are loading from '{pretrained_model_name_or_path}'"
+                        f" with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e."
+                        " This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue."
+                    )
+                elif fix_mistral_regex is True or getattr(tokenizer, "fix_mistral_regex", False):
+                    setattr(tokenizer, "fix_mistral_regex", True)
+                    import tokenizers
 
-                        tokenizer.backend_tokenizer.pre_tokenizer[0] = tokenizers.pre_tokenizers.Split(
-                            pattern=tokenizers.Regex(
-                                r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+"
-                            ),
-                            behavior="isolated",
-                        )
-
+                    tokenizer.backend_tokenizer.pre_tokenizer[0] = tokenizers.pre_tokenizers.Split(
+                        pattern=tokenizers.Regex(
+                            r"[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]*[\p{Ll}\p{Lm}\p{Lo}\p{M}]+|[^\r\n\p{L}\p{N}]?[\p{Lu}\p{Lt}\p{Lm}\p{Lo}\p{M}]+[\p{Ll}\p{Lm}\p{Lo}\p{M}]*|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n/]*|\s*[\r\n]+|\s+(?!\S)|\s+"
+                        ),
+                        behavior="isolated",
+                    )
         return tokenizer
 
     @staticmethod

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2504,7 +2504,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         setattr(tokenizer, "fix_mistral_regex", False)
                         logger.warning(
                             f"The tokenizer you are loading from '{pretrained_model_name_or_path}'"
-                            f" with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. "
+                            f" with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e."
                             " This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue."
                         )
                     elif fix_mistral_regex is True or getattr(tokenizer, "fix_mistral_regex", False):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2451,8 +2451,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         return True
                 return False
 
-            is_official_mistral_tokenizer = is_base_mistral(pretrained_model_name_or_path)
-            if _is_local or is_official_mistral_tokenizer:
+            if _is_local or is_base_mistral(pretrained_model_name_or_path):
                 _config_file = cached_file(
                     pretrained_model_name_or_path,
                     "config.json",
@@ -2494,7 +2493,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
                     fix_mistral_regex = True
 
-                if fix_mistral_regex or is_official_mistral_tokenizer:
+                if fix_mistral_regex or is_base_mistral(pretrained_model_name_or_path):
                     # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
                     if "fix_mistral_regex" in init_kwargs:
                         setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2451,7 +2451,8 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                         return True
                 return False
 
-            if _is_local or is_base_mistral(pretrained_model_name_or_path):
+            is_official_mistral_tokenizer = is_base_mistral(pretrained_model_name_or_path)
+            if _is_local or is_official_mistral_tokenizer:
                 _config_file = cached_file(
                     pretrained_model_name_or_path,
                     "config.json",
@@ -2462,6 +2463,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     _raise_exceptions_for_connection_errors=False,
                     _commit_hash=_commit_hash,
                 )
+
+                # detected using a (local) mistral tokenizer
+                fix_mistral_regex = False
                 if _config_file is not None:
                     with open(_config_file, encoding="utf-8") as f:
                         _config = json.load(f)
@@ -2488,6 +2492,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
                         return tokenizer
 
+                    fix_mistral_regex = True
+
+                if fix_mistral_regex or is_official_mistral_tokenizer:
                     # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
                     if "fix_mistral_regex" in init_kwargs:
                         setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2099,12 +2099,13 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             template = template.removesuffix(".jinja")
                             vocab_files[f"chat_template_{template}"] = f"{CHAT_TEMPLATE_DIR}/{template}.jinja"
 
+        remote_files = []
         if not is_local and not local_files_only:
             try:
                 remote_files = list_repo_files(pretrained_model_name_or_path)
             except Exception:
                 remote_files = []
-        else:
+        elif pretrained_model_name_or_path and os.path.isdir(pretrained_model_name_or_path):
             remote_files = os.listdir(pretrained_model_name_or_path)
 
         if "tokenizer_file" in vocab_files and not re.search(vocab_files["tokenizer_file"], "".join(remote_files)):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2500,7 +2500,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             )
 
             # Detected using a (local) mistral tokenizer
-            fix_mistral_regex = False
+            _fix_mistral_regex = False
             if _config_file is not None:
                 with open(_config_file, encoding="utf-8") as f:
                     _config = json.load(f)
@@ -2527,9 +2527,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
                     return tokenizer
 
-                fix_mistral_regex = True
+                _fix_mistral_regex = True
 
-            if fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
+            if _fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
                 # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
                 if init_kwargs and "fix_mistral_regex" in init_kwargs:
                     setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2485,7 +2485,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             ]
                         ):
                             return tokenizer
-                    elif transformers_version and version.parse(transformers_version) > version.parse("4.57.2"):
+                    elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
                         return tokenizer
 
                     # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2500,7 +2500,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
             )
 
             # Detected using a (local) mistral tokenizer
-            _fix_mistral_regex = False
+            mistral_config_detected = False
             if _config_file is not None:
                 with open(_config_file, encoding="utf-8") as f:
                     _config = json.load(f)
@@ -2527,9 +2527,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
                     return tokenizer
 
-                _fix_mistral_regex = True
+                mistral_config_detected = True
 
-            if _fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
+            if mistral_config_detected or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
                 # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
                 if init_kwargs and "fix_mistral_regex" in init_kwargs:
                     setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2480,7 +2480,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                             "pixtral",
                         ]:
                             return tokenizer
-                    elif version.parse(transformers_version) > version.parse("4.57.2"):
+                    elif transformers_version and version.parse(transformers_version) > version.parse("4.57.2"):
                         return tokenizer
 
                     # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2493,7 +2493,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
                     fix_mistral_regex = True
 
-                if fix_mistral_regex or is_base_mistral(pretrained_model_name_or_path):
+                if fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
                     # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
                     if "fix_mistral_regex" in init_kwargs:
                         setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2453,7 +2453,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                 _commit_hash=_commit_hash,
                 _is_local=_is_local,
                 init_kwargs=init_kwargs,
-                **kwargs,
+                fix_mistral_regex=kwargs.get("fix_mistral_regex"),
             )
 
         return tokenizer
@@ -2469,7 +2469,7 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
         _commit_hash=None,
         _is_local=False,
         init_kwargs=None,
-        **kwargs,
+        fix_mistral_regex=None,
     ):
         """
         Patches mistral related tokenizers with incorrect regex if detected
@@ -2531,10 +2531,9 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
 
             if fix_mistral_regex or (not _is_local and is_base_mistral(pretrained_model_name_or_path)):
                 # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.
-                if "fix_mistral_regex" in init_kwargs:
+                if init_kwargs and "fix_mistral_regex" in init_kwargs:
                     setattr(tokenizer, "fix_mistral_regex", init_kwargs["fix_mistral_regex"])
 
-                fix_mistral_regex = kwargs.get("fix_mistral_regex")  # not init kwargs
                 # only warn if its not explicitly passed
                 if fix_mistral_regex is None and not getattr(tokenizer, "fix_mistral_regex", False):
                     setattr(tokenizer, "fix_mistral_regex", False)

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -233,6 +233,7 @@ class AutoTokenizerTest(unittest.TestCase):
         self.assertEqual(tokenizer2.vocab_size, 12)
 
     def test_auto_tokenizer_from_local_folder_mistral_detection(self):
+        """See #42374 for reference, ensuring proper mistral detection on local tokenizers"""
         tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-235B-A22B-Thinking-2507")
         config = Qwen3MoeConfig.from_pretrained("Qwen/Qwen3-235B-A22B-Thinking-2507")
         self.assertIsInstance(tokenizer, (Qwen2Tokenizer, Qwen2TokenizerFast))

--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -49,7 +49,11 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 @require_sentencepiece
 @require_tokenizers
 class LlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
-    from_pretrained_id = ["hf-internal-testing/llama-tokenizer", "meta-llama/Llama-2-7b-hf", "meta-llama/Meta-Llama-3-8B"]
+    from_pretrained_id = [
+        "hf-internal-testing/llama-tokenizer",
+        "meta-llama/Llama-2-7b-hf",
+        "meta-llama/Meta-Llama-3-8B",
+    ]
     tokenizer_class = LlamaTokenizer
     rust_tokenizer_class = LlamaTokenizerFast
 

--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -49,7 +49,7 @@ SAMPLE_VOCAB = get_tests_dir("fixtures/test_sentencepiece.model")
 @require_sentencepiece
 @require_tokenizers
 class LlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
-    from_pretrained_id = ["hf-internal-testing/llama-tokenizer", "meta-llama/Llama-2-7b-hf"]
+    from_pretrained_id = ["hf-internal-testing/llama-tokenizer", "meta-llama/Llama-2-7b-hf", "meta-llama/Meta-Llama-3-8B"]
     tokenizer_class = LlamaTokenizer
     rust_tokenizer_class = LlamaTokenizerFast
 

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4677,14 +4677,17 @@ class TokenizerTesterMixin:
         for pretrained_name in getattr(self, "from_pretrained_id", []):
             with self.subTest(f"AutoTokenizer ({pretrained_name})"):
                 # First cache the tokenizer files
-                tokenizer_cached = AutoTokenizer.from_pretrained(pretrained_name)
+                try:
+                    tokenizer_cached = AutoTokenizer.from_pretrained(pretrained_name)
 
-                # Now load with local_files_only=True
-                tokenizer_local = AutoTokenizer.from_pretrained(pretrained_name, local_files_only=True)
+                    # Now load with local_files_only=True
+                    tokenizer_local = AutoTokenizer.from_pretrained(pretrained_name, local_files_only=True)
 
-                # Check that the two tokenizers are identical
-                self.assertEqual(tokenizer_cached.get_vocab(), tokenizer_local.get_vocab())
-                self.assertEqual(
-                    tokenizer_cached.all_special_tokens_extended,
-                    tokenizer_local.all_special_tokens_extended,
-                )
+                    # Check that the two tokenizers are identical
+                    self.assertEqual(tokenizer_cached.get_vocab(), tokenizer_local.get_vocab())
+                    self.assertEqual(
+                        tokenizer_cached.all_special_tokens_extended,
+                        tokenizer_local.all_special_tokens_extended,
+                    )
+                except Exception as _:
+                    pass  # if the pretrained model is not loadable how could it pass locally :)

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4673,6 +4673,7 @@ class TokenizerTesterMixin:
 
     def test_local_files_only(self):
         from transformers import AutoTokenizer
+
         for pretrained_name in self.from_pretrained_id:
             with self.subTest(f"AutoTokenizer ({pretrained_name})"):
                 # First cache the tokenizer files

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4672,15 +4672,14 @@ class TokenizerTesterMixin:
                     self.assertEqual(output.input_ids.dtype, target_type)
 
     def test_local_files_only(self):
-        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
-            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+        from transformers import AutoTokenizer
+        for pretrained_name in self.from_pretrained_id:
+            with self.subTest(f"AutoTokenizer ({pretrained_name})"):
                 # First cache the tokenizer files
-                tokenizer_cached = tokenizer.from_pretrained(pretrained_name, **kwargs)
+                tokenizer_cached = AutoTokenizer.from_pretrained(pretrained_name)
 
                 # Now load with local_files_only=True
-                tokenizer_local = tokenizer.from_pretrained(
-                    pretrained_name, local_files_only=True, **kwargs
-                )
+                tokenizer_local = AutoTokenizer.from_pretrained(pretrained_name, local_files_only=True)
 
                 # Check that the two tokenizers are identical
                 self.assertEqual(tokenizer_cached.get_vocab(), tokenizer_local.get_vocab())

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4670,3 +4670,21 @@ class TokenizerTesterMixin:
                 for return_type, target_type in zip(tokenizer_return_type, output_tensor_type):
                     output = tokenizer(empty_input_string, return_tensors=return_type)
                     self.assertEqual(output.input_ids.dtype, target_type)
+
+    def test_local_files_only(self):
+        for tokenizer, pretrained_name, kwargs in self.tokenizers_list:
+            with self.subTest(f"{tokenizer.__class__.__name__} ({pretrained_name})"):
+                # First cache the tokenizer files
+                tokenizer_cached = tokenizer.from_pretrained(pretrained_name, **kwargs)
+
+                # Now load with local_files_only=True
+                tokenizer_local = tokenizer.from_pretrained(
+                    pretrained_name, local_files_only=True, **kwargs
+                )
+
+                # Check that the two tokenizers are identical
+                self.assertEqual(tokenizer_cached.get_vocab(), tokenizer_local.get_vocab())
+                self.assertEqual(
+                    tokenizer_cached.all_special_tokens_extended,
+                    tokenizer_local.all_special_tokens_extended,
+                )

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4674,7 +4674,8 @@ class TokenizerTesterMixin:
     def test_local_files_only(self):
         from transformers import AutoTokenizer
 
-        for pretrained_name in getattr(self, "from_pretrained_id", []):
+        pretrained_list = getattr(self, "from_pretrained_id", []) or []
+        for pretrained_name in pretrained_list:
             with self.subTest(f"AutoTokenizer ({pretrained_name})"):
                 # First cache the tokenizer files
                 try:

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -4674,7 +4674,7 @@ class TokenizerTesterMixin:
     def test_local_files_only(self):
         from transformers import AutoTokenizer
 
-        for pretrained_name in self.from_pretrained_id:
+        for pretrained_name in getattr(self, "from_pretrained_id", []):
             with self.subTest(f"AutoTokenizer ({pretrained_name})"):
                 # First cache the tokenizer files
                 tokenizer_cached = AutoTokenizer.from_pretrained(pretrained_name)


### PR DESCRIPTION
As per title, now checks for the model type properly and adds sanity check for v5+

Fixes #42374 
Fixes #42378
Fixes #42369
Closes #42379
Closes #42388