### PR TITLE
[docs] embed dataset viewer

### DIFF
--- a/docs/source/en/experts_interface.md
+++ b/docs/source/en/experts_interface.md
@@ -110,15 +110,15 @@ model.forward = torch.compile(model.forward, mode="max-autotune-no-cudagraphs")
 This [benchmark](https://github.com/user-attachments/files/24125816/bench.py) compares different input sizes and experts implementations with and without `torch.compile`.
 
 <iframe
-  src="https://huggingface.co/datasets/docs-benchmarks/experts-backends/embed/viewer/bs1-seq16/train"
-  frameborder="0"
-  width="100%"
-  height="560px"
-></iframe>
-
-<iframe
 	src="https://huggingface-moe-experts-benchmarks.static.hf.space"
 	frameborder="0"
 	width="100%"
 	height="800"
+></iframe>
+
+<iframe
+  src="https://huggingface.co/datasets/docs-benchmarks/experts-backends/embed/viewer/bs1-seq16/train"
+  frameborder="0"
+  width="100%"
+  height="560px"
 ></iframe>

--- a/docs/source/en/experts_interface.md
+++ b/docs/source/en/experts_interface.md
@@ -117,7 +117,7 @@ This [benchmark](https://github.com/user-attachments/files/24125816/bench.py) co
 ></iframe>
 
 <iframe
-	src="https://huggingface-moe-experts.static.hf.space"
+	src="https://huggingface-moe-experts-benchmarks.static.hf.space"
 	frameborder="0"
 	width="100%"
 	height="800"

--- a/docs/source/en/experts_interface.md
+++ b/docs/source/en/experts_interface.md
@@ -109,58 +109,9 @@ model.forward = torch.compile(model.forward, mode="max-autotune-no-cudagraphs")
 
 This [benchmark](https://github.com/user-attachments/files/24125816/bench.py) compares different input sizes and experts implementations with and without `torch.compile`.
 
-### Batch Size 1, Sequence Length 16
-
-| Torch Compile              | Implementation | Mean Latency (ms)                            | Median Latency (ms)                          | P90 Latency (ms)                             | Peak Mem (MB) |
-| -------------------------- | -------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | ------------- |
-| False                      | eager          | 271.80                                       | 272.94                                       | 295.34                                       | 27324.65      |
-| True                       | eager          | 351.86                                       | 351.64                                       | 384.64                                       | 27329.29      |
-| max-autotune-no-cudagraphs | eager          | 352.52                                       | 352.15                                       | 382.79                                       | 27329.29      |
-| False                      | batched_mm     | 52.03                                        | 52.07                                        | 52.67                                        | 28382.50      |
-| True                       | batched_mm     | 53.04                                        | 53.04                                        | 53.11                                        | 28029.63      |
-| max-autotune-no-cudagraphs | batched_mm     | **<span style="color: green;">23.87</span>** | **<span style="color: green;">23.86</span>** | **<span style="color: green;">24.02</span>** | **27329.29**  |
-| False                      | grouped_mm     | 64.27                                        | 64.09                                        | 65.49                                        | 27329.29      |
-| True                       | grouped_mm     | 59.45                                        | 59.52                                        | 60.99                                        | 27329.29      |
-| max-autotune-no-cudagraphs | grouped_mm     | 59.61                                        | 59.55                                        | 60.89                                        | 27329.29      |
-
-### Batch Size 1, Sequence Length 128
-
-| Torch Compile              | Implementation | Mean Latency (ms)                            | Median Latency (ms)                          | P90 Latency (ms)                             | Peak Mem (MB) |
-| -------------------------- | -------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | ------------- |
-| False                      | eager          | 471.73                                       | 472.65                                       | 487.97                                       | 27396.46      |
-| True                       | eager          | <span style="color: red;">637.32</span>      | 613.70                                       | <span style="color: red;">845.01</span>      | 27429.82      |
-| max-autotune-no-cudagraphs | eager          | 620.21                                       | 619.35                                       | 657.74                                       | 27429.82      |
-| False                      | batched_mm     | 316.67                                       | 316.94                                       | 317.92                                       | 35854.56      |
-| True                       | batched_mm     | 370.29                                       | 370.29                                       | 370.57                                       | 33031.64      |
-| max-autotune-no-cudagraphs | batched_mm     | 151.87                                       | 150.38                                       | 158.01                                       | 27429.82      |
-| False                      | grouped_mm     | 78.50                                        | 78.53                                        | 80.00                                        | **27429.82**  |
-| True                       | grouped_mm     | 72.95                                        | 72.99                                        | 74.60                                        | **27429.82**  |
-| max-autotune-no-cudagraphs | grouped_mm     | **<span style="color: green;">72.71</span>** | **<span style="color: green;">72.89</span>** | **<span style="color: green;">73.55</span>** | **27429.82**  |
-
-### Batch Size 4, Sequence Length 16
-
-| Torch Compile              | Implementation | Mean Latency (ms)                            | Median Latency (ms)                          | P90 Latency (ms)                             | Peak Mem (MB) |
-| -------------------------- | -------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | ------------- |
-| False                      | eager          | 431.87                                       | 433.38                                       | 448.01                                       | 27391.57      |
-| True                       | eager          | <span style="color: red;">566.63</span>      | <span style="color: red;">569.74</span>      | <span style="color: red;">598.98</span>      | 27372.12      |
-| max-autotune-no-cudagraphs | eager          | 563.13                                       | 567.79                                       | 588.25                                       | 27372.12      |
-| False                      | batched_mm     | 163.41                                       | 163.38                                       | 164.84                                       | 31585.54      |
-| True                       | batched_mm     | 189.18                                       | 189.08                                       | 189.79                                       | 30173.45      |
-| max-autotune-no-cudagraphs | batched_mm     | 79.15                                        | 79.10                                        | 79.74                                        | 27372.11      |
-| False                      | grouped_mm     | 75.23                                        | 75.18                                        | 76.74                                        | 27372.11      |
-| True                       | grouped_mm     | 70.35                                        | 70.40                                        | 71.71                                        | **27372.12**  |
-| max-autotune-no-cudagraphs | grouped_mm     | **<span style="color: green;">70.26</span>** | **<span style="color: green;">70.43</span>** | **<span style="color: green;">71.32</span>** | **27372.12**  |
-
-### Batch Size 4, Sequence Length 128
-
-| Torch Compile              | Implementation | Mean Latency (ms)                            | Median Latency (ms)                          | P90 Latency (ms)                             | Peak Mem (MB)                             |
-| -------------------------- | -------------- | -------------------------------------------- | -------------------------------------------- | -------------------------------------------- | ----------------------------------------- |
-| False                      | eager          | 526.88                                       | 522.75                                       | 570.01                                       | 27632.62                                  |
-| True                       | eager          | 678.18                                       | 677.54                                       | 690.97                                       | 27762.46                                  |
-| max-autotune-no-cudagraphs | eager          | 676.22                                       | 677.07                                       | 681.91                                       | 27762.45                                  |
-| False                      | batched_mm     | 1235.25                                      | 1235.33                                      | 1237.90                                      | <span style="color: red;">61465.85</span> |
-| True                       | batched_mm     | <span style="color: red;">1505.00</span>     | <span style="color: red;">1503.31</span>     | <span style="color: red;">1536.10</span>     | 50174.26                                  |
-| max-autotune-no-cudagraphs | batched_mm     | 572.37                                       | 570.81                                       | 589.74                                       | **27762.45**                              |
-| False                      | grouped_mm     | 80.95                                        | 81.06                                        | 81.70                                        | **27762.45**                              |
-| True                       | grouped_mm     | **<span style="color: green;">79.67</span>** | **<span style="color: green;">79.69</span>** | **<span style="color: green;">80.54</span>** | **27762.45**                              |
-| max-autotune-no-cudagraphs | grouped_mm     | 83.29                                        | 79.83                                        | 111.83                                       | **27762.46**                              |
+<iframe
+  src="https://huggingface.co/datasets/docs-benchmarks/experts-backends/embed/viewer/bs1-seq16/train"
+  frameborder="0"
+  width="100%"
+  height="560px"
+></iframe>

--- a/docs/source/en/experts_interface.md
+++ b/docs/source/en/experts_interface.md
@@ -115,3 +115,10 @@ This [benchmark](https://github.com/user-attachments/files/24125816/bench.py) co
   width="100%"
   height="560px"
 ></iframe>
+
+<iframe
+	src="https://huggingface-moe-experts.static.hf.space"
+	frameborder="0"
+	width="100%"
+	height="800"
+></iframe>


### PR DESCRIPTION
replaces large markdown tables with the cleaner dataset viewer

<img width="966" height="722" alt="Screenshot 2026-01-07 at 2 24 23 PM" src="https://github.com/user-attachments/assets/53f71b23-9d25-4855-abb5-f0eedb2acf3f" />
