### PR TITLE
[GGUF] Add attn_logit_softcapping to Gemma2/Gemma3 config mapping

### DIFF
--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -244,6 +244,7 @@ GGUF_CONFIG_MAPPING = {
         "attention.head_count_kv": "num_key_value_heads",
         "attention.layer_norm_rms_epsilon": "rms_norm_eps",
         "attention.sliding_window": "sliding_window",
+        "attention.logit_softcapping": "attn_logit_softcapping",
         "vocab_size": "vocab_size",
     },
     "gemma3": {
@@ -260,6 +261,7 @@ GGUF_CONFIG_MAPPING = {
         "attention.head_count_kv": "num_key_value_heads",
         "attention.layer_norm_rms_epsilon": "rms_norm_eps",
         "attention.sliding_window": "sliding_window",
+        "attention.logit_softcapping": "attn_logit_softcapping",
         "vocab_size": "vocab_size",
     },
     "umt5": {

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -1040,6 +1040,22 @@ class GgufModelTests(unittest.TestCase):
 
         self.assertIsNone(deci_mapping["rope.dimension_count"])
 
+    def test_gemma_softcap_config_mapping(self):
+        """Test that Gemma2/Gemma3 GGUF config mapping includes attn_logit_softcapping."""
+        from transformers.integrations.ggml import GGUF_CONFIG_MAPPING
+
+        # Test Gemma2
+        self.assertIn("gemma2", GGUF_CONFIG_MAPPING)
+        gemma2_mapping = GGUF_CONFIG_MAPPING["gemma2"]
+        self.assertIn("attention.logit_softcapping", gemma2_mapping)
+        self.assertEqual(gemma2_mapping["attention.logit_softcapping"], "attn_logit_softcapping")
+
+        # Test Gemma3
+        self.assertIn("gemma3", GGUF_CONFIG_MAPPING)
+        gemma3_mapping = GGUF_CONFIG_MAPPING["gemma3"]
+        self.assertIn("attention.logit_softcapping", gemma3_mapping)
+        self.assertEqual(gemma3_mapping["attention.logit_softcapping"], "attn_logit_softcapping")
+
     def test_deci_architecture_mapping(self):
         """Test that Deci architectures are mapped to GGUFLlamaConverter."""
         from transformers.integrations.ggml import GGUF_TO_FAST_CONVERTERS, GGUFLlamaConverter


### PR DESCRIPTION
## Summary

Add `attn_logit_softcapping` extraction to GGUF config mapping for Gemma2 and Gemma3 architectures.

## Problem

When loading Gemma2/Gemma3 GGUF models, the `attn_logit_softcapping` parameter is not extracted from GGUF metadata. This causes models to use the default value instead of the actual value stored in the GGUF file.

This parameter is critical for attention score scaling and affects model output quality. The llama.cpp GGUF exporter stores this value in the `attention.logit_softcapping` field, but Transformers' GGUF loader doesn't map it to the HuggingFace config attribute.

## Changes

- Add `"attention.logit_softcapping": "attn_logit_softcapping"` to `gemma2` mapping in `GGUF_CONFIG_MAPPING`
- Add `"attention.logit_softcapping": "attn_logit_softcapping"` to `gemma3` mapping in `GGUF_CONFIG_MAPPING`
- Add `test_gemma_softcap_config_mapping` test (follows `test_deci_config_mapping` pattern)

## Testing

**Unit Test Added**: `test_gemma_softcap_config_mapping` in `tests/quantization/ggml/test_ggml.py`

**Manual Verification** (before/after comparison):

```python
# Transformers 4.49.0 (PyPI - before fix)
>>> from transformers.integrations.ggml import GGUF_CONFIG_MAPPING
>>> "attention.logit_softcapping" in GGUF_CONFIG_MAPPING["gemma2"]
False  # ❌ Missing

# Transformers 5.0.0.dev0 (with this PR)
>>> "attention.logit_softcapping" in GGUF_CONFIG_MAPPING["gemma2"]
True   # ✅ Present
>>> GGUF_CONFIG_MAPPING["gemma2"]["attention.logit_softcapping"]
'attn_logit_softcapping'
```

## Related

This fix enables proper GGUF model loading in downstream projects like vLLM that rely on Transformers' GGUF config extraction.

- vLLM workaround PR: https://github.com/vllm-project/vllm/pull/30427 (can be removed once this is merged)