### PR TITLE
image_transforms: fix tensor annotations

### DIFF
--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -15,7 +15,7 @@
 from collections import defaultdict
 from collections.abc import Collection, Iterable
 from math import ceil
-from typing import Optional, Union
+from typing import Any, Optional, Union, overload
 
 import numpy as np
 
@@ -547,7 +547,13 @@ def _center_to_corners_format_numpy(bboxes_center: np.ndarray) -> np.ndarray:
 
 
 # 2 functions below inspired by https://github.com/facebookresearch/detr/blob/master/util/box_ops.py
-def center_to_corners_format(bboxes_center: "torch.Tensor") -> "torch.Tensor":
+@overload
+def center_to_corners_format(bboxes_center: "torch.Tensor") -> "torch.Tensor": ...
+
+@overload
+def center_to_corners_format(bboxes_center: np.ndarray) -> np.ndarray: ...
+
+def center_to_corners_format(bboxes_center: "torch.Tensor | np.ndarray") -> Any:
     """
     Converts bounding boxes from center format to corners format.
 
@@ -590,7 +596,13 @@ def _corners_to_center_format_numpy(bboxes_corners: np.ndarray) -> np.ndarray:
     return bboxes_center
 
 
-def corners_to_center_format(bboxes_corners: "torch.Tensor") -> "torch.Tensor":
+@overload
+def corners_to_center_format(bboxes_corners: "torch.Tensor") -> "torch.Tensor": ...
+
+@overload
+def corners_to_center_format(bboxes_corners: np.ndarray) -> np.ndarray: ...
+
+def corners_to_center_format(bboxes_corners: "torch.Tensor | np.ndarray") -> Any:
     """
     Converts bounding boxes from corners format to center format.
 

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -550,8 +550,10 @@ def _center_to_corners_format_numpy(bboxes_center: np.ndarray) -> np.ndarray:
 @overload
 def center_to_corners_format(bboxes_center: "torch.Tensor") -> "torch.Tensor": ...
 
+
 @overload
 def center_to_corners_format(bboxes_center: np.ndarray) -> np.ndarray: ...
+
 
 def center_to_corners_format(bboxes_center: "torch.Tensor | np.ndarray") -> Any:
     """
@@ -599,8 +601,10 @@ def _corners_to_center_format_numpy(bboxes_corners: np.ndarray) -> np.ndarray:
 @overload
 def corners_to_center_format(bboxes_corners: "torch.Tensor") -> "torch.Tensor": ...
 
+
 @overload
 def corners_to_center_format(bboxes_corners: np.ndarray) -> np.ndarray: ...
+
 
 def corners_to_center_format(bboxes_corners: "torch.Tensor | np.ndarray") -> Any:
     """

--- a/src/transformers/image_transforms.py
+++ b/src/transformers/image_transforms.py
@@ -26,7 +26,7 @@ from .image_utils import (
     get_image_size,
     infer_channel_dimension_format,
 )
-from .utils import ExplicitEnum, TensorType, is_torch_tensor
+from .utils import ExplicitEnum, is_torch_tensor
 from .utils.import_utils import (
     is_torch_available,
     is_vision_available,
@@ -547,7 +547,7 @@ def _center_to_corners_format_numpy(bboxes_center: np.ndarray) -> np.ndarray:
 
 
 # 2 functions below inspired by https://github.com/facebookresearch/detr/blob/master/util/box_ops.py
-def center_to_corners_format(bboxes_center: TensorType) -> TensorType:
+def center_to_corners_format(bboxes_center: "torch.Tensor") -> "torch.Tensor":
     """
     Converts bounding boxes from center format to corners format.
 
@@ -590,7 +590,7 @@ def _corners_to_center_format_numpy(bboxes_corners: np.ndarray) -> np.ndarray:
     return bboxes_center
 
 
-def corners_to_center_format(bboxes_corners: TensorType) -> TensorType:
+def corners_to_center_format(bboxes_corners: "torch.Tensor") -> "torch.Tensor":
     """
     Converts bounding boxes from corners format to center format.
 


### PR DESCRIPTION
# What does this PR do?

pyright complains when I call these functions. This is because their inputs and outputs are ostensibly tensors, but have been annotated with TensorType, which is an enum.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@yonigozlan @amyeroberts