### PR TITLE
[loading] `tie_weights` is finally symmetric

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2295,7 +2295,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         tied_keys = list(tied_keys.items())
         for i, (target_param_name, source_param_name) in enumerate(tied_keys):
-            # If both source and target are missing later, we may need to tie 2 weights
+            # If both source and target are missing later, we may need to tie 2 weights so we use a list here
             target_param_names = [target_param_name]
             # This is `from_pretrained` -> let's check symmetrically
             if missing_keys is not None:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2297,6 +2297,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         for i, (target_param_name, source_param_name) in enumerate(tied_keys):
             # If both source and target are missing later, we may need to tie 2 weights so we use a list here
             target_param_names = [target_param_name]
+
             # This is `from_pretrained` -> let's check symmetrically
             if missing_keys is not None:
                 source_is_there = source_param_name not in missing_keys

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2338,8 +2338,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                         # test loading model from empty dicts to perform init checks
                         logger.warning(
                             f"This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie "
-                            f"{source_param_name} to {target_param_name}, but both are absent from the checkpoints, "
-                            "and we could not find another related tie weights for those keys"
+                            f"{source_param_name} to {target_param_name}, but both are absent from the checkpoint, "
+                            "and we could not find another related tied weight for those keys"
                         )
 
             # Perform the actual tying

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2334,7 +2334,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                                 break
                     # If we did not break from the loop, it was impossible to find a source key -> let's raise
                     else:
