### PR TITLE
Fix flaky SAM-HQ integration tests by adding set_seed

### DIFF
--- a/tests/models/sam_hq/test_modeling_sam_hq.py
+++ b/tests/models/sam_hq/test_modeling_sam_hq.py
@@ -29,6 +29,7 @@ from transformers import (
     pipeline,
 )
 from transformers.testing_utils import Expectations, cleanup, require_torch, slow, torch_device
+from transformers.trainer_utils import set_seed
 from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_configuration_common import ConfigTester
@@ -775,6 +776,11 @@ def prepare_dog_img():
 
 @slow
 class SamHQModelIntegrationTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        # Set seed for deterministic positional embeddings (randomly initialized via torch.randn)
+        set_seed(0)
+
     def tearDown(self):
         super().tearDown()
         # clean-up as much as possible GPU memory occupied by PyTorch


### PR DESCRIPTION
# What does this PR do?

Fixes flaky `SamHQModelIntegrationTest` by adding `set_seed(0)` in `setUp()`.

The root cause: HF SAM-HQ creates two independent `SamHQPositionalEmbedding` instances (`shared_image_embedding` and `prompt_encoder.shared_embedding`), but the checkpoint only loads weights to `shared_image_embedding`. The other one stays randomly initialized, causing non-deterministic test results.

Note: This is a workaround. The proper fix would be to share the embedding between both (like the original SAM-HQ) or copy weights to both during loading. Happy to implement that instead if preferred.

Fixes #42890

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #42890
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@NielsRogge @molbap @yonigozlan