### PR TITLE
fix(qwen2_5_omni): allow custom Token2Wav noise initialization

### DIFF
--- a/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
@@ -1015,4 +1015,11 @@ class Qwen2_5OmniConfig(PreTrainedConfig):
         return self.thinker_config.get_text_config(*args, **kwargs)
 
 
-__all__ = ["Qwen2_5OmniConfig", "Qwen2_5OmniThinkerConfig", "Qwen2_5OmniTalkerConfig", "Qwen2_5OmniToken2WavConfig"]
+__all__ = [
+    "Qwen2_5OmniConfig",
+    "Qwen2_5OmniThinkerConfig",
+    "Qwen2_5OmniTalkerConfig",
+    "Qwen2_5OmniToken2WavConfig",
+    "Qwen2_5OmniDiTConfig",
+    "Qwen2_5OmniBigVGANConfig",
+]

--- a/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/configuration_qwen2_5_omni.py
@@ -725,42 +725,51 @@ class Qwen2_5OmniDiTConfig(PreTrainedConfig):
 
     Args:
         hidden_size (`int`, *optional*, defaults to 1024):
-            The dimension of the model.
+            Hidden dimension of the DiT blocks.
         num_hidden_layers (`int`, *optional*, defaults to 22):
-            The number of transformer blocks in the DiT model.
+            Number of DiT decoder layers.
         num_attention_heads (`int`, *optional*, defaults to 16):
-            The number of attention heads in each transformer block.
+            Number of attention heads per layer.
         ff_mult (`int`, *optional*, defaults to 2):
-            The multiplier for the feedforward layer in each transformer block.
+            Multiplier applied inside the feed-forward expansion.
         emb_dim (`int`, *optional*, defaults to 512):
-            The dimension of the embedding layer.
+            Dimension of the codec embedding table.
         head_dim (`int`, *optional*, defaults to 64):
-            The dimension of each attention head.
+            Dimension of each attention head.
+        rope_parameters (`Dict` or [`RopeParameters`], *optional*):
+            Parameters controlling the rotary positional encoding.
+        max_position_embeddings (`int`, *optional*, defaults to 32768):
+            Maximum number of timesteps supported by the DiT.
+        block_size (`int`, *optional*, defaults to 24):
+            Temporal block size used when building block-wise attention masks.
+        look_ahead_layers (`List[int]`, *optional*, defaults to `[10]`):
+            Layer indices that enable look-ahead attention.
+        look_backward_layers (`List[int]`, *optional*, defaults to `[0, 20]`):
+            Layer indices that enable look-back attention.
         repeats (`int`, *optional*, defaults to 2):
-            The number of times the codec embeddings are repeated.
+            Number of times codec embeddings are repeated across time.
         num_embeds (`int`, *optional*, defaults to 8193):
-            The number of unique embeddings in the codec.
+            Vocabulary size of the codec embeddings.
         mel_dim (`int`, *optional*, defaults to 80):
-            The dimension of the mel-spectrogram.
+            Mel-spectrogram dimension predicted by the DiT.
         dropout (`float`, *optional*, defaults to 0.1):
-            The dropout rate for the transformer blocks.
-
+            Dropout probability applied within the DiT.
         enc_emb_dim (`int`, *optional*, defaults to 192):
-            The dimension of the pre-trained speaker embedding.
+            Dimension of the speaker embedding input.
         enc_dim (`int`, *optional*, defaults to 128):
-            The dimension of the encoder output.
-        enc_channels (`list[int]`, *optional*, defaults to `[256, 256, 256, 256, 768]`):
-            A list of output channels for each TDNN/SERes2Net layer in the encoder.
-        enc_kernel_sizes (`list[int]`, *optional*, defaults to `[5, 3, 3, 3, 1]`):
-            A list of kernel sizes for each layer in the encoder.
-        enc_dilations (`list[int]`, *optional*, defaults to `[1, 2, 3, 4, 1]`):
-            A list of dilations for each layer in the encoder.
+            Hidden dimension of the reference encoder output.
+        enc_channels (`List[int]`, *optional*, defaults to `[256, 256, 256, 256, 768]`):
+            Output channels for each TDNN/SE-Res2Net block.
+        enc_kernel_sizes (`List[int]`, *optional*, defaults to `[5, 3, 3, 3, 1]`):
+            Kernel sizes per encoder block.
+        enc_dilations (`List[int]`, *optional*, defaults to `[1, 2, 3, 4, 1]`):
+            Dilations per encoder block.
         enc_attention_channels (`int`, *optional*, defaults to 64):
