### PR TITLE
Allow `validation_fn` to be `None` in `validate_rope`

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -692,14 +692,14 @@ class RotaryEmbeddingConfigMixin:
 
         for rope_parameters in rope_parameters_dict.values():
             rope_type = rope_parameters.get("rope_type", rope_parameters.get("type", "default"))
-            validation_fn = getattr(self, f"_validate_{rope_type}_rope_parameters")
+            validation_fn = getattr(self, f"_validate_{rope_type}_rope_parameters", None)
             rope_parameters["rope_type"] = rope_type
 
             if validation_fn is not None:
                 validation_fn(rope_parameters, ignore_keys=ignore_keys)
             else:
                 logger.warning(
-                    f"Missing validation function mapping in `ROPE_VALIDATION_FUNCTIONS` for 'rope_type'='{rope_type}'"
+                    f"Missing validation function in 'RotaryEmbeddingConfigMixin' for 'rope_type'='{rope_type}'"
                 )
 
     def _validate_default_rope_parameters(self, rope_parameters: dict, ignore_keys: Optional[set] = None):


### PR DESCRIPTION
Custom models which specify `mrope` as their `rope_type` were failing to initialise because of an attribute error when attempting to get `_validate_mrope_rope_parameters`, which doesn't exist.

The lines following this `getattr` indicate that this is suppose to trigger a warning, not an error.

This PR fixes that.