### PR TITLE
[Quantization] Removing misleading int8 quantization in Finegrained FP8

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -37,9 +37,7 @@ try:
 except AttributeError:
     _FP8_DTYPE = None
     _FP8_MIN, _FP8_MAX = -448, 448
-    logger.warning_once(
-        "torch.float8_e4m3fn not available"
-    )
+    logger.warning_once("torch.float8_e4m3fn not available")
 
 
 # Copied from https://huggingface.co/deepseek-ai/DeepSeek-V3/blob/main/inference/kernel.py

--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -34,13 +34,11 @@ try:
     _FP8_DTYPE = torch.float8_e4m3fn
     _FP8_MIN = torch.finfo(_FP8_DTYPE).min
     _FP8_MAX = torch.finfo(_FP8_DTYPE).max
-    _FP8_IS_INT = False
 except AttributeError:
-    _FP8_DTYPE = torch.int8
-    _FP8_MIN, _FP8_MAX = -127, 127
-    _FP8_IS_INT = True
+    _FP8_DTYPE = None
+    _FP8_MIN, _FP8_MAX = -448, 448
     logger.warning_once(
-        "torch.float8_e4m3fn not available; falling back to int8 emulation for Fp8Quantize operations."
+        "torch.float8_e4m3fn not available"
     )
 
 
@@ -701,10 +699,7 @@ class Fp8Quantize(ConversionOps):
         scales_broadcast = scales.unsqueeze(-1).unsqueeze(-3)  # -> (..., rows_tiles, 1, cols_tiles, 1)
         scaled = reshaped * scales_broadcast
 
-        if _FP8_IS_INT:
-            quantized = torch.clamp(scaled.round(), min=_FP8_MIN, max=_FP8_MAX).to(_FP8_DTYPE)
-        else:
-            quantized = torch.clamp(scaled, min=_FP8_MIN, max=_FP8_MAX).to(_FP8_DTYPE)
+        quantized = torch.clamp(scaled, min=_FP8_MIN, max=_FP8_MAX).to(_FP8_DTYPE)
 
         quantized = quantized.reshape(original_shape)
 

--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -48,7 +48,8 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
             if (major < 8) or (major == 8 and minor < 9):
                 logger.warning_once(
                     "FP8 quantized models is only supported on GPUs with compute capability >= 8.9 (e.g 4090/H100)"
-                    f", actual = `{major}.{minor}`. We will default to dequantizing the model to bf16 "
+                    f", actual = `{major}.{minor}`. We will default to dequantizing the model to bf16. Feel free "
+                    f"to use a different quantization method like bitsandbytes or torchao"
                 )
                 self.quantization_config.dequantize = True
                 return


### PR DESCRIPTION
# What does this PR do?

instead of falling to int8 quantization, which we don't do for now since we validate that the environment has a `8.9` compute capability at least, we just ask the user to use an other quantization method