-                        raise ValueError(
+                        # TODO Cyril: here ideally we want to raise instead of warning, but will break our CI as we have
+                        # test loading model from empty dicts to perform init checks
+                        logger.warning(
                             f"This checkpoint seem corrupted. The tied weights mapping for this model specifies to tie "
                             f"{source_param_name} to {target_param_name}, but both are absent from the checkpoints, "
                             "and we could not find another related tie weights for those keys"

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2336,7 +2336,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                     # If we did not break from the loop, it was impossible to find a source key -> let's raise
                     else:
                         # TODO Cyril: here ideally we want to raise instead of warning, but will break our CI as we have
-                        # test loading model from empty dicts to perform init checks - since we don't raise, add a flag
+                        # tests loading model from empty dicts to perform init checks - since we don't raise, add a flag
                         # to NOT remove from missing keys as it's actually still missing
                         remove_from_missing = False
                         logger.warning(

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -897,21 +897,6 @@ class BartModel(BartPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys: Optional[set[str]] = None, recompute_mapping: bool = True):
-        """We need to overload here to handle the wrong key saved in some main checkpoints."""
-        if self.config.tie_word_embeddings:
-            # Some model checkpoints like "facebook/bart-large-cnn"'s embedding weight is in decoder.embed_tokens,
-            # need check here, see issue #36247
-            if missing_keys is not None:
-                if "shared.weight" in missing_keys and "decoder.embed_tokens.weight" not in missing_keys:
-                    self.encoder.embed_tokens.weight = self.decoder.embed_tokens.weight
-                    self.shared.weight = self.decoder.embed_tokens.weight
-                    missing_keys.discard("encoder.embed_token.weight")
-                    missing_keys.discard("shared.weight")
-
-        # needs to be done after, otherwise it raises an Error because the correct weights are not present
-        super().tie_weights(missing_keys=missing_keys, recompute_mapping=recompute_mapping)
-
     def get_input_embeddings(self):
         return self.shared
 
@@ -1048,21 +1033,6 @@ class BartForConditionalGeneration(BartPreTrainedModel, GenerationMixin):
 
         # Initialize weights and apply final processing
         self.post_init()
-
-    def tie_weights(self, missing_keys: Optional[set[str]] = None, recompute_mapping: bool = True):
-        """We need to overload here to handle the wrong key saved in some main checkpoints."""
-        if self.config.tie_word_embeddings:
-            # Some model checkpoints like "facebook/bart-large-cnn"'s embedding weight is in decoder.embed_tokens,
-            # need check here, see issue #36247
-            if missing_keys is not None:
-                if "model.shared.weight" in missing_keys and "model.decoder.embed_tokens.weight" not in missing_keys:
-                    self.model.encoder.embed_tokens.weight = self.model.decoder.embed_tokens.weight
-                    self.model.shared.weight = self.model.decoder.embed_tokens.weight
-                    missing_keys.discard("model.encoder.embed_token.weight")
-                    missing_keys.discard("model.shared.weight")
-
-        # needs to be done after, otherwise it raises an Error because the correct weights are not present
-        super().tie_weights(missing_keys=missing_keys, recompute_mapping=recompute_mapping)
 
     def resize_token_embeddings(
         self, new_num_tokens: int, pad_to_multiple_of: Optional[int] = None, mean_resizing: bool = True
@@ -1242,21 +1212,6 @@ class BartForSequenceClassification(BartPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    def tie_weights(self, missing_keys: Optional[set[str]] = None, recompute_mapping: bool = True):
-        """We need to overload here to handle the wrong key saved in some main checkpoints."""
-        if self.config.tie_word_embeddings:
-            # Some model checkpoints like "facebook/bart-large-cnn"'s embedding weight is in decoder.embed_tokens,
-            # need check here, see issue #36247
-            if missing_keys is not None:
-                if "model.shared.weight" in missing_keys and "model.decoder.embed_tokens.weight" not in missing_keys:
-                    self.model.encoder.embed_tokens.weight = self.model.decoder.embed_tokens.weight
-                    self.model.shared.weight = self.model.decoder.embed_tokens.weight
-                    missing_keys.discard("model.encoder.embed_token.weight")
-                    missing_keys.discard("model.shared.weight")
-
-        # needs to be done after, otherwise it raises an Error because the correct weights are not present
-        super().tie_weights(missing_keys=missing_keys, recompute_mapping=recompute_mapping)
-
     @auto_docstring
     def forward(
         self,
@@ -1387,21 +1342,6 @@ class BartForQuestionAnswering(BartPreTrainedModel):
 
         # Initialize weights and apply final processing
         self.post_init()
-
-    def tie_weights(self, missing_keys: Optional[set[str]] = None, recompute_mapping: bool = True):
-        """We need to overload here to handle the wrong key saved in some main checkpoints."""
-        if self.config.tie_word_embeddings:
-            # Some model checkpoints like "facebook/bart-large-cnn"'s embedding weight is in decoder.embed_tokens,
-            # need check here, see issue #36247
-            if missing_keys is not None:
-                if "model.shared.weight" in missing_keys and "model.decoder.embed_tokens.weight" not in missing_keys:
-                    self.model.encoder.embed_tokens.weight = self.model.decoder.embed_tokens.weight
-                    self.model.shared.weight = self.model.decoder.embed_tokens.weight
-                    missing_keys.discard("model.encoder.embed_token.weight")
-                    missing_keys.discard("model.shared.weight")
-
-        # needs to be done after, otherwise it raises an Error because the correct weights are not present
-        super().tie_weights(missing_keys=missing_keys, recompute_mapping=recompute_mapping)
 
     @auto_docstring
     def forward(

--- a/tests/models/openai/test_modeling_openai.py
+++ b/tests/models/openai/test_modeling_openai.py
@@ -269,13 +269,6 @@ class OpenAIGPTModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         model = OpenAIGPTModel.from_pretrained(model_name)
         self.assertIsNotNone(model)
 
-    @unittest.skip("Tied weights mapping is reversed, so this is supposed to error out")
-    def test_correct_missing_keys(self):
-        # openai defines `_tied_weights_keys = {"transformer.tokens_embed.weight": "lm_head.weight"}` instead
-        # of the usual `_tied_weights_keys = {"lm_head.weight": "transformer.tokens_embed.weight"}`, so removing
-        # the head parameters actually removes the source weight, so this test is supposed to fail
-        pass
-
 
 @require_torch
 class OPENAIGPTModelLanguageGenerationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

As per the title. This makes `tie_weights` work fully symmetrically, even in cases where one weight is tied between more than 2 keys.
This will hopefully end the pain of all models checkpoints having the saved weight in the "wrong" key.

This fixes several opened issues: https://github.com/huggingface/transformers/issues/42313 (though we still have an issue with the tokenizer here apparently), https://github.com/huggingface/transformers/issues/42460 and I think others that I lost track of.

Note: for `facebook/bart-large` bart checkpoint, all 3 tied weight keys are explicitly present in the safetensors checkpoint. So according to this PR, they are not tied anymore (with a warning), whereas they would be anyway before. IMO this is fine as if they are in the checkpoints, they were not tied when saved. We could introduce a value check if both source and targets are present and still tie if everything is equal, but I think this is too expensive and too niche to add for now. We may consider doing it if we notice this is more frequent so those `bart` checkpoints