### PR TITLE
Raise conversion errors after loading

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -409,7 +409,7 @@ class WeightRenaming(WeightTransform):
         config=None,
         hf_quantizer=None,
         missing_keys: Optional[MutableSet[str]] = None,
-        misc: Optional[MutableMapping[str, str]] = None,
+        conversion_errors: Optional[MutableMapping[str, str]] = None,
     ):
         # Collect the tensors here - we use a new dictionary to avoid keeping them in memory in the internal
         # attribute during the whole process
@@ -421,7 +421,9 @@ class WeightRenaming(WeightTransform):
         collected_tensors = {target_key: collected_tensors[self.source_patterns[0]]}
 
         if hf_quantizer is not None and self.quantization_operation is not None:
-            with log_to_misc(layer_name, misc, (len(collected_tensors), layer_name), self.quantization_operation):
+            with log_conversion_errors(
+                layer_name, conversion_errors, (len(collected_tensors), layer_name), self.quantization_operation
+            ):
                 collected_tensors = self.quantization_operation.convert(
                     collected_tensors,
                     source_patterns=self.source_patterns,
@@ -432,7 +434,7 @@ class WeightRenaming(WeightTransform):
                     missing_keys=missing_keys,
                 )
 
-        return collected_tensors, misc
+        return collected_tensors, conversion_errors
 
 
 @dataclass(slots=True)
@@ -455,14 +457,14 @@ class WeightConverter(WeightTransform):
         config=None,
         hf_quantizer=None,
         missing_keys: Optional[MutableSet[str]] = None,
-        misc: Optional[MutableMapping[str, str]] = None,
+        conversion_errors: Optional[MutableMapping[str, str]] = None,
     ):
         # Collect the tensors here - we use a new dictionary to avoid keeping them in memory in the internal
         # attribute during the whole process
         collected_tensors = self.materialize_tensors()
 
         for op in self.operations:
