### PR TITLE
[bugfix] fix qwen3vlmoe loading

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -234,6 +234,18 @@ def _build_checkpoint_conversion_mapping():
     mapping["qwen3_omni_moe"] = mapping["qwen2_moe"].copy()
     mapping["qwen3_next"] = mapping["qwen2_moe"].copy()
     mapping["qwen3_vl_moe"] = mapping["qwen2_moe"].copy()
+    mapping["qwen3_vl_moe"] += [
+        WeightConverter(
+            source_patterns="mlp.experts.gate_up_proj",
+            target_patterns="mlp.experts.gate_up_proj",
+            operations=[Transpose(dim0=1, dim1=2)],
+        ),
+        WeightConverter(
+            source_patterns="mlp.experts.down_proj",
+            target_patterns="mlp.experts.down_proj",
+            operations=[Transpose(dim0=1, dim1=2)],
+        ),
+    ]
     mapping["hunyuan_v1_moe"] = mapping["qwen2_moe"].copy()
     mapping["minimax"] = mapping["mixtral"].copy()
     mapping["minimax_m2"] = mapping["mixtral"].copy()


### PR DESCRIPTION
# What does this PR do?

Fix the loading of qwen3vlmoe experts.

test script:

```
from transformers import AutoProcessor, AutoModelForImageTextToText

model = AutoModelForImageTextToText.from_pretrained("Qwen/Qwen3-VL-30B-A3B-Instruct", torch_dtype="auto", device_map="auto")
```

before:
```
model.language_model.layers.{0...47}.mlp.experts.down_proj    | MISMATCH | Reinit due to size mismatch ckpt: torch.Size([128, 768, 2048]) vs model:torch.Size([128, 2048, 768])  
model.language_model.layers.{0...47}.mlp.experts.gate_up_proj | MISMATCH | Reinit due to size mismatch ckpt: torch.Size([128, 2048, 1536]) vs model:torch.Size([128, 1536, 2048])
```

The reason is that the official checkpoint of Qwen3VLMoe follows the shape `[num_experts, out_features, in_features]`, but in the latest code, these weights are transposed in the last two dimensions. This pr transposes them back during conversion.

The model now loads successfully after the fix. 🫡
