### PR TITLE
Fix InvalidVersion exception in is_flash_attn_2_available

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -880,7 +880,7 @@ def is_bitsandbytes_available(min_version: str = BITSANDBYTES_MIN_VERSION) -> bo
 @lru_cache
 def is_flash_attn_2_available() -> bool:
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
-    if not is_available or not (is_torch_cuda_available() or is_torch_mlu_available()):
+    if not is_available or flash_attn_version == "N/A" or not (is_torch_cuda_available() or is_torch_mlu_available()):
         return False
 
     import torch


### PR DESCRIPTION
Fixes #42999

## Summary
When  package is not installed or its version cannot be determined,  returns  as the version string. This caused  to raise  exception.

## Changes
Added a check for  before attempting to parse the version, returning  early if the version cannot be determined.

## Test Plan
- Tested with flash_attn not installed - should return False without exception
- Tested with flash_attn 2.x installed - should work as before
- Tested with flash_attn 3.x only installed - should properly skip FA2 check and allow FA3 to be used