### PR TITLE
Use `HF_TOKEN` directly and remove `require_read_token` 

### DIFF
--- a/.github/workflows/benchmark_v2.yml
+++ b/.github/workflows/benchmark_v2.yml
@@ -8,7 +8,7 @@ env:
   TRANSFORMERS_IS_CI: yes
   # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access.
   # This token is created under the bot `hf-transformers-bot`.
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
 
 jobs:
   benchmark-v2:

--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -37,7 +37,7 @@ env:
   RUN_SLOW: yes
   # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access.
   # This token is created under the bot `hf-transformers-bot`.
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 

--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -40,7 +40,7 @@ env:
   RUN_SLOW: yes
   # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access.
   # This token is created under the bot `hf-transformers-bot`.
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 

--- a/.github/workflows/model_jobs_intel_gaudi.yml
+++ b/.github/workflows/model_jobs_intel_gaudi.yml
@@ -25,7 +25,7 @@ env:
   PT_HPU_LAZY_MODE: 0
   TRANSFORMERS_IS_CI: yes
   PT_ENABLE_INT64_SUPPORT: 1
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache/.cache/huggingface
 
 jobs:

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -19,7 +19,7 @@ env:
   RUN_SLOW: yes
   # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access.
   # This token is created under the bot `hf-transformers-bot`.
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 

--- a/.github/workflows/self-scheduled-intel-gaudi.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi.yml
@@ -25,7 +25,7 @@ env:
   PT_HPU_LAZY_MODE: 0
   TRANSFORMERS_IS_CI: yes
   PT_ENABLE_INT64_SUPPORT: 1
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache/.cache/huggingface
 
 jobs:

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -57,7 +57,7 @@ env:
   RUN_SLOW: yes
   # For gated repositories, we still need to agree to share information on the Hub repo. page in order to get access.
   # This token is created under the bot `hf-transformers-bot`.
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -14,7 +14,7 @@ on:
         required: true
 
 env:
-  HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache
   TRANSFORMERS_IS_CI: yes
   OMP_NUM_THREADS: 8
@@ -140,11 +140,11 @@ jobs:
           cd /transformers 2>/dev/null || true
           
           # Remind user to set token if needed
-          if [ -z "$HF_HUB_READ_TOKEN" ]; then
-              echo "⚠️  HF_HUB_READ_TOKEN not set. Set it with:"
-              echo "    export HF_HUB_READ_TOKEN=hf_xxxxx"
+          if [ -z "$HF_TOKEN" ]; then
+              echo "⚠️  HF_TOKEN not set. Set it with:"
+              echo "    export HF_TOKEN=hf_xxxxx"
           else
-              echo "✅ HF_HUB_READ_TOKEN is set"
+              echo "✅ HF_TOKEN is set"
           fi
           
           echo "📁 Working directory: $(pwd)"

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -652,34 +652,7 @@ def require_read_token(test_case):
     """
     A decorator that loads the HF token for tests that require to load gated models.
     """
-    token = os.getenv("HF_HUB_READ_TOKEN")
-
-    if isinstance(test_case, type):
-        for attr_name in dir(test_case):
-            attr = getattr(test_case, attr_name)
-            if isinstance(attr, types.FunctionType):
-                if getattr(attr, "__require_read_token__", False):
-                    continue
-                wrapped = require_read_token(attr)
-                if isinstance(inspect.getattr_static(test_case, attr_name), staticmethod):
-                    # Don't accidentally bind staticmethods to `self`
-                    wrapped = staticmethod(wrapped)
-                setattr(test_case, attr_name, wrapped)
-        return test_case
-    else:
-        if getattr(test_case, "__require_read_token__", False):
-            return test_case
-
-        @functools.wraps(test_case)
-        def wrapper(*args, **kwargs):
-            if token is not None:
-                with patch("huggingface_hub.utils._headers.get_token", return_value=token):
-                    return test_case(*args, **kwargs)
-            else:  # Allow running locally with the default token env variable
-                return test_case(*args, **kwargs)
-
-        wrapper.__require_read_token__ = True
-        return wrapper
+    return test_case
 
 
 def require_peft(test_case):

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -648,13 +648,6 @@ def require_flash_attn_3(test_case):
     return unittest.skipUnless(is_flash_attn_3_available(), "test requires Flash Attention 3")(test_case)
 
 
-def require_read_token(test_case):
-    """
-    A decorator that loads the HF token for tests that require to load gated models.
-    """
-    return test_case
-
-
 def require_peft(test_case):
     """
     Decorator marking a test that requires PEFT.

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -44,7 +44,6 @@ from transformers.testing_utils import (
     require_flash_attn,
     require_flash_attn_3,
     require_optimum_quanto,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
@@ -3943,7 +3942,6 @@ class GenerationIntegrationTests(unittest.TestCase):
         gen_out = compiled_generate(**model_inputs, generation_config=generation_config)
         self.assertTrue(gen_out.shape[1] > model_inputs["input_ids"].shape[1])  # some text was generated
 
-    @require_read_token
     @slow
     def test_assisted_generation_early_exit(self):
         """
@@ -4471,7 +4469,6 @@ class GenerationIntegrationTests(unittest.TestCase):
         # test that we can generate without inputs, i.e. from BOS
         _ = model.generate()
 
-    @require_read_token
     @slow
     @require_torch_accelerator
     def test_cache_device_map_with_vision_layer_device_map(self):

