### PR TITLE
New Feature: Enabling Speculative Decoding with Batch Size > 1 (If draft and target model share tokenizer)

### DIFF
--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1315,9 +1315,9 @@ def _prepare_attention_mask(
     mask = model_kwargs[mask_key]
     mask_length_diff = new_length - mask.shape[1]
     if mask_length_diff == 0:
-        pass # no need to do anything
+        pass  # no need to do anything
     elif input_ids is not None and pad_token_id is not None:
-        # this could be a problem if the original mask is ignoring tokens that are not pad tokens. 
+        # this could be a problem if the original mask is ignoring tokens that are not pad tokens.
         model_kwargs[mask_key] = (input_ids != pad_token_id).to(mask.dtype)
     elif mask_length_diff < 0:
         model_kwargs[mask_key] = mask[:, :mask_length_diff]

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -1314,9 +1314,12 @@ def _prepare_attention_mask(
 
     mask = model_kwargs[mask_key]
     mask_length_diff = new_length - mask.shape[1]
-    if input_ids is not None and pad_token_id is not None:
+    if mask_length_diff == 0:
+        pass # no need to do anything
+    elif input_ids is not None and pad_token_id is not None:
+        # this could be a problem if the original mask is ignoring tokens that are not pad tokens. 
         model_kwargs[mask_key] = (input_ids != pad_token_id).to(mask.dtype)
-    elif mask_length_diff < 0:  # not sure when we get into this case
+    elif mask_length_diff < 0:
         model_kwargs[mask_key] = mask[:, :mask_length_diff]
     elif mask_length_diff > 0:
         model_kwargs[mask_key] = torch.cat([mask, mask.new_ones((mask.shape[0], mask_length_diff))], dim=-1)

--- a/src/transformers/generation/candidate_generator.py
+++ b/src/transformers/generation/candidate_generator.py
@@ -41,13 +41,16 @@ if TYPE_CHECKING:
 class CandidateGenerator:
     """Abstract base class for all candidate generators that can be applied during assisted generation."""
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, assistant_ids_in_cache: torch.LongTensor = None
+    ) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
         """
         Fetches the candidates to be tried for the current input.
 
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 Indices of input sequence tokens in the vocabulary. [What are input IDs?](../glossary#input-ids)
+            assistant_ids_in_cache (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
 
         Return:
             `torch.LongTensor` of shape `(batch_size, candidate_length)` containing the candidate sequences to be
@@ -58,7 +61,9 @@ class CandidateGenerator:
             f"{self.__class__} is an abstract class. Only classes inheriting this class can call `get_candidates`."
         )
 
-    def update_candidate_strategy(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int):
+    def update_candidate_strategy(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int, assistant_used: bool = True
+    ):
         """
         Updates the candidate generation strategy based on the outcomes.
 
@@ -70,6 +75,8 @@ class CandidateGenerator:
                 beam search or log softmax for each vocabulary token when using beam search
             num_matches (`int`):
                 The number of matches between the candidate sequences and the model predictions.
+            assistant_used (`bool`):
+                Whether the assistant was used to generate the candidates. Assistant was not used if max_new_tokens is 0.
         """
         raise NotImplementedError(
             f"{self.__class__} is an abstract class. Only classes inheriting this class can call "
@@ -192,10 +199,14 @@ class AssistedCandidateGenerator(CandidateGenerator):
             and self.assistant_model.generation_config.assistant_confidence_threshold
             and type(self) is AssistedCandidateGenerator
         ):
+            # only needed for ROC curve calculation
             self.probs = []
             self.matches = []
+            self.clean_probs = []
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, assistant_ids_in_cache: torch.LongTensor = None
+    ) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
         """
         Fetches the candidates to be tried for the current input.
 
@@ -214,13 +225,15 @@ class AssistedCandidateGenerator(CandidateGenerator):
         if max_new_tokens == 0:
             return input_ids, None
         # Update past key values and masks
-        self._update_past_and_masks(input_ids)
+        self._update_past_and_masks(input_ids, assistant_ids_in_cache=assistant_ids_in_cache)
         # Generate candidates
         generation_args = self._prepare_generation_args(input_ids, min_new_tokens, max_new_tokens)
         candidate_ids, candidate_logits = self._generate_candidates(generation_args)
         return candidate_ids, candidate_logits
 
-    def update_candidate_strategy(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int):
+    def update_candidate_strategy(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int, assistant_used: bool = True
+    ):
         """
         Updates the candidate generation strategy based on the outcomes.
 
@@ -230,9 +243,19 @@ class AssistedCandidateGenerator(CandidateGenerator):
             scores (`torch.FloatTensor` of shape `(batch_size, candidate_length, config.vocab_size)`):
                 Prediction scores of a language modeling head. These can be logits for each vocabulary when not using
                 beam search or log softmax for each vocabulary token when using beam search
-            num_matches (`int`):
-                The number of matches between the candidate sequences and the model predictions.
+            num_matches (`torch.LongTensor` of shape `(batch_size,)` or `int`):
+                The number of matches between the candidate sequences and the model predictions for each batch item.
+                If `int`, assumes `batch_size=1` for backward compatibility.
+            assistant_used (`bool`):
+                Whether the assistant was used to generate the candidates. Assistant was not used if max_new_tokens is 0.
         """
+        # Handle backward compatibility: convert int to tensor
+        if isinstance(num_matches, int):
+            assert input_ids.shape[0] == 1, "num_matches should be a tensor of shape (batch_size,) when batch_size > 1"
+            num_matches = torch.tensor([num_matches], device=input_ids.device)
+
+        batch_size = input_ids.shape[0]
+
         # Adjust the max number of assistant tokens to use in the next iteration. This is a simple heuristic,
         # probably can be improved -- we want to balance the benefits of getting assistant tokens correct with the
         # cost of forecasting incorrect assistant tokens.
@@ -240,33 +263,51 @@ class AssistedCandidateGenerator(CandidateGenerator):
             "heuristic",
             "heuristic_transient",
         }:
