### PR TITLE
Add torch compile to CB

### DIFF
--- a/benchmark_v2/framework/benchmark_config.py
+++ b/benchmark_v2/framework/benchmark_config.py
@@ -103,9 +103,9 @@ class BenchmarkConfig:
 
         # The combination of flash_attention_2, compile and generate is not supported # FIXME: support it
         if (
-            not self.continuous_batching and
-            self.attn_implementation == "flash_attention_2" and
-            self.compile_config is not None
+            not self.continuous_batching
+            and self.attn_implementation == "flash_attention_2"
+            and self.compile_config is not None
         ):
             logger.error(
                 "The combination of flash_attention_2, compile and generate is not supported. Turning off compile."
@@ -121,9 +121,9 @@ class BenchmarkConfig:
 
         # Continuous batching supports compile mode "default" or "max-autotune-no-cudagraphs"
         if (
-            self.continuous_batching and
-            self.compile_config is not None and
-            self.compile_config.mode not in ["default", "max-autotune-no-cudagraphs"]
+            self.continuous_batching
+            and self.compile_config is not None
+            and self.compile_config.mode not in ["default", "max-autotune-no-cudagraphs"]
         ):
             logger.error(
                 f"You have continuous batching and compile enabled, but {self.compile_config.mode = } is not supported."

--- a/benchmark_v2/framework/benchmark_config.py
+++ b/benchmark_v2/framework/benchmark_config.py
@@ -79,7 +79,14 @@ class BenchmarkConfig:
         # Generation parameters
         self.attn_implementation = attn_implementation
         # Optimization parameters
-        self.compile_config = CompileConfig(**compile_kwargs) if compile_kwargs is not None else None
+        if compile_kwargs is None:
+            self.compile_config = None
+        else:
+            default_compile_kwargs = {
+                "mode": "max-autotune-no-cudagraphs" if continuous_batching else "default",
+                "fullgraph": True,
+            }
+            self.compile_config = CompileConfig(**default_compile_kwargs.update(compile_kwargs))
         self.kernelize = kernelize
         # Constant parameters
         self.dtype = "torch.bfloat16"

--- a/benchmark_v2/framework/benchmark_config.py
+++ b/benchmark_v2/framework/benchmark_config.py
@@ -5,6 +5,7 @@ import logging
 from functools import lru_cache
 from typing import Any
 
+from transformers.generation.configuration_utils import CompileConfig
 from transformers.utils.import_utils import is_flash_attn_2_available, is_kernels_available
 
 
@@ -61,8 +62,7 @@ class BenchmarkConfig:
         sequence_length: int = 128,
         num_tokens_to_generate: int = 128,
         attn_implementation: str = "eager",
-        compile_mode: str | None = None,
-        compile_options: dict[str, Any] | None = None,
+        compile_kwargs: dict[str, Any] | None = None,
         kernelize: bool = False,
         name: str | None = None,
         skip_validity_check: bool = False,
@@ -79,8 +79,7 @@ class BenchmarkConfig:
         # Generation parameters
         self.attn_implementation = attn_implementation
         # Optimization parameters
-        self.compile_mode = compile_mode
-        self.compile_options = compile_options if compile_options is not None else {}
+        self.compile_config = CompileConfig(**compile_kwargs) if compile_kwargs is not None else None
         self.kernelize = kernelize
         # Constant parameters
         self.dtype = "torch.bfloat16"
@@ -92,22 +91,29 @@ class BenchmarkConfig:
     def check_validity(self, skip_validity_check: bool = False) -> None:
         if skip_validity_check:
             return
-        # Check FA is installed
-        is_fa = self.attn_implementation == "flash_attention_2"
-        if is_fa and not is_fa2_or_kernel_available():
+
+        # If flash_attention_2 is selected but not available, default to SDPA
+        if self.attn_implementation == "flash_attention_2" and not is_fa2_or_kernel_available():
             logger.warning("Flash attention is not available. Defaulting to SDPA.")
             self.attn_implementation = "sdpa"
-        # Flash attention does not support compile mode, so we turn it off # FIXME: it would be better to support it
-        if is_fa and self.compile_mode is not None:
-            logger.warning("Flash attention does not support compile mode. Turning off compile mode.")
-            self.compile_mode = None
-        # Handle continuous batching cases
-        if self.continuous_batching:
-            if self.attn_implementation == "flex_attention":
-                logger.error(
-                    "Disabling continuous batching because of invalid configuration: flex attention is not supported."
-                )
-                self.continuous_batching = False
+
+        # The combination of flash_attention_2, compile and generate is not supported # FIXME: support it
+        if all((
+            self.attn_implementation == "flash_attention_2",
+            self.compile_config is not None,
+            not self.continuous_batching,
+        )):
+            logger.warning(
+                "The combination of flash_attention_2, compile and generate is not supported. Turning off compile."
+            )
+            self.compile_config = None
+
+        # Continuous batching does not support flex attention as an attention implementation # FIXME: support it
+        if self.attn_implementation == "flex_attention" and self.continuous_batching:
+            logger.error(
+                "Disabling continuous batching because of invalid configuration: flex attention is not supported."
+            )
+            self.continuous_batching = False
 
     @property
     def hash(self) -> str:
@@ -120,7 +126,7 @@ class BenchmarkConfig:
             gpu_monitor_str = "monitored" if self.gpu_monitoring else "unmonitored"
             dimensions_str = f"b{self.batch_size}_s{self.sequence_length}_n{self.num_tokens_to_generate}"
             attn_code = self.attn_implementation
-            compile_str = f"compiled_{self.compile_mode}" if self.compile_mode is not None else "uncompiled"
+            compile_str = f"compiled_{self.compile_config.mode}" if self.compile_config is not None else "uncompiled"
             kernelize_str = "kernelized" if self.kernelize else "unkernelized"
             continuous_batching_str = "cb" if self.continuous_batching else "generate"
             sep = "-"
@@ -129,7 +135,7 @@ class BenchmarkConfig:
             gpu_monitor_str = ("with" if self.gpu_monitoring else "no") + " GPU monitoring"
             dimensions_str = f"batch size {self.batch_size}, sequence length {self.sequence_length}, {self.num_tokens_to_generate} generated tokens"
             attn_code = f"{self.attn_implementation} attention"
-            compile_str = "compiled" if self.compile_mode is not None else "not compiled"
+            compile_str = "compiled" if self.compile_config is not None else "not compiled"
             kernelize_str = "kernelized" if self.kernelize else "not kernelized"
             continuous_batching_str = "continuous batching" if self.continuous_batching else "regular generate"
             sep = ", "
@@ -148,8 +154,7 @@ class BenchmarkConfig:
             "sequence_length": self.sequence_length,
             "num_tokens_to_generate": self.num_tokens_to_generate,
             "attn_implementation": self.attn_implementation,
-            "compile_mode": self.compile_mode,
-            "compile_options": self.compile_options | {},  # to avoid inplace modification of the original dict
+            "compile_kwargs": self.compile_config.to_dict() if self.compile_config is not None else None,
             "kernelize": self.kernelize,
         }
 
@@ -164,8 +169,7 @@ class BenchmarkConfig:
             sequence_length=data.get("sequence_length", 128),
             num_tokens_to_generate=data.get("num_tokens_to_generate", 128),
             attn_implementation=data.get("attn_implementation", "eager"),
-            compile_mode=data.get("compile_mode"),
-            compile_options=data.get("compile_options"),
+            compile_kwargs=data.get("compile_kwargs"),
             kernelize=data.get("kernelize", False),
             name=data.get("name"),
             skip_validity_check=skip_validity_check,
@@ -218,12 +222,13 @@ def get_config_by_level(level: int) -> list[BenchmarkConfig]:
             # Usually there is not much to gain by compiling with other modes, but we allow it for level 4
             compile_modes = BenchmarkConfig.all_compiled_modes if level >= 4 else [None, "default"]
             for cm in compile_modes:
+                compile_kwargs = {"mode": cm} if cm is not None else None
                 for kernelize_on in {False, KERNELIZATION_AVAILABLE}:
                     for cb_on in [False, True]:
                         configs.append(
                             BenchmarkConfig(
                                 attn_implementation=attn_implementation,
-                                compile_mode=cm,
+                                compile_kwargs=compile_kwargs,
                                 kernelize=kernelize_on,
                                 continuous_batching=cb_on,
                             )
@@ -231,14 +236,14 @@ def get_config_by_level(level: int) -> list[BenchmarkConfig]:
         return configs
     # Otherwise, we add the configs for the given level
     if level >= 0:
-        configs.append(BenchmarkConfig(attn_implementation="flex_attention", compile_mode="default"))
+        configs.append(BenchmarkConfig(attn_implementation="flex_attention", compile_kwargs={}))
     if level >= 1:
         configs.append(BenchmarkConfig(attn_implementation="flash_attention_2"))
-        configs.append(BenchmarkConfig(attn_implementation="eager", compile_mode="default"))
+        configs.append(BenchmarkConfig(attn_implementation="eager", compile_kwargs={}))
         configs.append(BenchmarkConfig(attn_implementation="flash_attention_2", continuous_batching=True))
     if level >= 2:
-        configs.append(BenchmarkConfig(attn_implementation="sdpa", compile_mode="default"))
-        configs.append(BenchmarkConfig(attn_implementation="flex_attention", compile_mode="default", kernelize=True))
+        configs.append(BenchmarkConfig(attn_implementation="sdpa", compile_kwargs={}))
+        configs.append(BenchmarkConfig(attn_implementation="flex_attention", compile_kwargs={}, kernelize=True))
         configs.append(BenchmarkConfig(attn_implementation="flash_attention_2", kernelize=True))
         configs.append(BenchmarkConfig(attn_implementation="sdpa", continuous_batching=True))
     return configs

--- a/benchmark_v2/framework/benchmark_runner.py
+++ b/benchmark_v2/framework/benchmark_runner.py
@@ -315,6 +315,7 @@ class BenchmarkRunner:
         benchmark_configs: list[BenchmarkConfig],
         num_tokens_to_profile: int = 0,
         pretty_print_summary: bool = True,
+        summarized: bool = True,
     ) -> tuple[str, dict[str, Any]]:
         """Run multiple benchmarks for the given model ID and list of benchmark configs."""
         all_results = {}
@@ -356,7 +357,7 @@ class BenchmarkRunner:
 
             # Cleanup model and save results
             self.cleanup()
-            self.save_results(model_id, all_results, timestamp=timestamp)
+            self.save_results(model_id, all_results, timestamp=timestamp, summarized=summarized)
 
         if len(all_results) < 1:
             raise RuntimeError("No benchmark was run successfully")
@@ -383,7 +384,7 @@ class BenchmarkRunner:
 
         return (timestamp, all_results)
 
-    def save_results(self, model_name: str, results: dict, timestamp: str = "") -> str:
+    def save_results(self, model_name: str, results: dict, timestamp: str = "", summarized: bool = True) -> str:
         """Save benchmark results to JSON file."""
         # Create model-specific subdirectory
         model_name = model_name.replace("/", "_")
@@ -400,7 +401,7 @@ class BenchmarkRunner:
         for cfg_hash in results.keys():
             converted_results[cfg_hash] = {
                 "metadata": results[cfg_hash]["metadata"].to_dict(),
-                "measurements": results[cfg_hash]["measurements"].to_dict(),
+                "measurements": results[cfg_hash]["measurements"].to_dict(summarized=summarized),
                 "config": results[cfg_hash]["config"].to_dict(),
             }
 

--- a/benchmark_v2/framework/data_classes.py
+++ b/benchmark_v2/framework/data_classes.py
@@ -64,14 +64,18 @@ class BenchmarkMetadata:
     commit_id: str
     commit_message: str
     hardware_info: HardwareInfo
+    success: bool
 
-    def __init__(self, model_id: str, commit_id: str, branch_name: str = "main", commit_message: str = "") -> None:
+    def __init__(
+        self, model_id: str, commit_id: str, branch_name: str = "main", commit_message: str = "", success: bool = True
+    ) -> None:
         self.model_id = model_id
         self.timestamp = datetime.now(timezone.utc).isoformat()
         self.branch_name = branch_name
         self.commit_id = commit_id
         self.commit_message = commit_message
         self.hardware_info = HardwareInfo()
+        self.success = success
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -81,6 +85,7 @@ class BenchmarkMetadata:
             "commit_id": self.commit_id,
             "commit_message": self.commit_message,
             "hardware_info": self.hardware_info.to_dict(),
+            "success": self.success,
         }
 
 

