### PR TITLE
docs: add doctest for SqueezeBERT

### DIFF
--- a/src/transformers/models/squeezebert/modeling_squeezebert.py
+++ b/src/transformers/models/squeezebert/modeling_squeezebert.py
@@ -534,6 +534,27 @@ class SqueezeBertForMaskedLM(SqueezeBertPreTrainedModel):
             Labels for computing the masked language modeling loss. Indices should be in `[-100, 0, ...,
             config.vocab_size]` (see `input_ids` docstring) Tokens with indices set to `-100` are ignored (masked), the
             loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`
+
+        Example:
+
+        ```python
+        >>> from transformers import AutoTokenizer, SqueezeBertForMaskedLM
+        >>> import torch
+
+        >>> tokenizer = AutoTokenizer.from_pretrained("squeezebert/squeezebert-uncased")
+        >>> model = SqueezeBertForMaskedLM.from_pretrained("squeezebert/squeezebert-uncased")
+
+        >>> inputs = tokenizer("The capital of France is [MASK].", return_tensors="pt")
+        >>> with torch.no_grad():
+        ...     logits = model(**inputs).logits
+
+        >>> # retrieve index of [MASK]
+        >>> mask_token_index = (inputs.input_ids == tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]
+
+        >>> predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
+        >>> tokenizer.decode(predicted_token_id)  # doctest: +SKIP
+        'paris'
+        ```
         """
         return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 

--- a/utils/slow_documentation_tests.txt
+++ b/utils/slow_documentation_tests.txt
@@ -13,3 +13,4 @@ src/transformers/models/idefics2/modeling_idefics2.py
 src/transformers/models/kosmos2/modeling_kosmos2.py
 src/transformers/models/musicgen_melody/modeling_musicgen_melody.py
 src/transformers/models/musicgen_melody/processing_musicgen_melody.py
+src/transformers/models/squeezebert/modeling_squeezebert.py


### PR DESCRIPTION
Adds documentation test for SqueezeBertForMaskedLM as part of the Doc Tests Sprint (#16292).

- Added example to forward() method showing masked language modeling
- Used squeezebert-uncased checkpoint for testing
- Added file to slow_documentation_tests.txt

# What does this PR do?

Fixes #16292 (partial - adds SqueezeBERT)


<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
