### PR TITLE
Delete irrelevant test that sometimes fails

### DIFF
--- a/tests/models/bert_japanese/test_tokenization_bert_japanese.py
+++ b/tests/models/bert_japanese/test_tokenization_bert_japanese.py
@@ -448,24 +448,3 @@ class AutoTokenizerCustomTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(EXAMPLE_BERT_JAPANESE_ID)
         self.assertIsInstance(tokenizer, BertJapaneseTokenizer)
 
-
-class BertTokenizerMismatchTest(unittest.TestCase):
-    def test_tokenizer_mismatch_warning(self):
-        EXAMPLE_BERT_JAPANESE_ID = "cl-tohoku/bert-base-japanese"
-        with self.assertLogs("transformers", level="WARNING") as cm:
-            BertTokenizer.from_pretrained(EXAMPLE_BERT_JAPANESE_ID)
-            self.assertTrue(
-                cm.records[0].message.startswith(
-                    "The tokenizer class you load from this checkpoint is not the same type as the class this function"
-                    " is called from."
-                )
-            )
-        EXAMPLE_BERT_ID = "google-bert/bert-base-cased"
-        with self.assertLogs("transformers", level="WARNING") as cm:
-            BertJapaneseTokenizer.from_pretrained(EXAMPLE_BERT_ID)
-            self.assertTrue(
-                cm.records[0].message.startswith(
-                    "The tokenizer class you load from this checkpoint is not the same type as the class this function"
-                    " is called from."
-                )
-            )

--- a/tests/models/bert_japanese/test_tokenization_bert_japanese.py
+++ b/tests/models/bert_japanese/test_tokenization_bert_japanese.py
@@ -19,7 +19,6 @@ import tempfile
 import unittest
 
 from transformers import AutoTokenizer
-from transformers.models.bert.tokenization_bert import BertTokenizer
 from transformers.models.bert_japanese.tokenization_bert_japanese import (
     VOCAB_FILES_NAMES,
     BertJapaneseTokenizer,
@@ -447,4 +446,3 @@ class AutoTokenizerCustomTest(unittest.TestCase):
         EXAMPLE_BERT_JAPANESE_ID = "cl-tohoku/bert-base-japanese"
         tokenizer = AutoTokenizer.from_pretrained(EXAMPLE_BERT_JAPANESE_ID)
         self.assertIsInstance(tokenizer, BertJapaneseTokenizer)
-

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -89,12 +89,6 @@ class PreTrainedTokenizationFastTest(unittest.TestCase):
     @unittest.skip(
         "We disable this test for PreTrainedTokenizerFast because it is the only tokenizer that is not linked to any model"
     )
-    def test_tokenizer_mismatch_warning(self):
-        pass
-
-    @unittest.skip(
-        "We disable this test for PreTrainedTokenizerFast because it is the only tokenizer that is not linked to any model"
-    )
     def test_encode_decode_with_spaces(self):
         pass
 


### PR DESCRIPTION
`test_tokenizer_mismatch_warning` is causing errors in `BertJapanese`. This test has been removed in the main tokenizer classes now, and I don't think it tests anything useful anymore. I also remove the skip for it in `test_tokenizer_fast` because there's nothing to skip anymore!