### PR TITLE
Remove redundant else in activations.py

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -345,8 +345,8 @@ ACT2FN = ClassInstantier(ACT2CLS)
 def get_activation(activation_string):
     if activation_string in ACT2FN:
         return ACT2FN[activation_string]
-    else:
-        raise KeyError(f"function {activation_string} not found in ACT2FN mapping {list(ACT2FN.keys())}")
+
+    raise KeyError(f"function {activation_string} not found in ACT2FN mapping {list(ACT2FN.keys())}")
 
 
 # For backwards compatibility with: from activations import gelu_python


### PR DESCRIPTION
# Remove Redundant Else Block in get_activation()

**Fixes #42621**

This PR removes a redundant `else` block in `get_activation()` in `src/transformers/activations.py`. The `else` was unnecessary because the `if` branch already returned, and keeping it went against the project's preferred early-return style.

## Previous Control Flow

```python
def get_activation(activation_string):
    if activation_string in ACT2FN:
        return ACT2FN[activation_string]
    else:
        raise KeyError(f"function {activation_string} not found in ACT2FN mapping {list(ACT2FN.keys())}")
```

## Updated Control Flow

```python
def get_activation(activation_string):
    if activation_string in ACT2FN:
        return ACT2FN[activation_string]
    raise KeyError(f"function {activation_string} not found in ACT2FN mapping {list(ACT2FN.keys())}")
```

## Summary

- Pure cleanup (no behavior change)
- Simplifies logic and matches HF style
- All style & repo checks pass
