### PR TITLE
Fix typos: Remove duplicate duplicate words words

### DIFF
--- a/MIGRATION_GUIDE_V5.md
+++ b/MIGRATION_GUIDE_V5.md
@@ -197,7 +197,7 @@ This tokenizer will behave as a Llama-like tokenizer, with an updated vocabulary
 
 **Simplified file loading:** Support is added for passing`vocab` and `merges` as file paths directly to tokenizer initialization. The tokenizer will automatically detect the format (SentencePiece `.model`, Tekken `tekken.json`, or plain vocab/merges files) for loading. For BPE tokenizers, if a vocab is provided but no merges, merges will be automatically generated (excluding special tokens).
 
-Note: Loading from file paths with `vocab="<path_to_a_file>"`'s primary goal is to allow you to do some quick testing, but for `BPE` models for example we don't check wether you properly passed the merges or not. 
+Note: Loading from file paths with `vocab="<path_to_a_file>"`'s primary goal is to allow you to do some quick testing, but for `BPE` models for example we don't check whether you properly passed the merges or not. 
 
 #### 2. Simplified decoding API
 
@@ -524,7 +524,7 @@ Linked PRs:
 - Old, deprecated output type aliases were removed (e.g. `GreedySearchEncoderDecoderOutput`). We now only have 4 output classes built from the following matrix: decoder-only vs encoder-decoder, uses beams vs doesn't use beams (https://github.com/huggingface/transformers/pull/40998)
 - Removed deprecated classes regarding decoding methods that were moved to the Hub due to low usage (constraints and beam scores) (https://github.com/huggingface/transformers/pull/41223)
 - If `generate` doesn't receive any KV Cache argument, the default cache class used is now defined by the model (as opposed to always being `DynamicCache`) (https://github.com/huggingface/transformers/pull/41505)
-- Generation parameters are no longer accessible via model's config. If generation paramaters are serialized in `config.json` for any old model, it will be loaded back into model's generation config. Users are expected to access or modify generation parameters only with `model.generation_config.do_sample = True`. 
+- Generation parameters are no longer accessible via model's config. If generation parameters are serialized in `config.json` for any old model, it will be loaded back into model's generation config. Users are expected to access or modify generation parameters only with `model.generation_config.do_sample = True`. 
 
 ## Trainer
 

--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -430,7 +430,7 @@ class StopStringCriteria(StoppingCriteria):
         initial_match = end_lengths > 0
 
         # Tokens continue the string if the cumsum() so far is one of the valid positions for that token
-        # Note that we're actually tracking one cumsum() for for each possible end_length
+        # Note that we're actually tracking one cumsum() for each possible end_length
         later_match = torch.any(cumsum[:, :-1, :, None] == valid_positions[:, :, :, :, None], axis=-2)
 
         # The match vector is a boolean vector that indicates which positions have valid tokens

--- a/src/transformers/models/clap/feature_extraction_clap.py
+++ b/src/transformers/models/clap/feature_extraction_clap.py
@@ -71,7 +71,7 @@ class ClapFeatureExtractor(SequenceFeatureExtractor):
             Truncation pattern for long audio inputs. Two patterns are available:
                 - `fusion` will use `_random_mel_fusion`, which stacks 3 random crops from the mel spectrogram and a
                   downsampled version of the entire mel spectrogram.
-            If `config.fusion` is set to True, shorter audios also need to to return 4 mels, which will just be a copy
+            If `config.fusion` is set to True, shorter audios also need to return 4 mels, which will just be a copy
             of the original mel obtained from the padded audio.
                 - `rand_trunc` will select a random crop of the mel spectrogram.
         padding (`str`, *optional*, defaults to `"repeatpad"`):
@@ -279,7 +279,7 @@ class ClapFeatureExtractor(SequenceFeatureExtractor):
                 Truncation pattern for long audio inputs. Two patterns are available:
                     - `fusion` will use `_random_mel_fusion`, which stacks 3 random crops from the mel spectrogram and
                       a downsampled version of the entire mel spectrogram.
-                If `config.fusion` is set to True, shorter audios also need to to return 4 mels, which will just be a
+                If `config.fusion` is set to True, shorter audios also need to return 4 mels, which will just be a
                 copy of the original mel obtained from the padded audio.
                     - `rand_trunc` will select a random crop of the mel spectrogram.
             padding (`str`, *optional*):

--- a/src/transformers/models/dia/processing_dia.py
+++ b/src/transformers/models/dia/processing_dia.py
@@ -74,7 +74,7 @@ class DiaProcessor(ProcessorMixin):
         tokenizer (`DiaTokenizer`):
             An instance of [`DiaTokenizer`]. The tokenizer is a required input.
         audio_tokenizer (`DacModel`):
-            An instance of [`DacModel`] used to encode/decode audio into/from codebooks. It is is a required input.
+            An instance of [`DacModel`] used to encode/decode audio into/from codebooks. It is a required input.
     """
 
     audio_tokenizer_class = "DacModel"

--- a/src/transformers/models/hunyuan_v1_moe/configuration_hunyuan_v1_moe.py
+++ b/src/transformers/models/hunyuan_v1_moe/configuration_hunyuan_v1_moe.py
@@ -177,7 +177,7 @@ class HunYuanMoEV1Config(PreTrainedConfig):
 
         if not isinstance(self.rope_parameters, dict) or len(self.rope_parameters) != 2:
             raise ValueError(
-                "`rope_parameters` must be a dictionary with with two fields, `type` and `factor` or `type` and `alpha`, "
+                "`rope_parameters` must be a dictionary with two fields, `type` and `factor` or `type` and `alpha`,"
                 f"got {self.rope_parameters}"
             )
         rope_parameters_type = self.rope_parameters.get("type", None)

--- a/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/configuration_omdet_turbo.py
@@ -68,7 +68,7 @@ class OmDetTurboConfig(PreTrainedConfig):
         class_embed_dim (`int`, *optional*, defaults to 512):
             The dimension of the classes embeddings.
         class_distance_type (`str`, *optional*, defaults to `"cosine"`):
-            The type of of distance to compare predicted classes to projected classes embeddings.
+            The type of distance to compare predicted classes to projected classes embeddings.
             Can be `"cosine"` or `"dot"`.
         num_queries (`int`, *optional*, defaults to 900):
             The number of queries.

--- a/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
+++ b/src/transformers/models/qwen2_audio/modeling_qwen2_audio.py
@@ -477,7 +477,7 @@ class Qwen2AudioForConditionalGeneration(Qwen2AudioPreTrainedModel, GenerationMi
         self, audio_features, num_audio_tokens, inputs_embeds, input_ids, attention_mask, labels
     ):
         """
-        Merge input_ids with with audio features into final embeddings
+        Merge input_ids with audio features into final embeddings
 
         Args:
             audio_features (`torch.Tensor` of shape `(num_audios, max_audio_tokens, embed_dim)`):

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -111,7 +111,7 @@ class SwitchTransformersTop1Router(nn.Module):
         router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
         expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
         token_priority = torch.cumsum(expert_index, dim=-2)
-        # mask if the token routed to to the expert will overflow
+        # mask if the token routed to the expert will overflow
         expert_capacity_mask = token_priority <= self.expert_capacity
         expert_index = expert_index * expert_capacity_mask
         router_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -170,7 +170,7 @@ class SwitchTransformersTop1Router(nn.Module):
         router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
         expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
         token_priority = torch.cumsum(expert_index, dim=-2)
-        # mask if the token routed to to the expert will overflow
+        # mask if the token routed to the expert will overflow
         expert_capacity_mask = token_priority <= self.expert_capacity
         expert_index = expert_index * expert_capacity_mask
         router_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)

