### PR TITLE
Fix `test_reverse_loading_mapping` common test

### DIFF
--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -4514,9 +4514,7 @@ class ModelTesterMixin:
                     for source_pattern in conversion.source_patterns:
                         # Sometimes the mappings specify keys that are tied, so absent from the saved state dict
                         if isinstance(conversion, WeightRenaming):
-                            if any(
-                                re.search(conversion.target_patterns[0], k) for k in model.all_tied_weights_keys.keys()
-                            ):
+                            if any(re.search(source_pattern, k) for k in model.all_tied_weights_keys.values()):
                                 continue
                         num_matches = sum(re.search(source_pattern, key) is not None for key in serialized_keys)
                         self.assertTrue(


### PR DESCRIPTION
The test currently search for the target pattern in the keys of the tied_weights dict, but target pattern can break regex search (if they contain a group search/replace like `\1`, so this fix searches for the source pattern in the values of the tied_weights dict,

Needed for https://github.com/huggingface/transformers/pull/41549

Cc @Cyrilvallez 