### PR TITLE
[Quantization] torchao serialization

### DIFF
--- a/src/transformers/quantizers/quantizer_torchao.py
+++ b/src/transformers/quantizers/quantizer_torchao.py
@@ -146,7 +146,7 @@ class TorchAoHfQuantizer(HfQuantizer):
         We flatten the state dict of tensor subclasses so that it is compatible with the safetensors format.
         """
         if TORCHAO_VERSION >= version.parse("0.15.0"):
-            return flatten_tensor_state_dict(model.state_dict()), {}
+            return flatten_tensor_state_dict(model.state_dict())
         else:
             raise RuntimeError(
                 f"In order to use safetensors with torchao, please use torchao version >= 0.15.0. Current version: {TORCHAO_VERSION}"

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -529,7 +529,7 @@ class TorchAoTest(unittest.TestCase):
         quant_config = TorchAoConfig(quant_type=config)
         quantized_model = AutoModelForCausalLM.from_pretrained(
             "jcaip/Llama-4-Scout-17B-two-layers-only-testing",
-            device_map="auto",
+            device_map="cuda",
             dtype=torch.bfloat16,
             quantization_config=quant_config,
         )


### PR DESCRIPTION
# What does this PR do?

Fixes torchao serialization, some tests are still failling for Int8/Int4 quantization with: 

```
ValueError: Unsupported tensor type: <class 'torchao.dtypes.affine_quantized_tensor.AffineQuantizedTensor'>
``` 

which seems to be a problem on torchao's end

