### PR TITLE
Use `getattr` in `standardize_rope_params` because `rope_parameters` not always present

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -657,7 +657,7 @@ class RotaryEmbeddingConfigMixin:
         # Move `rope_theta` and `partial_rotary_factor` to the params dict, if not there yet
         rope_theta = getattr(self, "rope_theta", None)
         partial_rotary_factor = getattr(self, "partial_rotary_factor", None)
-        rope_parameters = self.rope_parameters or {}
+        rope_parameters = getattr(self, "rope_parameters", None) or {}
 
         # Case 1: RoPE param keys do not intersect with possible `layer_types` -> one global dict
         if getattr(self, "layer_types", None) is None or not set(rope_parameters.keys()).issubset(self.layer_types):


### PR DESCRIPTION
Some custom models written for v4 will specify `rope_theta` but not `rope_scaling`/`rope_parameters`. In this case, there was an attribute error when accessing `rope_parameters` in `standardize_rope_params`. This PR fixes that.