### PR TITLE
Add regression test for offline tokenizer loading (fixes #43200)

### DIFF
--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -39,6 +39,7 @@ from transformers import (
     AutoModel,
     AutoModelForImageClassification,
     AutoModelForSequenceClassification,
+    AutoTokenizer,
     BartConfig,
     BartForConditionalGeneration,
     BartModel,
@@ -348,6 +349,16 @@ if is_torch_available():
                 AutoModelForImageClassification.from_pretrained(
                     TINY_IMAGE_CLASSIF, cache_dir=tmpdir, local_files_only=True
                 )
+
+        def test_offline_tokenizer(self):
+            with tempfile.TemporaryDirectory() as tmpdir:
+                # Populate cache
+                with patch("huggingface_hub.constants.HF_HUB_OFFLINE", False):
+                    snapshot_download(TINY_IMAGE_CLASSIF, cache_dir=tmpdir)
+
+                # Load tokenizer in offline mode - should work
+                with patch("huggingface_hub.constants.HF_HUB_OFFLINE", True):
+                    AutoTokenizer.from_pretrained(TINY_IMAGE_CLASSIF, cache_dir=tmpdir)
 
 
 # Need to be serializable, which means they cannot be in a test class method


### PR DESCRIPTION
## Summary

This PR adds a regression test for issue #43200 where `AutoTokenizer.from_pretrained()` failed in offline mode (`HF_HUB_OFFLINE=1`) even when the model was cached locally.

**Good news:** The underlying bug was already fixed on main as part of the tokenizer refactoring. The `_patch_mistral_regex` function now correctly checks `is_offline_mode()` and sets `is_local = True` to prevent network calls (see `tokenization_utils_tokenizers.py` lines 1177-1178).

This PR adds a test to prevent regression.

## Root Cause (for reference)

In v4.57.3, commit d3ee5e8f14 added `_patch_mistral_regex` which called `model_info()` without handling offline mode:

```python
def is_base_mistral(model_id: str) -> bool:
    model = model_info(model_id)  # No error handling for offline mode
    ...

if _is_local or is_base_mistral(pretrained_model_name_or_path):
```

When `HF_HUB_OFFLINE=1` and using a model ID (not local path), `is_base_mistral()` was called and `model_info()` raised `OfflineModeIsEnabled`.

## The Fix (already on main)

The refactored code in `tokenization_utils_tokenizers.py` now includes:

```python
if is_offline_mode():
    is_local = True
```

This ensures `is_base_mistral()` is never called in offline mode due to short-circuit evaluation.

## Test Plan

- [x] New test `test_offline_tokenizer` passes
- [x] All existing `TestOffline` tests pass
- [x] Verified offline tokenizer loading works manually