### PR TITLE
Update replace_with_ for quants methods to not use recursion

### DIFF
--- a/src/transformers/integrations/aqlm.py
+++ b/src/transformers/integrations/aqlm.py
@@ -27,7 +27,7 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 def replace_with_aqlm_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with AQLM quantized layers.

--- a/src/transformers/integrations/aqlm.py
+++ b/src/transformers/integrations/aqlm.py
@@ -21,14 +21,12 @@ if is_accelerate_available():
     from accelerate import init_empty_weights
 
 if is_torch_available():
-    import torch
     import torch.nn as nn
 
 logger = logging.get_logger(__name__)
 
-def replace_with_aqlm_linear(
-    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
-):
+
+def replace_with_aqlm_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
     Public method that recursively replaces the Linear layers of the given model with AQLM quantized layers.
 
@@ -51,14 +49,14 @@ def replace_with_aqlm_linear(
         with init_empty_weights():
             if isinstance(module, nn.Linear):
                 new_module = QuantizedLinear(
-                        module.in_features,
-                        module.out_features,
-                        bias=module.bias is not None,
-                        in_group_size=quantization_config.in_group_size,
-                        out_group_size=quantization_config.out_group_size,
-                        num_codebooks=quantization_config.num_codebooks,
-                        nbits_per_codebook=quantization_config.nbits_per_codebook,
-                    )
+                    module.in_features,
+                    module.out_features,
+                    bias=module.bias is not None,
+                    in_group_size=quantization_config.in_group_size,
+                    out_group_size=quantization_config.out_group_size,
+                    num_codebooks=quantization_config.num_codebooks,
+                    nbits_per_codebook=quantization_config.nbits_per_codebook,
+                )
                 new_module.source_cls = type(module)
                 new_module.requires_grad_(False)
                 model.set_submodule(module_name, new_module)

--- a/src/transformers/integrations/aqlm.py
+++ b/src/transformers/integrations/aqlm.py
@@ -13,88 +13,62 @@
 # limitations under the License.
 "AQLM (Additive Quantization of Language Model) integration file"
 
-from ..utils import ACCELERATE_MIN_VERSION, is_accelerate_available, is_aqlm_available, is_torch_available
+from ..quantizers.quantizers_utils import should_convert_module
+from ..utils import is_accelerate_available, is_torch_available, logging
 
+
+if is_accelerate_available():
+    from accelerate import init_empty_weights
 
 if is_torch_available():
+    import torch
     import torch.nn as nn
 
