### PR TITLE
Fix: add None check for extractors in video_processor_class_from_name

### DIFF
--- a/src/transformers/models/auto/video_processing_auto.py
+++ b/src/transformers/models/auto/video_processing_auto.py
@@ -91,7 +91,7 @@ VIDEO_PROCESSOR_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, VIDEO_PROCESSOR
 
 def video_processor_class_from_name(class_name: str):
     for module_name, extractors in VIDEO_PROCESSOR_MAPPING_NAMES.items():
-        if class_name in extractors:
+        if extractors is not None and class_name in extractors:
             module_name = model_type_to_module_name(module_name)
 
             module = importlib.import_module(f".{module_name}", "transformers.models")


### PR DESCRIPTION
Here's a PR message for the fix:

---

# What does this PR do?

Fixes `TypeError: argument of type 'NoneType' is not iterable` when loading VLM processors without `torchvision` installed.

## The Problem

When `torchvision` is not available, the `VIDEO_PROCESSOR_MAPPING_NAMES` dictionary values are set to `None` (lines 84-87 in `video_processing_auto.py`). However, `video_processor_class_from_name()` attempts to check `if class_name in extractors` without first verifying that `extractors` is not `None`, causing the TypeError.

## The Fix

Added a `None` check before the membership test:

```python
# Before
if class_name in extractors:

# After  
if extractors is not None and class_name in extractors:
```

This allows the function to safely skip entries where the video processor class is `None` (i.e., when `torchvision` is unavailable) and continue searching through other mappings or return `None` gracefully pointing out the root cause of the error.

## Traceback

Before fix:
```bash
Traceback (most recent call last):
  File "/opt/homebrew/Caskroom/miniconda/base/envs/mlx/bin/mlx_vlm.generate", line 7, in <module>
    sys.exit(main())
  ...
  File ".../transformers/models/auto/video_processing_auto.py", line 94, in video_processor_class_from_name
    if class_name in extractors:
       ^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: argument of type 'NoneType' is not iterable
```

After fix: 

```bash
  File "/Users/prince_canuma/Documents/Projects/LLMs/transformers/transformers/src/transformers/utils/import_utils.py", line 1863, in __getattribute__
    requires_backends(cls, cls._backends)
  File "/Users/prince_canuma/Documents/Projects/LLMs/transformers/transformers/src/transformers/utils/import_utils.py", line 1849, in requires_backends
    raise ImportError("".join(failed))
ImportError: 
Qwen3VLVideoProcessor requires the Torchvision library but it was not found in your environment. Check out the instructions on the
installation page: https://pytorch.org/get-started/locally/ and follow the ones that match your environment.
Please note that you may need to restart your runtime after installation.
```

## Reproduction

```bash
# In an environment without torchvision
mlx_vlm.generate --model Qwen/Qwen3-VL-2B-Instruct --prompt "Describe this image." --image "image.png"
```