### PR TITLE
Replace VMap that Fails Torch.Export

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -386,6 +386,7 @@ def sdpa_mask_recent_torch(
     q_indices = torch.arange(kv_length - q_length, kv_length)
     k_indices = torch.arange(kv_length)
     causal_mask = q_indices[:, None] >= k_indices[None, :]
+    causal_mask = causal_mask.unsqueeze(0).unsqueeze(0)
 
     return causal_mask
 

--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -340,7 +340,7 @@ class Llama4TextAttention(nn.Module):
             attn_scales = (
                 torch.log1p(torch.floor((cache_position.float() + 1.0) / self.floor_scale)) * self.attn_scale + 1.0
             )
-            attn_scales = attn_scales.view((1, input_shape[-1], 1, 1)).expand((*input_shape, 1, 1))  # batch size > 1
+            attn_scales = attn_scales.view((1, -1, 1, 1)).expand((*input_shape, 1, 1))  # batch size > 1
             query_states = (query_states * attn_scales).to(query_states.dtype)
 
         query_states = query_states.transpose(1, 2)


### PR DESCRIPTION
The specific vmap used in causal mask construction would fail torch.export by
```log
torch._dynamo.exc.TorchRuntimeError: Dynamo failed to run FX node with fake tensors: call_function <built-in function getitem>(*(FakeTensor(..., size=(1, 8), dtype=torch.int64), (BatchedTensor(lvl=1, bdim=0, value=
    FakeTensor(..., size=(1,), dtype=torch.int64)
), BatchedTensor(lvl=3, bdim=0, value=
    FakeTensor(..., size=(8,), dtype=torch.int64)
))), **{}): got RuntimeError("vmap: It looks like you're calling .item() on a Tensor. We don't support vmap over calling .item() on a Tensor, please try to rewrite what you're doing with other operations. If error is occurring somewhere inside PyTorch internals, please file a bug report.")
```

The solution is to use a simple causal mask construction
```python
    q_indices = torch.arange(kv_length - q_length, kv_length)
    k_indices = torch.arange(kv_length)
    causal_mask = q_indices[:, None] >= k_indices[None, :]
```

cc @ArthurZucker @Cyrilvallez