### PR TITLE
[Bug] qwen2_5_omni: cap generation length to be less than the max_position_embedding in DiT

### DIFF
--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -3831,33 +3831,17 @@ class Qwen2_5OmniToken2WavDiTModel(Qwen2_5OmniPreTrainedModel):
         num_steps=10,
         guidance_scale=0.5,
         sway_coefficient=-1.0,
-        max_mel_frames=30000,
     ):
         maximum_duration = quantized_code.shape[1] * self.repeats
         batch_size = reference_mel_spectrogram.shape[0]
         if batch_size != 1:
             raise ValueError("Only batch size = 1 is currently supported")
 
-        max_target_duration = min(max_mel_frames, self.config.max_position_embeddings)
-        target_duration = min(maximum_duration, max_target_duration)
-        align_to = math.lcm(self.repeats, self.block_size)
-        target_duration = target_duration // align_to * align_to
-        if target_duration == 0:
-            target_duration = min(maximum_duration, max_target_duration) // self.repeats * self.repeats
-        if target_duration == 0:
+        if maximum_duration > self.config.max_position_embeddings:
             raise ValueError(
-                f"Aligned mel length is 0 (got `max_mel_frames`={max_mel_frames}, "
-                f"`dit_config.max_position_embeddings`={self.config.max_position_embeddings})."
+                f"Requested mel length ({maximum_duration}) exceeds `dit_config.max_position_embeddings` "
+                f"({self.config.max_position_embeddings}). Provide shorter `quantized_code`."
             )
-
-        if target_duration != maximum_duration:
-            logger.warning_once(
-                f"Requested mel length ({maximum_duration}) exceeds the supported length "
-                f"(`max_mel_frames`={max_mel_frames}, `dit_config.max_position_embeddings`={self.config.max_position_embeddings}); "
-                f"capping to {target_duration}."
-            )
-            quantized_code = quantized_code[:, : target_duration // self.repeats]
-            maximum_duration = target_duration
 
         initial_state = torch.randn(
             [batch_size, maximum_duration, self.mel_dim],
@@ -3949,7 +3933,6 @@ class Qwen2_5OmniToken2WavModel(Qwen2_5OmniPreTrainedModel):
         num_steps=10,
         guidance_scale=0.5,
         sway_coefficient=-1.0,
-        max_mel_frames=30000,
         **kwargs,
     ):
         """Generates a waveform from input code and conditioning parameters."""
@@ -3961,7 +3944,6 @@ class Qwen2_5OmniToken2WavModel(Qwen2_5OmniPreTrainedModel):
             num_steps=num_steps,
             guidance_scale=guidance_scale,
             sway_coefficient=sway_coefficient,
-            max_mel_frames=max_mel_frames,
         )
 
         waveform = self.code2wav_bigvgan_model(mel_spectrogram)

--- a/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py
@@ -946,7 +946,9 @@ class Qwen2_5OmniToken2WavShapeMismatchTest(unittest.TestCase):
 
         conditioning_vector = torch.randn(batch_size, small_config.enc_emb_dim, device=torch_device)
         reference_mel = torch.randn(batch_size, 30000, small_config.mel_dim, device=torch_device)
-        quantized_code = torch.randint(0, small_config.num_embeds, (batch_size, num_speech_tokens), device=torch_device)
+        quantized_code = torch.randint(
+            0, small_config.num_embeds, (batch_size, num_speech_tokens), device=torch_device
+        )
 
         with self.assertLogs("transformers.models.qwen2_5_omni.modeling_qwen2_5_omni", level="WARNING") as log:
             output = small_model.sample(


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR resolved the following issue and added tests and provided a test script to validate the behavior before/after the fix to further validate the correctness. 
Issue: mel frames of noise_initialization is hardcoded to `30000` in current implmentation, it will cause issue of 'shape mismatch' if the hidden_states time len doesn't match that of condition_vector/code_embed tensors. i.e, We will get the below error when we run the script attached.
```
  File "/root/transformers/test_before.py", line 20, in <module>
    m.sample(cond, ref_mel, code, num_steps=2)
  File "/root/transformers/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 3718, in sample
    solution_trajectory = ode_solver.integrate(time_embedding)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 3550, in integrate
    delta_value, _ = self._compute_step(self.function, time_start, time_step, time_end, current_value)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 3524, in _compute_step
    function_value_start = function(time_start, value_start)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 3698, in ode_function
    model_output = self(
                   ^^^^^
  File "/root/transformers/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 3636, in forward
    hidden_states = self.input_embed(
                    ^^^^^^^^^^^^^^^^^
  File "/root/transformers/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1775, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/.venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1786, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/transformers/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py", line 2975, in forward
    hidden_states = self.proj(torch.cat((hidden_states, condition_vector, code_embed, speaker_embedding), dim=-1))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: Sizes of tensors must match except in dimension 2. Expected size 30000 but got size 32000 for tensor number 2 in the list.
```
The bug is found when I used vllm-omni to run the exact qwen 2.5 omni mode and [a similar PR  ](https://github.com/vllm-project/vllm-omni/pull/543) has been merged to resolve the issue.
<!--
### To produce the bug: run this script on the main branch
[test_before.py](https://github.com/user-attachments/files/24402896/test_before.py)
result error logs: 
[before_fix.log](https://github.com/user-attachments/files/24402897/before_fix.log)

### To verify the issue has been resolved by this change: run this script on the current fix branch
[test_after.py](https://github.com/user-attachments/files/24402905/test_after.py)
result logs show it's been fixed:
[after_fix.log](https://github.com/user-attachments/files/24402901/after_fix.log)
-->

### To validate the issue exists before the fix ang get resolved after the fix. Run the following script:

[test_validate_max_position_embeddings_fix.py](https://github.com/user-attachments/files/24447776/test_validate_max_position_embeddings_fix.py)

All the re-production and validation is running on a B300 GPU.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
