### PR TITLE
[loading] Really initialize on meta device for huge perf gains

### DIFF
--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -21,7 +21,6 @@ import inspect
 import os
 import re
 from collections import OrderedDict, defaultdict
-from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
 from safetensors import safe_open
@@ -53,114 +52,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
-
-
-@contextmanager
-def init_empty_weights(include_buffers: bool = False):
-    """
-    A context manager under which models are initialized with all parameters on the meta device, therefore creating an
-    empty model. Useful when just initializing the model would blow the available RAM.
-
-    Args:
-        include_buffers (`bool`, *optional*):
-            Whether or not to also put all buffers on the meta device while initializing.
-
-    Example:
-
-    ```python
-    import torch.nn as nn
-    from accelerate import init_empty_weights
-
-    # Initialize a model with 100 billions parameters in no time and without using any RAM.
-    with init_empty_weights():
-        tst = nn.Sequential(*[nn.Linear(10000, 10000) for _ in range(1000)])
-    ```
-
-    <Tip warning={true}>
-
-    Any model created under this context manager has no weights. As such you can't do something like
-    `model.to(some_device)` with it. To load weights inside your empty model, see [`load_checkpoint_and_dispatch`].
-    Make sure to overwrite the default device_map param for [`load_checkpoint_and_dispatch`], otherwise dispatch is not
-    called.
-
-    </Tip>
-    """
-    with init_on_device(torch.device("meta"), include_buffers=include_buffers) as f:
-        yield f
-
-
-@contextmanager
-def init_on_device(device: "torch.device", include_buffers: bool = False):
-    """
-    A context manager under which models are initialized with all parameters on the specified device.
-
-    Args:
-        device (`torch.device`):
-            Device to initialize all parameters on.
-        include_buffers (`bool`, *optional*):
-            Whether or not to also put all buffers on the meta device while initializing.
-
-    Example:
-
-    ```python
-    import torch.nn as nn
-    from accelerate import init_on_device
-
-    with init_on_device(device=torch.device("cuda")):
-        tst = nn.Linear(100, 100)  # on `cuda` device
-    ```
-    """
-    if include_buffers:
-        with device:
-            yield
-        return
-
-    old_register_parameter = nn.Module.register_parameter
-    if include_buffers:
-        old_register_buffer = nn.Module.register_buffer
-
-    def register_empty_parameter(module, name, param):
-        old_register_parameter(module, name, param)
-        if param is not None:
-            param_cls = type(module._parameters[name])
-            kwargs = module._parameters[name].__dict__
-            kwargs["requires_grad"] = param.requires_grad
-            module._parameters[name] = param_cls(module._parameters[name].to(device), **kwargs)
-
-    def register_empty_buffer(module, name, buffer, persistent=True):
-        old_register_buffer(module, name, buffer, persistent=persistent)
-        if buffer is not None:
-            module._buffers[name] = module._buffers[name].to(device)
-
-    # Patch tensor creation
-    if include_buffers:
-        tensor_constructors_to_patch = {
-            torch_function_name: getattr(torch, torch_function_name)
-            for torch_function_name in ["empty", "zeros", "ones", "full"]
-        }
-    else:
-        tensor_constructors_to_patch = {}
-
-    def patch_tensor_constructor(fn):
-        def wrapper(*args, **kwargs):
-            kwargs["device"] = device
-            return fn(*args, **kwargs)
-
-        return wrapper
-
-    try:
-        nn.Module.register_parameter = register_empty_parameter
-        if include_buffers:
-            nn.Module.register_buffer = register_empty_buffer
-        for torch_function_name in tensor_constructors_to_patch:
-            setattr(torch, torch_function_name, patch_tensor_constructor(getattr(torch, torch_function_name)))
-        yield
-    finally:
-        nn.Module.register_parameter = old_register_parameter
-        if include_buffers:
-            nn.Module.register_buffer = old_register_buffer
-        for torch_function_name, old_torch_function in tensor_constructors_to_patch.items():
-            setattr(torch, torch_function_name, old_torch_function)
 
 
 def check_and_set_device_map(device_map: "torch.device | int | str | dict | None") -> dict | str | None:

--- a/src/transformers/integrations/aqlm.py
+++ b/src/transformers/integrations/aqlm.py
@@ -14,13 +14,11 @@
 "AQLM (Additive Quantization of Language Model) integration file"
 
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_torch_available, logging
+from ..utils import is_torch_available, logging
 
-
-if is_accelerate_available():
-    from accelerate import init_empty_weights
 
 if is_torch_available():
+    import torch
     import torch.nn as nn
 
 logger = logging.get_logger(__name__)
