### PR TITLE
[docs] dtype

### DIFF
--- a/docs/source/en/models.md
+++ b/docs/source/en/models.md
@@ -220,33 +220,22 @@ model.hf_device_map
 
 ### Model data type
 
-PyTorch model weights are initialized in `torch.float32` by default. Loading a model in a different data type, like `torch.float16`, requires additional memory because the model is loaded again in the desired data type.
+The `dtype` argument controls which PyTorch [dtype](https://pytorch.org/docs/stable/tensor_attributes.html#torch.dtype) model weights are instantiated in. By default, `dtype="auto"` scans `config.json` for a `dtype` or legacy `torch_dtype` entry and loads weights in that format. If `config.json` lacks this information, Transformers inspects the first floating-point weight in the checkpoint and adopts its data type.
 
-Explicitly set the [dtype](https://pytorch.org/docs/stable/tensor_attributes.html#torch.dtype) parameter to directly initialize the model in the desired data type instead of loading the weights twice (`torch.float32` then `torch.float16`). You could also set `dtype="auto"` to automatically load the weights in the data type they are stored in.
-
-<hfoptions id="dtype">
-<hfoption id="specific dtype">
+Override the default by passing a specific data type.
 
 ```py
 import torch
 from transformers import AutoModelForCausalLM
 
-gemma = AutoModelForCausalLM.from_pretrained("google/gemma-7b", dtype=torch.float16)
+# default
+model = AutoModelForCausalLM.from_pretrained("google/gemma-3-1b-it", dtype="auto")
+
+# specific dtype
+model = AutoModelForCausalLM.from_pretrained("google/gemma-3-1b-it", dtype=torch.float16)
 ```
 
-</hfoption>
-<hfoption id="auto dtype">
-
-```py
-from transformers import AutoModelForCausalLM
-
-gemma = AutoModelForCausalLM.from_pretrained("google/gemma-7b", dtype="auto")
-```
-
-</hfoption>
-</hfoptions>
-
-The `dtype` parameter can also be configured in [`AutoConfig`] for models instantiated from scratch.
+[`AutoConfig`] also accepts `dtype` for models instantiated from scratch.
 
 ```py
 import torch

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3660,7 +3660,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
             > Parameters for big model inference
 
-            dtype (`str` or `torch.dtype`, *optional*):
+            dtype (`str` or `torch.dtype`, *optional*, defaults to `"auto"`):
                 Override the default `torch_dtype` and load the model under a specific `dtype`. The different options
                 are:
 


### PR DESCRIPTION
update the model loading docs to clarify that `"auto"` is the default now in `from_pretrained`