### PR TITLE
Fix kernel mapping bug when multiple devices exist (Issue #42451)

### DIFF
--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -61,15 +61,15 @@ def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
         raise ValueError(f"Only cuda, rocm, xpu and npu devices supported, got: {device}")
     repo_layer_name = repo_name.split(":")[1]
     repo_id = repo_name.split(":")[0]
-    
+
     # Initialise layer_name entry if it doesn't exist
     if layer_name not in compatible_mapping:
         compatible_mapping[layer_name] = {}
-    
+
     # Initialise device entry if it doesn't exist
     if device not in compatible_mapping[layer_name]:
         compatible_mapping[layer_name][device] = {}
-    
+
     # Add the mode entry (this can overwrite if mode already exists, which is fine)
     compatible_mapping[layer_name][device][mode] = LayerRepository(
         repo_id=repo_id,

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -61,14 +61,20 @@ def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
         raise ValueError(f"Only cuda, rocm, xpu and npu devices supported, got: {device}")
     repo_layer_name = repo_name.split(":")[1]
     repo_id = repo_name.split(":")[0]
-    compatible_mapping[layer_name] = {
-        device: {
-            mode: LayerRepository(
-                repo_id=repo_id,
-                layer_name=repo_layer_name,
-            )
-        }
-    }
+    
+    # Initialise layer_name entry if it doesn't exist
+    if layer_name not in compatible_mapping:
+        compatible_mapping[layer_name] = {}
+    
+    # Initialise device entry if it doesn't exist
+    if device not in compatible_mapping[layer_name]:
+        compatible_mapping[layer_name][device] = {}
+    
+    # Add the mode entry (this can overwrite if mode already exists, which is fine)
+    compatible_mapping[layer_name][device][mode] = LayerRepository(
+        repo_id=repo_id,
+        layer_name=repo_layer_name,
+    )
 
 
 class KernelConfig(PushToHubMixin):

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -315,58 +315,68 @@ class TestKernelUtilities(TestCasePlus):
             _KERNEL_MODULE_MAPPING.pop(name, None)
 
     def test_add_to_mapping_multiple_devices(self):
-        """Test that add_to_mapping preserves multiple devices for the same layer_name."""
+        """Test that add_to_mapping preserves multiple devices for the same layer_name."""  # noqa: E501
         compatible_mapping = {}
-        
+
         # Add cuda device
-        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
-        
+        add_to_mapping(
+            "RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping
+        )
+
         # Add rocm device - should NOT overwrite cuda
-        add_to_mapping("RMSNorm", "rocm", "repo:layer", Mode.INFERENCE, compatible_mapping)
-        
+        add_to_mapping(
+            "RMSNorm", "rocm", "repo:layer", Mode.INFERENCE, compatible_mapping
+        )
+
         # Verify both devices exist
         self.assertIn("cuda", compatible_mapping["RMSNorm"])
         self.assertIn("rocm", compatible_mapping["RMSNorm"])
-        
+
         # Verify the structure is correct
         self.assertIn(Mode.INFERENCE, compatible_mapping["RMSNorm"]["cuda"])
         self.assertIn(Mode.INFERENCE, compatible_mapping["RMSNorm"]["rocm"])
-        
+
         # Verify LayerRepository objects are created correctly
         cuda_repo = compatible_mapping["RMSNorm"]["cuda"][Mode.INFERENCE]
         rocm_repo = compatible_mapping["RMSNorm"]["rocm"][Mode.INFERENCE]
-        self.assertEqual(cuda_repo.repo_id, "repo")
+        self.assertEqual(cuda_repo._repo_id, "repo")
         self.assertEqual(cuda_repo.layer_name, "layer")
-        self.assertEqual(rocm_repo.repo_id, "repo")
+        self.assertEqual(rocm_repo._repo_id, "repo")
         self.assertEqual(rocm_repo.layer_name, "layer")
 
     def test_add_to_mapping_single_device(self):
         """Test that add_to_mapping works correctly with a single device."""
         compatible_mapping = {}
-        
+
         # Add single device
-        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
-        
+        add_to_mapping(
+            "RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping
+        )
+
         # Verify structure
         self.assertIn("RMSNorm", compatible_mapping)
         self.assertIn("cuda", compatible_mapping["RMSNorm"])
         self.assertIn(Mode.INFERENCE, compatible_mapping["RMSNorm"]["cuda"])
-        
+
         # Verify LayerRepository object
         repo = compatible_mapping["RMSNorm"]["cuda"][Mode.INFERENCE]
-        self.assertEqual(repo.repo_id, "repo")
+        self.assertEqual(repo._repo_id, "repo")
         self.assertEqual(repo.layer_name, "layer")
 
     def test_add_to_mapping_multiple_modes(self):
-        """Test that add_to_mapping can handle multiple modes for the same device."""
+        """Test that add_to_mapping can handle multiple modes for the same device."""  # noqa: E501
         compatible_mapping = {}
-        
+
         # Add inference mode
-        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
-        
+        add_to_mapping(
+            "RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping
+        )
+
         # Add training mode - should NOT overwrite inference
-        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.TRAINING, compatible_mapping)
-        
+        add_to_mapping(
+            "RMSNorm", "cuda", "repo:layer", Mode.TRAINING, compatible_mapping
+        )
+
         # Verify both modes exist
         self.assertIn(Mode.INFERENCE, compatible_mapping["RMSNorm"]["cuda"])
         self.assertIn(Mode.TRAINING, compatible_mapping["RMSNorm"]["cuda"])

--- a/tests/kernels/test_kernels.py
+++ b/tests/kernels/test_kernels.py
@@ -27,7 +27,6 @@ from transformers.integrations.hub_kernels import (
     lazy_load_kernel,
     load_and_register_attn_kernel,
 )
-from transformers.utils.kernel_config import add_to_mapping
 from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
 from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
 from transformers.testing_utils import (
@@ -39,6 +38,7 @@ from transformers.testing_utils import (
     torch_device,
 )
 from transformers.utils.import_utils import is_kernels_available
+from transformers.utils.kernel_config import add_to_mapping
 
 
 if is_kernels_available():
@@ -319,14 +319,10 @@ class TestKernelUtilities(TestCasePlus):
         compatible_mapping = {}
 
         # Add cuda device
-        add_to_mapping(
-            "RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping
-        )
+        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
 
         # Add rocm device - should NOT overwrite cuda
-        add_to_mapping(
-            "RMSNorm", "rocm", "repo:layer", Mode.INFERENCE, compatible_mapping
-        )
+        add_to_mapping("RMSNorm", "rocm", "repo:layer", Mode.INFERENCE, compatible_mapping)
 
         # Verify both devices exist
         self.assertIn("cuda", compatible_mapping["RMSNorm"])
@@ -349,9 +345,7 @@ class TestKernelUtilities(TestCasePlus):
         compatible_mapping = {}
 
         # Add single device
-        add_to_mapping(
-            "RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping
-        )
+        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
 
         # Verify structure
         self.assertIn("RMSNorm", compatible_mapping)
@@ -368,14 +362,10 @@ class TestKernelUtilities(TestCasePlus):
         compatible_mapping = {}
 
         # Add inference mode
-        add_to_mapping(
-            "RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping
-        )
+        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
 
         # Add training mode - should NOT overwrite inference
-        add_to_mapping(
-            "RMSNorm", "cuda", "repo:layer", Mode.TRAINING, compatible_mapping
-        )
+        add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.TRAINING, compatible_mapping)
 
         # Verify both modes exist
         self.assertIn(Mode.INFERENCE, compatible_mapping["RMSNorm"]["cuda"])


### PR DESCRIPTION
# Fix kernel mapping bug when multiple devices exist (Issue #42451)

Fixes #42451

## Summary

Fixes issue #42451 where `add_to_mapping()` would overwrite existing device entries when `kernel_mapping` contained multipl
same layer (e.g., both "cuda" and "rocm").

## Problem

When `kernel_mapping` contains multiple devices for the same layer, calling `add_to_mapping()` repeatedly would overwrite t
entry instead of adding to it. This occurred because the function was completely replacing `compatible_mapping[layer_name]`

**Example of the bug:**
```python
# Before fix: second call overwrites the first
add_to_mapping("RMSNorm", "cuda", "repo:layer", Mode.INFERENCE, compatible_mapping)
add_to_mapping("RMSNorm", "rocm", "repo:layer", Mode.INFERENCE, compatible_mapping)
# Result: only "rocm" exists, "cuda" was lost
```

## Solution

Updated `add_to_mapping()` to check if `layer_name` and `device` entries already exist before overwriting. The function now
1. Initialises the `layer_name` entry if it doesn't exist
2. Initialises the `device` entry if it doesn't exist  
3. Adds the mode entry (which can overwrite if mode already exists, which is fine)

This ensures all devices are preserved in the `compatible_mapping` structure.

## Changes

- **Modified**: `src/transformers/utils/kernel_config.py`
  - Updated `add_to_mapping()` function to preserve existing device entries
  
- **Added**: `tests/kernels/test_kernels.py`
  - `test_add_to_mapping_multiple_devices`: Verifies multiple devices are preserved
  - `test_add_to_mapping_single_device`: Ensures backward compatibility
  - `test_add_to_mapping_multiple_modes`: Verifies multiple modes work correctly

## Testing

All tests pass:
- `test_add_to_mapping_multiple_devices` - PASSED
- `test_add_to_mapping_multiple_modes` - PASSED
- `test_add_to_mapping_single_device` - PASSED
- All existing tests in `TestKernelUtilities` - PASSED