-            # len(scores[0])-1 is the number of candidates according to the target tokenizer.
-            if num_matches == len(scores[0]) - 1:
+            # For batch processing, we can use different strategies:
+            # Option 1: Use average matches across batch
+            avg_matches = num_matches.float().mean().item()
+            # Option 2: Use max matches (more aggressive)
+            # avg_matches = num_matches.float().max().item()
+            # Option 3: Use min matches (more conservative)
+            # avg_matches = num_matches.float().min().item()
+            max_candidate_length = scores.shape[1] - 1
+            if avg_matches == max_candidate_length:
                 self.num_assistant_tokens += 2.0
             else:
                 self.num_assistant_tokens = max(1.0, self.num_assistant_tokens - 1.0)
 
-        # The assistant's confidence threshold is adjusted throughout the speculative iterations to reduce the number of unnecessary draft and target forward passes. The costs are estimated based on the ROC curve, which considers the probability of the draft token and its match with the target. A cost of 25% is assigned to false positives and 75% to false negatives.
+        # The assistant's confidence threshold is adjusted throughout the speculative iterations to reduce the number of unnecessary draft and target forward passes.
+        # The costs are estimated based on the ROC curve, which considers the probability of the draft token and its match with the target.
+        # A cost of 25% is assigned to false positives and 75% to false negatives.
         # This adaptation is not compatible with UAG, as it relies on the number of matched tokens based on the draft vocabulary, which is unavailable in UAG.
         if (
             is_sklearn_available()
             and self.assistant_model.generation_config.assistant_confidence_threshold
             and type(self) is AssistedCandidateGenerator
+            and assistant_used
         ):
-            # update self.matches
-            self.matches.extend([1] * num_matches)
-            if len(self.probs) > len(self.matches):
-                self.matches.append(0)
+            # Update matches: add one match per token for each batch item
+            # Flatten the matches across all batches
+            for batch_idx in range(batch_size):
+                matches_count = num_matches[batch_idx].item()
+                item_matches = [1] * matches_count
+                if len(self.probs[len(self.matches)]) > matches_count:
+                    # if the number of probabilities is greater than the number of matches, add a 0 to the end of the matches.
+                    # this means we reject a token.
+                    item_matches.append(0)
+                # taking only the relevant probabilities. for all the accepted tokens and the first rejected token.
+                self.clean_probs.extend([self.probs[len(self.matches)][: len(item_matches)]])
+                self.matches.extend([item_matches])
 
-            # update self.probs
-            excess_length = len(self.probs) - len(self.matches)
-            if excess_length > 0:
-                del self.probs[-excess_length:]
+            assert len(self.matches) == len(self.clean_probs), "matches and probs must have the same length"
+            clean_matches = np.concatenate(self.matches)
+            clean_probs = np.concatenate(self.clean_probs)
 
+            # calculate ROC curve and update threshold if we have enough samples
             if (
-                len(self.probs) > 5 and {0, 1}.issubset(self.matches)
+                len(clean_probs) > 5 and {0, 1}.issubset(clean_matches)
             ):  # require at least 5 samples to calculate the ROC curve and at least one positive and one negative sample
-                fpr, tpr, thresholds = roc_curve(self.matches, self.probs)
+                fpr, tpr, thresholds = roc_curve(clean_matches, clean_probs)
                 fnr = 1 - tpr
 
                 # Calculate the cost for each threshold
@@ -286,15 +327,28 @@ class AssistedCandidateGenerator(CandidateGenerator):
         return min_new_tokens, max_new_tokens
 
     def _update_past_and_masks(
-        self, input_ids: torch.LongTensor, remove_from_pkv: int = 0, num_added_tokens: int = 1
+        self,
+        input_ids: torch.LongTensor,
+        remove_from_pkv: int = 0,
+        num_added_tokens: int = 1,
+        assistant_ids_in_cache: torch.LongTensor = None,
     ) -> bool:
         """Update past key values and attention masks for subsequent generation rounds."""
         has_past_key_values = self.assistant_kwargs.get("past_key_values", None) is not None
         if has_past_key_values:
