### PR TITLE
fix: make mistral base check conditional to fix offline loading

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2435,7 +2435,12 @@ class PreTrainedTokenizerBase(SpecialTokensMixin, PushToHubMixin):
                     return True
             return False
 
-        if _is_local or is_base_mistral(pretrained_model_name_or_path):
+        if is_offline_mode():
+            _is_local = True
+
+        if pretrained_model_name_or_path is not None and (
+            _is_local or (not _is_local and is_base_mistral(pretrained_model_name_or_path))
+        ):
             _config_file = cached_file(
                 pretrained_model_name_or_path,
                 "config.json",

--- a/tests/utils/test_tokenization_utils.py
+++ b/tests/utils/test_tokenization_utils.py
@@ -80,6 +80,22 @@ class TokenizerUtilTester(unittest.TestCase):
             # This check we did call the fake head request
             mock_head.assert_called()
 
+    def test_offline_mode_does_not_call_model_info_api(self):
+        # Test that when in offline mode, model_info is not called during Mistral base check
+        # This prevents network errors when loading tokenizers offline
+
+        # Download this model to make sure it's in the cache
+        _ = BertTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
+
+        # Mock is_offline_mode to return True
+        with mock.patch("transformers.tokenization_utils_base.is_offline_mode", return_value=True):
+            # Mock model_info to track if it's called
+            with mock.patch("huggingface_hub.model_info") as mock_model_info:
+                # Load tokenizer in offline mode
+                _ = BertTokenizer.from_pretrained("hf-internal-testing/tiny-random-bert")
+                # model_info should NOT be called when in offline mode
+                mock_model_info.assert_not_called()
+
     def test_legacy_load_from_one_file(self):
         # This test is for deprecated behavior and can be removed in v5
         try:


### PR DESCRIPTION
Backport of a small part of #42528, the model_info call currently breaks offline loading

⚒️ with ❤️ by @siemens