### PR TITLE
add require_deterministic_for_xpu to make the case pass in xpu

### DIFF
--- a/tests/models/dac/test_modeling_dac.py
+++ b/tests/models/dac/test_modeling_dac.py
@@ -21,7 +21,13 @@ from datasets import Audio, load_dataset
 from parameterized import parameterized
 
 from transformers import AutoProcessor, DacConfig, DacModel
-from transformers.testing_utils import is_torch_available, require_torch, slow, torch_device
+from transformers.testing_utils import (
+    is_torch_available,
+    require_deterministic_for_xpu,
+    require_torch,
+    slow,
+    torch_device,
+)
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, floats_tensor
@@ -658,6 +664,7 @@ EXPECTED_CODEC_ERROR_BATCH = {
 @require_torch
 class DacIntegrationTest(unittest.TestCase):
     @parameterized.expand([(model_name,) for model_name in EXPECTED_PREPROC_SHAPE.keys()])
+    @require_deterministic_for_xpu
     def test_integration(self, model_name):
         # load model and processor
         model_id = f"descript/{model_name}"

--- a/tests/models/xcodec/test_modeling_xcodec.py
+++ b/tests/models/xcodec/test_modeling_xcodec.py
@@ -28,6 +28,7 @@ from tests.test_modeling_common import ModelTesterMixin, floats_tensor, ids_tens
 from transformers import AutoFeatureExtractor, XcodecConfig
 from transformers.testing_utils import (
     is_torch_available,
+    require_deterministic_for_xpu,
     require_torch,
     slow,
     torch_device,
@@ -303,6 +304,7 @@ EXPECTED_OUTPUTS_JSON = [
 @require_torch
 class XcodecIntegrationTest(unittest.TestCase):
     @parameterized.expand(EXPECTED_OUTPUTS_JSON)
+    @require_deterministic_for_xpu
     def test_integration(
         self, test_name, repo_id, bandwidth, exp_codes, exp_decoded, exp_codec_err, codec_tol, dec_tol
     ):


### PR DESCRIPTION
make xpu pass in  pytest -rA tests/models/dac/test_modeling_dac.py::DacIntegrationTest::test_integration_0_dac_16khz and pytest tests/models/xcodec/test_modeling_xcodec.py::XcodecIntegrationTest