### PR TITLE
Fix failing `owlv2` image processor integration test

### DIFF
--- a/tests/models/owlv2/test_image_processing_owlv2.py
+++ b/tests/models/owlv2/test_image_processing_owlv2.py
@@ -151,7 +151,9 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             with torch.no_grad():
                 outputs = model(**inputs)
 
-            results = processor.post_process_object_detection(outputs, threshold=0.2, target_sizes=[target_size])[0]
+            results = processor.image_processor.post_process_object_detection(
+                outputs, threshold=0.2, target_sizes=[target_size]
+            )[0]
 
             boxes = results["boxes"]
             torch.testing.assert_close(boxes, expected_boxes, atol=1e-1, rtol=1e-1)
@@ -160,7 +162,7 @@ class Owlv2ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             inputs = processor(text=[text, text], images=[image, image], return_tensors="pt")
             with torch.no_grad():
                 outputs = model(**inputs)
-            results = processor.post_process_object_detection(
+            results = processor.image_processor.post_process_object_detection(
                 outputs, threshold=0.2, target_sizes=[target_size, target_size]
             )
 


### PR DESCRIPTION
# What does this PR do?
Fixes [failing Owlv2ImageProcessingTest](https://github.com/huggingface/transformers/actions/runs/19983883282/job/57315088143#step:14:2390)

<img width="1320" height="115" alt="image" src="https://github.com/user-attachments/assets/8317e26b-1a60-48d9-af18-c5d61961925f" />


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@yonigozlan @Rocketknight1 