### PR TITLE
Fix deepspeed sp loss due to missing labels 

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3943,6 +3943,9 @@ class Trainer:
         # Both standard transformer models and Liger-patched models handle shift_labels correctly,
         # so we can directly use the computed loss from the model output.
         # See: https://huggingface.co/docs/accelerate/en/concept_guides/sequence_parallelism
+        if "labels" not in inputs and "shift_labels" in inputs:
+            # DeepSpeed SP Dataloader removes "labels" but we need it, otherwise, we won't compute the loss.
+            inputs["labels"] = inputs["shift_labels"]
         outputs = model(**inputs)
         loss = outputs.loss
 


### PR DESCRIPTION
# What does this PR do?

This PR fixes `_deepspeed_sp_compute_loss`. [UlyssesSPDataLoaderAdapter](https://github.com/deepspeedai/DeepSpeed/blob/6eb98aaf03419d1a3a608b0955eb3eae5ad2dc27/deepspeed/runtime/sequence_parallel/ulysses_sp.py#L598) took `labels` out from `inputs` while inserting `shift_labels` so it doesn't compute the `loss` at all since we didn't pass `labels` ...

Fixes https://github.com/huggingface/transformers/pull/42444#issuecomment-3639642523