### PR TITLE
Fix cuda index

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -182,6 +182,10 @@ def check_and_set_device_map(device_map: "torch.device | int | str | dict | None
         device_map = {"": device_map}
     elif isinstance(device_map, str) and device_map not in ["auto", "balanced", "balanced_low_0", "sequential"]:
         try:
+            if device_map == "cuda":
+                # setting to the local rank
+                local_rank = int(os.environ.get("LOCAL_RANK", 0))
+                device_map = f"cuda:{local_rank}"
             device_map = {"": torch.device(device_map)}
         except RuntimeError:
             raise ValueError(


### PR DESCRIPTION
# What does this PR do?

This PR fixes this issue https://github.com/huggingface/transformers/issues/42851. As we moved to multi-threaded loading by default, if the users passes `device_map="cuda"`, it will always load the model on cuda:0 as in threaded mode all the default devices reset to 0. 