### PR TITLE
Fix multi-label prediction thresholding in run_classification

### DIFF
--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -41,6 +41,7 @@ import datasets
 import evaluate
 import numpy as np
 from datasets import Value, load_dataset
+from scipy.special import expit
 
 import transformers
 from transformers import (
@@ -709,7 +710,7 @@ def main():
             # Convert logits to multi-hot encoding. We compare the logits to 0 instead of 0.5, because the sigmoid is not applied.
             # You can also pass `preprocess_logits_for_metrics=lambda logits, labels: nn.functional.sigmoid(logits)` to the Trainer
             # and set p > 0.5 below (less efficient in this case)
-            predictions = np.array([np.where(p > 0, 1, 0) for p in predictions])
+            predictions = np.array([np.where(expit(p) > 0.5, 1, 0) for p in predictions])
         else:
             predictions = np.argmax(predictions, axis=1)
         output_predict_file = os.path.join(training_args.output_dir, "predict_results.txt")

--- a/tests/examples/test_run_classification.py
+++ b/tests/examples/test_run_classification.py
@@ -1,0 +1,21 @@
+import numpy as np
+from scipy.special import expit
+
+
+def test_multilabel_prediction_thresholding():
+    # Simulated logits from a multi-label model
+    logits = np.array([
+        [-1.2, 0.3, 2.1],
+        [-0.7, -0.2, 1.5],
+    ])
+
+    predictions = np.array(
+        [np.where(expit(p) > 0.5, 1, 0) for p in logits]
+    )
+
+    # Ensure shape is preserved
+    assert predictions.shape == logits.shape
+
+    # Ensure at least one positive label is predicted
+    assert predictions.sum() > 0
+


### PR DESCRIPTION
Fixes incorrect multi-label prediction thresholding that caused empty
predictions in predict_results.txt for multi-label classification.
