### PR TITLE
Update Japanese README to match English version

### DIFF
--- a/i18n/README_ja.md
+++ b/i18n/README_ja.md
@@ -60,6 +60,7 @@ user: ユーザ
 </p>
 
 <p align="center">
+    <a href="https://huggingface.com/models"><img alt="Checkpoints on Hub" src="https://img.shields.io/endpoint?url=https://huggingface.co/api/shields/models&color=brightgreen"></a>
     <a href="https://circleci.com/gh/huggingface/transformers"><img alt="Build" src="https://img.shields.io/circleci/build/github/huggingface/transformers/main"></a>
     <a href="https://github.com/huggingface/transformers/blob/main/LICENSE"><img alt="GitHub" src="https://img.shields.io/github/license/huggingface/transformers.svg?color=blue"></a>
     <a href="https://huggingface.co/docs/transformers/index"><img alt="Documentation" src="https://img.shields.io/website/http/huggingface.co/docs/transformers/index.svg?down_color=red&down_message=offline&up_message=online"></a>
@@ -78,7 +79,7 @@ user: ユーザ
         <b>日本語</b> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_hd.md">हिन्दी</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_ru.md">Русский</a> |
-        <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_pt-br.md">Рortuguês</a> |
+        <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_pt-br.md">Português</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_te.md">తెలుగు</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_fr.md">Français</a> |
         <a href="https://github.com/huggingface/transformers/blob/main/i18n/README_de.md">Deutsch</a> |
@@ -91,237 +92,261 @@ user: ユーザ
 </h4>
 
 <h3 align="center">
-    <p>JAX、PyTorch、TensorFlowのための最先端機械学習</p>
+    <p>推論と学習のための最先端の事前学習済みモデル</p>
 </h3>
 
 <h3 align="center">
-    <a href="https://hf.co/course"><img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/course_banner.png"></a>
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/transformers_as_a_model_definition.png"/>
 </h3>
 
-🤗Transformersは、テキスト、視覚、音声などの異なるモダリティに対してタスクを実行するために、事前に学習させた数千のモデルを提供します。
+Transformersは、テキスト、コンピュータビジョン、音声、動画、マルチモーダルモデルを用いた最先端の機械学習のためのモデル定義フレームワークとして、推論と学習の両方で機能します。
 
-これらのモデルは次のような場合に適用できます:
+モデル定義を一元化することで、エコシステム全体でその定義が合意されるようにします。`transformers`はフレームワーク間のピボット（要）となります。モデル定義がサポートされていれば、大部分の学習フレームワーク(Axolotl, Unsloth, DeepSpeed, FSDP, PyTorch-Lightning, ...)、推論エンジン(vLLM, SGLang, TGI, ...)、および`transformers`のモデル定義を活用する隣接するモデリングライブラリ(llama.cpp, mlx, ...)と互換性があります。
 
-* 📝 テキストは、テキストの分類、情報抽出、質問応答、要約、翻訳、テキスト生成などのタスクのために、100以上の言語に対応しています。
-* 🖼️ 画像分類、物体検出、セグメンテーションなどのタスクのための画像。
-* 🗣️ 音声は、音声認識や音声分類などのタスクに使用します。
+私たちは、モデル定義をシンプル、カスタマイズ可能、かつ効率的なものにすることで、新しい最先端モデルのサポートを支援し、その利用を民主化することを誓います。
 
