### PR TITLE
Remove `rope_theta` attribute map for `ModernBert`

### DIFF
--- a/src/transformers/models/modernbert/configuration_modernbert.py
+++ b/src/transformers/models/modernbert/configuration_modernbert.py
@@ -130,7 +130,6 @@ class ModernBertConfig(PreTrainedConfig):
     ```"""
 
     model_type = "modernbert"
-    attribute_map = {"rope_theta": "global_rope_theta"}
     keys_to_ignore_at_inference = ["past_key_values"]
 
     def __init__(


### PR DESCRIPTION
This attribute being present via `attribute_map` causes problems for vLLM's backward compatibility.

We have the following code snippet for backward compatibility with custom models which were written for Transformers v4 

https://github.com/vllm-project/vllm/blob/d9d342d214b8c13f71215318a6d9252cc4a5ca47/vllm/transformers_utils/config.py#L466-L472

```py
        # When Transformers v5 is installed, legacy rope_theta may be present
        # when using custom code models written for Transformers v4
        if (rope_theta := getattr(config, "rope_theta", None)) is not None:
            standardize_rope_params(config, rope_theta=rope_theta)
            rope_config_validation(config)
            # Delete rope_theta to avoid confusion in downstream code
            del config.rope_theta
```

The attribute map makes `rope_theta` readable but not deletable, which causes this block to raise an error. 