### PR TITLE
Fix QA max_answer_len validation error message

### DIFF
--- a/src/transformers/pipelines/question_answering.py
+++ b/src/transformers/pipelines/question_answering.py
@@ -328,7 +328,7 @@ class QuestionAnsweringPipeline(ChunkPipeline):
             postprocess_params["top_k"] = top_k
         if max_answer_len is not None:
             if max_answer_len < 1:
-                raise ValueError(f"max_answer_len parameter should be >= 1 (got {max_answer_len}")
+                raise ValueError(f"max_answer_len parameter should be >= 1 (got {max_answer_len})")
             postprocess_params["max_answer_len"] = max_answer_len
         if handle_impossible_answer is not None:
             postprocess_params["handle_impossible_answer"] = handle_impossible_answer

--- a/tests/pipelines/test_pipelines_question_answering.py
+++ b/tests/pipelines/test_pipelines_question_answering.py
@@ -546,3 +546,9 @@ class QuestionAnsweringArgumentHandlerTests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             qa(1)
+
+class QuestionAnsweringPipelineSanitizeParametersTests(unittest.TestCase):
+    def test_sanitize_parameters_max_answer_len_error_message(self):
+        qa = object.__new__(QuestionAnsweringPipeline)
+        with self.assertRaisesRegex(ValueError, r"max_answer_len parameter should be >= 1 \(got 0\)"):
+            qa._sanitize_parameters(max_answer_len=0)


### PR DESCRIPTION
Summary
This PR fixes a small typo in QuestionAnsweringPipeline._sanitize_parameters() where the ValueError raised for invalid max_answer_len was missing a closing parenthesis in the "(got ...)" portion of the message.

Changes
- Fix malformed ValueError message for max_answer_len validation in:
  - src/transformers/pipelines/question_answering.py
- Add a lightweight regression test (no model downloads) that asserts the error message is well-formed:
  - tests/pipelines/test_pipelines_question_answering.py

Testing
- python -m pytest tests/pipelines/test_pipelines_question_answering.py -k sanitize_parameters_max_answer_len_error_message -q