### PR TITLE
Fix incorrect library name in BitNet integration warning

### DIFF
--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -173,7 +173,7 @@ class BitLinear(nn.Module):
         Activation function : Performs symmetric, per-token quantization on the input activations.
         Parameters:
         -----------
-        x : torch.Tensor
+        input : torch.Tensor
             Input activations to be quantized.
         num_bits : int, optional (default=8)
             Number of bits to use for quantization, determining the quantization range.

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -92,7 +92,7 @@ def unpack_weights(packed: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
 
     Explanation of the example:
     ---------------------------
-    Let's take the first value for example 0b10100001, we we will only focus on the first column,
+    Let's take the first value for example 0b10100001, we will only focus on the first column,
     because every element is unpacked across the first dimension
     - First 2 bits: `01` → 0 at [0][0]
     - Second 2 bits: `00` → -1 at [0][2]

--- a/src/transformers/integrations/bitnet.py
+++ b/src/transformers/integrations/bitnet.py
@@ -365,7 +365,7 @@ def replace_with_bitnet_linear(model, modules_to_not_convert: list[str] | None =
 
     if not has_been_replaced:
         logger.warning(
-            "You are loading your model using eetq but no linear modules were found in your model."
+            "You are loading your model using bitnet but no linear modules were found in your model."
             " Please double check your model architecture, or submit an issue on github if you think this is"
             " a bug."
         )


### PR DESCRIPTION
# Fix Typos and Documentation Issues in BitNet Integration

## Summary
This PR addresses three minor issues in [src/transformers/integrations/bitnet.py](/transformers/src/transformers/integrations/bitnet.py:0:0-0:0) to improve code quality, documentation accuracy, and consistency.

## Issues Fixed
1. **Incorrect Warning Message**:
   The warning message logged when no linear modules are found during [replace_with_bitnet_linear](/transformers/src/transformers/integrations/bitnet.py:314:0-369:16) incorrectly referenced "eetq" instead of "bitnet" (likely due to a copy-paste error from the EETQ integration).

2. **Docstring Grammar**:
   Fixed a grammar error in the [unpack_weights](/transformers/src/transformers/integrations/bitnet.py:54:0-120:33) docstring where the word "we" was repeated ("we we").

3. **Docstring Parameter Mismatch**:
   The [activation_quant](/transformers/src/transformers/integrations/bitnet.py:166:4-188:43) method in [BitLinear](/transformers/src/transformers/integrations/bitnet.py:123:0-207:16) accepts an argument named `input`, but the docstring incorrectly listed it as `x`.

## Solution
- Updated the log message to accurately reflect the "bitnet" integration, avoiding confusion during debugging.
- Removed the duplicate "we" from the [unpack_weights](/transformers/src/transformers/integrations/bitnet.py:54:0-120:33) docstring for better readability.
- Corrected the parameter name in the [activation_quant](/transformers/src/transformers/integrations/bitnet.py:166:4-188:43) docstring to match the function signature (`x` → `input`).

## Files Changed
- `src/transformers/integrations/bitnet.py`