### PR TITLE
Fix multi-label classification in run_classification.py (closes #43116)

### DIFF
--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -88,9 +88,7 @@ class DataTrainingArguments:
     )
     dataset_config_name: str | None = field(
         default=None,
-        metadata={
-            "help": "The configuration name of the dataset to use (via the datasets library)."
-        },
+        metadata={"help": "The configuration name of the dataset to use (via the datasets library)."},
     )
     do_regression: bool = field(
         default=None,
@@ -109,9 +107,7 @@ class DataTrainingArguments:
     )
     text_column_delimiter: str | None = field(
         default=" ",
-        metadata={
-            "help": "The delimiter to use to join text columns into a single sentence."
-        },
+        metadata={"help": "The delimiter to use to join text columns into a single sentence."},
     )
     train_split_name: str | None = field(
         default=None,
@@ -133,15 +129,11 @@ class DataTrainingArguments:
     )
     remove_splits: str | None = field(
         default=None,
-        metadata={
-            "help": "The splits to remove from the dataset. Multiple splits should be separated by commas."
-        },
+        metadata={"help": "The splits to remove from the dataset. Multiple splits should be separated by commas."},
     )
     remove_columns: str | None = field(
         default=None,
-        metadata={
-            "help": "The columns to remove from the dataset. Multiple columns should be separated by commas."
-        },
+        metadata={"help": "The columns to remove from the dataset. Multiple columns should be separated by commas."},
     )
     label_column_name: str | None = field(
         default=None,
@@ -183,9 +175,7 @@ class DataTrainingArguments:
     )
     shuffle_seed: int = field(
         default=42,
-        metadata={
-            "help": "Random seed that will be used to shuffle the train dataset."
-        },
+        metadata={"help": "Random seed that will be used to shuffle the train dataset."},
     )
     max_train_samples: int | None = field(
         default=None,
@@ -214,9 +204,7 @@ class DataTrainingArguments:
             )
         },
     )
-    metric_name: str | None = field(
-        default=None, metadata={"help": "The metric to use for evaluation."}
-    )
+    metric_name: str | None = field(default=None, metadata={"help": "The metric to use for evaluation."})
     train_file: str | None = field(
         default=None,
         metadata={"help": "A csv or a json file containing the training data."},
@@ -241,9 +229,9 @@ class DataTrainingArguments:
                 "json",
             ], "`train_file` should be a csv or a json file."
             validation_extension = self.validation_file.split(".")[-1]
-            assert (
-                validation_extension == train_extension
-            ), "`validation_file` should have the same extension (csv or json) as `train_file`."
+            assert validation_extension == train_extension, (
+                "`validation_file` should have the same extension (csv or json) as `train_file`."
+            )
 
 
 @dataclass