--- a/benchmark_v2/framework/data_classes.py
+++ b/benchmark_v2/framework/data_classes.py
@@ -9,12 +9,12 @@ from .hardware_metrics import GPURawMetrics, HardwareInfo
 
 def compute_basic_statistics(measurements: list[float]) -> dict[str, float]:
     return {
-        "avg": np.mean(measurements),
-        "std": np.std(measurements),
-        "min": np.min(measurements),
-        "med": np.median(measurements),
-        "max": np.max(measurements),
-        "p95": np.percentile(measurements, 95),
+        "avg": np.mean(measurements) if measurements else 0,
+        "std": np.std(measurements) if measurements else 0,
+        "min": np.min(measurements) if measurements else 0,
+        "med": np.median(measurements) if measurements else 0,
+        "max": np.max(measurements) if measurements else 0,
+        "p95": np.percentile(measurements, 95) if measurements else 0,
     }
 
 

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -250,7 +250,8 @@ if __name__ == "__main__":
                 question = prefix + "\n\n" + question
         messages.append({"role": "user", "content": question})
         inputs = tokenizer.apply_chat_template(messages, add_generation_prompt=True)
-        batched_inputs.append(inputs["input_ids"])
+        inputs = inputs if isinstance(inputs, list) else inputs["input_ids"]
+        batched_inputs.append(inputs)
 
     # Prepare generation config
     generation_cfg = GenerationConfig(

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -172,7 +172,7 @@ if __name__ == "__main__":
 
     # Model parameters
     parser.add_argument("--sliding-window", type=int, default=0)
-    parser.add_argument("--attn", type=str, default="kernels-community/flash-attn2", help="Attention implementation")
+    parser.add_argument("--attn", type=str, default=None, help="Attention implementation")
 
     # Performance parameters
     parser.add_argument("--matmul-precision", "-mp", type=str, default="high")  # set to "none" to disable
@@ -196,6 +196,18 @@ if __name__ == "__main__":
     parser.add_argument("--output-file", type=str, default=None)
 
     args = parser.parse_args()
+
+    # Choose attention implementation
+    if args.attn is None:
+        if args.compile:
+            args.attn = "kernels-community/flash-attn3@fake-ops-return-probs"
+            logger.warning(
+                "No attention implementation was provided and compile is enabled. Using experimental kernel: "
+                "kernels-community/flash-attn3@fake-ops-return-probs because compile is not supported on main. Change "
+                "this when main supports it." # TODO: cf comment
+            )
+        else:
+            args.attn = "kernels-community/flash-attn3"
 
     # Create model
     model_id = "google/gemma-2-2b-it" if args.sliding_window > 0 else "meta-llama/Llama-3.1-8B-Instruct"

--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -204,7 +204,7 @@ if __name__ == "__main__":
             logger.warning(
                 "No attention implementation was provided and compile is enabled. Using experimental kernel: "
                 "kernels-community/flash-attn3@fake-ops-return-probs because compile is not supported on main. Change "
-                "this when main supports it." # TODO: cf comment
+                "this when main supports it."  # TODO: cf comment
             )
         else:
             args.attn = "kernels-community/flash-attn3"

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -841,7 +841,6 @@ class ContinuousBatchingManager:
         )
         return use_cuda_graph
 
