### PR TITLE
Add optional backend parameter to VideosKwargs

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -316,6 +316,10 @@ class VideosKwargs(TypedDict, total=False):
             The channel dimension format for the output video.
         input_data_format (`ChannelDimension` or `str`, *optional*):
             The channel dimension format for the input video.
+        backend (`str`,  *optional*):
+            The backend to use for processing videos (e.g. "torchcodec", "torchvision").
+        torchcodec_device (`str`,  *optional*):
+            The device to use for processing videos with `TorchCodec`.
         device (`Union[str, torch.Tensor]`, *optional*):
             The device to use for processing (e.g. "cpu", "cuda"), only relevant for fast image processing.
         return_metadata (`bool`, *optional*):
@@ -341,6 +345,8 @@ class VideosKwargs(TypedDict, total=False):
     crop_size: Annotated[Optional[Union[int, list[int], tuple[int, ...], dict[str, int]]], image_size_validator()]
     data_format: Optional[Union[str, ChannelDimension]]
     input_data_format: Optional[Union[str, ChannelDimension]]
+    backend: Optional[str]
+    torchcodec_device: Optional[str]
     device: Annotated[Optional[Union[str, "torch.device"]], device_validator()]
     do_sample_frames: Optional[bool]
     video_metadata: Annotated[Optional[VideoMetadataType], video_metadata_validator()]

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -864,13 +864,16 @@ class BaseVideoProcessor(BaseImageProcessorFast):
         If a single url is passed, the return value will be a single object. If a list is passed a list of objects is
         returned.
         """
-        backend = "torchcodec"
-        if not is_torchcodec_available():
+        backend = sample_indices_fn.keywords.get("backend", "torchcodec")
+        if backend == "torchcodec" and not is_torchcodec_available():
             warnings.warn(
                 "`torchcodec` is not installed and cannot be used to decode the video by default. "
-                "Falling back to `torchvision`. Note that `torchvision` decoding is deprecated and will be removed in future versions. "
+                "Falling back to `torchvision`."
             )
             backend = "torchvision"
+
+        if backend == "torchvision":
+            warnings.warn("`torchvision` decoding is deprecated and will be removed in future versions.")
 
         if isinstance(video_url_or_urls, list):
             return list(zip(*[self.fetch_videos(x, sample_indices_fn=sample_indices_fn) for x in video_url_or_urls]))

--- a/src/transformers/video_utils.py
+++ b/src/transformers/video_utils.py
@@ -602,7 +602,7 @@ def read_video_torchcodec(
         seek_mode="exact",
         # Allow FFmpeg decide on the number of threads for efficiency
         num_ffmpeg_threads=0,
-        device=kwargs.get("device", "cpu"),
+        device=sample_indices_fn.keywords.get("torchcodec_device", "cpu"),
     )
     total_num_frames = decoder.metadata.num_frames
     video_fps = decoder.metadata.average_fps


### PR DESCRIPTION
- Add optional backend and torchcodec_device parameter in VideosKwargs to allow users to specify the desired video processing backend.
- Fix device detection while reading videos with torchcodec.