### PR TITLE
Fix PEFT gradient checkpointing with frozen input embeddings

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2875,7 +2875,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # When using PEFT via `get_peft_model`, `_hf_peft_config_loaded` is False.
             # We check if input embeddings are frozen. If they are, we must enable input grads
             # for gradient checkpointing to work.
-            input_embeddings = self.get_input_embeddings()
+            try:
+                input_embeddings = self.get_input_embeddings()
+            except (NotImplementedError, AttributeError):
+                input_embeddings = None
             if input_embeddings is not None:
                 for param in input_embeddings.parameters():
                     if not param.requires_grad:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2871,6 +2871,17 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # the gradients to make sure the gradient flows.
             self.enable_input_require_grads()
 
+        else:
+            # When using PEFT via `get_peft_model`, `_hf_peft_config_loaded` is False.
+            # We check if input embeddings are frozen. If they are, we must enable input grads
+            # for gradient checkpointing to work.
+            input_embeddings = self.get_input_embeddings()
+            if input_embeddings is not None:
+                for param in input_embeddings.parameters():
+                    if not param.requires_grad:
+                        self.enable_input_require_grads()
+                        break
+
     def _set_gradient_checkpointing(self, enable: bool = True, gradient_checkpointing_func: Callable = checkpoint):
         is_gradient_checkpointing_set = False
 


### PR DESCRIPTION
error: #42489
I have added a fallback check in gradient_checkpointing_enable, if the PEFT flag is missing, the code now checks if the input embeddings are frozen. If they are, it explicitly calls enable_input_require_grads().

@qgallouedec 