### PR TITLE
fix: skip weight initialization for quantized models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4445,7 +4445,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             )
             with deepspeed.zero.GatheredParameters(not_initialized_parameters, modifier_rank=0):
                 self.initialize_weights()
-        else:
+        elif not is_quantized:
             self.initialize_weights()
 
     def _adjust_missing_and_unexpected_keys(


### PR DESCRIPTION
# What does this PR do?

Fixes #39366 

This PR resolves a `RuntimeError` when loading llmcompressor W8A8 quantized models by skipping weight initialization for quantized models.

## Problem

When loading quantized models with int8/uint8 weights, the model initialization fails with:

RuntimeError: expected a floating-point or complex dtype, but got dtype=torch.int8

This occurs because `_initialize_missing_keys()` unconditionally calls `initialize_weights()`, which attempts to use `normal_()` on int8 tensors. PyTorch's `normal_()` only supports floating-point dtypes.

## Solution

Added a `not is_quantized` check to the else branch in `_initialize_missing_keys()` method (line 4448 of `modeling_utils.py`):

```python
elif not is_quantized:
    self.initialize_weights()