### PR TITLE
Pass in position_ids into attention for GPT2

### DIFF
--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -710,6 +710,7 @@ class GPT2Model(GPT2PreTrainedModel):
                 encoder_attention_mask=encoder_attention_mask,
                 use_cache=use_cache,
                 output_attentions=output_attentions,
+                position_ids=position_ids,
                 **kwargs,
             )
 


### PR DESCRIPTION
# What does this PR do?

Pass in `position_ids` so that the custom attention interface implementations have access to it.

## Who can review?

@ArthurZucker @Cyrilvallez 