### PR TITLE
[Trainer] use output.loss when using liger-kernel

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3925,7 +3925,7 @@ class Trainer:
 
     def _deepspeed_sp_compute_loss(self, model, inputs, return_outputs, pc):
         """
-        How the loss is computed by Trainer under sequence parallelism with sp_backend=="deepspeed" and sp_size>1.
+        How the loss is computed by the Trainer under sequence parallelism with sp_backend=="deepspeed" and sp_size>1.
         Performs weighted loss aggregation across SP ranks, accounting for varying numbers of valid tokens per rank
         (e.g., when some ranks receive only padding or prompt tokens that are masked with -100).
 
@@ -3945,18 +3945,14 @@ class Trainer:
 
         unwrapped_model = self.accelerator.unwrap_model(model)
 
+        # DeepSpeed SP automatically injects shift_labels into inputs (pre-shifted labels for SP).
+        # The model's forward pass receives shift_labels via **kwargs and passes it to the loss function.
+        # Both standard transformer models and Liger-patched models handle shift_labels correctly,
+        # so we can directly use the computed loss from the model output.
+        # See: https://huggingface.co/docs/accelerate/en/concept_guides/sequence_parallelism
         outputs = model(**inputs)
         shift_labels = inputs["shift_labels"]
-        # When using Liger-kernel, the model already computed the loss and outputs.logits is None
-        if outputs.loss is not None:
-            loss = outputs.loss
-        else:
-            loss = unwrapped_model.loss_function(
-                logits=outputs.logits,
-                labels=None,
-                shift_labels=shift_labels,
-                vocab_size=unwrapped_model.config.vocab_size,
-            )
+        loss = outputs.loss
 
         sp_group = self.accelerator.torch_device_mesh["sp"].get_group()
         sp_world_size = pc.sp_size

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3943,8 +3943,6 @@ class Trainer:
             The loss of the model along with its output if return_outputs was set to True
         """
 
-        unwrapped_model = self.accelerator.unwrap_model(model)
-
         # DeepSpeed SP automatically injects shift_labels into inputs (pre-shifted labels for SP).
         # The model's forward pass receives shift_labels via **kwargs and passes it to the loss function.
         # Both standard transformer models and Liger-patched models handle shift_labels correctly,

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3947,8 +3947,8 @@ class Trainer:
 
         outputs = model(**inputs)
         shift_labels = inputs["shift_labels"]
-        # When using Liger-kernel, the model already computed the loss internally and outputs.logits is None
-        if outputs.logits is None:
+        # When using Liger-kernel, the model already computed the loss and outputs.logits is None
+        if outputs.loss is not None:
             loss = outputs.loss
         else:
             loss = unwrapped_model.loss_function(

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3947,12 +3947,16 @@ class Trainer:
 
         outputs = model(**inputs)
         shift_labels = inputs["shift_labels"]
-        loss = unwrapped_model.loss_function(
-            logits=outputs.logits,
-            labels=None,
-            shift_labels=shift_labels,
-            vocab_size=unwrapped_model.config.vocab_size,
-        )
+        # When using Liger-kernel, the model already computed the loss internally and outputs.logits is None
+        if outputs.logits is None:
+            loss = outputs.loss
+        else:
+            loss = unwrapped_model.loss_function(
+                logits=outputs.logits,
+                labels=None,
+                shift_labels=shift_labels,
+                vocab_size=unwrapped_model.config.vocab_size,
+            )
 
         sp_group = self.accelerator.torch_device_mesh["sp"].get_group()
         sp_world_size = pc.sp_size


### PR DESCRIPTION
# What does this PR do?

Handle loss computation for models using Liger-kernel. 


<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #42414


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
