### PR TITLE
Fix safe _file_ access in CLIP lazy module

### DIFF
--- a/src/transformers/models/clip/__init__.py
+++ b/src/transformers/models/clip/__init__.py
@@ -28,5 +28,5 @@ if TYPE_CHECKING:
 else:
     import sys
 
-    _file = globals()["__file__"]
+    _file = globals().get("__file__", "")
     sys.modules[__name__] = _LazyModule(__name__, _file, define_import_structure(_file), module_spec=__spec__)

--- a/src/transformers/models/clip/__init__.py
+++ b/src/transformers/models/clip/__init__.py
@@ -28,5 +28,5 @@ if TYPE_CHECKING:
 else:
     import sys
 
-    _file = globals().get("__file__", "")
+    _file = globals().get("__file__")
     sys.modules[__name__] = _LazyModule(__name__, _file, define_import_structure(_file), module_spec=__spec__)


### PR DESCRIPTION
Avoid potential KeyError when accessing _file_ in CLIP lazy module.
