### PR TITLE
[pipeline] fix unwanted import failure

### DIFF
--- a/src/transformers/pipelines/audio_classification.py
+++ b/src/transformers/pipelines/audio_classification.py
@@ -182,7 +182,7 @@ class AudioClassificationPipeline(Pipeline):
             if isinstance(inputs, torch.Tensor):
                 inputs = inputs.cpu().numpy()
 
-        if is_torchcodec_available():
+        if is_torchcodec_available() and type(inputs).__module__.startswith("torchcodec."):
             import torch
             import torchcodec
 

--- a/src/transformers/pipelines/automatic_speech_recognition.py
+++ b/src/transformers/pipelines/automatic_speech_recognition.py
@@ -372,7 +372,7 @@ class AutomaticSpeechRecognitionPipeline(ChunkPipeline):
             if isinstance(inputs, torch.Tensor):
                 inputs = inputs.cpu().numpy()
 
-        if is_torchcodec_available():
+        if is_torchcodec_available() and type(inputs).__module__.startswith("torchcodec."):
             import torchcodec
 
             if isinstance(inputs, torchcodec.decoders.AudioDecoder):


### PR DESCRIPTION
# What does this PR do?

FIxes #42499

torchcodec installation can be tricky and right now pipeline can fail (if torchcodec is installed) even if torchcodec is actually not required. The lazy import can be even laziest :)