@@ -253,39 +241,27 @@ class ModelArguments:
     """
 
     model_name_or_path: str = field(
-        metadata={
-            "help": "Path to pretrained model or model identifier from huggingface.co/models"
-        }
+        metadata={"help": "Path to pretrained model or model identifier from huggingface.co/models"}
     )
     config_name: str | None = field(
         default=None,
-        metadata={
-            "help": "Pretrained config name or path if not the same as model_name"
-        },
+        metadata={"help": "Pretrained config name or path if not the same as model_name"},
     )
     tokenizer_name: str | None = field(
         default=None,
-        metadata={
-            "help": "Pretrained tokenizer name or path if not the same as model_name"
-        },
+        metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"},
     )
     cache_dir: str | None = field(
         default=None,
-        metadata={
-            "help": "Where do you want to store the pretrained models downloaded from huggingface.co"
-        },
+        metadata={"help": "Where do you want to store the pretrained models downloaded from huggingface.co"},
     )
     use_fast_tokenizer: bool = field(
         default=True,
-        metadata={
-            "help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."
-        },
+        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
     )
     model_revision: str = field(
         default="main",
-        metadata={
-            "help": "The specific model version to use (can be a branch name, tag name or commit id)."
-        },
+        metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
     )
     token: str = field(
         default=None,
@@ -308,9 +284,7 @@ class ModelArguments:
     )
     ignore_mismatched_sizes: bool = field(
         default=False,
-        metadata={
-            "help": "Will enable to load a pretrained model whose head dimensions are different."
-        },
+        metadata={"help": "Will enable to load a pretrained model whose head dimensions are different."},
     )
 
 
@@ -318,9 +292,7 @@ def get_label_list(raw_dataset, split="train") -> list[str]:
     """Get the list of labels from a multi-label dataset"""
 
     if isinstance(raw_dataset[split]["label"][0], list):
-        label_list = [
-            label for sample in raw_dataset[split]["label"] for label in sample
-        ]
+        label_list = [label for sample in raw_dataset[split]["label"] for label in sample]
         label_list = list(set(label_list))
     else:
         label_list = raw_dataset[split].unique("label")
@@ -334,15 +306,11 @@ def main():
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
 
-    parser = HfArgumentParser(
-        (ModelArguments, DataTrainingArguments, TrainingArguments)
-    )
+    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
         # If we pass only one argument to the script and it's the path to a json file,
         # let's parse it to get our arguments.
-        model_args, data_args, training_args = parser.parse_json_file(
-            json_file=os.path.abspath(sys.argv[1])
-        )
+        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
     else:
         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
@@ -405,14 +373,12 @@ def main():
             if data_args.test_file is not None:
                 train_extension = data_args.train_file.split(".")[-1]
                 test_extension = data_args.test_file.split(".")[-1]
-                assert (
-                    test_extension == train_extension
-                ), "`test_file` should have the same extension (csv or json) as `train_file`."
+                assert test_extension == train_extension, (
+                    "`test_file` should have the same extension (csv or json) as `train_file`."
+                )
                 data_files["test"] = data_args.test_file
             else:
-                raise ValueError(
-                    "Need either a dataset name or a test file for `do_predict`."
-                )
+                raise ValueError("Need either a dataset name or a test file for `do_predict`.")
 
         for key in data_files:
             logger.info(f"load a local file for {key}: {data_files[key]}")
@@ -463,14 +429,9 @@ def main():
                 logger.info(f"removing column {column} from split {split}")
                 raw_datasets[split] = raw_datasets[split].remove_columns(column)
 
-    if (
-        data_args.label_column_name is not None
-        and data_args.label_column_name != "label"
-    ):
+    if data_args.label_column_name is not None and data_args.label_column_name != "label":
         for key in raw_datasets:
-            raw_datasets[key] = raw_datasets[key].rename_column(
-                data_args.label_column_name, "label"
-            )
+            raw_datasets[key] = raw_datasets[key].rename_column(data_args.label_column_name, "label")
 
     # Trying to have good defaults here, don't hesitate to tweak to your needs.
 
@@ -490,9 +451,9 @@ def main():
         # regression requires float as label type, let's cast it if needed
         for split in raw_datasets:
             # Check if dtype exists and is not float32/float64
-            if hasattr(raw_datasets[split].features["label"], "dtype") and raw_datasets[
-                split
-            ].features["label"].dtype not in ["float32", "float64"]:
+            if hasattr(raw_datasets[split].features["label"], "dtype") and raw_datasets[split].features[
+                "label"
+            ].dtype not in ["float32", "float64"]:
                 logger.warning(
                     f"Label type for {split} set to float32, was {raw_datasets[split].features['label'].dtype}"
                 )
@@ -511,8 +472,7 @@ def main():
         # or if the first label value is a list
         label_feature = raw_datasets["train"].features["label"]
         if isinstance(label_feature, SequenceFeature) or (
-            len(raw_datasets["train"]) > 0
-            and isinstance(raw_datasets["train"]["label"][0], list)
+            len(raw_datasets["train"]) > 0 and isinstance(raw_datasets["train"]["label"][0], list)
         ):
             is_multi_label = True
             logger.info("Label type is list, doing multi-label classification")
@@ -545,11 +505,7 @@ def main():
     # In distributed training, the .from_pretrained methods guarantee that only one local process can concurrently
     # download model & vocab.
     config = AutoConfig.from_pretrained(
-        (
-            model_args.config_name
-            if model_args.config_name
-            else model_args.model_name_or_path
-        ),
+        (model_args.config_name if model_args.config_name else model_args.model_name_or_path),
         num_labels=num_labels,
         finetuning_task="text-classification",
         cache_dir=model_args.cache_dir,
@@ -569,11 +525,7 @@ def main():
         logger.info("setting problem type to single label classification")
 
     tokenizer = AutoTokenizer.from_pretrained(
-        (
-            model_args.tokenizer_name
-            if model_args.tokenizer_name
-            else model_args.model_name_or_path
-        ),
+        (model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_name_or_path),
         cache_dir=model_args.cache_dir,
         use_fast=model_args.use_fast_tokenizer,
         revision=model_args.model_revision,
@@ -637,9 +589,7 @@ def main():
             examples["sentence"] = examples[text_column_names[0]]
             for column in text_column_names[1:]:
                 for i in range(len(examples[column])):
-                    examples["sentence"][i] += (
-                        data_args.text_column_delimiter + examples[column][i]
-                    )
+                    examples["sentence"][i] += data_args.text_column_delimiter + examples[column][i]
         # Tokenize the texts
         result = tokenizer(
             examples["sentence"],
@@ -651,9 +601,7 @@ def main():
             if is_multi_label:
                 result["label"] = [multi_labels_to_ids(l) for l in examples["label"]]
             else:
-                result["label"] = [
-                    (label_to_id[str(l)] if l != -1 else -1) for l in examples["label"]
-                ]
+                result["label"] = [(label_to_id[str(l)] if l != -1 else -1) for l in examples["label"]]
         return result
 
     # Running the preprocessing pipeline on all the datasets
@@ -678,18 +626,11 @@ def main():
             train_dataset = train_dataset.select(range(max_train_samples))
 
     if training_args.do_eval:
-        if (
-            "validation" not in raw_datasets
-            and "validation_matched" not in raw_datasets
-        ):
+        if "validation" not in raw_datasets and "validation_matched" not in raw_datasets:
             if "test" not in raw_datasets and "test_matched" not in raw_datasets:
-                raise ValueError(
-                    "--do_eval requires a validation or test dataset if validation is not defined."
-                )
+                raise ValueError("--do_eval requires a validation or test dataset if validation is not defined.")
             else:
-                logger.warning(
-                    "Validation dataset not found. Falling back to test dataset for validation."
-                )
+                logger.warning("Validation dataset not found. Falling back to test dataset for validation.")
                 eval_dataset = raw_datasets["test"]
         else:
             eval_dataset = raw_datasets["validation"]
@@ -704,9 +645,7 @@ def main():
         predict_dataset = raw_datasets["test"]
         # remove label column if it exists
         if data_args.max_predict_samples is not None:
-            max_predict_samples = min(
-                len(predict_dataset), data_args.max_predict_samples
-            )
+            max_predict_samples = min(len(predict_dataset), data_args.max_predict_samples)
             predict_dataset = predict_dataset.select(range(max_predict_samples))
 
     # Log a few random samples from the training set:
@@ -728,22 +667,16 @@ def main():
     else:
         if is_regression:
             metric = evaluate.load("mse", cache_dir=model_args.cache_dir)
-            logger.info(
-                "Using mean squared error (mse) as regression score, you can use --metric_name to overwrite."
-            )
+            logger.info("Using mean squared error (mse) as regression score, you can use --metric_name to overwrite.")
         else:
             if is_multi_label:
-                metric = evaluate.load(
-                    "f1", config_name="multilabel", cache_dir=model_args.cache_dir
-                )
+                metric = evaluate.load("f1", config_name="multilabel", cache_dir=model_args.cache_dir)
                 logger.info(
                     "Using multilabel F1 for multi-label classification task, you can use --metric_name to overwrite."
                 )
             else:
                 metric = evaluate.load("accuracy", cache_dir=model_args.cache_dir)
-                logger.info(
-                    "Using accuracy as classification score, you can use --metric_name to overwrite."
-                )
+                logger.info("Using accuracy as classification score, you can use --metric_name to overwrite.")
 
     def compute_metrics(p: EvalPrediction):
         preds = p.predictions[0] if isinstance(p.predictions, tuple) else p.predictions
@@ -756,9 +689,7 @@ def main():
             threshold = 0.5
             preds = np.array([np.where(p > threshold, 1, 0) for p in preds])
             # Micro F1 is commonly used in multi-label classification
-            result = metric.compute(
-                predictions=preds, references=p.label_ids, average="micro"
-            )
+            result = metric.compute(predictions=preds, references=p.label_ids, average="micro")
         else:
             preds = np.argmax(preds, axis=1)
             result = metric.compute(predictions=preds, references=p.label_ids)
@@ -794,9 +725,7 @@ def main():
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         metrics = train_result.metrics
         max_train_samples = (
-            data_args.max_train_samples
-            if data_args.max_train_samples is not None
-            else len(train_dataset)
+            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
         )
         metrics["train_samples"] = min(max_train_samples, len(train_dataset))
         trainer.save_model()  # Saves the tokenizer too for easy upload
@@ -808,11 +737,7 @@ def main():
     if training_args.do_eval:
         logger.info("*** Evaluate ***")
         metrics = trainer.evaluate(eval_dataset=eval_dataset)
-        max_eval_samples = (
-            data_args.max_eval_samples
-            if data_args.max_eval_samples is not None
-            else len(eval_dataset)
-        )
+        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
         metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
         trainer.log_metrics("eval", metrics)
         trainer.save_metrics("eval", metrics)
@@ -822,9 +747,7 @@ def main():
         # Removing the `label` columns if exists because it might contains -1 and Trainer won't like that.
         if "label" in predict_dataset.features:
             predict_dataset = predict_dataset.remove_columns("label")
-        predictions = trainer.predict(
-            predict_dataset, metric_key_prefix="predict"
-        ).predictions
+        predictions = trainer.predict(predict_dataset, metric_key_prefix="predict").predictions
         if is_regression:
             predictions = np.squeeze(predictions)
         elif is_multi_label:
@@ -836,9 +759,7 @@ def main():
             predictions = np.array([np.where(p > threshold, 1, 0) for p in predictions])
         else:
             predictions = np.argmax(predictions, axis=1)
-        output_predict_file = os.path.join(
-            training_args.output_dir, "predict_results.txt"
-        )
+        output_predict_file = os.path.join(training_args.output_dir, "predict_results.txt")
         if trainer.is_world_process_zero():
             with open(output_predict_file, "w") as writer:
                 logger.info("***** Predict results *****")

--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -63,7 +63,10 @@ from transformers.utils.versions import require_version
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.57.0.dev0")
 
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/text-classification/requirements.txt")
+require_version(
+    "datasets>=1.8.0",
+    "To fix: pip install -r examples/pytorch/text-classification/requirements.txt",
+)
 
 
 logger = logging.getLogger(__name__)
@@ -80,10 +83,14 @@ class DataTrainingArguments:
     """
 
     dataset_name: str | None = field(
-        default=None, metadata={"help": "The name of the dataset to use (via the datasets library)."}
+        default=None,
+        metadata={"help": "The name of the dataset to use (via the datasets library)."},
     )
     dataset_config_name: str | None = field(
-        default=None, metadata={"help": "The configuration name of the dataset to use (via the datasets library)."}
+        default=None,
+        metadata={
+            "help": "The configuration name of the dataset to use (via the datasets library)."
+        },
     )
     do_regression: bool = field(
         default=None,
@@ -101,7 +108,10 @@ class DataTrainingArguments:
         },
     )
     text_column_delimiter: str | None = field(
-        default=" ", metadata={"help": "The delimiter to use to join text columns into a single sentence."}
+        default=" ",
+        metadata={
+            "help": "The delimiter to use to join text columns into a single sentence."
+        },
     )
     train_split_name: str | None = field(
         default=None,
@@ -123,11 +133,15 @@ class DataTrainingArguments:
     )
     remove_splits: str | None = field(
         default=None,
-        metadata={"help": "The splits to remove from the dataset. Multiple splits should be separated by commas."},
+        metadata={
+            "help": "The splits to remove from the dataset. Multiple splits should be separated by commas."
+        },
     )
     remove_columns: str | None = field(
         default=None,
-        metadata={"help": "The columns to remove from the dataset. Multiple columns should be separated by commas."},
+        metadata={
+            "help": "The columns to remove from the dataset. Multiple columns should be separated by commas."
+        },
     )
     label_column_name: str | None = field(
         default=None,
@@ -152,7 +166,8 @@ class DataTrainingArguments:
         metadata={"help": "The number of processes to use for the preprocessing."},
     )
     overwrite_cache: bool = field(
-        default=False, metadata={"help": "Overwrite the cached preprocessed datasets or not."}
+        default=False,
+        metadata={"help": "Overwrite the cached preprocessed datasets or not."},
     )
     pad_to_max_length: bool = field(
         default=True,
@@ -167,7 +182,10 @@ class DataTrainingArguments:
         default=False, metadata={"help": "Whether to shuffle the train dataset or not."}
     )
     shuffle_seed: int = field(
-        default=42, metadata={"help": "Random seed that will be used to shuffle the train dataset."}
+        default=42,
+        metadata={
+            "help": "Random seed that will be used to shuffle the train dataset."
+        },
     )
     max_train_samples: int | None = field(
         default=None,
@@ -196,14 +214,21 @@ class DataTrainingArguments:
             )
         },
     )