--- a/src/transformers/models/xcodec/modeling_xcodec.py
+++ b/src/transformers/models/xcodec/modeling_xcodec.py
@@ -519,7 +519,7 @@ class XcodecModel(XcodecPreTrainedModel):
         e_semantic = self.encoder_semantic(e_semantic_input.transpose(1, 2))
 
         # orignal codebase infer to get the output length, but we can directly infer it
-        # from the model and know wether we should pad
+        # from the model and know whether we should pad
         if self._get_conv1d_output_lengths(input_values.shape[2], self.acoustic_encoder) != e_semantic.shape[2]:
             e_acoustic = self.acoustic_encoder(F.pad(input_values, (self.pad, self.pad)))
         else:

--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -279,7 +279,7 @@ class TokenClassificationPipeline(ChunkPipeline):
                 raise ValueError("When `is_split_into_words=True`, `sentence` must be a list of tokens.")
             words = sentence
             sentence = delimiter.join(words)  # Recreate the sentence string for later display and slicing
-            # This map will allows to convert back word => char indices
+            # This map will allow to convert back word => char indices
             word_to_chars_map = []
             delimiter_len = len(delimiter)
             char_offset = 0

--- a/tests/utils/test_video_utils.py
+++ b/tests/utils/test_video_utils.py
@@ -98,7 +98,7 @@ class BaseVideoProcessorTester(unittest.TestCase):
         self.assertEqual(videos_list[0].shape, (1, 16, 32, 3))
         self.assertTrue(np.array_equal(videos_list[0][0], video))
 
-        # Test a 4d array of videos is converted to a a list of 1 video
+        # Test a 4d array of videos is converted to a list of 1 video
         video = get_random_video(16, 32)
         videos_list = make_batched_videos(video)
         self.assertIsInstance(videos_list, list)
@@ -126,7 +126,7 @@ class BaseVideoProcessorTester(unittest.TestCase):
         self.assertEqual(videos_list[0].shape, (1, 16, 32, 3))
         self.assertTrue(np.array_equal(videos_list[0][0], video))
 
-        # Test a 4d array of videos is converted to a a list of 1 video
+        # Test a 4d array of videos is converted to a list of 1 video
         video = get_random_video(16, 32)
         torch_video = torch.from_numpy(video)
         videos_list = make_batched_videos(torch_video)


### PR DESCRIPTION
- Fixed spelling: "wether" → "whether", "paramaters" → "parameters"
- Fixed grammar: "will allows" → "will allow"
- Removed duplicate words: "a a", "of of", "to to", "is is", "for for", "with with"