### PR TITLE
Fixes StaticCache Crashes 

### DIFF
--- a/docs/source/en/model_doc/afmoe.md
+++ b/docs/source/en/model_doc/afmoe.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on {release_date} and added to Hugging Face Transformers on 2025-11-18.*
+*This model was released on {release_date} and added to Hugging Face Transformers on 2025-11-29.*
 
 <div style="float: right;">
     <div class="flex flex-wrap space-x-1">

--- a/docs/source/en/model_doc/fast_vlm.md
+++ b/docs/source/en/model_doc/fast_vlm.md
@@ -14,7 +14,7 @@ rendered properly in your Markdown viewer.
 
 -->
 
-*This model was released on 2025-05-06 and added to Hugging Face Transformers on 2025-10-07.*
+*This model was released on 2025-05-06 and added to Hugging Face Transformers on 2025-12-02.*
 
 # FastVLM
 

--- a/docs/source/en/model_doc/glm46v.md
+++ b/docs/source/en/model_doc/glm46v.md
@@ -1,3 +1,20 @@
+<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+*This model was released on {release_date} and added to Hugging Face Transformers on 2025-11-15.*
+
 # GLM-4.6V
 
 ## Glm46VConfig

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -353,8 +353,9 @@ class StaticLayer(CacheLayerMixin):
         )
 
         batch_size = key_states.shape[0]
+        self.keys = self.keys_map[batch_size]
+        self.values = self.values_map[batch_size]
 
-        
         self._current_batch_size = batch_size
 
         try:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -318,6 +318,11 @@ class StaticLayer(CacheLayerMixin):
                 torch._dynamo.mark_static_address(self.keys_map[batch_size])
                 torch._dynamo.mark_static_address(self.values_map[batch_size])
         self.is_initialized = True
