### PR TITLE
Fix missing UTF-8 encoding in check_repo.py for Windows compatibility

### DIFF
--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -1233,7 +1233,7 @@ def check_models_have_kwargs():
         if model_dir.is_dir() and (modeling_file := list(model_dir.glob("modeling_*.py"))):
             modeling_file = modeling_file[0]
 
-            with open(modeling_file, "r") as f:
+            with open(modeling_file, "r", encoding="utf-8") as f:
                 tree = ast.parse(f.read())
 
             # Map all classes in the file to their base classes


### PR DESCRIPTION
## What does this PR do?

This PR fixes an inconsistent file-opening pattern in `utils/check_repo.py` by explicitly specifying `encoding="utf-8"` when reading Python source files.

Several utilities in `utils/` already open files with an explicit UTF-8 encoding, but this particular code path relied on the platform default. On Windows, this can lead to `UnicodeDecodeError` or inconsistent behavior when parsing Python files containing non-ASCII characters.

This change aligns the implementation with existing patterns across the repository and improves cross-platform robustness without altering any functional logic.

---

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue or the forum? (Not required for a small mechanical fix)
- [ ] Did you make sure to update the documentation with your changes? (Not applicable)
- [ ] Did you write any new necessary tests? (Not required for this change)

---

## Who can review?

@ydshieh or anyone else in the community after the checks have passed!
