### PR TITLE
[Quantization] rm _pre_quantization_dtype from quantization tests

### DIFF
--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -181,14 +181,6 @@ class Bnb4BitTest(Base4bitTest):
         linear = get_some_linear_layer(self.model_4bit)
         self.assertTrue(linear.weight.__class__ == Params4bit)
 
-    def test_original_dtype(self):
-        r"""
-        A simple test to check if the model successfully stores the original dtype
-        """
-        self.assertTrue(hasattr(self.model_4bit.config, "_pre_quantization_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
-        self.assertTrue(self.model_4bit.config._pre_quantization_dtype == torch.float16)
-
     def test_linear_are_4bit(self):
         r"""
         A simple test to check if the model conversion has been done correctly by checking on the
@@ -266,7 +258,6 @@ class Bnb4BitTest(Base4bitTest):
 
         self.assertFalse(hasattr(model_4bit, "hf_quantizer"))
         self.assertFalse(hasattr(model_4bit.config, "quantization_config"))
-        self.assertFalse(hasattr(model_4bit.config, "_pre_quantization_dtype"))
         self.assertFalse(hasattr(model_4bit, "quantization_method"))
         self.assertFalse(model_4bit.is_quantized)
 

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -197,14 +197,6 @@ class MixedInt8Test(BaseMixedInt8Test):
 
         _ = config.to_json_string()
 
-    def test_original_dtype(self):
-        r"""
-        A simple test to check if the model successfully stores the original dtype
-        """
-        self.assertTrue(hasattr(self.model_8bit.config, "_pre_quantization_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
-        self.assertTrue(self.model_8bit.config._pre_quantization_dtype == torch.float16)
-
     def test_memory_footprint(self):
         r"""
         A simple test to check if the model conversion has been done correctly by checking on the

--- a/tests/quantization/gptq/test_gptq.py
+++ b/tests/quantization/gptq/test_gptq.py
@@ -174,14 +174,6 @@ class GPTQTest(unittest.TestCase):
             # Tries with a `dtype``
             self.quantized_model.to(torch.float16)
 
-    def test_original_dtype(self):
-        r"""
-        A simple test to check if the model successfully stores the original dtype
-        """
-        self.assertTrue(hasattr(self.quantized_model.config, "_pre_quantization_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
-        self.assertEqual(self.quantized_model.config._pre_quantization_dtype, torch.float16)
-
     def test_quantized_layers_class(self):
         """
         Simple test to check if the model conversion has been done correctly by checking on

--- a/tests/quantization/quark_integration/test_quark.py
+++ b/tests/quantization/quark_integration/test_quark.py
@@ -105,14 +105,10 @@ class QuarkTest(unittest.TestCase):
             # Tries with a `dtype``
             self.quantized_model.to(torch.float16)
 
-    def test_original_dtype(self):
+    def test_quantized_layers_class(self):
         r"""
-        A simple test to check if the model successfully stores the original dtype
+        A simple test to check if the model successfully changes the class type of the linear layers
         """
-        self.assertTrue(hasattr(self.quantized_model.config, "_pre_quantization_dtype"))
-        self.assertFalse(hasattr(self.model_fp16.config, "_pre_quantization_dtype"))
-        self.assertTrue(self.quantized_model.config._pre_quantization_dtype == torch.float16)
-
         self.assertTrue(isinstance(self.quantized_model.model.layers[0].mlp.gate_proj, QParamsLinear))
 
     def check_inference_correctness(self, model):


### PR DESCRIPTION
# What does this PR do?

Removes tests related to `_pre_quantization_dtype` since it was removed in this pr : https://github.com/huggingface/transformers/pull/42882