-
     @traced
     def start(self) -> None:
         """Start the background generation thread."""

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -818,7 +818,7 @@ class ContinuousBatchingManager:
         - (use_cuda_graph) which is the user choice
         - (num_q_padding_intervals) or (num_kv_padding_intervals) which is used to pad inputs: if it was specified by
             the user, it's probable they want to use cuda graphs so inputs need to be padded
-        - (compile_config): if the compile mode uses its own cudagraphs, we turn off cuda graphs on CB side
+        - (compile_config): if compile is on, turn on cuda graphs unless the compile mode uses its own cudagraphs
         If none of the above criteria are met, we use a default heuristic based on the attention implementation: we turn
         on cuda graphs if and only if no attention mask is needed.
         """
@@ -837,7 +837,7 @@ class ContinuousBatchingManager:
                     f"Compile config {compile_config.mode = } uses cudagraphs, which usually does not work well with "
                     "continuous batching. We recommend using mode 'default' or 'max-autotune-no-cudagraphs' instead."
                 )
-                return False
+            return not compile_uses_cudagraphs  # TODO: should this also match the dynamic shapes?
         # Otherwise we have a default heuristic based on the attention implementation:
         # attention implementations where an attention mask is needed suffer a lot more from the padding associated
         # with cuda graphs, so default is to turn cuda graphs off for those implementations

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1300,12 +1300,20 @@ def is_jit_tracing() -> bool:
     except Exception:
         return False
 
+def is_cuda_stream_capturing() -> bool:
+    try:
+        import torch
+
+        return torch.cuda.is_current_stream_capturing()
+    except Exception:
+        return False
+
 
 def is_tracing(tensor=None) -> bool:
-    """Checks whether we are tracing a graph with dynamo (compile or export), torch.jit, or torch.fx"""
+    """Checks whether we are tracing a graph with dynamo (compile or export), torch.jit, torch.fx or CUDA stream capturing"""
     # Note that `is_torchdynamo_compiling` checks both compiling and exporting (the export check is stricter and
     # only checks export)
-    _is_tracing = is_torchdynamo_compiling() or is_jit_tracing()
+    _is_tracing = is_torchdynamo_compiling() or is_jit_tracing() or is_cuda_stream_capturing()
     if tensor is not None:
         _is_tracing |= is_torch_fx_proxy(tensor)
     return _is_tracing

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1300,6 +1300,7 @@ def is_jit_tracing() -> bool:
     except Exception:
         return False
 
+
 def is_cuda_stream_capturing() -> bool:
     try:
         import torch


### PR DESCRIPTION
This PR adds the option to wrap the GPU-side of continuous batching with `torch.compile`
It also enable the benchmarking of CB with a compile config, and simplifies how benchmarking handles everything related to compile by using a `transformers` `CompileConfig` object