### PR TITLE
fix FastSpeech2ConformerTokenizer crash in tokenize

### DIFF
--- a/src/transformers/models/fastspeech2_conformer/tokenization_fastspeech2_conformer.py
+++ b/src/transformers/models/fastspeech2_conformer/tokenization_fastspeech2_conformer.py
@@ -79,6 +79,7 @@ class FastSpeech2ConformerTokenizer(PreTrainedTokenizer):
             unk_token=unk_token,
             pad_token=pad_token,
             should_strip_spaces=should_strip_spaces,
+            special_tokens_pattern="none",
             **kwargs,
         )
 


### PR DESCRIPTION

- tokenizers: @ArthurZucker and @itazap

how to reproduce:
```
from transformers import FastSpeech2ConformerTokenizer
tokenizer = FastSpeech2ConformerTokenizer.from_pretrained("espnet/fastspeech2_conformer")
text = "Test that this generates speech"
input_ids = tokenizer(text, return_tensors="pt")
```

Traceback (most recent call last):
  File "/transformers/bug.py", line 4, in <module>
    input_ids = tokenizer(text, return_tensors="pt")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/transformers/src/transformers/tokenization_utils_base.py", line 2566, in __call__
    encodings = self._encode_plus(
                ^^^^^^^^^^^^^^^^^^
  File "/transformers/src/transformers/tokenization_python.py", line 814, in _encode_plus
    return self.prepare_for_model(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/transformers/src/transformers/tokenization_python.py", line 1193, in prepare_for_model
    encoded_inputs = self.pad(
                     ^^^^^^^^^
  File "/transformers/src/transformers/tokenization_utils_base.py", line 2742, in pad
    raise ValueError(
ValueError: type of None unknown: <class 'NoneType'>. Should be one of a python, numpy, or pytorch object.


