### PR TITLE
Fix: Skip weight initialization for quantized int8 models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4116,6 +4116,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             # This is not true but for now we assume only best-case scenario with deepspeed, i.e. perfectly matching checkpoints
             missing_keys, unexpected_keys, mismatched_keys, misc = set(), set(), set(), set()
         else:
+            # Skip weight initialization for quantized models (int8 weights)
+            if is_quantized:
+                print("Skipping weight initialization for quantized model.")
+                return missing_keys, unexpected_keys, mismatched_keys, None, set()
+
             all_pointer = set()
             # Checkpoints are safetensors
             if checkpoint_files is not None and checkpoint_files[0].endswith(".safetensors"):


### PR DESCRIPTION
This PR fixes the RuntimeError encountered when loading quantized models (int8 weights). 

The issue occurs because PyTorch’s `normal_()` cannot operate on integer tensors. 

Changes:
- Skip weight initialization for quantized models in `_load_pretrained_model()`
- Print a small info message when skipping

Fixes #42574

- @SunMarc
- @MekkCyber