### PR TITLE
feat: Add device consistency support to BatchFeature and ProcessorMixin #42722

### DIFF
--- a/src/transformers/feature_extraction_utils.py
+++ b/src/transformers/feature_extraction_utils.py
@@ -69,6 +69,9 @@ class BatchFeature(UserDict):
             initialization.
         skip_tensor_conversion (`list[str]` or `set[str]`, *optional*):
             List or set of keys that should NOT be converted to tensors, even when `tensor_type` is specified.
+        device (`str` or `torch.device`, *optional*):
+            The device to place tensors on. When specified, all tensor values will be moved to this device.
+            Note: This is a simple tensor movement operation, not GPU-accelerated processing.
     """
 
     def __init__(
@@ -76,9 +79,12 @@ class BatchFeature(UserDict):
         data: Optional[dict[str, Any]] = None,
         tensor_type: Union[None, str, TensorType] = None,
         skip_tensor_conversion: Optional[Union[list[str], set[str]]] = None,
+        device: Optional[Union[str, "torch.device"]] = None,
     ):
         super().__init__(data)
         self.convert_to_tensors(tensor_type=tensor_type, skip_tensor_conversion=skip_tensor_conversion)
+        if device is not None:
+            self.to(device)
 
     def __getitem__(self, item: str) -> Any:
         """
@@ -663,3 +669,4 @@ if FeatureExtractionMixin.push_to_hub.__doc__ is not None:
     FeatureExtractionMixin.push_to_hub.__doc__ = FeatureExtractionMixin.push_to_hub.__doc__.format(
         object="feature extractor", object_class="AutoFeatureExtractor", object_files="feature extractor file"
     )
+

