### PR TITLE
[WIP] Processor moves to `device` in `__call__`

### DIFF
--- a/src/transformers/image_processing_utils_fast.py
+++ b/src/transformers/image_processing_utils_fast.py
@@ -852,7 +852,6 @@ class BaseImageProcessorFast(BaseImageProcessor):
         # Extract parameters that are only used for preparing the input images
         do_convert_rgb = kwargs.pop("do_convert_rgb")
         input_data_format = kwargs.pop("input_data_format")
-        device = kwargs.pop("device")
 
         # Update kwargs that need further processing before being validated
         kwargs = self._further_process_kwargs(**kwargs)
@@ -864,7 +863,7 @@ class BaseImageProcessorFast(BaseImageProcessor):
         kwargs.pop("data_format")
 
         return self._preprocess_image_like_inputs(
-            images, *args, do_convert_rgb=do_convert_rgb, input_data_format=input_data_format, device=device, **kwargs
+            images, *args, do_convert_rgb=do_convert_rgb, input_data_format=input_data_format, **kwargs
         )
 
     def _preprocess_image_like_inputs(
@@ -885,7 +884,7 @@ class BaseImageProcessorFast(BaseImageProcessor):
         images = self._prepare_image_like_inputs(
             images=images, do_convert_rgb=do_convert_rgb, input_data_format=input_data_format, device=device
         )
-        return self._preprocess(images, *args, **kwargs)
+        return self._preprocess(images, *args, device=device, **kwargs)
 
     def _preprocess(
         self,
@@ -904,6 +903,7 @@ class BaseImageProcessorFast(BaseImageProcessor):
         pad_size: Optional[SizeDict],
         disable_grouping: Optional[bool],
         return_tensors: Optional[Union[str, TensorType]],
+        device: torch.device | str | None,
         **kwargs,
     ) -> BatchFeature:
         # Group images by size for batched resizing
@@ -932,7 +932,7 @@ class BaseImageProcessorFast(BaseImageProcessor):
         if do_pad:
             processed_images = self.pad(processed_images, pad_size=pad_size, disable_grouping=disable_grouping)
 
-        return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
+        return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors, device=device)
 
     def to_dict(self):
         encoder_dict = super().to_dict()

--- a/src/transformers/models/llava/image_processing_llava.py
+++ b/src/transformers/models/llava/image_processing_llava.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Image processor class for LLaVa."""
 
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 
@@ -45,6 +45,8 @@ from ...utils import TensorType, is_vision_available, logging
 
 logger = logging.get_logger(__name__)
 
+if TYPE_CHECKING:
+    import torch.device
 
 if is_vision_available():
     import PIL
@@ -294,6 +296,7 @@ class LlavaImageProcessor(BaseImageProcessor):
         return_tensors: Optional[Union[str, TensorType]] = None,
         data_format: Optional[ChannelDimension] = ChannelDimension.FIRST,
         input_data_format: Optional[Union[str, ChannelDimension]] = None,
+        device: Optional[Union["torch.device", str]] = None,
         **kwargs,
     ) -> PIL.Image.Image:
         """
@@ -426,7 +429,7 @@ class LlavaImageProcessor(BaseImageProcessor):
             image = to_channel_dimension_format(image, data_format, input_channel_dim=input_data_format)
             processed_images.append(image)
 
-        return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
+        return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors, device=device)
 
 
 __all__ = ["LlavaImageProcessor"]

--- a/src/transformers/models/llava/image_processing_llava_fast.py
+++ b/src/transformers/models/llava/image_processing_llava_fast.py
@@ -112,6 +112,7 @@ class LlavaImageProcessorFast(BaseImageProcessorFast):
         image_std: Optional[Union[float, list[float]]],
         disable_grouping: Optional[bool],
         return_tensors: Optional[Union[str, TensorType]],
+        device: torch.device | str | None,
         **kwargs,
     ) -> BatchFeature:
         # Group images by size for batched resizing
@@ -150,7 +151,7 @@ class LlavaImageProcessorFast(BaseImageProcessorFast):
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
 
-        return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
+        return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors, device=device)
 
 
 __all__ = ["LlavaImageProcessorFast"]

--- a/src/transformers/models/llava/processing_llava.py
+++ b/src/transformers/models/llava/processing_llava.py
@@ -156,6 +156,7 @@ class LlavaProcessor(ProcessorMixin):
                 prompt_strings.append(sample)
 
         return_tensors = output_kwargs["text_kwargs"].pop("return_tensors", None)
+        device = output_kwargs["text_kwargs"].get("device")
         return_mm_token_type_ids = output_kwargs["text_kwargs"].pop("return_mm_token_type_ids", False)
         text_inputs = self.tokenizer(prompt_strings, **output_kwargs["text_kwargs"], return_tensors=None)
         self._check_special_mm_tokens(prompt_strings, text_inputs, modalities=["image"])
