### PR TITLE
Add backward compatibility for `rope_theta` in the same way as `rope_scaling`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -424,6 +424,14 @@ class PreTrainedConfig(PushToHubMixin):
     def rope_scaling(self, value):
         self.rope_parameters = value
 
+    @property
+    def rope_theta(self):
+        return self.rope_parameters["rope_theta"]
+    
+    @rope_theta.setter
+    def rope_theta(self, value):
+        self.rope_parameters["rope_theta"] = value
+
     def save_pretrained(self, save_directory: str | os.PathLike, push_to_hub: bool = False, **kwargs):
         """
         Save a configuration object to the directory `save_directory`, so that it can be re-loaded using the


### PR DESCRIPTION
Custom models may still be using `rope_scaling` and `rope_theta`. If they are, we should also add a property for `rope_theta` for full backward compatibility.