### PR TITLE
Stop ContinuousBatchingManager.request_id_iter after terminal outputs

### DIFF
--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -14,8 +14,8 @@
 
 import gc
 import itertools
-import unittest
 import queue
+import unittest
 
 import torch
 from parameterized import parameterized


### PR DESCRIPTION
## Summary 
ContinuousBatchingManager.request_id_iter() could keep polling after a request had already reached a terminal state. This PR makes the iterator stop once it yields a terminal GenerationOutput (`FINISHED` or `FAILED`), and also exit when the generation thread is no longer alive and there are no more results to drain.

## Changes
- Stop iterating after emitting `RequestStatus.FINISHED` or `RequestStatus.FAILED` for the request.
- Add a unit test that verifies request_id_iter() terminates after a terminal output, even if the manager thread is still alive.