### PR TITLE
Fix evaluation loop behavior when max_eval_steps is set

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4472,6 +4472,10 @@ class Trainer:
 
         # Main evaluation loop
         for step, inputs in enumerate(dataloader):
+
+            if self.args.max_eval_steps is not None and step >= self.args.max_eval_steps:
+                break
+
             # Update the observed num examples
             observed_batch_size = find_batch_size(inputs)
             if observed_batch_size is not None:
@@ -4552,6 +4556,12 @@ class Trainer:
         # Number of samples
         if has_length(eval_dataset):
             num_samples = len(eval_dataset)
+        else:
+            num_samples = observed_num_examples
+
+        # NEW: cap by max_eval_steps if set
+        if self.args.max_eval_steps is not None:
+            num_samples = min(num_samples, observed_num_examples)
         # The instance check is weird and does not actually check for the type, but whether the dataset has the right
         # methods. Therefore we need to make sure it also has the attribute.
         elif isinstance(eval_dataset, IterableDatasetShard) and getattr(eval_dataset, "num_examples", 0) > 0:

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4472,7 +4472,6 @@ class Trainer:
 
         # Main evaluation loop
         for step, inputs in enumerate(dataloader):
-
             if self.args.max_eval_steps is not None and step >= self.args.max_eval_steps:
                 break
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1369,15 +1369,17 @@ class TrainingArguments:
         },
     )
     
-    max_eval_steps: Optional[int] = field(
+    max_eval_steps: int | None = field(
         default=None,
         metadata={
             "help": (
                 "Maximum number of evaluation steps (batches) to run during evaluation. "
-                "Useful for debugging or very large evaluation datasets."
-        )
-    },
-)
+                "If set, evaluation will stop after this many steps even if the evaluation "
+                "dataset has more batches."
+            )
+        },
+    )
+
 
 
     batch_eval_metrics: bool = field(
@@ -1487,7 +1489,9 @@ class TrainingArguments:
                     f"evaluation strategy {self.eval_strategy} requires either non-zero --eval_steps or"
                     " --logging_steps"
                 )
-
+        if self.max_eval_steps is not None:
+            if not isinstance(self.max_eval_steps, int) or self.max_eval_steps <= 0:
+                raise ValueError("`max_eval_steps` must be a positive integer.")
         # logging_steps must be non-zero for logging_strategy that is other than 'no'
         if self.logging_strategy == IntervalStrategy.STEPS and self.logging_steps == 0:
             raise ValueError(f"logging strategy {self.logging_strategy} requires non-zero --logging_steps")

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1368,7 +1368,7 @@ class TrainingArguments:
             "help": "Target modules for the optimizer defined in the `optim` argument. Only used for the GaLore optimizer at the moment."
         },
     )
-    
+
     max_eval_steps: int | None = field(
         default=None,
         metadata={

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1368,6 +1368,17 @@ class TrainingArguments:
             "help": "Target modules for the optimizer defined in the `optim` argument. Only used for the GaLore optimizer at the moment."
         },
     )
+    
+    max_eval_steps: Optional[int] = field(
+        default=None,
+        metadata={
+            "help": (
+                "Maximum number of evaluation steps (batches) to run during evaluation. "
+                "Useful for debugging or very large evaluation datasets."
+        )
+    },
+)
+
 
     batch_eval_metrics: bool = field(
         default=False,

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1380,8 +1380,6 @@ class TrainingArguments:
         },
     )
 
-
-
     batch_eval_metrics: bool = field(
         default=False,
         metadata={"help": "Break eval metrics calculation into batches to save memory."},


### PR DESCRIPTION
This PR follows up on #41299 and fixes remaining issues around max_eval_steps.

- Adds max_eval_steps to TrainingArguments
- Limits evaluation by number of batches
- Fixes num_samples handling for iterable datasets
- Preserves callback event ordering

All trainer tests pass locally.
