### PR TITLE
Fix gpt2 tokenizer `add_prefix_space` default value 

### DIFF
--- a/src/transformers/models/gpt2/tokenization_gpt2.py
+++ b/src/transformers/models/gpt2/tokenization_gpt2.py
@@ -101,7 +101,7 @@ class GPT2Tokenizer(TokenizersBackend):
         bos_token="<|endoftext|>",
         eos_token="<|endoftext|>",
         pad_token=None,
-        add_prefix_space=True,
+        add_prefix_space=False,
         add_bos_token=False,
         vocab: Optional[dict] = None,
         merges: Optional[list] = None,


### PR DESCRIPTION
# What does this PR do?

This PR fixes a regression wrt gpt2 tokenizer. `add_prefix_space` should be `False`, not sure if there are other regression like that cc @itazap 