### PR TITLE
[Quantization] From config Quantization for FP8

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import nullcontext
-
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import should_convert_module
 from ..utils import is_accelerate_available, is_torch_accelerator_available, is_torch_available, logging
@@ -28,7 +26,7 @@ if is_torch_available():
     from torch.nn import functional as F
 
 if is_accelerate_available():
-    from accelerate import init_empty_weights
+    pass
 
 
 logger = logging.get_logger(__name__)
@@ -574,7 +572,9 @@ class FP8Expert(nn.Module):
         # Note: We create new Parameters because copy_() doesn't change dtype
         gate_up_f32 = torch.empty_like(self.gate_up_proj, dtype=torch.float32)
         nn.init.xavier_uniform_(gate_up_f32)
-        self.gate_up_proj = nn.Parameter(gate_up_f32.clamp(min=torch.finfo(dtype).min, max=torch.finfo(dtype).max).to(dtype))
+        self.gate_up_proj = nn.Parameter(
+            gate_up_f32.clamp(min=torch.finfo(dtype).min, max=torch.finfo(dtype).max).to(dtype)
+        )
 
         # Initialize down_proj in float32, clamp to FP8 range, then convert to FP8
         down_f32 = torch.empty_like(self.down_proj, dtype=torch.float32)
@@ -691,7 +691,7 @@ def replace_with_fp8_linear(
                 block_size=quantization_config.weight_block_size,
                 **module_kwargs,
             )
-        if new_module is not None :
+        if new_module is not None:
             model.set_submodule(module_name, new_module)
             has_been_replaced = True
 

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import nullcontext
+
 from ..core_model_loading import ConversionOps
 from ..quantizers.quantizers_utils import should_convert_module
 from ..utils import is_accelerate_available, is_torch_accelerator_available, is_torch_available, logging
