### PR TITLE
43062: Updated the gemma tokenizer docstring and added a separate test to verify

### DIFF
--- a/src/transformers/models/gemma/tokenization_gemma_fast.py
+++ b/src/transformers/models/gemma/tokenization_gemma_fast.py
@@ -36,6 +36,7 @@ class GemmaTokenizerFast(PreTrainedTokenizerFast):
     Construct a Gemma tokenizer fast. Based on byte-level Byte-Pair-Encoding.
 
     This uses notably ByteFallback and no prefix space. Normalization is applied to replace  `" "` with `"▁"`
+    The fast tokenizer does not apply an additional whitespace pre-tokenizer (`backend_tokenizer.pre_tokenizer` is `None`).
 
     ```python
     >>> from transformers import GemmaTokenizerFast

--- a/tests/models/gemma/test_tokenization_gemma_fast.py
+++ b/tests/models/gemma/test_tokenization_gemma_fast.py
@@ -1,0 +1,9 @@
+import unittest
+
+from transformers import GemmaTokenizerFast
+
+
+class GemmaTokenizerFastTest(unittest.TestCase):
+    def test_backend_has_no_pre_tokenizer(self):
+        tok = GemmaTokenizerFast.from_pretrained("hf-internal-testing/dummy-gemma")
+        self.assertIsNone(tok.backend_tokenizer.pre_tokenizer)


### PR DESCRIPTION
# What does this PR do?
This PR clarifies the behavior of GemmaTokenizerFast.
The fast tokenizer normalizes spaces to "▁" and does not apply an additional whitespace pre-tokenizer (pre_tokenizer=None).

The change adds a brief docstring clarification and a small test to document and lock in this behavior, addressing the confusion raised in #43062

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # 43062


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