-トランスフォーマーモデルは、テーブル質問応答、光学文字認識、スキャン文書からの情報抽出、ビデオ分類、視覚的質問応答など、**複数のモダリティを組み合わせた**タスクも実行可能です。
+[Hugging Face Hub](https://huggingface.com/models)には、100万を超えるTransformersの[モデルチェックポイント](https://huggingface.co/models?library=transformers&sort=trending)があり、すぐに使用できます。
 
-🤗Transformersは、与えられたテキストに対してそれらの事前学習されたモデルを素早くダウンロードして使用し、あなた自身のデータセットでそれらを微調整し、私たちの[model hub](https://huggingface.co/models)でコミュニティと共有するためのAPIを提供します。同時に、アーキテクチャを定義する各Pythonモジュールは完全にスタンドアロンであり、迅速な研究実験を可能にするために変更することができます。
+[Hub](https://huggingface.com/)を探索してモデルを見つけ、Transformersを使ってすぐに始めましょう。
 
-🤗Transformersは[Jax](https://jax.readthedocs.io/en/latest/)、[PyTorch](https://pytorch.org/)、[TensorFlow](https://www.tensorflow.org/)という3大ディープラーニングライブラリーに支えられ、それぞれのライブラリをシームレスに統合しています。片方でモデルを学習してから、もう片方で推論用にロードするのは簡単なことです。
+## インストール
 
-## オンラインデモ
+TransformersはPython 3.9以上、[PyTorch](https://pytorch.org/get-started/locally/) 2.1以上で動作します。
 
-[model hub](https://huggingface.co/models)から、ほとんどのモデルのページで直接テストすることができます。また、パブリックモデル、プライベートモデルに対して、[プライベートモデルのホスティング、バージョニング、推論API](https://huggingface.co/pricing)を提供しています。
+[venv](https://docs.python.org/3/library/venv.html)または、高速なRustベースのPythonパッケージおよびプロジェクトマネージャーである[uv](https://docs.astral.sh/uv/)を使用して、仮想環境を作成し、有効化してください。
 
-以下はその一例です:
-
- 自然言語処理にて:
-- [BERTによるマスクドワード補完](https://huggingface.co/google-bert/bert-base-uncased?text=Paris+is+the+%5BMASK%5D+of+France)
-- [Electraによる名前実体認識](https://huggingface.co/dbmdz/electra-large-discriminator-finetuned-conll03-english?text=My+name+is+Sarah+and+I+live+in+London+city)
-- [GPT-2によるテキスト生成](https://huggingface.co/openai-community/gpt2?text=A+long+time+ago%2C+)
-- [RoBERTaによる自然言語推論](https://huggingface.co/FacebookAI/roberta-large-mnli?text=The+dog+was+lost.+Nobody+lost+any+animal)
-- [BARTによる要約](https://huggingface.co/facebook/bart-large-cnn?text=The+tower+is+324+metres+%281%2C063+ft%29+tall%2C+about+the+same+height+as+an+81-storey+building%2C+and+the+tallest+structure+in+Paris.+Its+base+is+square%2C+measuring+125+metres+%28410+ft%29+on+each+side.+During+its+construction%2C+the+Eiffel+Tower+surpassed+the+Washington+Monument+to+become+the+tallest+man-made+structure+in+the+world%2C+a+title+it+held+for+41+years+until+the+Chrysler+Building+in+New+York+City+was+finished+in+1930.+It+was+the+first+structure+to+reach+a+height+of+300+metres.+Due+to+the+addition+of+a+broadcasting+aerial+at+the+top+of+the+tower+in+1957%2C+it+is+now+taller+than+the+Chrysler+Building+by+5.2+metres+%2817+ft%29.+Excluding+transmitters%2C+the+Eiffel+Tower+is+the+second+tallest+free-standing+structure+in+France+after+the+Millau+Viaduct)
-- [DistilBERTによる質問応答](https://huggingface.co/distilbert/distilbert-base-uncased-distilled-squad?text=Which+name+is+also+used+to+describe+the+Amazon+rainforest+in+English%3F&context=The+Amazon+rainforest+%28Portuguese%3A+Floresta+Amaz%C3%B4nica+or+Amaz%C3%B4nia%3B+Spanish%3A+Selva+Amaz%C3%B3nica%2C+Amazon%C3%ADa+or+usually+Amazonia%3B+French%3A+For%C3%AAt+amazonienne%3B+Dutch%3A+Amazoneregenwoud%29%2C+also+known+in+English+as+Amazonia+or+the+Amazon+Jungle%2C+is+a+moist+broadleaf+forest+that+covers+most+of+the+Amazon+basin+of+South+America.+This+basin+encompasses+7%2C000%2C000+square+kilometres+%282%2C700%2C000+sq+mi%29%2C+of+which+5%2C500%2C000+square+kilometres+%282%2C100%2C000+sq+mi%29+are+covered+by+the+rainforest.+This+region+includes+territory+belonging+to+nine+nations.+The+majority+of+the+forest+is+contained+within+Brazil%2C+with+60%25+of+the+rainforest%2C+followed+by+Peru+with+13%25%2C+Colombia+with+10%25%2C+and+with+minor+amounts+in+Venezuela%2C+Ecuador%2C+Bolivia%2C+Guyana%2C+Suriname+and+French+Guiana.+States+or+departments+in+four+nations+contain+%22Amazonas%22+in+their+names.+The+Amazon+represents+over+half+of+the+planet%27s+remaining+rainforests%2C+and+comprises+the+largest+and+most+biodiverse+tract+of+tropical+rainforest+in+the+world%2C+with+an+estimated+390+billion+individual+trees+divided+into+16%2C000+species)
-- [T5による翻訳](https://huggingface.co/google-t5/t5-base?text=My+name+is+Wolfgang+and+I+live+in+Berlin)
-
-コンピュータビジョンにて:
-- [ViTによる画像分類](https://huggingface.co/google/vit-base-patch16-224)
-- [DETRによる物体検出](https://huggingface.co/facebook/detr-resnet-50)
-- [SegFormerによるセマンティックセグメンテーション](https://huggingface.co/nvidia/segformer-b0-finetuned-ade-512-512)
-- [DETRによるパノプティックセグメンテーション](https://huggingface.co/facebook/detr-resnet-50-panoptic)
-
-オーディオにて:
-- [Wav2Vec2による自動音声認識](https://huggingface.co/facebook/wav2vec2-base-960h)
-- [Wav2Vec2によるキーワード検索](https://huggingface.co/superb/wav2vec2-base-superb-ks)
-
-マルチモーダルなタスクにて:
-- [ViLTによる視覚的質問応答](https://huggingface.co/dandelin/vilt-b32-finetuned-vqa)
-
-Hugging Faceチームによって作られた **[トランスフォーマーを使った書き込み](https://transformer.huggingface.co)** は、このリポジトリのテキスト生成機能の公式デモである。
-
-## Hugging Faceチームによるカスタム・サポートをご希望の場合
-
-<a target="_blank" href="https://huggingface.co/support">
-    <img alt="HuggingFace Expert Acceleration Program" src="https://cdn-media.huggingface.co/marketing/transformers/new-support-improved.png" style="max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
-</a><br>
-
-## クイックツアー
-
-与えられた入力（テキスト、画像、音声、...）に対してすぐにモデルを使うために、我々は`pipeline`というAPIを提供しております。pipelineは、学習済みのモデルと、そのモデルの学習時に使用された前処理をグループ化したものです。以下は、肯定的なテキストと否定的なテキストを分類するためにpipelineを使用する方法です:
-
-```python
->>> from transformers import pipeline
-
-# Allocate a pipeline for sentiment-analysis
->>> classifier = pipeline('sentiment-analysis')
->>> classifier('We are very happy to introduce pipeline to the transformers repository.')
-[{'label': 'POSITIVE', 'score': 0.9996980428695679}]
+```py
+# venv
+python -m venv .my-env
+source .my-env/bin/activate
+# uv
+uv venv .my-env
+source .my-env/bin/activate
 ```
 
-2行目のコードでは、pipelineで使用される事前学習済みモデルをダウンロードしてキャッシュし、3行目では与えられたテキストに対してそのモデルを評価します。ここでは、答えは99.97%の信頼度で「ポジティブ」です。
+仮想環境にTransformersをインストールします。
 
-自然言語処理だけでなく、コンピュータビジョンや音声処理においても、多くのタスクにはあらかじめ訓練された`pipeline`が用意されている。例えば、画像から検出された物体を簡単に抽出することができる:
+```py
+# pip
+pip install "transformers[torch]"
 
-``` python
->>> import requests
->>> from PIL import Image
->>> from transformers import pipeline
-
-# Download an image with cute cats
->>> url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/coco_sample.png"
->>> image_data = requests.get(url, stream=True).raw
->>> image = Image.open(image_data)
-
-# Allocate a pipeline for object detection
->>> object_detector = pipeline('object-detection')
->>> object_detector(image)
-[{'score': 0.9982201457023621,
-  'label': 'remote',
-  'box': {'xmin': 40, 'ymin': 70, 'xmax': 175, 'ymax': 117}},
- {'score': 0.9960021376609802,
-  'label': 'remote',
-  'box': {'xmin': 333, 'ymin': 72, 'xmax': 368, 'ymax': 187}},
- {'score': 0.9954745173454285,
-  'label': 'couch',
-  'box': {'xmin': 0, 'ymin': 1, 'xmax': 639, 'ymax': 473}},
- {'score': 0.9988006353378296,
-  'label': 'cat',
-  'box': {'xmin': 13, 'ymin': 52, 'xmax': 314, 'ymax': 470}},
- {'score': 0.9986783862113953,
-  'label': 'cat',
-  'box': {'xmin': 345, 'ymin': 23, 'xmax': 640, 'ymax': 368}}]
+# uv
+uv pip install "transformers[torch]"
 ```
 
-ここでは、画像から検出されたオブジェクトのリストが得られ、オブジェクトを囲むボックスと信頼度スコアが表示されます。左側が元画像、右側が予測結果を表示したものです:
+ライブラリの最新の変更が必要な場合や、貢献に興味がある場合は、ソースからTransformersをインストールしてください。ただし、*最新*バージョンは安定していない可能性があります。エラーが発生した場合は、お気軽に[issue](https://github.com/huggingface/transformers/issues)を開いてください。
+
+```shell
+git clone https://github.com/huggingface/transformers.git
+cd transformers
+
+# pip
+pip install '.[torch]'
+
+# uv
+uv pip install '.[torch]'
+```
+
+## クイックスタート
+
+[Pipeline](https://huggingface.co/docs/transformers/pipeline_tutorial) APIを使用して、すぐにTransformersを始めましょう。`Pipeline`は、テキスト、音声、視覚、およびマルチモーダルタスクをサポートする高レベルの推論クラスです。入力の前処理を行い、適切な出力を返します。
+
+パイプラインをインスタンス化し、テキスト生成に使用するモデルを指定します。モデルはダウンロードされキャッシュされるため、簡単に再利用できます。最後に、モデルにプロンプトとしてテキストを渡します。
+
+```py
+from transformers import pipeline
+
+pipeline = pipeline(task="text-generation", model="Qwen/Qwen2.5-1.5B")
+pipeline("the secret to baking a really good cake is ")
+[{'generated_text': 'the secret to baking a really good cake is 1) to use the right ingredients and 2) to follow the recipe exactly. the recipe for the cake is as follows: 1 cup of sugar, 1 cup of flour, 1 cup of milk, 1 cup of butter, 1 cup of eggs, 1 cup of chocolate chips. if you want to make 2 cakes, how much sugar do you need? To make 2 cakes, you will need 2 cups of sugar.'}]
+```
+
+モデルとチャットする場合も、使用パターンは同じです。唯一の違いは、あなたとシステムの間でチャット履歴（`Pipeline`への入力）を構築する必要があることです。
+
+> [!TIP]
+> コマンドラインから直接モデルとチャットすることもできます。
+> ```shell
+> transformers chat Qwen/Qwen2.5-0.5B-Instruct
+> ```
+
+```py
+import torch
+from transformers import pipeline
+
+chat = [
+    {"role": "system", "content": "You are a sassy, wise-cracking robot as imagined by Hollywood circa 1986."},
+    {"role": "user", "content": "Hey, can you tell me any fun things to do in New York?"}
+]
+
+pipeline = pipeline(task="text-generation", model="meta-llama/Meta-Llama-3-8B-Instruct", dtype=torch.bfloat16, device_map="auto")
+response = pipeline(chat, max_new_tokens=512)
+print(response[0]["generated_text"][-1]["content"])
+```
+
+以下の例を展開して、さまざまなモダリティやタスクで`Pipeline`がどのように機能するかを確認してください。
+
+<details>
+<summary>自動音声認識</summary>
+
+```py
+from transformers import pipeline
+
+pipeline = pipeline(task="automatic-speech-recognition", model="openai/whisper-large-v3")
+pipeline("https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/mlk.flac")
+{'text': ' I have a dream that one day this nation will rise up and live out the true meaning of its creed.'}
+```
+
+</details>
+
+<details>
+<summary>画像分類</summary>
 
 <h3 align="center">
-    <a><img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/coco_sample.png" width="400"></a>
-    <a><img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/coco_sample_post_processed.png" width="400"></a>
+    <a><img src="https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"></a>
 </h3>
 
-[このチュートリアル](https://huggingface.co/docs/transformers/task_summary)では、`pipeline`APIでサポートされているタスクについて詳しく説明しています。
+```py
+from transformers import pipeline
 
-`pipeline`に加えて、与えられたタスクに学習済みのモデルをダウンロードして使用するために必要なのは、3行のコードだけです。以下はPyTorchのバージョンです:
-```python
->>> from transformers import AutoTokenizer, AutoModel
-
->>> tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-uncased")
->>> model = AutoModel.from_pretrained("google-bert/bert-base-uncased")
-
->>> inputs = tokenizer("Hello world!", return_tensors="pt")
->>> outputs = model(**inputs)
+pipeline = pipeline(task="image-classification", model="facebook/dinov2-small-imagenet1k-1-layer")
+pipeline("https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png")
+[{'label': 'macaw', 'score': 0.997848391532898},
+ {'label': 'sulphur-crested cockatoo, Kakatoe galerita, Cacatua galerita',
+  'score': 0.0016551691805943847},
+ {'label': 'lorikeet', 'score': 0.00018523589824326336},
+ {'label': 'African grey, African gray, Psittacus erithacus',
+  'score': 7.85409429227002e-05},
+ {'label': 'quail', 'score': 5.502637941390276e-05}]
 ```
 
-そしてこちらはTensorFlowと同等のコードとなります:
-```python
->>> from transformers import AutoTokenizer, TFAutoModel
+</details>
 
->>> tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-uncased")
->>> model = TFAutoModel.from_pretrained("google-bert/bert-base-uncased")
+<details>
+<summary>視覚的質問応答</summary>
 
->>> inputs = tokenizer("Hello world!", return_tensors="tf")
->>> outputs = model(**inputs)
+<h3 align="center">
+    <a><img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/idefics-few-shot.jpg"></a>
+</h3>
+
+```py
+from transformers import pipeline
+
+pipeline = pipeline(task="visual-question-answering", model="Salesforce/blip-vqa-base")
+pipeline(
+    image="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/idefics-few-shot.jpg",
+    question="What is in the image?",
+)
+[{'answer': 'statue of liberty'}]
 ```
 
-トークナイザは学習済みモデルが期待するすべての前処理を担当し、単一の文字列 (上記の例のように) またはリストに対して直接呼び出すことができます。これは下流のコードで使用できる辞書を出力します。また、単純に ** 引数展開演算子を使用してモデルに直接渡すこともできます。
-
-モデル自体は通常の[Pytorch `nn.Module`](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) または [TensorFlow `tf.keras.Model`](https://www.tensorflow.org/api_docs/python/tf/keras/Model) (バックエンドによって異なる)で、通常通り使用することが可能です。[このチュートリアル](https://huggingface.co/docs/transformers/training)では、このようなモデルを従来のPyTorchやTensorFlowの学習ループに統合する方法や、私たちの`Trainer`APIを使って新しいデータセットで素早く微調整を行う方法について説明します。
+</details>
 
 ## なぜtransformersを使う必要があるのでしょうか？
 
-1. 使いやすい最新モデル:
-    - 自然言語理解・生成、コンピュータビジョン、オーディオの各タスクで高いパフォーマンスを発揮します。
-    - 教育者、実務者にとっての低い参入障壁。
+1. 使いやすい最先端のモデル:
+    - 自然言語理解・生成、コンピュータビジョン、音声、動画、マルチモーダルタスクで高いパフォーマンスを発揮します。
+    - 研究者、エンジニア、開発者にとっての低い参入障壁。
     - 学習するクラスは3つだけで、ユーザが直面する抽象化はほとんどありません。
-    - 学習済みモデルを利用するための統一されたAPI。
+    - すべての事前学習済みモデルを利用するための統一されたAPI。
 
 1. 低い計算コスト、少ないカーボンフットプリント:
-    - 研究者は、常に再トレーニングを行うのではなく、トレーニングされたモデルを共有することができます。
-    - 実務家は、計算時間や生産コストを削減することができます。
-    - すべてのモダリティにおいて、60,000以上の事前学習済みモデルを持つ数多くのアーキテクチャを提供します。
+    - ゼロから学習するのではなく、学習済みモデルを共有できます。
+    - 計算時間や生産コストを削減できます。
+    - すべてのモダリティにおいて、100万以上の事前学習済みチェックポイントを持つ多数のモデルアーキテクチャを提供します。
 
-1. モデルのライフタイムのあらゆる部分で適切なフレームワークを選択可能:
-    - 3行のコードで最先端のモデルをトレーニング。
-    - TF2.0/PyTorch/JAXフレームワーク間で1つのモデルを自在に移動させる。
-    - 学習、評価、生産に適したフレームワークをシームレスに選択できます。
+1. モデルのライフサイクルのあらゆる部分で適切なフレームワークを選択可能:
+    - 3行のコードで最先端のモデルを学習。
+    - PyTorch/JAX/TF2.0フレームワーク間で1つのモデルを自在に移動可能。
+    - 学習、評価、本番環境に適したフレームワークを選択できます。
 
-1. モデルやサンプルをニーズに合わせて簡単にカスタマイズ可能:
+1. モデルや例をニーズに合わせて簡単にカスタマイズ可能:
     - 原著者が発表した結果を再現するために、各アーキテクチャの例を提供しています。
     - モデル内部は可能な限り一貫して公開されています。
     - モデルファイルはライブラリとは独立して利用することができ、迅速な実験が可能です。
 
+<a target="_blank" href="https://huggingface.co/enterprise">
+    <img alt="Hugging Face Enterprise Hub" src="https://github.com/user-attachments/assets/247fb16d-d251-4583-96c4-d3d76dda4925">
+</a><br>
+
 ## なぜtransformersを使ってはいけないのでしょうか？
 
 - このライブラリは、ニューラルネットのためのビルディングブロックのモジュール式ツールボックスではありません。モデルファイルのコードは、研究者が追加の抽象化/ファイルに飛び込むことなく、各モデルを素早く反復できるように、意図的に追加の抽象化でリファクタリングされていません。
-- 学習APIはどのようなモデルでも動作するわけではなく、ライブラリが提供するモデルで動作するように最適化されています。一般的な機械学習のループには、別のライブラリ(おそらく[Accelerate](https://huggingface.co/docs/accelerate))を使用する必要があります。
-- 私たちはできるだけ多くの使用例を紹介するよう努力していますが、[examples フォルダ](https://github.com/huggingface/transformers/tree/main/examples) にあるスクリプトはあくまで例です。あなたの特定の問題に対してすぐに動作するわけではなく、あなたのニーズに合わせるために数行のコードを変更する必要があることが予想されます。
+- 学習APIはTransformersが提供するPyTorchモデルで動作するように最適化されています。一般的な機械学習のループには、[Accelerate](https://huggingface.co/docs/accelerate)のような別のライブラリを使用する必要があります。
+- [example scripts](https://github.com/huggingface/transformers/tree/main/examples)にあるスクリプトはあくまで*例*です。あなたの特定の問題に対してすぐに動作するわけではなく、あなたのニーズに合わせるためにコードを適応させる必要があるでしょう。
 
-## インストール
+## Transformersを使用している100のプロジェクト
 
-### pipにて
+Transformersは事前学習済みモデルを使用するためのツールキット以上のものであり、それとHugging Face Hubを中心に構築されたプロジェクトのコミュニティです。私たちは、開発者、研究者、学生、教授、エンジニア、そしてその他の誰もが夢のプロジェクトを構築できるようにTransformersを提供したいと考えています。
 
-このリポジトリは、Python 3.9+, Flax 0.4.1+, PyTorch 2.1+, TensorFlow 2.6+ でテストされています。
+Transformersの10万スターを記念して、Transformersで構築された100の素晴らしいプロジェクトをリストアップした[awesome-transformers](./awesome-transformers.md)ページで、コミュニティにスポットライトを当てたいと考えました。
 
-🤗Transformersは[仮想環境](https://docs.python.org/3/library/venv.html)にインストールする必要があります。Pythonの仮想環境に慣れていない場合は、[ユーザーガイド](https://packaging.python.org/guides/installing-using-pip-and-virtual-environments/)を確認してください。
+もしあなたがリストに加えるべきだと思うプロジェクトを所有または使用しているなら、ぜひPRを開いて追加してください！
 
-まず、使用するバージョンのPythonで仮想環境を作成し、アクティベートします。
+## モデルの例
 
-その後、Flax, PyTorch, TensorFlowのうち少なくとも1つをインストールする必要があります。
-[TensorFlowインストールページ](https://www.tensorflow.org/install/)、[PyTorchインストールページ](https://pytorch.org/get-started/locally/#start-locally)、[Flax](https://github.com/google/flax#quick-install)、[Jax](https://github.com/google/jax#installation)インストールページで、お使いのプラットフォーム別のインストールコマンドを参照してください。
+[Hubのモデルページ](https://huggingface.co/models)で、ほとんどのモデルを直接テストすることができます。
 
-これらのバックエンドのいずれかがインストールされている場合、🤗Transformersは以下のようにpipを使用してインストールすることができます:
+以下の各モダリティを展開して、さまざまなユースケースのモデル例をいくつか確認してください。
 
-```bash
-pip install transformers
-```
+<details>
+<summary>音声</summary>
 
-もしサンプルを試したい、またはコードの最先端が必要で、新しいリリースを待てない場合は、[ライブラリをソースからインストール](https://huggingface.co/docs/transformers/installation#installing-from-source)する必要があります。
+- [Whisper](https://huggingface.co/openai/whisper-large-v3-turbo)による音声分類
+- [Moonshine](https://huggingface.co/UsefulSensors/moonshine)による自動音声認識
+- [Wav2Vec2](https://huggingface.co/superb/wav2vec2-base-superb-ks)によるキーワードスポッティング
+- [Moshi](https://huggingface.co/kyutai/moshiko-pytorch-bf16)による音声対音声生成
+- [MusicGen](https://huggingface.co/facebook/musicgen-large)によるテキスト対音声
+- [Bark](https://huggingface.co/suno/bark)によるテキスト読み上げ
 
-### condaにて
+</details>
 
-🤗Transformersは以下のようにcondaを使って設置することができます:
+<details>
+<summary>コンピュータビジョン</summary>
 
-```shell script
-conda install conda-forge::transformers
-```
+- [SAM](https://huggingface.co/facebook/sam-vit-base)による自動マスク生成
+- [DepthPro](https://huggingface.co/apple/DepthPro-hf)による深度推定
+- [DINO v2](https://huggingface.co/facebook/dinov2-base)による画像分類
+- [SuperPoint](https://huggingface.co/magic-leap-community/superpoint)によるキーポイント検出
+- [SuperGlue](https://huggingface.co/magic-leap-community/superglue_outdoor)によるキーポイントマッチング
+- [RT-DETRv2](https://huggingface.co/PekingU/rtdetr_v2_r50vd)による物体検出
+- [VitPose](https://huggingface.co/usyd-community/vitpose-base-simple)による姿勢推定
+- [OneFormer](https://huggingface.co/shi-labs/oneformer_ade20k_swin_large)によるユニバーサルセグメンテーション
+- [VideoMAE](https://huggingface.co/MCG-NJU/videomae-large)による動画分類
 
-> **_注意:_**  `huggingface` チャンネルから `transformers` をインストールすることは非推奨です。
+</details>
 
-Flax、PyTorch、TensorFlowをcondaでインストールする方法は、それぞれのインストールページに従ってください。
+<details>
+<summary>マルチモーダル</summary>
 
-> **_注意:_**  Windowsでは、キャッシュの恩恵を受けるために、デベロッパーモードを有効にするよう促されることがあります。このような場合は、[このissue](https://github.com/huggingface/huggingface_hub/issues/1062)でお知らせください。
+- [Qwen2-Audio](https://huggingface.co/Qwen/Qwen2-Audio-7B)による音声またはテキスト対テキスト
+- [LayoutLMv3](https://huggingface.co/microsoft/layoutlmv3-base)による文書質問応答
+- [Qwen-VL](https://huggingface.co/Qwen/Qwen2.5-VL-3B-Instruct)による画像またはテキスト対テキスト
+- [BLIP-2](https://huggingface.co/Salesforce/blip2-opt-2.7b)による画像キャプション
+- [GOT-OCR2](https://huggingface.co/stepfun-ai/GOT-OCR-2.0-hf)によるOCRベースの文書理解
+- [TAPAS](https://huggingface.co/google/tapas-base)による表質問応答
+- [Emu3](https://huggingface.co/BAAI/Emu3-Gen)による統一マルチモーダル理解と生成
+- [Llava-OneVision](https://huggingface.co/llava-hf/llava-onevision-qwen2-0.5b-ov-hf)による視覚対テキスト
+- [Llava](https://huggingface.co/llava-hf/llava-1.5-7b-hf)による視覚的質問応答
+- [Kosmos-2](https://huggingface.co/microsoft/kosmos-2-patch14-224)による視覚的参照表現セグメンテーション
 
-## モデルアーキテクチャ
+</details>
 
-🤗Transformersが提供する **[全モデルチェックポイント](https://huggingface.co/models)** は、[ユーザー](https://huggingface.co/users)や[組織](https://huggingface.co/organizations)によって直接アップロードされるhuggingface.co [model hub](https://huggingface.co)からシームレスに統合されています。
+<details>
+<summary>自然言語処理 (NLP)</summary>
 
-現在のチェックポイント数: ![](https://img.shields.io/endpoint?url=https://huggingface.co/api/shields/models&color=brightgreen)
+- [ModernBERT](https://huggingface.co/answerdotai/ModernBERT-base)によるマスク単語補完
+- [Gemma](https://huggingface.co/google/gemma-2-2b)による固有表現認識
+- [Mixtral](https://huggingface.co/mistralai/Mixtral-8x7B-v0.1)による質問応答
+- [BART](https://huggingface.co/facebook/bart-large-cnn)による要約
+- [T5](https://huggingface.co/google-t5/t5-base)による翻訳
+- [Llama](https://huggingface.co/meta-llama/Llama-3.2-1B)によるテキスト生成
+- [Qwen](https://huggingface.co/Qwen/Qwen2.5-0.5B)によるテキスト分類
 
-🤗Transformersは現在、以下のアーキテクチャを提供しています: それぞれのハイレベルな要約は[こちら](https://huggingface.co/docs/transformers/model_summary)を参照してください.
-
-各モデルがFlax、PyTorch、TensorFlowで実装されているか、🤗Tokenizersライブラリに支えられた関連トークナイザを持っているかは、[この表](https://huggingface.co/docs/transformers/index#supported-frameworks)を参照してください。
-
-これらの実装はいくつかのデータセットでテストされており(サンプルスクリプトを参照)、オリジナルの実装の性能と一致するはずである。性能の詳細は[documentation](https://github.com/huggingface/transformers/tree/main/examples)のExamplesセクションで見ることができます。
-
-
-## さらに詳しく
-
-| セクション | 概要 |
-|-|-|
-| [ドキュメント](https://huggingface.co/docs/transformers/) | 完全なAPIドキュメントとチュートリアル |
-| [タスク概要](https://huggingface.co/docs/transformers/task_summary) | 🤗Transformersがサポートするタスク |
-| [前処理チュートリアル](https://huggingface.co/docs/transformers/preprocessing) | モデル用のデータを準備するために`Tokenizer`クラスを使用 |
-| [トレーニングと微調整](https://huggingface.co/docs/transformers/training) | PyTorch/TensorFlowの学習ループと`Trainer`APIで🤗Transformersが提供するモデルを使用 |
-| [クイックツアー: 微調整/使用方法スクリプト](https://github.com/huggingface/transformers/tree/main/examples) | 様々なタスクでモデルの微調整を行うためのスクリプト例 |
-| [モデルの共有とアップロード](https://huggingface.co/docs/transformers/model_sharing) | 微調整したモデルをアップロードしてコミュニティで共有する |
-| [マイグレーション](https://huggingface.co/docs/transformers/migration) | `pytorch-transformers`または`pytorch-pretrained-bert`から🤗Transformers に移行する |
+</details>
 
 ## 引用
 
-🤗 トランスフォーマーライブラリに引用できる[論文](https://www.aclweb.org/anthology/2020.emnlp-demos.6/)が出来ました:
+🤗 Transformersライブラリについて引用できる[論文](https://www.aclweb.org/anthology/2020.emnlp-demos.6/)ができました:
 ```bibtex
 @inproceedings{wolf-etal-2020-transformers,
     title = "Transformers: State-of-the-Art Natural Language Processing",


### PR DESCRIPTION
### PR Title:
Docs: Update Japanese README to match main English version

### PR Content:
# What does this PR do?
This PR updates the Japanese version of the README ( README_ja.md ) to align with the latest changes in the main English README.md .

The Japanese documentation was significantly outdated compared to the English version. This update ensures that Japanese-speaking users have access to the most current information regarding:

- Installation : Added uv as a recommended installation method.
- Quickstart : Updated code snippets with modern models (Qwen2.5, Whisper v3, Llama 3.2).
- Example Models : Included newly added models across all modalities (ModernBERT, DepthPro, Moshi, etc.).
- New Sections : Added the "100 projects using Transformers" section.
- Structure : Reorganized the document to mirror the English version's flow.
No functional code changes are included; this is purely a documentation update for internationalization.

## Before submitting
- This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- Did you read the https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request , Pull Request section?
- Was this discussed/approved via a Github issue or the https://discuss.huggingface.co/ ? Please add a link to it if that's the case. (N/A)
- Did you make sure to update the documentation with your changes?
- Did you write any new necessary tests? (N/A for docs)
## Who can review?
Documentation: @stevhliu
Others: @ArthurZucker (for general maintenance)