--- a/tests/test_batchfeature_device_consistency.py
+++ b/tests/test_batchfeature_device_consistency.py
@@ -1,0 +1,195 @@
+"""
+Test script to verify the new BatchFeature device consistency implementation.
+This test verifies that the device parameter works correctly in BatchFeature.__init__.
+"""
+
+import torch
+import transformers
+from PIL import Image
+import requests
+from torchvision import transforms
+
+def test_batchfeature_device_parameter():
+    """Test BatchFeature device parameter directly"""
+    print("Testing BatchFeature device parameter...")
+    
+    # Skip test if CUDA is not available
+    if not torch.cuda.is_available():
+        print("CUDA not available, skipping device parameter test")
+        return True
+    
+    try:
+        # Create some test data
+        data = {
+            "input_ids": torch.tensor([[1, 2, 3, 4]]),
+            "attention_mask": torch.tensor([[1, 1, 1, 1]]),
+            "pixel_values": torch.randn(1, 3, 224, 224)
+        }
+        
+        print("Original tensors devices:")
+        for key, value in data.items():
+            print(f"  {key}: {value.device}")
+        
+        # Create BatchFeature with device parameter
+        batch_feature = transformers.feature_extraction_utils.BatchFeature(
+            data=data, 
+            tensor_type="pt", 
+            device="cuda"
+        )
+        
+        # Check if all tensors are on CUDA
+        print("\nAfter BatchFeature with device='cuda':")
+        all_on_cuda = True
+        for key, value in batch_feature.items():
+            if isinstance(value, torch.Tensor):
+                print(f"  {key}: {value.device}")
+                if value.device.type != "cuda":
+                    all_on_cuda = False
+                    print(f"  ERROR: {key} is not on CUDA")
+        
+        if all_on_cuda:
+            print("✅ SUCCESS: All tensors moved to CUDA!")
+            return True
+        else:
+            print("❌ FAILURE: Not all tensors are on CUDA!")
+            return False
+            
+    except Exception as e:
+        print(f"Error during BatchFeature device test: {e}")
+        return False
+
+def test_oneformer_with_new_implementation():
+    """Test OneFormer processor with new BatchFeature device implementation"""
+    print("\nTesting OneFormer processor with new device implementation...")
+    
+    # Skip test if CUDA is not available
+    if not torch.cuda.is_available():
+        print("CUDA not available, skipping OneFormer device test")
+        return True
+    
+    try:
+        # Setup processor
+        processor = transformers.OneFormerImageProcessorFast()
+        processor = transformers.OneFormerProcessor(
+            image_processor=processor,
+            tokenizer=transformers.AutoTokenizer.from_pretrained("openai/clip-vit-base-patch32"),
+        )
+        
+        # Load test image
+        url = "https://huggingface.co/datasets/hf-internal-testing/fixtures_ade20k/resolve/main/ADE_val_00000001.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        
+        # Convert image to tensor and move to CUDA
+        to_tensor_transform = transforms.ToTensor()
+        image = to_tensor_transform(image).to("cuda")
+        
+        print(f"Input image device: {image.device}")
+        
+        # Process with explicit device parameter
+        inputs = processor(image, ["semantic"], return_tensors="pt", device="cuda")
+        
+        # Check device consistency
+        print("Checking output devices:")
+        all_on_same_device = True
+        reference_device = None
+        
+        for key, value in inputs.items():
+            if isinstance(value, torch.Tensor):
+                print(f"  {key}: {value.device}")
+                if reference_device is None:
+                    reference_device = value.device
+                elif value.device != reference_device:
+                    all_on_same_device = False
+                    print(f"  ERROR: {key} is on {value.device} but expected {reference_device}")
+            elif isinstance(value, (list, tuple)) and len(value) > 0 and isinstance(value[0], torch.Tensor):
+                device = value[0].device
+                print(f"  {key}[0]: {device}")
+                if reference_device is None:
+                    reference_device = device
+                elif device != reference_device:
+                    all_on_same_device = False
+                    print(f"  ERROR: {key}[0] is on {device} but expected {reference_device}")
+        
+        if all_on_same_device and reference_device.type == "cuda":
+            print("✅ SUCCESS: All tensors are on CUDA and consistent!")
+            return True
+        else:
+            print("❌ FAILURE: Device consistency issue!")
+            return False
+            
+    except Exception as e:
+        print(f"Error during OneFormer test: {e}")
+        return False
+
+def test_cpu_to_cuda_movement():
+    """Test moving CPU tensors to CUDA using device parameter"""
+    print("\nTesting CPU to CUDA movement...")
+    
+    if not torch.cuda.is_available():
+        print("CUDA not available, skipping CPU to CUDA test")
+        return True
+    
+    try:
+        # Setup processor
+        processor = transformers.OneFormerImageProcessorFast()
+        processor = transformers.OneFormerProcessor(
+            image_processor=processor,
+            tokenizer=transformers.AutoTokenizer.from_pretrained("openai/clip-vit-base-patch32"),
+        )
+        
+        # Load test image (keep on CPU)
+        url = "https://huggingface.co/datasets/hf-internal-testing/fixtures_ade20k/resolve/main/ADE_val_00000001.jpg"
+        image = Image.open(requests.get(url, stream=True).raw)
+        
+        print("Input image device: CPU (PIL Image)")
+        
+        # Process with device parameter to move to CUDA
+        inputs = processor(image, ["semantic"], return_tensors="pt", device="cuda")
+        
+        # Check if all outputs are on CUDA
+        print("Checking if all outputs moved to CUDA:")
+        all_on_cuda = True
+        
+        for key, value in inputs.items():
+            if isinstance(value, torch.Tensor):
+                print(f"  {key}: {value.device}")
+                if value.device.type != "cuda":
+                    all_on_cuda = False
+                    print(f"  ERROR: {key} is not on CUDA")
+            elif isinstance(value, (list, tuple)) and len(value) > 0 and isinstance(value[0], torch.Tensor):
+                device = value[0].device
+                print(f"  {key}[0]: {device}")
+                if device.type != "cuda":
+                    all_on_cuda = False
+                    print(f"  ERROR: {key}[0] is not on CUDA")
+        
+        if all_on_cuda:
+            print("✅ SUCCESS: All tensors moved to CUDA as requested!")
+            return True
+        else:
+            print("❌ FAILURE: Not all tensors are on CUDA!")
+            return False
+            
+    except Exception as e:
+        print(f"Error during CPU to CUDA test: {e}")
+        return False
+
+if __name__ == "__main__":
+    print("Testing new BatchFeature device consistency implementation...")
+    print("=" * 70)
+    
+    # Run tests
+    test1_passed = test_batchfeature_device_parameter()
+    test2_passed = test_oneformer_with_new_implementation()
+    test3_passed = test_cpu_to_cuda_movement()
+    
+    print("\n" + "=" * 70)
+    print("Test Summary:")
+    print(f"BatchFeature device parameter: {'✅ PASSED' if test1_passed else '❌ FAILED'}")
+    print(f"OneFormer device consistency: {'✅ PASSED' if test2_passed else '❌ FAILED'}")
+    print(f"CPU to CUDA movement: {'✅ PASSED' if test3_passed else '❌ FAILED'}")
+    
+    if test1_passed and test2_passed and test3_passed:
+        print("\n🎉 All tests passed! New BatchFeature device implementation is working correctly.")
+    else:
+        print("\n⚠️  Some tests failed. Please check the implementation.")


### PR DESCRIPTION
feat: Add device consistency support to BatchFeature and ProcessorMixin

fix : #42722
# What does this PR do?
feat: Add device consistency support to BatchFeature and ProcessorMixin

- Add device parameter to BatchFeature.__init__ for automatic tensor device placement
- Add device parameter to ProcessingKwargs as a common argument alongside return_tensors
- Update ProcessorMixin.__call__ to pass device parameter to BatchFeature
- Add comprehensive documentation explaining device parameter usage
- Implement device consistency logic that moves all tensors to the specified device

This change addresses the device inconsistency issue in OneFormerProcessor and provides
a general solution for all processors that use BatchFeature. The implementation
follows community feedback to centralize device handling in BatchFeature rather than
individual processors.

Usage: processor(image, ["semantic"], return_tensors="pt", device="cuda")
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #42722


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
