### PR TITLE
Fixes for the failures of AMD CI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,7 @@ _deps = [
     "tensorboard",
     "timeout-decorator",
     "tiktoken",
-    "timm<=1.0.19,!=1.0.18",
+    "timm>=1.0.20",
     "tokenizers>=0.22.0,<=0.23.0",
     "torch>=2.2",
     "torchaudio",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -75,7 +75,7 @@ deps = {
     "tensorboard": "tensorboard",
     "timeout-decorator": "timeout-decorator",
     "tiktoken": "tiktoken",
-    "timm": "timm<=1.0.19,!=1.0.18",
+    "timm": "timm>=1.0.20",
     "tokenizers": "tokenizers>=0.22.0,<=0.23.0",
     "torch": "torch>=2.2",
     "torchaudio": "torchaudio",

--- a/src/transformers/models/align/modeling_align.py
+++ b/src/transformers/models/align/modeling_align.py
@@ -316,8 +316,6 @@ class AlignVisionSqueezeExciteLayer(nn.Module):
 
         hidden_states = self.expand(hidden_states)
         hidden_states = self.act_expand(hidden_states)
-
-        inputs = inputs.to(hidden_states.device)
         hidden_states = torch.mul(inputs, hidden_states)
 
         return hidden_states
@@ -978,6 +976,7 @@ class AlignVisionModel(AlignPreTrainedModel):
     main_input_name = "pixel_values"
     input_modalities = ("image",)
     supports_gradient_checkpointing = False
+    _no_split_modules = ["AlignVisionBlock"]
 
     def __init__(self, config: AlignVisionConfig):
         super().__init__(config)

--- a/src/transformers/models/align/modeling_align.py
+++ b/src/transformers/models/align/modeling_align.py
@@ -316,6 +316,8 @@ class AlignVisionSqueezeExciteLayer(nn.Module):
 
         hidden_states = self.expand(hidden_states)
         hidden_states = self.act_expand(hidden_states)
+
+        inputs = inputs.to(hidden_states.device)
         hidden_states = torch.mul(inputs, hidden_states)
 
         return hidden_states

--- a/src/transformers/models/blt/modeling_blt.py
+++ b/src/transformers/models/blt/modeling_blt.py
@@ -952,7 +952,7 @@ def compute_hash_embeddings(
             hash_ids = byte_group_hash_function(local_encoder_tokens, group_size, prime, encoder_hash_byte_group_vocab)
             # Apply offset to get the correct slice of the fused embedding
             offset_hash_ids = hash_ids + embedding_idx * encoder_hash_byte_group_vocab
-            embeddings += encoder_hash_tok_embedding(offset_hash_ids)
+            embeddings += encoder_hash_tok_embedding(offset_hash_ids).to(embeddings.device)
             embedding_idx += 1
 
     return embeddings

--- a/src/transformers/models/blt/modular_blt.py
+++ b/src/transformers/models/blt/modular_blt.py
@@ -133,7 +133,7 @@ def compute_hash_embeddings(
             hash_ids = byte_group_hash_function(local_encoder_tokens, group_size, prime, encoder_hash_byte_group_vocab)
             # Apply offset to get the correct slice of the fused embedding
             offset_hash_ids = hash_ids + embedding_idx * encoder_hash_byte_group_vocab
-            embeddings += encoder_hash_tok_embedding(offset_hash_ids)
+            embeddings += encoder_hash_tok_embedding(offset_hash_ids).to(embeddings.device)
             embedding_idx += 1
 
     return embeddings

--- a/src/transformers/models/efficientnet/modeling_efficientnet.py
+++ b/src/transformers/models/efficientnet/modeling_efficientnet.py
@@ -220,8 +220,6 @@ class EfficientNetSqueezeExciteLayer(nn.Module):
 
         hidden_states = self.expand(hidden_states)
         hidden_states = self.act_expand(hidden_states)
-
-        inputs = inputs.to(hidden_states.device)
         hidden_states = torch.mul(inputs, hidden_states)
 
         return hidden_states
@@ -437,7 +435,7 @@ class EfficientNetPreTrainedModel(PreTrainedModel):
     base_model_prefix = "efficientnet"
     main_input_name = "pixel_values"
     input_modalities = ("image",)
-    _no_split_modules = []
+    _no_split_modules = ["EfficientNetBlock"]
 
     @torch.no_grad()
     def _init_weights(self, module: nn.Module):

--- a/src/transformers/models/efficientnet/modeling_efficientnet.py
+++ b/src/transformers/models/efficientnet/modeling_efficientnet.py
@@ -220,6 +220,8 @@ class EfficientNetSqueezeExciteLayer(nn.Module):
 
         hidden_states = self.expand(hidden_states)
         hidden_states = self.act_expand(hidden_states)
+
+        inputs = inputs.to(hidden_states.device)
         hidden_states = torch.mul(inputs, hidden_states)
 
         return hidden_states

--- a/src/transformers/models/ernie/modeling_ernie.py
+++ b/src/transformers/models/ernie/modeling_ernie.py
@@ -113,8 +113,6 @@ class ErnieEmbeddings(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
-
-        inputs_embeds = inputs_embeds.to(token_type_embeddings.device)
         embeddings = inputs_embeds + token_type_embeddings
 
         position_embeddings = self.position_embeddings(position_ids)
@@ -570,7 +568,7 @@ class ErniePreTrainedModel(PreTrainedModel):
     """
 )
 class ErnieModel(ErniePreTrainedModel):
-    _no_split_modules = ["ErnieLayer"]
+    _no_split_modules = ["ErnieLayer", "ErnieEmbeddings"]
 
     def __init__(self, config, add_pooling_layer=True):
         r"""

--- a/src/transformers/models/ernie/modeling_ernie.py
+++ b/src/transformers/models/ernie/modeling_ernie.py
@@ -113,6 +113,8 @@ class ErnieEmbeddings(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        inputs_embeds = inputs_embeds.to(token_type_embeddings.device)
         embeddings = inputs_embeds + token_type_embeddings
 
         position_embeddings = self.position_embeddings(position_ids)

--- a/src/transformers/models/ernie/modeling_ernie.py
+++ b/src/transformers/models/ernie/modeling_ernie.py
@@ -113,6 +113,9 @@ class ErnieEmbeddings(nn.Module):
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        # .to is better than using _no_split_modules on ErnieEmbeddings as it's the first module and >1/2 the model size
+        inputs_embeds = inputs_embeds.to(token_type_embeddings.device)
         embeddings = inputs_embeds + token_type_embeddings
 
         position_embeddings = self.position_embeddings(position_ids)
@@ -568,7 +571,7 @@ class ErniePreTrainedModel(PreTrainedModel):
     """
 )
 class ErnieModel(ErniePreTrainedModel):
-    _no_split_modules = ["ErnieLayer", "ErnieEmbeddings"]
+    _no_split_modules = ["ErnieLayer"]
 
     def __init__(self, config, add_pooling_layer=True):
         r"""

--- a/src/transformers/models/ernie/modular_ernie.py
+++ b/src/transformers/models/ernie/modular_ernie.py
@@ -107,6 +107,8 @@ class ErnieEmbeddings(BertEmbeddings):
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        inputs_embeds = inputs_embeds.to(token_type_embeddings.device)
         embeddings = inputs_embeds + token_type_embeddings
 
         position_embeddings = self.position_embeddings(position_ids)

--- a/src/transformers/models/ernie/modular_ernie.py
+++ b/src/transformers/models/ernie/modular_ernie.py
@@ -107,6 +107,9 @@ class ErnieEmbeddings(BertEmbeddings):
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
+
+        # .to is better than using _no_split_modules on ErnieEmbeddings as it's the first module and >1/2 the model size
+        inputs_embeds = inputs_embeds.to(token_type_embeddings.device)
         embeddings = inputs_embeds + token_type_embeddings
 
         position_embeddings = self.position_embeddings(position_ids)
@@ -172,7 +175,7 @@ class ErniePreTrainedModel(PreTrainedModel):
 
 
 class ErnieModel(BertModel):
-    _no_split_modules = ["ErnieLayer", "ErnieEmbeddings"]
+    _no_split_modules = ["ErnieLayer"]
 
     def __init__(self, config, add_pooling_layer=True):
         super().__init__(self, config)

--- a/src/transformers/models/ernie/modular_ernie.py
+++ b/src/transformers/models/ernie/modular_ernie.py
@@ -107,8 +107,6 @@ class ErnieEmbeddings(BertEmbeddings):
         if inputs_embeds is None:
             inputs_embeds = self.word_embeddings(input_ids)
         token_type_embeddings = self.token_type_embeddings(token_type_ids)
-
-        inputs_embeds = inputs_embeds.to(token_type_embeddings.device)
         embeddings = inputs_embeds + token_type_embeddings
 
         position_embeddings = self.position_embeddings(position_ids)
@@ -174,7 +172,7 @@ class ErniePreTrainedModel(PreTrainedModel):
 
 
 class ErnieModel(BertModel):
-    _no_split_modules = ["ErnieLayer"]
+    _no_split_modules = ["ErnieLayer", "ErnieEmbeddings"]
 
     def __init__(self, config, add_pooling_layer=True):
         super().__init__(self, config)

--- a/src/transformers/models/mimi/modeling_mimi.py
+++ b/src/transformers/models/mimi/modeling_mimi.py
@@ -1380,7 +1380,7 @@ class MimiPreTrainedModel(PreTrainedModel):
     main_input_name = "input_values"
     input_modalities = "audio"
     supports_gradient_checkpointing = True
-    _no_split_modules = ["MimiDecoderLayer"]
+    _no_split_modules = ["MimiResidualVectorQuantizer", "MimiTransformerLayer"]
     _skip_keys_device_placement = "past_key_values"
     _supports_flash_attn = True
     _supports_sdpa = True

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -2342,6 +2342,7 @@ class ModelTesterMixin:
 
             # Wrap model in nn.DataParallel
             model = nn.DataParallel(model)
+            torch.cuda.synchronize()  # otherwise the transfer might not be complete
             with torch.no_grad():
                 _ = model(**self._prepare_for_class(inputs_dict, model_class))
 


### PR DESCRIPTION
This PR fixes the following:
- multiple devices errors for `blt`, `efficientnet`, `ernie` and `mimi`
- added a synchronization to fix a `test_multi_gpu_data_parallel_forward` that failed with `align`
- removed the requirement that `timm` should be version `<=.19` because there are some new models that are not supported by this version. The real requirement should have been version `>.19` (https://github.com/huggingface/transformers/pull/39640)

This reduces the number of fails on the AMD CI by a lot (~150 I think)