### PR TITLE
Fix InvalidVersion error when flash_attn version is N/A

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -888,6 +888,10 @@ def is_flash_attn_2_available() -> bool:
     if not is_available or not (is_torch_cuda_available() or is_torch_mlu_available()):
         return False
 
+    # Version could be "N/A" if __version__ attribute is not available
+    if flash_attn_version == "N/A":
+        return False
+
     import torch
 
     if torch.version.cuda:
@@ -909,13 +913,17 @@ def is_flash_attn_3_available() -> bool:
 @lru_cache
 def is_flash_attn_greater_or_equal_2_10() -> bool:
     _, flash_attn_version = _is_package_available("flash_attn", return_version=True)
+    if flash_attn_version == "N/A":
+        return False
     return is_flash_attn_2_available() and version.parse(flash_attn_version) >= version.parse("2.1.0")
 
 
 @lru_cache
 def is_flash_attn_greater_or_equal(library_version: str) -> bool:
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
-    return is_available and version.parse(flash_attn_version) >= version.parse(library_version)
+    if not is_available or flash_attn_version == "N/A":
+        return False
+    return version.parse(flash_attn_version) >= version.parse(library_version)
 
 
 @lru_cache


### PR DESCRIPTION
# What does this PR do?

Fixes #42999

This PR handles the case where `flash_attn` package is installed but `__version__` attribute is not available, resulting in version being "N/A". When `version.parse("N/A")` is called, it raises `packaging.version.InvalidVersion`.

The fix adds a check for "N/A" version in the following functions:
- `is_flash_attn_2_available()`
- `is_flash_attn_greater_or_equal_2_10()`
- `is_flash_attn_greater_or_equal()`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Issue: #42999
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@vasqu @ArthurZucker @CyrilVallez (mentioned in the issue)