### PR TITLE
Feature/add max eval steps

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4471,6 +4471,10 @@ class Trainer:
 
         # Main evaluation loop
         for step, inputs in enumerate(dataloader):
+            # Stop evaluation early if max_eval_steps is set — added as part of issue #31561 fix by @priyankaz-ml
+            if self.args.max_eval_steps is not None and step >= self.args.max_eval_steps:
+             \ break
+
             # Update the observed num examples
             observed_batch_size = find_batch_size(inputs)
             if observed_batch_size is not None:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4231,44 +4231,24 @@ class Trainer:
         ignore_keys: list[str] | None = None,
         metric_key_prefix: str = "eval",
     ) -> dict[str, float]:
-        """
-        Run evaluation and returns metrics.
+       """
+    Run evaluation and returns metrics.
 
-        The calling script will be responsible for providing a method to compute metrics, as they are task-dependent
-        (pass it to the init `compute_metrics` argument).
+    The calling script will be responsible for providing a method to compute metrics, as they are task-dependent
+    (pass it to the init `compute_metrics` argument).
 
-        You can also subclass and override this method to inject custom behavior.
+    You can also subclass and override this method to inject custom behavior.
 
-        Args:
-            eval_dataset (Union[`Dataset`, dict[str, `Dataset`]], *optional*):
-                Pass a dataset if you wish to override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns
-                not accepted by the `model.forward()` method are automatically removed. If it is a dictionary, it will
-                evaluate on each dataset, prepending the dictionary key to the metric name. Datasets must implement the
-                `__len__` method.
-
-                <Tip>
-
-                If you pass a dictionary with names of datasets as keys and datasets as values, evaluate will run
-                separate evaluations on each dataset. This can be useful to monitor how training affects other
-                datasets or simply to get a more fine-grained evaluation.
-                When used with `load_best_model_at_end`, make sure `metric_for_best_model` references exactly one
-                of the datasets. If you, for example, pass in `{"data1": data1, "data2": data2}` for two datasets
-                `data1` and `data2`, you could specify `metric_for_best_model="eval_data1_loss"` for using the
-                loss on `data1` and `metric_for_best_model="eval_data2_loss"` for the loss on `data2`.
-
-                </Tip>
-
-            ignore_keys (`list[str]`, *optional*):
-                A list of keys in the output of your model (if it is a dictionary) that should be ignored when
-                gathering predictions.
-            metric_key_prefix (`str`, *optional*, defaults to `"eval"`):
-                An optional prefix to be used as the metrics key prefix. For example the metrics "bleu" will be named
-                "eval_bleu" if the prefix is "eval" (default)
-
-        Returns:
-            A dictionary containing the evaluation loss and the potential metrics computed from the predictions. The
-            dictionary also contains the epoch number which comes from the training state.
-        """
+    Args:
+        eval_dataset (Union[Dataset, dict[str, Dataset]], *optional*):
+            Pass a dataset if you wish to override `self.eval_dataset`. If it is a [`~datasets.Dataset`], columns not
+            accepted by the `model.forward()` method are automatically removed. If it is a dictionary, it will evaluate
+            on each dataset, prepending the dictionary key to the metric name. Datasets must implement the
+            `__len__` method.
+        max_eval_steps (`int`, *optional*):
+            If set, limits the number of batches used during evaluation. Evaluation will stop once this threshold
+            is reached, even if the dataset has more batches.
+    """
         # handle multiple eval datasets
         override = eval_dataset is not None
         eval_dataset = eval_dataset if override else self.eval_dataset

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -809,6 +809,12 @@ class TrainingArguments:
         default=1,
         metadata={"help": "Number of updates steps to accumulate before performing a backward/update pass."},
     )
+    # Added as part of issue #31561 fix by @priyankaz-ml — allows users to limit evaluation to a fixed number of batches
+    max_eval_steps: Optional[int] = field(
+    default=None,
+    metadata={"help": "If set, limits the number of batches used during evaluation."}
+    )
+
     eval_accumulation_steps: int | None = field(
         default=None,
         metadata={"help": "Number of predictions steps to accumulate before moving the tensors to the CPU."},


### PR DESCRIPTION
Summary:
This PR introduces a new optional argument max_eval_steps to TrainingArguments and integrates it into the Trainer evaluation loop. When set, evaluation will stop after the specified number of batches, even if the dataset has more batches.

Changes:

Added max_eval_steps to TrainingArguments with documentation.

Updated Trainer.evaluation_loop() to break early when max_eval_steps is reached.

Updated evaluate() docstring to mention the new behavior.

Added inline comments for traceability (#31561).

Motivation:
Large evaluation datasets can be time-consuming. This feature allows users to limit evaluation runtime for quicker experiments and debugging.

Issue Reference: Fixes #31561