### PR TITLE
[`Generation`] Fix default overwrite for non-`None` defaults

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1805,7 +1805,7 @@ class GenerationMixin(ContinuousMixin):
                 for k, v in self.generation_config.to_dict().items()
                 if isinstance(v, bool)
                 and hasattr(default_generation_config, k)
-                and getattr(generation_config, k) == getattr(default_generation_config, k)
+                and getattr(generation_config, k, None) == getattr(default_generation_config, k)
             }
         )
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1788,6 +1788,10 @@ class GenerationMixin(ContinuousMixin):
         # with ``strict=True``. deepcopy can only be processed if ``strict=False``.
         generation_config = copy.deepcopy(generation_config)
 
+        # Due to some values being boolean and not `None`, we need additional logic to overwrite
+        # them explicitly (`defaults_only=False`)
+        generation_config.update(**{k: v for k, v in self.generation_config.to_dict().items() if isinstance(v, bool)})
+
         # First set values from the loaded `self.generation_config`, then set default values (BC)
         # Do not update any values that aren't `None`, i.e. if set by users explicitly and passed
         # to `generate()`. Thus the `defaults_only=True` is used

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1773,7 +1773,6 @@ class GenerationMixin(ContinuousMixin):
         # TODO: (raushan) doesn't make sense to allow kwargs and `generation_config`. Should be mutually exclusive!
         # TODO (joao): per-model generation config classes.
 
-        default_generation_config = GenerationConfig()
         if generation_config is None:
             # Users may modify `model.config` to control generation. This is a legacy behavior and is not supported anymore
             if len(self.config._get_generation_parameters()) > 0:
@@ -1797,13 +1796,16 @@ class GenerationMixin(ContinuousMixin):
         generation_config.update(**global_defaults, defaults_only=True)
 
         # Due to some values being boolean and not `None`, we need additional logic to overwrite
-        # them explicitly (`defaults_only=False`) on the condition that it is something different
-        # than the default value of that item
+        # them explicitly (`defaults_only=False`) on the condition that it's only a previous
+        # default value
+        default_generation_config = GenerationConfig()
         generation_config.update(
             **{
                 k: v
                 for k, v in self.generation_config.to_dict().items()
-                if isinstance(v, bool) and getattr(generation_config, k) == getattr(default_generation_config, k)
+                if isinstance(v, bool)
+                and hasattr(default_generation_config, k)
+                and getattr(generation_config, k) == getattr(default_generation_config, k)
             }
         )
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -4802,6 +4802,25 @@ class GenerationIntegrationTests(unittest.TestCase):
         output = model.generate(**generation_kwargs, **model_inputs)
         self.assertEqual(output.sequences.shape, (1, 9))
 
+    def test_model_generation_config_can_override_defaults(self):
+        """Sanity check that the model samples, not ignoring the model's generation config"""
+        torch.manual_seed(42)  # make it deterministic
+
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM").eval()
+        model = model.to(torch_device)
+
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-LlamaForCausalLM")
+        model_inputs = tokenizer(["Write a poem about the market crashing in summer"], return_tensors="pt")
+        model_inputs = model_inputs.to(model.device)
+
+        # Overwrite default value or sampling
+        model.generation_config.do_sample = True
+        output = model.generate(**model_inputs, max_new_tokens=32)
+
+        EXPECTED_TEXT = 'Write a poem about the market crashing in summersong contradictionPr aucitated realiz Comicsflutterąc inventминцій Glad:` Raymond moreover KulturMillteger мартаTEXT CFщая Русбе Świ Sendlink heuresListener Luigiaceae'  # fmt: skip
+        output = tokenizer.decode(output[0], skip_special_tokens=True)
+        self.assertTrue(output == EXPECTED_TEXT)
+
 
 @require_torch
 class TokenHealingTestCase(unittest.TestCase):


### PR DESCRIPTION
Followup to #42702 where defaults are now either `None` or a boolean value. 

The logic was dependent on the values being `None` which ignored overriding other values, e.g. `do_sample`. The fails due to this can be seen in a few integration tests, e.g. gpt2.