-            The number of attention channels in the SqueezeExcitationBlock.
+            Channels used inside the squeeze-and-excitation attention module.
         enc_res2net_scale (`int`, *optional*, defaults to 2):
-            The scale of the Res2Net block in the encoder.
+            Res2Net scale factor for the encoder.
         enc_se_channels (`int`, *optional*, defaults to 64):
-            The number of output channels after squeeze in the SqueezeExcitationBlock.
+            Output channels after the SE squeeze step.
     """
 
     model_type = "qwen2_5_omni_dit"

--- a/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
@@ -3709,6 +3709,20 @@ class Qwen2_5OmniToken2WavDiTModel(Qwen2_5OmniPreTrainedModel):
 
         return output
 
+    def _prepare_initial_state(
+        self,
+        reference_mel_spectrogram: torch.Tensor,
+        quantized_code: torch.Tensor,
+        noise_initialization: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, int]:
+        return _prepare_initial_state(
+            reference_mel_spectrogram,
+            quantized_code,
+            self.repeats,
+            self.mel_dim,
+            noise_initialization,
+        )
+
     @torch.no_grad()
     def sample(
         self,
@@ -3720,8 +3734,8 @@ class Qwen2_5OmniToken2WavDiTModel(Qwen2_5OmniPreTrainedModel):
         sway_coefficient=-1.0,
         noise_initialization: Optional[torch.Tensor] = None,
     ):
-        initial_state, maximum_duration = _prepare_initial_state(
-            reference_mel_spectrogram, quantized_code, self.repeats, self.mel_dim, noise_initialization
+        initial_state, maximum_duration = self._prepare_initial_state(
+            reference_mel_spectrogram, quantized_code, noise_initialization
         )
         batch_size = reference_mel_spectrogram.shape[0]
         conditioning_vector = conditioning_vector.unsqueeze(1).repeat(1, maximum_duration, 1)

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -3720,6 +3720,52 @@ class RungeKutta4ODESolver:
         return solution
 
 
+def _prepare_initial_state(
+    reference_mel_spectrogram: torch.Tensor,
+    quantized_code: torch.Tensor,
+    repeats: int,
+    mel_dim: int,
+    noise_initialization: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, int]:
+    """
+    Utility function that prepares the initial state used by the diffusion sampler.
+    """
+
+    batch_size = reference_mel_spectrogram.shape[0]
+    maximum_duration = quantized_code.shape[1] * repeats
+
+    if noise_initialization is None:
+        noise_length = max(maximum_duration, reference_mel_spectrogram.shape[1])
+        noise_initialization = torch.randn(
+            (batch_size, noise_length, mel_dim),
+            dtype=reference_mel_spectrogram.dtype,
+            device=quantized_code.device,
+        )
+    else:
+        if noise_initialization.ndim != 3:
+            raise ValueError(
+                f"`noise_initialization` has to be a 3D tensor of shape (batch, time, mel_dim), "
+                f"but received a tensor with shape {noise_initialization.shape}."
+            )
+        if noise_initialization.shape[0] != batch_size or noise_initialization.shape[2] != mel_dim:
+            raise ValueError(
+                "The provided `noise_initialization` must match the batch size and mel dimension of the model. "
+                f"Expected ({batch_size}, *, {mel_dim}) but got {tuple(noise_initialization.shape)}."
+            )
+        if noise_initialization.shape[1] < maximum_duration:
+            raise ValueError(
+                "`noise_initialization` must have a time dimension that is at least as long as "
+                f"`quantized_code.shape[1] * repeats` (got {noise_initialization.shape[1]} "
+                f"while the minimum required length is {maximum_duration})."
+            )
+        noise_initialization = noise_initialization.to(
+            device=quantized_code.device, dtype=reference_mel_spectrogram.dtype
+        )
+
+    initial_state = noise_initialization[:, :maximum_duration]
+    return initial_state, maximum_duration
+
+
 @auto_docstring(
     custom_intro="""
     The full Qwen2.5Omni Token2WavDiT model. Which take speech tokens as input and predict mel spectrogram.
