### PR TITLE
Bump huggingface_hub minimal version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ _deps = [
     "GitPython<3.1.19",
     "hf-doc-builder>=0.3.0",
     "hf_xet",
-    "huggingface-hub>=1.2.1,<2.0",
+    "huggingface-hub>=1.3.0,<2.0",
     "importlib_metadata",
     "ipadic>=1.0.0,<2.0",
     "jinja2>=3.1.0",

--- a/src/transformers/cli/transformers.py
+++ b/src/transformers/cli/transformers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Transformers CLI."""
 
-from huggingface_hub import typer_factory
+from huggingface_hub import check_cli_update, typer_factory
 
 from transformers.cli.add_fast_image_processor import add_fast_image_processor
 from transformers.cli.add_new_model_like import add_new_model_like
@@ -35,6 +35,7 @@ app.command()(version)
 
 
 def main():
+    check_cli_update("transformers")
     app()
 
 

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -22,7 +22,7 @@ deps = {
     "GitPython": "GitPython<3.1.19",
     "hf-doc-builder": "hf-doc-builder>=0.3.0",
     "hf_xet": "hf_xet",
-    "huggingface-hub": "huggingface-hub>=1.2.1,<2.0",
+    "huggingface-hub": "huggingface-hub>=1.3.0,<2.0",
     "importlib_metadata": "importlib_metadata",
     "ipadic": "ipadic>=1.0.0,<2.0",
     "jinja2": "jinja2>=3.1.0",


### PR DESCRIPTION
This PR bumps `huggingface_hub` minimal version to 1.3.0 (current latest release, see https://github.com/huggingface/huggingface_hub/releases/tag/v1.3.0).

This release includes:
- https://github.com/huggingface/huggingface_hub/pull/3666 => running `transformers` CLI will now run an auto-update check similar to what we do for `hf` CLI. If a new version is available, we let the user know + provide the exact command line to run
- https://github.com/huggingface/huggingface_hub/pull/3668 => fixes this [TODO](https://github.com/huggingface/transformers/blob/3a275d3581c0ecf962f7412aa764c2047331fd6b/pyproject.toml#L53C2-L53C44). I'll open a separate PR with all the code style fixes. => **EDIT:** opened https://github.com/huggingface/transformers/pull/43189

---

(Failing CI doesn't seem related to this PR)