### PR TITLE
`transformers chat` launched without base_url has a direct tie to localhost:8000

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ pipeline("the secret to baking a really good cake is ")
 To chat with a model, the usage pattern is the same. The only difference is you need to construct a chat history (the input to `Pipeline`) between you and the system.
 
 > [!TIP]
-> You can also chat with a model directly from the command line.
+> You can also chat with a model directly from the command line, as long as [`transformers serve` is running](https://huggingface.co/docs/transformers/main/en/serving).
 > ```shell
 > transformers chat Qwen/Qwen2.5-0.5B-Instruct
 > ```

--- a/docs/source/en/conversations.md
+++ b/docs/source/en/conversations.md
@@ -26,6 +26,8 @@ This guide shows you how to quickly load chat models in Transformers from the co
 
 After you've [installed Transformers](./installation), you can chat with a model directly from the command line. The command below launches an interactive session with a model, with a few base commands listed at the start of the session.
 
+> For the following commands, please make sure [`transformers serve` is running](https://huggingface.co/docs/transformers/main/en/serving).
+
 ```bash
 transformers chat Qwen/Qwen2.5-0.5B-Instruct
 ```

--- a/docs/source/en/llm_tutorial.md
+++ b/docs/source/en/llm_tutorial.md
@@ -23,7 +23,7 @@ Text generation is the most popular application for large language models (LLMs)
 In Transformers, the [`~GenerationMixin.generate`] API handles text generation, and it is available for all models with generative capabilities. This guide will show you the basics of text generation with [`~GenerationMixin.generate`] and some common pitfalls to avoid.
 
 > [!TIP]
-> You can also chat with a model directly from the command line. ([reference](./conversations.md#transformers))
+> For the following commands, please make sure [`transformers serve` is running](https://huggingface.co/docs/transformers/main/en/serving).
 >
 > ```shell
 > transformers chat Qwen/Qwen2.5-0.5B-Instruct

--- a/docs/source/en/serving.md
+++ b/docs/source/en/serving.md
@@ -44,6 +44,12 @@ The server supports the following REST APIs:
 - `/v1/audio/transcriptions`
 - `/v1/models`
 
+Please make sure to have the correct dependencies installed for the instructions below:
+
+```shell
+pip install transformers[serving]
+```
+
 To launch a server, simply use the `transformers serve` CLI command:
 
 ```shell
@@ -53,7 +59,7 @@ transformers serve
 The simplest way to interact with the server is through our `transformers chat` CLI
 
 ```shell
-transformers chat localhost:8000 --model-name-or-path Qwen/Qwen3-4B
+transformers chat Qwen/Qwen3-4B
 ```
 
 or by sending an HTTP request, like we'll see below.

--- a/setup.py
+++ b/setup.py
@@ -276,7 +276,7 @@ extras["hub-kernels"] = deps_list("kernels")
 
 extras["integrations"] = extras["hub-kernels"] + extras["optuna"] + extras["ray"]
 
-extras["serving"] = deps_list("openai", "pydantic", "uvicorn", "fastapi", "starlette") + extras["torch"]
+extras["serving"] = deps_list("openai", "pydantic", "uvicorn", "fastapi", "starlette", "rich") + extras["torch"]
 extras["audio"] = deps_list(
     "librosa",
     "pyctcdecode",

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -306,7 +306,10 @@ class Chat:
                     f"The server running on {url} returned status code {output.status_code} on health check (/health)."
                 )
         except requests.exceptions.ConnectionError:
-            raise ValueError(f"No server currently running on {url}")
+            raise ValueError(
+                f"No server currently running on {url}. In case you're running with a remote endpoint, please make sure"
+                f"to specify a URL following the model ID specification:\n\ntransformers chat <model_id> <base_url>"
+            )
 
         return True
 

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -20,8 +20,10 @@ import string
 import time
 from collections.abc import AsyncIterator
 from typing import Annotated, Any, Optional
+from urllib.parse import urljoin, urlparse
 
 import click
+import requests
 import typer
 import yaml
 from huggingface_hub import AsyncInferenceClient, ChatCompletionStreamOutput
@@ -44,6 +46,7 @@ if is_rich_available():
     from rich.live import Live
     from rich.markdown import Markdown
 
+DEFAULT_HTTP_ENDPOINT = {"hostname": "localhost", "port": 8000}
 ALLOWED_KEY_CHARS = set(string.ascii_letters + string.whitespace)
 ALLOWED_VALUE_CHARS = set(
     string.ascii_letters + string.digits + string.whitespace + r".!\"#$%&'()*+,\-/:<=>?@[]^_`{|}~"
@@ -225,8 +228,10 @@ class Chat:
     # TODO: refactor into a proper module with helpers + 1 main method
     def __init__(
         self,
-        base_url: Annotated[str, typer.Argument(help="Base url to connect to (e.g. http://localhost:8000/v1).")],
         model_id: Annotated[str, typer.Argument(help="ID of the model to use (e.g. 'HuggingFaceTB/SmolLM3-3B').")],
+        base_url: Annotated[
+            Optional[str], typer.Argument(help="Base url to connect to (e.g. http://localhost:8000/v1).")
+        ] = f"http://{DEFAULT_HTTP_ENDPOINT['hostname']}:{DEFAULT_HTTP_ENDPOINT['port']}",
         generate_flags: Annotated[
             list[str] | None,
             typer.Argument(
@@ -257,6 +262,11 @@ class Chat:
     ) -> None:
         """Chat with a model from the command line."""
         self.base_url = base_url
+
+        parsed = urlparse(self.base_url)
+        if parsed.hostname == DEFAULT_HTTP_ENDPOINT["hostname"] and parsed.port == DEFAULT_HTTP_ENDPOINT["port"]:
+            self.check_health(self.base_url)
+
         self.model_id = model_id
         self.system_prompt = system_prompt
         self.save_folder = save_folder
@@ -286,8 +296,20 @@ class Chat:
         # Run chat session
         asyncio.run(self._inner_run())
 
-    # -----------------------------------------------------------------------------------------------------------------
-    # User commands
+    @staticmethod
+    def check_health(url):
+        health_url = urljoin(url + "/", "health")
+        try:
+            output = requests.get(health_url)
+            if output.status_code != 200:
+                raise ValueError(
+                    f"The server running on {url} returned status code {output.status_code} on health check (/health)."
+                )
+        except requests.exceptions.ConnectionError:
+            raise ValueError(f"No server currently running on {url}")
+
+        return True
+
     def handle_non_exit_user_commands(
         self,
         user_input: str,
@@ -361,9 +383,6 @@ class Chat:
             interface.print_help()
 
         return chat, valid_command, config
-
-    # -----------------------------------------------------------------------------------------------------------------
-    # Main logic
 
     async def _inner_run(self):
         interface = RichInterface(model_id=self.model_id, user_id=self.user)

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -22,7 +22,7 @@ from collections.abc import AsyncIterator
 from typing import Annotated, Any, Optional
 from urllib.parse import urljoin, urlparse
 
-import requests
+import httpx
 import typer
 import yaml
 from huggingface_hub import AsyncInferenceClient, ChatCompletionStreamOutput
@@ -276,12 +276,12 @@ class Chat:
     def check_health(url):
         health_url = urljoin(url + "/", "health")
         try:
-            output = requests.get(health_url)
+            output = httpx.get(health_url)
             if output.status_code != 200:
                 raise ValueError(
                     f"The server running on {url} returned status code {output.status_code} on health check (/health)."
                 )
-        except requests.exceptions.ConnectionError:
+        except httpx.ConnectError:
             raise ValueError(
                 f"No server currently running on {url}. To run a local server, please run `transformers serve` in a"
                 f"separate shell. Find more information here: https://huggingface.co/docs/transformers/serving"

--- a/src/transformers/cli/chat.py
+++ b/src/transformers/cli/chat.py
@@ -22,7 +22,6 @@ from collections.abc import AsyncIterator
 from typing import Annotated, Any, Optional
 from urllib.parse import urljoin, urlparse
 
-import click
 import requests
 import typer
 import yaml
@@ -198,29 +197,6 @@ class RichInterface:
         self._console.print()
 
 
-class ChatCommand(typer.core.TyperCommand):
-    """Custom Click command to override missing parameter error message.
-
-    Transformers v5 introduced a breaking change in the `transformers chat` command: the `model_id` parameter
-    is now required, and the command can no longer starts a server. This class overrides the default error message
-    to provide a more helpful message to users who may be used to the old behavior.
-    """
-
-    def parse_args(self, ctx, args):
-        try:
-            return super().parse_args(ctx, args)
-        except click.MissingParameter as e:
-            if e.param and e.param.name == "model_id":
-                typer.echo("Error: Missing argument 'MODEL_ID'.\n")
-                typer.echo(
-                    "Launching a server directly from the `transformers chat` command is no longer supported. "
-                    "Please use `transformers serve` to launch a server. "
-                    "Use --help for more information.",
-                )
-                ctx.exit(1)
-            raise
-
-
 class Chat:
     """Chat with a model from the command line."""
 
@@ -307,8 +283,8 @@ class Chat:
                 )
         except requests.exceptions.ConnectionError:
             raise ValueError(
-                f"No server currently running on {url}. In case you're running with a remote endpoint, please make sure"
-                f"to specify a URL following the model ID specification:\n\ntransformers chat <model_id> <base_url>"
+                f"No server currently running on {url}. To run a local server, please run `transformers serve` in a"
+                f"separate shell. Find more information here: https://huggingface.co/docs/transformers/serving"
             )
 
         return True

--- a/src/transformers/cli/transformers.py
+++ b/src/transformers/cli/transformers.py
@@ -17,7 +17,7 @@ from huggingface_hub import typer_factory
 
 from transformers.cli.add_fast_image_processor import add_fast_image_processor
 from transformers.cli.add_new_model_like import add_new_model_like
-from transformers.cli.chat import Chat, ChatCommand
+from transformers.cli.chat import Chat
 from transformers.cli.download import download
 from transformers.cli.serve import Serve
 from transformers.cli.system import env, version
@@ -27,7 +27,7 @@ app = typer_factory(help="Transformers CLI")
 
 app.command()(add_fast_image_processor)
 app.command()(add_new_model_like)
-app.command(name="chat", cls=ChatCommand)(Chat)
+app.command(name="chat")(Chat)
 app.command()(download)
 app.command()(env)
 app.command(name="serve")(Serve)


### PR DESCRIPTION
To significantly simplify the `transformers chat` launch, specifying a base URL is no-longer necessary as it will default to `http://localhost:8000`.

It will perform a health-check to ensure the server is running, and error out otherwise.