### PR TITLE
[loading][TP] Fix device placement at loading-time, and simplify sharding primitives

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -712,13 +712,13 @@ def spawn_materialize(
 
 
 def spawn_tp_materialize(
-    thread_pool: ThreadPoolExecutor | None, tensor: torch.Tensor, sharding_method, tensor_idx, dtype=None
+    thread_pool: ThreadPoolExecutor | None, tensor: torch.Tensor, sharding_method, tensor_idx, device=None, dtype=None
 ) -> Future | Callable:
     """Materialize and shard a tensor (according to the TP-plan) from file asynchronously if `thread_pool` is provided, or
     return a Callable that will load the tensor synchronously when called."""
 
     def _job():
-        return sharding_method.shard_tensor(tensor, param_casting_dtype=dtype, tensor_idx=tensor_idx)[0]
+        return sharding_method.shard_tensor(tensor, tensor_idx=tensor_idx, device=device, dtype=dtype)
 
     if thread_pool is not None:
         return thread_pool.submit(_job)
@@ -796,20 +796,18 @@ def set_param_for_module(
     if ref is None:
         unexpected_keys.add(target_name)
     else:
-        use_dtensor = hasattr(distributed_operation, "use_dtensor") and distributed_operation.use_dtensor
         if not isinstance(param_value, torch.nn.Parameter):
             if distributed_operation is not None:
-                param_value = DTensor.from_local(
-                    param_value,
-                    distributed_operation.device_mesh,
-                    getattr(distributed_operation, "shard", Replicate()),
-                    run_check=False,
-                    shape=ref.size(),
-                    stride=ref.stride(),
-                )
-                if not use_dtensor:
-                    # we convert to local
-                    param_value = param_value.to_local()
+                use_dtensor = getattr(distributed_operation, "use_dtensor", False)
+                if use_dtensor:
+                    param_value = DTensor.from_local(
+                        param_value,
+                        distributed_operation.device_mesh,
+                        getattr(distributed_operation, "shard", Replicate()),
+                        run_check=False,
+                        shape=ref.size(),
+                        stride=ref.stride(),
+                    )
             if param_name not in module_obj._buffers:
                 param_value = torch.nn.Parameter(param_value, requires_grad=param_value.is_floating_point())
 

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1076,7 +1076,7 @@ def convert_and_load_state_dict_in_model(
                         tensor,
                         mapping.distributed_operation,
                         shard_index,
-                        device_map[""].index,
+                        device_map[""],
                         _dtype,
                     )
 

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -798,8 +798,7 @@ def set_param_for_module(
     else:
         if not isinstance(param_value, torch.nn.Parameter):
             if distributed_operation is not None:
-                use_dtensor = getattr(distributed_operation, "use_dtensor", False)
-                if use_dtensor:
+                if getattr(distributed_operation, "use_dtensor", False):
                     param_value = DTensor.from_local(
                         param_value,
                         distributed_operation.device_mesh,
@@ -1077,6 +1076,7 @@ def convert_and_load_state_dict_in_model(
                         tensor,
                         mapping.distributed_operation,
                         shard_index,
+                        device_map[""].index,
                         _dtype,
                     )
 

--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -19,6 +19,9 @@ import os
 import re
 from functools import partial, reduce
 
+from ..distributed import DistributedConfig
+from ..utils import is_torch_greater_or_equal, logging
+from ..utils.generic import GeneralInterface
 from ..utils.import_utils import is_torch_available
 
 
@@ -27,19 +30,14 @@ if is_torch_available():
     import torch.distributed as dist
     from torch import nn
 
-from ..distributed import DistributedConfig
-from ..utils import is_torch_greater_or_equal, logging
-from ..utils.generic import GeneralInterface
-
-
-logger = logging.get_logger(__name__)
-
-if is_torch_available():
     # Cache this result has it's a C FFI call which can be pretty time-consuming
     _torch_distributed_available = torch.distributed.is_available()
 
     if is_torch_greater_or_equal("2.5") and _torch_distributed_available:
         from torch.distributed.tensor import DTensor, Placement, Replicate, Shard
+
+
+logger = logging.get_logger(__name__)
 
 
 def initialize_tensor_parallelism(


### PR DESCRIPTION
# What does this PR do?

As per the title.
Device placement was not correct during loading. It would be loaded on cpu, and only moved thanks to the `param_value = DTensor.from_local(` call in `set_param_for_module` function that would implicitly set it to the correct device. However, this is less efficient than doing it during loading directly.

For llama3 70B and TP 8, it goes from ~9s to ~6.5s in loading time for the following code:

```python
from transformers import AutoModelForCausalLM
import torch
import time
import os

model_id = "meta-llama/Llama-3.3-70B-Instruct"

rank = int(os.environ["RANK"])
world_size = int(os.environ["WORLD_SIZE"])
device = torch.device(f"cuda:{rank}")
# Need to be initialized explicitly to use the `barrier` before loading
torch.distributed.init_process_group(backend="nccl", rank=rank, world_size=world_size, device_id=rank)

torch.cuda.synchronize(device)
torch.distributed.barrier()
t0 = time.time()
model = AutoModelForCausalLM.from_pretrained(model_id, tp_plan="auto")
torch.cuda.synchronize(device)
torch.distributed.barrier()
dt = time.time() - t0
if rank == 0:
    print(f"Took {dt:.2f} s")

torch.distributed.destroy_process_group()
```

So it's quite a big difference.

Also, there was a lot of redundancy and useless args in sharding primitive functions. This PR cleans it.