### PR TITLE
Fix name mix-up in tie weights logic

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2424,7 +2424,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                             if target_backup_is_there:
                                 source_param_name = target_backup
                                 # Append the source as well, since both are missing we'll tie both
-                                target_param_names.append(source_param_name)
+                                target_param_names.append(source_backup)
                                 break
                     # If we did not break from the loop, it was impossible to find a source key -> let's raise
                     else:


### PR DESCRIPTION
# What does this PR do?

As per the title! This one slipped through!
The name cannot be updated before we append it to the targets! 