-            new_cache_size = input_ids.shape[-1] - 1 - remove_from_pkv
-            self.assistant_kwargs["past_key_values"].crop(new_cache_size - num_added_tokens)
+            if input_ids.shape[0] > 1:
+                self.assistant_kwargs["past_key_values"].align(
+                    input_ids, assistant_ids_in_cache, self.generation_config._pad_token_tensor.item()
+                )
+            else:
+                new_cache_size = input_ids.shape[-1] - 1 - remove_from_pkv
+                self.assistant_kwargs["past_key_values"].crop(new_cache_size - num_added_tokens)
             self.assistant_kwargs = _prepare_attention_mask(
-                self.assistant_kwargs, input_ids.shape[-1], self.assistant_model.config.is_encoder_decoder
+                self.assistant_kwargs,
+                input_ids.shape[-1],
+                self.assistant_model.config.is_encoder_decoder,
+                input_ids,
+                self.generation_config._pad_token_tensor.item(),
             )
             self.assistant_kwargs = _prepare_token_type_ids(self.assistant_kwargs, input_ids.shape[-1])
 
@@ -318,17 +372,24 @@ class AssistedCandidateGenerator(CandidateGenerator):
         """Generate candidate sequences using the assistant model."""
         assistant_output = self.assistant_model.generate(**generation_args, **self.assistant_kwargs)
         self.assistant_kwargs["past_key_values"] = assistant_output.past_key_values
+        candidate_logits = torch.stack(
+            assistant_output.scores, dim=1
+        )  # shape: (batch_size, candidate_length, vocab_size)
         if (
             is_sklearn_available()
             and self.assistant_model.generation_config.assistant_confidence_threshold
             and type(self) is AssistedCandidateGenerator
         ):
-            scores_tensor = torch.cat(assistant_output.scores, dim=0)
-            scores_softmax = torch.softmax(scores_tensor, dim=-1)
-            ids = assistant_output.sequences[-1, -len(assistant_output.scores) :]
-            p = scores_softmax[range(len(ids)), ids]
+            scores_softmax = torch.softmax(
+                candidate_logits, dim=-1
+            )  # shape: (batch_size, candidate_length, vocab_size)
+            ids = assistant_output.sequences[
+                :, -len(assistant_output.scores) :
+            ]  # shape: (batch_size, candidate_length)
+            p = torch.gather(scores_softmax, dim=-1, index=ids.unsqueeze(-1)).squeeze(
+                -1
+            )  # shape: (batch_size, candidate_length)
             self.probs.extend(p.tolist())
-        candidate_logits = torch.stack(assistant_output.scores, dim=1)
         candidate_ids = assistant_output.sequences
         return candidate_ids, candidate_logits
 
@@ -494,14 +555,17 @@ class AssistedCandidateGeneratorDifferentTokenizers(AssistedCandidateGenerator):
         dest_ids = destination_tokenizer(text, add_special_tokens=True, return_tensors="pt")["input_ids"]
         return dest_ids.to(input_ids.device)
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, assistant_ids_in_cache: torch.LongTensor = None
+    ) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
         """
         Fetches the candidates to be tried for the current input.
 
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 Indices of input sequence tokens in the vocabulary. [What are input IDs?](../glossary#input-ids)
-
+            assistant_ids_in_cache (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                Indices of input sequence tokens in the assistant vocabulary that are in the cache.
         Return:
             `torch.LongTensor` of shape `(batch_size, candidate_length)` containing the candidate sequences to be
             assessed by the model and a `torch.FloatTensor` of shape `(batch_size, candidate_length,
@@ -519,7 +583,9 @@ class AssistedCandidateGeneratorDifferentTokenizers(AssistedCandidateGenerator):
 
         min_new_tokens = max(min(max_new_tokens, self.main_model_min_length - assistant_input_ids.shape[-1]), 0)
 
-        self._update_past_and_masks(assistant_input_ids, remove_from_pkv)
+        self._update_past_and_masks(
+            assistant_input_ids, remove_from_pkv, assistant_ids_in_cache=assistant_ids_in_cache
+        )
         generation_args = self._prepare_generation_args(assistant_input_ids, min_new_tokens, max_new_tokens)
         self.assistant_kwargs.pop("attention_mask", None)
 
@@ -797,7 +863,7 @@ class AssistantToTargetTranslator:
         Moreover, assistant ids of the original prompt does not necessarily appear in _assistant_to_target_input_ids.
         """
 
-        num_new_tokens = len(assistant_candidate_ids[0]) - assistant_input_ids.shape[1]
+        num_new_tokens = assistant_candidate_ids.shape[1] - assistant_input_ids.shape[1]
         if num_new_tokens == 0:
             return target_input_ids
         else:
@@ -919,7 +985,9 @@ class UniversalSpeculativeDecodingGenerator(AssistedCandidateGeneratorDifferentT
         self._target_seq_len_with_candidates: int = 0
         self._prev_assistant_ids: torch.LongTensor | None = None
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, assistant_ids_in_cache: torch.LongTensor = None
+    ) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
         """
         Simplified version of get_candidates that uses the translator cache for token conversion.
         """