@@ -3831,10 +3877,11 @@ class Qwen2_5OmniToken2WavDiTModel(Qwen2_5OmniPreTrainedModel):
         num_steps=10,
         guidance_scale=0.5,
         sway_coefficient=-1.0,
+        noise_initialization: Optional[torch.Tensor] = None,
     ):
-        noise_initialization = torch.randn([1, 30000, self.mel_dim], dtype=reference_mel_spectrogram.dtype)
-        maximum_duration = quantized_code.shape[1] * self.repeats
-        initial_state = noise_initialization[:, :maximum_duration].to(quantized_code.device)
+        initial_state, maximum_duration = _prepare_initial_state(
+            reference_mel_spectrogram, quantized_code, self.repeats, self.mel_dim, noise_initialization
+        )
         batch_size = reference_mel_spectrogram.shape[0]
         conditioning_vector = conditioning_vector.unsqueeze(1).repeat(1, maximum_duration, 1)
 
@@ -3923,6 +3970,7 @@ class Qwen2_5OmniToken2WavModel(Qwen2_5OmniPreTrainedModel):
         num_steps=10,
         guidance_scale=0.5,
         sway_coefficient=-1.0,
+        noise_initialization: Optional[torch.Tensor] = None,
         **kwargs,
     ):
         """Generates a waveform from input code and conditioning parameters."""
@@ -3934,6 +3982,7 @@ class Qwen2_5OmniToken2WavModel(Qwen2_5OmniPreTrainedModel):
             num_steps=num_steps,
             guidance_scale=guidance_scale,
             sway_coefficient=sway_coefficient,
+            noise_initialization=noise_initialization,
         )
 
         waveform = self.code2wav_bigvgan_model(mel_spectrogram)

--- a/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/modular_qwen2_5_omni.py
@@ -3868,6 +3868,20 @@ class Qwen2_5OmniToken2WavDiTModel(Qwen2_5OmniPreTrainedModel):
 
         return output
 
+    def _prepare_initial_state(
+        self,
+        reference_mel_spectrogram: torch.Tensor,
+        quantized_code: torch.Tensor,
+        noise_initialization: Optional[torch.Tensor] = None,
+    ) -> tuple[torch.Tensor, int]:
+        return _prepare_initial_state(
+            reference_mel_spectrogram,
+            quantized_code,
+            self.repeats,
+            self.mel_dim,
+            noise_initialization,
+        )
+
     @torch.no_grad()
     def sample(
         self,
@@ -3879,8 +3893,8 @@ class Qwen2_5OmniToken2WavDiTModel(Qwen2_5OmniPreTrainedModel):
         sway_coefficient=-1.0,
         noise_initialization: Optional[torch.Tensor] = None,
     ):
-        initial_state, maximum_duration = _prepare_initial_state(
-            reference_mel_spectrogram, quantized_code, self.repeats, self.mel_dim, noise_initialization
+        initial_state, maximum_duration = self._prepare_initial_state(
+            reference_mel_spectrogram, quantized_code, noise_initialization
         )
         batch_size = reference_mel_spectrogram.shape[0]
         conditioning_vector = conditioning_vector.unsqueeze(1).repeat(1, maximum_duration, 1)


### PR DESCRIPTION
# What does this PR do?

- I exposed `Qwen2_5OmniDiTConfig`/`BigVGANConfig` at the top level so the test suite (and user code) can import them directly.
- I added an instance-level `_prepare_initial_state` helper to `Qwen2_5OmniToken2WavDiTModel` so callers/tests can pass their own noise tensors; the modular + generated implementations now share that logic.
- I regenerated `modeling_qwen2_5_omni.py` via `utils/modular_model_converter.py` and added regression tests (`Token2WavSamplingTest`) to cover both the default and custom-noise paths.
- Fixes #43079.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue or the forum? (linked above)
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Testing
- `PYTHONPATH=src pytest tests/models/qwen2_5_omni/test_modeling_qwen2_5_omni.py -k Token2WavSamplingTest`

## Dependencies
- None.

## Who can review?
Anyone interested in Qwen2.5 Omni audio/token2wav internals. Tagging @zucchini-nlp for visibility.