@@ -413,7 +415,7 @@ def w8a8_block_fp8_matmul_compile(
     return output.to(output_dtype)
 
 
-class FP8Linear(nn.Linear):
+class FP8Linear(nn.Module):
     def __init__(
         self,
         in_features: int,
@@ -423,10 +425,13 @@ class FP8Linear(nn.Linear):
         block_size: tuple[int, int] | None = None,
         activation_scheme="dynamic",
     ):
-        super().__init__(in_features, out_features)
+        super().__init__()
 
-        # If block size is None, it means that we are doing per-tensor quantization
         self.block_size = block_size
+        self.dtype = dtype
+        self.in_features = in_features
+        self.out_features = out_features
+        # If block size is None, it means that we are doing per-tensor quantization
         self.activation_scheme = activation_scheme
 
         self.weight = torch.nn.Parameter(torch.empty(out_features, in_features, dtype=dtype))
@@ -447,6 +452,30 @@ class FP8Linear(nn.Linear):
             self.bias = nn.Parameter(torch.empty(self.out_features))
         else:
             self.register_parameter("bias", None)
+
+        # Even without this check, initialization is a no-op on meta device
+        # but it's still a good practice to check
+        if self.weight.device != torch.device("meta"):
+            self.reset_parameters()
+
+    # TODO: look into other initialization methods for FP8Linear especially for training when we have QAT
+    def reset_parameters(self) -> None:
+        """Initialize weights using Xavier uniform initialization, clamped to FP8 range."""
+        if self.block_size is None:
+            self.weight_scale_inv.data.fill_(1.0)
+        else:
+            nn.init.ones_(self.weight_scale_inv)
+
+        dtype = torch.float8_e4m3fn
+
+        # Initialize in float32, clamp to FP8 range, then convert to FP8
+        # Note: We create a new Parameter because copy_() doesn't change dtype
+        weight_f32 = torch.empty(self.out_features, self.in_features, dtype=torch.float32, device=self.weight.device)
+        nn.init.xavier_uniform_(weight_f32)
+        self.weight = nn.Parameter(weight_f32.clamp(min=torch.finfo(dtype).min, max=torch.finfo(dtype).max).to(dtype))
+
+        if self.bias is not None:
+            nn.init.zeros_(self.bias)
 
     def forward(self, input: torch.Tensor) -> torch.Tensor:
         if self.weight.element_size() > 1:
@@ -501,6 +530,7 @@ class FP8Expert(nn.Module):
         from ..activations import ACT2FN
 
         self.block_size = block_size
+        self.dtype = dtype
         self.num_experts = config.num_local_experts
         self.hidden_dim = config.hidden_size
         self.intermediate_dim = config.intermediate_size
@@ -534,6 +564,35 @@ class FP8Expert(nn.Module):
         # Activation used in the MLP (same as your config / ACT2FN)
         # Keep a handle here; actual usage happens in forward of your MoE block
         self.act_fn = ACT2FN[config.hidden_act]
+
+        # Even without this check, initialization is a no-op on meta device
+        # but it's still a good practice to check
+        if self.gate_up_proj.device != torch.device("meta"):
+            self.reset_parameters()
+
+    def reset_parameters(self) -> None:
+        """Initialize weights using Xavier uniform initialization, clamped to FP8 range."""
+        dtype = torch.float8_e4m3fn
+
+        # Initialize gate_up_proj in float32, clamp to FP8 range, then convert to FP8
+        # Note: We create new Parameters because copy_() doesn't change dtype
+        gate_up_f32 = torch.empty_like(self.gate_up_proj, dtype=torch.float32)
+        nn.init.xavier_uniform_(gate_up_f32)
+        self.gate_up_proj = nn.Parameter(gate_up_f32.clamp(min=torch.finfo(dtype).min, max=torch.finfo(dtype).max).to(dtype))
+
+        # Initialize down_proj in float32, clamp to FP8 range, then convert to FP8
+        down_f32 = torch.empty_like(self.down_proj, dtype=torch.float32)
+        nn.init.xavier_uniform_(down_f32)
+        self.down_proj = nn.Parameter(down_f32.clamp(min=torch.finfo(dtype).min, max=torch.finfo(dtype).max).to(dtype))
+
+        # Initialize scale tensors
+        nn.init.ones_(self.gate_up_proj_scale_inv)
+        nn.init.ones_(self.down_proj_scale_inv)
+
+        if self.gate_up_proj_bias is not None:
+            nn.init.zeros_(self.gate_up_proj_bias)
+        if self.down_proj_bias is not None:
+            nn.init.zeros_(self.down_proj_bias)
 
     def forward(
         self,
@@ -592,7 +651,10 @@ class FP8Expert(nn.Module):
 
 
 def replace_with_fp8_linear(
-    model, modules_to_not_convert: list[str] | None = None, quantization_config=None, pre_quantized=False
+    model,
+    modules_to_not_convert: list[str] | None = None,
+    quantization_config=None,
+    pre_quantized=False,
 ):
     """
     A helper function to replace all `torch.nn.Linear` modules by `FP8Linear` modules.
@@ -604,7 +666,7 @@ def replace_with_fp8_linear(
             Names of the modules to not convert. In practice we keep the `lm_head` in full precision for numerical stability reasons.
         quantization_config (`FbgemmFp8Config`):
             The quantization config object that contains the quantization parameters.
-        pre_quantized (`book`, defaults to `False`):
+        pre_quantized (`bool`, defaults to `False`):
             Whether the model is pre-quantized or not
     """
 
@@ -618,23 +680,24 @@ def replace_with_fp8_linear(
         # we need this to correctly materialize the weights during quantization
         module_kwargs = {} if pre_quantized else {"dtype": None}
         new_module = None
-        with init_empty_weights():
-            if module_name.endswith(".experts"):
-                new_module = FP8Expert(
-                    config=model.config, block_size=quantization_config.weight_block_size, **module_kwargs
-                )
-            elif isinstance(module, nn.Linear):
-                new_module = FP8Linear(
-                    in_features=module.in_features,
-                    out_features=module.out_features,
-                    bias=module.bias is not None,
-                    activation_scheme=quantization_config.activation_scheme,
-                    block_size=quantization_config.weight_block_size,
-                    **module_kwargs,
-                )
-            if new_module is not None:
-                model.set_submodule(module_name, new_module)
-                has_been_replaced = True
+
+        if module_name.endswith(".experts"):
+            new_module = FP8Expert(
+                config=model.config, block_size=quantization_config.weight_block_size, **module_kwargs
+            )
+
+        elif isinstance(module, nn.Linear):
+            new_module = FP8Linear(
+                in_features=module.in_features,
+                out_features=module.out_features,
+                bias=module.bias is not None,
+                activation_scheme=quantization_config.activation_scheme,
+                block_size=quantization_config.weight_block_size,
+                **module_kwargs,
+            )
+        if new_module is not None :
+            model.set_submodule(module_name, new_module)
+            has_been_replaced = True
 
     if not has_been_replaced:
         logger.warning(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -215,6 +215,7 @@ def no_init_weights():
         for name, init_func in TORCH_INIT_FUNCTIONS.items():
             setattr(torch.nn.init, name, init_func)
 
+
 @contextmanager
 def set_quantized_state():
     global _is_quantized
@@ -1495,7 +1496,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             dtype (`torch.dtype`, *optional*):
                 Override the default `dtype` and load the model under this dtype.
         """
-        from .quantizers.auto import AutoHfQuantizer
 
         # For BC on the old `torch_dtype`
         dtype = kwargs.pop("dtype", config.dtype)
@@ -1519,7 +1519,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             quant_method = getattr(quantization_config, "quant_method", None)
             # Only FP8 quantization methods are supported in _from_config
             if quant_method in (QuantizationMethod.FP8):
-                hf_quantizer, config, _ = get_hf_quantizer(config, quantization_config, device_map=None, weights_only=False, user_agent=None)
+                hf_quantizer, config, _ = get_hf_quantizer(
+                    config, quantization_config, device_map=None, weights_only=False, user_agent=None
+                )
             else:
                 logger.warning_once(
                     f"Quantization method `{quant_method}` is not supported in `_from_config`. "

--- a/src/transformers/quantizers/auto.py
+++ b/src/transformers/quantizers/auto.py
@@ -334,5 +334,7 @@ def get_hf_quantizer(config, quantization_config, device_map, weights_only, user
         # In order to ensure popular quantization methods are supported. Can be disable with `disable_telemetry`
         if not getattr(hf_quantizer.quantization_config, "dequantize", False):
             quant_method = hf_quantizer.quantization_config.quant_method
-            user_agent["quant"] = getattr(quant_method, "value", quant_method)
+            if user_agent is not None:
+                user_agent["quant"] = getattr(quant_method, "value", quant_method)
+
     return hf_quantizer, config, device_map


### PR DESCRIPTION
# What does this PR do?

Make the FP8 logic accessible from `from_config` instead of having to call `from_pretrained`
