### PR TITLE
Qwen-VL video processor accepts min/max pixels

### DIFF
--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -122,7 +122,7 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
             size = {"shortest_edge": min_pixels, "longest_edge": max_pixels}
         elif size is not None:
             if "shortest_edge" not in size or "longest_edge" not in size:
-                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+                raise ValueError("dictionary `size` must contain 'shortest_edge' and 'longest_edge' keys.")
             min_pixels = size["shortest_edge"]
             max_pixels = size["longest_edge"]
         else:

--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -107,6 +107,29 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
 
         super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
 
+    def _further_process_kwargs(
+        self,
+        size: SizeDict | None = None,
+        min_pixels: int | None = None,
+        max_pixels: int | None = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Update kwargs that need further processing before being validated
+        Can be overridden by subclasses to customize the processing of kwargs.
+        """
+        if min_pixels is not None and max_pixels is not None:
+            size = {"shortest_edge": min_pixels, "longest_edge": max_pixels}
+        elif size is not None:
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
+            min_pixels = size["shortest_edge"]
+            max_pixels = size["longest_edge"]
+        else:
+            size = {**self.size}
+
+        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+
     def sample_frames(
         self,
         metadata: VideoMetadata,

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1474,8 +1474,8 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
     model_input_names = ["pixel_values_videos", "video_grid_thw", "video_merge_sizes", "video_compression_mask"]
 
     def _further_process_kwargs(self):
-        raise AttributeError("VideoLlama3 never supported min/max pixels")
-    
+        raise AttributeError("VideoLlama3 never supported min/max pixels, no need to copy from Qwen")
+
     def _get_compression_mask(
         self,
         pixel_values_videos: torch.FloatTensor,

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1473,6 +1473,9 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
     valid_kwargs = VideoLlama3VideoProcessorInitKwargs
     model_input_names = ["pixel_values_videos", "video_grid_thw", "video_merge_sizes", "video_compression_mask"]
 
+    def _further_process_kwargs(self):
+        raise AttributeError("VideoLlama3 never supported min/max pixels")
+    
     def _get_compression_mask(
         self,
         pixel_values_videos: torch.FloatTensor,


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/43183 and makes sure we can pass `min/max pixels` to video processor's call.