### PR TITLE
Added doctests for SwiftFormer model

### DIFF
--- a/src/transformers/models/swiftformer/modeling_swiftformer.py
+++ b/src/transformers/models/swiftformer/modeling_swiftformer.py
@@ -429,6 +429,25 @@ class SwiftFormerModel(SwiftFormerPreTrainedModel):
         output_hidden_states: Optional[bool] = None,
         return_dict: Optional[bool] = None,
     ) -> Union[tuple, BaseModelOutputWithNoAttention]:
+        r"""
+        Example:
+        ```python
+        >>> from transformers import AutoImageProcessor, SwiftFormerModel
+        >>> import torch
+        >>> from datasets import load_dataset
+        >>> dataset = load_dataset("huggingface/cats-image", split="test")
+        >>> image = dataset[0]["image"]
+        >>> image_processor = AutoImageProcessor.from_pretrained("MBZUAI/swiftformer-xs")
+        >>> model = SwiftFormerModel.from_pretrained("MBZUAI/swiftformer-xs")
+        >>> inputs = image_processor(images=image, return_tensors="pt")
+        >>> with torch.no_grad():
+        ...     outputs = model(**inputs)
+        
+        >>> last_hidden_states = outputs.last_hidden_state
+        >>> print(list(last_hidden_states.shape))
+        [1, 220, 7, 7]
+        ```
+        """
         output_hidden_states = (
             output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
         )
@@ -484,6 +503,25 @@ class SwiftFormerForImageClassification(SwiftFormerPreTrainedModel):
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
+
+        Example:
+        ```python
+        >>> from transformers import AutoImageProcessor, SwiftFormerForImageClassification
+        >>> import torch
+        >>> from datasets import load_dataset
+        >>> dataset = load_dataset("huggingface/cats-image", split="test")
+        >>> image = dataset[0]["image"]
+        >>> image_processor = AutoImageProcessor.from_pretrained("MBZUAI/swiftformer-xs")
+        >>> model = SwiftFormerForImageClassification.from_pretrained("MBZUAI/swiftformer-xs")
+        >>> inputs = image_processor(images=image, return_tensors="pt")
+        >>> with torch.no_grad():
+        ...     logits = model(**inputs).logits
+
+        >>> # model predicts one of the 1000 ImageNet classes
+        >>> predicted_label = logits.argmax(-1).item()
+        >>> print(model.config.id2label[predicted_label])
+        tabby, tabby cat
+        ```
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/src/transformers/models/swiftformer/modeling_swiftformer.py
+++ b/src/transformers/models/swiftformer/modeling_swiftformer.py
@@ -442,7 +442,6 @@ class SwiftFormerModel(SwiftFormerPreTrainedModel):
         >>> inputs = image_processor(images=image, return_tensors="pt")
         >>> with torch.no_grad():
         ...     outputs = model(**inputs)
-        
         >>> last_hidden_states = outputs.last_hidden_state
         >>> print(list(last_hidden_states.shape))
         [1, 220, 7, 7]
@@ -516,7 +515,6 @@ class SwiftFormerForImageClassification(SwiftFormerPreTrainedModel):
         >>> inputs = image_processor(images=image, return_tensors="pt")
         >>> with torch.no_grad():
         ...     logits = model(**inputs).logits
-
         >>> # model predicts one of the 1000 ImageNet classes
         >>> predicted_label = logits.argmax(-1).item()
         >>> print(model.config.id2label[predicted_label])

--- a/utils/not_doctested.txt
+++ b/utils/not_doctested.txt
@@ -616,7 +616,6 @@ src/transformers/models/stablelm/modeling_stablelm.py
 src/transformers/models/starcoder2/modeling_starcoder2.py
 src/transformers/models/swiftformer/configuration_swiftformer.py
 src/transformers/models/swiftformer/convert_swiftformer_original_to_hf.py
-src/transformers/models/swiftformer/modeling_swiftformer.py
 src/transformers/models/swin/convert_swin_simmim_to_pytorch.py
 src/transformers/models/swin/convert_swin_timm_to_pytorch.py
 src/transformers/models/swin2sr/configuration_swin2sr.py


### PR DESCRIPTION
# What does this PR do?

This PR adds documentation tests for `SwiftFormerModel` and `SwiftFormerForImageClassification` as part of the Doc Tests Sprint (#16292).

The doctests include examples for:
- `SwiftFormerModel.forward()` - Showing how to get hidden states
- `SwiftFormerForImageClassification.forward()` - Showing image classification

Fixes #16292 (SwiftFormerModel & SwiftFormerForImageClassification)


## Before submitting
- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@yonigozlan @molbap @NielsRogge 