### PR TITLE
Remove splitted_tests.txt file

### DIFF
--- a/splitted_tests.txt
+++ b/splitted_tests.txt
@@ -1,1 +1,0 @@
-tests/models/afmoe/test_modeling_afmoe.py


### PR DESCRIPTION
An extra file was added to the repo root in #42168, I think by accident. This PR removes it.

cc @ydshieh in case you know why it's here!