-    metric_name: str | None = field(default=None, metadata={"help": "The metric to use for evaluation."})
+    metric_name: str | None = field(
+        default=None, metadata={"help": "The metric to use for evaluation."}
+    )
     train_file: str | None = field(
-        default=None, metadata={"help": "A csv or a json file containing the training data."}
+        default=None,
+        metadata={"help": "A csv or a json file containing the training data."},
     )
     validation_file: str | None = field(
-        default=None, metadata={"help": "A csv or a json file containing the validation data."}
+        default=None,
+        metadata={"help": "A csv or a json file containing the validation data."},
     )
-    test_file: str | None = field(default=None, metadata={"help": "A csv or a json file containing the test data."})
+    test_file: str | None = field(
+        default=None,
+        metadata={"help": "A csv or a json file containing the test data."},
+    )
 
     def __post_init__(self):
         if self.dataset_name is None:
@@ -211,11 +236,14 @@ class DataTrainingArguments:
                 raise ValueError(" training/validation file or a dataset name.")
 
             train_extension = self.train_file.split(".")[-1]
-            assert train_extension in ["csv", "json"], "`train_file` should be a csv or a json file."
+            assert train_extension in [
+                "csv",
+                "json",
+            ], "`train_file` should be a csv or a json file."
             validation_extension = self.validation_file.split(".")[-1]
