### PR TITLE
Fix failing `DebertaV2ModelIntegrationTest`

### DIFF
--- a/tests/models/deberta_v2/test_modeling_deberta_v2.py
+++ b/tests/models/deberta_v2/test_modeling_deberta_v2.py
@@ -301,7 +301,7 @@ class DebertaV2ModelIntegrationTest(unittest.TestCase):
 
     @slow
     def test_inference_no_head(self):
-        model = DebertaV2Model.from_pretrained("microsoft/deberta-v2-xlarge")
+        model = DebertaV2Model.from_pretrained("microsoft/deberta-v2-xlarge", dtype=torch.float32)
 
         input_ids = torch.tensor([[0, 31414, 232, 328, 740, 1140, 12695, 69, 46078, 1588, 2]])
         attention_mask = torch.tensor([[0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]])


### PR DESCRIPTION
# What does this PR do?
Fixes this failing [DebertaV2ModelIntegrationTest](https://github.com/huggingface/transformers/actions/runs/20706072009/job/59437072475#step:14:1608).

<img width="1327" height="147" alt="image" src="https://github.com/user-attachments/assets/6cef8469-03ae-4e46-b533-ec94627f4dd9" />

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@Rocketknight1 @zucchini-nlp