### PR TITLE
fix(processing): use feature_extractor.sampling_rate as default in apply_chat_template

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -514,12 +514,15 @@ class ChatTemplateLoadKwargs(TypedDict, total=False):
 
     num_frames (`int`, *optional*):
         Number of frames to sample uniformly. If not passed, the whole video is loaded.
+    sampling_rate (`int`, *optional*):
+        The sampling rate at which the audio should be loaded. If not provided, defaults to the
+        processor's feature_extractor.sampling_rate, or 16000 if not available.
     load_audio_from_video (`bool`, *optional*):
             Whether to use the audio track of input video. If `True` the audio track will be loaded and passed to the
             processor. This flag has no effect if the model doesn't support audio modality.
     """
 
-    sampling_rate: int | None = 16_000
+    sampling_rate: int | None = None
     load_audio_from_video: bool | None = False
 
 
@@ -1737,6 +1740,13 @@ class ProcessorMixin(PushToHubMixin):
         tokenize = processed_kwargs["template_kwargs"].pop("tokenize", False)
         return_dict = processed_kwargs["template_kwargs"].pop("return_dict", True)
         mm_load_kwargs = processed_kwargs["mm_load_kwargs"]
+
+        # Use the processor's feature_extractor sampling rate as default if not explicitly provided
+        if mm_load_kwargs.get("sampling_rate") is None:
+            if hasattr(self, "feature_extractor") and hasattr(self.feature_extractor, "sampling_rate"):
+                mm_load_kwargs["sampling_rate"] = self.feature_extractor.sampling_rate
+            else:
+                mm_load_kwargs["sampling_rate"] = 16_000
 
         if tokenize:
             batch_images, batch_videos = [], []


### PR DESCRIPTION
## Summary

- Use processor's `feature_extractor.sampling_rate` as default when loading audio in `apply_chat_template()`
- Fall back to 16kHz only when no feature_extractor is available

## Problem

`apply_chat_template()` hardcoded 16kHz as the default sampling rate, ignoring the processor's configured value. This caused audio to be incorrectly resampled (e.g., 24kHz audio resampled to 16kHz for CsmProcessor).

## Fix

1. Changed `ChatTemplateLoadKwargs.sampling_rate` default from `16_000` to `None`
2. Added runtime resolution using `self.feature_extractor.sampling_rate` when available

Fixes #43262