@@ -46,7 +44,7 @@ def replace_with_aqlm_linear(model, modules_to_not_convert: list[str] | None = N
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 new_module = QuantizedLinear(
                     module.in_features,

--- a/src/transformers/integrations/awq.py
+++ b/src/transformers/integrations/awq.py
@@ -16,11 +16,8 @@
 from typing import Optional, Union
 
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_torch_available, logging
+from ..utils import is_torch_available, logging
 
-
-if is_accelerate_available():
-    pass
 
 if is_torch_available():
     import torch

--- a/src/transformers/integrations/awq.py
+++ b/src/transformers/integrations/awq.py
@@ -20,7 +20,7 @@ from ..utils import is_accelerate_available, is_torch_available, logging
 
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 if is_torch_available():
     import torch
@@ -97,7 +97,7 @@ def replace_with_awq_linear(
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 new_module = target_cls(
                     bits=quantization_config.bits,

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -1,9 +1,6 @@
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_torch_available, logging
+from ..utils import is_torch_available, logging
 
-
-if is_accelerate_available():
-    pass
 
 if is_torch_available():
     import torch

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -3,7 +3,7 @@ from ..utils import is_accelerate_available, is_torch_available, logging
 
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 if is_torch_available():
     import torch
@@ -334,7 +334,7 @@ def replace_with_bitnet_linear(model, modules_to_not_convert: list[str] | None =
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 if quantization_config and quantization_config.linear_class == "autobitlinear":
                     new_module = AutoBitLinear(

--- a/src/transformers/integrations/eetq.py
+++ b/src/transformers/integrations/eetq.py
@@ -14,15 +14,13 @@
 # limitations under the License.
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_torch_available, logging
+from ..utils import is_torch_available, logging
 
 
 if is_torch_available():
     import torch
     import torch.nn as nn
 
-if is_accelerate_available():
-    pass
 
 logger = logging.get_logger(__name__)
 

--- a/src/transformers/integrations/eetq.py
+++ b/src/transformers/integrations/eetq.py
@@ -22,7 +22,7 @@ if is_torch_available():
     import torch.nn as nn
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 logger = logging.get_logger(__name__)
 
@@ -108,7 +108,7 @@ def replace_with_eetq_linear(model, modules_to_not_convert: list[str] | None = N
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 new_module = EetqLinear(
                     module.in_features, module.out_features, bias=module.bias is not None, **module_kwargs

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -15,7 +15,7 @@
 
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_torch_accelerator_available, is_torch_available, logging
+from ..utils import is_torch_accelerator_available, is_torch_available, logging
 
 
 if is_torch_available():
@@ -24,9 +24,6 @@ if is_torch_available():
     import triton
     import triton.language as tl
     from torch.nn import functional as F
-
-if is_accelerate_available():
-    pass
 
 
 logger = logging.get_logger(__name__)

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -26,7 +26,7 @@ if is_torch_available():
     from torch.nn import functional as F
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 logger = logging.get_logger(__name__)
@@ -618,7 +618,7 @@ def replace_with_fp8_linear(
         # we need this to correctly materialize the weights during quantization
         module_kwargs = {} if pre_quantized else {"dtype": None}
         new_module = None
-        with init_empty_weights():
+        with torch.device("meta"):
             if module_name.endswith(".experts"):
                 new_module = FP8Expert(
                     config=model.config, block_size=quantization_config.weight_block_size, **module_kwargs

--- a/src/transformers/integrations/higgs.py
+++ b/src/transformers/integrations/higgs.py
@@ -20,7 +20,7 @@ from ..utils import is_accelerate_available, is_flute_available, is_hadamard_ava
 
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 if is_torch_available():
     import torch
@@ -569,7 +569,7 @@ def replace_with_higgs_linear(model, modules_to_not_convert: list[str] | None = 
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 new_module = HiggsLinear(
                     module.in_features,

--- a/src/transformers/integrations/higgs.py
+++ b/src/transformers/integrations/higgs.py
@@ -16,11 +16,8 @@
 from math import sqrt
 
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_flute_available, is_hadamard_available, is_torch_available, logging
+from ..utils import is_flute_available, is_hadamard_available, is_torch_available, logging
 
-
-if is_accelerate_available():
-    pass
 
 if is_torch_available():
     import torch

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -24,7 +24,7 @@ from ..core_model_loading import ConversionOps
 
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 from contextlib import contextmanager
 
@@ -620,7 +620,7 @@ def replace_with_mxfp4_linear(model, quantization_config=None, modules_to_not_co
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
         if module.__class__.__name__ == "GptOssExperts" and not quantization_config.dequantize:
-            with init_empty_weights():
+            with torch.device("meta"):
                 model.set_submodule(module_name, Mxfp4GptOssExperts(model.config))
                 has_been_replaced = True
         if module.__class__.__name__ == "GptOssMLP" and not quantization_config.dequantize:

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -12,22 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utils import is_accelerate_available, is_torch_available, is_torch_xpu_available, logging
+from ..utils import is_torch_available, is_torch_xpu_available, logging
 
 
 if is_torch_available():
     import torch
     from torch import nn
+from contextlib import contextmanager
 from typing import Optional
 
 from ..core_model_loading import ConversionOps
-
-
-if is_accelerate_available():
-    pass
-
-from contextlib import contextmanager
-
 from ..quantizers.quantizers_utils import get_module_from_name, should_convert_module
 
 

--- a/src/transformers/integrations/quanto.py
+++ b/src/transformers/integrations/quanto.py
@@ -73,7 +73,6 @@ def replace_with_quanto_layers(
             A list of modules to not convert. If a module name is in the list (e.g. `lm_head`), it will not be
             converted.
     """
-    from accelerate import init_empty_weights
     from optimum.quanto import QLayerNorm, QLinear, qfloat8, qint2, qint4, qint8
 
     w_mapping = {"float8": qfloat8, "int8": qint8, "int4": qint4, "int2": qint2}
@@ -83,7 +82,7 @@ def replace_with_quanto_layers(
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             new_module = None
             if isinstance(module, nn.Linear):
                 new_module = QLinear(

--- a/src/transformers/integrations/spqr.py
+++ b/src/transformers/integrations/spqr.py
@@ -14,13 +14,11 @@
 "SpQR (Sparse-Quantized Representation) integration file"
 
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_spqr_available, is_torch_available, logging
+from ..utils import is_spqr_available, is_torch_available, logging
 
-
-if is_accelerate_available():
-    from accelerate import init_empty_weights
 
 if is_torch_available():
+    import torch
     import torch.nn as nn
 
 logger = logging.get_logger(__name__)
@@ -47,7 +45,7 @@ def replace_with_spqr_linear(model, modules_to_not_convert: list[str] | None = N
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 shapes = quantization_config.shapes
 

--- a/src/transformers/integrations/timm.py
+++ b/src/transformers/integrations/timm.py
@@ -20,21 +20,20 @@ won't need to reinit them.
 Do not rely on it, as we will work to integrate it directly in `timm`, to then remove this file without warning.
 """
 
-from dataclasses import dataclass
-from typing import Optional, Union
-
-import torch
-from torch import Tensor, nn
-
 from ... import initialization as init
-from ...modeling_outputs import ImageClassifierOutput, ModelOutput
-from ...modeling_utils import PreTrainedModel
-from ...utils import auto_docstring, is_timm_available, requires_backends
-from .configuration_timm_wrapper import TimmWrapperConfig
+from ...utils import is_timm_available
 
 
 if is_timm_available():
-    from timm.layers.pos_embed_sincos import FourierEmbed, pixel_freq_bands, RotaryEmbedding, freq_bands, RotaryEmbeddingCat, RotaryEmbeddingMixed, RotaryEmbeddingDinoV3
+    from timm.layers.pos_embed_sincos import (
+        FourierEmbed,
+        RotaryEmbedding,
+        RotaryEmbeddingCat,
+        RotaryEmbeddingDinoV3,
+        RotaryEmbeddingMixed,
+        freq_bands,
+        pixel_freq_bands,
+    )
 
 
 def _maybe_reinit_non_persistent_buffer(module):
@@ -44,7 +43,11 @@ def _maybe_reinit_non_persistent_buffer(module):
         init.copy_(module.bands, pixel_freq_bands(module.max_res, module.num_bands))
     elif isinstance(module, RotaryEmbedding):
         if module.bands is not None:
-            bands = pixel_freq_bands(module.dim // 4, float(module.max_res), linear_bands=module.linear_bands) if module.in_pixels else bands = freq_bands(module.dim // 4, temperature=module.temperature, step=1)
+            bands = (
+                pixel_freq_bands(module.dim // 4, float(module.max_res), linear_bands=module.linear_bands)
+                if module.in_pixels
+                else freq_bands(module.dim // 4, temperature=module.temperature, step=1)
+            )
             init.copy_(module.bands, bands)
         elif module.pos_embed_sin is not None:
             emb_sin, emb_cos = module._get_pos_embed_values(module.feat_shape)
@@ -52,7 +55,11 @@ def _maybe_reinit_non_persistent_buffer(module):
             init.copy_(module.pos_embed_cos, emb_cos)
     elif isinstance(module, RotaryEmbeddingCat):
         if module.bands is not None:
-            bands = pixel_freq_bands(module.dim // 4, float(module.max_res), linear_bands=module.linear_bands) if module.in_pixels else bands = freq_bands(module.dim // 4, temperature=module.temperature, step=1)
+            bands = (
+                pixel_freq_bands(module.dim // 4, float(module.max_res), linear_bands=module.linear_bands)
+                if module.in_pixels
+                else freq_bands(module.dim // 4, temperature=module.temperature, step=1)
+            )
             init.copy_(module.bands, bands)
         elif module.pos_embed is not None:
             init.copy_(module.pos_embed, module._get_pos_embed_values(feat_shape=module.feat_shape))

--- a/src/transformers/integrations/timm.py
+++ b/src/transformers/integrations/timm.py
@@ -20,8 +20,8 @@ won't need to reinit them.
 Do not rely on it, as we will work to integrate it directly in `timm`, to then remove this file without warning.
 """
 
-from ... import initialization as init
-from ...utils import is_timm_available
+from .. import initialization as init
+from ..utils import is_timm_available
 
 
 if is_timm_available():

--- a/src/transformers/integrations/timm.py
+++ b/src/transformers/integrations/timm.py
@@ -45,6 +45,7 @@ if is_timm_available():
 
 
 def _maybe_reinit_non_persistent_buffer(module):
+    """Reinit the non-persistent buffers of `module` if it matches any timm Module which has any."""
     # This is a loooong list of hardcoded combinations from timm, as the modules do not provide a nice way to do
     # it natively
     if isinstance(module, FourierEmbed):

--- a/src/transformers/integrations/timm.py
+++ b/src/transformers/integrations/timm.py
@@ -51,7 +51,6 @@ if is_timm_available():
     )
     from timm.models.beit import Attention
     from timm.models.beit import gen_relative_position_index as beit_gen_relative_position_index
-    from timm.models.csatv2 import _DCT_MEAN, _DCT_VAR, LearnableDct2d
     from timm.models.efficientformer_v2 import Attention2d, Attention2dDownsample
     from timm.models.eva import EvaAttention
     from timm.models.levit import AttentionDownsample
@@ -61,6 +60,12 @@ if is_timm_available():
     from timm.models.swin_transformer_v2 import WindowAttention as Swin2WindowAttention
     from timm.models.swin_transformer_v2_cr import SwinTransformerV2CrBlock, WindowMultiHeadAttention
     from timm.models.vision_transformer import ParallelScalingBlock
+
+    # This one is very recent and is not necesarily in all versions we support (we require timm>=1.0.20)
+    try:
+        from timm.models.csatv2 import _DCT_MEAN, _DCT_VAR, LearnableDct2d
+    except Exception:
+        _DCT_MEAN, _DCT_VAR, LearnableDct2d = None, None, type(None)
 
 
 def _maybe_reinit_non_persistent_buffer(module):

--- a/src/transformers/integrations/timm.py
+++ b/src/transformers/integrations/timm.py
@@ -90,10 +90,11 @@ def _maybe_reinit_non_persistent_buffer(module):
         )
     elif isinstance(module, RelPosMlp):
         init.copy_(module.relative_position_index, gen_relative_position_index(module.window_size).view(-1))
-        # This one is supposed to pass args `pretrained_window_size` and `mode` in `gen_relative_log_coords`, but they
-        # are not recorded as class attributes in `__init__` so we cannot get the values back... Let's hope it's always
-        # default values
-        init.copy_(module.rel_coords_log, gen_relative_log_coords(module.window_size))
+        # This one is supposed to pass args `pretrained_window_size` as well to `gen_relative_log_coords`, but it's
+        # not recorded as class attributes in `__init__` and we have no way to infer its value back as we do for `mode` here...
+        # Let's hope it's always default value
+        mode = "cr" if module.bias_gain is None else "swin"
+        init.copy_(module.rel_coords_log, gen_relative_log_coords(module.window_size, mode=mode))
     elif isinstance(module, RelPosBiasTf):
         init.copy_(module.height_lookup, generate_lookup_tensor(module.window_size[0]))
         init.copy_(module.width_lookup, generate_lookup_tensor(module.window_size[1]))

--- a/src/transformers/integrations/timm.py
+++ b/src/transformers/integrations/timm.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This integration has for unique goal to allow re-initialization of the non-persistent buffers of `timm` models.
+Indeed, as we load models fully on meta by default, we need a way to get back the correct value of non-persistent buffers.
+We assume that everything else, i.e. parameters and persistent buffers, will correctly reside in model checkpoints, so we
+won't need to reinit them.
+Do not rely on it, as we will work to integrate it directly in `timm`, to then remove this file without warning.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Union
+
+import torch
+from torch import Tensor, nn
+
+from ... import initialization as init
+from ...modeling_outputs import ImageClassifierOutput, ModelOutput
+from ...modeling_utils import PreTrainedModel
+from ...utils import auto_docstring, is_timm_available, requires_backends
+from .configuration_timm_wrapper import TimmWrapperConfig
+
+
+if is_timm_available():
+    from timm.layers.pos_embed_sincos import FourierEmbed, pixel_freq_bands, RotaryEmbedding, freq_bands, RotaryEmbeddingCat, RotaryEmbeddingMixed, RotaryEmbeddingDinoV3
+
+
+def _maybe_reinit_non_persistent_buffer(module):
+    # This is a loooong list of hardcoded combinations from timm, as the modules do not provide a nice way to do
+    # it natively
+    if isinstance(module, FourierEmbed):
+        init.copy_(module.bands, pixel_freq_bands(module.max_res, module.num_bands))
+    elif isinstance(module, RotaryEmbedding):
+        if module.bands is not None:
+            bands = pixel_freq_bands(module.dim // 4, float(module.max_res), linear_bands=module.linear_bands) if module.in_pixels else bands = freq_bands(module.dim // 4, temperature=module.temperature, step=1)
+            init.copy_(module.bands, bands)
+        elif module.pos_embed_sin is not None:
+            emb_sin, emb_cos = module._get_pos_embed_values(module.feat_shape)
+            init.copy_(module.pos_embed_sin, emb_sin)
+            init.copy_(module.pos_embed_cos, emb_cos)
+    elif isinstance(module, RotaryEmbeddingCat):
+        if module.bands is not None:
+            bands = pixel_freq_bands(module.dim // 4, float(module.max_res), linear_bands=module.linear_bands) if module.in_pixels else bands = freq_bands(module.dim // 4, temperature=module.temperature, step=1)
+            init.copy_(module.bands, bands)
+        elif module.pos_embed is not None:
+            init.copy_(module.pos_embed, module._get_pos_embed_values(feat_shape=module.feat_shape))
+    elif isinstance(module, RotaryEmbeddingMixed):
+        if module.t_x is not None:
+            t_x, t_y = module._get_grid_values(module.feat_shape)
+            init.copy_(module.t_x, t_x)
+            init.copy(module.t_y, t_y)
+    elif isinstance(module, RotaryEmbeddingDinoV3):
+        init.copy_(module.periods, module._compute_periods())
+        if module.pos_embed_cached is not None:
+            init.copy_(module.pos_embed_cached, module._create_embed(module.feat_shape, no_aug=True))

--- a/src/transformers/integrations/vptq.py
+++ b/src/transformers/integrations/vptq.py
@@ -14,13 +14,11 @@
 "VPTQ (Vector Post-Training Quantization) integration file"
 
 from ..quantizers.quantizers_utils import should_convert_module
-from ..utils import is_accelerate_available, is_torch_available, logging
+from ..utils import is_torch_available, logging
 
-
-if is_accelerate_available():
-    from accelerate import init_empty_weights
 
 if is_torch_available():
+    import torch
     import torch.nn as nn
 
 logger = logging.get_logger(__name__)
@@ -48,7 +46,7 @@ def replace_with_vptq_linear(model, modules_to_not_convert: list[str] | None = N
     for module_name, module in model.named_modules():
         if not should_convert_module(module_name, modules_to_not_convert):
             continue
-        with init_empty_weights():
+        with torch.device("meta"):
             if isinstance(module, nn.Linear):
                 layer_params = config_for_layers.get(module_name, None) or shared_layer_config.get(
                     module_name.rsplit(".")[1], None

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4416,7 +4416,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             _load_parameter_into_model(self, key, value)
         # We need to move back non-persistent buffers as well, as they are not part of loaded weights anyway
         for key, buffer in self.named_buffers():
-            if key in self._non_persistent_buffers_set:
+            parent, buf_name = key.rsplit(".", 1) if "." in key else ("", key)
+            parent = self.get_submodule(parent)
+            if buf_name in parent._non_persistent_buffers_set:
                 value = torch.empty_like(buffer, dtype=dtype, device="cpu")
                 _load_parameter_into_model(self, key, value)
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2987,12 +2987,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         Maybe initializes weights. If using a custom `PreTrainedModel`, you need to implement any
         initialization logic in `_init_weights`.
         """
-        if not _init_weights or get_torch_context_manager_or_global_device() == torch.device("meta"):
-            return
-        # Initialize weights
-        self.initialize_weights()
-        # Tie weights needs to be called here, but it can use the pre-computed `all_tied_weights_keys`
-        self.tie_weights(recompute_mapping=False)
+        if _init_weights:
+            # If we are using the meta device in a context, no need to actually initialize
+            if get_torch_context_manager_or_global_device() != torch.device("meta"):
+                # Initialize weights
+                self.initialize_weights()
+            # Tie weights needs to be called here, but it can use the pre-computed `all_tied_weights_keys`
+            self.tie_weights(recompute_mapping=False)
 
     def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
         """

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4415,7 +4415,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         # will be re-initialized for nothing (which can be quite long)
         for key in missing_keys - self.all_tied_weights_keys.keys():
             param = self.get_parameter_or_buffer(key)
-            value = torch.empty_like(param, dtype=dtype, device="cpu")
+            value = torch.empty_like(param, device="cpu")
             _load_parameter_into_model(self, key, value)
         # We need to move back non-persistent buffers as well, as they are not part of loaded weights anyway
         for key, buffer in self.named_non_persistent_buffers():

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2987,13 +2987,12 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         Maybe initializes weights. If using a custom `PreTrainedModel`, you need to implement any
         initialization logic in `_init_weights`.
         """
-        if _init_weights:
-            # If we are using the meta device in a context, no need to actually initialize
-            if get_torch_context_manager_or_global_device() != torch.device("meta"):
-                # Initialize weights
-                self.initialize_weights()
-            # Tie weights needs to be called here, but it can use the pre-computed `all_tied_weights_keys`
-            self.tie_weights(recompute_mapping=False)
+        if not _init_weights or get_torch_context_manager_or_global_device() == torch.device("meta"):
+            return
+        # Initialize weights
+        self.initialize_weights()
+        # Tie weights needs to be called here, but it can use the pre-computed `all_tied_weights_keys`
+        self.tie_weights(recompute_mapping=False)
 
     def gradient_checkpointing_enable(self, gradient_checkpointing_kwargs=None):
         """

--- a/src/transformers/models/chameleon/convert_chameleon_weights_to_hf.py
+++ b/src/transformers/models/chameleon/convert_chameleon_weights_to_hf.py
@@ -19,7 +19,6 @@ import os
 import requests
 import torch
 import yaml
-from accelerate import init_empty_weights
 from PIL import Image
 
 from transformers import (
@@ -373,7 +372,7 @@ def write_model(model_path, input_base_path, model_size, chameleon_version=1):
         vq_config=vq_config,
         vocabulary_map=vocabulary_map,
     )
-    with init_empty_weights():
+    with torch.device("meta"):
         model = ChameleonForConditionalGeneration(config)
 
     model.load_state_dict(state_dict, assign=True, strict=False)

--- a/src/transformers/models/codegen/modeling_codegen.py
+++ b/src/transformers/models/codegen/modeling_codegen.py
@@ -19,6 +19,7 @@ from typing import Optional, Union
 import torch
 from torch import nn
 
+from ... import initialization as init
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
@@ -69,7 +70,7 @@ class CodeGenAttention(nn.Module):
     def __init__(self, config, layer_idx=None):
         super().__init__()
 
-        max_positions = config.max_position_embeddings
+        self.max_positions = config.max_position_embeddings
         self.attn_dropout = nn.Dropout(config.attn_pdrop)
         self.resid_dropout = nn.Dropout(config.resid_pdrop)
         self.layer_idx = layer_idx
@@ -93,8 +94,10 @@ class CodeGenAttention(nn.Module):
 
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)
         self.rotary_dim = config.rotary_dim
-        pos_embd_dim = self.rotary_dim or self.embed_dim
-        self.embed_positions = create_sinusoidal_positions(max_positions, pos_embd_dim)
+        self.pos_embd_dim = self.rotary_dim or self.embed_dim
+        self.register_buffer(
+            "embed_positions", create_sinusoidal_positions(self.max_positions, self.pos_embd_dim), persistent=False
+        )
 
     def _split_heads(self, x, n_head, dim_head, mp_num):
         reshaped = x.reshape(x.shape[:-1] + (n_head // mp_num, dim_head))
@@ -278,6 +281,11 @@ class CodeGenPreTrainedModel(PreTrainedModel):
     _no_split_modules = ["CodeGenBlock"]
     _skip_keys_device_placement = "past_key_values"
     _can_compile_fullgraph = True
+
+    def _init_weights(self, module):
+        super()._init_weights(module)
+        if isinstance(module, CodeGenAttention):
+            init.copy_(module.embed_positions, create_sinusoidal_positions(module.max_positions, module.pos_embd_dim))
 
 
 @auto_docstring

--- a/src/transformers/models/codegen/modeling_codegen.py
+++ b/src/transformers/models/codegen/modeling_codegen.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """PyTorch CodeGen model."""
 
+import math
 from typing import Optional, Union
 
 import torch
@@ -89,7 +90,7 @@ class CodeGenAttention(nn.Module):
                 f"embed_dim must be divisible by num_attention_heads (got `embed_dim`: {self.embed_dim} and"
                 f" `num_attention_heads`: {self.num_attention_heads})."
             )
-        self.scale_attn = torch.sqrt(torch.tensor(self.head_dim, dtype=torch.float32)).to(torch.get_default_dtype())
+        self.scale_attn = math.sqrt(self.head_dim)
         self.qkv_proj = nn.Linear(self.embed_dim, self.embed_dim * 3, bias=False)
 
         self.out_proj = nn.Linear(self.embed_dim, self.embed_dim, bias=False)

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -22,6 +22,7 @@ import torch
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
+from ... import initialization as init
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast, SequenceClassifierOutput
@@ -187,6 +188,13 @@ class CTRLPreTrainedModel(PreTrainedModel):
     config: CTRLConfig
     base_model_prefix = "transformer"
 
+    def _init_weights(self, module):
+        super()._init_weights(module)
+        if isinstance(module, CTRLModel):
+            init.copy_(
+                module.pos_encoding, positional_encoding(module.config.n_positions, module.d_model_size, torch.float)
+            )
+
 
 @auto_docstring
 class CTRLModel(CTRLPreTrainedModel):
@@ -196,7 +204,9 @@ class CTRLModel(CTRLPreTrainedModel):
         self.d_model_size = config.n_embd
         self.num_layers = config.n_layer
 
-        self.pos_encoding = positional_encoding(config.n_positions, self.d_model_size, torch.float)
+        self.register_buffer(
+            "pos_encoding", positional_encoding(config.n_positions, self.d_model_size, torch.float), persistent=False
+        )
 
         self.w = nn.Embedding(config.vocab_size, config.n_embd)
 

--- a/src/transformers/models/deepseek_vl/convert_deepseek_vl_weights_to_hf.py
+++ b/src/transformers/models/deepseek_vl/convert_deepseek_vl_weights_to_hf.py
@@ -20,7 +20,6 @@ from typing import Optional
 
 import regex as re
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import HFValidationError
 from safetensors.torch import load_file
@@ -285,7 +284,7 @@ def convert_model(
     # ------------------------------------------------------------
 
     print("Creating empty model...")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = DeepseekVLForConditionalGeneration(config)
 
     # Load and convert state dict

--- a/src/transformers/models/deepseek_vl_hybrid/convert_deepseek_vl_hybrid_weights_to_hf.py
+++ b/src/transformers/models/deepseek_vl_hybrid/convert_deepseek_vl_hybrid_weights_to_hf.py
@@ -20,7 +20,6 @@ from typing import Optional
 
 import regex as re
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import HFValidationError
 from safetensors.torch import load_file
@@ -323,7 +322,7 @@ def convert_model(
     # ------------------------------------------------------------
 
     print("Creating empty model...")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = DeepseekVLHybridForConditionalGeneration(config)
 
     # Load and convert state dict

--- a/src/transformers/models/emu3/convert_emu3_weights_to_hf.py
+++ b/src/transformers/models/emu3/convert_emu3_weights_to_hf.py
@@ -19,7 +19,6 @@ from typing import Optional
 
 import requests
 import torch
-from accelerate import init_empty_weights
 from PIL import Image
 
 from transformers import (
@@ -288,7 +287,7 @@ def convert_model(vq_model_id, llm_model_id, output_dir, hub_model_id=None, test
     )
     config = Emu3Config(text_config=text_config, vocabulary_map=vocabulary_map)
 
-    with init_empty_weights():
+    with torch.device("meta"):
         model = Emu3ForConditionalGeneration(config=config)
         model.generation_config = GenerationConfig(
             do_sample=True,

--- a/src/transformers/models/eomt/convert_eomt_to_hf.py
+++ b/src/transformers/models/eomt/convert_eomt_to_hf.py
@@ -21,7 +21,6 @@ import re
 from typing import Optional
 
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import snapshot_download
 
 from transformers import EomtConfig, EomtForUniversalSegmentation, EomtImageProcessorFast
@@ -255,7 +254,7 @@ def convert_model(
 
     # Initialize model with empty weights
     print("Creating empty model...")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = EomtForUniversalSegmentation(config)
 
     # Load and convert state dict

--- a/src/transformers/models/fastspeech2_conformer/modeling_fastspeech2_conformer.py
+++ b/src/transformers/models/fastspeech2_conformer/modeling_fastspeech2_conformer.py
@@ -727,19 +727,20 @@ class FastSpeech2ConformerRelPositionalEncoding(nn.Module):
         self.embed_dim = config.hidden_size
         self.input_scale = math.sqrt(self.embed_dim)
         self.dropout = nn.Dropout(p=module_config["positional_dropout_rate"])
-        self.pos_enc = None
         self.max_len = 5000
-        self.extend_pos_enc(torch.tensor(0.0).expand(1, self.max_len))
+        self.register_buffer(
+            "pos_enc", self.extend_pos_enc(torch.tensor(0.0).expand(1, self.max_len)), persistent=False
+        )
 
-    def extend_pos_enc(self, x):
+    def extend_pos_enc(self, x, pos_enc=None):
         """Reset the positional encodings."""
-        if self.pos_enc is not None:
+        if pos_enc is not None:
             # self.pos_enc contains both positive and negative parts
             # the length of self.pos_enc is 2 * input_len - 1
-            if self.pos_enc.size(1) >= x.size(1) * 2 - 1:
-                if self.pos_enc.dtype != x.dtype or self.pos_enc.device != x.device:
-                    self.pos_enc = self.pos_enc.to(dtype=x.dtype, device=x.device)
-                return
+            if pos_enc.size(1) >= x.size(1) * 2 - 1:
+                if pos_enc.dtype != x.dtype or pos_enc.device != x.device:
+                    pos_enc = pos_enc.to(dtype=x.dtype, device=x.device)
+                return pos_enc
         # Suppose `i` means to the position of query vector and `j` means the
         # position of key vector. We use position relative positions when keys
         # are to the left (i>j) and negative relative positions otherwise (i<j).
@@ -760,7 +761,7 @@ class FastSpeech2ConformerRelPositionalEncoding(nn.Module):
         pos_enc_positive = torch.flip(pos_enc_positive, [0]).unsqueeze(0)
         pos_enc_negative = pos_enc_negative[1:].unsqueeze(0)
         pos_enc = torch.cat([pos_enc_positive, pos_enc_negative], dim=1)
-        self.pos_enc = pos_enc.to(device=x.device, dtype=x.dtype)
+        return pos_enc.to(device=x.device, dtype=x.dtype)
 
     def forward(self, feature_representation):
         """
@@ -771,7 +772,7 @@ class FastSpeech2ConformerRelPositionalEncoding(nn.Module):
         Returns:
             `torch.Tensor`: Encoded tensor (batch_size, time, `*`).
         """
-        self.extend_pos_enc(feature_representation)
+        self.pos_enc = self.extend_pos_enc(feature_representation, self.pos_enc)
         hidden_states = feature_representation * self.input_scale
         center_idx = self.pos_enc.size(1) // 2
         pos_emb = self.pos_enc[:, center_idx - hidden_states.size(1) + 1 : center_idx + hidden_states.size(1)]
@@ -1022,6 +1023,8 @@ class FastSpeech2ConformerPreTrainedModel(PreTrainedModel):
         elif isinstance(module, FastSpeech2ConformerAttention):
             init.xavier_uniform_(module.pos_bias_u)
             init.xavier_uniform_(module.pos_bias_v)
+        elif isinstance(module, FastSpeech2ConformerRelPositionalEncoding):
+            init.copy_(module.pos_enc, module.extend_pos_enc(torch.tensor(0.0).expand(1, module.max_len)))
 
     def _set_gradient_checkpointing(self, module, value=False):
         if isinstance(module, FastSpeech2ConformerEncoder):

--- a/src/transformers/models/gemma/convert_gemma_weights_to_hf.py
+++ b/src/transformers/models/gemma/convert_gemma_weights_to_hf.py
@@ -16,7 +16,6 @@ import os
 import warnings
 
 import torch
-from accelerate import init_empty_weights
 
 from transformers import GemmaConfig, GemmaForCausalLM, GemmaTokenizer
 
@@ -110,7 +109,7 @@ def write_model(save_path, input_base_path, config, push_to_hub=False, dtype=tor
     torch.set_default_dtype(dtype)
 
     print("Loading the checkpoint in a Gemma model.")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = GemmaForCausalLM(config)
     model.load_state_dict(state_dict, assign=True, strict=False)
 

--- a/src/transformers/models/gemma2/convert_gemma2_weights_to_hf.py
+++ b/src/transformers/models/gemma2/convert_gemma2_weights_to_hf.py
@@ -16,7 +16,6 @@ import os
 import warnings
 
 import torch
-from accelerate import init_empty_weights
 
 from transformers import Gemma2Config, Gemma2ForCausalLM, GemmaTokenizer
 
@@ -143,7 +142,7 @@ def write_model(save_path, input_base_path, config, push_to_hub=False, dtype=tor
     torch.set_default_dtype(dtype)
 
     print("Loading the checkpoint in a Gemma2 model.")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = Gemma2ForCausalLM(config)
     model.load_state_dict(state_dict, assign=True, strict=False)
 

--- a/src/transformers/models/idefics2/convert_idefics2_weights_to_hf.py
+++ b/src/transformers/models/idefics2/convert_idefics2_weights_to_hf.py
@@ -16,7 +16,6 @@ import argparse
 import copy
 
 import torch
-from accelerate import init_empty_weights
 
 from transformers import (
     AutoConfig,
@@ -146,7 +145,7 @@ def convert_idefics2_hub_to_hf(original_model_id, output_hub_path, push_to_hub):
 
     config = get_config(original_model_id)
 
-    with init_empty_weights():
+    with torch.device("meta"):
         model = Idefics2ForConditionalGeneration(config)
 
     model.load_state_dict(state_dict, strict=True, assign=True)

--- a/src/transformers/models/idefics3/convert_idefics3_weights_to_hf.py
+++ b/src/transformers/models/idefics3/convert_idefics3_weights_to_hf.py
@@ -16,7 +16,6 @@ import argparse
 import json
 
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import hf_hub_download
 
 from transformers import (
@@ -175,7 +174,7 @@ def convert_idefics3_hub_to_hf(original_model_id, output_hub_path, push_to_hub):
     config = get_config(original_model_id)
     print(config)
 
-    with init_empty_weights():
+    with torch.device("meta"):
         model = Idefics3ForConditionalGeneration(config)
 
     model.load_state_dict(new_state_dict, strict=True, assign=True)

--- a/src/transformers/models/janus/convert_janus_weights_to_hf.py
+++ b/src/transformers/models/janus/convert_janus_weights_to_hf.py
@@ -28,7 +28,6 @@ import re
 from typing import Optional
 
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import snapshot_download
 
 from transformers import (
@@ -403,7 +402,7 @@ def convert_model(
 
     # Initialize model with empty weights
     print("Creating empty model...")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = JanusForConditionalGeneration(config)
 
     model.generation_config._from_model_config = False

--- a/src/transformers/models/llava_next/convert_llava_next_weights_to_hf.py
+++ b/src/transformers/models/llava_next/convert_llava_next_weights_to_hf.py
@@ -31,7 +31,6 @@ from pathlib import Path
 
 import requests
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import hf_hub_download, snapshot_download
 from PIL import Image
 from safetensors import safe_open
@@ -145,7 +144,7 @@ def convert_llava_to_hf(model_id, pytorch_dump_folder_path, push_to_hub=False):
         image_token_id=image_token_id,
     )
 
-    with init_empty_weights():
+    with torch.device("meta"):
         model = LlavaNextForConditionalGeneration(config)
 
     # load original state dict

--- a/src/transformers/models/llava_next_video/convert_llava_next_video_weights_to_hf.py
+++ b/src/transformers/models/llava_next_video/convert_llava_next_video_weights_to_hf.py
@@ -23,7 +23,6 @@ import json
 from pathlib import Path
 
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import hf_hub_download, snapshot_download
 from safetensors import safe_open
 
@@ -203,7 +202,7 @@ def convert_llava_to_hf(model_id, pytorch_dump_folder_path, push_to_hub=False):
         image_token_id=image_token_id,
     )
 
-    with init_empty_weights():
+    with torch.device("meta"):
         model = LlavaNextVideoForConditionalGeneration(config)
 
     # load original state dict

--- a/src/transformers/models/llava_onevision/convert_llava_onevision_weights_to_hf.py
+++ b/src/transformers/models/llava_onevision/convert_llava_onevision_weights_to_hf.py
@@ -26,7 +26,6 @@ from pathlib import Path
 
 import requests
 import torch
-from accelerate import init_empty_weights
 from huggingface_hub import hf_hub_download, snapshot_download
 from PIL import Image
 from safetensors import safe_open
@@ -153,7 +152,7 @@ def convert_llava_to_hf(model_id, pytorch_dump_folder_path, push_to_hub=False):
         use_image_newline_parameter=True,
     )
 
-    with init_empty_weights():
+    with torch.device("meta"):
         model = LlavaOnevisionForConditionalGeneration(config)
 
     # load original state dict

--- a/src/transformers/models/recurrent_gemma/convert_recurrent_gemma_to_hf.py
+++ b/src/transformers/models/recurrent_gemma/convert_recurrent_gemma_to_hf.py
@@ -16,7 +16,6 @@ import os
 import warnings
 
 import torch
-from accelerate import init_empty_weights
 
 from transformers import GemmaTokenizer, RecurrentGemmaConfig, RecurrentGemmaForCausalLM
 
@@ -127,7 +126,7 @@ def write_model(save_path, input_base_path, config, push_to_hub=False, dtype=tor
     torch.set_default_dtype(dtype)
 
     print("Loading the checkpoint in a Gemma model.")
-    with init_empty_weights():
+    with torch.device("meta"):
         model = RecurrentGemmaForCausalLM(config)
     model.load_state_dict(state_dict, assign=True, strict=True)
 

--- a/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
@@ -287,18 +287,17 @@ class SeamlessM4TConformerRelPositionalEmbedding(nn.Module):
         super().__init__()
         self.max_len = config.max_source_positions
         self.d_model = config.hidden_size
-        self.pe = None
-        self.extend_pe(torch.tensor(0.0).expand(1, self.max_len))
+        self.register_buffer("pe", self.extend_pe(torch.tensor(0.0).expand(1, self.max_len)), persistent=False)
 
-    def extend_pe(self, x):
+    def extend_pe(self, x, pe=None):
         # Reset the positional encodings
-        if self.pe is not None:
+        if pe is not None:
             # self.pe contains both positive and negative parts
             # the length of self.pe is 2 * input_len - 1
-            if self.pe.size(1) >= x.size(1) * 2 - 1:
-                if self.pe.dtype != x.dtype or self.pe.device != x.device:
-                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
-                return
+            if pe.size(1) >= x.size(1) * 2 - 1:
+                if pe.dtype != x.dtype or pe.device != x.device:
+                    pe = pe.to(dtype=x.dtype, device=x.device)
+                return pe
         # Suppose `i` is the position of query vector and `j` is the
         # position of key vector. We use positive relative positions when keys
         # are to the left (i>j) and negative relative positions otherwise (i<j).
@@ -319,10 +318,10 @@ class SeamlessM4TConformerRelPositionalEmbedding(nn.Module):
         pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
         pe_negative = pe_negative[1:].unsqueeze(0)
         pe = torch.cat([pe_positive, pe_negative], dim=1)
-        self.pe = pe.to(device=x.device, dtype=x.dtype)
+        return pe.to(device=x.device, dtype=x.dtype)
 
     def forward(self, hidden_states: torch.Tensor):
-        self.extend_pe(hidden_states)
+        self.pe = self.extend_pe(hidden_states, self.pe)
         start_idx = self.pe.size(1) // 2 - hidden_states.size(1) + 1
         end_idx = self.pe.size(1) // 2 + hidden_states.size(1)
         relative_position_embeddings = self.pe[:, start_idx:end_idx]

--- a/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/modeling_seamless_m4t.py
@@ -1394,6 +1394,8 @@ class SeamlessM4TPreTrainedModel(PreTrainedModel):
             base = self.config.rotary_embedding_base
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
+        elif isinstance(module, SeamlessM4TConformerRelPositionalEmbedding):
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, module.max_len)))
 
     def _compute_sub_sample_lengths_from_attention_mask(self, attention_mask):
         kernel_size, stride = self.config.adaptor_kernel_size, self.config.adaptor_stride

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -29,7 +29,7 @@ from .configuration_timm_wrapper import TimmWrapperConfig
 if is_timm_available():
     import timm
 
-    from ..integrations.timm import _maybe_reinit_non_persistent_buffer
+    from ...integrations.timm import _maybe_reinit_non_persistent_buffer
 
 
 @dataclass

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -29,6 +29,8 @@ from .configuration_timm_wrapper import TimmWrapperConfig
 if is_timm_available():
     import timm
 
+    from ..integrations.timm import _maybe_reinit_non_persistent_buffer
+
 
 @dataclass
 @auto_docstring(
@@ -109,10 +111,12 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
         Since model architectures may vary, we assume only the classifier requires
         initialization, while all other weights should be loaded from the checkpoint.
         """
-        if isinstance(module, (nn.Linear)):
+        if isinstance(module, nn.Linear):
             init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             if module.bias is not None:
                 init.zeros_(module.bias)
+        # Also, reinit all non-persistemt buffers if any!
+        _maybe_reinit_non_persistent_buffer(module)
 
     def _timm_model_supports_gradient_checkpointing(self):
         """

--- a/src/transformers/models/wav2vec2_bert/modeling_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/modeling_wav2vec2_bert.py
@@ -753,6 +753,8 @@ class Wav2Vec2BertPreTrainedModel(PreTrainedModel):
             base = self.config.rotary_embedding_base
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
+        elif isinstance(module, Wav2Vec2BertRelPositionalEmbedding):
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, module.max_len)))
 
     # Ignore copy
     def _get_feat_extract_output_lengths(

--- a/src/transformers/models/wav2vec2_bert/modeling_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/modeling_wav2vec2_bert.py
@@ -74,18 +74,17 @@ class Wav2Vec2BertRelPositionalEmbedding(nn.Module):
         super().__init__()
         self.max_len = config.max_source_positions
         self.d_model = config.hidden_size
-        self.pe = None
-        self.extend_pe(torch.tensor(0.0).expand(1, self.max_len))
+        self.register_buffer("pe", self.extend_pe(torch.tensor(0.0).expand(1, self.max_len)), persistent=False)
 
-    def extend_pe(self, x):
+    def extend_pe(self, x, pe=None):
         # Reset the positional encodings
-        if self.pe is not None:
+        if pe is not None:
             # self.pe contains both positive and negative parts
             # the length of self.pe is 2 * input_len - 1
-            if self.pe.size(1) >= x.size(1) * 2 - 1:
-                if self.pe.dtype != x.dtype or self.pe.device != x.device:
-                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
-                return
+            if pe.size(1) >= x.size(1) * 2 - 1:
+                if pe.dtype != x.dtype or pe.device != x.device:
+                    pe = pe.to(dtype=x.dtype, device=x.device)
+                return pe
         # Suppose `i` is the position of query vector and `j` is the
         # position of key vector. We use positive relative positions when keys
         # are to the left (i>j) and negative relative positions otherwise (i<j).
@@ -106,10 +105,10 @@ class Wav2Vec2BertRelPositionalEmbedding(nn.Module):
         pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
         pe_negative = pe_negative[1:].unsqueeze(0)
         pe = torch.cat([pe_positive, pe_negative], dim=1)
-        self.pe = pe.to(device=x.device, dtype=x.dtype)
+        return pe.to(device=x.device, dtype=x.dtype)
 
     def forward(self, hidden_states: torch.Tensor):
-        self.extend_pe(hidden_states)
+        self.pe = self.extend_pe(hidden_states, self.pe)
         start_idx = self.pe.size(1) // 2 - hidden_states.size(1) + 1
         end_idx = self.pe.size(1) // 2 + hidden_states.size(1)
         relative_position_embeddings = self.pe[:, start_idx:end_idx]

--- a/src/transformers/models/wav2vec2_bert/modular_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/modular_wav2vec2_bert.py
@@ -626,6 +626,8 @@ class Wav2Vec2BertPreTrainedModel(PreTrainedModel):
             base = self.config.rotary_embedding_base
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
+        elif isinstance(module, Wav2Vec2BertRelPositionalEmbedding):
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, module.max_len)))
 
     # Ignore copy
     def _get_feat_extract_output_lengths(

--- a/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
@@ -903,7 +903,7 @@ class Wav2Vec2ConformerPreTrainedModel(PreTrainedModel):
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
         elif isinstance(module, Wav2Vec2ConformerRelPositionalEmbedding):
-            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, self.max_len)))
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, module.max_len)))
 
     def _get_feat_extract_output_lengths(
         self, input_lengths: Union[torch.LongTensor, int], add_adapter: Optional[bool] = None

--- a/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/modeling_wav2vec2_conformer.py
@@ -164,18 +164,17 @@ class Wav2Vec2ConformerRelPositionalEmbedding(nn.Module):
         super().__init__()
         self.max_len = config.max_source_positions
         self.d_model = config.hidden_size
-        self.pe = None
-        self.extend_pe(torch.tensor(0.0).expand(1, self.max_len))
+        self.register_buffer("pe", self.extend_pe(torch.tensor(0.0).expand(1, self.max_len)), persistent=False)
 
-    def extend_pe(self, x):
+    def extend_pe(self, x, pe=None):
         # Reset the positional encodings
-        if self.pe is not None:
+        if pe is not None:
             # self.pe contains both positive and negative parts
             # the length of self.pe is 2 * input_len - 1
-            if self.pe.size(1) >= x.size(1) * 2 - 1:
-                if self.pe.dtype != x.dtype or self.pe.device != x.device:
-                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
-                return
+            if pe.size(1) >= x.size(1) * 2 - 1:
+                if pe.dtype != x.dtype or pe.device != x.device:
+                    pe = pe.to(dtype=x.dtype, device=x.device)
+                return pe
         # Suppose `i` is the position of query vector and `j` is the
         # position of key vector. We use positive relative positions when keys
         # are to the left (i>j) and negative relative positions otherwise (i<j).
@@ -196,10 +195,10 @@ class Wav2Vec2ConformerRelPositionalEmbedding(nn.Module):
         pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
         pe_negative = pe_negative[1:].unsqueeze(0)
         pe = torch.cat([pe_positive, pe_negative], dim=1)
-        self.pe = pe.to(device=x.device, dtype=x.dtype)
+        return pe.to(device=x.device, dtype=x.dtype)
 
     def forward(self, hidden_states: torch.Tensor):
-        self.extend_pe(hidden_states)
+        self.pe = self.extend_pe(hidden_states, self.pe)
         start_idx = self.pe.size(1) // 2 - hidden_states.size(1) + 1
         end_idx = self.pe.size(1) // 2 + hidden_states.size(1)
         relative_position_embeddings = self.pe[:, start_idx:end_idx]
@@ -903,6 +902,8 @@ class Wav2Vec2ConformerPreTrainedModel(PreTrainedModel):
             base = self.config.rotary_embedding_base
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
+        elif isinstance(module, Wav2Vec2ConformerRelPositionalEmbedding):
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, self.max_len)))
 
     def _get_feat_extract_output_lengths(
         self, input_lengths: Union[torch.LongTensor, int], add_adapter: Optional[bool] = None

--- a/src/transformers/models/wav2vec2_conformer/modular_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/modular_wav2vec2_conformer.py
@@ -602,7 +602,7 @@ class Wav2Vec2ConformerPreTrainedModel(PreTrainedModel):
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
         elif isinstance(module, Wav2Vec2ConformerRelPositionalEmbedding):
-            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, self.max_len)))
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, module.max_len)))
 
     def _get_feat_extract_output_lengths(
         self, input_lengths: Union[torch.LongTensor, int], add_adapter: Optional[bool] = None

--- a/src/transformers/models/wav2vec2_conformer/modular_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/modular_wav2vec2_conformer.py
@@ -116,18 +116,17 @@ class Wav2Vec2ConformerRelPositionalEmbedding(nn.Module):
         super().__init__()
         self.max_len = config.max_source_positions
         self.d_model = config.hidden_size
-        self.pe = None
-        self.extend_pe(torch.tensor(0.0).expand(1, self.max_len))
+        self.register_buffer("pe", self.extend_pe(torch.tensor(0.0).expand(1, self.max_len)), persistent=False)
 
-    def extend_pe(self, x):
+    def extend_pe(self, x, pe=None):
         # Reset the positional encodings
-        if self.pe is not None:
+        if pe is not None:
             # self.pe contains both positive and negative parts
             # the length of self.pe is 2 * input_len - 1
-            if self.pe.size(1) >= x.size(1) * 2 - 1:
-                if self.pe.dtype != x.dtype or self.pe.device != x.device:
-                    self.pe = self.pe.to(dtype=x.dtype, device=x.device)
-                return
+            if pe.size(1) >= x.size(1) * 2 - 1:
+                if pe.dtype != x.dtype or pe.device != x.device:
+                    pe = pe.to(dtype=x.dtype, device=x.device)
+                return pe
         # Suppose `i` is the position of query vector and `j` is the
         # position of key vector. We use positive relative positions when keys
         # are to the left (i>j) and negative relative positions otherwise (i<j).
@@ -148,10 +147,10 @@ class Wav2Vec2ConformerRelPositionalEmbedding(nn.Module):
         pe_positive = torch.flip(pe_positive, [0]).unsqueeze(0)
         pe_negative = pe_negative[1:].unsqueeze(0)
         pe = torch.cat([pe_positive, pe_negative], dim=1)
-        self.pe = pe.to(device=x.device, dtype=x.dtype)
+        return pe.to(device=x.device, dtype=x.dtype)
 
     def forward(self, hidden_states: torch.Tensor):
-        self.extend_pe(hidden_states)
+        self.pe = self.extend_pe(hidden_states, self.pe)
         start_idx = self.pe.size(1) // 2 - hidden_states.size(1) + 1
         end_idx = self.pe.size(1) // 2 + hidden_states.size(1)
         relative_position_embeddings = self.pe[:, start_idx:end_idx]
@@ -602,6 +601,8 @@ class Wav2Vec2ConformerPreTrainedModel(PreTrainedModel):
             base = self.config.rotary_embedding_base
             inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
             init.copy_(module.inv_freq, inv_freq)
+        elif isinstance(module, Wav2Vec2ConformerRelPositionalEmbedding):
+            init.copy_(module.pe, module.extend_pe(torch.tensor(0.0).expand(1, self.max_len)))
 
     def _get_feat_extract_output_lengths(
         self, input_lengths: Union[torch.LongTensor, int], add_adapter: Optional[bool] = None

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -260,15 +260,13 @@ class HfQuantizer(ABC):
     def is_trainable(self): ...
 
     def _convert_model_for_quantization(self, model):
-        from accelerate import init_empty_weights
-
         for name, module in model.named_modules():
             module_class_name = module.__class__.__name__
             if module_class_name in MODULES_TO_PATCH_FOR_QUANTIZATION and (
                 self.quantization_config.quant_method
                 in MODULES_TO_PATCH_FOR_QUANTIZATION[module_class_name]["quantization_methods"]
             ):
-                with init_empty_weights():
+                with torch.device("meta"):
                     parent_module, name = get_module_from_name(model, name)
                     parent_module._modules[name] = MODULES_TO_PATCH_FOR_QUANTIZATION[module_class_name]["module_name"](
                         model.config.get_text_config()

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -31,14 +31,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_aqlm_available, is_torch_available
+from transformers.utils import is_aqlm_available, is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @require_torch_accelerator

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -38,7 +38,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @require_torch_accelerator
@@ -112,7 +112,7 @@ class AqlmTest(unittest.TestCase):
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
         quantization_config = AqlmConfig()
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0
@@ -129,7 +129,7 @@ class AqlmTest(unittest.TestCase):
         self.assertEqual(nb_linears, nb_aqlm_linear)
 
         # Try with `linear_weights_not_to_quantize`
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         model, _ = replace_with_aqlm_linear(

--- a/tests/quantization/autoawq/test_awq.py
+++ b/tests/quantization/autoawq/test_awq.py
@@ -35,7 +35,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @require_torch_accelerator
@@ -154,7 +154,7 @@ class AwqTest(unittest.TestCase):
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
         quantization_config = AwqConfig(bits=4)
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0
@@ -171,7 +171,7 @@ class AwqTest(unittest.TestCase):
         self.assertEqual(nb_linears, nb_awq_linear)
 
         # Try with `modules_not_to_convert`
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         model, _ = replace_with_awq_linear(

--- a/tests/quantization/autoawq/test_awq.py
+++ b/tests/quantization/autoawq/test_awq.py
@@ -27,15 +27,12 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 from transformers.utils.quantization_config import AwqBackend
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @require_torch_accelerator

--- a/tests/quantization/bitnet_integration/test_bitnet.py
+++ b/tests/quantization/bitnet_integration/test_bitnet.py
@@ -36,7 +36,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @require_torch_accelerator
@@ -80,7 +80,7 @@ class BitNetTest(unittest.TestCase):
         model_id = "facebook/opt-350m"
         config = AutoConfig.from_pretrained(model_id)
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0

--- a/tests/quantization/bitnet_integration/test_bitnet.py
+++ b/tests/quantization/bitnet_integration/test_bitnet.py
@@ -29,14 +29,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @require_torch_accelerator

--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -148,21 +148,20 @@ class MixedInt8Test(BaseMixedInt8Test):
         r"""
         Test the `get_keys_to_not_convert` function.
         """
-        from accelerate import init_empty_weights
 
         from transformers import AutoModelForMaskedLM, Blip2ForConditionalGeneration, MptForCausalLM, OPTForCausalLM
         from transformers.quantizers.base import get_keys_to_not_convert
 
         model_id = "mosaicml/mpt-7b"
         config = AutoConfig.from_pretrained(model_id, revision="72e5f594ce36f9cabfa2a9fd8f58b491eb467ee7")
-        with init_empty_weights():
+        with torch.device("meta"):
             model = MptForCausalLM(config)
         # The order of the keys does not matter, so we sort them before comparing, same for the other tests.
         self.assertEqual(get_keys_to_not_convert(model).sort(), ["lm_head", "transformer.wte"].sort())
 
         model_id = "Salesforce/blip2-opt-2.7b"
         config = AutoConfig.from_pretrained(model_id, revision="1ef7f63a8f0a144c13fdca8103eb7b4691c74cec")
-        with init_empty_weights():
+        with torch.device("meta"):
             model = Blip2ForConditionalGeneration(config)
         self.assertEqual(
             get_keys_to_not_convert(model).sort(),
@@ -171,13 +170,13 @@ class MixedInt8Test(BaseMixedInt8Test):
 
         model_id = "facebook/opt-350m"
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
         self.assertEqual(get_keys_to_not_convert(model).sort(), ["lm_head", "model.decoder.embed_tokens"].sort())
 
         model_id = "FacebookAI/roberta-large"
         config = AutoConfig.from_pretrained(model_id, revision="716877d372b884cad6d419d828bac6c85b3b18d9")
-        with init_empty_weights():
+        with torch.device("meta"):
             model = AutoModelForMaskedLM.from_config(config)
         self.assertEqual(
             get_keys_to_not_convert(model).sort(),

--- a/tests/quantization/eetq_integration/test_eetq.py
+++ b/tests/quantization/eetq_integration/test_eetq.py
@@ -33,7 +33,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @require_torch_gpu
@@ -101,7 +101,7 @@ class EetqTest(unittest.TestCase):
         model_id = "facebook/opt-350m"
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0
@@ -118,7 +118,7 @@ class EetqTest(unittest.TestCase):
         self.assertEqual(nb_linears, nb_eetq_linear)
 
         # Try with `modules_to_not_convert`
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
         model = replace_with_eetq_linear(model, modules_to_not_convert=["fc1"])
         nb_eetq_linear = 0

--- a/tests/quantization/eetq_integration/test_eetq.py
+++ b/tests/quantization/eetq_integration/test_eetq.py
@@ -26,14 +26,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @require_torch_gpu

--- a/tests/quantization/fbgemm_fp8/test_fbgemm_fp8.py
+++ b/tests/quantization/fbgemm_fp8/test_fbgemm_fp8.py
@@ -153,7 +153,7 @@ class FbgemmFp8Test(unittest.TestCase):
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
         quantization_config = FbgemmFp8Config()
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0
@@ -169,7 +169,7 @@ class FbgemmFp8Test(unittest.TestCase):
 
         self.assertEqual(nb_linears, nb_fbgemm_linear)
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
         quantization_config = FbgemmFp8Config(modules_to_not_convert=["fc1"])
         model = replace_with_fbgemm_fp8_linear(

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -30,14 +30,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @contextmanager

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -37,7 +37,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @contextmanager
@@ -145,7 +145,7 @@ class FP8QuantizerTest(unittest.TestCase):
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
         quantization_config = FineGrainedFP8Config()
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0
@@ -158,7 +158,7 @@ class FP8QuantizerTest(unittest.TestCase):
             if isinstance(module, FP8Linear):
                 nb_fp8_linear += 1
         self.assertEqual(nb_linears, nb_fp8_linear)
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
         quantization_config = FineGrainedFP8Config()
         model = replace_with_fp8_linear(model, modules_to_not_convert=["fc1"], quantization_config=quantization_config)

--- a/tests/quantization/higgs/test_higgs.py
+++ b/tests/quantization/higgs/test_higgs.py
@@ -33,7 +33,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @require_torch_gpu
@@ -102,7 +102,7 @@ class HiggsTest(unittest.TestCase):
         config = AutoConfig.from_pretrained(model_id, revision="cb32f77e905cccbca1d970436fb0f5e6b58ee3c5")
         quantization_config = HiggsConfig()
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
 
         nb_linears = 0
@@ -118,7 +118,7 @@ class HiggsTest(unittest.TestCase):
 
         self.assertEqual(nb_linears - 1, nb_higgs_linear)
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = OPTForCausalLM(config)
         quantization_config = HiggsConfig(modules_to_not_convert=["fc1"])
         model, _ = replace_with_higgs_linear(model, quantization_config=quantization_config)

--- a/tests/quantization/higgs/test_higgs.py
+++ b/tests/quantization/higgs/test_higgs.py
@@ -26,14 +26,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @require_torch_gpu

--- a/tests/quantization/quanto_integration/test_quanto.py
+++ b/tests/quantization/quanto_integration/test_quanto.py
@@ -24,14 +24,12 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_optimum_quanto_available, is_torch_available
+from transformers.utils import is_optimum_quanto_available, is_torch_available
 
 
 if is_torch_available():
     import torch
 
-if is_accelerate_available():
-    pass
 
 if is_optimum_quanto_available():
     from optimum.quanto import QLayerNorm, QLinear

--- a/tests/quantization/quanto_integration/test_quanto.py
+++ b/tests/quantization/quanto_integration/test_quanto.py
@@ -31,7 +31,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 if is_optimum_quanto_available():
     from optimum.quanto import QLayerNorm, QLinear
@@ -46,7 +46,7 @@ class QuantoTestIntegration(unittest.TestCase):
 
     def setUp(self):
         config = AutoConfig.from_pretrained(self.model_id)
-        with init_empty_weights():
+        with torch.device("meta"):
             self.model = AutoModelForCausalLM.from_config(config)
         self.nb_linear = 0
         self.nb_layernorm = 0

--- a/tests/quantization/spqr_integration/test_spqr.py
+++ b/tests/quantization/spqr_integration/test_spqr.py
@@ -35,7 +35,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 @require_torch_gpu
@@ -115,7 +115,7 @@ class SpQRTest(unittest.TestCase):
         quantization_config = AutoConfig.from_pretrained(self.model_name, return_dict=False).quantization_config
         quantization_config = SpQRConfig.from_dict(quantization_config)
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=model_id, config=config)
 
         nb_linears = 0

--- a/tests/quantization/spqr_integration/test_spqr.py
+++ b/tests/quantization/spqr_integration/test_spqr.py
@@ -28,14 +28,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 @require_torch_gpu

--- a/tests/quantization/vptq_integration/test_vptq.py
+++ b/tests/quantization/vptq_integration/test_vptq.py
@@ -26,14 +26,11 @@ from transformers.testing_utils import (
     slow,
     torch_device,
 )
-from transformers.utils import is_accelerate_available, is_torch_available
+from transformers.utils import is_torch_available
 
 
 if is_torch_available():
     import torch
-
-if is_accelerate_available():
-    pass
 
 
 class VptqConfigTest(unittest.TestCase):

--- a/tests/quantization/vptq_integration/test_vptq.py
+++ b/tests/quantization/vptq_integration/test_vptq.py
@@ -33,7 +33,7 @@ if is_torch_available():
     import torch
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 class VptqConfigTest(unittest.TestCase):
@@ -162,7 +162,7 @@ class VptqTest(unittest.TestCase):
         layer_configs["model.decoder.project_in"] = value
         quantization_config = VptqConfig(config_for_layers=layer_configs, shared_layer_config=shared_layer_config)
 
-        with init_empty_weights():
+        with torch.device("meta"):
             model = AutoModelForCausalLM.from_config(config)
 
         nb_linears = 0
@@ -179,7 +179,7 @@ class VptqTest(unittest.TestCase):
         self.assertEqual(nb_linears - 1, nb_vptq_linear)
 
         # Try with `linear_weights_not_to_quantize`
-        with init_empty_weights():
+        with torch.device("meta"):
             model = AutoModelForCausalLM.from_config(config)
         quantization_config = VptqConfig(config_for_layers=layer_configs, shared_layer_config=shared_layer_config)
         model, _ = replace_with_vptq_linear(

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1195,6 +1195,42 @@ class ModelTesterMixin:
                 f"them correctly if the model is on meta device):\n{unique_bad_module_traceback}",
             )
 
+    def test_all_tensors_are_parameter_or_buffer(self):
+        """Check that all tensors are registered as Parameter or Buffer, i.e. we don't have simple assignments such
+        as `self.x = torch.tensor(...)` in a Module (as we cannot correctly recover from meta device if it's not registered as
+        parameter/buffer)"""
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+
+        for model_class in self.all_model_classes:
+            # apparently this model cannot correctly create its inputs....
+            if "modeling_perceiver.py" in inspect.getfile(model_class):
+                _, inputs_dict = self.model_tester.prepare_config_and_inputs_for_model_class(model_class)
+
+            # Initialize the model fully on meta device, then move everything to cpu and run `init_weights`
+            with torch.device("meta"):
+                model = model_class(copy.deepcopy(config)).eval()
+            # move everything randomly to cpu
+            model.to_empty(device="cpu")
+            # Now, run all the inits
+            model.init_weights()
+
+            # Try running a forward, to see if a tensor stayed on meta somewhere
+            try:
+                _ = model(**self._prepare_for_class(inputs_dict, model_class))
+            except (RuntimeError, NotImplementedError) as e:
+                # Re-raise a more friendly exception (unfortunately, we cannot know which tensor it was...)
+                if "Cannot copy out of meta tensor; no data!" in str(
+                    e
+                ) or "Tensor on device meta is not on the expected device cpu!" in str(e):
+                    raise ValueError(
+                        "A tensor is still on meta device. It means it was not properly registered as a Parameter or "
+                        "Buffer.\nMost of the time, it should be added as a non-persistent buffer if you don't want to include "
+                        "it in the model's state dict. It can also be a scalar that was added as a torch.Tensor, consider making it "
+                        "a Python scalar in this case and use it as such in forward"
+                    ) from e
+                else:
+                    raise e
+
     def test_torch_save_load(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         if config.__class__ not in MODEL_MAPPING:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -1202,7 +1202,7 @@ class ModelTesterMixin:
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 
         for model_class in self.all_model_classes:
-            # apparently this model cannot correctly create its inputs....
+            # apparently this model cannot correctly create its inputs and has to use another function....
             if "modeling_perceiver.py" in inspect.getfile(model_class):
                 _, inputs_dict = self.model_tester.prepare_config_and_inputs_for_model_class(model_class)
 


### PR DESCRIPTION
# What does this PR do?

Follow-up to https://github.com/huggingface/transformers/pull/42309 to really leverage meta device loading. Gives crazy speedups for loading some models, e.g. *about 2.5x on gpt-oss 20b* and *about 3x on the 120b version*

## The issue at hand

Currently, during loading we initialize the model on meta device before loading weights, thanks to `init_empty_weights` from `accelerate`.
However, this context manager has BIG drawbacks:
- everything (every parameter and buffer) is first materialized on cpu before being moved to meta device
- this is extremely inefficient of course, as we only want them on meta -> it wastes time and memory
- all buffers stay on cpu (even the persistent ones, that we are loading again after anyway, so don't need to be there...)

For some models, e.g. gpt-oss, we have the following during loading:

<img width="1437" height="674" alt="Screenshot 2025-12-19 at 12 11 30" src="https://github.com/user-attachments/assets/4a30f275-3992-47c2-9d69-fbfaa6d7d8c3" />

Note how most of the loading time is BEFORE the actual loading of the weights (`_load_pretrained` call), just to initialize parameters that should be on meta device anyway.... 

## What this PR is doing

This PR completely removes `init_empty_weights` in favor of `torch.device("meta")` to really start with a model on meta device, without first putting them on cpu.
We are free to do so since I've merged https://github.com/huggingface/transformers/pull/42309 yesterday, to correctly handle re-initialization of the non-persistent buffers which are put on meta device as well.

The performance gains are immense, the same benchmark as before for gpt-oss shows it:

<img width="1064" height="525" alt="Screenshot 2025-12-19 at 12 16 00" src="https://github.com/user-attachments/assets/3e014b39-7687-4bc3-a451-71dbe5d551d0" />

and we can now see that most of the time in `from_pretrained` is used for the actual weight loading (`_load_pretrained` call), as it should be.

Raw numbers for the following simple benchmark script (from which the above traces are from) on our cluster:

```python
from transformers import AutoModelForCausalLM
import torch
import time
from viztracer import VizTracer

model_id = "openai/gpt-oss-20b"
device = 0

tracer = VizTracer()
tracer.start()

torch.cuda.synchronize()
t0 = time.time()
model = AutoModelForCausalLM.from_pretrained(model_id, device_map=device, dtype=torch.float16)
torch.cuda.synchronize()
dt = time.time() - t0
print(f"Took {dt:.2f} s")

tracer.stop()
tracer.save(output_file="../trace.json")
```

are the following:

BEFORE THIS PR -> ~9.1s
ON THIS PR -> ~3.7s

*Which means a speedup of about 2.5x*.

For the 120B gpt-oss version, we have:

BEFORE THIS PR -> ~32.4s
ON THIS PR -> ~10.7s

or a *speedup of about 3x*