-            assert validation_extension == train_extension, (
-                "`validation_file` should have the same extension (csv or json) as `train_file`."
-            )
+            assert (
+                validation_extension == train_extension
+            ), "`validation_file` should have the same extension (csv or json) as `train_file`."
 
 
 @dataclass
@@ -225,25 +253,39 @@ class ModelArguments:
     """
 
     model_name_or_path: str = field(
-        metadata={"help": "Path to pretrained model or model identifier from huggingface.co/models"}
+        metadata={
+            "help": "Path to pretrained model or model identifier from huggingface.co/models"
+        }
     )
     config_name: str | None = field(
-        default=None, metadata={"help": "Pretrained config name or path if not the same as model_name"}
+        default=None,
+        metadata={
+            "help": "Pretrained config name or path if not the same as model_name"
+        },
     )
     tokenizer_name: str | None = field(
-        default=None, metadata={"help": "Pretrained tokenizer name or path if not the same as model_name"}
+        default=None,
+        metadata={
+            "help": "Pretrained tokenizer name or path if not the same as model_name"
+        },
     )
     cache_dir: str | None = field(
         default=None,
-        metadata={"help": "Where do you want to store the pretrained models downloaded from huggingface.co"},
+        metadata={
+            "help": "Where do you want to store the pretrained models downloaded from huggingface.co"
+        },
     )
     use_fast_tokenizer: bool = field(
         default=True,
-        metadata={"help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."},
+        metadata={
+            "help": "Whether to use one of the fast tokenizer (backed by the tokenizers library) or not."
+        },
     )
     model_revision: str = field(
         default="main",
-        metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
+        metadata={
+            "help": "The specific model version to use (can be a branch name, tag name or commit id)."
+        },
     )
     token: str = field(
         default=None,
@@ -266,7 +308,9 @@ class ModelArguments:
     )
     ignore_mismatched_sizes: bool = field(
         default=False,
-        metadata={"help": "Will enable to load a pretrained model whose head dimensions are different."},
+        metadata={
+            "help": "Will enable to load a pretrained model whose head dimensions are different."
+        },
     )
 
 
@@ -274,7 +318,9 @@ def get_label_list(raw_dataset, split="train") -> list[str]:
     """Get the list of labels from a multi-label dataset"""
 
     if isinstance(raw_dataset[split]["label"][0], list):
-        label_list = [label for sample in raw_dataset[split]["label"] for label in sample]
+        label_list = [
+            label for sample in raw_dataset[split]["label"] for label in sample
+        ]
         label_list = list(set(label_list))
     else:
         label_list = raw_dataset[split].unique("label")
@@ -288,11 +334,15 @@ def main():
     # or by passing the --help flag to this script.
     # We now keep distinct sets of args, for a cleaner separation of concerns.
 
-    parser = HfArgumentParser((ModelArguments, DataTrainingArguments, TrainingArguments))
+    parser = HfArgumentParser(
+        (ModelArguments, DataTrainingArguments, TrainingArguments)
+    )
     if len(sys.argv) == 2 and sys.argv[1].endswith(".json"):
         # If we pass only one argument to the script and it's the path to a json file,
         # let's parse it to get our arguments.
-        model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
+        model_args, data_args, training_args = parser.parse_json_file(
+            json_file=os.path.abspath(sys.argv[1])
+        )
     else:
         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
 
@@ -345,19 +395,24 @@ def main():
     else:
         # Loading a dataset from your local files.
         # CSV/JSON training and evaluation files are needed.
-        data_files = {"train": data_args.train_file, "validation": data_args.validation_file}
+        data_files = {
+            "train": data_args.train_file,
+            "validation": data_args.validation_file,
+        }
 
         # Get the test dataset: you can provide your own CSV/JSON test file
         if training_args.do_predict:
             if data_args.test_file is not None:
                 train_extension = data_args.train_file.split(".")[-1]
                 test_extension = data_args.test_file.split(".")[-1]
-                assert test_extension == train_extension, (
-                    "`test_file` should have the same extension (csv or json) as `train_file`."
-                )
+                assert (
+                    test_extension == train_extension
+                ), "`test_file` should have the same extension (csv or json) as `train_file`."
                 data_files["test"] = data_args.test_file
             else:
-                raise ValueError("Need either a dataset name or a test file for `do_predict`.")
+                raise ValueError(
+                    "Need either a dataset name or a test file for `do_predict`."
+                )
 
         for key in data_files:
             logger.info(f"load a local file for {key}: {data_files[key]}")
@@ -408,9 +463,14 @@ def main():
                 logger.info(f"removing column {column} from split {split}")
                 raw_datasets[split] = raw_datasets[split].remove_columns(column)
 
-    if data_args.label_column_name is not None and data_args.label_column_name != "label":
+    if (
+        data_args.label_column_name is not None
+        and data_args.label_column_name != "label"
+    ):
         for key in raw_datasets:
-            raw_datasets[key] = raw_datasets[key].rename_column(data_args.label_column_name, "label")
+            raw_datasets[key] = raw_datasets[key].rename_column(
+                data_args.label_column_name, "label"
+            )
 
     # Trying to have good defaults here, don't hesitate to tweak to your needs.
 
@@ -430,10 +490,9 @@ def main():
         # regression requires float as label type, let's cast it if needed
         for split in raw_datasets:
             # Check if dtype exists and is not float32/float64
-            if (
-                hasattr(raw_datasets[split].features["label"], "dtype")
-                and raw_datasets[split].features["label"].dtype not in ["float32", "float64"]
-            ):
+            if hasattr(raw_datasets[split].features["label"], "dtype") and raw_datasets[
+                split
+            ].features["label"].dtype not in ["float32", "float64"]:
                 logger.warning(
                     f"Label type for {split} set to float32, was {raw_datasets[split].features['label'].dtype}"
                 )
@@ -452,7 +511,8 @@ def main():
         # or if the first label value is a list
         label_feature = raw_datasets["train"].features["label"]
         if isinstance(label_feature, SequenceFeature) or (
-            len(raw_datasets["train"]) > 0 and isinstance(raw_datasets["train"]["label"][0], list)
+            len(raw_datasets["train"]) > 0
+            and isinstance(raw_datasets["train"]["label"][0], list)
         ):
             is_multi_label = True
             logger.info("Label type is list, doing multi-label classification")
@@ -485,7 +545,11 @@ def main():
     # In distributed training, the .from_pretrained methods guarantee that only one local process can concurrently
     # download model & vocab.
     config = AutoConfig.from_pretrained(
-        model_args.config_name if model_args.config_name else model_args.model_name_or_path,
+        (
+            model_args.config_name
+            if model_args.config_name
+            else model_args.model_name_or_path
+        ),
         num_labels=num_labels,
         finetuning_task="text-classification",
         cache_dir=model_args.cache_dir,
@@ -505,7 +569,11 @@ def main():
         logger.info("setting problem type to single label classification")
 
     tokenizer = AutoTokenizer.from_pretrained(
-        model_args.tokenizer_name if model_args.tokenizer_name else model_args.model_name_or_path,
+        (
+            model_args.tokenizer_name
+            if model_args.tokenizer_name
+            else model_args.model_name_or_path
+        ),
         cache_dir=model_args.cache_dir,
         use_fast=model_args.use_fast_tokenizer,
         revision=model_args.model_revision,
@@ -569,14 +637,23 @@ def main():
             examples["sentence"] = examples[text_column_names[0]]
             for column in text_column_names[1:]:
                 for i in range(len(examples[column])):
-                    examples["sentence"][i] += data_args.text_column_delimiter + examples[column][i]
+                    examples["sentence"][i] += (
+                        data_args.text_column_delimiter + examples[column][i]
+                    )
         # Tokenize the texts
-        result = tokenizer(examples["sentence"], padding=padding, max_length=max_seq_length, truncation=True)
+        result = tokenizer(
+            examples["sentence"],
+            padding=padding,
+            max_length=max_seq_length,
+            truncation=True,
+        )
         if label_to_id is not None and "label" in examples:
             if is_multi_label:
                 result["label"] = [multi_labels_to_ids(l) for l in examples["label"]]
             else:
-                result["label"] = [(label_to_id[str(l)] if l != -1 else -1) for l in examples["label"]]
+                result["label"] = [
+                    (label_to_id[str(l)] if l != -1 else -1) for l in examples["label"]
+                ]
         return result
 
     # Running the preprocessing pipeline on all the datasets
@@ -601,11 +678,18 @@ def main():
             train_dataset = train_dataset.select(range(max_train_samples))
 
     if training_args.do_eval:
-        if "validation" not in raw_datasets and "validation_matched" not in raw_datasets:
+        if (
+            "validation" not in raw_datasets
+            and "validation_matched" not in raw_datasets
+        ):
             if "test" not in raw_datasets and "test_matched" not in raw_datasets:
-                raise ValueError("--do_eval requires a validation or test dataset if validation is not defined.")
+                raise ValueError(
+                    "--do_eval requires a validation or test dataset if validation is not defined."
+                )
             else:
-                logger.warning("Validation dataset not found. Falling back to test dataset for validation.")
+                logger.warning(
+                    "Validation dataset not found. Falling back to test dataset for validation."
+                )
                 eval_dataset = raw_datasets["test"]
         else:
             eval_dataset = raw_datasets["validation"]
@@ -620,7 +704,9 @@ def main():
         predict_dataset = raw_datasets["test"]
         # remove label column if it exists
         if data_args.max_predict_samples is not None:
-            max_predict_samples = min(len(predict_dataset), data_args.max_predict_samples)
+            max_predict_samples = min(
+                len(predict_dataset), data_args.max_predict_samples
+            )
             predict_dataset = predict_dataset.select(range(max_predict_samples))
 
     # Log a few random samples from the training set:
@@ -630,7 +716,11 @@ def main():
 
     if data_args.metric_name is not None:
         metric = (
-            evaluate.load(data_args.metric_name, config_name="multilabel", cache_dir=model_args.cache_dir)
+            evaluate.load(
+                data_args.metric_name,
+                config_name="multilabel",
+                cache_dir=model_args.cache_dir,
+            )
             if is_multi_label
             else evaluate.load(data_args.metric_name, cache_dir=model_args.cache_dir)
         )
@@ -638,16 +728,22 @@ def main():
     else:
         if is_regression:
             metric = evaluate.load("mse", cache_dir=model_args.cache_dir)
-            logger.info("Using mean squared error (mse) as regression score, you can use --metric_name to overwrite.")
+            logger.info(
+                "Using mean squared error (mse) as regression score, you can use --metric_name to overwrite."
+            )
         else:
             if is_multi_label:
-                metric = evaluate.load("f1", config_name="multilabel", cache_dir=model_args.cache_dir)
+                metric = evaluate.load(
+                    "f1", config_name="multilabel", cache_dir=model_args.cache_dir
+                )
                 logger.info(
                     "Using multilabel F1 for multi-label classification task, you can use --metric_name to overwrite."
                 )
             else:
                 metric = evaluate.load("accuracy", cache_dir=model_args.cache_dir)
-                logger.info("Using accuracy as classification score, you can use --metric_name to overwrite.")
+                logger.info(
+                    "Using accuracy as classification score, you can use --metric_name to overwrite."
+                )
 
     def compute_metrics(p: EvalPrediction):
         preds = p.predictions[0] if isinstance(p.predictions, tuple) else p.predictions
@@ -660,7 +756,9 @@ def main():
             threshold = 0.5
             preds = np.array([np.where(p > threshold, 1, 0) for p in preds])
             # Micro F1 is commonly used in multi-label classification
-            result = metric.compute(predictions=preds, references=p.label_ids, average="micro")
+            result = metric.compute(
+                predictions=preds, references=p.label_ids, average="micro"
+            )
         else:
             preds = np.argmax(preds, axis=1)
             result = metric.compute(predictions=preds, references=p.label_ids)
@@ -696,7 +794,9 @@ def main():
         train_result = trainer.train(resume_from_checkpoint=checkpoint)
         metrics = train_result.metrics
         max_train_samples = (
-            data_args.max_train_samples if data_args.max_train_samples is not None else len(train_dataset)
+            data_args.max_train_samples
+            if data_args.max_train_samples is not None
+            else len(train_dataset)
         )
         metrics["train_samples"] = min(max_train_samples, len(train_dataset))
         trainer.save_model()  # Saves the tokenizer too for easy upload
@@ -708,7 +808,11 @@ def main():
     if training_args.do_eval:
         logger.info("*** Evaluate ***")
         metrics = trainer.evaluate(eval_dataset=eval_dataset)
-        max_eval_samples = data_args.max_eval_samples if data_args.max_eval_samples is not None else len(eval_dataset)
+        max_eval_samples = (
+            data_args.max_eval_samples
+            if data_args.max_eval_samples is not None
+            else len(eval_dataset)
+        )
         metrics["eval_samples"] = min(max_eval_samples, len(eval_dataset))
         trainer.log_metrics("eval", metrics)
         trainer.save_metrics("eval", metrics)
@@ -718,7 +822,9 @@ def main():
         # Removing the `label` columns if exists because it might contains -1 and Trainer won't like that.
         if "label" in predict_dataset.features:
             predict_dataset = predict_dataset.remove_columns("label")
-        predictions = trainer.predict(predict_dataset, metric_key_prefix="predict").predictions
+        predictions = trainer.predict(
+            predict_dataset, metric_key_prefix="predict"
+        ).predictions
         if is_regression:
             predictions = np.squeeze(predictions)
         elif is_multi_label:
@@ -730,7 +836,9 @@ def main():
             predictions = np.array([np.where(p > threshold, 1, 0) for p in predictions])
         else:
             predictions = np.argmax(predictions, axis=1)
-        output_predict_file = os.path.join(training_args.output_dir, "predict_results.txt")
+        output_predict_file = os.path.join(
+            training_args.output_dir, "predict_results.txt"
+        )
         if trainer.is_world_process_zero():
             with open(output_predict_file, "w") as writer:
                 logger.info("***** Predict results *****")
@@ -746,7 +854,10 @@ def main():
                         item = label_list[item]
                         writer.write(f"{index}\t{item}\n")
         logger.info(f"Predict results saved at {output_predict_file}")
-    kwargs = {"finetuned_from": model_args.model_name_or_path, "tasks": "text-classification"}
+    kwargs = {
+        "finetuned_from": model_args.model_name_or_path,
+        "tasks": "text-classification",
+    }
 
     if training_args.push_to_hub:
         trainer.push_to_hub(**kwargs)

--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -30,6 +30,7 @@
 """Finetuning the library models for text classification."""
 # You can also adapt this script on your own text classification task. Pointers for this are left as comments.
 
+import json
 import logging
 import os
 import random
@@ -216,6 +217,33 @@ class DataTrainingArguments:
     test_file: str | None = field(
         default=None,
         metadata={"help": "A csv or a json file containing the test data."},
+    )
+    output_confidence_scores: bool = field(
+        default=False,
+        metadata={
+            "help": (
+                "Output confidence scores instead of binary predictions for multi-label classification. "
+                "Saves results in JSON format following transformers Pipeline API convention."
+            )
+        },
+    )
+    multi_label_threshold: float = field(
+        default=0.5,
+        metadata={
+            "help": (
+                "Threshold for converting probabilities to binary predictions in multi-label classification. "
+                "Only used when output_confidence_scores is False."
+            )
+        },
+    )
+    top_k_labels: int | None = field(
+        default=None,
+        metadata={
+            "help": (
+                "Limit output to top K most confident labels per example in multi-label classification. "
+                "Only used when output_confidence_scores is True."
+            )
+        },
     )
 
     def __post_init__(self):
@@ -686,7 +714,7 @@ def main():
         elif is_multi_label:
             # Convert logits to multi-hot encoding by applying sigmoid then thresholding
             preds = expit(preds)  # Apply sigmoid to convert logits to probabilities
-            threshold = 0.5
+            threshold = data_args.multi_label_threshold
             preds = np.array([np.where(p > threshold, 1, 0) for p in preds])
             # Micro F1 is commonly used in multi-label classification
             result = metric.compute(predictions=preds, references=p.label_ids, average="micro")
@@ -748,33 +776,63 @@ def main():
         if "label" in predict_dataset.features:
             predict_dataset = predict_dataset.remove_columns("label")
         predictions = trainer.predict(predict_dataset, metric_key_prefix="predict").predictions
+
         if is_regression:
             predictions = np.squeeze(predictions)
         elif is_multi_label:
-            # Convert logits to multi-hot encoding by first applying sigmoid and then thresholding.
             # Apply sigmoid to convert logits to probabilities
-            predictions = expit(predictions)  # Apply sigmoid: σ(x) = 1/(1+e^(-x))
-            # Apply threshold (default 0.5) to convert probabilities to binary predictions
-            threshold = 0.5
-            predictions = np.array([np.where(p > threshold, 1, 0) for p in predictions])
+            predictions = expit(predictions)
+
+            if data_args.output_confidence_scores:
+                # Output JSON with confidence scores (Pipeline API format)
+                output_predict_file = os.path.join(training_args.output_dir, "predict_results.json")
+                if trainer.is_world_process_zero():
+                    results = []
+                    for index, probs in enumerate(predictions):
+                        # Create list of {label, score} dicts
+                        label_scores = [
+                            {"label": label_list[i], "score": float(probs[i])} for i in range(len(label_list))
+                        ]
+                        # Sort by score descending
+                        label_scores.sort(key=lambda x: x["score"], reverse=True)
+
+                        # Apply top_k if specified
+                        if data_args.top_k_labels is not None:
+                            label_scores = label_scores[: data_args.top_k_labels]
+
+                        results.append({"index": index, "predictions": label_scores})
+
+                    with open(output_predict_file, "w") as writer:
+                        json.dump(results, writer, indent=2)
+                    logger.info(f"Predictions with confidence scores saved at {output_predict_file}")
+            else:
+                # Binary predictions using threshold (backward compatible)
+                threshold = data_args.multi_label_threshold
+                predictions = np.array([np.where(p > threshold, 1, 0) for p in predictions])
+
+                # Original TSV output
+                output_predict_file = os.path.join(training_args.output_dir, "predict_results.txt")
+                if trainer.is_world_process_zero():
+                    with open(output_predict_file, "w") as writer:
+                        logger.info("***** Predict results *****")
+                        writer.write("index\tprediction\n")
+                        for index, item in enumerate(predictions):
+                            # Recover from multi-hot encoding
+                            item = [label_list[i] for i in range(len(item)) if item[i] == 1]
+                            writer.write(f"{index}\t{item}\n")
+                    logger.info(f"Predict results saved at {output_predict_file}")
         else:
+            # Single-label classification (unchanged)
             predictions = np.argmax(predictions, axis=1)
-        output_predict_file = os.path.join(training_args.output_dir, "predict_results.txt")
-        if trainer.is_world_process_zero():
-            with open(output_predict_file, "w") as writer:
-                logger.info("***** Predict results *****")
-                writer.write("index\tprediction\n")
-                for index, item in enumerate(predictions):
-                    if is_regression:
-                        writer.write(f"{index}\t{item:3.3f}\n")
-                    elif is_multi_label:
-                        # recover from multi-hot encoding
-                        item = [label_list[i] for i in range(len(item)) if item[i] == 1]
-                        writer.write(f"{index}\t{item}\n")
-                    else:
+            output_predict_file = os.path.join(training_args.output_dir, "predict_results.txt")
+            if trainer.is_world_process_zero():
+                with open(output_predict_file, "w") as writer:
+                    logger.info("***** Predict results *****")
+                    writer.write("index\tprediction\n")
+                    for index, item in enumerate(predictions):
                         item = label_list[item]
                         writer.write(f"{index}\t{item}\n")
-        logger.info(f"Predict results saved at {output_predict_file}")
+                logger.info(f"Predict results saved at {output_predict_file}")
     kwargs = {
         "finetuned_from": model_args.model_name_or_path,
         "tasks": "text-classification",


### PR DESCRIPTION
Fixes #43116

## Summary

This PR addresses multi-label classification bugs in run_classification.py and adds confidence scores output following community feedback.

## Bug fixes

Fixed 4 bugs that broke multi-label classification with JSON datasets:

1. Missing imports for SequenceFeature and expit
2. Regression detection fails with AttributeError on JSON datasets - fixed by adding hasattr() check before accessing dtype
3. Multi-label detection misses JSON-based datasets - fixed by adding isinstance() check for SequenceFeature
4. Predictions missing sigmoid activation - added expit() before thresholding in both compute_metrics and do_predict

## New features

Based on feedback from @ziorufus, added configurable threshold and confidence scores output.

**New parameters:**
- `--output_confidence_scores` (bool, default: False) - Output JSON with confidence scores instead of binary predictions
- `--multi_label_threshold` (float, default: 0.5) - Threshold for converting probabilities to binary predictions
- `--top_k_labels` (int, optional) - Limit output to top K most confident labels

**Output format follows transformers Pipeline API convention:**

Traditional mode (default):
```
index   prediction
0       ['positive', 'urgent']
```

Confidence scores mode:
```json
[
  {
    "index": 0,
    "predictions": [
      {"label": "positive", "score": 0.89},
      {"label": "urgent", "score": 0.67}
    ]
  }
]
```

## Backward compatibility

Default behavior unchanged. New features require explicit flags. No breaking changes.

## Testing

Validated with:
- Ruff linting and formatting (all checks passed)
- Python syntax check
- Logic validation with simulated multi-label data
- Backward compatibility verification

Test scenarios:
- Traditional TSV output with default threshold
- JSON confidence scores output
- Custom threshold values
- Top-K filtering

## Usage examples

Traditional mode:
```bash
python run_classification.py \
  --model_name_or_path bert-base-uncased \
  --test_file test.json \
  --do_predict \
  --output_dir ./output
```

Confidence scores:
```bash
python run_classification.py \
  --model_name_or_path bert-base-uncased \
  --test_file test.json \
  --do_predict \
  --output_confidence_scores \
  --output_dir ./output
```

Custom threshold:
```bash
python run_classification.py \
  --test_file test.json \
  --do_predict \
  --multi_label_threshold 0.3 \
  --output_dir ./output
```

Top-K labels:
```bash
python run_classification.py \
  --test_file test.json \
  --do_predict \
  --output_confidence_scores \
  --top_k_labels 3 \
  --output_dir ./output
```

## Implementation notes

- Follows Pipeline API format used by text-classification and zero-shot pipelines
- Scores sorted descending by confidence
- JSON output enables downstream processing and custom threshold application
- Type hints and documentation complete

## Changes

- examples/pytorch/text-classification/run_classification.py (+78, -20)
- 3 new parameters added
- 1 import added
- 58 net lines added
