### PR TITLE
Fix minor bugs in ConversionOps and WeightConverter

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -105,7 +105,10 @@ class ConversionOps:
     """Base class for weight conversion operations."""
 
     def __repr__(self):
-        return f"{self.__class__.__name__}(dim={self.dim})"
+        if hasattr(self, "dim"):
+            return f"{self.__class__.__name__}(dim={self.dim})"
+        else:
+            return f"{self.__class__.__name__}"
 
     @abstractmethod
     def convert(
@@ -435,6 +438,7 @@ class WeightConverter(WeightTransform):
                     source_patterns=self.source_patterns,
                     target_patterns=self.target_patterns,
                     # Additional kwargs, ususally not used
+                    full_layer_name=layer_name,
                     model=model,
                     config=config,
                     missing_keys=missing_keys,
@@ -448,7 +452,6 @@ class WeightConverter(WeightTransform):
         prefix, _, suffix = next(full_name.partition(k) for k in collected_tensors.keys() if k in full_name)
         # Rename the tensors
         collected_tensors = {prefix + k + suffix: v for k, v in collected_tensors.items()}
-
         if hf_quantizer is not None and self.quantization_operation is not None:
             with log_to_misc(layer_name, misc, (collected_tensors, layer_name), self.quantization_operation):
                 collected_tensors = self.quantization_operation.convert(

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -75,14 +75,13 @@ class Bnb4bitDeserialize(ConversionOps):
         Deserialization of bnb keys. We need 6 keys to recreate the quantized weights
         """
         if len(input_dict) == 1:
-            # special case when we only fetched the weight
-            # since we collected keys, we need to return it like that
-            return {full_layer_name: input_dict["weight"]}
+            return input_dict
 
         for key, value in input_dict.items():
             if isinstance(value, list):
                 input_dict[key] = value[0]
 
+        key_weight = "weight"
         weight = input_dict.pop("weight")
         module, _ = get_module_from_name(model, full_layer_name)
         new_value = bnb.nn.Params4bit.from_prequantized(
@@ -93,7 +92,7 @@ class Bnb4bitDeserialize(ConversionOps):
             module=module,
         )
         module._is_hf_initialized = True
-        return {full_layer_name: new_value}
+        return {key_weight: new_value}
 
 
 class Bnb8bitQuantize(ConversionOps):
@@ -140,7 +139,7 @@ class Bnb8bitDeserialize(ConversionOps):
         if len(input_dict) == 1:
             # special case when we only fetched the weight
             # since we collected keys, we need to return it like that
-            return {full_layer_name: input_dict["weight"]}
+            return input_dict
 
         for key, value in input_dict.items():
             if isinstance(value, list):
@@ -148,12 +147,13 @@ class Bnb8bitDeserialize(ConversionOps):
 
         module, _ = get_module_from_name(model, full_layer_name)
 
-        weight = input_dict["weight"]
+        key_weight = "weight"
+        weight = input_dict[key_weight]
         kwargs = model.get_parameter_or_buffer(full_layer_name).__dict__
         kwargs["SCB"] = input_dict["SCB"]
         new_value = bnb.nn.Int8Params(weight, requires_grad=False, **kwargs).to(weight.device)
         module._is_hf_initialized = True
-        return {full_layer_name: new_value}
+        return {key_weight: new_value}
 
 
 def _replace_with_bnb_linear(

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -82,7 +82,7 @@ class Bnb4bitDeserialize(ConversionOps):
                 input_dict[key] = value[0]
 
         key_weight = "weight"
-        weight = input_dict.pop("weight")
+        weight = input_dict.pop(key_weight)
         module, _ = get_module_from_name(model, full_layer_name)
         new_value = bnb.nn.Params4bit.from_prequantized(
             data=weight,

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -579,7 +579,6 @@ class Fp8Quantize(ConversionOps):
 
     def __init__(self, hf_quantizer):
         self.hf_quantizer = hf_quantizer
-        self.reverse_op = Fp8Dequantize
 
     def convert(self, input_dict: torch.Tensor, **kwargs) -> dict[str, torch.Tensor]:
         # Unpack single key/value (value may be wrapped in a list)
@@ -655,7 +654,6 @@ class Fp8Dequantize(ConversionOps):
 
     def __init__(self, block_size: tuple[int, int] | None = None):
         self.block_size = block_size
-        self.reverse_op = Fp8Quantize
 
     def convert(
         self,

--- a/src/transformers/models/gpt2/tokenization_gpt2.py
+++ b/src/transformers/models/gpt2/tokenization_gpt2.py
@@ -101,7 +101,7 @@ class GPT2Tokenizer(TokenizersBackend):
         bos_token="<|endoftext|>",
         eos_token="<|endoftext|>",
         pad_token=None,
-        add_prefix_space=True,
+        add_prefix_space=False,
         add_bos_token=False,
         vocab: Optional[dict] = None,
         merges: Optional[list] = None,

--- a/src/transformers/models/gpt2/tokenization_gpt2.py
+++ b/src/transformers/models/gpt2/tokenization_gpt2.py
@@ -101,7 +101,7 @@ class GPT2Tokenizer(TokenizersBackend):
         bos_token="<|endoftext|>",
         eos_token="<|endoftext|>",
         pad_token=None,
-        add_prefix_space=False,
+        add_prefix_space=True,
         add_bos_token=False,
         vocab: Optional[dict] = None,
         merges: Optional[list] = None,


### PR DESCRIPTION
# What does this PR do?

This fixes a couple of minor details in ConversionOps and WeightConverter. We still need to pass `full_layer_name` as we won't be able to get the module otherwise. Also dim is not always defined, so the __repr__ was failing.

cc @Cyrilvallez for vis