### PR TITLE
Add backward compatibility for methods which have been moved to `RotaryEmbeddingConfigMixin`

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -916,29 +916,29 @@ class RotaryEmbeddingConfigMixin:
             logger.warning(f"Unrecognized keys in `rope_parameters` for 'rope_type'='{rope_type}': {unused_keys}")
 
 
-def standardize_rope_params(*args, **kwargs):
+def standardize_rope_params(config, rope_theta: float | dict[str, float] | None = None):
     """
     This is a deprecated function.
     It has been kept for backward compatibility with custom code models.
-    It does nothing except issuing a warning.
     """
     warnings.warn(
         "`standardize_rope_params` is deprecated and has been removed. "
         "Its functionality has been moved to RotaryEmbeddingConfigMixin.standardize_rope_params method. "
-        "PreTrainedConfig inherits this class, so you can simply remove the function call.",
+        "PreTrainedConfig inherits this class, so please call self.standardize_rope_params() instead.",
         FutureWarning,
     )
+    config.standardize_rope_params()
 
 
-def rope_config_validation(*args, **kwargs):
+def rope_config_validation(config: PreTrainedConfig, ignore_keys: Optional[set] = None):
     """
     This is a deprecated function.
     It has been kept for backward compatibility with custom code models.
-    It does nothing except issuing a warning.
     """
     warnings.warn(
         "`rope_config_validation` is deprecated and has been removed. "
         "Its functionality has been moved to RotaryEmbeddingConfigMixin.validate_rope method. "
-        "PreTrainedConfig inherits this class, so you can simply remove the function call.",
+        "PreTrainedConfig inherits this class, so please call self.validate_rope() instead.",
         FutureWarning,
     )
+    config.validate_rope(ignore_keys=ignore_keys)

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -916,7 +916,7 @@ class RotaryEmbeddingConfigMixin:
             logger.warning(f"Unrecognized keys in `rope_parameters` for 'rope_type'='{rope_type}': {unused_keys}")
 
 
-def standardize_rope_params(config, rope_theta: float | dict[str, float] | None = None):
+def standardize_rope_params(config: RotaryEmbeddingConfigMixin, rope_theta: float | dict[str, float] | None = None):
     """
     This is a deprecated function.
     It has been kept for backward compatibility with custom code models.
@@ -930,7 +930,7 @@ def standardize_rope_params(config, rope_theta: float | dict[str, float] | None 
     config.standardize_rope_params()
 
 
-def rope_config_validation(config: PreTrainedConfig, ignore_keys: Optional[set] = None):
+def rope_config_validation(config: RotaryEmbeddingConfigMixin, ignore_keys: Optional[set] = None):
     """
     This is a deprecated function.
     It has been kept for backward compatibility with custom code models.

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import math
+import warnings
 from functools import wraps
 from typing import TYPE_CHECKING, Optional, TypedDict
 
@@ -913,3 +914,31 @@ class RotaryEmbeddingConfigMixin:
             unused_keys = received_keys - required_keys
         if unused_keys:
             logger.warning(f"Unrecognized keys in `rope_parameters` for 'rope_type'='{rope_type}': {unused_keys}")
+
+
+def standardize_rope_params(*args, **kwargs):
+    """
+    This is a deprecated function.
+    It has been kept for backward compatibility with custom code models.
+    It does nothing except issuing a warning.
+    """
+    warnings.warn(
+        "`standardize_rope_params` is deprecated and has been removed. "
+        "Its functionality has been moved to RotaryEmbeddingConfigMixin.standardize_rope_params method. "
+        "PreTrainedConfig inherits this class, so you can simply remove the function call.",
+        FutureWarning,
+    )
+
+
+def rope_config_validation(*args, **kwargs):
+    """
+    This is a deprecated function.
+    It has been kept for backward compatibility with custom code models.
+    It does nothing except issuing a warning.
+    """
+    warnings.warn(
+        "`rope_config_validation` is deprecated and has been removed. "
+        "Its functionality has been moved to RotaryEmbeddingConfigMixin.validate_rope method. "
+        "PreTrainedConfig inherits this class, so you can simply remove the function call.",
+        FutureWarning,
+    )

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -657,7 +657,7 @@ class RotaryEmbeddingConfigMixin:
         # Move `rope_theta` and `partial_rotary_factor` to the params dict, if not there yet
         rope_theta = getattr(self, "rope_theta", None)
         partial_rotary_factor = getattr(self, "partial_rotary_factor", None)
-        rope_parameters = self.rope_parameters
+        rope_parameters = self.rope_parameters or {}
 
         # Case 1: RoPE param keys do not intersect with possible `layer_types` -> one global dict
         if getattr(self, "layer_types", None) is None or not set(rope_parameters.keys()).issubset(self.layer_types):
@@ -938,7 +938,10 @@ def rope_config_validation(config: RotaryEmbeddingConfigMixin, ignore_keys: Opti
     warnings.warn(
         "`rope_config_validation` is deprecated and has been removed. "
         "Its functionality has been moved to RotaryEmbeddingConfigMixin.validate_rope method. "
-        "PreTrainedConfig inherits this class, so please call self.validate_rope() instead.",
+        "PreTrainedConfig inherits this class, so please call self.validate_rope() instead. "
+        "Also, make sure to use the new rope_parameters syntax. "
+        "You can call self.standardize_rope_params() in the meantime.",
         FutureWarning,
     )
+    config.standardize_rope_params()
     config.validate_rope(ignore_keys=ignore_keys)

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -916,20 +916,6 @@ class RotaryEmbeddingConfigMixin:
             logger.warning(f"Unrecognized keys in `rope_parameters` for 'rope_type'='{rope_type}': {unused_keys}")
 
 
-def standardize_rope_params(config: RotaryEmbeddingConfigMixin, rope_theta: float | dict[str, float] | None = None):
-    """
-    This is a deprecated function.
-    It has been kept for backward compatibility with custom code models.
-    """
-    warnings.warn(
-        "`standardize_rope_params` is deprecated and has been removed. "
-        "Its functionality has been moved to RotaryEmbeddingConfigMixin.standardize_rope_params method. "
-        "PreTrainedConfig inherits this class, so please call self.standardize_rope_params() instead.",
-        FutureWarning,
-    )
-    config.standardize_rope_params()
-
-
 def rope_config_validation(config: RotaryEmbeddingConfigMixin, ignore_keys: Optional[set] = None):
     """
     This is a deprecated function.


### PR DESCRIPTION
This function was moved in https://github.com/huggingface/transformers/pull/42255. Many custom code models import this function, which is arguably good practise as it shows they are leveraging our first party utilities.

This PR reinstates the function by calling the methods which now live in `RotaryEmbeddingConfigMixin` so that these custom code models will continue to work with Transformers v5.