+logger = logging.get_logger(__name__)
 
 def replace_with_aqlm_linear(
-    model,
-    quantization_config=None,
-    linear_weights_not_to_quantize=None,
-    current_key_name=None,
-    has_been_replaced=False,
+    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with AQLM quantized layers.
-    `accelerate` is needed to use this method. Returns the converted model and a boolean that indicates if the
-    conversion has been successful or not.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        quantization_config (`AqlmConfig`):
-            The quantization config object that contains the quantization parameters.
-        linear_weights_not_to_quantize (`list[str]`, *optional*):
+        modules_not_to_quantize (`list[str]`, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
-        current_key_name (`list`, *optional*):
-            A list that contains the current key name. This is used for recursion and should not be passed by the user.
-        has_been_replaced (`bool`, *optional*):
-            A boolean that indicates if the conversion has been successful or not. This is used for recursion and
-            should not be passed by the user.
+        quantization_config (`AqlmConfig`):
+            The quantization config object that contains the quantization parameters.
     """
-    if not is_aqlm_available():
-        raise ValueError("AQLM is not available. Please install it with `pip install aqlm[cpu,gpu]`")
-
-    if not is_accelerate_available():
-        raise ValueError(
-            f"AQLM requires Accelerate to be installed: `pip install 'accelerate>={ACCELERATE_MIN_VERSION}'`"
-        )
-
-    if linear_weights_not_to_quantize is None:
-        linear_weights_not_to_quantize = []
-
-    from accelerate import init_empty_weights
     from aqlm import QuantizedLinear
 
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
-
-        if isinstance(module, nn.Linear):
-            # Check if the current key is not in the `linear_weights_not_to_quantize`
-            if ".".join(current_key_name) + ".weight" not in linear_weights_not_to_quantize:
-                with init_empty_weights():
-                    in_features = module.in_features
-                    out_features = module.out_features
-
-                    model._modules[name] = QuantizedLinear(
-                        in_features,
-                        out_features,
+    has_been_replaced = False
+    # we need this to correctly materialize the weights during quantization
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+        with init_empty_weights():
+            if isinstance(module, nn.Linear):
+                new_module = QuantizedLinear(
+                        module.in_features,
+                        module.out_features,
                         bias=module.bias is not None,
                         in_group_size=quantization_config.in_group_size,
                         out_group_size=quantization_config.out_group_size,
                         num_codebooks=quantization_config.num_codebooks,
                         nbits_per_codebook=quantization_config.nbits_per_codebook,
                     )
-                    has_been_replaced = True
+                new_module.source_cls = type(module)
+                new_module.requires_grad_(False)
+                model.set_submodule(module_name, new_module)
+                has_been_replaced = True
 
-                    # Store the module class in case we need to transpose the weight later
-                    model._modules[name].source_cls = type(module)
-                    # Force requires grad to False to avoid unexpected errors
-                    model._modules[name].requires_grad_(False)
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = replace_with_aqlm_linear(
-                module,
-                quantization_config=quantization_config,
-                linear_weights_not_to_quantize=linear_weights_not_to_quantize,
-                current_key_name=current_key_name,
-                has_been_replaced=has_been_replaced,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
+    if not has_been_replaced:
+        logger.warning(
+            "You are loading your model using eetq but no linear modules were found in your model."
+            " Please double check your model architecture, or submit an issue on github if you think this is"
+            " a bug."
+        )
+
+    return model

--- a/src/transformers/integrations/aqlm.py
+++ b/src/transformers/integrations/aqlm.py
@@ -33,7 +33,7 @@ def replace_with_aqlm_linear(model, modules_to_not_convert: list[str] | None = N
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        modules_not_to_quantize (`list[str]`, defaults to `None`):
+        modules_to_not_convert (`list[str]`, *optional*, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
         quantization_config (`AqlmConfig`):

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -315,7 +315,7 @@ class AutoBitLinear(nn.Linear):
         return output
 
 def replace_with_bitnet_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the kinear layers of the given model with bitnet quantized layers.

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -314,9 +314,8 @@ class AutoBitLinear(nn.Linear):
             output = output * self.weight_scale
         return output
 
-def replace_with_bitnet_linear(
-    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
-):
+
+def replace_with_bitnet_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
     Public method that recursively replaces the kinear layers of the given model with bitnet quantized layers.
 
@@ -339,27 +338,27 @@ def replace_with_bitnet_linear(
             if isinstance(module, nn.Linear):
                 if quantization_config and quantization_config.linear_class == "autobitlinear":
                     new_module = AutoBitLinear(
-                                in_features=module.in_features,
-                                out_features=module.out_features,
-                                bias=module.bias is not None,
-                                device=module.weight.device,
-                                dtype=module.weight.dtype,
-                                online_quant=(quantization_config.quantization_mode == "online"),
-                                use_rms_norm=quantization_config.use_rms_norm,
-                                rms_norm_eps=quantization_config.rms_norm_eps,
-                            )
+                        in_features=module.in_features,
+                        out_features=module.out_features,
+                        bias=module.bias is not None,
+                        device=module.weight.device,
+                        dtype=module.weight.dtype,
+                        online_quant=(quantization_config.quantization_mode == "online"),
+                        use_rms_norm=quantization_config.use_rms_norm,
+                        rms_norm_eps=quantization_config.rms_norm_eps,
+                    )
                     if quantization_config.quantization_mode == "offline":
                         new_module.requires_grad_(False)
                 else:
                     new_module = BitLinear(
-                    in_features=module.in_features,
-                    out_features=module.out_features,
-                    bias=module.bias is not None,
-                    device=module.weight.device,
-                    dtype=module.weight.dtype,
-                    use_rms_norm=quantization_config.use_rms_norm if quantization_config else False,
-                    rms_norm_eps=quantization_config.rms_norm_eps if quantization_config else 1e-6,
-                )
+                        in_features=module.in_features,
+                        out_features=module.out_features,
+                        bias=module.bias is not None,
+                        device=module.weight.device,
+                        dtype=module.weight.dtype,
+                        use_rms_norm=quantization_config.use_rms_norm if quantization_config else False,
+                        rms_norm_eps=quantization_config.rms_norm_eps if quantization_config else 1e-6,
+                    )
                     new_module.requires_grad_(False)
                 model.set_submodule(module_name, new_module)
                 has_been_replaced = True
@@ -372,4 +371,3 @@ def replace_with_bitnet_linear(
         )
 
     return model
-

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -1,3 +1,4 @@
+from ..quantizers.quantizers_utils import should_convert_module
 from ..utils import is_accelerate_available, is_torch_available, logging
 
 
@@ -313,116 +314,62 @@ class AutoBitLinear(nn.Linear):
             output = output * self.weight_scale
         return output
 
-
-def _replace_with_bitnet_linear(
-    model,
-    modules_to_not_convert=None,
-    current_key_name=None,
-    quantization_config=None,
-    has_been_replaced=False,
-    pre_quantized=False,
-):
-    """
-    Private method that wraps the recursion for module replacement.
-
-    Returns the converted model and a boolean that indicates if the conversion has been successful or not.
-    """
-
-    if current_key_name is None:
-        current_key_name = []
-
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
-
-        # Check if the current key is not in the `modules_to_not_convert`
-        if not any(key in ".".join(current_key_name) for key in modules_to_not_convert):
-            with init_empty_weights():
-                if isinstance(module, nn.Linear) and name not in modules_to_not_convert:
-                    in_features = module.in_features
-                    out_features = module.out_features
-                    if quantization_config and quantization_config.linear_class == "autobitlinear":
-                        model._modules[name] = AutoBitLinear(
-                            in_features=in_features,
-                            out_features=out_features,
-                            bias=module.bias is not None,
-                            device=module.weight.device,
-                            dtype=module.weight.dtype,
-                            online_quant=(quantization_config.quantization_mode == "online"),
-                            use_rms_norm=quantization_config.use_rms_norm,
-                            rms_norm_eps=quantization_config.rms_norm_eps,
-                        )
-                        if quantization_config.quantization_mode == "offline":
-                            model._modules[name].requires_grad_(False)
-                    else:
-                        model._modules[name] = BitLinear(
-                            in_features=in_features,
-                            out_features=out_features,
-                            bias=module.bias is not None,
-                            device=module.weight.device,
-                            dtype=module.weight.dtype,
-                            use_rms_norm=quantization_config.use_rms_norm if quantization_config else False,
-                            rms_norm_eps=quantization_config.rms_norm_eps if quantization_config else 1e-6,
-                        )
-                        model._modules[name].requires_grad_(False)
-                    has_been_replaced = True
-
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = _replace_with_bitnet_linear(
-                module,
-                modules_to_not_convert=modules_to_not_convert,
-                current_key_name=current_key_name,
-                quantization_config=quantization_config,
-                has_been_replaced=has_been_replaced,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
-
-
 def replace_with_bitnet_linear(
-    model,
-    modules_to_not_convert=None,
-    current_key_name=None,
-    quantization_config=None,
-    pre_quantized=False,
+    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
-    A helper function to replace all `torch.nn.Linear` modules by `BitLinear158` modules`.
+    Public method that recursively replaces the kinear layers of the given model with bitnet quantized layers.
 
-    The function will be run recursively and replace all `torch.nn.Linear` modules except for the `lm_head` that should
-    be kept as a `torch.nn.Linear` module. The replacement is done under `init_empty_weights` context manager so no
-    CPU/GPU memory is required to run this function. Each weight will be quantized along the channel.
-
-    Parameters:
+    Args:
         model (`torch.nn.Module`):
-            Input model or `torch.nn.Module` as the function is run recursively.
-        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `["lm_head"]`):
-            Names of the modules to not convert in `BitLinear`. In practice we keep the `lm_head` in full precision
-            for numerical stability reasons.
-        current_key_name (`list[`str`]`, *optional*):
-            An array to track the current key of the recursion. This is used to check whether the current key (part of
-            it) is not in the list of modules to not convert (for instances modules that are offloaded to `cpu` or
-            `disk`).
+            The model to convert, can be any `torch.nn.Module` instance.
+        modules_not_to_quantize (`list[str]`, defaults to `None`):
+            A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
+            converted.
+        quantization_config (`BitNetConfig`):
+            The quantization config object that contains the quantization parameters.
     """
-    modules_to_not_convert = ["lm_head"] if modules_to_not_convert is None else modules_to_not_convert
-    if quantization_config and quantization_config.modules_to_not_convert is not None:
-        modules_to_not_convert.extend(quantization_config.modules_to_not_convert)
-    modules_to_not_convert = list(set(modules_to_not_convert))
-    model, has_been_replaced = _replace_with_bitnet_linear(
-        model,
-        modules_to_not_convert,
-        current_key_name,
-        quantization_config,
-        pre_quantized=pre_quantized,
-    )
+
+    has_been_replaced = False
+    # we need this to correctly materialize the weights during quantization
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+        with init_empty_weights():
+            if isinstance(module, nn.Linear):
+                if quantization_config and quantization_config.linear_class == "autobitlinear":
+                    new_module = AutoBitLinear(
+                                in_features=module.in_features,
+                                out_features=module.out_features,
+                                bias=module.bias is not None,
+                                device=module.weight.device,
+                                dtype=module.weight.dtype,
+                                online_quant=(quantization_config.quantization_mode == "online"),
+                                use_rms_norm=quantization_config.use_rms_norm,
+                                rms_norm_eps=quantization_config.rms_norm_eps,
+                            )
+                    if quantization_config.quantization_mode == "offline":
+                        new_module.requires_grad_(False)
+                else:
+                    new_module = BitLinear(
+                    in_features=module.in_features,
+                    out_features=module.out_features,
+                    bias=module.bias is not None,
+                    device=module.weight.device,
+                    dtype=module.weight.dtype,
+                    use_rms_norm=quantization_config.use_rms_norm if quantization_config else False,
+                    rms_norm_eps=quantization_config.rms_norm_eps if quantization_config else 1e-6,
+                )
+                    new_module.requires_grad_(False)
+                model.set_submodule(module_name, new_module)
+                has_been_replaced = True
 
     if not has_been_replaced:
         logger.warning(
-            "You are loading your model using bitnet but no linear modules were found in your model."
+            "You are loading your model using eetq but no linear modules were found in your model."
             " Please double check your model architecture, or submit an issue on github if you think this is"
             " a bug."
         )
 
     return model
+

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -317,12 +317,12 @@ class AutoBitLinear(nn.Linear):
 
 def replace_with_bitnet_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
-    Public method that recursively replaces the kinear layers of the given model with bitnet quantized layers.
+    Public method that replaces the linear layers of the given model with bitnet quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        modules_not_to_quantize (`list[str]`, defaults to `None`):
+        modules_to_not_convert (`list[str]`, *optional*, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
         quantization_config (`BitNetConfig`):

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -182,13 +182,12 @@ def replace_with_bnb_linear(
             continue
         new_module = None
         with init_empty_weights():
-            if isinstance(module, Conv1D):
-                in_features, out_features = module.weight.shape
-            else:
-                in_features = module.in_features
-                out_features = module.out_features
-
-            if isinstance(module, nn.Linear):
+            if (isinstance(module, (nn.Linear, Conv1D))):
+                if isinstance(module, Conv1D):
+                    in_features, out_features = module.weight.shape
+                else:
+                    in_features = module.in_features
+                    out_features = module.out_features
                 if quantization_config.quantization_method() == "llm_int8":
                     new_module = bnb.nn.Linear8bitLt(
                         in_features,

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -156,7 +156,10 @@ class Bnb8bitDeserialize(ConversionOps):
 
 
 def replace_with_bnb_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None, pre_quantized=False
+    model: torch.nn.Module,
+    modules_to_not_convert: list[str] | None = None,
+    quantization_config=None,
+    pre_quantized=False,
 ):
     """
     A helper function to replace all `torch.nn.Linear` modules by bnb modules from the `bitsandbytes` library.
@@ -188,26 +191,26 @@ def replace_with_bnb_linear(
             if isinstance(module, nn.Linear):
                 if quantization_config.quantization_method() == "llm_int8":
                     new_module = bnb.nn.Linear8bitLt(
-                            in_features,
-                            out_features,
-                            module.bias is not None,
-                            has_fp16_weights=quantization_config.llm_int8_has_fp16_weight,
-                            threshold=quantization_config.llm_int8_threshold,
-                        )
+                        in_features,
+                        out_features,
+                        module.bias is not None,
+                        has_fp16_weights=quantization_config.llm_int8_has_fp16_weight,
+                        threshold=quantization_config.llm_int8_threshold,
+                    )
                     if pre_quantized:
                         # this is kind of an edge case when supporting both loading and quantization ...
                         # we need to set the right dtype as we cast the checkpoint with the dtype of the meta model
                         new_module.weight.data = new_module.weight.data.to(dtype=torch.int8)
                 else:
                     new_module = bnb.nn.Linear4bit(
-                                in_features,
-                                out_features,
-                                module.bias is not None,
-                                quantization_config.bnb_4bit_compute_dtype,
-                                compress_statistics=quantization_config.bnb_4bit_use_double_quant,
-                                quant_type=quantization_config.bnb_4bit_quant_type,
-                                quant_storage=quantization_config.bnb_4bit_quant_storage
-                            )
+                        in_features,
+                        out_features,
+                        module.bias is not None,
+                        quantization_config.bnb_4bit_compute_dtype,
+                        compress_statistics=quantization_config.bnb_4bit_use_double_quant,
+                        quant_type=quantization_config.bnb_4bit_quant_type,
+                        quant_storage=quantization_config.bnb_4bit_quant_storage,
+                    )
                     if pre_quantized:
                         # same here
                         new_module.weight.data = new_module.weight.data.to(

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -1,5 +1,4 @@
 import inspect
-from inspect import signature
 
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import get_module_from_name, should_convert_module
@@ -160,7 +159,7 @@ def replace_with_bnb_linear(
     model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None, pre_quantized=False
 ):
     """
-    A helper function to replace all `torch.nn.Linear` modules by bnb modules from the `bitsandbytes` library. 
+    A helper function to replace all `torch.nn.Linear` modules by bnb modules from the `bitsandbytes` library.
 
     Args:
         model (`torch.nn.Module`):
@@ -314,12 +313,12 @@ def dequantize_and_replace(
             new_module.to(module.weight.device)
             model.set_submodule(module_name, new_module)
             has_been_replaced = True
-            
+
     if not has_been_replaced:
         logger.warning(
             "For some reason the model has not been properly dequantized. You might see unexpected behavior."
         )
-    return model 
+    return model
 
 
 def validate_bnb_backend_availability(raise_exception=False):

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -182,7 +182,7 @@ def replace_with_bnb_linear(
             continue
         new_module = None
         with init_empty_weights():
-            if (isinstance(module, (nn.Linear, Conv1D))):
+            if isinstance(module, (nn.Linear, Conv1D)):
                 if isinstance(module, Conv1D):
                     in_features, out_features = module.weight.shape
                 else:

--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -2,7 +2,7 @@ import inspect
 from inspect import signature
 
 from ..core_model_loading import ConversionOps
-from ..quantizers.quantizers_utils import get_module_from_name
+from ..quantizers.quantizers_utils import get_module_from_name, should_convert_module
 from ..utils import (
     get_available_devices,
     is_accelerate_available,
@@ -156,136 +156,75 @@ class Bnb8bitDeserialize(ConversionOps):
         return {key_weight: new_value}
 
 
-def _replace_with_bnb_linear(
-    model,
-    modules_to_not_convert=None,
-    current_key_name=None,
-    quantization_config=None,
-    has_been_replaced=False,
-    pre_quantized=False,
+def replace_with_bnb_linear(
+    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None, pre_quantized=False
 ):
     """
-    Private method that wraps the recursion for module replacement.
+    A helper function to replace all `torch.nn.Linear` modules by bnb modules from the `bitsandbytes` library. 
 
-    Returns the converted model and a boolean that indicates if the conversion has been successful or not.
+    Args:
+        model (`torch.nn.Module`):
+            The model to convert, can be any `torch.nn.Module` instance.
+        modules_to_not_convert (`list[str]`, defaults to `None`):
+            A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
+            converted.
+        quantization_config (`BitsAndBytesConfig`):
+            The quantization config object that contains the quantization parameters.
+        pre_quantized (`book`, defaults to `False`):
+            Whether the model is pre-quantized or not
     """
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
+    has_been_replaced = False
+    # we need this to correctly materialize the weights during quantization
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+        new_module = None
+        with init_empty_weights():
+            if isinstance(module, Conv1D):
+                in_features, out_features = module.weight.shape
+            else:
+                in_features = module.in_features
+                out_features = module.out_features
 
-        if (isinstance(module, (nn.Linear, Conv1D))) and name not in modules_to_not_convert:
-            # Check if the current key is not in the `modules_to_not_convert`
-            current_key_name_str = ".".join(current_key_name)
-            if not any(
-                (key + "." in current_key_name_str) or (key == current_key_name_str) for key in modules_to_not_convert
-            ):
-                with init_empty_weights():
-                    if isinstance(module, Conv1D):
-                        in_features, out_features = module.weight.shape
-                    else:
-                        in_features = module.in_features
-                        out_features = module.out_features
-
-                    if quantization_config.quantization_method() == "llm_int8":
-                        new_module = bnb.nn.Linear8bitLt(
+            if isinstance(module, nn.Linear):
+                if quantization_config.quantization_method() == "llm_int8":
+                    new_module = bnb.nn.Linear8bitLt(
                             in_features,
                             out_features,
                             module.bias is not None,
                             has_fp16_weights=quantization_config.llm_int8_has_fp16_weight,
                             threshold=quantization_config.llm_int8_threshold,
                         )
-                        if pre_quantized:
-                            new_module.weight.data = new_module.weight.data.to(dtype=torch.int8)
-                        model._modules[name] = new_module
-                        has_been_replaced = True
-                    else:
-                        if (
-                            quantization_config.llm_int8_skip_modules is not None
-                            and name in quantization_config.llm_int8_skip_modules
-                        ):
-                            pass
-                        else:
-                            extra_kwargs = (
-                                {"quant_storage": quantization_config.bnb_4bit_quant_storage}
-                                if "quant_storage" in list(signature(bnb.nn.Linear4bit).parameters)
-                                else {}
-                            )
-                            new_module = bnb.nn.Linear4bit(
+                    if pre_quantized:
+                        # this is kind of an edge case when supporting both loading and quantization ...
+                        # we need to set the right dtype as we cast the checkpoint with the dtype of the meta model
+                        new_module.weight.data = new_module.weight.data.to(dtype=torch.int8)
+                else:
+                    new_module = bnb.nn.Linear4bit(
                                 in_features,
                                 out_features,
                                 module.bias is not None,
                                 quantization_config.bnb_4bit_compute_dtype,
                                 compress_statistics=quantization_config.bnb_4bit_use_double_quant,
                                 quant_type=quantization_config.bnb_4bit_quant_type,
-                                **extra_kwargs,
+                                quant_storage=quantization_config.bnb_4bit_quant_storage
                             )
-                            if pre_quantized:
-                                # this is kind of an edge case when supporting both loading and quantization ...
-                                # we need to set the right dtype as we cast the checkpoint with the dtype of the meta model
-                                new_module.weight.data = new_module.weight.data.to(
-                                    dtype=quantization_config.bnb_4bit_quant_storage
-                                )
-                            model._modules[name] = new_module
-                            has_been_replaced = True
+                    if pre_quantized:
+                        # same here
+                        new_module.weight.data = new_module.weight.data.to(
+                            dtype=quantization_config.bnb_4bit_quant_storage
+                        )
+                if new_module is not None:
                     # Store the module class in case we need to transpose the weight later
-                    model._modules[name].source_cls = type(module)
+                    new_module.source_cls = type(module)
                     # Force requires grad to False to avoid unexpected errors
-                    model._modules[name].requires_grad_(False)
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = _replace_with_bnb_linear(
-                module,
-                modules_to_not_convert,
-                current_key_name,
-                quantization_config,
-                has_been_replaced=has_been_replaced,
-                pre_quantized=pre_quantized,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
-
-
-def replace_with_bnb_linear(
-    model, modules_to_not_convert=None, current_key_name=None, quantization_config=None, pre_quantized=False
-):
-    """
-    A helper function to replace all `torch.nn.Linear` modules by `bnb.nn.Linear8bit` modules from the `bitsandbytes`
-    library. This will enable running your models using mixed int8 precision as described by the paper `LLM.int8():
-    8-bit Matrix Multiplication for Transformers at Scale`. Make sure `bitsandbytes` compiled with the correct CUDA
-    version of your hardware is installed before running this function. `pip install -i https://test.pypi.org/simple/
-    bitsandbytes`
-
-    The function will be run recursively and replace all `torch.nn.Linear` modules except for the `lm_head` that should
-    be kept as a `torch.nn.Linear` module. The replacement is done under `init_empty_weights` context manager so no
-    CPU/GPU memory is required to run this function. Int8 mixed-precision matrix decomposition works by separating a
-    matrix multiplication into two streams: (1) and systematic feature outlier stream matrix multiplied in fp16
-    (0.01%), (2) a regular stream of int8 matrix multiplication (99.9%). With this method, int8 inference with no
-    predictive degradation is possible for very large models (>=176B parameters).
-
-    Parameters:
-        model (`torch.nn.Module`):
-            Input model or `torch.nn.Module` as the function is run recursively.
-        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `["lm_head"]`):
-            Names of the modules to not convert in `Linear8bitLt`. In practice we keep the `lm_head` in full precision
-            for numerical stability reasons.
-        current_key_name (`list[`str`]`, *optional*):
-            An array to track the current key of the recursion. This is used to check whether the current key (part of
-            it) is not in the list of modules to not convert (for instances modules that are offloaded to `cpu` or
-            `disk`).
-        quantization_config ('transformers.utils.quantization_config.BitsAndBytesConfig'):
-            To configure and manage settings related to quantization, a technique used to compress neural network models
-            by reducing the precision of the weights and activations, thus making models more efficient in terms of both
-            storage and computation.
-    """
-    modules_to_not_convert = ["lm_head"] if modules_to_not_convert is None else modules_to_not_convert
-    model, has_been_replaced = _replace_with_bnb_linear(
-        model, modules_to_not_convert, current_key_name, quantization_config, pre_quantized=pre_quantized
-    )
+                    new_module.requires_grad_(False)
+                    model.set_submodule(module_name, new_module)
+                    has_been_replaced = True
 
     if not has_been_replaced:
         logger.warning(
-            "You are loading your model in 8bit or 4bit but no linear modules were found in your model."
+            "You are loading your model using eetq but no linear modules were found in your model."
             " Please double check your model architecture, or submit an issue on github if you think this is"
             " a bug."
         )
@@ -343,104 +282,50 @@ def _create_accelerate_new_hook(old_hook):
     return new_hook
 
 
-def _dequantize_and_replace(
+def dequantize_and_replace(
     model,
-    dtype,
-    modules_to_not_convert=None,
-    current_key_name=None,
     quantization_config=None,
-    has_been_replaced=False,
 ):
     """
     Converts a quantized model into its dequantized original version. The newly converted model will have
     some performance drop compared to the original model before quantization - use it only for specific usecases
     such as QLoRA adapters merging.
 
-    Returns the converted model and a boolean that indicates if the conversion has been successful or not.
+    Returns the converted model.
     """
     quant_method = quantization_config.quantization_method()
 
     target_cls = bnb.nn.Linear8bitLt if quant_method == "llm_int8" else bnb.nn.Linear4bit
 
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
-
-        if isinstance(module, target_cls) and name not in modules_to_not_convert:
-            # Check if the current key is not in the `modules_to_not_convert`
-            current_key_name_str = ".".join(current_key_name)
-
-            if not any(
-                (key + "." in current_key_name_str) or (key == current_key_name_str) for key in modules_to_not_convert
-            ):
+    for module_name, module in model.named_modules():
+        if isinstance(module, target_cls):
+            with init_empty_weights():
                 bias = getattr(module, "bias", None)
-
-                device = module.weight.device
-                with init_empty_weights():
-                    new_module = torch.nn.Linear(module.in_features, module.out_features, bias=bias is not None)
-
-                if quant_method == "llm_int8":
-                    state = module.state
-                else:
-                    state = None
-
-                new_module.weight = torch.nn.Parameter(dequantize_bnb_weight(module.weight, dtype, state))
-
-                if bias is not None:
-                    new_module.bias = bias
-
-                # Create a new hook and attach it in case we use accelerate
-                if hasattr(module, "_hf_hook"):
-                    old_hook = module._hf_hook
-                    new_hook = _create_accelerate_new_hook(old_hook)
-
-                    remove_hook_from_module(module)
-                    add_hook_to_module(new_module, new_hook)
-
-                new_module.to(device)
-                model._modules[name] = new_module
-                has_been_replaced = True
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = _dequantize_and_replace(
-                module,
-                dtype,
-                modules_to_not_convert,
-                current_key_name,
-                quantization_config,
-                has_been_replaced=has_been_replaced,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
-
-
-def dequantize_and_replace(
-    model,
-    modules_to_not_convert=None,
-    quantization_config=None,
-):
-    model, has_been_replaced = _dequantize_and_replace(
-        model,
-        model.dtype,
-        modules_to_not_convert=modules_to_not_convert,
-        quantization_config=quantization_config,
-    )
-
+                new_module = torch.nn.Linear(module.in_features, module.out_features, bias=bias is not None)
+            state = module.state if quant_method == "llm_int8" else None
+            new_module.weight = torch.nn.Parameter(dequantize_bnb_weight(module.weight, model.dtype, state))
+            if bias is not None:
+                new_module.bias = bias
+            if hasattr(module, "_hf_hook"):
+                old_hook = module._hf_hook
+                new_hook = _create_accelerate_new_hook(old_hook)
+                remove_hook_from_module(module)
+                add_hook_to_module(new_module, new_hook)
+            new_module.to(module.weight.device)
+            model.set_submodule(module_name, new_module)
+            has_been_replaced = True
+            
     if not has_been_replaced:
         logger.warning(
             "For some reason the model has not been properly dequantized. You might see unexpected behavior."
         )
-
-    return model
+    return model 
 
 
 def validate_bnb_backend_availability(raise_exception=False):
     """
     Validates if the available devices are supported by bitsandbytes, optionally raising an exception if not.
     """
-    import bitsandbytes as bnb
-
     bnb_supported_devices = getattr(bnb, "supported_torch_devices", set())
     available_devices = set(get_available_devices())
 

--- a/src/transformers/integrations/eetq.py
+++ b/src/transformers/integrations/eetq.py
@@ -86,9 +86,7 @@ class EetqLinear(nn.Module):
         return output
 
 
-def replace_with_eetq_linear(
-    model, modules_to_not_convert: list[str] | None = None, pre_quantized=False
-):
+def replace_with_eetq_linear(model, modules_to_not_convert: list[str] | None = None, pre_quantized=False):
     """
     A helper function to replace all `torch.nn.Linear` modules by `EetqLinear` modules.
 

--- a/src/transformers/integrations/eetq.py
+++ b/src/transformers/integrations/eetq.py
@@ -91,20 +91,13 @@ def replace_with_eetq_linear(
 ):
     """
     A helper function to replace all `torch.nn.Linear` modules by `EetqLinear` modules.
-    The function will be run recursively and replace all `torch.nn.Linear` modules except for the `modules_to_not_convert` that should
-    be kept as a `torch.nn.Linear` module. The replacement is done under `init_empty_weights` context manager so no
-    CPU/GPU memory is required to run this function. Each weight will be quantized along the channel.
 
     Parameters:
         model (`torch.nn.Module`):
             Input model or `torch.nn.Module` as the function is run recursively.
-        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `None`):
+        modules_to_not_convert (`list[`str`]`, defaults to `None`):
             Names of the modules to not convert in `EetqLinear`. In practice we keep the `lm_head` in full precision
             for numerical stability reasons.
-        current_key_name (`list[`str`]`, *optional*):
-            An array to track the current key of the recursion. This is used to check whether the current key (part of
-            it) is not in the list of modules to not convert (for instances modules that are offloaded to `cpu` or
-            `disk`).
     """
     from kernels import get_kernel
 

--- a/src/transformers/integrations/eetq.py
+++ b/src/transformers/integrations/eetq.py
@@ -93,7 +93,7 @@ def replace_with_eetq_linear(model, modules_to_not_convert: list[str] | None = N
     Parameters:
         model (`torch.nn.Module`):
             Input model or `torch.nn.Module` as the function is run recursively.
-        modules_to_not_convert (`list[`str`]`, defaults to `None`):
+        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `None`):
             Names of the modules to not convert in `EetqLinear`. In practice we keep the `lm_head` in full precision
             for numerical stability reasons.
     """

--- a/src/transformers/integrations/eetq.py
+++ b/src/transformers/integrations/eetq.py
@@ -87,7 +87,7 @@ class EetqLinear(nn.Module):
 
 
 def replace_with_eetq_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, pre_quantized=False
+    model, modules_to_not_convert: list[str] | None = None, pre_quantized=False
 ):
     """
     A helper function to replace all `torch.nn.Linear` modules by `EetqLinear` modules.

--- a/src/transformers/integrations/fbgemm_fp8.py
+++ b/src/transformers/integrations/fbgemm_fp8.py
@@ -217,25 +217,24 @@ class FbgemmFp8Llama4TextExperts(nn.Module):
 
 def replace_with_fbgemm_fp8_linear(
     model,
-    modules_to_not_convert=None,
+    modules_to_not_convert: list[str] | None = None,
     quantization_config=None,
     pre_quantized=False,
-    tp_plan=None,
-):
+    tp_plan=None
+    ):
     """
     A helper function to replace all `torch.nn.Linear` modules by `FbgemmFp8Linear` modules.
     This will enable running your models using high performance fp8 kernel from FBGEMM library.
 
-    The function will be run recursively and replace all `torch.nn.Linear` modules except for the `lm_head` that should
-    be kept as a `torch.nn.Linear` module. The replacement is done under `init_empty_weights` context manager so no
-    CPU/GPU memory is required to run this function. Each weight will be quantized along the channel.
-
     Parameters:
         model (`torch.nn.Module`):
             Input model or `torch.nn.Module` as the function is run recursively.
-        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `["lm_head"]`):
-            Names of the modules to not convert in `FP8Linear`. In practice we keep the `lm_head` in full precision
-            for numerical stability reasons.
+        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `None`):
+            Names of the modules to not convert. In practice we keep the `lm_head` in full precision for numerical stability reasons.
+        quantization_config (`FbgemmFp8Config`):
+            The quantization config object that contains the quantization parameters.
+        pre_quantized (`book`, defaults to `False`):
+            Whether the model is pre-quantized or not
     """
 
     has_been_replaced = False

--- a/src/transformers/integrations/fbgemm_fp8.py
+++ b/src/transformers/integrations/fbgemm_fp8.py
@@ -216,12 +216,8 @@ class FbgemmFp8Llama4TextExperts(nn.Module):
 
 
 def replace_with_fbgemm_fp8_linear(
-    model,
-    modules_to_not_convert: list[str] | None = None,
-    quantization_config=None,
-    pre_quantized=False,
-    tp_plan=None
-    ):
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None, pre_quantized=False, tp_plan=None
+):
     """
     A helper function to replace all `torch.nn.Linear` modules by `FbgemmFp8Linear` modules.
     This will enable running your models using high performance fp8 kernel from FBGEMM library.

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -597,7 +597,7 @@ def replace_with_fp8_linear(
     Parameters:
         model (`torch.nn.Module`):
             Input model or `torch.nn.Module` as the function is run recursively.
-        modules_to_not_convert (`list[`str`]`, defaults to `None`):
+        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `None`):
             Names of the modules to not convert. In practice we keep the `lm_head` in full precision for numerical stability reasons.
         quantization_config (`FbgemmFp8Config`):
             The quantization config object that contains the quantization parameters.

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -590,11 +590,23 @@ class FP8Expert(nn.Module):
 
 def replace_with_fp8_linear(
     model,
-    modules_to_not_convert=None,
+    modules_to_not_convert = list[str] | None = None,
     quantization_config=None,
-    pre_quantized=False,
-):
-    """Helper function to replace model layers with FP8 versions."""
+    pre_quantized=False):
+    """
+    A helper function to replace all `torch.nn.Linear` modules by `FP8Linear` modules.
+
+    Parameters:
+        model (`torch.nn.Module`):
+            Input model or `torch.nn.Module` as the function is run recursively.
+        modules_to_not_convert (`list[`str`]`, defaults to `None`):
+            Names of the modules to not convert. In practice we keep the `lm_head` in full precision for numerical stability reasons.
+        quantization_config (`FbgemmFp8Config`):
+            The quantization config object that contains the quantization parameters.
+        pre_quantized (`book`, defaults to `False`):
+            Whether the model is pre-quantized or not
+    """
+
     if quantization_config.dequantize:
         return model
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -590,7 +590,7 @@ class FP8Expert(nn.Module):
 
 def replace_with_fp8_linear(
     model,
-    modules_to_not_convert = list[str] | None = None,
+    modules_to_not_convert: list[str] | None = None,
     quantization_config=None,
     pre_quantized=False):
     """

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -589,10 +589,8 @@ class FP8Expert(nn.Module):
 
 
 def replace_with_fp8_linear(
-    model,
-    modules_to_not_convert: list[str] | None = None,
-    quantization_config=None,
-    pre_quantized=False):
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None, pre_quantized=False
+):
     """
     A helper function to replace all `torch.nn.Linear` modules by `FP8Linear` modules.
 

--- a/src/transformers/integrations/higgs.py
+++ b/src/transformers/integrations/higgs.py
@@ -15,17 +15,16 @@
 
 from math import sqrt
 
-from ..utils import (
-    is_flute_available,
-    is_hadamard_available,
-    is_torch_available,
-)
+from ..quantizers.quantizers_utils import should_convert_module
+from ..utils import is_accelerate_available, is_flute_available, is_hadamard_available, is_torch_available, logging
 
+
+if is_accelerate_available():
+    from accelerate import init_empty_weights
 
 if is_torch_available():
     import torch
-    from torch import nn
-
+    import torch.nn as nn
 
 if is_flute_available():
     from flute.integrations.higgs import prepare_data_transposed
@@ -34,6 +33,7 @@ if is_flute_available():
 if is_hadamard_available():
     from fast_hadamard_transform import hadamard_transform
 
+logger = logging.get_logger(__name__)
 
 def pad_to_block(tensor, dims, had_block_size, value=0):
     pad_dims = [0 for _ in range(2 * len(tensor.shape))]
@@ -548,71 +548,49 @@ class HiggsLinear(torch.nn.Module):
             hadamard_size=self.hadamard_size,
         )
 
-
 def replace_with_higgs_linear(
-    model,
-    quantization_config=None,
-    current_key_name=None,
-    has_been_replaced=False,
-    modules_to_not_convert=None,
+    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with HIGGS quantized layers.
-    `accelerate` is needed to use this method. Returns the converted model and a boolean that indicates if the
-    conversion has been successful or not.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
+        modules_not_to_quantize (`list[str]`, defaults to `None`):
+            A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
+            converted.
         quantization_config (`HiggsConfig`):
             The quantization config object that contains the quantization parameters.
-        current_key_name (`list`, *optional*):
-            A list that contains the current key name. This is used for recursion and should not be passed by the user.
-        has_been_replaced (`bool`, *optional*):
-            A boolean that indicates if the conversion has been successful or not. This is used for recursion and
-            should not be passed by the user.
     """
 
-    from accelerate import init_empty_weights
-
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
-
-        if isinstance(module, nn.Linear):
-            # Check if the current key is not in the `quantization_config.modules_to_not_convert`
-            current_key_name_str = ".".join(current_key_name)
-            if not any(current_key_name_str.endswith(key) for key in modules_to_not_convert):
-                with init_empty_weights():
-                    in_features = module.in_features
-                    out_features = module.out_features
-
-                    model._modules[name] = HiggsLinear(
-                        in_features,
-                        out_features,
+    has_been_replaced = False
+    # we need this to correctly materialize the weights during quantization
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+        with init_empty_weights():
+            if isinstance(module, nn.Linear):
+                new_module = HiggsLinear(
+                        module.in_features,
+                        module.out_features,
                         bias=module.bias is not None,
                         num_bits=quantization_config.bits,
                         hadamard_size=quantization_config.hadamard_size,
                         group_size=quantization_config.group_size,
                     )
-                    has_been_replaced = True
+                new_module.source_cls = type(module)
+                new_module.requires_grad_(False)
+                model.set_submodule(module_name, new_module)
+                has_been_replaced = True
 
-                    # Store the module class in case we need to transpose the weight later
-                    model._modules[name].source_cls = type(module)
-                    # Force requires grad to False to avoid unexpected errors
-                    model._modules[name].requires_grad_(False)
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = replace_with_higgs_linear(
-                module,
-                quantization_config=quantization_config,
-                current_key_name=current_key_name,
-                has_been_replaced=has_been_replaced,
-                modules_to_not_convert=modules_to_not_convert,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
+    if not has_been_replaced:
+        logger.warning(
+            "You are loading your model using eetq but no linear modules were found in your model."
+            " Please double check your model architecture, or submit an issue on github if you think this is"
+            " a bug."
+        )
+    return model
 
 
 def dequantize_higgs(model, current_key_name=None):

--- a/src/transformers/integrations/higgs.py
+++ b/src/transformers/integrations/higgs.py
@@ -552,12 +552,12 @@ class HiggsLinear(torch.nn.Module):
 
 def replace_with_higgs_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
-    Public method that recursively replaces the Linear layers of the given model with HIGGS quantized layers.
+    Public method that replaces the Linear layers of the given model with HIGGS quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        modules_not_to_quantize (`list[str]`, defaults to `None`):
+        modules_to_not_convert (`list[str]`, *optional*, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
         quantization_config (`HiggsConfig`):

--- a/src/transformers/integrations/higgs.py
+++ b/src/transformers/integrations/higgs.py
@@ -35,6 +35,7 @@ if is_hadamard_available():
 
 logger = logging.get_logger(__name__)
 
+
 def pad_to_block(tensor, dims, had_block_size, value=0):
     pad_dims = [0 for _ in range(2 * len(tensor.shape))]
     for dim in dims:
@@ -548,9 +549,8 @@ class HiggsLinear(torch.nn.Module):
             hadamard_size=self.hadamard_size,
         )
 
-def replace_with_higgs_linear(
-    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
-):
+
+def replace_with_higgs_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
     Public method that recursively replaces the Linear layers of the given model with HIGGS quantized layers.
 
@@ -572,13 +572,13 @@ def replace_with_higgs_linear(
         with init_empty_weights():
             if isinstance(module, nn.Linear):
                 new_module = HiggsLinear(
-                        module.in_features,
-                        module.out_features,
-                        bias=module.bias is not None,
-                        num_bits=quantization_config.bits,
-                        hadamard_size=quantization_config.hadamard_size,
-                        group_size=quantization_config.group_size,
-                    )
+                    module.in_features,
+                    module.out_features,
+                    bias=module.bias is not None,
+                    num_bits=quantization_config.bits,
+                    hadamard_size=quantization_config.hadamard_size,
+                    group_size=quantization_config.group_size,
+                )
                 new_module.source_cls = type(module)
                 new_module.requires_grad_(False)
                 model.set_submodule(module_name, new_module)

--- a/src/transformers/integrations/higgs.py
+++ b/src/transformers/integrations/higgs.py
@@ -549,7 +549,7 @@ class HiggsLinear(torch.nn.Module):
         )
 
 def replace_with_higgs_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with HIGGS quantized layers.

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -596,14 +596,14 @@ def swizzle_mxfp4_convertops(blocks, scales, module, proj, target_device, triton
 
 def replace_with_mxfp4_linear(model, quantization_config=None, modules_to_not_convert: list[str] | None = None):
     """
-    Public method that recursively replaces the expert layers of the given model with mxfp4 quantized layers.
+    Public method that replaces the expert layers of the given model with mxfp4 quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
         quantization_config (`Mxfp4Config`, defaults to `None`):
             The quantization config object that contains the quantization parameters.
-        modules_to_not_convert (`list`, defaults to `None`):
+        modules_to_not_convert (`list`, *optional*, defaults to `None`):
             A list of modules to not convert. If a module name is in the list (e.g. `lm_head`), it will not be
             converted.
     """

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -594,7 +594,19 @@ def swizzle_mxfp4_convertops(blocks, scales, module, proj, target_device, triton
     )
 
 
-def replace_with_mxfp4_linear(model, modules_to_not_convert=None, quantization_config=None):
+def replace_with_mxfp4_linear(model, quantization_config=None, modules_to_not_convert: list[str] | None = None):
+    """
+    Public method that recursively replaces the expert layers of the given model with mxfp4 quantized layers.
+
+    Args:
+        model (`torch.nn.Module`):
+            The model to convert, can be any `torch.nn.Module` instance.
+        quantization_config (`Mxfp4Config`, defaults to `None`):
+            The quantization config object that contains the quantization parameters.
+        modules_to_not_convert (`list`, defaults to `None`):
+            A list of modules to not convert. If a module name is in the list (e.g. `lm_head`), it will not be
+            converted.
+    """
     if quantization_config.dequantize:
         return model
 

--- a/src/transformers/integrations/quanto.py
+++ b/src/transformers/integrations/quanto.py
@@ -57,7 +57,7 @@ class QuantoQuantize(ConversionOps):
 def replace_with_quanto_layers(
     model,
     quantization_config=None,
-    modules_to_not_convert=None,
+    modules_to_not_convert: list[str] | None = None,
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with Quanto quantized layers.
@@ -68,7 +68,7 @@ def replace_with_quanto_layers(
             The model to convert, can be any `torch.nn.Module` instance.
         quantization_config (`QuantoConfig`, defaults to `None`):
             The quantization config object that contains the quantization parameters.
-        modules_to_not_convert (`list`, *optional*, defaults to `None`):
+        modules_to_not_convert (`list`, defaults to `None`):
             A list of modules to not convert. If a module name is in the list (e.g. `lm_head`), it will not be
             converted.
     """

--- a/src/transformers/integrations/quanto.py
+++ b/src/transformers/integrations/quanto.py
@@ -68,7 +68,7 @@ def replace_with_quanto_layers(
             The model to convert, can be any `torch.nn.Module` instance.
         quantization_config (`QuantoConfig`, defaults to `None`):
             The quantization config object that contains the quantization parameters.
-        modules_to_not_convert (`list`, defaults to `None`):
+        modules_to_not_convert (`list`, *optional*, defaults to `None`):
             A list of modules to not convert. If a module name is in the list (e.g. `lm_head`), it will not be
             converted.
     """

--- a/src/transformers/integrations/spqr.py
+++ b/src/transformers/integrations/spqr.py
@@ -28,12 +28,12 @@ logger = logging.get_logger(__name__)
 
 def replace_with_spqr_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
-    Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.
+    Public method that replaces the Linear layers of the given model with SPQR quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        modules_to_not_convert (`list[str]`, defaults to `None`):
+        modules_to_not_convert (`list[str]`, *optional*, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
         quantization_config (`SpQRConfig`):

--- a/src/transformers/integrations/spqr.py
+++ b/src/transformers/integrations/spqr.py
@@ -21,14 +21,12 @@ if is_accelerate_available():
     from accelerate import init_empty_weights
 
 if is_torch_available():
-    import torch
     import torch.nn as nn
 
 logger = logging.get_logger(__name__)
 
-def replace_with_spqr_linear(
-    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
-):
+
+def replace_with_spqr_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
     Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.
 
@@ -54,17 +52,17 @@ def replace_with_spqr_linear(
                 shapes = quantization_config.shapes
 
                 new_module = QuantizedLinear.create_placehodler(
-                        rows=module.out_features,
-                        cols=module.in_features,
-                        bits=quantization_config.bits,
-                        beta1=quantization_config.beta1,
-                        beta2=quantization_config.beta2,
-                        dense_weights_shape=shapes[f"{module_name}.dense_weights.shape"],
-                        row_offsets_shape=shapes[f"{module_name}.row_offsets.shape"],
-                        col_vals_shape=shapes[f"{module_name}.col_vals.shape"],
-                        in_perm_shape=shapes[f"{module_name}.in_perm.shape"]
-                    )
-                    # Force requires grad to False to avoid unexpected errors
+                    rows=module.out_features,
+                    cols=module.in_features,
+                    bits=quantization_config.bits,
+                    beta1=quantization_config.beta1,
+                    beta2=quantization_config.beta2,
+                    dense_weights_shape=shapes[f"{module_name}.dense_weights.shape"],
+                    row_offsets_shape=shapes[f"{module_name}.row_offsets.shape"],
+                    col_vals_shape=shapes[f"{module_name}.col_vals.shape"],
+                    in_perm_shape=shapes[f"{module_name}.in_perm.shape"],
+                )
+                # Force requires grad to False to avoid unexpected errors
                 model._modules[module_name].requires_grad_(False)
                 model.set_submodule(module_name, new_module)
                 has_been_replaced = True

--- a/src/transformers/integrations/spqr.py
+++ b/src/transformers/integrations/spqr.py
@@ -27,7 +27,7 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 def replace_with_spqr_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.

--- a/src/transformers/integrations/spqr.py
+++ b/src/transformers/integrations/spqr.py
@@ -13,110 +13,66 @@
 # limitations under the License.
 "SpQR (Sparse-Quantized Representation) integration file"
 
-from ..utils import is_accelerate_available, is_spqr_available, is_torch_available
+from ..quantizers.quantizers_utils import should_convert_module
+from ..utils import is_accelerate_available, is_spqr_available, is_torch_available, logging
 
+
+if is_accelerate_available():
+    from accelerate import init_empty_weights
 
 if is_torch_available():
+    import torch
     import torch.nn as nn
 
+logger = logging.get_logger(__name__)
 
 def replace_with_spqr_linear(
-    model,
-    quantization_config=None,
-    modules_to_not_convert=None,
-    current_key_name=None,
-    has_been_replaced=False,
+    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
-    Public method that recursively replaces the Linear layers of the given model with SpQR quantized layers.
-    `accelerate` is needed to use this method. Returns the converted model and a boolean that indicates if the
-    conversion has been successful or not.
+    Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        quantization_config (`SpQRConfig`):
-            The quantization config object that contains the quantization parameters.
-        modules_to_not_convert (`list[str]`, *optional*):
+        modules_to_not_convert (`list[str]`, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
-        current_key_name (`list`, *optional*):
-            A list that contains the current key name. This is used for recursion and should not be passed by the user.
-        has_been_replaced (`bool`, *optional*):
-            A boolean that indicates if the conversion has been successful or not. This is used for recursion and
-            should not be passed by the user.
+        quantization_config (`SpQRConfig`):
+            The quantization config object that contains the quantization parameters.
     """
-    if modules_to_not_convert is None:
-        modules_to_not_convert = []
-
-    if is_accelerate_available():
-        from accelerate import init_empty_weights
     if is_spqr_available():
         from spqr_quant import QuantizedLinear
 
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
+    has_been_replaced = False
+    # we need this to correctly materialize the weights during quantization
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+        with init_empty_weights():
+            if isinstance(module, nn.Linear):
+                shapes = quantization_config.shapes
 
-        if isinstance(module, nn.Linear):
-            # Check if the current key is not in the `modules_to_not_convert`
-            if ".".join(current_key_name) + ".weight" not in modules_to_not_convert:
-                with init_empty_weights():
-                    tensor_name = ".".join(current_key_name)
-
-                    shapes = quantization_config.shapes
-                    shapes_keys = shapes.keys()
-
-                    shapes_valid = (
-                        f"{tensor_name}.dense_weights.shape" in shapes_keys
-                        and f"{tensor_name}.row_offsets.shape" in shapes_keys
-                        and f"{tensor_name}.col_vals.shape" in shapes_keys
-                        and f"{tensor_name}.in_perm.shape" in shapes_keys
-                    )
-
-                    if not shapes_valid:
-                        raise ValueError(
-                            f"The SpQR quantization config does not contain the shape "
-                            f"configuration for {tensor_name}. This indicates that the "
-                            f"configuration is either invalid or corrupted."
-                        )
-
-                    dense_weights_shape = shapes[f"{tensor_name}.dense_weights.shape"]
-                    row_offsets_shape = shapes[f"{tensor_name}.row_offsets.shape"]
-                    col_vals_shape = shapes[f"{tensor_name}.col_vals.shape"]
-                    in_perm_shape = shapes[f"{tensor_name}.in_perm.shape"]
-
-                    in_features = module.in_features
-                    out_features = module.out_features
-
-                    model._modules[name] = QuantizedLinear.create_placehodler(
-                        rows=out_features,
-                        cols=in_features,
+                new_module = QuantizedLinear.create_placehodler(
+                        rows=module.out_features,
+                        cols=module.in_features,
                         bits=quantization_config.bits,
                         beta1=quantization_config.beta1,
                         beta2=quantization_config.beta2,
-                        dense_weights_shape=dense_weights_shape,
-                        row_offsets_shape=row_offsets_shape,
-                        col_vals_shape=col_vals_shape,
-                        in_perm_shape=in_perm_shape,
+                        dense_weights_shape=shapes[f"{module_name}.dense_weights.shape"],
+                        row_offsets_shape=shapes[f"{module_name}.row_offsets.shape"],
+                        col_vals_shape=shapes[f"{module_name}.col_vals.shape"],
+                        in_perm_shape=shapes[f"{module_name}.in_perm.shape"]
                     )
-                    has_been_replaced = True
-
-                    # Store the module class in case we need to transpose the weight later
-                    model._modules[name].source_cls = type(module)
                     # Force requires grad to False to avoid unexpected errors
-                    model._modules[name].requires_grad_(False)
-            else:
-                pass
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = replace_with_spqr_linear(
-                module,
-                quantization_config=quantization_config,
-                modules_to_not_convert=modules_to_not_convert,
-                current_key_name=current_key_name,
-                has_been_replaced=has_been_replaced,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
+                model._modules[module_name].requires_grad_(False)
+                model.set_submodule(module_name, new_module)
+                has_been_replaced = True
+    if not has_been_replaced:
+        logger.warning(
+            "You are loading your model using eetq but no linear modules were found in your model."
+            " Please double check your model architecture, or submit an issue on github if you think this is"
+            " a bug."
+        )
+
+    return model

--- a/src/transformers/integrations/vptq.py
+++ b/src/transformers/integrations/vptq.py
@@ -21,14 +21,12 @@ if is_accelerate_available():
     from accelerate import init_empty_weights
 
 if is_torch_available():
-    import torch
     import torch.nn as nn
 
 logger = logging.get_logger(__name__)
 
-def replace_with_vptq_linear(
-    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
-):
+
+def replace_with_vptq_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
     Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.
 
@@ -52,7 +50,9 @@ def replace_with_vptq_linear(
             continue
         with init_empty_weights():
             if isinstance(module, nn.Linear):
-                layer_params = config_for_layers.get(module_name, None) or shared_layer_config.get(module_name.rsplit(".")[1], None)
+                layer_params = config_for_layers.get(module_name, None) or shared_layer_config.get(
+                    module_name.rsplit(".")[1], None
+                )
                 new_module = VQuantLinear(
                     module.in_features,
                     module.out_features,

--- a/src/transformers/integrations/vptq.py
+++ b/src/transformers/integrations/vptq.py
@@ -13,64 +13,49 @@
 # limitations under the License.
 "VPTQ (Vector Post-Training Quantization) integration file"
 
-import torch.nn as nn
-from accelerate import init_empty_weights
-from vptq import VQuantLinear
+from ..quantizers.quantizers_utils import should_convert_module
+from ..utils import is_accelerate_available, is_torch_available, logging
 
+
+if is_accelerate_available():
+    from accelerate import init_empty_weights
+
+if is_torch_available():
+    import torch
+    import torch.nn as nn
+
+logger = logging.get_logger(__name__)
 
 def replace_with_vptq_linear(
-    model,
-    quantization_config=None,
-    modules_to_not_convert=None,
-    current_key_name=None,
-    has_been_replaced=False,
+    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
-    Public method that recursively replaces the Linear layers of the given model with VPTQ quantized layers.
-    `accelerate` is needed to use this method. Returns the converted model and a boolean that indicates if the
-    conversion has been successful or not.
+    Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
+        modules_not_to_quantize (`list[str]`, defaults to `None`):
+            A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
+            converted.
         quantization_config (`VptqConfig`):
             The quantization config object that contains the quantization parameters.
-        modules_to_not_convert (`list[`str`]`, *optional*, defaults to `["lm_head"]`):
-            Names of the modules to not convert in `VQuantLinear`. In practice we keep the `lm_head` in full precision
-            for numerical stability reasons.
-        current_key_name (`list`, *optional*):
-            A list that contains the current key name. This is used for recursion and should not be passed by the user.
-        has_been_replaced (`bool`, *optional*):
-            A boolean that indicates if the conversion has been successful or not. This is used for recursion and
-            should not be passed by the user.
     """
+    from vptq import VQuantLinear
 
-    modules_to_not_convert = modules_to_not_convert if modules_to_not_convert else ["lm_head"]
+    has_been_replaced = False
+    shared_layer_config = quantization_config.shared_layer_config
+    config_for_layers = quantization_config.config_for_layers
 
-    for name, module in model.named_children():
-        if current_key_name is None:
-            current_key_name = []
-        current_key_name.append(name)
-        layer_name = ".".join(current_key_name)
-        shared_layer_config = quantization_config.shared_layer_config
-        config_for_layers = quantization_config.config_for_layers
-
-        if (
-            isinstance(module, nn.Linear)
-            and layer_name not in modules_to_not_convert
-            and ((layer_name in config_for_layers) or (current_key_name[-1] in shared_layer_config))
-        ):
-            layer_params = config_for_layers.get(layer_name, None) or shared_layer_config.get(
-                current_key_name[-1], None
-            )
-
-            with init_empty_weights():
-                in_features = module.in_features
-                out_features = module.out_features
-
-                model._modules[name] = VQuantLinear(
-                    in_features,
-                    out_features,
+    for module_name, module in model.named_modules():
+        if not should_convert_module(module_name, modules_to_not_convert):
+            continue
+        with init_empty_weights():
+            if isinstance(module, nn.Linear):
+                layer_params = config_for_layers.get(module_name, None) or shared_layer_config.get(module_name.rsplit(".")[1], None)
+                new_module = VQuantLinear(
+                    module.in_features,
+                    module.out_features,
                     vector_lens=layer_params["vector_lens"],
                     num_centroids=layer_params["num_centroids"],
                     num_res_centroids=layer_params["num_res_centroids"],
@@ -84,18 +69,16 @@ def replace_with_vptq_linear(
                     enable_proxy_error=False,
                     bias=module.bias is not None,
                 )
+                # Force requires grad to False to avoid unexpected errors
+                model._modules[module_name].requires_grad_(False)
+                model.set_submodule(module_name, new_module)
                 has_been_replaced = True
 
-                # Force requires grad to False to avoid unexpected errors
-                model._modules[name].requires_grad_(False)
-        if len(list(module.children())) > 0:
-            _, has_been_replaced = replace_with_vptq_linear(
-                module,
-                quantization_config=quantization_config,
-                modules_to_not_convert=modules_to_not_convert,
-                current_key_name=current_key_name,
-                has_been_replaced=has_been_replaced,
-            )
-        # Remove the last key for recursion
-        current_key_name.pop(-1)
-    return model, has_been_replaced
+    if not has_been_replaced:
+        logger.warning(
+            "You are loading your model using eetq but no linear modules were found in your model."
+            " Please double check your model architecture, or submit an issue on github if you think this is"
+            " a bug."
+        )
+
+    return model

--- a/src/transformers/integrations/vptq.py
+++ b/src/transformers/integrations/vptq.py
@@ -27,7 +27,7 @@ if is_torch_available():
 logger = logging.get_logger(__name__)
 
 def replace_with_vptq_linear(
-    model: torch.nn.Module, modules_to_not_convert: list[str] | None = None, quantization_config=None
+    model, modules_to_not_convert: list[str] | None = None, quantization_config=None
 ):
     """
     Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.

--- a/src/transformers/integrations/vptq.py
+++ b/src/transformers/integrations/vptq.py
@@ -28,12 +28,12 @@ logger = logging.get_logger(__name__)
 
 def replace_with_vptq_linear(model, modules_to_not_convert: list[str] | None = None, quantization_config=None):
     """
-    Public method that recursively replaces the Linear layers of the given model with SPQR quantized layers.
+    Public method that replaces the Linear layers of the given model with SPQR quantized layers.
 
     Args:
         model (`torch.nn.Module`):
             The model to convert, can be any `torch.nn.Module` instance.
-        modules_not_to_quantize (`list[str]`, defaults to `None`):
+        modules_to_not_convert (`list[str]`, *optional*, defaults to `None`):
             A list of nn.Linear weights to not convert. If a parameter path is in the list (e.g. `lm_head.weight`), the corresponding module will not be
             converted.
         quantization_config (`VptqConfig`):

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -195,9 +195,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
     def _dequantize(self, model):
         from ..integrations import dequantize_and_replace
 
-        model = dequantize_and_replace(
-            model, quantization_config=self.quantization_config
-        )
+        model = dequantize_and_replace(model, quantization_config=self.quantization_config)
         return model
 
     def get_quantize_ops(self):

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -196,7 +196,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         from ..integrations import dequantize_and_replace
 
         model = dequantize_and_replace(
-            model, self.modules_to_not_convert, quantization_config=self.quantization_config
+            model, quantization_config=self.quantization_config
         )
         return model
 

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -165,7 +165,7 @@ class Bnb8BitHfQuantizer(HfQuantizer):
         from ..integrations import dequantize_and_replace
 
         model = dequantize_and_replace(
-            model, self.modules_to_not_convert, quantization_config=self.quantization_config
+            model, quantization_config=self.quantization_config
         )
         return model
 

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -164,9 +164,7 @@ class Bnb8BitHfQuantizer(HfQuantizer):
     def _dequantize(self, model):
         from ..integrations import dequantize_and_replace
 
-        model = dequantize_and_replace(
-            model, quantization_config=self.quantization_config
-        )
+        model = dequantize_and_replace(model, quantization_config=self.quantization_config)
         return model
 
     def get_quantize_ops(self):


### PR DESCRIPTION
# What does this PR do?

This PR updates replace_with_xxx methods to not use recursion anymore. This is simpler and easier to read.  The only one left is hqq and awq. For awq, I will wait for the refactor, for hqq let's see. 