### PR TITLE
Fixing wrong information in Mimi Docs

### DIFF
--- a/docs/source/en/model_doc/mimi.md
+++ b/docs/source/en/model_doc/mimi.md
@@ -25,7 +25,7 @@ rendered properly in your Markdown viewer.
 
 # Mimi
 
-[Mimi](huggingface.co/papers/2410.00037) is a neural audio codec model with pretrained and quantized variants, designed for efficient speech representation and compression. The model operates at 1.1 kbps with a 12 Hz frame rate and uses a convolutional encoder-decoder architecture combined with a residual vector quantizer of 16 codebooks. Mimi outputs dual token streams i.e. semantic and acoustic to balance linguistic richness with high fidelity reconstruction. Key features include a causal streaming encoder for low-latency use, dual-path tokenization for flexible downstream generation, and integration readiness with large speech models like Moshi.
+[Mimi](huggingface.co/papers/2410.00037) is a neural audio codec model with pretrained and quantized variants, designed for efficient speech representation and compression. The model operates at 1.1 kbps with a 25 Hz frame rate and uses a convolutional encoder-decoder architecture combined with a residual vector quantizer of 32 codebooks. Mimi outputs dual token streams i.e. semantic and acoustic to balance linguistic richness with high fidelity reconstruction. Key features include a causal streaming encoder for low-latency use, dual-path tokenization for flexible downstream generation, and integration readiness with large speech models like Moshi.
 
 You can find the original Mimi checkpoints under the [Kyutai](https://huggingface.co/kyutai/models?search=mimi) organization.
 


### PR DESCRIPTION
```python
model_id = "kyutai/mimi"
mimi_model = MimiModel.from_pretrained(model_id)
feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)

# Check your exact frame rate
total_stride = 1
for ratio in mimi_model.config.upsampling_ratios:
    total_stride *= ratio

frame_rate = mimi_model.config.sampling_rate / total_stride
print(f"Sampling Rate: {mimi_model.config.sampling_rate}")
print(f"Total Stride: {total_stride}")
print(f"ACTUAL Frame Rate: {frame_rate} Hz")
print(f"Duration per frame: {1/frame_rate:.4f} seconds")
```
The output of this code is:
```
Sampling Rate: 24000
Total Stride: 960
ACTUAL Frame Rate: 25.0 Hz
Duration per frame: 0.0400 seconds
```
So the correct frame rate is 25Hz not 12.5, also the codebooks returned are 32 not 16.