### PR TITLE
Fix saving multiple tokenizers for custom processors

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -696,14 +696,10 @@ class ProcessorMixin(PushToHubMixin):
         # extra attributes to be kept
         attrs_to_save += ["auto_map"]
 
-        if "tokenizer" in output:
-            del output["tokenizer"]
-        if "qformer_tokenizer" in output:
-            del output["qformer_tokenizer"]
-        if "protein_tokenizer" in output:
-            del output["protein_tokenizer"]
-        if "char_tokenizer" in output:
-            del output["char_tokenizer"]
+        for attribute in self.__class__.get_attributes():
+            if "tokenizer" in attribute and attribute in output:
+                del output[attribute]
+
         if "chat_template" in output:
             del output["chat_template"]
 


### PR DESCRIPTION
Fixes this issue https://github.com/huggingface/transformers/issues/41816
Instead of harcoding a set of tokenizer attribute that shouldn't be saved as part of `preprocessor_config`, this remove all attributes that contain "tokenizer" from `preprocessor_config`, which allows for more flexibility when creating a custom processor with multiple tokenizers.