+        batch_size = key_states.shape[0]
+
+        # Slice to current batch size
+        self.keys = self.keys_map[batch_size]
+        self.values = self.values_map[batch_size]
 
     def update(
         self,
@@ -349,9 +354,7 @@ class StaticLayer(CacheLayerMixin):
 
         batch_size = key_states.shape[0]
 
-        # Slice to current batch size
-        self.keys = self.keys_map[batch_size]
-        self.values = self.values_map[batch_size]
+        
         self._current_batch_size = batch_size
 
         try:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -251,16 +251,7 @@ class DynamicSlidingWindowLayer(DynamicLayer):
 
 
 class StaticLayer(CacheLayerMixin):
-    """
-    A static cache layer that stores the key and value states as static tensors of shape `[batch_size, num_heads, max_cache_len), head_dim]`.
-    It lazily allocates its full backing tensors, and then mutates them in-place. Built for `torch.compile` support.
-
-    Args:
-        max_cache_len (`int`):
-            Maximum number of tokens that can be stored, used for tensor preallocation.
-        max_batch_size(`int`, *optional*):
-            Maximum batch size that can be stored
-    """
+    """Fixed StaticLayer that handles variable batch sizes."""
 
     is_compileable = True
     is_sliding = False
@@ -269,44 +260,28 @@ class StaticLayer(CacheLayerMixin):
         super().__init__()
         self.max_cache_len = max_cache_len
         self.max_batch_size = max_batch_size
+        self._current_batch_size = None  # Track current batch size
 
     def lazy_initialization(self, key_states: torch.Tensor):
-        """
-        Lazy initialization of the keys and values tensors. This allows to get all properties (dtype, device,
-        num_heads in case of TP etc...) at runtime directly, which is extremely practical as it avoids moving
-        devices, dtypes etc later on for each `update` (which could break the static dynamo addresses as well).
-
-        If this is unwanted, one can call `early_initialization(...)` on the Cache directly, which will call this
-        function ahead-of-time (this is required for `torch.export` for example). Note that for `compile`, as we
-        internally don't compile the prefill, this is guaranteed to have been called already when compiling.
-        If compiling the prefill as well, e.g. calling `model.compile(...)` before `generate` with a static cache,
-        it is still supported in general, but without guarantees depending on the compilation options (e.g. cuda graphs,
-        i.e. `mode="reduce-overhead"` is known to fail). But it will in general work correctly, and prefill should
-        not be compiled anyway for performances!
-        """
         if self.max_batch_size is None:
             self.max_batch_size = key_states.shape[0]
         _, self.num_heads, _, self.head_dim = key_states.shape
         self.dtype, self.device = key_states.dtype, key_states.device
 
-        self.keys = torch.zeros(
+        self.keys_full = torch.zeros(
             (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
             dtype=self.dtype,
             device=self.device,
         )
-        self.values = torch.zeros(
+        self.values_full = torch.zeros(
             (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
             dtype=self.dtype,
             device=self.device,
         )
 
-        # Note: `mark_static_address` is used to tag the cache as a fixed data pointer, preventing compiled graph
-        # breaks when updating the cache. However, it is not supported when tracing the graph, so we skip it in this case.
-        # As prefill should never be compiled, this is not an issue and it will still be run (except when users compile
-        # prefill explicitly, but this should be avoided!)
         if not is_torchdynamo_compiling():
-            torch._dynamo.mark_static_address(self.keys)
-            torch._dynamo.mark_static_address(self.values)
+            torch._dynamo.mark_static_address(self.keys_full)
+            torch._dynamo.mark_static_address(self.values_full)
 
         self.is_initialized = True
 
@@ -316,58 +291,74 @@ class StaticLayer(CacheLayerMixin):
         value_states: torch.Tensor,
         cache_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """
-        Update the key and value caches in-place, and return the necessary keys and value states.
-
-        Args:
-            key_states (`torch.Tensor`): The new key states to cache.
-            value_states (`torch.Tensor`): The new value states to cache.
-            cache_kwargs (`dict[str, Any]`, *optional*): Additional arguments for the cache.
-
-        Returns:
-            tuple[`torch.Tensor`, `torch.Tensor`]: The key and value states.
-        """
-        # Lazy initialization
         if not self.is_initialized:
             self.lazy_initialization(key_states)
 
-        # Some old models give None for `cache_position` or even omit passing `cache_kwargs` when used as cross-attention,
-        # in which case we should copy the whole Layer (key_states.shape[-2] == self.max_cache_len)
         cache_position = cache_kwargs.get("cache_position") if cache_kwargs is not None else None
         cache_position = (
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
+
         batch_size = key_states.shape[0]
-        k_out = self.keys[:batch_size]
-        v_out = self.values[:batch_size]
-        try:
-            k_out.index_copy_(2, cache_position, key_states)
-            v_out.index_copy_(2, cache_position, value_states)
-        except NotImplementedError:
-            k_out[:, :, cache_position] = key_states
-            v_out[:, :, cache_position] = value_states
-        return k_out, v_out
+        self._current_batch_size = batch_size
+
+        # Slice to current batch size
+        self.keys = self.keys_full[:batch_size]
+        self.values = self.values_full[:batch_size]
+
+        # Use slice assignment instead of index_copy_ for better compatibility
+        # with variable batch sizes
+        if cache_position.numel() == self.max_cache_len:
+            # Full cache update (e.g., cross-attention initialization)
+            self.keys.copy_(key_states)
+            self.values.copy_(value_states)
+        else:
+            # Incremental update
+            try:
+                # Try index_copy_ first (faster when it works)
+                self.keys.index_copy_(2, cache_position, key_states)
+                self.values.index_copy_(2, cache_position, value_states)
+            except (NotImplementedError, RuntimeError):
+                # Fallback to direct indexing
+                self.keys[:, :, cache_position] = key_states
+                self.values[:, :, cache_position] = value_states
+
+        return self.keys, self.values
 
     def reset(self):
         if self.is_initialized:
-            self.keys.zero_()
-            self.values.zero_()
+            self.keys_full.zero_()
+            self.values_full.zero_()
+            self._current_batch_size = None
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
-        """Return the length and offset of the cache, used to generate the attention mask"""
         kv_offset = 0
         kv_length = self.max_cache_len
         return kv_length, kv_offset
 
     def get_seq_length(self) -> int:
-        """Returns the sequence length of the cached states."""
-        # Occupied cache == any slot in the 3rd dim (sequence length) holds a non-zero value. To save on compute, let's
-        # limit the check to the first batch member and head dimension.
         return (self.keys[0, 0].any(dim=-1)).sum() if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:
-        """Return the maximum cache shape of the cache"""
         return self.max_cache_len
+
+    def reorder_cache(self, beam_idx: torch.LongTensor):
+        if not self.is_initialized:
+            return
+
+        if beam_idx.device != self.device:
+            beam_idx = beam_idx.to(self.device)
+
+        # We must reorder the BACKING STORAGE (keys_full)
+        current_batch_size = beam_idx.shape[0]
+
+        # Select the beams from backing storage
+        new_keys = self.keys_full[:current_batch_size].index_select(0, beam_idx)
+        new_values = self.values_full[:current_batch_size].index_select(0, beam_idx)
+
+        # Write back to storage
+        self.keys_full[:current_batch_size].copy_(new_keys)
+        self.values_full[:current_batch_size].copy_(new_values)
 
 
 class StaticSlidingWindowLayer(StaticLayer):
@@ -421,8 +412,8 @@ class StaticSlidingWindowLayer(StaticLayer):
         )
 
         batch_size = key_states.shape[0]
-        k_out = self.keys[:batch_size]
-        v_out = self.values[:batch_size]
+        self.keys = self.keys_full[:batch_size]
+        self.values = self.values_full[:batch_size]
 
         cumulative_length = self.cumulative_length
         is_full = cumulative_length >= self.max_cache_len
@@ -434,8 +425,8 @@ class StaticSlidingWindowLayer(StaticLayer):
             # dynamo is currently bugged when doing it - see https://github.com/pytorch/pytorch/issues/159855 for more details
             if key_states.shape[-2] == 1:
                 # Roll all values to the left by 1 position
-                new_keys = k_out.roll(-1, dims=-2)
-                new_values = v_out.roll(-1, dims=-2)
+                new_keys = self.keys.roll(-1, dims=-2)
+                new_values = self.values.roll(-1, dims=-2)
                 # Overwrite the last position with new states
                 # (note: very important to use a tensor to index here, see https://github.com/pytorch/pytorch/issues/159855)
                 index = torch.tensor([-1], dtype=int, device=self.device)
@@ -446,11 +437,11 @@ class StaticSlidingWindowLayer(StaticLayer):
                 self.keys[:batch_size].copy_(new_keys)
                 self.values[:batch_size].copy_(new_values)
                 # Return the batch-sliced view
-                return k_out, v_out
+                return self.keys, self.values
             # Already full but using more than 1 new token (e.g. prefill caching, chat continuation, etc...)
             else:
-                full_key_states = torch.cat((k_out[:, :, 1:, :], key_states), dim=-2)
-                full_value_states = torch.cat((v_out[:, :, 1:, :], value_states), dim=-2)
+                full_key_states = torch.cat((self.keys[:, :, 1:, :], key_states), dim=-2)
+                full_value_states = torch.cat((self.values[:, :, 1:, :], value_states), dim=-2)
         # Not yet full, but becoming full on this update
         elif cumulative_length + key_states.shape[2] > self.max_cache_len:
             # Fast prefill path, no need to cat() in this case, as the cache is currently empty
@@ -458,18 +449,18 @@ class StaticSlidingWindowLayer(StaticLayer):
                 full_key_states = key_states
                 full_value_states = value_states
             else:
-                full_key_states = torch.cat((k_out[:, :, :cumulative_length, :], key_states), dim=-2)
-                full_value_states = torch.cat((v_out[:, :, :cumulative_length, :], value_states), dim=-2)
+                full_key_states = torch.cat((self.keys[:, :, :cumulative_length, :], key_states), dim=-2)
+                full_value_states = torch.cat((self.values[:, :, :cumulative_length, :], value_states), dim=-2)
         else:
             try:
-                k_out.index_copy_(2, cache_position, key_states)
-                v_out.index_copy_(2, cache_position, value_states)
+                self.keys.index_copy_(2, cache_position, key_states)
+                self.values.index_copy_(2, cache_position, value_states)
             except NotImplementedError:
-                k_out[:, :, cache_position] = key_states
-                v_out[:, :, cache_position] = value_states
+                self.keys[:, :, cache_position] = key_states
+                self.values[:, :, cache_position] = value_states
 
             # Return the batch-sliced view
-            return k_out, v_out
+            return self.keys, self.values
 
         # We only cache the last `sliding_window` tokens
         self.keys[:batch_size].copy_(full_key_states[:, :, -self.max_cache_len :, :])

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -258,7 +258,6 @@ class StaticLayer(CacheLayerMixin):
     Args:
         max_cache_len (`int`):
             Maximum number of tokens that can be stored, used for tensor preallocation.
-    Args:
         max_batch_size(`int`, *optional*):
             Maximum batch size that can be stored
     """
@@ -270,6 +269,24 @@ class StaticLayer(CacheLayerMixin):
         super().__init__()
         self.max_cache_len = max_cache_len
         self.max_batch_size = max_batch_size
+
+    def init_full_cache(self, key_states: torch.Tensor):
+        """Init the full batch with max_batch_size ahead of time."""
+        if self.max_batch_size is None:
+            self.max_batch_size = key_states.shape[0]
+        _, self.num_heads, _, self.head_dim = key_states.shape
+        self.dtype, self.device = key_states.dtype, key_states.device
+
+        self.keys_full = torch.zeros(
+            (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
+            dtype=self.dtype,
+            device=self.device,
+        )
+        self.values_full = torch.zeros(
+            (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
+            dtype=self.dtype,
+            device=self.device,
+        )
 
     def lazy_initialization(self, key_states: torch.Tensor):
         """
@@ -286,31 +303,20 @@ class StaticLayer(CacheLayerMixin):
         not be compiled anyway for performances!
         """
 
-        if self.max_batch_size is None:
-            self.max_batch_size = key_states.shape[0]
-        _, self.num_heads, _, self.head_dim = key_states.shape
-        self.dtype, self.device = key_states.dtype, key_states.device
+        self.init_full_cache(key_states)
 
-        self.keys_full = torch.zeros(
-            (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
-            dtype=self.dtype,
-            device=self.device,
-        )
-        self.values_full = torch.zeros(
-            (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
-            dtype=self.dtype,
-            device=self.device,
-        )
-        self.keys = self.keys_full
-        self.values = self.values_full
-        # Note: `mark_static_address` is used to tag the cache as a fixed data pointer, preventing compiled graph
-        # breaks when updating the cache. However, it is not supported when tracing the graph, so we skip it in this case.
-        # As prefill should never be compiled, this is not an issue and it will still be run (except when users compile
-        # prefill explicitly, but this should be avoided!)
-        if not is_torchdynamo_compiling():
-            torch._dynamo.mark_static_address(self.keys_full)
-            torch._dynamo.mark_static_address(self.values_full)
-
+        self.keys_map = [None] * (self.max_batch_size + 1)
+        self.values_map = [None] * (self.max_batch_size + 1)
+        for batch_size in range(1, self.max_batch_size + 1):
+            self.keys_map[batch_size] = self.keys_full[:batch_size]
+            self.values_map[batch_size] = self.values_full[:batch_size]
+            # Note: `mark_static_address` is used to tag the cache as a fixed data pointer, preventing compiled graph
+            # breaks when updating the cache. However, it is not supported when tracing the graph, so we skip it in this case.
+            # As prefill should never be compiled, this is not an issue and it will still be run (except when users compile
+            # prefill explicitly, but this should be avoided!)
+            if not is_torchdynamo_compiling():
+                torch._dynamo.mark_static_address(self.keys_map[batch_size])
+                torch._dynamo.mark_static_address(self.values_map[batch_size])
         self.is_initialized = True
 
     def update(
@@ -344,24 +350,18 @@ class StaticLayer(CacheLayerMixin):
         batch_size = key_states.shape[0]
 
         # Slice to current batch size
-        self.keys = self.keys_full[:batch_size]
-        self.values = self.values_full[:batch_size]
+        self.keys = self.keys_map[batch_size]
+        self.values = self.values_map[batch_size]
+        self._current_batch_size = batch_size
 
-        # Use slice assignment instead of index_copy_ for better compatibility
-        # with variable batch sizes
-        if cache_position.numel() == self.max_cache_len:
-            # Full cache update (e.g., cross-attention initialization)
-            self.keys.copy_(key_states)
-            self.values.copy_(value_states)
-        else:
-            try:
-                # Try index_copy_ first (faster when it works)
-                self.keys.index_copy_(2, cache_position, key_states)
-                self.values.index_copy_(2, cache_position, value_states)
-            except (NotImplementedError, RuntimeError):
-                # Fallback for devices like MPS where index_copy_ might not be supported.
-                self.keys[:, :, cache_position] = key_states
-                self.values[:, :, cache_position] = value_states
+        try:
+            # Try index_copy_ first (faster when it works)
+            self.keys.index_copy_(2, cache_position, key_states)
+            self.values.index_copy_(2, cache_position, value_states)
+        except (NotImplementedError, RuntimeError):
+            # Fallback for devices like MPS where index_copy_ might not be supported.
+            self.keys[:, :, cache_position] = key_states
+            self.values[:, :, cache_position] = value_states
 
         return self.keys, self.values
 
@@ -369,6 +369,7 @@ class StaticLayer(CacheLayerMixin):
         if self.is_initialized:
             self.keys_full.zero_()
             self.values_full.zero_()
+            self._current_batch_size = None
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
         """Return the length and offset of the cache, used to generate the attention mask"""
@@ -385,19 +386,20 @@ class StaticLayer(CacheLayerMixin):
         return self.max_cache_len
 
     def reorder_cache(self, beam_idx: torch.LongTensor):
-        if not self.is_initialized:
-            return
-
+        """Reorders this layer's cache for beam search."""
         if beam_idx.device != self.device:
             beam_idx = beam_idx.to(self.device)
 
         current_batch_size = beam_idx.shape[0]
+        # Use the map to get the view for the current batch size
+        current_keys = self.keys_map[current_batch_size]
+        current_values = self.values_map[current_batch_size]
 
-        new_keys = self.keys_full[:current_batch_size].index_select(0, beam_idx)
-        new_values = self.values_full[:current_batch_size].index_select(0, beam_idx)
+        new_keys = current_keys.index_select(0, beam_idx)
+        new_values = current_values.index_select(0, beam_idx)
 
-        self.keys_full[:current_batch_size].copy_(new_keys)
-        self.values_full[:current_batch_size].copy_(new_values)
+        current_keys.copy_(new_keys)
+        current_values.copy_(new_values)
 
 
 class StaticSlidingWindowLayer(StaticLayer):
@@ -451,8 +453,8 @@ class StaticSlidingWindowLayer(StaticLayer):
         )
 
         batch_size = key_states.shape[0]
-        self.keys = self.keys_full[:batch_size]
-        self.values = self.values_full[:batch_size]
+        self.keys = self.keys_map[batch_size]
+        self.values = self.values_map[batch_size]
 
         cumulative_length = self.cumulative_length
         is_full = cumulative_length >= self.max_cache_len

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -278,6 +278,8 @@ class StaticLayer(CacheLayerMixin):
             dtype=self.dtype,
             device=self.device,
         )
+        self.keys = self.keys_full
+        self.values = self.values_full
 
         if not is_torchdynamo_compiling():
             torch._dynamo.mark_static_address(self.keys_full)
@@ -349,7 +351,7 @@ class StaticLayer(CacheLayerMixin):
         if beam_idx.device != self.device:
             beam_idx = beam_idx.to(self.device)
 
-        # We must reorder the BACKING STORAGE (keys_full)
+        # We must reorder the BACKING STORAGE (keys_)
         current_batch_size = beam_idx.shape[0]
 
         # Select the beams from backing storage

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -251,7 +251,17 @@ class DynamicSlidingWindowLayer(DynamicLayer):
 
 
 class StaticLayer(CacheLayerMixin):
-    """Fixed StaticLayer that handles variable batch sizes."""
+    """
+    A static cache layer that stores the key and value states as static tensors of shape `[batch_size, num_heads, max_cache_len), head_dim]`.
+    It lazily allocates its full backing tensors, and then mutates them in-place. Built for `torch.compile` support.
+
+    Args:
+        max_cache_len (`int`):
+            Maximum number of tokens that can be stored, used for tensor preallocation.
+    Args:
+        max_batch_size(`int`, *optional*):
+            Maximum batch size that can be stored
+    """
 
     is_compileable = True
     is_sliding = False
@@ -260,9 +270,22 @@ class StaticLayer(CacheLayerMixin):
         super().__init__()
         self.max_cache_len = max_cache_len
         self.max_batch_size = max_batch_size
-        self._current_batch_size = None  # Track current batch size
 
     def lazy_initialization(self, key_states: torch.Tensor):
+        """
+        Lazy initialization of the keys and values tensors. This allows to get all properties (dtype, device,
+        num_heads in case of TP etc...) at runtime directly, which is extremely practical as it avoids moving
+        devices, dtypes etc later on for each `update` (which could break the static dynamo addresses as well).
+
+        If this is unwanted, one can call `early_initialization(...)` on the Cache directly, which will call this
+        function ahead-of-time (this is required for `torch.export` for example). Note that for `compile`, as we
+        internally don't compile the prefill, this is guaranteed to have been called already when compiling.
+        If compiling the prefill as well, e.g. calling `model.compile(...)` before `generate` with a static cache,
+        it is still supported in general, but without guarantees depending on the compilation options (e.g. cuda graphs,
+        i.e. `mode="reduce-overhead"` is known to fail). But it will in general work correctly, and prefill should
+        not be compiled anyway for performances!
+        """
+
         if self.max_batch_size is None:
             self.max_batch_size = key_states.shape[0]
         _, self.num_heads, _, self.head_dim = key_states.shape
@@ -280,7 +303,10 @@ class StaticLayer(CacheLayerMixin):
         )
         self.keys = self.keys_full
         self.values = self.values_full
-
+        # Note: `mark_static_address` is used to tag the cache as a fixed data pointer, preventing compiled graph
+        # breaks when updating the cache. However, it is not supported when tracing the graph, so we skip it in this case.
+        # As prefill should never be compiled, this is not an issue and it will still be run (except when users compile
+        # prefill explicitly, but this should be avoided!)
         if not is_torchdynamo_compiling():
             torch._dynamo.mark_static_address(self.keys_full)
             torch._dynamo.mark_static_address(self.values_full)
@@ -293,16 +319,29 @@ class StaticLayer(CacheLayerMixin):
         value_states: torch.Tensor,
         cache_kwargs: Optional[dict[str, Any]] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Update the key and value caches in-place, and return the necessary keys and value states.
+
+        Args:
+            key_states (`torch.Tensor`): The new key states to cache.
+            value_states (`torch.Tensor`): The new value states to cache.
+            cache_kwargs (`dict[str, Any]`, *optional*): Additional arguments for the cache.
+
+        Returns:
+            tuple[`torch.Tensor`, `torch.Tensor`]: The key and value states.
+        """
+        # Lazy initialization
         if not self.is_initialized:
             self.lazy_initialization(key_states)
 
+        # Some old models give None for `cache_position` or even omit passing `cache_kwargs` when used as cross-attention,
+        # in which case we should copy the whole Layer (key_states.shape[-2] == self.max_cache_len)
         cache_position = cache_kwargs.get("cache_position") if cache_kwargs is not None else None
         cache_position = (
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
 
         batch_size = key_states.shape[0]
-        self._current_batch_size = batch_size
 
         # Slice to current batch size
         self.keys = self.keys_full[:batch_size]
@@ -315,13 +354,12 @@ class StaticLayer(CacheLayerMixin):
             self.keys.copy_(key_states)
             self.values.copy_(value_states)
         else:
-            # Incremental update
             try:
                 # Try index_copy_ first (faster when it works)
                 self.keys.index_copy_(2, cache_position, key_states)
                 self.values.index_copy_(2, cache_position, value_states)
             except (NotImplementedError, RuntimeError):
-                # Fallback to direct indexing
+                # Fallback for devices like MPS where index_copy_ might not be supported.
                 self.keys[:, :, cache_position] = key_states
                 self.values[:, :, cache_position] = value_states
 
@@ -331,17 +369,19 @@ class StaticLayer(CacheLayerMixin):
         if self.is_initialized:
             self.keys_full.zero_()
             self.values_full.zero_()
-            self._current_batch_size = None
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
+        """Return the length and offset of the cache, used to generate the attention mask"""
         kv_offset = 0
         kv_length = self.max_cache_len
         return kv_length, kv_offset
 
     def get_seq_length(self) -> int:
+        """Returns the sequence length of the cached states."""
         return (self.keys[0, 0].any(dim=-1)).sum() if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:
+        """Return the maximum cache shape of the cache"""
         return self.max_cache_len
 
     def reorder_cache(self, beam_idx: torch.LongTensor):
@@ -351,14 +391,11 @@ class StaticLayer(CacheLayerMixin):
         if beam_idx.device != self.device:
             beam_idx = beam_idx.to(self.device)
 
-        # We must reorder the BACKING STORAGE (keys_)
         current_batch_size = beam_idx.shape[0]
 
-        # Select the beams from backing storage
         new_keys = self.keys_full[:current_batch_size].index_select(0, beam_idx)
         new_values = self.values_full[:current_batch_size].index_select(0, beam_idx)
 
-        # Write back to storage
         self.keys_full[:current_batch_size].copy_(new_keys)
         self.values_full[:current_batch_size].copy_(new_values)
 

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -289,25 +289,24 @@ class StaticLayer(CacheLayerMixin):
         _, self.num_heads, _, self.head_dim = key_states.shape
         self.dtype, self.device = key_states.dtype, key_states.device
 
-        self.keys_ = torch.zeros(
+        self.keys = torch.zeros(
             (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
             dtype=self.dtype,
             device=self.device,
         )
-        self.values_ = torch.zeros(
+        self.values = torch.zeros(
             (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
             dtype=self.dtype,
             device=self.device,
         )
-        self.keys = self.keys_
-        self.values = self.values_
+
         # Note: `mark_static_address` is used to tag the cache as a fixed data pointer, preventing compiled graph
         # breaks when updating the cache. However, it is not supported when tracing the graph, so we skip it in this case.
         # As prefill should never be compiled, this is not an issue and it will still be run (except when users compile
         # prefill explicitly, but this should be avoided!)
         if not is_torchdynamo_compiling():
-            torch._dynamo.mark_static_address(self.keys_)
-            torch._dynamo.mark_static_address(self.values_)
+            torch._dynamo.mark_static_address(self.keys)
+            torch._dynamo.mark_static_address(self.values)
 
         self.is_initialized = True
 
@@ -339,23 +338,20 @@ class StaticLayer(CacheLayerMixin):
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
         batch_size = key_states.shape[0]
-        self.keys = self.keys_[:batch_size]
-        self.values = self.values_[:batch_size]
+        k_out = self.keys[:batch_size]
+        v_out = self.values[:batch_size]
         try:
-            self.keys.index_copy_(2, cache_position, key_states)
-            self.values.index_copy_(2, cache_position, value_states)
+            k_out.index_copy_(2, cache_position, key_states)
+            v_out.index_copy_(2, cache_position, value_states)
         except NotImplementedError:
-            self.keys[:, :, cache_position] = key_states
-            self.values[:, :, cache_position] = value_states
-
-        return self.keys, self.values
+            k_out[:, :, cache_position] = key_states
+            v_out[:, :, cache_position] = value_states
+        return k_out, v_out
 
     def reset(self):
         if self.is_initialized:
-            self.keys_.zero_()
-            self.values_.zero_()
-            self.keys = self.keys_
-            self.values = self.values_
+            self.keys.zero_()
+            self.values.zero_()
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
         """Return the length and offset of the cache, used to generate the attention mask"""
@@ -425,8 +421,8 @@ class StaticSlidingWindowLayer(StaticLayer):
         )
 
         batch_size = key_states.shape[0]
-        self.keys = self.keys_[:batch_size]
-        self.values = self.values_[:batch_size]
+        k_out = self.keys[:batch_size]
+        v_out = self.values[:batch_size]
 
         cumulative_length = self.cumulative_length
         is_full = cumulative_length >= self.max_cache_len
@@ -438,23 +434,23 @@ class StaticSlidingWindowLayer(StaticLayer):
             # dynamo is currently bugged when doing it - see https://github.com/pytorch/pytorch/issues/159855 for more details
             if key_states.shape[-2] == 1:
                 # Roll all values to the left by 1 position
-                new_keys = self.keys.roll(-1, dims=-2)
-                new_values = self.values.roll(-1, dims=-2)
+                new_keys = k_out.roll(-1, dims=-2)
+                new_values = v_out.roll(-1, dims=-2)
                 # Overwrite the last position with new states
                 # (note: very important to use a tensor to index here, see https://github.com/pytorch/pytorch/issues/159855)
                 index = torch.tensor([-1], dtype=int, device=self.device)
                 new_keys[:, :, index] = key_states
                 new_values[:, :, index] = value_states
 
-                # Copy back into `self` (do not just assign again) in order to keep the static dynamo address
-                self.keys.copy_(new_keys)
-                self.values.copy_(new_values)
-                # Very important to return the `self` tensors here, as they have the static dynamo address
-                return self.keys, self.values
+                # Copy back into the batch-sliced portion (NOT the full cache)
+                self.keys[:batch_size].copy_(new_keys)
+                self.values[:batch_size].copy_(new_values)
+                # Return the batch-sliced view
+                return k_out, v_out
             # Already full but using more than 1 new token (e.g. prefill caching, chat continuation, etc...)
             else:
-                full_key_states = torch.cat((self.keys[:, :, 1:, :], key_states), dim=-2)
-                full_value_states = torch.cat((self.values[:, :, 1:, :], value_states), dim=-2)
+                full_key_states = torch.cat((k_out[:, :, 1:, :], key_states), dim=-2)
+                full_value_states = torch.cat((v_out[:, :, 1:, :], value_states), dim=-2)
         # Not yet full, but becoming full on this update
         elif cumulative_length + key_states.shape[2] > self.max_cache_len:
             # Fast prefill path, no need to cat() in this case, as the cache is currently empty
@@ -462,23 +458,23 @@ class StaticSlidingWindowLayer(StaticLayer):
                 full_key_states = key_states
                 full_value_states = value_states
             else:
-                full_key_states = torch.cat((self.keys[:, :, :cumulative_length, :], key_states), dim=-2)
-                full_value_states = torch.cat((self.values[:, :, :cumulative_length, :], value_states), dim=-2)
+                full_key_states = torch.cat((k_out[:, :, :cumulative_length, :], key_states), dim=-2)
+                full_value_states = torch.cat((v_out[:, :, :cumulative_length, :], value_states), dim=-2)
         else:
             try:
-                self.keys.index_copy_(2, cache_position, key_states)
-                self.values.index_copy_(2, cache_position, value_states)
+                k_out.index_copy_(2, cache_position, key_states)
+                v_out.index_copy_(2, cache_position, value_states)
             except NotImplementedError:
-                self.keys[:, :, cache_position] = key_states
-                self.values[:, :, cache_position] = value_states
+                k_out[:, :, cache_position] = key_states
+                v_out[:, :, cache_position] = value_states
 
-            # Very important to return the `self` tensors here, as they have the static dynamo address
-            return self.keys, self.values
+            # Return the batch-sliced view
+            return k_out, v_out
 
         # We only cache the last `sliding_window` tokens
-        self.keys.copy_(full_key_states[:, :, -self.max_cache_len :, :])
-        self.values.copy_(full_value_states[:, :, -self.max_cache_len :, :])
-        # we should return the whole states instead of `self.keys/values` here, as otherwise we lose some context
+        self.keys[:batch_size].copy_(full_key_states[:, :, -self.max_cache_len :, :])
+        self.values[:batch_size].copy_(full_value_states[:, :, -self.max_cache_len :, :])
+        # we should return the whole states instead of sliced cache here, as otherwise we lose some context
         return full_key_states, full_value_states
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
@@ -503,6 +499,12 @@ class StaticSlidingWindowLayer(StaticLayer):
     def get_seq_length(self) -> int:
         """Returns the sequence length of the cached states."""
         return self.cumulative_length
+
+    def reset(self):
+        if self.is_initialized:
+            self.keys.zero_()
+            self.values.zero_()
+        self.cumulative_length = 0
 
 
 class QuantizedLayer(DynamicLayer):

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -385,13 +385,15 @@ class StaticSlidingWindowLayer(StaticLayer):
             Maximum number of tokens that can be stored, used for tensor preallocation.
         sliding_window (`int`):
             The size of the sliding window.
+        max_batch_size(`int`, *optional*):
+            Maximum batch size that can be stored
     """
 
     is_sliding = True
 
-    def __init__(self, max_cache_len: int, sliding_window: int):
+    def __init__(self, max_cache_len: int, sliding_window: int, max_batch_size: int | None = None):
         effective_max_cache_len = min(sliding_window, max_cache_len)
-        super().__init__(max_cache_len=effective_max_cache_len)
+        super().__init__(max_cache_len=effective_max_cache_len, max_batch_size=max_batch_size)
         self.cumulative_length = 0
 
     def update(
@@ -421,6 +423,10 @@ class StaticSlidingWindowLayer(StaticLayer):
         cache_position = (
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
+
+        batch_size = key_states.shape[0]
+        self.keys = self.keys_[:batch_size]
+        self.values = self.values_[:batch_size]
 
         cumulative_length = self.cumulative_length
         is_full = cumulative_length >= self.max_cache_len

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -258,14 +258,17 @@ class StaticLayer(CacheLayerMixin):
     Args:
         max_cache_len (`int`):
             Maximum number of tokens that can be stored, used for tensor preallocation.
+        max_batch_size(`int`, *optional*):
+            Maximum batch size that can be stored
     """
 
     is_compileable = True
     is_sliding = False
 
-    def __init__(self, max_cache_len: int):
+    def __init__(self, max_cache_len: int, max_batch_size: int | None = None):
         super().__init__()
         self.max_cache_len = max_cache_len
+        self.max_batch_size = max_batch_size
 
     def lazy_initialization(self, key_states: torch.Tensor):
         """
@@ -281,26 +284,30 @@ class StaticLayer(CacheLayerMixin):
         i.e. `mode="reduce-overhead"` is known to fail). But it will in general work correctly, and prefill should
         not be compiled anyway for performances!
         """
-        self.max_batch_size, self.num_heads, _, self.head_dim = key_states.shape
+        if self.max_batch_size is None:
+            self.max_batch_size = key_states.shape[0]
+        _, self.num_heads, _, self.head_dim = key_states.shape
         self.dtype, self.device = key_states.dtype, key_states.device
 
-        self.keys = torch.zeros(
+        self.keys_ = torch.zeros(
             (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
             dtype=self.dtype,
             device=self.device,
         )
-        self.values = torch.zeros(
+        self.values_ = torch.zeros(
             (self.max_batch_size, self.num_heads, self.max_cache_len, self.head_dim),
             dtype=self.dtype,
             device=self.device,
         )
+        self.keys = self.keys_
+        self.values = self.values_
         # Note: `mark_static_address` is used to tag the cache as a fixed data pointer, preventing compiled graph
         # breaks when updating the cache. However, it is not supported when tracing the graph, so we skip it in this case.
         # As prefill should never be compiled, this is not an issue and it will still be run (except when users compile
         # prefill explicitly, but this should be avoided!)
         if not is_torchdynamo_compiling():
-            torch._dynamo.mark_static_address(self.keys)
-            torch._dynamo.mark_static_address(self.values)
+            torch._dynamo.mark_static_address(self.keys_)
+            torch._dynamo.mark_static_address(self.values_)
 
         self.is_initialized = True
 
@@ -331,21 +338,25 @@ class StaticLayer(CacheLayerMixin):
         cache_position = (
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
-        k_out = self.keys
-        v_out = self.values
         batch_size = key_states.shape[0]
-        if k_out.shape[0] != batch_size:
-            k_out = k_out[:batch_size]
-            v_out = v_out[:batch_size]
-        # Update the cache
+        # 3. Dynamic Slicing: Update the view to match current batch
+        self.keys = self.keys_[:batch_size]
+        self.values = self.values_[:batch_size]
         try:
-            k_out.index_copy_(2, cache_position, key_states)
-            v_out.index_copy_(2, cache_position, value_states)
+            self.keys.index_copy_(2, cache_position, key_states)
+            self.values.index_copy_(2, cache_position, value_states)
         except NotImplementedError:
-            # Fallback for devices like MPS where index_copy_ might not be supported.
-            k_out[:, :, cache_position] = key_states
-            v_out[:, :, cache_position] = value_states
-        return k_out, v_out
+            self.keys[:, :, cache_position] = key_states
+            self.values[:, :, cache_position] = value_states
+
+        return self.keys, self.values
+
+    def reset(self):
+        if self.is_initialized:
+            self.keys_.zero_()
+            self.values_.zero_()
+            self.keys = self.keys_
+            self.values = self.values_
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
         """Return the length and offset of the cache, used to generate the attention mask"""
@@ -1024,6 +1035,8 @@ class StaticCache(Cache):
         offload_only_non_sliding (`bool`, *optional*, defaults to `True`):
             If `offloading` is `True`, this further decides if only the non-sliding layers will be offloaded (because
             usually the sliding layers are small in size, so there is no need to offload them, and skipping it is faster).
+        max_batch_size (`int`, *optional*):
+            The maximum batch size that will be used with this Cache .
 
     Example:
 
@@ -1052,6 +1065,7 @@ class StaticCache(Cache):
         max_cache_len: int,
         offloading: bool = False,
         offload_only_non_sliding: bool = True,
+        max_batch_size: int | None = None,
         **kwargs,
     ):
         config = config.get_text_config(decoder=True)
@@ -1071,18 +1085,38 @@ class StaticCache(Cache):
         layers = []
         for layer_type in layer_types:
             if layer_type == "sliding_attention":
-                layer = StaticSlidingWindowLayer(max_cache_len=max_cache_len, sliding_window=config.sliding_window)
+                layer = StaticSlidingWindowLayer(
+                    max_cache_len=max_cache_len, sliding_window=config.sliding_window, max_batch_size=max_batch_size
+                )
             elif layer_type == "chunked_attention":
                 # From a cache point of view, both sliding and chunked are the same in how they should behave and how many
                 # states they should return - only the mask changes to make them different at the end!
                 layer = StaticSlidingWindowLayer(
-                    max_cache_len=max_cache_len, sliding_window=config.attention_chunk_size
+                    max_cache_len=max_cache_len,
+                    sliding_window=config.attention_chunk_size,
+                    max_batch_size=max_batch_size,
                 )
             else:
-                layer = StaticLayer(max_cache_len=max_cache_len)
+                layer = StaticLayer(max_cache_len=max_cache_len, max_batch_size=max_batch_size)
             layers.append(layer)
 
         super().__init__(layers=layers, offloading=offloading, offload_only_non_sliding=offload_only_non_sliding)
+
+    def update(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        cache_kwargs: Optional[dict[str, Any]] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.layers[layer_idx].update(key_states, value_states, cache_kwargs)
+
+    def reset(self):
+        for layer in self.layers:
+            layer.reset()
+
+    def __len__(self):
+        return len(self.layers)
 
 
 class QuantizedCache(Cache):

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -337,10 +337,6 @@ class StaticLayer(CacheLayerMixin):
         if k_out.shape[0] != batch_size:
             k_out = k_out[:batch_size]
             v_out = v_out[:batch_size]
-        if key_states.dtype != k_out.dtype:
-            key_states = key_states.to(k_out.dtype)
-        if value_states.dtype != v_out.dtype:
-            value_states = value_states.to(v_out.dtype)
         # Update the cache
         try:
             k_out.index_copy_(2, cache_position, key_states)

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -331,16 +331,25 @@ class StaticLayer(CacheLayerMixin):
         cache_position = (
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
-
+        k_out = self.keys
+        v_out = self.values
+        batch_size = key_states.shape[0]
+        if k_out.shape[0] != batch_size:
+            k_out = k_out[:batch_size]
+            v_out = v_out[:batch_size]
+        if key_states.dtype != k_out.dtype:
+            key_states = key_states.to(k_out.dtype)
+        if value_states.dtype != v_out.dtype:
+            value_states = value_states.to(v_out.dtype)
         # Update the cache
         try:
-            self.keys.index_copy_(2, cache_position, key_states)
-            self.values.index_copy_(2, cache_position, value_states)
+            k_out.index_copy_(2, cache_position, key_states)
+            v_out.index_copy_(2, cache_position, value_states)
         except NotImplementedError:
             # Fallback for devices like MPS where index_copy_ might not be supported.
-            self.keys[:, :, cache_position] = key_states
-            self.values[:, :, cache_position] = value_states
-        return self.keys, self.values
+            k_out[:, :, cache_position] = key_states
+            v_out[:, :, cache_position] = value_states
+        return k_out, v_out
 
     def get_mask_sizes(self, cache_position: torch.Tensor) -> tuple[int, int]:
         """Return the length and offset of the cache, used to generate the attention mask"""

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -339,7 +339,6 @@ class StaticLayer(CacheLayerMixin):
             cache_position if cache_position is not None else torch.arange(key_states.shape[-2], device=self.device)
         )
         batch_size = key_states.shape[0]
-        # 3. Dynamic Slicing: Update the view to match current batch
         self.keys = self.keys_[:batch_size]
         self.values = self.values_[:batch_size]
         try:

--- a/tests_output.txt
+++ b/tests_output.txt
@@ -1,0 +1,695 @@
+============================= test session starts ==============================
+platform linux -- Python 3.12.3, pytest-8.4.2, pluggy-1.6.0 -- /home/vedth/stuhdy/transformers/venv/bin/python3
+cachedir: .pytest_cache
+hypothesis profile 'default'
+rootdir: /home/vedth/stuhdy/transformers
+configfile: pyproject.toml
+plugins: timeout-2.4.0, rich-0.2.0, xdist-3.8.0, rerunfailures-15.1, anyio-4.11.0, order-1.3.0, asyncio-1.3.0, hypothesis-6.148.3
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
+created: 2/2 workers
+2 workers [191 items]
+
+scheduling tests via LoadScheduling
+
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_with_global_device_set <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_fa2_generate <- tests/generation/test_utils.py 
+[gw1] [  0%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_fa2_generate <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_fa3_generate <- tests/generation/test_utils.py 
+[gw1] [  1%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_fa3_generate <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_00_fp16_pad_left_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  1%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_00_fp16_pad_left_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_01_fp16_pad_left <- tests/test_modeling_common.py 
+[gw1] [  2%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_01_fp16_pad_left <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_02_fp16_pad_left_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  2%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_02_fp16_pad_left_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_03_fp16_pad_left_no_attn_mask <- tests/test_modeling_common.py 
+[gw1] [  3%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_03_fp16_pad_left_no_attn_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_04_fp16_pad_right_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  3%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_04_fp16_pad_right_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_05_fp16_pad_right <- tests/test_modeling_common.py 
+[gw1] [  4%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_05_fp16_pad_right <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_06_fp16_pad_right_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  4%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_06_fp16_pad_right_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_07_fp16_pad_right_no_attn_mask <- tests/test_modeling_common.py 
+[gw1] [  5%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_07_fp16_pad_right_no_attn_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_08_fp32_pad_left_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  5%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_08_fp32_pad_left_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_09_fp32_pad_left <- tests/test_modeling_common.py 
+[gw1] [  6%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_09_fp32_pad_left <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_10_fp32_pad_left_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  6%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_10_fp32_pad_left_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_11_fp32_pad_left_no_attn_mask <- tests/test_modeling_common.py 
+[gw1] [  7%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_11_fp32_pad_left_no_attn_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_12_fp32_pad_right_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  7%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_12_fp32_pad_right_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_13_fp32_pad_right <- tests/test_modeling_common.py 
+[gw1] [  8%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_13_fp32_pad_right <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_14_fp32_pad_right_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  8%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_14_fp32_pad_right_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_15_fp32_pad_right_no_attn_mask <- tests/test_modeling_common.py 
+[gw1] [  9%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_15_fp32_pad_right_no_attn_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_16_bf16_pad_left_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [  9%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_16_bf16_pad_left_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_17_bf16_pad_left <- tests/test_modeling_common.py 
+[gw1] [ 10%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_17_bf16_pad_left <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_18_bf16_pad_left_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [ 10%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_18_bf16_pad_left_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_19_bf16_pad_left_no_attn_mask <- tests/test_modeling_common.py 
+[gw1] [ 11%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_19_bf16_pad_left_no_attn_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_20_bf16_pad_right_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [ 12%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_20_bf16_pad_right_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_21_bf16_pad_right <- tests/test_modeling_common.py 
+[gw1] [ 12%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_21_bf16_pad_right <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_22_bf16_pad_right_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+[gw1] [ 13%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_22_bf16_pad_right_no_attn_mask_sdpa_kernels <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_23_bf16_pad_right_no_attn_mask <- tests/test_modeling_common.py 
+[gw1] [ 13%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_23_bf16_pad_right_no_attn_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_24_fp32_pad_left_output_attentions <- tests/test_modeling_common.py 
+[gw1] [ 14%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_matches_sdpa_inference_24_fp32_pad_left_output_attentions <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_padding_matches_padding_free_with_position_ids 
+[gw1] [ 14%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_eager_padding_matches_padding_free_with_position_ids 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_feed_forward_chunking <- tests/test_modeling_common.py 
+[gw1] [ 15%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_feed_forward_chunking <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_2_continue_generate_with_position_ids <- tests/generation/test_utils.py 
+[gw1] [ 15%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_2_continue_generate_with_position_ids <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_2_padding_matches_padding_free_with_position_ids <- tests/generation/test_utils.py 
+[gw1] [ 16%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_2_padding_matches_padding_free_with_position_ids <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_2_padding_matches_padding_free_with_position_ids_and_fa_kwargs <- tests/generation/test_utils.py 
+[gw1] [ 16%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_2_padding_matches_padding_free_with_position_ids_and_fa_kwargs <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_3_padding_matches_padding_free_with_position_ids <- tests/generation/test_utils.py 
+[gw1] [ 17%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_3_padding_matches_padding_free_with_position_ids <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_3_padding_matches_padding_free_with_position_ids_and_fa_kwargs <- tests/generation/test_utils.py 
+[gw1] [ 17%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attention_3_padding_matches_padding_free_with_position_ids_and_fa_kwargs <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_can_compile_with_attention_mask_None_without_graph_break <- tests/test_modeling_common.py 
+[gw1] [ 18%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_can_compile_with_attention_mask_None_without_graph_break <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_can_dispatch_composite_models <- tests/test_modeling_common.py 
+[gw1] [ 18%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_can_dispatch_composite_models <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_equivalence <- tests/causal_lm_tester.py 
+[gw1] [ 19%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_equivalence <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_fp32_ln <- tests/test_modeling_common.py 
+[gw1] [ 19%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_fp32_ln <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_from_config <- tests/test_modeling_common.py 
+[gw1] [ 20%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_from_config <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_inference_equivalence <- tests/test_modeling_common.py 
+[gw1] [ 20%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_inference_equivalence <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_inference_equivalence_right_padding <- tests/test_modeling_common.py 
+[gw1] [ 21%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_2_inference_equivalence_right_padding <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_can_dispatch_composite_models <- tests/test_modeling_common.py 
+[gw1] [ 21%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_can_dispatch_composite_models <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_from_config <- tests/test_modeling_common.py 
+[gw1] [ 22%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_from_config <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_inference_equivalence <- tests/test_modeling_common.py 
+[gw1] [ 23%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_inference_equivalence <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_inference_equivalence_right_padding <- tests/test_modeling_common.py 
+[gw1] [ 23%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_3_inference_equivalence_right_padding <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_kernels_inference_equivalence <- tests/test_modeling_common.py 
+[gw1] [ 24%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_kernels_inference_equivalence <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_kernels_mps_inference_equivalence <- tests/test_modeling_common.py 
+[gw1] [ 24%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flash_attn_kernels_mps_inference_equivalence <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flex_attention_with_grads <- tests/test_modeling_common.py 
+[gw0] [ 25%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_with_global_device_set <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_attention_outputs <- tests/test_modeling_common.py 
+[gw0] [ 25%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_attention_outputs <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_attn_implementation_composite_models <- tests/test_modeling_common.py 
+[gw0] [ 26%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_attn_implementation_composite_models <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_batching_equivalence <- tests/test_modeling_common.py 
+[gw0] [ 26%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_batching_equivalence <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_bc_torch_dtype <- tests/test_modeling_common.py 
+[gw0] [ 27%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_bc_torch_dtype <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_be_initialized_on_meta <- tests/test_modeling_common.py 
+[gw0] [ 27%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_be_initialized_on_meta <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_init_all_missing_weights <- tests/test_modeling_common.py 
+[gw0] [ 28%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_init_all_missing_weights <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_from_already_mapped_keys <- tests/test_modeling_common.py 
+[gw0] [ 28%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_from_already_mapped_keys <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_ignoring_mismatched_shapes <- tests/test_modeling_common.py 
+[gw0] [ 29%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_ignoring_mismatched_shapes <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_with_device_context_manager <- tests/test_modeling_common.py 
+[gw0] [ 29%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_load_with_device_context_manager <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_set_attention_dynamically <- tests/test_modeling_common.py 
+[gw0] [ 30%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_set_attention_dynamically <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_set_attention_dynamically_composite_model <- tests/test_modeling_common.py 
+[gw0] [ 30%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_set_attention_dynamically_composite_model <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_use_safetensors <- tests/test_modeling_common.py 
+[gw0] [ 31%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_can_use_safetensors <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_cannot_load_with_meta_device_context_manager <- tests/test_modeling_common.py 
+[gw0] [ 31%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_cannot_load_with_meta_device_context_manager <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_causal_lm_can_accept_training_kwargs <- tests/causal_lm_tester.py 
+[gw0] [ 32%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_causal_lm_can_accept_training_kwargs <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_config <- tests/causal_lm_tester.py 
+[gw0] [ 32%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_config <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_config_attn_implementation_setter <- tests/test_modeling_common.py 
+[gw0] [ 33%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_config_attn_implementation_setter <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_correct_missing_keys <- tests/test_modeling_common.py 
+[gw0] [ 34%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_correct_missing_keys <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_cpu_offload <- tests/test_modeling_common.py 
+[gw0] [ 34%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_cpu_offload <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_custom_4d_attention_mask <- tests/generation/test_utils.py 
+[gw0] [ 35%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_custom_4d_attention_mask <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_determinism <- tests/test_modeling_common.py 
+[gw0] [ 35%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_determinism <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_disk_offload_bin <- tests/test_modeling_common.py 
+[gw0] [ 36%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_disk_offload_bin <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_disk_offload_safetensors <- tests/test_modeling_common.py 
+[gw0] [ 36%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_disk_offload_safetensors <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_from_config_2_yarn <- tests/causal_lm_tester.py 
+[gw0] [ 37%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_from_config_2_yarn <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_weights_reload_no_missing_tied_weights <- tests/test_modeling_common.py 
+[gw0] [ 37%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_weights_reload_no_missing_tied_weights <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_multi_gpu_data_parallel_forward <- tests/test_modeling_common.py 
+[gw0] [ 38%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_multi_gpu_data_parallel_forward <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_num_layers_is_small <- tests/test_modeling_common.py 
+[gw0] [ 38%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_num_layers_is_small <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_peft_gradient_checkpointing_enable_disable <- tests/test_modeling_common.py 
+[gw0] [ 39%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_peft_gradient_checkpointing_enable_disable <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_any_to_any <- tests/test_pipeline_mixin.py 
+[gw0] [ 39%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_any_to_any <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_any_to_any_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 40%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_any_to_any_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_audio_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 40%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_audio_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_audio_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 41%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_audio_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_automatic_speech_recognition <- tests/test_pipeline_mixin.py 
+[gw0] [ 41%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_automatic_speech_recognition <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_automatic_speech_recognition_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 42%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_automatic_speech_recognition_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_depth_estimation <- tests/test_pipeline_mixin.py 
+[gw0] [ 42%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_depth_estimation <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_depth_estimation_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 43%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_depth_estimation_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_document_question_answering <- tests/test_pipeline_mixin.py 
+[gw0] [ 43%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_document_question_answering <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_document_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 44%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_document_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_feature_extraction <- tests/test_pipeline_mixin.py 
+[gw0] [ 45%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_feature_extraction <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_feature_extraction_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 45%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_feature_extraction_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_fill_mask <- tests/test_pipeline_mixin.py 
+[gw0] [ 46%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_fill_mask <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_fill_mask_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 46%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_fill_mask_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 47%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 47%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_feature_extraction <- tests/test_pipeline_mixin.py 
+[gw0] [ 48%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_feature_extraction <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_feature_extraction_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 48%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_feature_extraction_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_segmentation <- tests/test_pipeline_mixin.py 
+[gw0] [ 49%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_segmentation <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_segmentation_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 49%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_segmentation_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_text_to_text <- tests/test_pipeline_mixin.py 
+[gw0] [ 50%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_text_to_text <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_text_to_text_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 50%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_text_to_text_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_to_text <- tests/test_pipeline_mixin.py 
+[gw0] [ 51%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_to_text <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_to_text_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 51%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_image_to_text_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_mask_generation <- tests/test_pipeline_mixin.py 
+[gw0] [ 52%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_mask_generation <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_mask_generation_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 52%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_mask_generation_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_object_detection <- tests/test_pipeline_mixin.py 
+[gw0] [ 53%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_object_detection <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_object_detection_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 53%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_object_detection_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_question_answering <- tests/test_pipeline_mixin.py 
+[gw0] [ 54%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_question_answering <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 54%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_summarization <- tests/test_pipeline_mixin.py 
+[gw0] [ 55%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_summarization <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_summarization_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 56%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_summarization_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_table_question_answering <- tests/test_pipeline_mixin.py 
+[gw0] [ 56%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_table_question_answering <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_table_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 57%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_table_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text2text_generation <- tests/test_pipeline_mixin.py 
+[gw0] [ 57%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text2text_generation <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text2text_generation_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 58%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text2text_generation_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 58%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 59%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_generation <- tests/test_pipeline_mixin.py 
+[gw0] [ 59%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_generation <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_generation_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 60%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_generation_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_to_audio <- tests/test_pipeline_mixin.py 
+[gw0] [ 60%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_to_audio <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_to_audio_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 61%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_text_to_audio_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_token_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 61%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_token_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_token_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 62%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_token_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_translation <- tests/test_pipeline_mixin.py 
+[gw0] [ 62%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_translation <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_translation_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 63%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_translation_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_video_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 63%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_video_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_video_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 64%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_video_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_visual_question_answering <- tests/test_pipeline_mixin.py 
+[gw0] [ 64%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_visual_question_answering <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_visual_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 65%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_visual_question_answering_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot <- tests/test_pipeline_mixin.py 
+[gw0] [ 65%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_audio_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 66%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_audio_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_audio_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 67%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_audio_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 67%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_image_classification <- tests/test_pipeline_mixin.py 
+[gw0] [ 68%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_image_classification <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_image_classification_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 68%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_image_classification_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_object_detection <- tests/test_pipeline_mixin.py 
+[gw0] [ 69%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_object_detection <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_object_detection_fp16 <- tests/test_pipeline_mixin.py 
+[gw0] [ 69%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_pipeline_zero_shot_object_detection_fp16 <- tests/test_pipeline_mixin.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_problem_types <- tests/test_modeling_common.py 
+[gw0] [ 70%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_problem_types <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_question_answering_model <- tests/causal_lm_tester.py 
+[gw0] [ 70%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_question_answering_model <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_embeddings_untied <- tests/test_modeling_common.py 
+[gw0] [ 71%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_embeddings_untied <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_embeddings_untied_with_deepspeed <- tests/test_modeling_common.py 
+[gw0] [ 71%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_embeddings_untied_with_deepspeed <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_embeddings_untied_with_deepspeed_multi_gpu <- tests/test_modeling_common.py 
+[gw0] [ 72%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_embeddings_untied_with_deepspeed_multi_gpu <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_position_vector_embeddings <- tests/test_modeling_common.py 
+[gw0] [ 72%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_position_vector_embeddings <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_tokens_embeddings <- tests/test_modeling_common.py 
+[gw0] [ 73%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_tokens_embeddings <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_tokens_embeddings_with_deepspeed <- tests/test_modeling_common.py 
+[gw0] [ 73%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_tokens_embeddings_with_deepspeed <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_tokens_embeddings_with_deepspeed_multi_gpu <- tests/test_modeling_common.py 
+[gw0] [ 74%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_resize_tokens_embeddings_with_deepspeed_multi_gpu <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_retain_grad_hidden_states_attentions <- tests/test_modeling_common.py 
+[gw0] [ 74%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_retain_grad_hidden_states_attentions <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_reverse_loading_mapping <- tests/test_modeling_common.py 
+[gw0] [ 75%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_reverse_loading_mapping <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_save_load <- tests/test_modeling_common.py 
+[gw0] [ 75%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_save_load <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_save_load_keys_to_ignore_on_save <- tests/test_modeling_common.py 
+[gw0] [ 76%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_save_load_keys_to_ignore_on_save <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_compile_dynamic <- tests/test_modeling_common.py 
+[gw0] [ 76%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_compile_dynamic <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_dispatch_composite_models <- tests/test_modeling_common.py 
+[gw0] [ 77%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_dispatch_composite_models <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_dispatch_non_composite_models <- tests/test_modeling_common.py 
+[gw0] [ 78%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_dispatch_non_composite_models <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_dispatch_on_flash <- tests/test_modeling_common.py 
+[gw0] [ 78%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_can_dispatch_on_flash <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_padding_matches_padding_free_with_position_ids 
+[gw0] [ 79%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sdpa_padding_matches_padding_free_with_position_ids 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sequence_classification_model <- tests/causal_lm_tester.py 
+[gw0] [ 79%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sequence_classification_model <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sequence_classification_model_for_multi_label <- tests/causal_lm_tester.py 
+[gw0] [ 80%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sequence_classification_model_for_multi_label <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sequence_classification_model_for_single_label <- tests/causal_lm_tester.py 
+[gw0] [ 80%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sequence_classification_model_for_single_label <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sliding_window_mask <- tests/test_modeling_common.py 
+[gw0] [ 81%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_sliding_window_mask <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_tied_weights_keys <- tests/test_modeling_common.py 
+[gw0] [ 81%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_tied_weights_keys <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_token_classification_model <- tests/causal_lm_tester.py 
+[gw0] [ 82%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_token_classification_model <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_torch_compile_for_training <- tests/test_modeling_common.py 
+[gw0] [ 82%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_torch_compile_for_training <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_torch_export <- tests/test_modeling_common.py 
+[gw0] [ 83%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_torch_export <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_torch_save_load <- tests/test_modeling_common.py 
+[gw0] [ 83%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_torch_save_load <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_tp_plan_matches_params <- tests/test_modeling_common.py 
+[gw0] [ 84%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_tp_plan_matches_params <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training <- tests/test_modeling_common.py 
+[gw0] [ 84%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training_gradient_checkpointing <- tests/test_modeling_common.py 
+[gw0] [ 85%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training_gradient_checkpointing <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training_gradient_checkpointing_use_reentrant <- tests/test_modeling_common.py 
+[gw0] [ 85%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training_gradient_checkpointing_use_reentrant <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training_gradient_checkpointing_use_reentrant_false <- tests/test_modeling_common.py 
+[gw0] [ 86%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_training_gradient_checkpointing_use_reentrant_false <- tests/test_modeling_common.py 
+[gw1] [ 86%] FAILED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flex_attention_with_grads <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_forward_with_logits_to_keep <- tests/generation/test_utils.py 
+[gw1] [ 87%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_forward_with_logits_to_keep <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_from_pretrained_no_checkpoint <- tests/test_modeling_common.py 
+[gw1] [ 87%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_from_pretrained_no_checkpoint <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds <- venv/lib/python3.12/site-packages/_pytest/mark/structures.py 
+[gw1] [ 88%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds <- venv/lib/python3.12/site-packages/_pytest/mark/structures.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds_0_greedy <- tests/generation/test_utils.py 
+[gw1] [ 89%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds_0_greedy <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds_1_beam_search <- tests/generation/test_utils.py 
+[gw1] [ 89%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds_1_beam_search <- tests/generation/test_utils.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generation_tester_mixin_inheritance <- tests/test_modeling_common.py 
+[gw1] [ 90%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generation_tester_mixin_inheritance <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_gradient_checkpointing_backward_compatibility <- tests/test_modeling_common.py 
+[gw1] [ 90%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_gradient_checkpointing_backward_compatibility <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_gradient_checkpointing_enable_disable <- tests/test_modeling_common.py 
+[gw1] [ 91%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_gradient_checkpointing_enable_disable <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_hidden_states_output <- tests/test_modeling_common.py 
+[gw1] [ 91%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_hidden_states_output <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_inputs_embeds <- tests/test_modeling_common.py 
+[gw1] [ 92%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_inputs_embeds <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_inputs_embeds_matches_input_ids <- tests/test_modeling_common.py 
+[gw1] [ 92%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_inputs_embeds_matches_input_ids <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_internal_model_config_and_subconfig_are_same <- tests/test_modeling_common.py 
+[gw1] [ 93%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_internal_model_config_and_subconfig_are_same <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_keep_in_fp32_modules <- tests/test_modeling_common.py 
+[gw1] [ 93%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_keep_in_fp32_modules <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_load_save_without_tied_weights <- tests/test_modeling_common.py 
+[gw1] [ 94%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_load_save_without_tied_weights <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_load_with_mismatched_shapes <- tests/test_modeling_common.py 
+[gw1] [ 94%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_load_with_mismatched_shapes <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model <- tests/causal_lm_tester.py 
+[gw1] [ 95%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_base_model_prefix <- tests/test_modeling_common.py 
+[gw1] [ 95%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_base_model_prefix <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_get_set_embeddings <- tests/test_modeling_common.py 
+[gw1] [ 96%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_get_set_embeddings <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_is_small <- tests/test_modeling_common.py 
+[gw1] [ 96%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_is_small <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_main_input_name <- tests/test_modeling_common.py 
+[gw1] [ 97%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_main_input_name <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_outputs_equivalence 
+[gw1] [ 97%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_outputs_equivalence 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_parallelism <- tests/test_modeling_common.py 
+[gw1] [ 98%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_parallelism <- tests/test_modeling_common.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_frequencies 
+[gw1] [ 98%] SKIPPED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_frequencies 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_from_config_0_linear <- tests/causal_lm_tester.py 
+[gw1] [ 99%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_from_config_0_linear <- tests/causal_lm_tester.py 
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_from_config_1_dynamic <- tests/causal_lm_tester.py 
+[gw1] [100%] PASSED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_model_rope_scaling_from_config_1_dynamic <- tests/causal_lm_tester.py 
+
+=================================== FAILURES ===================================
+________________ AfmoeModelTest.test_flex_attention_with_grads _________________
+[gw1] linux -- Python 3.12.3 /home/vedth/stuhdy/transformers/venv/bin/python3
+
+self = <tests.models.afmoe.test_modeling_afmoe.AfmoeModelTest testMethod=test_flex_attention_with_grads>
+
+    @require_torch_accelerator
+    def test_flex_attention_with_grads(self):
+        for model_class in self.all_model_classes:
+            config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+            inputs_dict = self._prepare_for_class(inputs_dict, model_class)
+            model = model_class(config).to(device=torch_device)
+    
+            # If not all sub-models support flex, skip the test
+            if not all(
+                submodel._supports_flex_attn for submodel in model.modules() if isinstance(submodel, PreTrainedModel)
+            ):
+                self.skipTest(reason="At least some parts of this model do not support flex attention")
+    
+            # Set default attention to flex and update config values
+            config = self._prepare_config_headdim(config, 16)  # specific to triton
+    
+            if model_class._can_set_attn_implementation():
+                model = model_class(config).to(device=torch_device)
+                model.set_attn_implementation("flex_attention")
+                self.assertTrue(model.config._attn_implementation == "flex_attention")
+            else:
+                config._attn_implementation = "flex_attention"
+                model = model_class(config).to(device=torch_device)
+    
+            # Elaborate workaround for encoder-decoder models as some do not specify their main input
+            dummy_inputs = {model.main_input_name: inputs_dict[model.main_input_name].to(torch_device)}
+            for key in getattr(self, "additional_model_inputs", []):
+                # Some models don't have all `additional_model_inputs`, especially when we
+                # craft cases to test model in different settings
+                if key in inputs_dict:
+                    dummy_inputs[key] = inputs_dict[key].to(torch_device)
+    
+            if config.is_encoder_decoder:
+                dummy_inputs["decoder_input_ids"] = inputs_dict["decoder_input_ids"].to(torch_device)
+                dummy_inputs["decoder_attention_mask"] = inputs_dict["decoder_attention_mask"].to(torch_device)
+    
+            # If this does not raise an error, the test passes (see https://github.com/huggingface/transformers/pull/35605)
+>           _ = model(**dummy_inputs)
+                ^^^^^^^^^^^^^^^^^^^^^
+
+tests/test_modeling_common.py:3761: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1775: in _wrapped_call_impl
+    return self._call_impl(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1786: in _call_impl
+    return forward_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+src/transformers/utils/generic.py:919: in wrapper
+    outputs = func(self, *args, **kwargs)
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+src/transformers/models/afmoe/modeling_afmoe.py:629: in forward
+    hidden_states = decoder_layer(
+src/transformers/modeling_layers.py:94: in __call__
+    return super().__call__(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1775: in _wrapped_call_impl
+    return self._call_impl(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1786: in _call_impl
+    return forward_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+src/transformers/models/afmoe/modeling_afmoe.py:479: in forward
+    hidden_states, _ = self.self_attn(
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1775: in _wrapped_call_impl
+    return self._call_impl(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1786: in _call_impl
+    return forward_call(*args, **kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+src/transformers/models/afmoe/modeling_afmoe.py:415: in forward
+    output, attn_weights = attention_interface(
+src/transformers/integrations/flex_attention.py:290: in flex_attention_forward
+    flex_attention_output = compile_friendly_flex_attention(
+src/transformers/integrations/flex_attention.py:97: in compile_friendly_flex_attention
+    return flex_attention_compiled(
+venv/lib/python3.12/site-packages/torch/_dynamo/eval_frame.py:845: in compile_wrapper
+    raise e.remove_dynamo_frames() from None  # see TORCHDYNAMO_VERBOSE=1
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/compile_fx.py:990: in _compile_fx_inner
+    raise InductorError(e, currentframe()).with_traceback(
+venv/lib/python3.12/site-packages/torch/_inductor/compile_fx.py:974: in _compile_fx_inner
+    mb_compiled_graph = fx_codegen_and_compile(
+venv/lib/python3.12/site-packages/torch/_inductor/compile_fx.py:1695: in fx_codegen_and_compile
+    return scheme.codegen_and_compile(gm, example_inputs, inputs_to_check, graph_kwargs)
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/compile_fx.py:1505: in codegen_and_compile
+    compiled_module = graph.compile_to_module()
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/graph.py:2319: in compile_to_module
+    return self._compile_to_module()
+           ^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/graph.py:2329: in _compile_to_module
+    mod = self._compile_to_module_lines(wrapper_code)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/graph.py:2397: in _compile_to_module_lines
+    mod = PyCodeCache.load_by_key_path(
+venv/lib/python3.12/site-packages/torch/_inductor/codecache.py:3548: in load_by_key_path
+    mod = _reload_python_module(key, path, set_sys_modules=in_toplevel)
+          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/runtime/compile_tasks.py:33: in _reload_python_module
+    exec(code, mod.__dict__, mod.__dict__)
+/tmp/torchinductor_vedth/ep/cep56kylllvniz3gr37e3fcgkrhmfv4xgxeohcmrpjftdphbcicz.py:624: in <module>
+    async_compile.wait(globals())
+venv/lib/python3.12/site-packages/torch/_inductor/async_compile.py:631: in wait
+    self._wait_futures(scope)
+venv/lib/python3.12/site-packages/torch/_inductor/async_compile.py:651: in _wait_futures
+    kernel = result.result()
+             ^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/codecache.py:4289: in result
+    return self.result_fn()
+           ^^^^^^^^^^^^^^^^
+venv/lib/python3.12/site-packages/torch/_inductor/async_compile.py:470: in get_result
+    kernel.precompile(
+venv/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py:451: in precompile
+    self._make_launchers()
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
+
+self = <torch._inductor.runtime.triton_heuristics.CachingAutotuner object at 0x798615294fe0>
+
+    def _make_launchers(self):
+        if len(self.launchers) == len(self.compile_results):
+            return
+    
+        from torch._dynamo.device_interface import DeviceGuard
+    
+        device_interface = self.get_device_interface()
+    
+        # load binary to the correct device
+        with DeviceGuard(device_interface, self.triton_meta["device"]):
+            # need to initialize context
+            with dynamo_timed(
+                "CachingAutotuner.synchronize",
+                # Deliberately avoid overloading pt2_compile_events:
+                log_pt2_compile_event=False,
+            ):
+                device_interface.synchronize(device_interface.current_device())
+    
+            launchers = []
+            exc = None
+            for result in self.compile_results:
+                try:
+                    launchers.append(result.make_launcher())
+    
+                except (OutOfResources, PTXASError, torch.cuda.OutOfMemoryError) as e:
+                    exc = e
+        if len(launchers) == 0:
+>           raise RuntimeError(f"No valid triton configs. {type(exc).__name__}: {exc}")
+E           torch._inductor.exc.InductorError: RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_tem_fused_0 Required: 147968 Hardware limit:101376 Reducing block sizes or `num_stages` may help.
+E           
+E           Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
+
+venv/lib/python3.12/site-packages/torch/_inductor/runtime/triton_heuristics.py:619: InductorError
+=============================== warnings summary ===============================
+<frozen importlib._bootstrap>:488
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute
+
+<frozen importlib._bootstrap>:488
+<frozen importlib._bootstrap>:488
+  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute
+
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_batching_equivalence
+  /home/vedth/stuhdy/transformers/tests/test_modeling_common.py:1091: UserWarning: Using a non-tuple sequence for multidimensional indexing is deprecated and will be changed in pytorch 2.9; use x[tuple(seq)] instead of x[seq]. In pytorch 2.9 this will be interpreted as tensor index, x[torch.tensor(seq)], which will result either in an error or a different result (Triggered internally at /pytorch/torch/csrc/autograd/python_variable_indexing.cpp:345.)
+    batched_row = batched_object[slice_ids]
+
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flex_attention_with_grads
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flex_attention_with_grads
+  /home/vedth/stuhdy/transformers/venv/lib/python3.12/site-packages/torch/nn/attention/flex_attention.py:1083: DeprecationWarning: _compile flag on create_block_mask was originally added to work around a torch.compile limitation. That limitation has since been addressed. So, to compile create_block_mask, we suggest doing torch.compile(create_block_mask). This still works for now, but will be removed in the future.
+    warnings.warn(
+
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flex_attention_with_grads
+  /home/vedth/stuhdy/transformers/venv/lib/python3.12/site-packages/torch/nn/attention/flex_attention.py:1622: FutureWarning: return_lse is deprecated and will be removed in v2.10. Please use return_aux=AuxRequest(lse=True) instead.
+    _warn_once(
+
+tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_generate_from_inputs_embeds
+  /usr/lib/python3.12/unittest/case.py:690: DeprecationWarning: It is deprecated to return a value that is not None from a test case (<bound method hub_retry.<locals>.decorator.<locals>.wrapper of <tests.models.afmoe.test_modeling_afmoe.AfmoeModelTest testMethod=test_generate_from_inputs_embeds>>)
+    return self.run(*args, **kwds)
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+-- generated xml file: /home/vedth/stuhdy/transformers/test-results/junit.xml --
+=========================== short test summary info ============================
+SKIPPED [1] tests/generation/test_utils.py:1849: test is slow
+SKIPPED [1] tests/generation/test_utils.py:1857: test requires Flash Attention 3
+SKIPPED [1] tests/models/afmoe/test_modeling_afmoe.py:107: Afmoe applies key/query norm which doesn't work with packing
+SKIPPED [1] tests/generation/test_utils.py:1865: AfmoeForCausalLM does not support Flash Attention.
+SKIPPED [1] tests/generation/test_utils.py:2082: test is slow
+SKIPPED [1] tests/generation/test_utils.py:2089: test is slow
+SKIPPED [1] tests/generation/test_utils.py:2098: test requires Flash Attention 3
+SKIPPED [1] tests/generation/test_utils.py:2105: test requires Flash Attention 3
+SKIPPED [1] tests/test_modeling_common.py:3367: test is slow
+SKIPPED [1] tests/test_modeling_common.py:3294: This model is not a composite model!
+SKIPPED [1] tests/causal_lm_tester.py:596: test is slow
+SKIPPED [1] tests/test_modeling_common.py:3306: test requires bitsandbytes
+SKIPPED [1] tests/test_modeling_common.py:3462: test is slow
+SKIPPED [1] tests/test_modeling_common.py:2894: test is slow
+SKIPPED [1] tests/test_modeling_common.py:2902: test is slow
+SKIPPED [1] tests/test_modeling_common.py:3300: test requires Flash Attention 3
+SKIPPED [1] tests/test_modeling_common.py:3469: test requires Flash Attention 3
+SKIPPED [1] tests/test_modeling_common.py:2910: test requires Flash Attention 3
+SKIPPED [1] tests/test_modeling_common.py:2918: test requires Flash Attention 3
+SKIPPED [1] tests/test_modeling_common.py:2876: test is slow
+SKIPPED [1] tests/test_modeling_common.py:2884: test requires MPS
+SKIPPED [1] tests/test_modeling_common.py:2926: Model is not a composite model.
+SKIPPED [1] tests/test_modeling_common.py:4162: No conversion found for this model
+SKIPPED [1] tests/test_modeling_common.py:3981: This model is not composite
+SKIPPED [1] tests/generation/test_utils.py:2149: AfmoeForCausalLM is not guaranteed to work with custom 4D attention masks
+SKIPPED [1] tests/test_modeling_common.py:2327: test requires multiple CUDA GPUs
+SKIPPED [1] tests/test_pipeline_mixin.py:595: AfmoeModelTest::test_pipeline_any_to_any_float32 is skipped: `any-to-any` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:601: AfmoeModelTest::test_pipeline_any_to_any_float16 is skipped: `any-to-any` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:493: AfmoeModelTest::test_pipeline_audio_classification_float32 is skipped: `audio-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:497: AfmoeModelTest::test_pipeline_audio_classification_float16 is skipped: `audio-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:502: AfmoeModelTest::test_pipeline_automatic_speech_recognition_float32 is skipped: `automatic-speech-recognition` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:506: AfmoeModelTest::test_pipeline_automatic_speech_recognition_float16 is skipped: `automatic-speech-recognition` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:511: AfmoeModelTest::test_pipeline_depth_estimation_float32 is skipped: `depth-estimation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:518: AfmoeModelTest::test_pipeline_depth_estimation_float16 is skipped: `depth-estimation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:525: test requires PyTesseract
+SKIPPED [1] tests/test_pipeline_mixin.py:532: test requires PyTesseract
+SKIPPED [1] tests/test_pipeline_mixin.py:539: AfmoeModelTest::test_pipeline_feature_extraction_float32 is skipped: Could not find any model architecture in the tiny models JSON file for `feature-extraction`.
+SKIPPED [1] tests/test_pipeline_mixin.py:543: AfmoeModelTest::test_pipeline_feature_extraction_float16 is skipped: Could not find any model architecture in the tiny models JSON file for `feature-extraction`.
+SKIPPED [1] tests/test_pipeline_mixin.py:548: AfmoeModelTest::test_pipeline_fill_mask_float32 is skipped: `fill-mask` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:552: AfmoeModelTest::test_pipeline_fill_mask_float16 is skipped: `fill-mask` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:557: AfmoeModelTest::test_pipeline_image_classification_float32 is skipped: `image-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:563: AfmoeModelTest::test_pipeline_image_classification_float16 is skipped: `image-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:618: AfmoeModelTest::test_pipeline_image_feature_extraction_float32 is skipped: `image-feature-extraction` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:625: AfmoeModelTest::test_pipeline_image_feature_extraction_float16 is skipped: `image-feature-extraction` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:569: AfmoeModelTest::test_pipeline_image_segmentation_float32 is skipped: `image-segmentation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:576: AfmoeModelTest::test_pipeline_image_segmentation_float16 is skipped: `image-segmentation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:583: AfmoeModelTest::test_pipeline_image_text_to_text_float32 is skipped: `image-text-to-text` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:589: AfmoeModelTest::test_pipeline_image_text_to_text_float16 is skipped: `image-text-to-text` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:607: AfmoeModelTest::test_pipeline_image_to_text_float32 is skipped: `image-to-text` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:612: AfmoeModelTest::test_pipeline_image_to_text_float16 is skipped: `image-to-text` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:632: `run_pipeline_test` is currently not implemented.
+SKIPPED [1] tests/test_pipeline_mixin.py:639: `run_pipeline_test` is currently not implemented.
+SKIPPED [1] tests/test_pipeline_mixin.py:646: AfmoeModelTest::test_pipeline_object_detection_float32 is skipped: `object-detection` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:653: AfmoeModelTest::test_pipeline_object_detection_float16 is skipped: `object-detection` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:660: AfmoeModelTest::test_pipeline_question_answering_float32 is skipped: `question-answering` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:664: AfmoeModelTest::test_pipeline_question_answering_float16 is skipped: `question-answering` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:669: AfmoeModelTest::test_pipeline_summarization_float32 is skipped: `summarization` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:673: AfmoeModelTest::test_pipeline_summarization_float16 is skipped: `summarization` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:678: AfmoeModelTest::test_pipeline_table_question_answering_float32 is skipped: `table-question-answering` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:682: AfmoeModelTest::test_pipeline_table_question_answering_float16 is skipped: `table-question-answering` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:687: AfmoeModelTest::test_pipeline_text2text_generation_float32 is skipped: `text2text-generation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:691: AfmoeModelTest::test_pipeline_text2text_generation_float16 is skipped: `text2text-generation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:696: AfmoeModelTest::test_pipeline_text_classification_float32 is skipped: `text-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:700: AfmoeModelTest::test_pipeline_text_classification_float16 is skipped: `text-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:705: AfmoeModelTest::test_pipeline_text_generation_float32 is skipped: Could not find any model architecture in the tiny models JSON file for `text-generation`.
+SKIPPED [1] tests/test_pipeline_mixin.py:710: AfmoeModelTest::test_pipeline_text_generation_float16 is skipped: Could not find any model architecture in the tiny models JSON file for `text-generation`.
+SKIPPED [1] tests/test_pipeline_mixin.py:715: AfmoeModelTest::test_pipeline_text_to_audio_float32 is skipped: `text-to-audio` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:720: AfmoeModelTest::test_pipeline_text_to_audio_float16 is skipped: `text-to-audio` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:725: AfmoeModelTest::test_pipeline_token_classification_float32 is skipped: `token-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:729: AfmoeModelTest::test_pipeline_token_classification_float16 is skipped: `token-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:734: AfmoeModelTest::test_pipeline_translation_float32 is skipped: `translation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:738: AfmoeModelTest::test_pipeline_translation_float16 is skipped: `translation` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:743: AfmoeModelTest::test_pipeline_video_classification_float32 is skipped: `video-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:750: AfmoeModelTest::test_pipeline_video_classification_float16 is skipped: `video-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:757: AfmoeModelTest::test_pipeline_visual_question_answering_float32 is skipped: `visual-question-answering` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:763: AfmoeModelTest::test_pipeline_visual_question_answering_float16 is skipped: `visual-question-answering` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:769: AfmoeModelTest::test_pipeline_zero_shot_float32 is skipped: `zero-shot` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:778: AfmoeModelTest::test_pipeline_zero_shot_audio_classification_float32 is skipped: `zero-shot-audio-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:783: AfmoeModelTest::test_pipeline_zero_shot_audio_classification_float16 is skipped: `zero-shot-audio-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:773: AfmoeModelTest::test_pipeline_zero_shot_float16 is skipped: `zero-shot` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:788: AfmoeModelTest::test_pipeline_zero_shot_image_classification_float32 is skipped: `zero-shot-image-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:793: AfmoeModelTest::test_pipeline_zero_shot_image_classification_float16 is skipped: `zero-shot-image-classification` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:799: AfmoeModelTest::test_pipeline_zero_shot_object_detection_float32 is skipped: `zero-shot-object-detection` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/test_pipeline_mixin.py:805: AfmoeModelTest::test_pipeline_zero_shot_object_detection_float16 is skipped: `zero-shot-object-detection` is not in `self.pipeline_model_mapping` for `AfmoeModelTest`.
+SKIPPED [1] tests/causal_lm_tester.py:404: Model does not support question answering
+SKIPPED [1] tests/test_modeling_common.py:1908: test requires deepspeed
+SKIPPED [1] tests/test_modeling_common.py:1920: test requires deepspeed
+SKIPPED [1] tests/test_modeling_common.py:1561: Model does not have position embeddings
+SKIPPED [1] tests/test_modeling_common.py:1796: test requires deepspeed
+SKIPPED [1] tests/test_modeling_common.py:1808: test requires deepspeed
+SKIPPED [1] tests/test_modeling_common.py:4084: No conversion found for this model
+SKIPPED [1] tests/test_modeling_common.py:3167: test is slow
+SKIPPED [1] tests/test_modeling_common.py:3023: AfmoeModel does not support SDPA
+SKIPPED [1] tests/test_modeling_common.py:3086: test is slow
+SKIPPED [1] tests/models/afmoe/test_modeling_afmoe.py:111: Afmoe  applies key/query norm which doesn't work with packing
+SKIPPED [1] tests/causal_lm_tester.py:341: Model does not support sequence classification
+SKIPPED [1] tests/causal_lm_tester.py:370: Model does not support sequence classification
+SKIPPED [1] tests/causal_lm_tester.py:355: Model does not support sequence classification
+SKIPPED [1] tests/test_modeling_common.py:3476: Model does not support sliding window mask
+SKIPPED [1] tests/causal_lm_tester.py:387: Model does not support token classification
+SKIPPED [1] tests/test_modeling_common.py:3530: test is slow
+SKIPPED [1] tests/test_modeling_common.py:3580: test is slow
+SKIPPED [1] tests/test_modeling_common.py:4042: Model does not have a TP plan.
+SKIPPED [1] tests/test_modeling_common.py:3896: No subconfigs so the test does not make sense
+SKIPPED [1] tests/models/afmoe/test_modeling_afmoe.py:119: Afmoe has moe, output can be different
+SKIPPED [1] tests/test_modeling_common.py:2492: test requires multiple accelerators
+SKIPPED [1] tests/models/afmoe/test_modeling_afmoe.py:115: Afmoe  applies key/query norm which doesn't work with packing
+FAILED tests/models/afmoe/test_modeling_afmoe.py::AfmoeModelTest::test_flex_attention_with_grads - torch._inductor.exc.InductorError: RuntimeError: No valid triton configs. OutOfMemoryError: out of resource: triton_tem_fused_0 Required: 147968 Hardware limit:101376 Reducing block sizes or `num_stages` may help.
+
+Set TORCHDYNAMO_VERBOSE=1 for the internal stack trace (please do this especially if you're reporting a bug to PyTorch). For even more developer context, set TORCH_LOGS="+dynamo"
+======= 1 failed, 83 passed, 107 skipped, 9 warnings in 73.49s (0:01:13) =======


### PR DESCRIPTION
# What does this PR do?


Fixes #42454 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@zucchini-nlp  @Rocketknight1 @mobicham 

Benchmarking script  - 
```python
import torch
import time
import numpy as np
from transformers import WhisperForConditionalGeneration
from transformers.cache_utils import StaticCache, EncoderDecoderCache


MODEL_ID = "openai/whisper-tiny"
DTYPE = torch.float16 if torch.cuda.is_available() else torch.float32
DEVICE = "cuda" if torch.cuda.is_available() else "cpu"

MAX_BATCH_SIZE = 64
TEST_BATCHES = [1, 8, 32, 64]

SEQ_LEN = 128
WARMUP = 10
REPEATS = 50


def load_model():
    model = WhisperForConditionalGeneration.from_pretrained(
        MODEL_ID,
        torch_dtype=DTYPE,
        attn_implementation="sdpa",
    ).to(DEVICE)
    model.eval()
    return model


def run_benchmark(model, batch_size, cache_cap, tag):
    decoder = model.model.decoder
    cache_len = SEQ_LEN + 10
    enc_len = SEQ_LEN

    self_cache = StaticCache(
        config=decoder.config,
        max_batch_size=cache_cap,
        max_cache_len=cache_len,
        device=DEVICE,
        dtype=DTYPE,
    )
    cross_cache = StaticCache(
        config=decoder.config,
        max_batch_size=cache_cap,
        max_cache_len=enc_len,
        device=DEVICE,
        dtype=DTYPE,
    )
    kv_cache = EncoderDecoderCache(self_cache, cross_cache)

    input_ids = torch.randint(0, 1000, (batch_size, SEQ_LEN), device=DEVICE)
    encoder_states = torch.randn(batch_size, enc_len, model.config.d_model, device=DEVICE, dtype=DTYPE)
    cache_pos = torch.arange(SEQ_LEN, device=DEVICE)

    for _ in range(WARMUP):
        kv_cache.reset()
        with torch.no_grad():
            decoder(
                input_ids=input_ids,
                encoder_hidden_states=encoder_states,
                past_key_values=kv_cache,
                cache_position=cache_pos,
                use_cache=True,
            )

    # actual runs
    start = [torch.cuda.Event(enable_timing=True) for _ in range(REPEATS)]
    end = [torch.cuda.Event(enable_timing=True) for _ in range(REPEATS)]

    torch.cuda.synchronize()

    for i in range(REPEATS):
        kv_cache.reset()
        start[i].record()

        with torch.no_grad():
            decoder(
                input_ids=input_ids,
                encoder_hidden_states=encoder_states,
                past_key_values=kv_cache,
                cache_position=cache_pos,
                use_cache=True,
            )

        end[i].record()

    torch.cuda.synchronize()
    times = [s.elapsed_time(e) for s, e in zip(start, end)]
    avg = float(np.mean(times))

    print(f"[{tag}]  batch={batch_size:2d}  cache_cap={cache_cap:2d}  latency={avg:.2f} ms")
    return avg



model = load_model()

results = []

for bs in TEST_BATCHES:
    base = run_benchmark(model, batch_size=bs, cache_cap=bs, tag="BASELINE")
    sliced = run_benchmark(model, batch_size=bs, cache_cap=MAX_BATCH_SIZE, tag="SLICED")
    diff = (sliced - base) / base * 100
    results.append((bs, base, sliced, diff))

print("Summary:")
print(f"{'Batch':<8} | {'Baseline (ms)':<15} | {'Sliced (ms)':<15} | Diff (%)")
for bs, base, sliced, diff in results:
    print(f"{bs:<8} | {base:<15.2f} | {sliced:<15.2f} | {diff:+.2f}%")
```