@@ -166,7 +167,11 @@ class LlavaProcessor(ProcessorMixin):
             mm_token_type_ids[array_ids == self.image_token_id] = 1
             text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
 
-        return BatchFeature(data={**text_inputs, **image_inputs}, tensor_type=return_tensors)
+        return BatchFeature(
+            data={**text_inputs, **image_inputs},
+            tensor_type=return_tensors,
+            device=device,
+        )
 
     def _get_num_multimodal_tokens(self, image_sizes=None, **kwargs):
         """

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -197,6 +197,8 @@ class TextKwargs(TypedDict, total=False):
             If set, will return tensors of a particular framework. Acceptable values are:
             - `'pt'`: Return PyTorch `torch.Tensor` objects.
             - `'np'`: Return NumPy `np.ndarray` objects.
+        device (`Union[str, torch.Tensor]`, *optional*):
+            The device to use for processing (e.g. "cpu", "cuda"), only relevant for fast image processing.
     """
 
     text_pair: Optional[Union[TextInput, PreTokenizedInput, list[TextInput], list[PreTokenizedInput]]]
@@ -219,6 +221,7 @@ class TextKwargs(TypedDict, total=False):
     padding_side: Optional[Literal["left", "right"]]
     return_mm_token_type_ids: Optional[bool]
     return_tensors: Annotated[Optional[Union[str, TensorType]], tensor_type_validator()]
+    device: Annotated[Optional[Union[str, "torch.device"]], device_validator()]
 
 
 class ImagesKwargs(TypedDict, total=False):
@@ -402,6 +405,8 @@ class AudioKwargs(TypedDict, total=False):
             If set, will return tensors of a particular framework. Acceptable values are:
             - `'pt'`: Return PyTorch `torch.Tensor` objects.
             - `'np'`: Return NumPy `np.ndarray` objects.
+        device (`Union[str, torch.Tensor]`, *optional*):
+            The device to use for processing (e.g. "cpu", "cuda"), only relevant for fast image processing.
     """
 
     sampling_rate: Annotated[Optional[int], positive_int()]
@@ -412,6 +417,7 @@ class AudioKwargs(TypedDict, total=False):
     pad_to_multiple_of: Annotated[Optional[int], positive_int()]
     return_attention_mask: Optional[bool]
     return_tensors: Annotated[Optional[Union[str, TensorType]], tensor_type_validator()]
+    device: Annotated[Optional[Union[str, "torch.device"]], device_validator()]
 
 
 class ProcessingKwargs(TypedDict, total=False):

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -18,7 +18,7 @@ import warnings
 from collections.abc import Callable, Mapping, Sized
 from enum import Enum
 from pathlib import Path
-from typing import Any, Union, overload
+from typing import TYPE_CHECKING, Any, Optional, Union, overload
 
 import numpy as np
 from huggingface_hub import create_repo
@@ -37,6 +37,10 @@ from transformers.utils import PaddingStrategy, TensorType, add_end_docstrings, 
 from transformers.utils.generic import is_torch_tensor
 from transformers.utils.hub import PushToHubMixin
 from transformers.utils.import_utils import is_mistral_common_available, is_torch_available, requires
+
+
+if TYPE_CHECKING:
+    import torch.device
 
 
 if is_mistral_common_available():
@@ -745,6 +749,7 @@ class MistralCommonBackend(PushToHubMixin):
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
         verbose: bool = True,
+        device: Optional[Union["torch.device", str]] = None,
     ) -> BatchEncoding:
         def get_input_ids(text):
             if isinstance(text, str):
@@ -943,6 +948,7 @@ class MistralCommonBackend(PushToHubMixin):
         return_length: bool = False,
         verbose: bool = True,
         prepend_batch_axis: bool = False,
+        device: Optional[Union["torch.device", str]] = None,
         **kwargs,
     ) -> BatchEncoding:
         """
@@ -1018,7 +1024,7 @@ class MistralCommonBackend(PushToHubMixin):
             encoded_inputs["length"] = len(encoded_inputs["input_ids"])
 
         batch_outputs = BatchEncoding(
-            encoded_inputs, tensor_type=return_tensors, prepend_batch_axis=prepend_batch_axis
+            encoded_inputs, tensor_type=return_tensors, prepend_batch_axis=prepend_batch_axis, device=device
         )
 
         return batch_outputs

--- a/src/transformers/tokenization_python.py
+++ b/src/transformers/tokenization_python.py
@@ -19,7 +19,7 @@ tokenization_utils_tokenizers.py
 import bisect
 import unicodedata
 from collections import OrderedDict
-from typing import Any, overload
+from typing import TYPE_CHECKING, Any, Optional, Union, overload
 
 from .tokenization_utils_base import (
     INIT_TOKENIZER_DOCSTRING,
@@ -33,6 +33,9 @@ from .tokenization_utils_base import (
 )
 from .utils import PaddingStrategy, TensorType, add_end_docstrings, logging
 
+
+if TYPE_CHECKING:
+    import torch.device
 
 logger = logging.get_logger(__name__)
 
@@ -711,6 +714,7 @@ class PythonBackend(PreTrainedTokenizerBase):
         return_special_tokens_mask: bool = False,
         return_length: bool = False,
         verbose: bool = True,
+        device: Optional[Union["torch.device", str]] = None,
         **kwargs,
     ) -> BatchEncoding:
         # Detect batched inputs (list of sequences)
