### PR TITLE
Fix `pr_build_doc_with_comment.yml` not reporting correctly

### DIFF
--- a/.github/workflows/pr_build_doc_with_comment.yml
+++ b/.github/workflows/pr_build_doc_with_comment.yml
@@ -110,7 +110,7 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      STATUS_OK: ${{ contains(fromJSON('["skipped", "success"]'), needs.create_run.result) }}
+      STATUS_OK: ${{ contains(fromJSON('["skipped", "success"]'), needs.build-doc.result) }}
     steps:
       - name: Get `build-doc` job status
         run: |


### PR DESCRIPTION
# What does this PR do?

The condition that determines if the run is ok or not uses the wrong job, so the reported comment was wrong.