### PR TITLE
Fix Mamba2ForCausalLM weight tying

### DIFF
--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -930,7 +930,7 @@ class Mamba2Model(Mamba2PreTrainedModel):
     """
 )
 class Mamba2ForCausalLM(Mamba2PreTrainedModel, GenerationMixin):
-    _tied_weights_keys = {}
+    _tied_weights_keys = {"lm_head.weight": "backbone.embeddings.weight"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -90,7 +90,7 @@ class Mamba2ModelTester:
         num_labels=3,
         num_choices=4,
         scope=None,
-        tie_word_embeddings=False,
+        tie_word_embeddings=True,
     ):
         self.parent = parent
         self.num_heads = num_heads


### PR DESCRIPTION
## What does this PR do?

Fixes #43206

Adds the `_tied_weights_keys` mapping to `Mamba2ForCausalLM` to enable proper weight tying when `tie_word_embeddings=True`.

## The Bug

When `tie_word_embeddings=True`, the embedding weights should be shared with the `lm_head`. However, `Mamba2ForCausalLM` had:
```python
_tied_weights_keys = {}  # Empty - weight tying never happens
```

This caused:
- Weights not actually tied (different tensors)
- `resize_token_embeddings()` not resizing `lm_head` properly

## The Fix

```python
_tied_weights_keys = {"lm_head.weight": "backbone.embeddings.weight"}
```

This is the standard pattern used by `MambaForCausalLM` (v1), GPT2, LLaMA, and other models.

## Verification

```python
from transformers import Mamba2ForCausalLM, Mamba2Config

config = Mamba2Config(vocab_size=1000, tie_word_embeddings=True)
model = Mamba2ForCausalLM(config)

# Weights are now properly tied
assert model.lm_head.weight.data_ptr() == model.backbone.embeddings.weight.data_ptr()

# Resize works correctly
model.resize_token_embeddings(1100)
assert model.lm_head.weight.shape[0] == 1100
```