### PR TITLE
Add instructions for appending NLLB language codes

### DIFF
--- a/docs/source/en/model_doc/nllb.md
+++ b/docs/source/en/model_doc/nllb.md
@@ -148,6 +148,28 @@ visualizer("UN Chief says there is no military solution in Syria")
     Le chef de l'ONU dit qu'il n'y a pas de solution militaire en Syrie
     ```
 
+- NLLB stores its language codes as special tokens in the tokenizer. When you fine-tune on a new language, you can append a new code without removing any existing ones:
+
+    ```python
+    from transformers import NllbTokenizer
+
+    tokenizer = NllbTokenizer.from_pretrained("facebook/nllb-200-distilled-600M")
+
+    new_codes = ["ami_Latn"]
+
+    # Append new language codes without removing existing ones
+    tokenizer.add_special_tokens(
+        {"extra_special_tokens": new_codes},
+        replace_extra_special_tokens=False,
+    )
+
+    # Optional: get the token ids for the new codes
+    token_ids = [tokenizer.convert_tokens_to_ids(code) for code in new_codes]
+    ```
+
+    > [!TIP]
+    > For Transformers versions earlier than 5.0, use the `additional_special_tokens` key and the `replace_additional_special_tokens` argument instead of `extra_special_tokens` and `replace_extra_special_tokens`.
+    
 ## NllbTokenizer
 
 [[autodoc]] NllbTokenizer


### PR DESCRIPTION
### What does this PR do?

This PR adds a short section to the NLLB documentation explaining how to add new language codes using the existing `add_special_tokens` / `extra_special_tokens` API in Transformers v5+.

This follows reviewer feedback that the current tokenizer API already supports this workflow and that a dedicated method isn't needed. The new docs make this workflow more discoverable for users who fine-tune NLLB on languages outside the FLoRes-200 set.

### Background / Related PRs

Supersedes and replaces #42756.
That PR attempted to add new tokenizer methods; based on reviewer feedback, this PR is documentation-only.

Thanks to @itazap for the review and guidance.

### Checklist

* [x] Documentation update only
* [x] No code changes
* [x] Builds cleanly with `doc-builder`
* [x] Reflects current v5 tokenizer behavior (`extra_special_tokens`, `replace_extra_special_tokens`, deduping logic, etc.)