### PR TITLE
dynamic_module_utils: fix false imports from conditional blocks (#28459)

### DIFF
--- a/tests/test_dynamic_module_utils.py
+++ b/tests/test_dynamic_module_utils.py
@@ -1,0 +1,55 @@
+import textwrap
+
+
+def test_conditional_import_ignored(tmp_path):
+    code = textwrap.dedent(
+        """
+        COND = False
+        if COND:
+            import flash_attn
+        import math
+        """
+    )
+    p = tmp_path / "sample.py"
+    p.write_text(code)
+
+    from transformers.dynamic_module_utils import get_imports
+    result = get_imports(str(p))
+
+    assert "math" in result
+    assert "flash_attn" not in result
+
+
+def test_dynamic_condition_import_ignored(tmp_path):
+    code = textwrap.dedent(
+        """
+        def cond():
+            return True
+
+        if cond():
+            import os
+        """
+    )
+    p = tmp_path / "sample2.py"
+    p.write_text(code)
+
+    from transformers.dynamic_module_utils import get_imports
+    result = get_imports(str(p))
+
+    assert "os" not in result
+
+
+def test_if_true_includes_import(tmp_path):
+    code = textwrap.dedent(
+        """
+        if True:
+            import json
+        """
+    )
+    p = tmp_path / "sample3.py"
+    p.write_text(code)
+
+    from transformers.dynamic_module_utils import get_imports
+    result = get_imports(str(p))
+
+    assert "json" in result


### PR DESCRIPTION
# What does this PR do?

Fixes an issue where 'get_imports' incorrectly reported imports that only appear inside conditional blocks as mandaroty dependencies

This replaces brittle condition specific logic with a general AST-based control

flow check:
-- imports are collected only from code paths that are guarenteed to execute at module import time (top-level or 'if True:' blocks)
-- imports inside conditional or runtime dependent blocks are ignored
-- existing behaviour of skipping 'try' blocks is preserved

Fixes # 28459


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [X] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
