### PR TITLE
[XPU] Fix fp8 UT patch func

### DIFF
--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -46,6 +46,7 @@ def _patch_no_accelerator():
         stack.enter_context(patch("torch.cuda.is_available", return_value=False))
         if hasattr(torch, "xpu"):
             stack.enter_context(patch("torch.xpu.is_available", return_value=False))
+            stack.enter_context(patch("transformers.quantizers.quantizer_finegrained_fp8.is_torch_xpu_available", return_value=False))
         yield
 
 

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -46,7 +46,9 @@ def _patch_no_accelerator():
         stack.enter_context(patch("torch.cuda.is_available", return_value=False))
         if hasattr(torch, "xpu"):
             stack.enter_context(patch("torch.xpu.is_available", return_value=False))
-            stack.enter_context(patch("transformers.quantizers.quantizer_finegrained_fp8.is_torch_xpu_available", return_value=False))
+            stack.enter_context(
+                patch("transformers.quantizers.quantizer_finegrained_fp8.is_torch_xpu_available", return_value=False)
+            )
         yield
 
 


### PR DESCRIPTION
# What does this PR do?

When testing `tests/quantization/finegrained_fp8/test_fp8.py` on XPU, it reported the following error:
```
FAILED tests/quantization/finegrained_fp8/test_fp8.py::FP8QuantizerTest::test_dequantization_no_accelerator - AssertionError: False is not true
FAILED tests/quantization/finegrained_fp8/test_fp8.py::FP8QuantizerTest::test_dequantize_when_no_accelerator - ValueError: Expected a xpu device, but got: cpu
FAILED tests/quantization/finegrained_fp8/test_fp8.py::FP8QuantizerTest::test_quantizer_validation_no_accelerator - AssertionError: RuntimeError not raised
```
The root cause is that the `_patch_no_accelerator` method does not fully take effect on XPU.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
