### PR TITLE
Fix generation config validation

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -687,7 +687,7 @@ class GenerationConfig(PushToHubMixin):
                 )
 
         # 2.5. check cache-related arguments
-        if self.use_cache is not True:
+        if self.use_cache is False:
             # In this case, all cache-related arguments should be unset. However, since `use_cache=False` is often used
             # passed to `generate` directly to hot-fix cache issues, let's raise a warning instead of an error
             # (otherwise a user might need to overwrite several parameters).

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2686,6 +2686,13 @@ class GenerationIntegrationTests(unittest.TestCase):
         out = model.generate(input_ids, generation_config=generation_config)
         self.assertTrue(len(out[0]) == 20)  # generated max_length=20 tokens, not 50!
 
+        # Lastly try saving to make sure no errors are raised about
+        # "generation params in config" or during config validation (#43175)
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model.generation_config.cache_implementation = "dynamic"
+            model.generation_config.use_cache = None
+            model.save_pretrained(tmpdirname)
+
     # TODO joao, manuel: remove in v4.62.0
     @slow
     def test_diverse_beam_search(self):


### PR DESCRIPTION
# What does this PR do?

Fixes an issue reported by @BenjaminBossan . The default of caching was `True` so we assume that new default of `None` is also `True`. So we need to check only if `False` is set explicitly by the user

```python
from transformers import AutoModelForCausalLM

model_id = 'hf-internal-testing/tiny-random-Gemma3ForCausalLM'
model = AutoModelForCausalLM.from_pretrained(model_id)
tmp_dirname = "/tmp/save-gemma3"
model.save_pretrained(tmp_dirname)

```
