### PR TITLE
Fix InvalidVersion error when flash_attn version cannot be determined

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -890,14 +890,17 @@ def is_flash_attn_2_available() -> bool:
 
     import torch
 
-    if torch.version.cuda:
-        return version.parse(flash_attn_version) >= version.parse("2.1.0")
-    elif torch.version.hip:
-        # TODO: Bump the requirement to 2.1.0 once released in https://github.com/ROCmSoftwarePlatform/flash-attention
-        return version.parse(flash_attn_version) >= version.parse("2.0.4")
-    elif is_torch_mlu_available():
-        return version.parse(flash_attn_version) >= version.parse("2.3.3")
-    else:
+    try:
+        if torch.version.cuda:
+            return version.parse(flash_attn_version) >= version.parse("2.1.0")
+        elif torch.version.hip:
+            # TODO: Bump the requirement to 2.1.0 once released in https://github.com/ROCmSoftwarePlatform/flash-attention
+            return version.parse(flash_attn_version) >= version.parse("2.0.4")
+        elif is_torch_mlu_available():
+            return version.parse(flash_attn_version) >= version.parse("2.3.3")
+        else:
+            return False
+    except packaging.version.InvalidVersion:
         return False
 
 
@@ -915,7 +918,12 @@ def is_flash_attn_greater_or_equal_2_10() -> bool:
 @lru_cache
 def is_flash_attn_greater_or_equal(library_version: str) -> bool:
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
-    return is_available and version.parse(flash_attn_version) >= version.parse(library_version)
+    if not is_available:
+        return False
+    try:
+        return version.parse(flash_attn_version) >= version.parse(library_version)
+    except packaging.version.InvalidVersion:
+        return False
 
 
 @lru_cache


### PR DESCRIPTION
## Problem

When `flash_attn_3` is installed without `flash_attn` (v2), calling `is_flash_attn_2_available()` raises:
```
packaging.version.InvalidVersion: Invalid version: 'N/A'
```

This happens because the `flash_attn` module is importable but its version cannot be determined, so `_is_package_available` returns `"N/A"`, which `version.parse()` cannot handle.

## Fix

Wrap version parsing in `try/except packaging.version.InvalidVersion`, returning `False` when the version is unparseable. This matches the existing pattern in `is_torch_available()` (lines 112-119).

## Note for maintainers

This fix works but is somewhat repetitive - the same try/except pattern now exists in three places. A cleaner long-term solution might be:

1. A `_parse_version_safe()` helper used across the file
2. Having `_is_package_available` return `None` instead of `"N/A"` for undetermined versions
3. Auditing other `version.parse()` calls that could hit similar issues

Happy to refactor if preferred, but kept this minimal to match existing patterns.

Fixes #42999