### PR TITLE
Fix PEFT integration with new weight loader

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -228,7 +228,7 @@ def get_model_conversion_mapping(
     """
     weight_conversions = []
 
-    # Load models with key mapping
+    # Load models with explicit, user-provided key mapping
     if key_mapping is not None:
         weight_conversions = [WeightRenaming(source_patterns=k, target_patterns=v) for k, v in key_mapping.items()]
     elif any(

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -17,6 +17,7 @@ import json
 import os
 from typing import Any, Literal
 
+from ..conversion_mapping import get_model_conversion_mapping
 from ..core_model_loading import WeightRenaming, rename_source_key
 from ..utils import (
     CONFIG_NAME,
@@ -44,26 +45,6 @@ MIN_PEFT_VERSION = "0.18.0"
 
 
 logger = logging.get_logger(__name__)
-
-
-# DO NOT MODIFY, KEPT FOR BC ONLY
-VLMS = [
-    "aria",
-    "ayavision",
-    "emu3",
-    "fuyu",
-    "gotocr2",
-    "gemma3",
-    "internvl",
-    "llava",  # all llava prefixed models fall under this check
-    "mistral3",
-    "mllama",
-    "paligemma",
-    "qwen2vl",
-    "qwen2_5_vl",
-    "videollava",
-    "vipllava",
-]
 
 
 class PeftAdapterMixin:
@@ -211,11 +192,10 @@ class PeftAdapterMixin:
             if any(conf.peft_type != PeftType.LORA for conf in self.peft_config.values()):
                 raise ValueError("Hotswapping is currently only supported for LoRA, please set `hotswap=False`.")
 
+        key_mapping = adapter_kwargs.pop("key_mapping", None) if adapter_kwargs is not None else None
+        weight_conversions = get_model_conversion_mapping(self, key_mapping=key_mapping)
         # peft only supports low_cpu_mem_usage starting from v0.13.0
         peft_load_kwargs = {}
-        key_mapping = adapter_kwargs.pop("key_mapping", None) if adapter_kwargs is not None else None
-        if key_mapping is None and any(allowed_name in self.__class__.__name__.lower() for allowed_name in VLMS):
-            key_mapping = self._checkpoint_conversion_mapping
         peft_load_kwargs["low_cpu_mem_usage"] = low_cpu_mem_usage
 
         adapter_name = adapter_name if adapter_name is not None else "default"
@@ -292,8 +272,8 @@ class PeftAdapterMixin:
 
         # We need to pre-process the state dict to remove unneeded prefixes - for backward compatibility
         renamings = []
-        if key_mapping:
-            renamings = [entry for entry in key_mapping if isinstance(entry, WeightRenaming)]
+        if weight_conversions:
+            renamings = [entry for entry in weight_conversions if isinstance(entry, WeightRenaming)]
         processed_adapter_state_dict = {}
         prefix = "base_model.model."
         state_dict = self.state_dict()

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4037,7 +4037,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             hf_quantizer.postprocess_model(model, config=config)  # usually a no-op but sometimes needed
 
         if _adapter_model_path is not None:
-            adapter_kwargs["key_mapping"] = weight_conversions  # TODO: Dynamic weight loader for adapters
+            adapter_kwargs["key_mapping"] = key_mapping
             model.load_adapter(
                 _adapter_model_path,
                 adapter_name=adapter_name,


### PR DESCRIPTION
# What does this PR do?

As per the title. The `VLMS` list should not be duplicated in `peft.py` at it's not getting updated! Also fix it when it's not coming from `from_pretrained`!