### PR TITLE
Fix Qwen2VLVideoProcessor ignoring runtime min_pixels/max_pixels kwargs

### DIFF
--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -107,6 +107,29 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
 
         super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
 
+    def _further_process_kwargs(
+        self,
+        size: SizeDict | None = None,
+        min_pixels: int | None = None,
+        max_pixels: int | None = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Update kwargs that need further processing before being validated
+        Can be overridden by subclasses to customize the processing of kwargs.
+        """
+        if min_pixels is not None and max_pixels is not None:
+            size = {"shortest_edge": min_pixels, "longest_edge": max_pixels}
+        elif size is not None:
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+            min_pixels = size["shortest_edge"]
+            max_pixels = size["longest_edge"]
+        else:
+            size = {**self.size}
+
+        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+
     def sample_frames(
         self,
         metadata: VideoMetadata,

--- a/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
@@ -109,6 +109,29 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
 
         super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
 
+    def _further_process_kwargs(
+        self,
+        size: SizeDict | None = None,
+        min_pixels: int | None = None,
+        max_pixels: int | None = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Update kwargs that need further processing before being validated
+        Can be overridden by subclasses to customize the processing of kwargs.
+        """
+        if min_pixels is not None and max_pixels is not None:
+            size = {"shortest_edge": min_pixels, "longest_edge": max_pixels}
+        elif size is not None:
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+            min_pixels = size["shortest_edge"]
+            max_pixels = size["longest_edge"]
+        else:
+            size = {**self.size}
+
+        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+
     def sample_frames(
         self,
         metadata: VideoMetadata,


### PR DESCRIPTION
## Summary
- Add `_further_process_kwargs` method to `Qwen2VLVideoProcessor` to handle runtime `min_pixels`/`max_pixels` kwargs
- Add test to verify runtime kwargs work correctly

## What does this PR do?

Fixes #43183

The video processor was missing the `_further_process_kwargs` method that the image processor has (see `image_processing_qwen2_vl_fast.py:87-108`). This caused `videos_kwargs{min_pixels, max_pixels}` to be silently ignored when passed at call time, resulting in ~15x more visual tokens than expected.

## Test plan
- [x] Added `test_video_processor_runtime_min_max_pixels` test
- [x] All existing video processor tests pass