### PR TITLE
Fix dimensional mismatch in Mistral3MultiModalProjector for multiple vision feature layers

### DIFF
--- a/src/transformers/models/mistral3/modular_mistral3.py
+++ b/src/transformers/models/mistral3/modular_mistral3.py
@@ -46,14 +46,18 @@ class Mistral3PatchMerger(nn.Module):
     Learned merging of spatial_merge_size ** 2 patches
     """
 
-    def __init__(self, config: Mistral3Config):
+    def __init__(self, config: Mistral3Config, num_feature_layers: int = 1):
         super().__init__()
         self.config = config
 
         hidden_size = config.vision_config.hidden_size
         self.spatial_merge_size = config.spatial_merge_size
         self.patch_size = self.config.vision_config.patch_size
-        self.merging_layer = nn.Linear(hidden_size * self.spatial_merge_size**2, hidden_size, bias=False)
+        self.merging_layer = nn.Linear(
+            hidden_size * num_feature_layers * self.spatial_merge_size**2,
+            hidden_size * num_feature_layers,
+            bias=False,
+        )
 
     def forward(self, image_features: torch.Tensor, image_sizes: torch.Tensor) -> torch.Tensor:
         image_sizes = [
@@ -82,10 +86,12 @@ class Mistral3PatchMerger(nn.Module):
 class Mistral3MultiModalProjector(nn.Module):
     def __init__(self, config: Mistral3Config):
         super().__init__()
-        self.norm = Mistral3RMSNorm(config.vision_config.hidden_size, eps=config.text_config.rms_norm_eps)
-        self.patch_merger = Mistral3PatchMerger(config)
         # We have hidden_size * the number of vision feature layers
         num_feature_layers = 1 if isinstance(config.vision_feature_layer, int) else len(config.vision_feature_layer)
+        self.norm = Mistral3RMSNorm(
+            config.vision_config.hidden_size * num_feature_layers, eps=config.text_config.rms_norm_eps
+        )
+        self.patch_merger = Mistral3PatchMerger(config, num_feature_layers=num_feature_layers)
         self.linear_1 = nn.Linear(
             config.vision_config.hidden_size * num_feature_layers,
             config.text_config.hidden_size,


### PR DESCRIPTION
## What does this PR do?

Fixes #42585 

This PR fixes a dimensional mismatch bug in the Mistral3 multimodal projector when using multiple vision feature layers.

## The Problem

When `vision_feature_layer` is configured as a list (e.g., `[-1, -2]` for multiple layers), the vision features from different layers are concatenated along the last dimension in `Mistral3PreTrainedModel.get_image_features()` (line 156):

```python
hs_pool = [image_outputs.hidden_states[layer_idx] for layer_idx in vision_feature_layer]
selected_image_feature = torch.cat(hs_pool, dim=-1)
```

This results in a tensor with shape `(batch, hidden_size * num_feature_layers)`.

However, `Mistral3PatchMerger` was initialized with only `hidden_size`, not accounting for the concatenated features. This caused:
1. The norm layer to have incorrect dimensions
2. The merging layer to have incorrect input/output dimensions
3. A mismatch between patch_merger output and linear_1 expected input

## The Solution

- Updated `Mistral3PatchMerger` to accept a `num_feature_layers` parameter (defaults to 1 for backward compatibility)
- Adjusted the merging layer dimensions to properly handle concatenated features:
  - Input: `hidden_size * num_feature_layers * spatial_merge_size**2`
  - Output: `hidden_size * num_feature_layers`
- Updated the norm layer in `Mistral3MultiModalProjector` to match the concatenated input dimensions

This ensures the dimensional flow is consistent:
- Input to projector: `hidden_size * num_feature_layers`
- After norm: `hidden_size * num_feature_layers`
- After patch_merger: `hidden_size * num_feature_layers`
- Input to linear_1: `hidden_size * num_feature_layers` ✅

The fix maintains backward compatibility - when `vision_feature_layer` is a single integer, `num_feature_layers = 1` and the behavior is identical to before.