### PR TITLE
Fix: pass kwargs to cross_entropy in fixed_cross_entropy

### DIFF
--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -35,7 +35,9 @@ def fixed_cross_entropy(
     reduction = "sum" if num_items_in_batch is not None else "mean"
     # Only pass kwargs that are valid for cross_entropy (e.g., label_smoothing, weight)
     valid_ce_kwargs = {k: v for k, v in kwargs.items() if k in ("label_smoothing", "weight")}
-    loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction=reduction, **valid_ce_kwargs)
+    loss = nn.functional.cross_entropy(
+        source, target, ignore_index=ignore_index, reduction=reduction, **valid_ce_kwargs
+    )
     if reduction == "sum":
         # just in case users pass an int for num_items_in_batch, which could be the case for custom trainer
         if torch.is_tensor(num_items_in_batch):

--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -33,7 +33,9 @@ def fixed_cross_entropy(
     **kwargs,
 ) -> torch.Tensor:
     reduction = "sum" if num_items_in_batch is not None else "mean"
-    loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction=reduction, **kwargs)
+    # Only pass kwargs that are valid for cross_entropy (e.g., label_smoothing, weight)
+    valid_ce_kwargs = {k: v for k, v in kwargs.items() if k in ("label_smoothing", "weight")}
+    loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction=reduction, **valid_ce_kwargs)
     if reduction == "sum":
         # just in case users pass an int for num_items_in_batch, which could be the case for custom trainer
         if torch.is_tensor(num_items_in_batch):

--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -33,7 +33,7 @@ def fixed_cross_entropy(
     **kwargs,
 ) -> torch.Tensor:
     reduction = "sum" if num_items_in_batch is not None else "mean"
-    loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction=reduction)
+    loss = nn.functional.cross_entropy(source, target, ignore_index=ignore_index, reduction=reduction, **kwargs)
     if reduction == "sum":
         # just in case users pass an int for num_items_in_batch, which could be the case for custom trainer
         if torch.is_tensor(num_items_in_batch):


### PR DESCRIPTION
## What does this PR do?

Fixes #43240

The `fixed_cross_entropy` function accepts `**kwargs` but wasn't using them properly. This meant parameters like `label_smoothing` were silently ignored.

**The fix:** Filter and pass only valid `cross_entropy` kwargs (`label_smoothing`, `weight`) to avoid TypeError when model-specific kwargs are present in the call chain.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue? → Issue #43240 