### PR TITLE
Perf: enable pin_memory in DataLoader for CLM no_trainer example

### DIFF
--- a/examples/pytorch/language-modeling/run_clm_no_trainer.py
+++ b/examples/pytorch/language-modeling/run_clm_no_trainer.py
@@ -507,10 +507,17 @@ def main():
 
     # DataLoaders creation:
     train_dataloader = DataLoader(
-        train_dataset, shuffle=True, collate_fn=default_data_collator, batch_size=args.per_device_train_batch_size
+        train_dataset,
+        shuffle=True,
+        collate_fn=default_data_collator,
+        batch_size=args.per_device_train_batch_size,
+        pin_memory=torch.cuda.is_available(),
     )
     eval_dataloader = DataLoader(
-        eval_dataset, collate_fn=default_data_collator, batch_size=args.per_device_eval_batch_size
+        eval_dataset,
+        collate_fn=default_data_collator,
+        batch_size=args.per_device_eval_batch_size,
+        pin_memory=torch.cuda.is_available(),
     )
 
     # Optimizer


### PR DESCRIPTION
This PR enables `pin_memory=True` in the `DataLoader` for the causal language modeling standalone example.

Pinned memory is a PyTorch best practice that improves host-to-device transfer efficiency.