### PR TITLE
Fix dtype mismatch in in modeling_llava_next

### DIFF
--- a/src/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/transformers/models/llava_next/modeling_llava_next.py
@@ -665,7 +665,7 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
         hidden_states = outputs[0]
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        logits = self.lm_head(hidden_states[:, slice_indices, :])
+        logits = self.lm_head(hidden_states[:, slice_indices, :].to(self.lm_head.weight.dtype))
 
         loss = None
         if labels is not None:


### PR DESCRIPTION
# What does this PR do?

Fixes #42968

This PR fixes a `RuntimeError` when running `LlavaNextForConditionalGeneration` with mixed precision (e.g., BFloat16 vs Float16).

**The Fix:**
I added a cast `.to(self.lm_head.weight.dtype)` to `hidden_states` before passing it to `lm_head`. This ensures the input tensor matches the linear layer's weight type.

**Verification:**
Verified locally on T4 GPU using the reproduction script from the issue. The forward pass now completes without crashing.

## Who can review?
@zucchini-nlp
<img width="1919" height="839" alt="image" src="https://github.com/user-attachments/assets/97fb9339-b5b7-4e21-ab5c-58cd00538e96" />
<img width="1772" height="626" alt="image" src="https://github.com/user-attachments/assets/1c7dd455-3ecf-4bb5-a594-45d7e852fb36" />