### PR TITLE
Add inputs_to_logits_ratio to LasrCTCConfig

### DIFF
--- a/src/transformers/models/lasr/configuration_lasr.py
+++ b/src/transformers/models/lasr/configuration_lasr.py
@@ -240,5 +240,11 @@ class LasrCTCConfig(PreTrainedConfig):
 
         return cls(encoder_config=encoder_config.to_dict(), **kwargs)
 
+    @property
+    def inputs_to_logits_ratio(self) -> int:
+        # Guaranteed by a check in LasrFeatureExtractor.__init__().
+        hop_length = 160
+        return hop_length * self.encoder_config.subsampling_conv_stride**2
+
 
 __all__ = ["LasrEncoderConfig", "LasrCTCConfig"]

--- a/src/transformers/models/lasr/feature_extraction_lasr.py
+++ b/src/transformers/models/lasr/feature_extraction_lasr.py
@@ -103,6 +103,10 @@ class LasrFeatureExtractor(SequenceFeatureExtractor):
         padding_value=0.0,
         **kwargs,
     ):
+        # TODO: This restriction is in-place because of LasrCTCConfig.inputs_to_logits_ratio. It should be removed
+        # after AutomaticSpeechRecognitionPipeline has a more flexible way of handling inputs_to_logits_ratio.
+        if hop_length != 160:
+            raise ValueError("Only hop_length==160 is supported.")
         super().__init__(feature_size=feature_size, sampling_rate=sampling_rate, padding_value=padding_value, **kwargs)
 
         self.hop_length = hop_length

--- a/src/transformers/models/lasr/modular_lasr.py
+++ b/src/transformers/models/lasr/modular_lasr.py
@@ -291,6 +291,12 @@ class LasrCTCConfig(ParakeetCTCConfig):
             **kwargs,
         )
 
+    @property
+    def inputs_to_logits_ratio(self) -> int:
+        # Guaranteed by a check in LasrFeatureExtractor.__init__().
+        hop_length = 160
+        return hop_length * self.encoder_config.subsampling_conv_stride**2
+
 
 class LasrEncoderSubsampling(nn.Module):
     def __init__(self, config: LasrEncoderConfig):


### PR DESCRIPTION
# What does this PR do?

This PR adds inputs_to_logits_ratio to LasrCTCConfig so that LasrForCTC can be used in an ASR pipeline with chunked decoding.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
