### PR TITLE
Add is_flash_attn_4_available() detection functionAdd is_flash_attn_4_available() detection function

### DIFF
--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -136,6 +136,7 @@ from .import_utils import (
     is_fbgemm_gpu_available,
     is_flash_attn_2_available,
     is_flash_attn_3_available,
+    is_flash_attn_4_available,
     is_flash_attn_greater_or_equal,
     is_flash_attn_greater_or_equal_2_10,
     is_flute_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -902,6 +902,35 @@ def is_flash_attn_3_available() -> bool:
 
 
 @lru_cache
+def is_flash_attn_4_available() -> bool:
+    """
+    Check if Flash Attention 4 is available.
+
+    FA4 requires:
+    - CUDA availability
+    - SM 8.0+ GPU (Hopper: H100/H200, or Blackwell architecture)
+    - flash_attn package with the cute module
+
+    Reference: https://github.com/huggingface/transformers/issues/42405
+    """
+    if not is_torch_cuda_available():
+        return False
+
+    try:
+        import torch
+
+        # FA4 requires SM 8.0+ (Hopper/Blackwell architectures)
+        if torch.cuda.get_device_capability()[0] < 8:
+            return False
+        # FA4 uses the flash_attn.cute module
+        from flash_attn.cute import flash_attn_func  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+@lru_cache
 def is_flash_attn_greater_or_equal_2_10() -> bool:
     _, flash_attn_version = _is_package_available("flash_attn", return_version=True)
     return is_flash_attn_2_available() and version.parse(flash_attn_version) >= version.parse("2.1.0")


### PR DESCRIPTION
## What does this PR do?

Partial contribution for #42405

This PR adds the `is_flash_attn_4_available()` detection function for Flash Attention 4 (Blackwell/Hopper GPUs).

## Changes

Added to `src/transformers/utils/import_utils.py`:

@lru_cache
def is_flash_attn_4_available() -> bool:
    """
    Check if Flash Attention 4 is available.

    FA4 requires:
    - CUDA availability
    - SM 8.0+ GPU (Hopper: H100/H200, or Blackwell architecture)
    - flash_attn package with the cute module
    """Also exported in `src/transformers/utils/__init__.py`.

## Scope

This is a **partial contribution** - just the detection function. The full FA4 integration requires:
- [ ] API compatibility layer for FA4 vs FA2/FA3
- [ ] Auto-selection priority logic
- [ ] Registration in AttentionInterface
- [ ] Testing (requires H100/H200/Blackwell hardware)

I don't have access to H100/H200 hardware, so I'm contributing what I can. The remaining integration can be done by someone with the appropriate hardware.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case)
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? *(N/A - detection function only, needs hardware to test)*

cc @sambhavnoobcoder (issue author)