### PR TITLE
Fix auto_docstring for Union type

### DIFF
--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -1294,10 +1294,12 @@ def _process_parameter_type(param, param_name, func):
         param_type = param.annotation
         if "typing" in str(param_type):
             param_type = "".join(str(param_type).split("typing.")).replace("transformers.", "~")
-        elif hasattr(param_type, "__module__"):
+        elif hasattr(param_type, "__module__") and hasattr(param_type, "__name__"):
             param_type = f"{param_type.__module__.replace('transformers.', '~').replace('builtins', '')}.{param.annotation.__name__}"
             if param_type[0] == ".":
                 param_type = param_type[1:]
+        elif isinstance(param_type, type(int | None)):  # types.UnionType
+            param_type = str(param_type).replace("transformers.", "~")
         else:
             if False:
                 print(


### PR DESCRIPTION
# What does this PR do?

Auto doc string generation for Union type have not supported. I found this issue happened for out-of-tree model (Kimi2)

```
(.venv) ➜  transformers git:(main) ✗ cat main.py
from transformers import AutoModelForCausalLM, AutoTokenizer

model_name = "moonshotai/Kimi-Linear-48B-A3B-Instruct"
model = AutoModelForCausalLM.from_pretrained(
        model_name,
        torch_dtype="auto",
        device_map="auto",
        trust_remote_code=True
        )
tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)

messages = [
        {"role": "system", "content": "You are a helpful assistant provided by Moonshot-AI."},
        {"role": "user", "content": "Is 123 a prime?"}
        ]
input_ids = tokenizer.apply_chat_template(
        messages,
        add_generation_prompt=True,
        return_tensors="pt"
        ).to(model.device)
generated_ids = model.generate(inputs=input_ids, max_new_tokens=500)
response = tokenizer.batch_decode(generated_ids)[0]
print(response)

```

```
(.venv) (ys) ➜  transformers git:(main) ✗ python main.py
/root/ys/transformers/.venv/lib/python3.13/site-packages/fla/utils.py:354: UserWarning: Triton is not supported on current platform, roll back to CPU.
  warnings.warn(('Triton is not supported on current platform, roll back to CPU.'), stacklevel=1)
Traceback (most recent call last):
  File "/root/ys/transformers/main.py", line 4, in <module>
    model = AutoModelForCausalLM.from_pretrained(
            model_name,
    ...<2 lines>...
            trust_remote_code=True
            )
  File "/root/ys/transformers/src/transformers/models/auto/auto_factory.py", line 355, in from_pretrained
    model_class = get_class_from_dynamic_module(
        class_ref, pretrained_model_name_or_path, code_revision=code_revision, **hub_kwargs, **kwargs
    )
  File "/root/ys/transformers/src/transformers/dynamic_module_utils.py", line 583, in get_class_from_dynamic_module
    return get_class_in_module(class_name, final_module, force_reload=force_download)
  File "/root/ys/transformers/src/transformers/dynamic_module_utils.py", line 309, in get_class_in_module
    module_spec.loader.exec_module(module)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "<frozen importlib._bootstrap_external>", line 1023, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/root/.cache/huggingface/modules/transformers_modules/moonshotai/Kimi_hyphen_Linear_hyphen_48B_hyphen_A3B_hyphen_Instruct/806a95e7fd27c24cc6a58260445f053adcc3b3cb/modeling_kimi.py", line 899, in <module>
    class KimiLinearModel(KimiPreTrainedModel):
    ...<106 lines>...
            )
  File "/root/.cache/huggingface/modules/transformers_modules/moonshotai/Kimi_hyphen_Linear_hyphen_48B_hyphen_A3B_hyphen_Instruct/806a95e7fd27c24cc6a58260445f053adcc3b3cb/modeling_kimi.py", line 939, in KimiLinearModel
    @auto_docstring
     ^^^^^^^^^^^^^^
  File "/root/ys/transformers/src/transformers/utils/auto_docstring.py", line 2052, in auto_docstring
    return auto_docstring_decorator(obj)
  File "/root/ys/transformers/src/transformers/utils/auto_docstring.py", line 2045, in auto_docstring_decorator
    return auto_method_docstring(
        obj, custom_args=custom_args, custom_intro=custom_intro, checkpoint=checkpoint
    )
  File "/root/ys/transformers/src/transformers/utils/auto_docstring.py", line 1746, in auto_method_docstring
    docstring += _process_parameters_section(
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        func_documentation, sig, func, class_name, model_name_lowercase, parent_class, indent_level, source_args_dict
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/root/ys/transformers/src/transformers/utils/auto_docstring.py", line 1576, in _process_parameters_section
    param_docstring, missing_args = _process_regular_parameters(
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        sig, func, class_name, documented_params, indent_level, undocumented_parameters, source_args_dict, parent_class
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/root/ys/transformers/src/transformers/utils/auto_docstring.py", line 1395, in _process_regular_parameters
    param_type, optional = _process_parameter_type(param, param_name, func)
                           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/ys/transformers/src/transformers/utils/auto_docstring.py", line 1298, in _process_parameter_type
    param_type = f"{param_type.__module__.replace('transformers.', '~').replace('builtins', '')}.{param.annotation.__name__}"
                                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'types.UnionType' object has no attribute '__name__'. Did you mean: '__ne__'?

```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

