### PR TITLE
Fixed failing Bart-Model Integration Tests

### DIFF
--- a/tests/models/bart/test_modeling_bart.py
+++ b/tests/models/bart/test_modeling_bart.py
@@ -962,7 +962,7 @@ class BartModelIntegrationTests(unittest.TestCase):
             " state."
             "</s>"
         )
-        dct = tok.batch_encode_plus(
+        dct = tok(
             [PGE_ARTICLE],
             max_length=1024,
             padding="max_length",
@@ -1188,7 +1188,7 @@ class BartModelIntegrationTests(unittest.TestCase):
             " up to four years in prison.  Her next court appearance is scheduled for May 18."
         )
 
-        dct = tok.batch_encode_plus(
+        dct = tok(
             [FRANCE_ARTICLE, SHORTER_ARTICLE, IRAN_ARTICLE, ARTICLE_SUBWAY],
             max_length=1024,
             padding="max_length",


### PR DESCRIPTION
# What does this PR do?

Fixes these failing [Bart-Model Integration Tests](https://github.com/huggingface/transformers/actions/runs/19983883282/job/57315087703#step:14:3737). As mentioned in the [V5 Migration guide](https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md#3-unified-encoding-api): The `encode_plus` method is deprecated in favor of the single `__call__` method.

<img width="1294" height="145" alt="image" src="https://github.com/user-attachments/assets/fde4f7a7-1a0b-4122-a93f-ebe58e3f212e" />



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker @Rocketknight1