@@ -789,7 +793,7 @@ class PythonBackend(PreTrainedTokenizerBase):
                 return_attention_mask=return_attention_mask,
             )
 
-            return BatchEncoding(batch_outputs, tensor_type=return_tensors)
+            return BatchEncoding(batch_outputs, tensor_type=return_tensors, device=device)
 
         # Single sequence handling
         def get_input_ids(text):

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -22,7 +22,7 @@ import os
 from collections import defaultdict
 from collections.abc import Iterable
 from shutil import copyfile
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import tokenizers.pre_tokenizers as pre_tokenizers_fast
 from huggingface_hub import is_offline_mode
@@ -45,6 +45,9 @@ from .tokenization_utils_base import (
 )
 from .utils import PaddingStrategy, add_end_docstrings, logging
 
+
+if TYPE_CHECKING:
+    import torch.device
 
 logger = logging.get_logger(__name__)
 
@@ -748,6 +751,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         return_length: bool = False,
         verbose: bool = True,
         split_special_tokens: Optional[bool] = None,
+        device: Optional[Union["torch.device", str]] = None,
         **kwargs,
     ) -> BatchEncoding:
         # Input validation (from _call_one)
@@ -877,6 +881,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                     for key, value in batched_output.items()
                 },
                 batched_output.encodings,
+                device=device,
             )
 
         return batched_output

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -376,7 +376,7 @@ class BaseVideoProcessor(BaseImageProcessorFast):
 
         input_data_format = kwargs.pop("input_data_format")
         do_sample_frames = kwargs.pop("do_sample_frames")
-        device = kwargs.pop("device")
+        device = kwargs.get("device")
         video_metadata = kwargs.pop("video_metadata")
 
         sample_indices_fn = partial(self.sample_frames, **kwargs) if do_sample_frames else None
@@ -415,6 +415,7 @@ class BaseVideoProcessor(BaseImageProcessorFast):
         image_mean: Optional[Union[float, list[float]]],
         image_std: Optional[Union[float, list[float]]],
         return_tensors: Optional[Union[str, TensorType]] = None,
+        device: torch.device | str | None = None,
         **kwargs,
     ) -> BatchFeature:
         # Group videos by size for batched resizing
@@ -443,7 +444,7 @@ class BaseVideoProcessor(BaseImageProcessorFast):
 
         processed_videos = reorder_videos(processed_videos_grouped, grouped_videos_index)
 
-        return BatchFeature(data={"pixel_values_videos": processed_videos}, tensor_type=return_tensors)
+        return BatchFeature(data={"pixel_values_videos": processed_videos}, tensor_type=return_tensors, device=device)
 
     @classmethod
     def from_pretrained(

--- a/tests/test_tokenization_common.py
+++ b/tests/test_tokenization_common.py
@@ -599,6 +599,22 @@ Hey how are you doing"""  # noqa: W293
             for i in range(len(batch_encode_plus_sequences["input_ids"]))
         ]
 
+    def test_tokenize_with_device(self):
+        tokenizer = self.get_tokenizer(do_lower_case=True)
+
+        inputs = tokenizer("lower newer", return_tensors="pt")
+        for key in inputs:
+            self.assertIsInstance(inputs[key], torch.Tensor)
+            self.assertTrue(inputs[key].device.type == "cpu")
+
+        inputs = tokenizer("lower newer", return_tensors="pt", device="cuda")
+        for key in inputs:
+            self.assertIsInstance(inputs[key], torch.Tensor)
+            self.assertTrue(inputs[key].device.type == "cuda")
+
+        with self.assertRaises(ValueError):
+            inputs = tokenizer("lower newer", return_tensors="np", device="cuda")
+
     # TODO: this test can be combined with `test_sentencepiece_tokenize_and_convert_tokens_to_string` after the latter is extended to all tokenizers.
     def test_tokenize_special_tokens(self):
         """Test `tokenize` with special tokens."""


### PR DESCRIPTION
# What does this PR do?

This PR allows users to pass the device to processor call and get all inputs in the requested device. Currently the `device` arg is used only in fast image/video processors. But users get confused by the following case

```python
inputs = processor(images, text, device='cuda', return_tensors='pt')

# Before the PR
print(inputs.input_ids.device) # "cpu"
print(inputs.pixel_values.device) # "cuda"

# After the PR
print(inputs.input_ids.device) # "cuda"
print(inputs.pixel_values.device) # "cuda
```

Now we will allow either to pass `device` and get all inputs initialized already on device, or to move to device manually by `inputs.to(device)`

Fixes https://github.com/huggingface/transformers/issues/42722