### PR TITLE
Simplify tie weights logic

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2387,7 +2387,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         tied_keys = list(tied_keys.items())
         for i, (target_param_name, source_param_name) in enumerate(tied_keys):
-
             # This is `from_pretrained` -> let's check symmetrically in case the source key is not present
             if missing_keys is not None:
                 remove_from_missing = True
@@ -2408,7 +2407,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 # We're missing the source but we have the target -> we swap them, tying the parameter that exists
                 elif not source_is_there and target_is_there:
                     target_param_name, source_param_name = source_param_name, target_param_name
-                    target_param_names = [target_param_name]
                 # Both are missing -> check other keys in case more than 2 keys are tied to the same weight
                 elif not source_is_there and not target_is_there:
                     for target_backup, source_backup in tied_keys[i + 1 :]:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2386,7 +2386,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             tied_keys = self.get_expanded_tied_weights_keys(all_submodels=True)
 
         tied_keys = list(tied_keys.items())
-        expected_present_pairs = []
+        expected_present_pairs = set()
         for i, (target_param_name, source_param_name) in enumerate(tied_keys):
             # Usually we tie a single target to a single source, but when both are missing we may later tie
             # both the source and target to a third "backup" parameter that is present in the checkpoint, so we use
@@ -2403,7 +2403,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 if source_is_there and target_is_there:
                     # In case of more than 2 keys tying to the same weight, it may be expected that both are
                     # already tied, so we need this check before showing the warning
-                    if not (target_param_name, source_param_name) in expected_present_pairs:
+                    if (target_param_name, source_param_name) not in expected_present_pairs:
                         logger.warning(
                             f"The tied weights mapping and config for this model specifies to tie {source_param_name} to "
                             f"{target_param_name}, but both are present in the checkpoints, so we will NOT tie them. "
@@ -2432,7 +2432,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                                 source_param_name = target_backup
                                 # When we will later iterate over the backups, both will be already present because we
                                 # tie the source as well, so we need to skip the warning in this case
-                                expected_present_pairs.append((target_backup, source_backup))
+                                expected_present_pairs.add((target_backup, source_backup))
                                 break
                     # If we did not break from the loop, it was impossible to find a source key -> let's raise
                     else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2424,7 +2424,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                             if target_backup_is_there:
                                 source_param_name = target_backup
                                 # Append the source as well, since both are missing we'll tie both
-                                target_param_names.append(source_param_name)
+                                target_param_names.append(source_backup)
                                 break
                     # If we did not break from the loop, it was impossible to find a source key -> let's raise
                     else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2422,9 +2422,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                             target_backup_is_there = target_backup not in missing_keys
                             # If the target is present, we found the correct weight to tie into (we know the source is missing)
                             if target_backup_is_there:
-                                source_param_name = target_backup
                                 # Append the source as well, since both are missing we'll tie both
-                                target_param_names.append(source_backup)
+                                target_param_names.append(source_param_name)
+                                # The new source to tie into both initial source and target is the target backup
+                                source_param_name = target_backup
                                 break
                     # If we did not break from the loop, it was impossible to find a source key -> let's raise
                     else:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2415,6 +2415,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                         if source_backup == source_param_name:
                             target_backup_is_there = target_backup not in missing_keys
                             # If the target is present, we found the correct weight to tie into (we know the source is missing)
+                            # Note here that we do not tie the missing source right now as well, as it will be done anyway when
+                            # the pair (target_backup, source_backup) becomes the main pair (target_param_name, source_param_name)
                             if target_backup_is_there:
                                 source_param_name = target_backup
                                 break


### PR DESCRIPTION
# What does this PR do?

As per the title! Originally, the logic should have tied both weights, but because there was a name mix-up, only the primary target was tied. This is however still logically correct, as then the original source will be tied later when reaching its turn in the mapping. So this PR removes the double tying when both are missing, as it's not needed logically! 
It is still correct to only check forward `for target_backup, source_backup in tied_keys[i + 1 :]:`, as if both are missing at this point, it means that we did not yet reach the actual weight, so it necessarily lives on a future pair.