### PR TITLE
Fix T5 tests: use generation_config for generation parameters

### DIFF
--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -117,11 +117,12 @@ class LlamaIntegrationTest(unittest.TestCase):
             ("xpu", 3): torch.tensor([[-6.5208, -4.1218, -4.9377, -3.2536,  0.8127, -2.9811,  1.2918, -3.3848]]),
             ("cuda", 7): torch.tensor([[-6.5061, -4.1147, -4.9669, -3.2038, 0.8069, -2.9694, 1.2864, -3.3786]]),
             ("cuda", 8): torch.tensor([[-6.5208, -4.1218, -4.9377, -3.2536,  0.8127, -2.9811,  1.2918, -3.3848]]),
-            ("rocm", (9, 4)): torch.tensor([[-6.5094, -4.1329, -4.9754, -3.5042,  0.8082, -2.9443,  1.2830, -3.3539]]),
+            ("rocm", (9, 4)): torch.tensor([[-6.5067, -4.1154, -4.9819, -3.1408,  0.8117, -2.9435,  1.2883, -3.3221]]),
         })
 
         expected_mean = expected_means.get_expectation().to(torch_device)
         actual_mean = out.logits.float().mean(-1)
+        print("actual_mean", actual_mean)
         self.assertTrue(
             torch.allclose(
                 expected_mean,

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -122,7 +122,6 @@ class LlamaIntegrationTest(unittest.TestCase):
 
         expected_mean = expected_means.get_expectation().to(torch_device)
         actual_mean = out.logits.float().mean(-1)
-        print("actual_mean", actual_mean)
         self.assertTrue(
             torch.allclose(
                 expected_mean,

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -935,26 +935,14 @@ class T5EncoderOnlyModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Tes
 def use_task_specific_params(model, task):
     task_params = model.config.task_specific_params[task]
 
-    # Separate generation parameters from config parameters
-    generation_params = {}
-    config_params = {}
-
     # Get all valid GenerationConfig attributes
     temp_config = GenerationConfig()
-    generation_config_attrs = set(temp_config.__dict__.keys())
+    generation_config_attrs = set(temp_config.to_dict().keys())
 
     for key, value in task_params.items():
         if key in generation_config_attrs or hasattr(temp_config, key):
-            generation_params[key] = value
-        else:
-            config_params[key] = value
-
-    if generation_params:
-        for key, value in generation_params.items():
             setattr(model.generation_config, key, value)
-
-    if config_params:
-        for key, value in config_params.items():
+        else:
             setattr(model.config, key, value)
 
 

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -1032,14 +1032,11 @@ class T5ModelIntegrationTests(unittest.TestCase):
     @slow
     def test_small_generation(self):
         model = T5ForConditionalGeneration.from_pretrained("google-t5/t5-small").to(torch_device)
-        model.config.max_length = 8
-        model.config.num_beams = 1
-        model.config.do_sample = False
         tokenizer = T5Tokenizer.from_pretrained("google-t5/t5-small")
 
         input_ids = tokenizer("summarize: Hello there", return_tensors="pt").input_ids.to(torch_device)
 
-        sequences = model.generate(input_ids)
+        sequences = model.generate(input_ids, max_length=8, num_beams=1, do_sample=False)
 
         output_str = tokenizer.batch_decode(sequences, skip_special_tokens=True)[0]
         self.assertTrue(output_str == "Hello there!")

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -940,7 +940,7 @@ def use_task_specific_params(model, task):
     generation_config_attrs = set(temp_config.to_dict().keys())
 
     for key, value in task_params.items():
-        if key in generation_config_attrs or hasattr(temp_config, key):
+        if key in generation_config_attrs:
             setattr(model.generation_config, key, value)
         else:
             setattr(model.config, key, value)

--- a/tests/models/t5/test_modeling_t5.py
+++ b/tests/models/t5/test_modeling_t5.py
@@ -934,25 +934,25 @@ class T5EncoderOnlyModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Tes
 
 def use_task_specific_params(model, task):
     task_params = model.config.task_specific_params[task]
-    
+
     # Separate generation parameters from config parameters
     generation_params = {}
     config_params = {}
-    
-    # Get all valid GenerationConfig attributes 
+
+    # Get all valid GenerationConfig attributes
     temp_config = GenerationConfig()
     generation_config_attrs = set(temp_config.__dict__.keys())
-    
+
     for key, value in task_params.items():
         if key in generation_config_attrs or hasattr(temp_config, key):
             generation_params[key] = value
         else:
             config_params[key] = value
-    
+
     if generation_params:
         for key, value in generation_params.items():
             setattr(model.generation_config, key, value)
-    
+
     if config_params:
         for key, value in config_params.items():
             setattr(model.config, key, value)


### PR DESCRIPTION
- Update T5 integration tests to use `model.generation_config` instead of  `model.config` for generation parameters. Updated `use_task_specific_params()` to properly separate generation and config parameters, and fixed affected 
tests to comply with the new generation configuration system. 

Fix : 
`test_small_generation`
`test_summarization`
`test_translation_en_to_de` 
`test_translation_en_to_fr` 
`test_translation_en_to_ro` 


- Update expectation for `meta-llama/Llama-2-7b-hf` on rocm 

Fix: 
`test_model_7b_logits_bf16`