### PR TITLE
Add `skip_post_init` flag

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1259,7 +1259,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         self._no_split_modules = self._no_split_modules or []
         _CAN_RECORD_REGISTRY[str(self.__class__)] = self._can_record_outputs  # added for executorch support only
-        
+
     def post_init(self):
         """
         A method executed at the end of each Transformer model initialization, to execute code that needs the model's


### PR DESCRIPTION
# What does this PR do?

This PR adds a `skip_post_init` parameter to `PreTrainedModel.from_pretrained()` to allow users to skip the post-initialization step that reinitializes model weights. This is essential for users who subclass models with custom parameters and want to preserve their initialization.

When users subclass HuggingFace models (e.g., `Qwen2VLForConditionalGeneration`) and add custom parameters initialized in their `__init__()`, the initialization gets silently overwritten by `post_init()` which calls `_init_weights()` .


Fixes #42418 


## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests? Let me know if additional tests are needed. 


## Who can review?

@ArthurZucker @Cyrilvallez 