### PR TITLE
Fix Fuyu processor width dimension bug in `_get_num_multimodal_tokens`

### DIFF
--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -626,7 +626,7 @@ class FuyuProcessor(ProcessorMixin):
                 optimal_scale_factor = min(height_scale_factor, width_scale_factor)
 
                 image_unpadded_h = min(int(image_size[0] * optimal_scale_factor), image_size[0])
-                image_unpadded_w = min(int(image_size[0] * optimal_scale_factor), image_size[0])
+                image_unpadded_w = min(int(image_size[1] * optimal_scale_factor), image_size[1])
 
                 # We can use torch here because Fuyu processor has hard dependency on torch. NOTE: Fuyu can't do multi-image
                 # thus the below (1, 1, 1) is hardcoded. Same as when calling the processor


### PR DESCRIPTION
# What does this PR do?

This PR fixes a critical bug in the Fuyu processor's `_get_num_multimodal_tokens` method where the image width calculation incorrectly uses the height dimension.

## The Bug

In `src/transformers/models/fuyu/processing_fuyu.py` at line 629, the code was:

```python
image_unpadded_h = min(int(image_size[0] * optimal_scale_factor), image_size[0])
image_unpadded_w = min(int(image_size[0] * optimal_scale_factor), image_size[0])  # BUG: uses [0] twice!

```

Both height and width were being calculated using `image_size[0]` (the height dimension). The width should use `image_size[1]`.

## The Fix

Changed line 629 to correctly use `image_size[1]` for the width calculation:

```python
image_unpadded_h = min(int(image_size[0] * optimal_scale_factor), image_size[0])
image_unpadded_w = min(int(image_size[1] * optimal_scale_factor), image_size[1])  # Fixed

```

## Impact

This bug caused incorrect image padding calculations for multimodal inputs in Fuyu, resulting in:

* **Wrong aspect ratio preservation** for images.
* **Incorrect token count computation** for variable-sized images.
* **Distorted image processing** when .

The fix ensures proper scaling of both dimensions independently, matching the intended behavior shown in the corresponding `image_processing_fuyu.py` file.

---

## Before submitting

* [x] This PR fixes a bug in model implementation.
* [x] Did you read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
* [ ] Was this discussed/approved via a Github issue or the forum?
* [x] This is a minimal change that does not require documentation updates.
* [ ] Did you write any new necessary tests? (Fix is self-evident and covered by existing tests).

## Who can review?

@zucchini-nlp (multimodal models) @molbap (vision models)