### PR TITLE
Fix failing `salesforce-ctrl`, `xlm` & `gpt-neo` model generation tests

### DIFF
--- a/tests/models/ctrl/test_modeling_ctrl.py
+++ b/tests/models/ctrl/test_modeling_ctrl.py
@@ -274,5 +274,6 @@ class CTRLModelLanguageGenerationTest(unittest.TestCase):
             5,
         ]  # Legal the president is a good guy and I don't want to lose my job. \n \n I have a
 
-        output_ids = model.generate(input_ids, do_sample=False)
+        output_ids = model.generate(input_ids, do_sample=False, max_length=20)
+        breakpoint()
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/models/ctrl/test_modeling_ctrl.py
+++ b/tests/models/ctrl/test_modeling_ctrl.py
@@ -274,5 +274,6 @@ class CTRLModelLanguageGenerationTest(unittest.TestCase):
             5,
         ]  # Legal the president is a good guy and I don't want to lose my job. \n \n I have a
 
+        # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
         output_ids = model.generate(input_ids, do_sample=False, max_length=20)
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/models/ctrl/test_modeling_ctrl.py
+++ b/tests/models/ctrl/test_modeling_ctrl.py
@@ -275,5 +275,4 @@ class CTRLModelLanguageGenerationTest(unittest.TestCase):
         ]  # Legal the president is a good guy and I don't want to lose my job. \n \n I have a
 
         output_ids = model.generate(input_ids, do_sample=False, max_length=20)
-        breakpoint()
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/models/gpt_neo/test_modeling_gpt_neo.py
+++ b/tests/models/gpt_neo/test_modeling_gpt_neo.py
@@ -491,7 +491,7 @@ class GPTNeoModelLanguageGenerationTest(unittest.TestCase):
             input_ids = torch.tensor([[464, 3290]], dtype=torch.long, device=torch_device)  # The dog
             # The dog-eared copy of the book, which is a collection of essays by the late author,
             expected_output_ids = [464, 3290, 12, 3380, 4866, 286, 262, 1492, 11, 543, 318, 257, 4947, 286, 27126, 416, 262, 2739, 1772, 11]  # fmt: skip
-            output_ids = model.generate(input_ids, do_sample=False)
+            output_ids = model.generate(input_ids, do_sample=False, max_length=20)
             self.assertListEqual(output_ids[0].tolist(), expected_output_ids)
 
     @slow
@@ -531,14 +531,16 @@ class GPTNeoModelLanguageGenerationTest(unittest.TestCase):
         outputs = model.generate(
             input_ids=input_ids,
             attention_mask=inputs["attention_mask"].to(torch_device),
+            max_length=20,
         )
 
         inputs_non_padded = tokenizer(sentences[0], return_tensors="pt").input_ids.to(torch_device)
-        output_non_padded = model.generate(input_ids=inputs_non_padded)
+        output_non_padded = model.generate(input_ids=inputs_non_padded, max_length=20)
 
         num_paddings = inputs_non_padded.shape[-1] - inputs["attention_mask"][-1].long().sum().item()
         inputs_padded = tokenizer(sentences[1], return_tensors="pt").input_ids.to(torch_device)
-        output_padded = model.generate(input_ids=inputs_padded, max_length=model.config.max_length - num_paddings)
+        # 20 is the default max_length of the generation config
+        output_padded = model.generate(input_ids=inputs_padded, max_length=20 - num_paddings)
 
         batch_out_sentence = tokenizer.batch_decode(outputs, skip_special_tokens=True)
         non_padded_sentence = tokenizer.decode(output_non_padded[0], skip_special_tokens=True)

--- a/tests/models/gpt_neo/test_modeling_gpt_neo.py
+++ b/tests/models/gpt_neo/test_modeling_gpt_neo.py
@@ -491,6 +491,7 @@ class GPTNeoModelLanguageGenerationTest(unittest.TestCase):
             input_ids = torch.tensor([[464, 3290]], dtype=torch.long, device=torch_device)  # The dog
             # The dog-eared copy of the book, which is a collection of essays by the late author,
             expected_output_ids = [464, 3290, 12, 3380, 4866, 286, 262, 1492, 11, 543, 318, 257, 4947, 286, 27126, 416, 262, 2739, 1772, 11]  # fmt: skip
+            # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
             output_ids = model.generate(input_ids, do_sample=False, max_length=20)
             self.assertListEqual(output_ids[0].tolist(), expected_output_ids)
 
@@ -528,6 +529,7 @@ class GPTNeoModelLanguageGenerationTest(unittest.TestCase):
         inputs = tokenizer(sentences, return_tensors="pt", padding=True)
         input_ids = inputs["input_ids"].to(torch_device)
 
+        # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
         outputs = model.generate(
             input_ids=input_ids,
             attention_mask=inputs["attention_mask"].to(torch_device),
@@ -535,11 +537,12 @@ class GPTNeoModelLanguageGenerationTest(unittest.TestCase):
         )
 
         inputs_non_padded = tokenizer(sentences[0], return_tensors="pt").input_ids.to(torch_device)
+        # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
         output_non_padded = model.generate(input_ids=inputs_non_padded, max_length=20)
 
         num_paddings = inputs_non_padded.shape[-1] - inputs["attention_mask"][-1].long().sum().item()
         inputs_padded = tokenizer(sentences[1], return_tensors="pt").input_ids.to(torch_device)
-        # 20 is the default max_length of the generation config
+        # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
         output_padded = model.generate(input_ids=inputs_padded, max_length=20 - num_paddings)
 
         batch_out_sentence = tokenizer.batch_decode(outputs, skip_special_tokens=True)

--- a/tests/models/xlm/test_modeling_xlm.py
+++ b/tests/models/xlm/test_modeling_xlm.py
@@ -525,5 +525,5 @@ class XLMModelLanguageGenerationTest(unittest.TestCase):
             447,
         ]  # the president the president the president the president the president the president the president the president the president the president
         # TODO(PVP): this and other input_ids I tried for generation give pretty bad results. Not sure why. Model might just not be made for auto-regressive inference
-        output_ids = model.generate(input_ids, do_sample=False)
+        output_ids = model.generate(input_ids, do_sample=False, max_length=20)
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)

--- a/tests/models/xlm/test_modeling_xlm.py
+++ b/tests/models/xlm/test_modeling_xlm.py
@@ -525,5 +525,6 @@ class XLMModelLanguageGenerationTest(unittest.TestCase):
             447,
         ]  # the president the president the president the president the president the president the president the president the president the president
         # TODO(PVP): this and other input_ids I tried for generation give pretty bad results. Not sure why. Model might just not be made for auto-regressive inference
+        # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
         output_ids = model.generate(input_ids, do_sample=False, max_length=20)
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)


### PR DESCRIPTION
# What does this PR do?

Fixes failing [salesforce-ctrl](https://github.com/huggingface/transformers/actions/runs/20706072009/job/59437072445#step:14:2512), [xlm](https://github.com/huggingface/transformers/actions/runs/20706072009/job/59437072306#step:14:1400) & [gpt-neo](https://github.com/huggingface/transformers/actions/runs/20706072009/job/59437072542#step:14:2902) models generation tests

<img width="1330" height="187" alt="image" src="https://github.com/user-attachments/assets/1f5b7904-9014-48b3-944b-67ae50a22781" />


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@vasqu