@@ -930,7 +998,9 @@ class UniversalSpeculativeDecodingGenerator(AssistedCandidateGeneratorDifferentT
         if max_new_tokens == 0:
             return input_ids, None
 
-        self._update_past_and_masks(assistant_input_ids, num_added_tokens=num_added_tokens)
+        self._update_past_and_masks(
+            assistant_input_ids, num_added_tokens=num_added_tokens, assistant_ids_in_cache=assistant_ids_in_cache
+        )
         generation_args = self._prepare_generation_args(assistant_input_ids, min_new_tokens, max_new_tokens)
 
         # Ensure scores are returned
@@ -951,7 +1021,12 @@ class UniversalSpeculativeDecodingGenerator(AssistedCandidateGeneratorDifferentT
 
         return target_candidate_ids, target_candidate_logits
 
-    def _update_past_and_masks(self, assistant_input_ids: torch.LongTensor, num_added_tokens: int = 1) -> bool:
+    def _update_past_and_masks(
+        self,
+        assistant_input_ids: torch.LongTensor,
+        num_added_tokens: int = 1,
+        assistant_ids_in_cache: torch.LongTensor = None,
+    ) -> bool:
         if self._prev_assistant_ids is None:
             # Prepare attention mask for the first generation.
             # For subsequent generations, the attention mask is updated in super()_update_past_and_masks.
@@ -1045,13 +1120,17 @@ class PromptLookupCandidateGenerator(CandidateGenerator):
         if self.max_matching_ngram_size <= 0 or self.num_output_tokens <= 0:
             raise ValueError("Invalid max_matching_ngram_size or num_output_tokens")
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, assistant_ids_in_cache: torch.LongTensor = None
+    ) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
         """
         Fetches the candidates to be tried for the current input.
 
         Args:
             input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
                 Indices of input sequence tokens in the vocabulary. [What are input IDs?](../glossary#input-ids)
+            assistant_ids_in_cache (`torch.LongTensor`, *optional*):
+                Assistant model input IDs that are already in the cache. Not used by prompt lookup decoding.
 
         Return:
             `torch.LongTensor` of shape `(num_candidates, candidate_length)`: The candidate sequences to be tried.
@@ -1139,7 +1218,9 @@ class PromptLookupCandidateGenerator(CandidateGenerator):
         # assisted_generation expects logits as well, but we don't have those here, so returning None
         return candidate_input_ids, None
 
-    def update_candidate_strategy(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int):
+    def update_candidate_strategy(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int, assistant_used: bool = True
+    ):
         """
         Updates the candidate generation strategy based on the outcomes.
 
@@ -1151,6 +1232,8 @@ class PromptLookupCandidateGenerator(CandidateGenerator):
                 beam search or log softmax for each vocabulary token when using beam search
             num_matches (`int`):
                 The number of matches between the candidate sequences and the model predictions.
+            assistant_used (`bool`):
+                Whether the assistant was used to generate the candidates. Assistant was not used if max_new_tokens is 0.
         """
         # Currently does nothing
         return
@@ -1202,17 +1285,27 @@ class EarlyExitCandidateGenerator(AssistedCandidateGenerator):
         self.assistant_early_exit = self.generation_config.assistant_early_exit
         self.generation_config.assistant_early_exit = None
 
-    def get_candidates(self, input_ids: torch.LongTensor) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
+    def get_candidates(
+        self, input_ids: torch.LongTensor, assistant_ids_in_cache: torch.LongTensor = None
+    ) -> tuple[torch.LongTensor, torch.FloatTensor | None]:
         # Temporarily sets the number of hidden layers to the early exit value
         base_model = getattr(self.assistant_model, self.assistant_model.base_model_prefix)
         original_num_hidden_layers = base_model.config.num_hidden_layers
         base_model.config.num_hidden_layers = self.assistant_early_exit
-        candidate_ids, candidate_logits = super().get_candidates(input_ids)
+        candidate_ids, candidate_logits = super().get_candidates(
+            input_ids, assistant_ids_in_cache=assistant_ids_in_cache
+        )
         base_model.config.num_hidden_layers = original_num_hidden_layers
         return candidate_ids, candidate_logits
 
 
-def _prepare_attention_mask(model_kwargs: dict[str, Any], new_length: int, is_encoder_decoder: bool) -> dict[str, Any]:
+def _prepare_attention_mask(
+    model_kwargs: dict[str, Any],
+    new_length: int,
+    is_encoder_decoder: bool,
+    input_ids: torch.LongTensor | None = None,
+    pad_token_id: int | None = None,
+) -> dict[str, Any]:
     """Expands or crops the model's mask for decoding purposes, to the defined length"""
 
     mask_key = "decoder_attention_mask" if is_encoder_decoder else "attention_mask"
@@ -1221,8 +1314,9 @@ def _prepare_attention_mask(model_kwargs: dict[str, Any], new_length: int, is_en
 
     mask = model_kwargs[mask_key]
     mask_length_diff = new_length - mask.shape[1]
-
-    if mask_length_diff < 0:
+    if input_ids is not None and pad_token_id is not None:
+        model_kwargs[mask_key] = (input_ids != pad_token_id).to(mask.dtype)
+    elif mask_length_diff < 0:  # not sure when we get into this case
         model_kwargs[mask_key] = mask[:, :mask_length_diff]
     elif mask_length_diff > 0:
         model_kwargs[mask_key] = torch.cat([mask, mask.new_ones((mask.shape[0], mask_length_diff))], dim=-1)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3693,8 +3693,8 @@ class GenerationMixin(ContinuousMixin):
                 candidate_kwargs,
                 candidate_input_ids.shape[1],
                 self.config.is_encoder_decoder,
-                candidate_input_ids,
-                pad_token_id,
+                candidate_input_ids if batch_size > 1 else None,
+                pad_token_id if batch_size > 1 else None,
             )
             candidate_kwargs = _prepare_token_type_ids(candidate_kwargs, candidate_input_ids.shape[1])
             if "cache_position" in candidate_kwargs:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -26,6 +26,7 @@ import torch
 import torch.distributed as dist
 from packaging import version
 from torch import nn
+from torch.nn.utils.rnn import pad_sequence
 
 from ..cache_utils import (
     Cache,
@@ -3649,20 +3650,34 @@ class GenerationMixin(ContinuousMixin):
         # keep track of which sequences are already finished
         batch_size, cur_len = input_ids.shape[:2]
         if batch_size > 1:
-            raise ValueError("assisted generate is only supported for batch_size = 1")
+            if assistant_tokenizer is not None:
+                raise ValueError(
+                    "assisted generate is only supported for batch_size > 1 if assistant_tokenizer is None"
+                )
+            if generation_config.prompt_lookup_num_tokens is not None:
+                raise ValueError(
+                    "assisted generate is only supported for batch_size > 1 if prompt_lookup_num_tokens is None"
+                )
+
         unfinished_sequences = torch.ones(batch_size, dtype=torch.long, device=input_ids.device)
         model_kwargs = self._get_initial_cache_position(cur_len, input_ids.device, model_kwargs)
 
         this_peer_finished = False
         is_first_iteration = True  # to preserve the same API in the output as other generation methods
+        assistant_ids_in_cache = None
+        pad_token_id = generation_config._pad_token_tensor
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             cur_len = input_ids.shape[1]
 
             #  1. Fetch candidate sequences from a `CandidateGenerator` and move to the correct device
-            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(input_ids)
+            candidate_input_ids, candidate_logits = candidate_generator.get_candidates(
+                input_ids, assistant_ids_in_cache
+            )
+            assistant_ids_in_cache = candidate_input_ids[:, :-1]
             candidate_input_ids = candidate_input_ids.to(self.device)
             if candidate_logits is not None:
                 candidate_logits = candidate_logits.to(self.device)
+            assistant_used = candidate_logits is not None
 
             candidate_length = candidate_input_ids.shape[1] - input_ids.shape[1]
             is_done_candidate = stopping_criteria(candidate_input_ids, None)
@@ -3674,7 +3689,11 @@ class GenerationMixin(ContinuousMixin):
             # 2.1. Prepare the model inputs
             candidate_kwargs = copy.copy(model_kwargs)
             candidate_kwargs = _prepare_attention_mask(
-                candidate_kwargs, candidate_input_ids.shape[1], self.config.is_encoder_decoder
+                candidate_kwargs,
+                candidate_input_ids.shape[1],
+                self.config.is_encoder_decoder,
+                candidate_input_ids,
+                pad_token_id,
             )
             candidate_kwargs = _prepare_token_type_ids(candidate_kwargs, candidate_input_ids.shape[1])
             if "cache_position" in candidate_kwargs:
@@ -3708,12 +3727,13 @@ class GenerationMixin(ContinuousMixin):
             # Case 1: `do_sample=True` and we have logits for the candidates (originally from speculative decoding)
             # 👉 Apply algorithm 1 from the speculative decoding paper (https://huggingface.co/papers/2211.17192).
             if do_sample and candidate_logits is not None:
-                valid_tokens, n_matches = _speculative_sampling(
+                valid_tokens_padded, n_matches = _speculative_sampling(
                     candidate_input_ids,
                     candidate_logits,
                     candidate_length,
                     new_logits,
                     is_done_candidate,
+                    pad_token_id,
                 )
 
             # Case 2: all other cases (originally from assisted generation) 👉 Compare the tokens selected from the
@@ -3722,17 +3742,37 @@ class GenerationMixin(ContinuousMixin):
             else:
                 if do_sample:
                     probs = new_logits.softmax(dim=-1)
-                    selected_tokens = torch.multinomial(probs[0, :, :], num_samples=1).squeeze(1)[None, :]
+                    selected_tokens = (
+                        torch.multinomial(probs.view(-1, probs.size(-1)), num_samples=1)
+                        .squeeze(-1)
+                        .view(probs.size(0), probs.size(1))
+                    )
                 else:
                     selected_tokens = new_logits.argmax(dim=-1)
 
                 candidate_new_tokens = candidate_input_ids[:, cur_len:]
-                n_matches = ((~(candidate_new_tokens == selected_tokens[:, :-1])).cumsum(dim=-1) < 1).sum()
+                not_accepted_tokens = ~(
+                    candidate_new_tokens == selected_tokens[:, :-1]
+                )  # shape: (batch_size, candidate_lenght)
+                n_matches = (not_accepted_tokens.cumsum(dim=-1) < 1).sum(dim=-1)  # shape: (batch_size,)
 
                 # Ensure we don't generate beyond max_len or an EOS token
-                if is_done_candidate and n_matches == candidate_length:
-                    n_matches -= 1
-                valid_tokens = selected_tokens[:, : n_matches + 1]
+                # Create fully padded tensor
+                valid_tokens_padded = torch.full(
+                    (batch_size, candidate_length + 1),  # YANIV: max_matches is at most candidate_length
+                    pad_token_id,
+                    dtype=torch.long,
+                    device=selected_tokens.device,
+                )
+
+                # Build mask for which positions in each row should be filled
+                range_row = torch.arange(candidate_length + 1, device=selected_tokens.device).unsqueeze(0)
+                mask = range_row <= n_matches.unsqueeze(1)
+
+                # Fill efficient batched slice
+                valid_tokens_padded[mask] = selected_tokens[:, : candidate_length + 1][
+                    mask
+                ]  # a tensor of the selected_tokens with trailing pad_token_id
 
             # 4. Update variables according to the number of matching assistant tokens. Remember: the token generated
             # by the model after the last candidate match is also valid, as it is generated from a correct sequence.
@@ -3740,23 +3780,25 @@ class GenerationMixin(ContinuousMixin):
             # is no match.
 
             # 4.1. Get the valid continuation, after the matching tokens
-            input_ids = torch.cat((input_ids, valid_tokens), dim=-1)
+            input_ids, outputs.past_key_values = repadd_batch_and_fix_cache(
+                input_ids, outputs.past_key_values, valid_tokens_padded, pad_token_id
+            )
             if streamer is not None:
-                streamer.put(valid_tokens.cpu())
+                streamer.put(
+                    valid_tokens_padded.cpu()
+                )  # we might want to remove the padding here. and allow only for batch size 1
             new_cur_len = input_ids.shape[1]
 
-            # 4.2. Discard past key values relative to unused assistant tokens
-            outputs.past_key_values.crop(new_cur_len - 1)
-
             # 5. Update the candidate generation strategy if needed
-            candidate_generator.update_candidate_strategy(input_ids, new_logits, n_matches)
+            candidate_generator.update_candidate_strategy(input_ids, new_logits, n_matches, assistant_used)
 
             # synced_gpus: don't waste resources running the code we don't need; kwargs must be updated before skipping
+            model_kwargs["cache_position"] = torch.tensor([new_cur_len - 1], device=input_ids.device, dtype=torch.long)
             model_kwargs = self._update_model_kwargs_for_generation(
                 outputs,
                 model_kwargs,
                 is_encoder_decoder=self.config.is_encoder_decoder,
-                num_new_tokens=n_matches + 1,
+                num_new_tokens=0,
             )
             if synced_gpus and this_peer_finished:
                 continue
@@ -3898,6 +3940,7 @@ def _speculative_sampling(
     candidate_length,
     new_logits,
     is_done_candidate,
+    pad_token_id,
 ):
     """
     Applies sampling as in the speculative decoding paper (https://huggingface.co/papers/2211.17192, algorithm 1). Returns
@@ -3909,43 +3952,53 @@ def _speculative_sampling(
     # Gets the probabilities from the logits. q_i and p_i denote the assistant and model probabilities of the tokens
     # selected by the assistant, respectively.
     q = candidate_logits.softmax(dim=-1)
-    q_i = q[:, torch.arange(candidate_length), new_candidate_input_ids].squeeze(0, 1)
+    q_i = q.gather(dim=-1, index=new_candidate_input_ids.unsqueeze(-1)).squeeze(-1)
     p = new_logits.softmax(dim=-1)
-    p_i = p[:, torch.arange(candidate_length), new_candidate_input_ids].squeeze(0, 1)
-    probability_ratio = p_i / q_i
+    p_i = p.gather(dim=-1, index=new_candidate_input_ids.unsqueeze(-1)).squeeze(-1)
+    probability_ratio = p_i / q_i  # [batch_size, candidate_length]
 
     # When probability_ratio > 1 (i.e. q_i(x) < p_i(x), or "assistant probability of the candidate token is smaller
     # than the model probability for the same token"), keep the token. Otherwise reject with p = 1 - probability_ratio
     # (= keep with p = probability_ratio). Keep all the tokens until the first rejection
     r_i = torch.rand_like(probability_ratio)
     is_accepted = r_i <= probability_ratio
-    n_matches = ((~is_accepted).cumsum(dim=-1) < 1).sum()  # this is `n` in algorithm 1
+    n_matches = ((~is_accepted).cumsum(dim=-1) < 1).sum(dim=-1)  # this is `n` in algorithm 1. shape: (batch_size,)
 
     # Ensure we don't generate beyond max_len or an EOS token (not in algorithm 1, but needed for correct behavior)
-    if is_done_candidate and n_matches == candidate_length:
-        # Output length is assumed to be `n_matches + 1`. Since we won't generate another token with the target model
-        # due to acceptance on EOS we fix `n_matches`
-        n_matches -= 1
-        valid_tokens = new_candidate_input_ids[:, : n_matches + 1]
-    else:
-        # Next token selection: if there is a rejection, adjust the distribution from the main model before sampling.
-        gamma = candidate_logits.shape[1]
-        p_n_plus_1 = p[:, n_matches, :]
-        if n_matches < gamma:
-            q_n_plus_1 = q[:, n_matches, :]
-            p_prime = torch.clamp((p_n_plus_1 - q_n_plus_1), min=0)
-            p_prime.div_(p_prime.sum())
+    valid_tokens_list = [None] * len(n_matches)
+    for i in range(len(n_matches)):
+        if is_done_candidate[i] and n_matches[i] == candidate_length:
+            # Output length is assumed to be `n_matches + 1`. Since we won't generate another token with the target model
+            # due to acceptance on EOS we fix `n_matches`
+            n_matches[i] -= 1
+            valid_tokens = new_candidate_input_ids[[i], : n_matches[i] + 1]
         else:
-            p_prime = p_n_plus_1
-        t = torch.multinomial(p_prime, num_samples=1).squeeze(1)[None, :]
+            # Next token selection: if there is a rejection, adjust the distribution from the main model before sampling.
+            gamma = candidate_logits.shape[1]
+            p_n_plus_1 = p[i, n_matches[i], :]
+            if n_matches[i] < gamma:
+                q_n_plus_1 = q[i, n_matches[i], :]
+                p_prime = torch.clamp((p_n_plus_1 - q_n_plus_1), min=0)
+                p_prime.div_(p_prime.sum())
+            else:
+                p_prime = p_n_plus_1
+            t = torch.multinomial(p_prime, num_samples=1)[None, :]
 
-        # The selected tokens include the matches (if any) plus the next sampled tokens
-        if n_matches > 0:
-            valid_tokens = torch.cat((new_candidate_input_ids[:, :n_matches], t), dim=-1)
-        else:
-            valid_tokens = t
-
-    return valid_tokens, n_matches
+            # The selected tokens include the matches (if any) plus the next sampled tokens
+            if n_matches[i] > 0:
+                valid_tokens = torch.cat((new_candidate_input_ids[[i], : n_matches[i]], t), dim=-1)
+            else:
+                valid_tokens = t
+        valid_tokens_list[i] = valid_tokens
+    pad_valid_tokens = torch.full(
+        (len(valid_tokens_list), candidate_length + 1),
+        pad_token_id,
+        dtype=torch.long,
+        device=valid_tokens_list[0].device,
+    )
+    for i in range(len(valid_tokens_list)):
+        pad_valid_tokens[i, -valid_tokens_list[i].shape[1] :] = valid_tokens_list[i]
+    return pad_valid_tokens, n_matches
 
 
 def _split_model_outputs(outputs, new_outputs, cur_len, added_len, is_decoder_attention=False):
@@ -3972,3 +4025,34 @@ def _split_model_outputs(outputs, new_outputs, cur_len, added_len, is_decoder_at
             new_tuple += (layer[..., i : i + 1, :last_dim_size],)
         outputs += (new_tuple,)
     return outputs
+
+
+def repadd_batch_and_fix_cache(input_ids, past_key_values, accepted_tokens_padded, pad_token_id):
+    """
+    params
+        input_ids: the input ids of the model (without the candidate tokens). shape: [B, S]
+        past_key_values: the past key values of the model. shape: [B, S, num_heads, head_dim] for each layer in the cache.
+        accepted_tokens_padded: the accepted tokens padded with the bonus token. shape: [B, candidate_length+1].
+        The bonus token is not always the last token (!). The rejected tokens are replaced with the pad_token_id.
+        pad_token_id: the pad token id.
+    returns:
+        repadded_tensor: the repadded tensor. shape: [B, ..]
+        cache: the cache after modifying the keys and values.
+
+    """
+    next_input_ids = torch.cat([input_ids, accepted_tokens_padded], dim=1)  # notive that accepted
+    # this will let us know which locations in the kv cache we should remove.
+    # we remove the last token because it is the bonus token and it does not appear in the cache.
+    cache_input_ids = next_input_ids.clone()
+    # last non zero token in each row is set to 0 because it is the bonus token and it does not appear in the cache.
+    cache_input_ids[torch.arange(cache_input_ids.shape[0]), (cache_input_ids != pad_token_id).cumsum(1).argmax(1)] = (
+        pad_token_id
+    )
+    padding_mask = cache_input_ids[:, :-1] == pad_token_id
+    past_key_values.compress_and_repad_cache(padding_mask)
+    # 1. Filter out current padding and repad to minimum length.
+    next_input_ids_clean = [row[row != pad_token_id] for row in next_input_ids]
+    next_input_ids_padded = pad_sequence(
+        next_input_ids_clean, batch_first=True, padding_value=pad_token_id, padding_side="left"
+    )
+    return next_input_ids_padded, past_key_values

--- a/tests/generation/test_candidate_generator.py
+++ b/tests/generation/test_candidate_generator.py
@@ -249,6 +249,8 @@ class TestUniversalSpeculativeDecoding(unittest.TestCase):
             self.assistant_tokenizer.pad_token_id = self.assistant_tokenizer.eos_token_id
         if self.assistant_tokenizer.bos_token_id is None:
             self.assistant_tokenizer.bos_token_id = self.assistant_tokenizer.eos_token_id
+            
+        self.generation_config._pad_token_tensor = torch.tensor([self.target_tokenizer.pad_token_id]).to(torch_device)
 
         self.input_ids = torch.tensor([[1, 2, 3]]).to(torch_device)
         self.model_kwargs = {

--- a/tests/generation/test_candidate_generator.py
+++ b/tests/generation/test_candidate_generator.py
@@ -249,7 +249,7 @@ class TestUniversalSpeculativeDecoding(unittest.TestCase):
             self.assistant_tokenizer.pad_token_id = self.assistant_tokenizer.eos_token_id
         if self.assistant_tokenizer.bos_token_id is None:
             self.assistant_tokenizer.bos_token_id = self.assistant_tokenizer.eos_token_id
-            
+
         self.generation_config._pad_token_tensor = torch.tensor([self.target_tokenizer.pad_token_id]).to(torch_device)
 
         self.input_ids = torch.tensor([[1, 2, 3]]).to(torch_device)


### PR DESCRIPTION
# What does this PR do?
Many discussions focused on speculative decoding with 'batch_size > 1' (#26875, #29769, #32165, #32189), but none were fully implemented. This PR does that.

### **Summary of Changes: Enable Batched Speculative Decoding**

Until now, invoking `generate()` with an `assistant_model` raised a `ValueError` if `batch_size > 1`. This update modifies the codebase to support batched speculative decoding.

#### **Key Features & Limitations**
* **Batch Support:** Enabled `batch_size > 1` for standard speculative decoding.
* **Tokenizer Constraint:** Batched execution is currently **restricted to scenarios where the draft (assistant) and target (main) models share the same tokenizer**.
    * *Universal Assisted Generation (UAG)*—where models use different tokenizers—remains restricted to `batch_size = 1` and will still raise a `ValueError` if used with a batch.

#### **Technical Implementation Details**
Supporting batches requires dealing with "ragged tensors", where different sequences in a batch accept a different number of speculative tokens, leading to misalignment in tensor shapes and KV caches. The implementation addresses this via the following mechanisms:

**1. Assistant Cache Alignment**
* When reusing the assistant model for the next draft generation, the previous KV cache must match the current state of the sequences.
* `align_cache` function was implemented in `candidate_generator.py`. It identify which parts of the old cache match the new inputs and removing the irrelevant keys and values from the cache. This ensures the assistant's cache correctly reflects the accepted tokens.

**2. Repadding Inputs and Main Model Cache**
* After verification, if Batch Item A accepts 2 tokens and Batch Item B accepts 4, the resulting input tensor becomes ragged.
* The rejected tokens and the padding tokens are removed from each item and the entire batch is repadded. The same is happening fo the main model KV cache

**3. Vectorized Verification & Sampling**
* **Greedy Search:** The acceptance logic (checking if candidate tokens match target output) now uses vectorized `cumsum` operations to identify the index of the first mismatch for every item in the batch simultaneously.
* **Sampling:** `_speculative_sampling` has been updated to calculate acceptance probabilities ($p$ vs $q$) and handle token rejection/resampling for the entire batch in parallel.

**4. Dynamic Heuristics (`update_candidate_strategy`)**
* The heuristic that adjusts the number of assistant tokens (`num_assistant_tokens`) now aggregates statistics across the batch (e.g., using the average number of matches) to determine if the draft model step size should increase or decrease.
* For the dynamic confidence threshold (ROC curve calculation), matches and probabilities are collected per batch item, flattened, and then used to update the threshold.

#### **Note on `max_new_tokens`**
When using speculative decoding with `batch_size > 1`, the behavior regarding `max_new_tokens` requires nuance. Because the generation loop serves the entire batch, the process continues until one items satisfy the stopping criteria. However, due to the repadding and varying acceptance rates, other items in the batch may effectively stop generating before reaching the global `max_new_tokens` limit.

### Batch Size = 3: Assistant vs Standard Decoding
WITHOUT assistant_model:  9.2215 seconds
WITH assistant_model:         7.4744 seconds

| Sequence | # Tokens w Assistant | # Tokens w/o Assistant |
|----------|----------------|-----------------|
| 1        | 50             | 50              |
| 2        | 41             | 50              |
| 3        | 40             | 50              |

**I look forward to your response and comments to ensure this can be included in the next version.**