### PR TITLE
[`Ernie 4.5 VL Moe`] Fix non contiguous params

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -432,7 +432,7 @@ class Transpose(ConversionOps):
             tensor = input_dict.get(key, [])
             if len(tensor) != 1:
                 raise ValueError(f"Transpose conversion requires exactly one tensor, found {len(tensor)}.")
-            output[target_pattern] = torch.transpose(tensor[0], dim0=self.dim0, dim1=self.dim1)
+            output[target_pattern] = torch.transpose(tensor[0], dim0=self.dim0, dim1=self.dim1).contiguous()
         return output
 
     @property

--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -155,6 +155,10 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
     def test_save_load(self):
         pass
 
+    @unittest.skip(reason="Only checkpoints on timm can be loaded into TimmBackbone")
+    def test_load_contiguous_weights(self):
+        pass
+
     @unittest.skip(reason="TimmBackbone uses its own `from_pretrained` without device_map support")
     def test_can_load_with_device_context_manager(self):
         pass

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -933,6 +933,23 @@ class ModelTesterMixin:
                     )
                     self.assertTrue(len(load_result.unexpected_keys) == 0)
 
+    def test_load_contigous_weights(self):
+        """
+        Checks whether the loaded weights are contiguous or not; inherently checking whether a conversion
+        operation from `core_model_loading` may have affected the original weights.
+        """
+        for model_class in self.all_model_classes:
+            config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+
+            model = model_class(config)
+            self.assertTrue(all(param.is_contiguous() for param in list(model.parameters())))
+
+            with tempfile.TemporaryDirectory() as tmpdirname:
+                model.save_pretrained(tmpdirname)
+
+                model = model_class.from_pretrained(tmpdirname)
+                self.assertTrue(all(param.is_contiguous() for param in list(model.parameters())))
+
     def test_gradient_checkpointing_backward_compatibility(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
 

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -933,7 +933,7 @@ class ModelTesterMixin:
                     )
                     self.assertTrue(len(load_result.unexpected_keys) == 0)
 
-    def test_load_contigous_weights(self):
+    def test_load_contiguous_weights(self):
         """
         Checks whether the loaded weights are contiguous or not; inherently checking whether a conversion
         operation from `core_model_loading` may have affected the original weights.


### PR DESCRIPTION
As per title, this is caused by the `transpose` conversion op which can cause non-contiguous layouts (kind of expected tbh). Simply forcing contiguous solves this.

Repro:
```python
from transformers import AutoModelForImageTextToText

model = AutoModelForImageTextToText.from_pretrained(
    "baidu/ERNIE-4.5-VL-28B-A3B-PT",
    device_map="auto",
    dtype="auto",
    revision="refs/pr/10",
)

assert all(param.is_contiguous() for param in list(model.parameters())), "Some parameters are not contiguous"
```