### PR TITLE
Fix incorrect fix_mistral_regex warning for local non-Mistral tokenizers

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1135,7 +1135,9 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 elif transformers_version and version.parse(transformers_version) >= version.parse("4.57.3"):
                     return tokenizer
 
-                mistral_config_detected = True
+                # Only set mistral_config_detected if it's actually a Mistral model
+                if transformers_model_type in ["mistral", "mistral3", "voxtral", "ministral", "pixtral"]:
+                    mistral_config_detected = True
 
             if mistral_config_detected or (not is_local and is_base_mistral(pretrained_model_name_or_path)):
                 # Expose the `fix_mistral_regex` flag on the tokenizer when provided, even if no correction is applied.


### PR DESCRIPTION
## What does this PR do?

Fixes #42591

This PR fixes an issue where loading a local non-Mistral tokenizer incorrectly triggers the `fix_mistral_regex` warning.

## The Problem

When loading a local tokenizer with a `config.json` file, the code was setting `mistral_config_detected = True` unconditionally on line 1136, regardless of whether the model was actually a Mistral variant or not.

This caused the warning to be triggered for **all** local tokenizers, including non-Mistral models like LLaMA, GPT, etc.

### Before:
```python
# Line 1136 in tokenization_utils_tokenizers.py
mistral_config_detected = True  # Set unconditionally if config.json exists
```

This meant that loading any local tokenizer would trigger:
```
The tokenizer you are loading from 'path/to/non-mistral-model' with an incorrect regex pattern...
You should set the fix_mistral_regex=True flag when loading this tokenizer to fix this issue.
```

## The Solution

Now, `mistral_config_detected` is only set to `True` when the `model_type` in the config is actually a Mistral variant:

```python
# Only set mistral_config_detected if it's actually a Mistral model
if transformers_model_type in ["mistral", "mistral3", "voxtral", "ministral", "pixtral"]:
    mistral_config_detected = True
```

This ensures the warning is only shown for Mistral-based models that actually need the regex fix.

## Testing

The fix ensures:
- ✅ Loading local non-Mistral tokenizers (e.g., LLaMA, GPT) no longer triggers the warning
- ✅ Loading local Mistral tokenizers still correctly triggers the warning when needed
- ✅ Loading remote tokenizers continues to work as expected