### PR TITLE
Add @torch.no_grad() to cache layer update methods

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -95,7 +95,6 @@ class DynamicLayer(CacheLayerMixin):
         self.values = torch.tensor([], dtype=self.dtype, device=self.device)
         self.is_initialized = True
 
-    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -183,7 +182,6 @@ class DynamicSlidingWindowLayer(DynamicLayer):
         super().lazy_initialization(key_states)
         self._sliding_window_tensor = self._sliding_window_tensor.to(self.device)
 
-    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -516,7 +514,6 @@ class QuantizedLayer(DynamicLayer):
         self.residual_length = residual_length
         self.cumulative_length = 0
 
-    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -95,6 +95,7 @@ class DynamicLayer(CacheLayerMixin):
         self.values = torch.tensor([], dtype=self.dtype, device=self.device)
         self.is_initialized = True
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -182,6 +183,7 @@ class DynamicSlidingWindowLayer(DynamicLayer):
         super().lazy_initialization(key_states)
         self._sliding_window_tensor = self._sliding_window_tensor.to(self.device)
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -304,6 +306,7 @@ class StaticLayer(CacheLayerMixin):
 
         self.is_initialized = True
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -379,6 +382,7 @@ class StaticSlidingWindowLayer(StaticLayer):
         super().__init__(max_cache_len=effective_max_cache_len)
         self.cumulative_length = 0
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -512,6 +516,7 @@ class QuantizedLayer(DynamicLayer):
         self.residual_length = residual_length
         self.cumulative_length = 0
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,


### PR DESCRIPTION
Fixes #43010

### What does this PR do?

Adds `@torch.no_grad()` decorator to cache layer `update()` methods that use in-place operations, preventing `torch.func.grad` from failing with "in-place operation would mutate a captured Tensor" errors.

### Why only StaticLayer and StaticSlidingWindowLayer?

After investigation, I found that only these two classes need the decorator:

| Cache Layer | Operation | In-Place? | Needs `@torch.no_grad()`? |
|-------------|-----------|-----------|---------------------------|
| `DynamicLayer` | `torch.cat()` | No | No - breaks gradient flow |
| `DynamicSlidingWindowLayer` | `torch.cat()` | No | No - breaks gradient flow |
| `StaticLayer` | `index_copy_()` | **Yes** | **Yes** |
| `StaticSlidingWindowLayer` | `copy_()`, `index_copy_()` | **Yes** | **Yes** |
| `QuantizedLayer` | `torch.cat()` | No | No - breaks gradient flow |

Adding the decorator to `DynamicLayer` (and subclasses) would break gradient flow because `torch.cat()` creates new tensors that participate in the computation graph. Models like T5 use `DynamicCache` and need gradients to flow through cached key/values.

### Changes

Added `@torch.no_grad()` decorator to:
- `StaticLayer.update()` 
- `StaticSlidingWindowLayer.update()`

### Testing

- All 9 cache unit tests pass
- Verified `torch.func.grad` works with StaticCache
- Verified gradient flow preserved for DynamicCache