--- a/tests/models/apertus/test_modeling_apertus.py
+++ b/tests/models/apertus/test_modeling_apertus.py
@@ -21,7 +21,6 @@ import unittest
 
 from transformers import is_torch_available
 from transformers.testing_utils import (
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -55,7 +54,6 @@ class ApertusModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
-@require_read_token
 @slow
 class ApertusIntegrationTest(unittest.TestCase):
     pass

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -28,7 +28,6 @@ from transformers.testing_utils import (
     cleanup,
     get_device_properties,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -208,7 +207,6 @@ class AyaVisionModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         pass
 
 
-@require_read_token
 @require_torch
 class AyaVisionIntegrationTest(unittest.TestCase):
     @classmethod

--- a/tests/models/bert/test_tokenization_bert.py
+++ b/tests/models/bert/test_tokenization_bert.py
@@ -18,12 +18,11 @@ import unittest
 from transformers.models.bert.tokenization_bert import (
     BertTokenizer,
 )
-from transformers.testing_utils import require_read_token, require_tokenizers
+from transformers.testing_utils import require_tokenizers
 
 from ...test_tokenization_common import TokenizerTesterMixin
 
 
-@require_read_token
 @require_tokenizers
 class BertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     from_pretrained_id = ["google-bert/bert-base-uncased"]

--- a/tests/models/blt/test_modeling_blt.py
+++ b/tests/models/blt/test_modeling_blt.py
@@ -21,7 +21,6 @@ from parameterized import parameterized
 from transformers import AutoTokenizer, is_torch_available
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_bf16,
@@ -240,7 +239,6 @@ class BltIntegrationTest(unittest.TestCase):
         cleanup(torch_device, gc_collect=True)
 
     @slow
-    @require_read_token
     def test_model(self):
         NUM_TOKENS_TO_GENERATE = 200
         EXPECTED_TEXT = "my name is alex and i am a student at the university of michigan. i am a senior majoring in computer science and minoring in mathematics. i am also a member of the michigan math club and the michigan computer s"
@@ -261,7 +259,6 @@ class BltIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXT)
 
     @slow
-    @require_read_token
     def test_model_logits(self):
         EXPECTED_OUTPUT = torch.tensor(
             [
@@ -342,7 +339,6 @@ class BltIntegrationTest(unittest.TestCase):
         torch.testing.assert_close(EXPECTED_OUTPUT, output[0, :2, :30], rtol=1e-4, atol=1e-4)
 
     @slow
-    @require_read_token
     @require_torch_bf16
     def test_model_bf16(self):
         """Test Blt model with bfloat16 precision."""
@@ -367,7 +363,6 @@ class BltIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXT)
 
     @slow
-    @require_read_token
     @require_torch_bf16
     def test_model_logits_bf16(self):
         """Test Blt model logits with bfloat16 precision."""
@@ -453,7 +448,6 @@ class BltIntegrationTest(unittest.TestCase):
         torch.testing.assert_close(EXPECTED_OUTPUT, output[0, :2, :30], rtol=1e-3, atol=1e-3)
 
     @slow
-    @require_read_token
     def test_model_eager(self):
         """Test Blt model with bfloat16 precision using eager attention implementation."""
         NUM_TOKENS_TO_GENERATE = 200
@@ -475,7 +469,6 @@ class BltIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXT)
 
     @slow
-    @require_read_token
     @require_torch_bf16
     def test_model_bf16_static_cache(self):
         """Test Blt model with bfloat16 precision and static cache."""

--- a/tests/models/chameleon/test_modeling_chameleon.py
+++ b/tests/models/chameleon/test_modeling_chameleon.py
@@ -22,7 +22,6 @@ from transformers import BitsAndBytesConfig, ChameleonConfig, is_torch_available
 from transformers.testing_utils import (
     Expectations,
     require_bitsandbytes,
-    require_read_token,
     require_torch,
     slow,
     torch_device,
@@ -328,7 +327,6 @@ class ChameleonVision2SeqModelTest(ModelTesterMixin, GenerationTesterMixin, Pipe
 class ChameleonIntegrationTest(unittest.TestCase):
     @slow
     @require_bitsandbytes
-    @require_read_token
     def test_model_7b(self):
         model = ChameleonForConditionalGeneration.from_pretrained(
             "facebook/chameleon-7b", quantization_config=BitsAndBytesConfig(load_in_4bit=True), device_map="auto"
@@ -358,7 +356,6 @@ class ChameleonIntegrationTest(unittest.TestCase):
 
     @slow
     @require_bitsandbytes
-    @require_read_token
     def test_model_7b_batched(self):
         model = ChameleonForConditionalGeneration.from_pretrained(
             "facebook/chameleon-7b", quantization_config=BitsAndBytesConfig(load_in_4bit=True), device_map="auto"
@@ -405,7 +402,6 @@ class ChameleonIntegrationTest(unittest.TestCase):
 
     @slow
     @require_bitsandbytes
-    @require_read_token
     def test_model_7b_multi_image(self):
         model = ChameleonForConditionalGeneration.from_pretrained(
             "facebook/chameleon-7b", quantization_config=BitsAndBytesConfig(load_in_4bit=True), device_map="auto"

--- a/tests/models/cohere2/test_modeling_cohere2.py
+++ b/tests/models/cohere2/test_modeling_cohere2.py
@@ -27,7 +27,6 @@ from transformers.testing_utils import (
     cleanup,
     is_flash_attn_2_available,
     require_flash_attn,
-    require_read_token,
     require_torch,
     require_torch_large_accelerator,
     slow,
@@ -88,7 +87,6 @@ class Cohere2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 
 
 @slow
-@require_read_token
 @require_torch_large_accelerator
 class Cohere2IntegrationTest(unittest.TestCase):
     input_text = ["Hello I am doing", "Hi today"]
@@ -240,7 +238,6 @@ class Cohere2IntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
-    @require_read_token
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a hybrid cache).

--- a/tests/models/cohere2_vision/test_modeling_cohere2_vision.py
+++ b/tests/models/cohere2_vision/test_modeling_cohere2_vision.py
@@ -25,7 +25,6 @@ from transformers.testing_utils import (
     cleanup,
     get_device_properties,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -169,7 +168,6 @@ class Cohere2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
         self.config_tester.run_common_tests()
 
 
-@require_read_token
 @require_torch
 class Cohere2IntegrationTest(unittest.TestCase):
     def setUp(self):

--- a/tests/models/cohere2_vision/test_processing_cohere2_vision.py
+++ b/tests/models/cohere2_vision/test_processing_cohere2_vision.py
@@ -15,7 +15,7 @@
 import unittest
 
 from transformers import Cohere2VisionProcessor
-from transformers.testing_utils import require_read_token, require_vision
+from transformers.testing_utils import require_vision
 from transformers.utils import is_torch_available, is_torchvision_available
 
 from ...test_processing_common import ProcessorTesterMixin, url_to_local_path
@@ -28,7 +28,6 @@ if is_torchvision_available():
     pass
 
 
-@require_read_token
 @require_vision
 @unittest.skip("Model not released yet!")
 class Cohere2VisionProcessorTest(ProcessorTesterMixin, unittest.TestCase):

--- a/tests/models/csm/test_modeling_csm.py
+++ b/tests/models/csm/test_modeling_csm.py
@@ -27,7 +27,6 @@ from transformers import (
 )
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch_accelerator,
     slow,
     torch_device,
@@ -320,7 +319,6 @@ class CsmForConditionalGenerationTest(ModelTesterMixin, GenerationTesterMixin, u
         return input_ids, position_ids, input_ids_shared_prefix, mask_shared_prefix, position_ids_shared_prefix
 
 
-@require_read_token
 class CsmForConditionalGenerationIntegrationTest(unittest.TestCase):
     def setUp(self):
         # TODO: @eustlb, update with correct sesame's repo

--- a/tests/models/cwm/test_modeling_cwm.py
+++ b/tests/models/cwm/test_modeling_cwm.py
@@ -19,7 +19,6 @@ from transformers.testing_utils import (
     Expectations,
     cleanup,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -88,7 +87,6 @@ class CwmModelTest(CausalLMModelTest, unittest.TestCase):
 
 @require_torch_accelerator
 @slow
-@require_read_token
 class CwmIntegrationTest(unittest.TestCase):
     def setUp(self):
         cleanup(torch_device, gc_collect=True)

--- a/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
+++ b/tests/models/deepseek_v2/test_modeling_deepseek_v2.py
@@ -16,7 +16,7 @@
 import unittest
 
 from transformers import BitsAndBytesConfig, Cache, is_torch_available
-from transformers.testing_utils import require_read_token, require_torch, require_torch_accelerator, slow, torch_device
+from transformers.testing_utils import require_torch, require_torch_accelerator, slow, torch_device
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 
@@ -145,7 +145,6 @@ class DeepseekV2ModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @slow
-@require_read_token
 @require_torch_accelerator
 class DeepseekV2IntegrationTest(unittest.TestCase):
     def test_deepseek_v2_lite(self):

--- a/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
+++ b/tests/models/deepseek_v3/test_modeling_deepseek_v3.py
@@ -22,7 +22,6 @@ from parameterized import parameterized
 from transformers import AutoTokenizer, DeepseekV3Config, is_torch_available
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_large_accelerator,
@@ -391,7 +390,6 @@ class DeepseekV3IntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @pytest.mark.torch_compile_test
-    @require_read_token
     def test_compile_static_cache(self):
         # `torch==2.2` will throw an error on this test (as in other compilation tests), but torch==2.1.2 and torch>2.2
         # work as intended. See https://github.com/pytorch/pytorch/issues/121943

--- a/tests/models/diffllama/test_modeling_diffllama.py
+++ b/tests/models/diffllama/test_modeling_diffllama.py
@@ -26,7 +26,6 @@ from transformers.testing_utils import (
     cleanup,
     require_bitsandbytes,
     require_flash_attn,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -326,7 +325,6 @@ class DiffLlamaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     @require_torch_accelerator
     @require_bitsandbytes
     @pytest.mark.flash_attn_test
-    @require_read_token
     @slow
     def test_flash_attn_2_generate_padding_right(self):
         """
@@ -457,7 +455,6 @@ class DiffLlamaIntegrationTest(unittest.TestCase):
 
     @slow
     @require_torch_accelerator
-    @require_read_token
     @pytest.mark.torch_compile_test
     def test_compile_static_cache(self):
         # `torch==2.2` will throw an error on this test (as in other compilation tests), but torch==2.1.2 and torch>2.2

--- a/tests/models/doge/test_modeling_doge.py
+++ b/tests/models/doge/test_modeling_doge.py
@@ -17,7 +17,6 @@ import unittest
 
 from transformers import AutoTokenizer, DogeConfig, is_torch_available, set_seed
 from transformers.testing_utils import (
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -367,7 +366,6 @@ class DogeIntegrationTest(unittest.TestCase):
             cls.cuda_compute_capability_major_version = torch.cuda.get_device_capability()[0]
 
     @slow
-    @require_read_token
     def test_Doge_20M_hard(self):
         """
         An integration test for Doge-20M. It tests against a long output to ensure the subtle numerical differences

--- a/tests/models/gemma/test_modeling_gemma.py
+++ b/tests/models/gemma/test_modeling_gemma.py
@@ -27,7 +27,6 @@ from transformers.testing_utils import (
     get_device_properties,
     require_bitsandbytes,
     require_flash_attn,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -92,7 +91,6 @@ class GemmaIntegrationTest(unittest.TestCase):
         # See LlamaIntegrationTest.tearDown(). Can be removed once LlamaIntegrationTest.tearDown() is removed.
         cleanup(torch_device, gc_collect=True)
 
-    @require_read_token
     def test_model_2b_fp16(self):
         model_id = "google/gemma-2b"
         EXPECTED_TEXTS = [
@@ -112,7 +110,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     def test_model_2b_bf16(self):
         model_id = "google/gemma-2b"
 
@@ -131,7 +128,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     def test_model_2b_eager(self):
         model_id = "google/gemma-2b"
 
@@ -153,7 +149,6 @@ class GemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_flash_attn
-    @require_read_token
     @pytest.mark.flash_attn_test
     def test_model_2b_flash_attn(self):
         model_id = "google/gemma-2b"
@@ -176,7 +171,6 @@ class GemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_bitsandbytes
-    @require_read_token
     def test_model_2b_4bit(self):
         model_id = "google/gemma-2b"
         EXPECTED_TEXTS = [
@@ -197,7 +191,6 @@ class GemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @unittest.skip(reason="The test will not fit our CI runners")
-    @require_read_token
     def test_model_7b_fp32(self):
         model_id = "google/gemma-7b"
         EXPECTED_TEXTS = [
@@ -215,7 +208,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     def test_model_7b_fp16(self):
         if self.device_properties[0] == "cuda" and self.device_properties[1] == 7:
             self.skipTest("This test is failing (`torch.compile` fails) on Nvidia T4 GPU (OOM).")
@@ -236,7 +228,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     def test_model_7b_bf16(self):
         if self.device_properties[0] == "cuda" and self.device_properties[1] == 7:
             self.skipTest("This test is failing (`torch.compile` fails) on Nvidia T4 GPU (OOM).")
@@ -267,7 +258,6 @@ class GemmaIntegrationTest(unittest.TestCase):
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
         self.assertEqual(output_text, expected_text)
 
-    @require_read_token
     def test_model_7b_fp16_static_cache(self):
         if self.device_properties[0] == "cuda" and self.device_properties[1] == 7:
             self.skipTest("This test is failing (`torch.compile` fails) on Nvidia T4 GPU (OOM).")
@@ -299,7 +289,6 @@ class GemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_bitsandbytes
-    @require_read_token
     def test_model_7b_4bit(self):
         model_id = "google/gemma-7b"
 
@@ -331,7 +320,6 @@ class GemmaIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @pytest.mark.torch_compile_test
-    @require_read_token
     def test_compile_static_cache(self):
         # `torch==2.2` will throw an error on this test (as in other compilation tests), but torch==2.1.2 and torch>2.2
         # work as intended. See https://github.com/pytorch/pytorch/issues/121943
@@ -371,7 +359,6 @@ class GemmaIntegrationTest(unittest.TestCase):
 
     @pytest.mark.torch_export_test
     @slow
-    @require_read_token
     def test_export_static_cache(self):
         if version.parse(torch.__version__) < version.parse("2.3.0"):
             self.skipTest(reason="This test requires torch >= 2.3 to run.")

--- a/tests/models/gemma/test_tokenization_gemma.py
+++ b/tests/models/gemma/test_tokenization_gemma.py
@@ -18,13 +18,11 @@ import unittest
 from tests.test_tokenization_common import TokenizerTesterMixin
 from transformers.models.gemma.tokenization_gemma import GemmaTokenizer
 from transformers.testing_utils import (
-    require_read_token,
     require_tokenizers,
 )
 
 
 @require_tokenizers
-@require_read_token
 class GemmaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     from_pretrained_id = "hf-internal-testing/dummy-gemma"
     tokenizer_class = GemmaTokenizer

--- a/tests/models/gemma2/test_modeling_gemma2.py
+++ b/tests/models/gemma2/test_modeling_gemma2.py
@@ -29,7 +29,6 @@ from transformers.testing_utils import (
     is_flash_attn_2_available,
     require_flash_attn,
     require_large_cpu_ram,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_large_accelerator,
@@ -73,7 +72,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         cleanup(torch_device, gc_collect=True)
 
     @require_torch_large_accelerator
-    @require_read_token
     def test_model_9b_bf16(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -94,7 +92,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @require_torch_large_accelerator
-    @require_read_token
     def test_model_9b_fp16(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -114,7 +111,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     @require_torch_large_accelerator
     def test_model_9b_pipeline_bf16(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Gemma2 before this PR
@@ -139,7 +135,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
     # TODO: run_test_using_subprocess was added because of an issue in torch 2.9, which is already fixed in nightly
     # We can remove this once we upgrade to torch 2.10
     @run_test_using_subprocess
-    @require_read_token
     def test_model_2b_pipeline_bf16_flex_attention(self):
         # See https://github.com/huggingface/transformers/pull/31747 -- pipeline was broken for Gemma2 before this PR
         model_id = "google/gemma-2-2b"
@@ -169,7 +164,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(output[0][0]["generated_text"], EXPECTED_BATCH_TEXT[0])
         self.assertEqual(output[1][0]["generated_text"], EXPECTED_BATCH_TEXT[1])
 
-    @require_read_token
     @require_flash_attn
     @require_torch_large_accelerator
     @mark.flash_attn_test
@@ -204,7 +198,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
 
     @pytest.mark.torch_export_test
     @slow
-    @require_read_token
     def test_export_static_cache(self):
         if version.parse(torch.__version__) < version.parse("2.5.0"):
             self.skipTest(reason="This test requires torch >= 2.5 to run.")
@@ -277,7 +270,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
     @slow
-    @require_read_token
     @require_large_cpu_ram
     @pytest.mark.torch_export_test
     def test_export_hybrid_cache(self):
@@ -320,7 +312,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(export_generated_text, eager_generated_text)
 
     @require_torch_large_accelerator
-    @require_read_token
     def test_model_9b_bf16_flex_attention(self):
         model_id = "google/gemma-2-9b"
         EXPECTED_TEXTS = [
@@ -341,7 +332,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
-    @require_read_token
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a hybrid cache).
@@ -387,7 +377,6 @@ class Gemma2IntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_COMPLETIONS)
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
-    @require_read_token
     def test_generation_beyond_sliding_window_dynamic(self, attn_implementation: str):
         """
         Same as above, but explicitly setting the cache to Dynamic, as it's otherwise static by default for

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -35,7 +35,6 @@ from transformers.testing_utils import (
     require_deterministic_for_xpu,
     require_flash_attn,
     require_flash_attn_3,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
@@ -457,7 +456,6 @@ class Gemma3Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitte
 
 @slow
 @require_torch_accelerator
-@require_read_token
 class Gemma3IntegrationTest(unittest.TestCase):
     def setUp(self):
         self.processor = Gemma3Processor.from_pretrained("google/gemma-3-4b-it", padding_side="left")

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -37,7 +37,6 @@ from transformers.testing_utils import (
     Expectations,
     cleanup,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     set_config_for_less_flaky_test,
@@ -809,7 +808,6 @@ class Gemma3nVision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
 
 @slow
 @require_torch_accelerator
-@require_read_token
 class Gemma3nIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.processor = AutoProcessor.from_pretrained("Google/gemma-3n-E4B-it", padding_side="left")

--- a/tests/models/glm4_moe/test_modeling_glm4_moe.py
+++ b/tests/models/glm4_moe/test_modeling_glm4_moe.py
@@ -22,7 +22,6 @@ from packaging import version
 from transformers import is_torch_available
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -65,7 +64,6 @@ class Glm4MoeModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
-@require_read_token
 @slow
 class Glm4MoeIntegrationTest(unittest.TestCase):
     def tearDown(self):
@@ -75,7 +73,6 @@ class Glm4MoeIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @pytest.mark.torch_compile_test
-    @require_read_token
     def test_compile_static_cache(self):
         # `torch==2.2` will throw an error on this test (as in other compilation tests), but torch==2.1.2 and torch>2.2
         # work as intended. See https://github.com/pytorch/pytorch/issues/121943

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -34,7 +34,6 @@ from transformers.testing_utils import (
     cleanup,
     require_flash_attn,
     require_kernels,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
@@ -343,7 +342,6 @@ if __name__ == "__main__":
     # Non-distributed test
     # ------------------------
     @parameterized.expand(PARAMETERS)
-    @require_read_token
     def test_model_outputs(self, quantized, model, kernels, attn_impl, mode):
         model_id = f"openai/gpt-oss-{model}"
         output_texts = self.load_and_forward(
@@ -406,7 +404,6 @@ if __name__ == "__main__":
     # Distributed test
     # ------------------------
     @parameterized.expand(PARAMETERS)
-    @require_read_token
     def test_model_outputs_distributed(self, quantized, model, kernels, attn_impl, mode):
         self.run_distributed_test(quantized, model, kernels, attn_impl, mode)
 
@@ -414,7 +411,6 @@ if __name__ == "__main__":
     # Training test
     # ------------------------
     @parameterized.expand(PARAMETERS)
-    @require_read_token
     def test_training_step(self, quantized, model, kernels, attn_impl, mode):
         if mode != "train":
             self.skipTest("This test is only for training mode.")

--- a/tests/models/granite/test_modeling_granite.py
+++ b/tests/models/granite/test_modeling_granite.py
@@ -18,7 +18,6 @@ import unittest
 from transformers import GraniteConfig, is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -194,7 +193,6 @@ class GraniteModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
 @require_torch_accelerator
 class GraniteIntegrationTest(unittest.TestCase):
     @slow
-    @require_read_token
     def test_model_3b_logits_bf16(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
 
@@ -238,7 +236,6 @@ class GraniteIntegrationTest(unittest.TestCase):
         )
 
     @slow
-    @require_read_token
     def test_model_3b_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
 

--- a/tests/models/granitemoe/test_modeling_granitemoe.py
+++ b/tests/models/granitemoe/test_modeling_granitemoe.py
@@ -18,7 +18,6 @@ import unittest
 from transformers import AutoTokenizer, GraniteMoeConfig, is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -193,7 +192,6 @@ class GraniteMoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
 @require_torch_accelerator
 class GraniteMoeIntegrationTest(unittest.TestCase):
     @slow
-    @require_read_token
     def test_model_3b_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
 

--- a/tests/models/granitemoeshared/test_modeling_granitemoeshared.py
+++ b/tests/models/granitemoeshared/test_modeling_granitemoeshared.py
@@ -18,7 +18,6 @@ import unittest
 from transformers import AutoTokenizer, GraniteMoeSharedConfig, is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -196,7 +195,6 @@ class GraniteMoeSharedModelTest(ModelTesterMixin, GenerationTesterMixin, unittes
 @require_torch_accelerator
 class GraniteMoeSharedIntegrationTest(unittest.TestCase):
     @slow
-    @require_read_token
     def test_model_3b_logits(self):
         input_ids = [1, 306, 4658, 278, 6593, 310, 2834, 338]
 

--- a/tests/models/helium/test_modeling_helium.py
+++ b/tests/models/helium/test_modeling_helium.py
@@ -18,7 +18,6 @@ import unittest
 from transformers import AutoModelForCausalLM, AutoTokenizer, is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_read_token,
     require_torch,
     slow,
     torch_device,
@@ -51,7 +50,6 @@ class HeliumModelTest(CausalLMModelTest, unittest.TestCase):
 class HeliumIntegrationTest(unittest.TestCase):
     input_text = ["Hello, today is a great day to"]
 
-    @require_read_token
     def test_model_2b(self):
         model_id = "kyutai/helium-1-preview"
         expected_texts = Expectations(

--- a/tests/models/jais2/test_modeling_jais2.py
+++ b/tests/models/jais2/test_modeling_jais2.py
@@ -18,7 +18,6 @@ import unittest
 from transformers import AutoTokenizer, is_torch_available
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -82,7 +81,6 @@ class Jais2IntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
 
-    @require_read_token
     def test_model_logits(self):
         model_id = "inceptionai/Jais-2-8B-Chat"
         dummy_input = torch.LongTensor([[0, 0, 0, 0, 0, 0, 1, 2, 3], [1, 1, 2, 3, 4, 5, 6, 7, 8]]).to(torch_device)
@@ -110,7 +108,6 @@ class Jais2IntegrationTest(unittest.TestCase):
             atol=1e-3,
         )
 
-    @require_read_token
     def test_model_generation(self):
         tokenizer = AutoTokenizer.from_pretrained("inceptionai/Jais-2-8B-Chat")
         model = Jais2ForCausalLM.from_pretrained(

--- a/tests/models/lfm2/test_modeling_lfm2.py
+++ b/tests/models/lfm2/test_modeling_lfm2.py
@@ -17,7 +17,6 @@ import unittest
 
 from transformers import is_torch_available
 from transformers.testing_utils import (
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -126,7 +125,6 @@ class Lfm2ModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
-@require_read_token
 @slow
 class Lfm2IntegrationTest(unittest.TestCase):
     pass

--- a/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
+++ b/tests/models/lfm2_moe/test_modeling_lfm2_moe.py
@@ -20,7 +20,6 @@ from transformers.testing_utils import (
     Expectations,
     cleanup,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -144,7 +143,6 @@ class Lfm2MoeModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
-@require_read_token
 @slow
 class Lfm2MoeIntegrationTest(unittest.TestCase):
     @classmethod

--- a/tests/models/lfm2_vl/test_modeling_lfm2_vl.py
+++ b/tests/models/lfm2_vl/test_modeling_lfm2_vl.py
@@ -24,7 +24,6 @@ from transformers import AutoProcessor, is_torch_available
 from transformers.models.lfm2_vl.modeling_lfm2_vl import Lfm2VlForConditionalGeneration
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -232,7 +231,6 @@ class Lfm2VlModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase
 
 
 @require_torch_accelerator
-@require_read_token
 @slow
 class Lfm2VlForConditionalGenerationIntegrationTest(unittest.TestCase):
     def setUp(self):

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -23,7 +23,6 @@ from transformers.generation.configuration_utils import GenerationConfig
 from transformers.testing_utils import (
     Expectations,
     cleanup,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     run_test_using_subprocess,
@@ -62,7 +61,6 @@ class LlamaModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
-@require_read_token
 class LlamaIntegrationTest(unittest.TestCase):
     def setup(self):
         cleanup(torch_device, gc_collect=True)

--- a/tests/models/llama4/test_modeling_llama4.py
+++ b/tests/models/llama4/test_modeling_llama4.py
@@ -19,7 +19,6 @@ from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,
     cleanup,
-    require_read_token,
     require_torch_large_accelerator,
     slow,
     torch_device,
@@ -37,7 +36,6 @@ if is_torch_available():
 
 @slow
 @require_torch_large_accelerator
-@require_read_token
 class Llama4IntegrationTest(unittest.TestCase):
     model_id = "meta-llama/Llama-4-Scout-17B-16E"
 

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -18,7 +18,6 @@ import unittest
 from transformers import AutoTokenizer, Mamba2Config, is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -344,14 +343,12 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
 
 @require_torch
 @slow
-@require_read_token
 class Mamba2IntegrationTest(unittest.TestCase):
     def setUp(self):
         self.model_id = "mistralai/Mamba-Codestral-7B-v0.1"
         self.tokenizer = AutoTokenizer.from_pretrained(self.model_id, from_slow=True, legacy=False)
         self.prompt = ("[INST]Write a hello world program in C++.",)
 
-    @require_read_token
     @slow
     @require_torch
     def test_simple_generate(self):
@@ -381,7 +378,6 @@ class Mamba2IntegrationTest(unittest.TestCase):
         ground_truth_sentence = ground_truth_sentences.get_expectation()
         self.assertEqual(output_sentence, ground_truth_sentence)
 
-    @require_read_token
     @slow
     @require_torch_accelerator
     def test_batched_equivalence_with_cache(self):
@@ -412,7 +408,6 @@ class Mamba2IntegrationTest(unittest.TestCase):
             individual_output = tokenizer.batch_decode(individual_gen, skip_special_tokens=True)[0]
             self.assertEqual(individual_output[:100], batched_output[index_gen][:100])
 
-    @require_read_token
     @slow
     @require_torch_accelerator
     def test_batched_equivalence_without_cache(self):

--- a/tests/models/mistral/test_modeling_mistral.py
+++ b/tests/models/mistral/test_modeling_mistral.py
@@ -30,7 +30,6 @@ from transformers.testing_utils import (
     get_device_properties,
     require_bitsandbytes,
     require_flash_attn,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -72,7 +71,6 @@ class MistralModelTest(CausalLMModelTest, unittest.TestCase):
 
 
 @require_torch_accelerator
-@require_read_token
 class MistralIntegrationTest(unittest.TestCase):
     # This variable is used to determine which accelerator are we using for our runners (e.g. A10 or T4)
     # Depending on the hardware we get different logits / generations

--- a/tests/models/mistral3/test_modeling_mistral3.py
+++ b/tests/models/mistral3/test_modeling_mistral3.py
@@ -27,7 +27,6 @@ from transformers.testing_utils import (
     Expectations,
     cleanup,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -232,7 +231,6 @@ class Mistral3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
 @slow
 @require_torch_accelerator
 class Mistral3IntegrationTest(unittest.TestCase):
-    @require_read_token
     def setUp(self):
         cleanup(torch_device, gc_collect=True)
         self.model_checkpoint = "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
@@ -242,7 +240,6 @@ class Mistral3IntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
 
-    @require_read_token
     def test_mistral3_integration_generate_text_only(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
         processor.chat_template = processor.chat_template.replace('strftime_now("%Y-%m-%d")', '"2025-06-20"')
@@ -274,7 +271,6 @@ class Mistral3IntegrationTest(unittest.TestCase):
         expected_output = expected_outputs.get_expectation()
         self.assertEqual(decoded_output, expected_output)
 
-    @require_read_token
     @require_deterministic_for_xpu
     def test_mistral3_integration_generate(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
@@ -309,7 +305,6 @@ class Mistral3IntegrationTest(unittest.TestCase):
         expected_output = expected_outputs.get_expectation()
         self.assertEqual(decoded_output, expected_output)
 
-    @require_read_token
     @require_deterministic_for_xpu
     def test_mistral3_integration_batched_generate(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)
@@ -382,7 +377,6 @@ class Mistral3IntegrationTest(unittest.TestCase):
             f"Decoded output: {decoded_output}\nExpected output: {expected_output}",
         )
 
-    @require_read_token
     @require_deterministic_for_xpu
     def test_mistral3_integration_batched_generate_multi_image(self):
         processor = AutoProcessor.from_pretrained(self.model_checkpoint)

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -35,7 +35,6 @@ from transformers.testing_utils import (
     cleanup,
     require_bitsandbytes,
     require_optimum_quanto,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -468,7 +467,6 @@ class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @require_bitsandbytes
-    @require_read_token
     def test_11b_model_integration_generate(self):
         # Prepare inputs
         processor = AutoProcessor.from_pretrained(self.base_model_checkpoint)
@@ -520,7 +518,6 @@ class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @require_bitsandbytes
-    @require_read_token
     def test_11b_model_integration_generate_text_only(self):
         # Prepare inputs
         processor = AutoProcessor.from_pretrained(self.base_model_checkpoint)
@@ -566,7 +563,6 @@ class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @require_bitsandbytes
-    @require_read_token
     def test_11b_model_integration_forward(self):
         # Prepare inputs
         processor = AutoProcessor.from_pretrained(self.base_model_checkpoint)
@@ -607,7 +603,6 @@ class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @require_bitsandbytes
-    @require_read_token
     def test_11b_model_integration_batched_generate(self):
         processor = AutoProcessor.from_pretrained(self.base_model_checkpoint)
 
@@ -673,7 +668,6 @@ class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):
     @slow
     @require_torch_accelerator
     @require_bitsandbytes
-    @require_read_token
     def test_11b_model_integration_multi_image_generate(self):
         processor = AutoProcessor.from_pretrained(self.instruct_model_checkpoint)
 

--- a/tests/models/nemotron/test_modeling_nemotron.py
+++ b/tests/models/nemotron/test_modeling_nemotron.py
@@ -19,7 +19,6 @@ import unittest
 from transformers import is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -62,7 +61,6 @@ class NemotronModelTest(CausalLMModelTest, unittest.TestCase):
 @require_torch_accelerator
 class NemotronIntegrationTest(unittest.TestCase):
     @slow
-    @require_read_token
     def test_nemotron_8b_generation_sdpa(self):
         text = ["What is the largest planet in solar system?"]
         EXPECTED_TEXT = [
@@ -80,7 +78,6 @@ class NemotronIntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT, output_text)
 
     @slow
-    @require_read_token
     def test_nemotron_8b_generation_eager(self):
         text = ["What is the largest planet in solar system?"]
         EXPECTED_TEXTS = Expectations(
@@ -106,7 +103,6 @@ class NemotronIntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT, output_text)
 
     @slow
-    @require_read_token
     def test_nemotron_8b_generation_fa2(self):
         text = ["What is the largest planet in solar system?"]
         EXPECTED_TEXT = [

--- a/tests/models/paligemma/test_modeling_paligemma.py
+++ b/tests/models/paligemma/test_modeling_paligemma.py
@@ -29,7 +29,6 @@ from transformers import (
 from transformers.testing_utils import (
     Expectations,
     cleanup,
-    require_read_token,
     require_torch,
     slow,
     torch_device,
@@ -336,7 +335,6 @@ class PaliGemmaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
 
 @slow
 @require_torch
-@require_read_token
 class PaliGemmaForConditionalGenerationIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.processor = PaliGemmaProcessor.from_pretrained("google/paligemma-3b-pt-224")

--- a/tests/models/patchtst/test_modeling_patchtst.py
+++ b/tests/models/patchtst/test_modeling_patchtst.py
@@ -22,7 +22,7 @@ from huggingface_hub import hf_hub_download
 
 from transformers import is_torch_available
 from transformers.models.auto import get_values
-from transformers.testing_utils import is_flaky, require_read_token, require_torch, slow, torch_device
+from transformers.testing_utils import is_flaky, require_torch, slow, torch_device
 from transformers.utils import check_torch_load_is_safe
 
 from ...test_configuration_common import ConfigTester
@@ -332,7 +332,6 @@ class PatchTSTModelIntegrationTests(unittest.TestCase):
         )
         torch.testing.assert_close(output[0, :7, :1, :1], expected_slice, rtol=TOLERANCE, atol=TOLERANCE)
 
-    @require_read_token
     def test_prediction_head(self):
         model = PatchTSTForPrediction.from_pretrained("namctin/patchtst_etth1_forecast").to(torch_device)
         batch = prepare_batch(file="test-batch.pt")
@@ -352,7 +351,6 @@ class PatchTSTModelIntegrationTests(unittest.TestCase):
         )
         torch.testing.assert_close(output[0, :1, :7], expected_slice, rtol=TOLERANCE, atol=TOLERANCE)
 
-    @require_read_token
     def test_prediction_generation(self):
         model = PatchTSTForPrediction.from_pretrained("namctin/patchtst_etth1_forecast").to(torch_device)
         batch = prepare_batch(file="test-batch.pt")

--- a/tests/models/perception_lm/test_modeling_perception_lm.py
+++ b/tests/models/perception_lm/test_modeling_perception_lm.py
@@ -28,7 +28,6 @@ from transformers import (
 from transformers.testing_utils import (
     cleanup,
     require_bitsandbytes,
-    require_read_token,
     require_torch,
     slow,
     torch_device,
@@ -374,7 +373,6 @@ TEST_MODEL_PATH = "facebook/Perception-LM-1B"
 @require_torch
 @require_bitsandbytes
 @slow
-@require_read_token
 class PerceptionLMForConditionalGenerationIntegrationTest(unittest.TestCase):
     def setUp(self):
         self.processor = AutoProcessor.from_pretrained(TEST_MODEL_PATH)

--- a/tests/models/perception_lm/test_processing_perception_lm.py
+++ b/tests/models/perception_lm/test_processing_perception_lm.py
@@ -17,7 +17,7 @@ import unittest
 from transformers import (
     PerceptionLMProcessor,
 )
-from transformers.testing_utils import require_read_token, require_vision
+from transformers.testing_utils import require_vision
 from transformers.utils import is_torch_available
 
 from ...test_processing_common import ProcessorTesterMixin
@@ -31,7 +31,6 @@ TEST_MODEL_PATH = "facebook/Perception-LM-1B"
 
 
 @require_vision
-@require_read_token
 @unittest.skip("Requires read token and we didn't requests access yet. FIXME @ydshieh when you are back :)")
 class PerceptionLMProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = PerceptionLMProcessor

--- a/tests/models/recurrent_gemma/test_modeling_recurrent_gemma.py
+++ b/tests/models/recurrent_gemma/test_modeling_recurrent_gemma.py
@@ -22,7 +22,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
 from transformers.testing_utils import (
     Expectations,
     require_bitsandbytes,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -134,7 +133,6 @@ class RecurrentGemmaIntegrationTest(unittest.TestCase):
     input_long_text = ['<bos><s>Marseille, France (CNN)The French prosecutor leading an investigation into the crash of Germanwings Flight 9525 insisted Wednesday that he was not aware of any video footage from on board the plane. Marseille prosecutor Brice Robin told CNN that "so far no videos were used in the crash investigation." He added, "A person who has such a video needs to immediately give it to the investigators." Robin\'s comments follow claims by two magazines, German daily Bild and French Paris Match, of a cell phone video showing the harrowing final seconds from on board Germanwings Flight 9525 as it crashed into the French Alps. All 150 on board were killed. Paris Match and Bild reported that the video was recovered from a phone at the wreckage site. The two publications described the supposed video, but did not post it on their websites. The publications said that they watched the video, which was found by a source close to the investigation. "One can hear cries of \'My God\' in several languages," Paris Match reported. "Metallic banging can also be heard more than three times, perhaps of the pilot trying to open the cockpit door with a heavy object.  Towards the end, after a heavy shake, stronger than the others, the screaming intensifies. Then nothing." "It is a very disturbing scene," said Julian Reichelt, editor-in-chief of Bild online. An official with France\'s accident investigation agency, the BEA, said the agency is not aware of any such video. Lt. Col.']  # fmt: skip
     model_id = "google/recurrentgemma-2b"
 
-    @require_read_token
     def test_2b_generate(self):
         EXPECTED_TEXTS = ['Hello I am doing a project on the topic of "The impact of the internet on the society" and I am looking for some information on the topic. I am looking for some information on the impact of the internet on the society. I am looking for some information on the impact of the internet on the society. I am looking for some', 'Hi today is a new app that allows you to make money by watching videos.\n\nThe app is very simple to use and you can earn money by watching videos.\n\nThe app is available for both Android and iOS devices and you can download it from the Google Play Store or the App Store.\n\nOnce you have downloaded the app']  # fmt: skip
         model = AutoModelForCausalLM.from_pretrained(
@@ -167,7 +165,6 @@ class RecurrentGemmaIntegrationTest(unittest.TestCase):
         output_text = tokenizer.batch_decode(output, skip_special_tokens=True)
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     def test_2b_sample(self):
         set_seed(0)
         expectations = Expectations(
@@ -191,7 +188,6 @@ class RecurrentGemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_TEXT)
 
     @require_bitsandbytes
-    @require_read_token
     def test_model_2b_8bit(self):
         # fmt: off
         EXPECTED_TEXTS = Expectations(
@@ -218,7 +214,6 @@ class RecurrentGemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXT)
 
-    @require_read_token
     def test_long_context(self):
         EXPECTED_GENERATION = [' Jean-Paul Delannoy told CNN that the BEA is "not aware of any video footage that could have been taken on board the plane." He added that the BEA is "not aware of any video footage that could have been taken on board the plane." The BEA is the French equivalent of the National Transportation Safety Board']  # fmt: skip
 
@@ -230,7 +225,6 @@ class RecurrentGemmaIntegrationTest(unittest.TestCase):
         print(output_text)
         self.assertEqual(output_text, EXPECTED_GENERATION)
 
-    @require_read_token
     def test_longer_than_window(self):
         EXPECTED_GENERATION = [" Robin's comments follow claims by two magazines, German daily Bild and French Paris Match, of a cell phone video showing the harrowing final seconds from on board Germanwings Flight 9525 as it crashed into the French Alps. All 150 on board were killed. Paris Match and Bild reported that the"]  # fmt: skip
 

--- a/tests/models/shieldgemma2/test_modeling_shieldgemma2.py
+++ b/tests/models/shieldgemma2/test_modeling_shieldgemma2.py
@@ -22,7 +22,6 @@ from PIL import Image
 from transformers import BitsAndBytesConfig, is_torch_available
 from transformers.testing_utils import (
     cleanup,
-    require_read_token,
     require_torch_accelerator,
     slow,
     torch_device,
@@ -35,7 +34,6 @@ if is_torch_available():
 
 @slow
 @require_torch_accelerator
-@require_read_token
 class ShieldGemma2IntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)

--- a/tests/models/vaultgemma/test_modeling_vaultgemma.py
+++ b/tests/models/vaultgemma/test_modeling_vaultgemma.py
@@ -32,7 +32,6 @@ from transformers.testing_utils import (
     Expectations,
     cleanup,
     is_flash_attn_2_available,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -73,7 +72,6 @@ class VaultGemmaIntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
 
-    @require_read_token
     def test_model_bf16(self):
         model_id = "google/vaultgemma-1b"
         EXPECTED_TEXTS = [
@@ -93,7 +91,6 @@ class VaultGemmaIntegrationTest(unittest.TestCase):
 
         self.assertEqual(output_text, EXPECTED_TEXTS)
 
-    @require_read_token
     def test_model_pipeline_bf16(self):
         model_id = "google/vaultgemma-1b"
         # EXPECTED_TEXTS should match the same non-pipeline test, minus the special tokens
@@ -113,7 +110,6 @@ class VaultGemmaIntegrationTest(unittest.TestCase):
 
     @pytest.mark.torch_export_test
     @slow
-    @require_read_token
     def test_export_static_cache(self):
         if version.parse(torch.__version__) < version.parse("2.5.0"):
             self.skipTest(reason="This test requires torch >= 2.5 to run.")
@@ -176,7 +172,6 @@ class VaultGemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(EXPECTED_TEXT_COMPLETION, ep_generated_text)
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
-    @require_read_token
     def test_generation_beyond_sliding_window(self, attn_implementation: str):
         """Test that we can correctly generate beyond the sliding window. This is non trivial as
         we need to correctly slice the attention mask in all cases (because we use a hybrid cache).
@@ -222,7 +217,6 @@ class VaultGemmaIntegrationTest(unittest.TestCase):
         self.assertEqual(output_text, EXPECTED_COMPLETIONS)
 
     @parameterized.expand([("flash_attention_2",), ("sdpa",), ("flex_attention",), ("eager",)])
-    @require_read_token
     def test_generation_beyond_sliding_window_dynamic(self, attn_implementation: str):
         """
         Same as above, but explicitly setting the cache to Dynamic, as it's otherwise static by default for

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -15,7 +15,6 @@
 
 import copy
 import inspect
-import os
 import random
 import re
 import tempfile

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -30,7 +30,6 @@ from transformers import WhisperConfig
 from transformers.testing_utils import (
     Expectations,
     is_flaky,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_fp16,
@@ -1485,7 +1484,6 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         transcript = processor.batch_decode(generated_ids, skip_special_tokens=True)
         self.assertListEqual(transcript, EXPECTED_TRANSCRIPT)
 
-    @require_read_token
     @slow
     def test_large_batched_generation_multilingual(self):
         processor = WhisperProcessor.from_pretrained("openai/whisper-large")

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1493,15 +1493,11 @@ class WhisperModelIntegrationTests(unittest.TestCase):
         model = WhisperForConditionalGeneration.from_pretrained("openai/whisper-large")
         model.to(torch_device)
 
-        token = os.getenv("HF_HUB_READ_TOKEN", None)
-        if token is None:
-            token = True
         ds = load_dataset(
             "hf-internal-testing/fixtures_common_voice",
             "ja",
             split="test",
             streaming=True,
-            token=token,
         )
         ds = ds.cast_column("audio", datasets.Audio(sampling_rate=16_000))
 

--- a/tests/models/xlstm/test_modeling_xlstm.py
+++ b/tests/models/xlstm/test_modeling_xlstm.py
@@ -19,7 +19,6 @@ from parameterized import parameterized
 
 from transformers import AutoTokenizer, is_torch_available, xLSTMConfig
 from transformers.testing_utils import (
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -246,7 +245,6 @@ class xLSTMModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
 
 @require_torch
 @slow
-@require_read_token
 @unittest.skip("Model is fully broken currently")
 class xLSTMIntegrationTest(unittest.TestCase):
     def setUp(self):

--- a/tests/quantization/fbgemm_fp8/test_fbgemm_fp8.py
+++ b/tests/quantization/fbgemm_fp8/test_fbgemm_fp8.py
@@ -22,7 +22,6 @@ from transformers.testing_utils import (
     backend_empty_cache,
     require_accelerate,
     require_deterministic_for_xpu,
-    require_read_token,
     require_torch_accelerator,
     require_torch_multi_accelerator,
     slow,
@@ -70,7 +69,6 @@ class FbgemmFp8ConfigTest(unittest.TestCase):
 @require_torch_accelerator
 @unittest.skipIf(not is_torch_xpu_available() and not is_fbgemm_gpu_available(), "test requires fbgemm-gpu or xpu")
 @require_accelerate
-@require_read_token
 class FbgemmFp8Test(unittest.TestCase):
     model_name = "meta-llama/Meta-Llama-3-8B"
 

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -24,7 +24,6 @@ from transformers.testing_utils import (
     backend_empty_cache,
     get_device_properties,
     require_accelerate,
-    require_read_token,
     require_torch_accelerator,
     require_torch_multi_accelerator,
     slow,
@@ -74,7 +73,6 @@ class FineGrainedFP8ConfigTest(unittest.TestCase):
 
 @slow
 @require_accelerate
-@require_read_token
 @require_torch_accelerator
 @unittest.skipIf(
     get_device_properties()[0] == "cuda"

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -26,7 +26,6 @@ from transformers import (
 )
 from transformers.testing_utils import (
     require_gguf,
-    require_read_token,
     require_torch_accelerator,
     slow,
     torch_device,
@@ -886,7 +885,6 @@ class GgufModelTests(unittest.TestCase):
         EXPECTED_TEXT = "Hello! 👋\n\nI'm a large language model"
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
-    @require_read_token
     def test_gemma2_weights_conversion_fp32(self):
         original_model = AutoModelForCausalLM.from_pretrained(
             self.original_gemma2_model_id,
@@ -909,7 +907,6 @@ class GgufModelTests(unittest.TestCase):
             else:
                 raise ValueError(f"Layer {layer_name} is not presented in GGUF model")
 
-    @require_read_token
     @unittest.skipUnless(is_gguf_available("0.16.0"), "test requires gguf version >= 0.16.0")
     def test_gemma3_qat_q4_0(self):
         model = AutoModelForCausalLM.from_pretrained(
@@ -926,7 +923,6 @@ class GgufModelTests(unittest.TestCase):
 
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
 
-    @require_read_token
     @unittest.skipUnless(is_gguf_available("0.16.0"), "test requires gguf version >= 0.16.0")
     def test_gemma3_text_weights_conversion_bf16(self):
         original_model = AutoModelForCausalLM.from_pretrained(
@@ -951,7 +947,7 @@ class GgufModelTests(unittest.TestCase):
                 raise ValueError(f"Layer {layer_name} is not presented in GGUF model")
 
     # Test text backbone conversion for gemma3 vision models
-    @require_read_token
+
     @unittest.skipUnless(is_gguf_available("0.16.0"), "test requires gguf version >= 0.16.0")
     def test_gemma3_vision_weights_conversion_bf16(self):
         original_model = AutoModelForCausalLM.from_pretrained(
@@ -1054,7 +1050,6 @@ class GgufModelTests(unittest.TestCase):
         self.assertEqual(GGUF_TO_FAST_CONVERTERS["deci"], GGUFLlamaConverter)
         self.assertEqual(GGUF_TO_FAST_CONVERTERS["decilm"], GGUFLlamaConverter)
 
-    @require_read_token
     @unittest.skipUnless(is_gguf_available("0.16.0"), "test requires gguf version >= 0.16.0")
     def test_qwen3_q8_0(self):
         tokenizer = AutoTokenizer.from_pretrained(self.qwen3_model_id, gguf_file=self.q8_0_qwen3_model_id)
@@ -1119,7 +1114,6 @@ class GgufModelTests(unittest.TestCase):
 
         torch.testing.assert_close(outputs.last_hidden_state[0, :3, :3], EXPECTED_OUTPUT, rtol=6e-3, atol=4e-4)
 
-    @require_read_token
     ## to be precise, it currently require upstream gguf-py to be installed as lfm2 is not yet present in gguf 0.17.1
     @unittest.skipUnless(is_gguf_available("0.17.0"), "test requires gguf version >= 0.17.0")
     def test_lfm2_q4_k_m(self):

--- a/tests/quantization/higgs/test_higgs.py
+++ b/tests/quantization/higgs/test_higgs.py
@@ -60,7 +60,7 @@ class HiggsConfigTest(unittest.TestCase):
 @require_torch_gpu
 @require_flute_hadamard
 @require_accelerate
-# @require_read_token
+#
 class HiggsTest(unittest.TestCase):
     model_name = "unsloth/Llama-3.2-1B"
 

--- a/tests/quantization/quanto_integration/test_quanto.py
+++ b/tests/quantization/quanto_integration/test_quanto.py
@@ -19,7 +19,6 @@ from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, Quanto
 from transformers.testing_utils import (
     require_accelerate,
     require_optimum_quanto,
-    require_read_token,
     require_torch_accelerator,
     slow,
     torch_device,
@@ -306,7 +305,6 @@ class QuantoQuantizationActivationTest(unittest.TestCase):
 @require_torch_accelerator
 class QuantoKVCacheQuantizationTest(unittest.TestCase):
     @slow
-    @require_read_token
     def test_quantized_cache(self):
         EXPECTED_TEXT_COMPLETION = [
             "Simply put, the theory of relativity states that 1) time and space are not absolute, but are relative to the observer, and 2) the laws of physics are the same everywhere in the universe. This means that the speed of light is",

--- a/tests/utils/test_attention_visualizer.py
+++ b/tests/utils/test_attention_visualizer.py
@@ -17,7 +17,7 @@ import io
 import re
 import unittest
 
-from transformers.testing_utils import require_read_token, require_torch
+from transformers.testing_utils import require_torch
 from transformers.utils.attention_visualizer import AttentionMaskVisualizer
 
 
@@ -36,7 +36,6 @@ def _normalize(s: str) -> str:
 class AttentionMaskVisualizerTester(unittest.TestCase):
     """Test suite for AttentionMaskVisualizer"""
 
-    @require_read_token
     def test_paligemma_multimodal_visualization(self):
         """Test AttentionMaskVisualizer with PaliGemma multimodal model"""
         model_name = "hf-internal-testing/namespace_google_repo_name_paligemma-3b-pt-224"
@@ -84,7 +83,6 @@ class AttentionMaskVisualizerTester(unittest.TestCase):
 
         self.assertEqual(_normalize(output), _normalize(expected_output))
 
-    @require_read_token
     def test_llama_text_only_visualization(self):
         """Test AttentionMaskVisualizer with Llama text-only model"""
         model_name = "hf-internal-testing/namespace_meta-llama_repo_name_Llama-2-7b-hf"

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -28,7 +28,6 @@ from transformers.testing_utils import (
     cleanup,
     get_gpu_count,
     is_torch_available,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_gpu,
@@ -497,7 +496,6 @@ class CacheHardIntegrationTest(unittest.TestCase):
 
     @require_torch_multi_accelerator
     @slow
-    @require_read_token
     def test_static_cache_multi_accelerator(self):
         """Regression test for #35164: static cache with multi-accelerator"""
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -72,7 +72,6 @@ from transformers.testing_utils import (
     is_staging_test,
     require_accelerate,
     require_non_hpu,
-    require_read_token,
     require_torch,
     require_torch_accelerator,
     require_torch_multi_accelerator,
@@ -1949,7 +1948,6 @@ class ModelUtilsTest(TestCasePlus):
 
     @parameterized.expand([("Qwen/Qwen2.5-3B-Instruct", 10), ("meta-llama/Llama-2-7b-chat-hf", 10)])
     @slow
-    @require_read_token
     @require_torch_accelerator
     def test_loading_is_fast_on_gpu(self, model_id: str, max_loading_time: float):
         """


### PR DESCRIPTION
# What does this PR do?

This makes the process more smooth: we only need to make sure the bot has access to the gated repositories.