### PR TITLE
docs: fix grammatical error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ pipeline(
     - Reduce compute time and production costs.
     - Dozens of model architectures with 1M+ pretrained checkpoints across all modalities.
 
-1. Choose the right framework for every part of a models lifetime:
+1. Choose the right framework for every part of a model's lifetime:
     - Train state-of-the-art models in 3 lines of code.
     - Move a single model between PyTorch/JAX/TF2.0 frameworks at will.
     - Pick the right framework for training, evaluation, and production.


### PR DESCRIPTION
## Description

This PR fixes a minor grammatical error in the README.md file.

## Changes

- Fixed possessive form: `models lifetime` → `model's lifetime`

## Location

The error was in the 'Why should I use Transformers?' section, under point #3:
- **Before**: 'Choose the right framework for every part of a models lifetime'
- **After**: 'Choose the right framework for every part of a model's lifetime'

## Motivation

Grammatical correctness improves documentation quality and readability.

## Testing

No code changes - documentation only. Verified the fix is grammatically correct.