-            with log_to_misc(layer_name, misc, (len(collected_tensors), layer_name), op):
+            with log_conversion_errors(layer_name, conversion_errors, (len(collected_tensors), layer_name), op):
                 collected_tensors = op.convert(
                     collected_tensors,
                     source_patterns=self.source_patterns,
@@ -489,7 +491,9 @@ class WeightConverter(WeightTransform):
             pass
 
         if hf_quantizer is not None and self.quantization_operation is not None:
-            with log_to_misc(layer_name, misc, (len(collected_tensors), layer_name), self.quantization_operation):
+            with log_conversion_errors(
+                layer_name, conversion_errors, (len(collected_tensors), layer_name), self.quantization_operation
+            ):
                 collected_tensors = self.quantization_operation.convert(
                     collected_tensors,
                     source_patterns=self.source_patterns,
@@ -499,7 +503,7 @@ class WeightConverter(WeightTransform):
                     model=model,
                     missing_keys=missing_keys,
                 )
-        return collected_tensors, misc
+        return collected_tensors, conversion_errors
 
 
 # For I/O bound operations (i.e. here reading files), it is better to have fewer threads, e.g. 4 is a good default.
@@ -560,9 +564,9 @@ def dot_natural_key(s: str):
 
 
 @contextmanager
-def log_to_misc(
+def log_conversion_errors(
     first_target_key: str,
-    misc: MutableMapping[str, str],
+    conversion_errors: MutableMapping[str, str],
     extras: Any = None,
     op: Union[list[ConversionOps], ConversionOps, None] = None,
 ):
@@ -585,16 +589,16 @@ def log_to_misc(
         if isinstance(extras, tuple) and len(extras) == 2:
             length, target_keys = extras
             descriptor = f"{op_name} " if op_name else ""
-            misc[first_target_key] = (
+            conversion_errors[first_target_key] = (
                 f"{e}\nError: {descriptor}on tensors destined for {target_keys}. Ckpt contains: {length}"
             )
         elif isinstance(extras, str):
             suffix = f" via {op_name}" if op_name else ""
-            misc[first_target_key] = f"{e}\nError{suffix} when processing parameter {extras}"
+            conversion_errors[first_target_key] = f"{e}\nError{suffix} when processing parameter {extras}"
         elif extras is None and op_name:
-            misc[first_target_key] = f"{op_name}: {e}"
+            conversion_errors[first_target_key] = f"{op_name}: {e}"
         else:
-            misc[first_target_key] = f"{extras} |Error: {e}"
+            conversion_errors[first_target_key] = f"{extras} |Error: {e}"
 
         # Raise a specific Exception that we can catch easily
         raise SkipParameters()
@@ -606,44 +610,42 @@ def set_param_for_module(
     param_value: torch.Tensor,
     mismatch_keys: MutableSet[tuple[str, torch.Size, torch.Size]],
     missing_keys: MutableSet[str],
-    misc: MutableMapping[str, Any],
     unexpected_keys: MutableSet[str],
     distributed_operation: Optional[TensorParallelLayer],
     hf_quantizer: HfQuantizer,
 ):
-    with log_to_misc(target_name, misc, target_name):
-        module_path, _, param_name = target_name.rpartition(".")
-        module_obj = model.get_submodule(module_path) if module_path else model
+    module_path, _, param_name = target_name.rpartition(".")
+    module_obj = model.get_submodule(module_path) if module_path else model
 
-        ref = getattr(module_obj, param_name)
-        if ref is None:
-            unexpected_keys.add(target_name)
+    ref = getattr(module_obj, param_name)
+    if ref is None:
+        unexpected_keys.add(target_name)
+    else:
+        use_dtensor = hasattr(distributed_operation, "use_dtensor") and distributed_operation.use_dtensor
+        if not isinstance(param_value, torch.nn.Parameter):
+            if distributed_operation is not None:
+                param_value = DTensor.from_local(
+                    param_value,
+                    distributed_operation.device_mesh,
+                    getattr(distributed_operation, "shard", Replicate()),
+                    run_check=False,
+                    shape=ref.size(),
+                    stride=ref.stride(),
+                )
+                if not use_dtensor:
+                    # we convert to local
+                    param_value = param_value.to_local()
+            if param_name not in module_obj._buffers:
+                param_value = torch.nn.Parameter(param_value, requires_grad=param_value.is_floating_point())
+
+        # Remove from missing keys (it's either mismatched, or all good)
+        missing_keys.discard(target_name)
+        if ref is not None and ref.shape != param_value.shape and hf_quantizer is None:
+            mismatch_keys.add((target_name, param_value.shape, ref.shape))
         else:
-            use_dtensor = hasattr(distributed_operation, "use_dtensor") and distributed_operation.use_dtensor
-            if not isinstance(param_value, torch.nn.Parameter):
-                if distributed_operation is not None:
-                    param_value = DTensor.from_local(
-                        param_value,
-                        distributed_operation.device_mesh,
-                        getattr(distributed_operation, "shard", Replicate()),
-                        run_check=False,
-                        shape=ref.size(),
-                        stride=ref.stride(),
-                    )
-                    if not use_dtensor:
-                        # we convert to local
-                        param_value = param_value.to_local()
-                if param_name not in module_obj._buffers:
-                    param_value = torch.nn.Parameter(param_value, requires_grad=param_value.is_floating_point())
-
-            # Remove from missing keys (it's either mismatched, or all good)
-            missing_keys.discard(target_name)
-            if ref is not None and ref.shape != param_value.shape and hf_quantizer is None:
-                mismatch_keys.add((target_name, param_value.shape, ref.shape))
-            else:
-                # super important otherwise _init_weight will re-init the param
-                param_value._is_hf_initialized = True
-                setattr(module_obj, param_name, param_value)
+            # super important otherwise _init_weight will re-init the param
+            param_value._is_hf_initialized = True
+            setattr(module_obj, param_name, param_value)
 
 
 def offload_and_maybe_resave_param(
@@ -821,7 +823,7 @@ def convert_and_load_state_dict_in_model(
     meta_model_state_dict = model.state_dict()
     missing_keys = set(meta_model_state_dict.keys())
 
-    misc = {}
+    conversion_errors = {}
     mismatch_keys = set()
     unexpected_keys = set()
 
@@ -928,13 +930,13 @@ def convert_and_load_state_dict_in_model(
                 pbar.set_postfix({"Materializing param": first_param_name})
                 pbar.refresh()
                 try:
-                    realized_value, misc = mapping.convert(
+                    realized_value, conversion_errors = mapping.convert(
                         first_param_name,
                         model=model,
                         config=model.config,
                         hf_quantizer=hf_quantizer,
                         missing_keys=missing_keys,
-                        misc=misc,
+                        conversion_errors=conversion_errors,
                     )
                     for target_name, param in realized_value.items():
                         param = param[0] if isinstance(param, list) else param
@@ -952,7 +954,6 @@ def convert_and_load_state_dict_in_model(
                                 param,
                                 mismatch_keys,
                                 missing_keys,
-                                misc,
                                 unexpected_keys,
                                 mapping.distributed_operation,
                                 hf_quantizer,
@@ -972,7 +973,7 @@ def convert_and_load_state_dict_in_model(
 
     # Keep the current weight conversion mapping for later saving (in case it was coming directly from the user)
     model._weight_conversions = weight_mapping
-    return missing_keys, unexpected_keys, mismatch_keys, disk_offload_index, misc
+    return missing_keys, unexpected_keys, mismatch_keys, disk_offload_index, conversion_errors
 
 
 def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch.Tensor]):
@@ -1019,7 +1020,7 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
     new_state_dict = {}
     for first_param_name, reversed_converter in conversion_mapping.items():
         # Apply the reverse converter
-        realized_value, misc = reversed_converter.convert(first_param_name, model=model, config=model.config)
+        realized_value, _ = reversed_converter.convert(first_param_name, model=model, config=model.config)
         for target_name, param in realized_value.items():
             param = param[0] if isinstance(param, list) else param
             new_state_dict[target_name] = param

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -595,7 +595,9 @@ def log_to_misc(
             misc[first_target_key] = f"{op_name}: {e}"
         else:
             misc[first_target_key] = f"{extras} |Error: {e}"
-        raise SkipLayer()
+
+        # Raise a specific Exception that we can catch easily
+        raise SkipParameters()
 
 
 def set_param_for_module(
@@ -663,8 +665,9 @@ def offload_and_maybe_resave_param(
     return disk_offload_index
 
 
-class SkipLayer(Exception):
-    """Control-flow sentinel: abort processing of the current layer only."""
+class SkipParameters(Exception):
+    """Control-flow sentinel: abort processing of the current parameters only (that were supposed to be created
+    by a WeightConverter)."""
 
     pass
 
@@ -958,7 +961,7 @@ def convert_and_load_state_dict_in_model(
                     # Cleanup all the tensors that were gathered before next iteration
                     del realized_value
 
-                except SkipLayer:
+                except SkipParameters:
                     continue
 
     # Close the pool, independently of whether the code was interrupted or finished successfully

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -570,7 +570,8 @@ def log_conversion_errors(
     extras: Any = None,
     op: Union[list[ConversionOps], ConversionOps, None] = None,
 ):
-    # A simple helper to handle errors with contextual messages.
+    """Catch all exceptions during `convert` calls, and log the errors for later. Re-raise a `SkipParameters` exception
+    that will be catched later to skip the parameters that raised the original Exception."""
     try:
         yield
     except Exception as e:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4102,7 +4102,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 state_dict = merged_state_dict
             error_msgs += _load_state_dict_into_zero3_model(model, state_dict)
             # This is not true but for now we assume only best-case scenario with deepspeed, i.e. perfectly matching checkpoints
-            missing_keys, unexpected_keys, mismatched_keys, misc = set(), set(), set(), set()
+            missing_keys, unexpected_keys, mismatched_keys, conversion_errors = set(), set(), set(), set()
         else:
             all_pointer = set()
             # Checkpoints are safetensors
@@ -4124,7 +4124,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             else:
                 raise ValueError("Neither a state dict nor checkpoint files were found.")
 
-            missing_keys, unexpected_keys, mismatched_keys, disk_offload_index, misc = (
+            missing_keys, unexpected_keys, mismatched_keys, disk_offload_index, conversion_errors = (
                 convert_and_load_state_dict_in_model(
                     model,
                     merged_state_dict,
@@ -4198,7 +4198,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             missing_keys=missing_keys,
             mismatched_keys=mismatched_keys,
             mismatched_shapes=mismatched_keys,
-            misc=misc,
+            conversion_errors=conversion_errors,
             ignore_mismatched_sizes=ignore_mismatched_sizes,
         )
 

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -170,6 +170,7 @@ def log_state_dict_report(
     color_enabled = bool(color and sys.stdout.isatty())
     ansi = ANSI(color_enabled)
 
+    # Re-raise errors early if needed
     if error_msgs:
         error_msg = "\n\t".join(error_msgs)
         if "size mismatch" in error_msg:
@@ -230,9 +231,7 @@ def log_state_dict_report(
     if missing_keys:
         tips += f"\n- {_color('MISSING', 'red', ansi) + ansi['italic']}\t:those params were newly initialized because missing form the checkpoint. Consider training on your downstream task."
     if mismatched_keys:
-        tips += f"\n- {_color('MISMATCH', 'yellow', ansi) + ansi['italic']}\t:ckpt weights were loaded, but they did not match the original empty weight."
-    if misc:
-        tips += f"\n- {_color('MISC', 'purple', ansi) + ansi['italic']}\t:originate from the conversion scheme"
+        tips += f"\n- {_color('MISMATCH', 'yellow', ansi) + ansi['italic']}\t:ckpt weights were loaded, but they did not match the original empty weight shapes."
     tips += f"{ansi['reset']}"
 
     # Log the report as warning

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -228,7 +228,7 @@ def log_state_dict_report(
     if unexpected_keys:
         tips += f"\n- {_color('UNEXPECTED', 'orange', ansi) + ansi['italic']}\t:can be ignored when loading from different task/architecture; not ok if you expect identical arch."
     if missing_keys:
-        tips += f"\n- {_color('MISSING', 'red', ansi) + ansi['italic']}\t:those params were newly initialized because missing form the checkpoint. Consider training on your downstream task."
+        tips += f"\n- {_color('MISSING', 'red', ansi) + ansi['italic']}\t:those params were newly initialized because missing from the checkpoint. Consider training on your downstream task."
     if mismatched_keys:
         tips += f"\n- {_color('MISMATCH', 'yellow', ansi) + ansi['italic']}\t:ckpt weights were loaded, but they did not match the original empty weight shapes."
     if misc:
@@ -241,7 +241,7 @@ def log_state_dict_report(
     # Re-raise in those case, after the report
     if misc:
         raise RuntimeError(
-            "We encountered some issues during automatic conversion of the weights. For details look at the `MISC` entry of "
+            "We encountered some issues during automatic conversion of the weights. For details look at the `MISC` entries of "
             "the above report!"
         )
     if not ignore_mismatched_sizes and mismatched_keys:

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -184,7 +184,7 @@ def log_state_dict_report(
         for k, v in update_key_name(misc).items():
             misc_error_msg += f"\n{k}: {v}"
         raise RuntimeError(
-            f"We encountered the following issues during automatic format conversion of the weights:{misc_error_msg}"
+            f"We encountered the following issues during automatic conversion of the weights:{misc_error_msg}"
         )
 
     term_w = _get_terminal_width()

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -150,7 +150,7 @@ def log_state_dict_report(
     ignore_mismatched_sizes=True,
     misc=None,
     color=True,  # allow disabling for plain logs
-) -> None:
+):
     """Log a readable report about state_dict loading issues.
 
     This version is terminal-size aware: for very small terminals it falls back to a compact
@@ -240,3 +240,5 @@ def log_state_dict_report(
         raise RuntimeError(
             "You set `ignore_mismatched_sizes` to `False`, thus raising an error. For details look at the above report!"
         )
+
+    return prelude + table + tips

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -236,6 +236,8 @@ def log_state_dict_report(
 
     # Log the report as warning
     logger.warning(prelude + table + tips)
+
+    # Re-raise in this case, after the report
     if not ignore_mismatched_sizes and mismatched_keys:
         raise RuntimeError(
             "You set `ignore_mismatched_sizes` to `False`, thus raising an error. For details look at the above report!"

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2240,7 +2240,7 @@ class ModelUtilsTest(TestCasePlus):
             with patch("transformers.core_model_loading.MergeModulelist.convert", side_effect=Exception("failed")):
                 # It should raise the proper error
                 with self.assertRaisesRegex(
-                    RuntimeError, "We encountered the following issues during automatic conversion of the weights:"
+                    RuntimeError, "We encountered some issues during automatic conversion of the weights."
                 ):
                     _ = MixtralModel.from_pretrained(tmpdirname)
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2238,10 +2238,10 @@ class ModelUtilsTest(TestCasePlus):
             # Now try to reload while mocking the WeightConversion to raise
             with patch.object(MergeModulelist, "convert", side_effect=Exception("failed")):
                 # It should raise the proper error
-                with self.assertRaisesRegex(
-                    RuntimeError, "We encountered some issues during automatic conversion of the weights."
-                ):
-                    _ = MixtralModel.from_pretrained(tmpdirname)
+                # with self.assertRaisesRegex(
+                #     RuntimeError, "We encountered some issues during automatic conversion of the weights."
+                # ):
+                _ = MixtralModel.from_pretrained(tmpdirname)
 
 
 @slow

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -114,22 +114,22 @@ if is_torch_available():
         BertModel,
         CLIPTextModel,
         GenerationMixin,
+        MixtralConfig,
+        MixtralModel,
         MusicgenConfig,
         MusicgenForConditionalGeneration,
         PreTrainedModel,
         T5Config,
         T5ForConditionalGeneration,
     )
+    from transformers.conversion_mapping import MergeModulelist, get_model_conversion_mapping
     from transformers.modeling_attn_mask_utils import (
         AttentionMaskConverter,
         _create_4d_causal_attention_mask,
         _prepare_4d_attention_mask,
         _prepare_4d_causal_attention_mask,
     )
-    from transformers.modeling_utils import (
-        _find_disjoint,
-        _find_identical,
-    )
+    from transformers.modeling_utils import _find_disjoint, _find_identical
     from transformers.pytorch_utils import isin_mps_friendly
 
     # Fake pretrained models for tests
@@ -2220,6 +2220,30 @@ class ModelUtilsTest(TestCasePlus):
 
         # Reverse monkey patch
         threading.Thread.__init__ = original_init
+
+    def test_error_in_weight_conversion_is_raised(self):
+        """Test that errors in `ConversionOps` are correctly re-raised after loading."""
+        small_config = MixtralConfig(num_hidden_layers=2, hidden_size=32, intermediate_size=32, num_attention_heads=8)
+        model = MixtralModel(small_config)
+        weight_conversions = get_model_conversion_mapping(model)
+        # Just a safeguard
+        self.assertTrue(
+            any(
+                isinstance(ops, MergeModulelist) for conversion in weight_conversions for ops in conversion.operations
+            ),
+            "The test is useless without conversions on the model",
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model.save_pretrained(tmpdirname)
+
+            # Now try to reload while mocking the WeightConversion to raise
+            with patch("transformers.core_model_loading.MergeModulelist.convert", side_effect=Exception("failed")):
+                # It should raise the proper error
+                with self.assertRaisesRegex(
+                    RuntimeError, "We encountered the following issues during automatic conversion of the weights:"
+                ):
+                    _ = MixtralModel.from_pretrained(tmpdirname)
 
 
 @slow

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2223,6 +2223,10 @@ class ModelUtilsTest(TestCasePlus):
 
     def test_error_in_weight_conversion_is_raised(self):
         """Test that errors in `ConversionOps` are correctly re-raised after loading."""
+        # needs to be imported explicitly otherwise complains that `transformers` has no attribute `core_model_loading`
+        # during `patch`
+        import transformers.core_model_loading  # noqa
+
         small_config = MixtralConfig(num_hidden_layers=2, hidden_size=32, intermediate_size=32, num_attention_heads=8)
         model = MixtralModel(small_config)
         weight_conversions = get_model_conversion_mapping(model)

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -122,7 +122,7 @@ if is_torch_available():
         T5Config,
         T5ForConditionalGeneration,
     )
-    from transformers.conversion_mapping import MergeModulelist, get_model_conversion_mapping
+    from transformers.conversion_mapping import MergeModulelist, WeightConverter, get_model_conversion_mapping
     from transformers.modeling_attn_mask_utils import (
         AttentionMaskConverter,
         _create_4d_causal_attention_mask,
@@ -2226,11 +2226,10 @@ class ModelUtilsTest(TestCasePlus):
         small_config = MixtralConfig(num_hidden_layers=2, hidden_size=32, intermediate_size=32, num_attention_heads=8)
         model = MixtralModel(small_config)
         weight_conversions = get_model_conversion_mapping(model)
+        converters = [conversion for conversion in weight_conversions if isinstance(conversion, WeightConverter)]
         # Just a safeguard
         self.assertTrue(
-            any(
-                isinstance(ops, MergeModulelist) for conversion in weight_conversions for ops in conversion.operations
-            ),
+            any(isinstance(ops, MergeModulelist) for converter in converters for ops in converter.operations),
             "The test is useless without conversions on the model",
         )
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2238,10 +2238,10 @@ class ModelUtilsTest(TestCasePlus):
             # Now try to reload while mocking the WeightConversion to raise
             with patch.object(MergeModulelist, "convert", side_effect=Exception("failed")):
                 # It should raise the proper error
-                # with self.assertRaisesRegex(
-                #     RuntimeError, "We encountered some issues during automatic conversion of the weights."
-                # ):
-                _ = MixtralModel.from_pretrained(tmpdirname)
+                with self.assertRaisesRegex(
+                    RuntimeError, "We encountered some issues during automatic conversion of the weights."
+                ):
+                    _ = MixtralModel.from_pretrained(tmpdirname)
 
 
 @slow

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2223,10 +2223,6 @@ class ModelUtilsTest(TestCasePlus):
 
     def test_error_in_weight_conversion_is_raised(self):
         """Test that errors in `ConversionOps` are correctly re-raised after loading."""
-        # needs to be imported explicitly otherwise complains that `transformers` has no attribute `core_model_loading`
-        # during `patch`
-        import transformers.core_model_loading  # noqa
-
         small_config = MixtralConfig(num_hidden_layers=2, hidden_size=32, intermediate_size=32, num_attention_heads=8)
         model = MixtralModel(small_config)
         weight_conversions = get_model_conversion_mapping(model)
@@ -2239,9 +2235,8 @@ class ModelUtilsTest(TestCasePlus):
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             model.save_pretrained(tmpdirname)
-
             # Now try to reload while mocking the WeightConversion to raise
-            with patch("transformers.core_model_loading.MergeModulelist.convert", side_effect=Exception("failed")):
+            with patch.object(MergeModulelist, "convert", side_effect=Exception("failed")):
                 # It should raise the proper error
                 with self.assertRaisesRegex(
                     RuntimeError, "We encountered some issues during automatic conversion of the weights."


### PR DESCRIPTION
# What does this PR do?

As per the title. As discussed offline, it's very dangerous in general to NOT re-raise them, as it would make any bug in Converters invisible to us in tests (and to users not looking properly at logs)