### PR TITLE
set `is_local` to avoid networking if `local_files_only=True`

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1616,7 +1616,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         vocab_files = {}
         init_configuration = {}
 
-        is_local = os.path.isdir(pretrained_model_name_or_path)
+        is_local = os.path.isdir(pretrained_model_name_or_path) or local_files_only
         single_file_id = None
         if os.path.isfile(pretrained_model_name_or_path):
             # For legacy support: allow single-file loading if:


### PR DESCRIPTION
# What does this PR do?
Fix networking when `local_files_only=True` or even `HF_HUB_OFFLINE=1`.

Here is what I face when I have already downloaded the model and set `HF_HUB_OFFLINE=1`:

```
  File "qwen3vl.py", line 57, in __init__
    self.processor = AutoProcessor.from_pretrained(model_path, local_files_only=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/models/auto/processing_auto.py", line 396, in from_pretrained
    return processor_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/processing_utils.py", line 1394, in from_pretrained
    args = cls._get_arguments_from_pretrained(pretrained_model_name_or_path, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/processing_utils.py", line 1453, in _get_arguments_from_pretrained
    args.append(attribute_class.from_pretrained(pretrained_model_name_or_path, **kwargs))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2113, in from_pretrained
    return cls._from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2395, in _from_pretrained
    tokenizer = cls._patch_mistral_regex(
                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2438, in _patch_mistral_regex
    if _is_local or is_base_mistral(pretrained_model_name_or_path):
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/transformers/tokenization_utils_base.py", line 2432, in is_base_mistral
    model = model_info(model_id)
            ^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/huggingface_hub/utils/_validators.py", line 114, in _inner_fn
    return fn(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/huggingface_hub/hf_api.py", line 2660, in model_info
    r = get_session().get(path, headers=headers, timeout=timeout, params=params)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/requests/sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/python3.12/site-packages/huggingface_hub/utils/_http.py", line 106, in send
    raise OfflineModeIsEnabled(
huggingface_hub.errors.OfflineModeIsEnabled: Cannot reach https://huggingface.co/api/models/Qwen/Qwen3-VL-30B-A3B-Thinking: offline mode is enabled. To disable it, please unset the `HF_HUB_OFFLINE` environment variable.
```

After this PR:

```
INFO 12-09 07:15:19 [arg_utils.py:592] HF_HUB_OFFLINE is True, replace model_id [Qwen/Qwen3-VL-30B-A3B-Thinking] to model_path [$HF_HOME/hub/models--Qwen--Qwen3-VL-30B-A3B-Thinking/snapshots/d0ed0380729be07a546fdefafbb4fe411f341e92]
INFO 12-09 07:15:19 [arg_utils.py:592] HF_HUB_OFFLINE is True, replace model_id [$HF_HOME/hub/models--Qwen--Qwen3-VL-30B-A3B-Thinking/snapshots/d0ed0380729be07a546fdefafbb4fe411f341e92] to model_path [$HF_HOME/hub/models--Qwen--Qwen3-VL-30B-A3B-Thinking/snapshots/d0ed0380729be07a546fdefafbb4fe411f341e92]
INFO 12-09 07:15:19 [utils.py:253] non-default args: {'tokenizer': 'Qwen/Qwen3-VL-30B-A3B-Thinking', 'trust_remote_code': True, 'max_model_len': 8192, 'disable_log_stats': True, 'model': '$HF_HOME/hub/models--Qwen--Qwen3-VL-30B-A3B-Thinking/snapshots/d0ed0380729be07a546fdefafbb4fe411f341e92'}
The argument `trust_remote_code` is to be used with Auto classes. It has no effect here and is ignored.
INFO 12-09 07:15:19 [model.py:631] Resolved architecture: Qwen3VLMoeForConditionalGeneration
INFO 12-09 07:15:19 [model.py:1745] Using max model len 8192
...
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@ArthurZucker and @itazap
