### PR TITLE
Fix inits in modernbert

### DIFF
--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -687,7 +687,7 @@ class ModernBertPreTrainedModel(PreTrainedModel):
                 init.copy_(getattr(module, f"{layer_type}_original_inv_freq"), curr_inv_freq)
         elif isinstance(module, ModernBertUnpaddedRotaryEmbedding):
             inv_freq = module._compute_inv_freq()
-            init.copy_(getattr(module, "inv_freq"), inv_freq)
+            init.copy_(module.inv_freq, inv_freq)
 
     def _check_and_adjust_attn_implementation(
         self, attn_implementation: Optional[str], is_init_check: bool = False

--- a/src/transformers/models/modernbert/modeling_modernbert.py
+++ b/src/transformers/models/modernbert/modeling_modernbert.py
@@ -685,6 +685,9 @@ class ModernBertPreTrainedModel(PreTrainedModel):
                 curr_inv_freq, _ = rope_init_fn(module.config, layer_type=layer_type)
                 init.copy_(getattr(module, f"{layer_type}_inv_freq"), curr_inv_freq)
                 init.copy_(getattr(module, f"{layer_type}_original_inv_freq"), curr_inv_freq)
+        elif isinstance(module, ModernBertUnpaddedRotaryEmbedding):
+            inv_freq = module._compute_inv_freq()
+            init.copy_(getattr(module, "inv_freq"), inv_freq)
 
     def _check_and_adjust_attn_implementation(
         self, attn_implementation: Optional[str], is_init_check: bool = False

--- a/src/transformers/models/modernbert/modular_modernbert.py
+++ b/src/transformers/models/modernbert/modular_modernbert.py
@@ -879,6 +879,9 @@ class ModernBertPreTrainedModel(PreTrainedModel):
                 curr_inv_freq, _ = rope_init_fn(module.config, layer_type=layer_type)
                 init.copy_(getattr(module, f"{layer_type}_inv_freq"), curr_inv_freq)
                 init.copy_(getattr(module, f"{layer_type}_original_inv_freq"), curr_inv_freq)
+        elif isinstance(module, ModernBertUnpaddedRotaryEmbedding):
+            inv_freq = module._compute_inv_freq()
+            init.copy_(getattr(module, "inv_freq"), inv_freq)
 
     def _check_and_adjust_attn_implementation(
         self, attn_implementation: Optional[str], is_init_check: bool = False

--- a/src/transformers/models/modernbert/modular_modernbert.py
+++ b/src/transformers/models/modernbert/modular_modernbert.py
@@ -881,7 +881,7 @@ class ModernBertPreTrainedModel(PreTrainedModel):
                 init.copy_(getattr(module, f"{layer_type}_original_inv_freq"), curr_inv_freq)
         elif isinstance(module, ModernBertUnpaddedRotaryEmbedding):
             inv_freq = module._compute_inv_freq()
-            init.copy_(getattr(module, "inv_freq"), inv_freq)
+            init.copy_(module.inv_freq, inv_freq)
 
     def _check_and_adjust_attn_implementation(
         self, attn_implementation: Optional[str], is_init_check: bool = False


### PR DESCRIPTION
# What does this PR do?
This PR fixes a few `modernbert` tests that are failing due to the new initialization scheme, only when `flash_attention` is available.

## Failure cause and fixes
The class  `ModernBertUnpaddedRotaryEmbedding` was not included in `init_weights`, which led to random initialization of `inv_freq`. It is now included and the initialization function used is the one of the parent class.

## Models affected
Modernbert only. 

## Fixed tests
- tests/models/modernbert/test_modeling_modernbert.py::ModernBertModelTest::test_cpu_offload
- tests/models/modernbert/test_modeling_modernbert.py::ModernBertModelTest::test_disk_offload_bin
- tests/models/modernbert/test_modeling_modernbert.py::ModernBertModelTest::test_disk_offload_safetensors
- tests/models/modernbert/test_modeling_modernbert.py::ModernBertModelTest::test_init_weights_can_init_buffers
- tests/models/modernbert/test_modeling_modernbert.py::ModernBertModelTest::test_model_parallelism
- tests/models/modernbert/test_modeling_modernbert.py::ModernBertModelTest::test_save_load

