### PR TITLE
Fix failing `fast_vlm` tests

### DIFF
--- a/tests/models/fast_vlm/test_modeling_fast_vlm.py
+++ b/tests/models/fast_vlm/test_modeling_fast_vlm.py
@@ -246,7 +246,7 @@ class FastVlmForConditionalGenerationIntegrationTest(unittest.TestCase):
         prompt = "user\n<image>\nWhat are the things I should be cautious about when I visit this place?\nassistant"
         image_file = "https://llava-vl.github.io/static/images/view.jpg"
         raw_image = Image.open(requests.get(image_file, stream=True).raw)
-        inputs = self.processor(images=raw_image, text=prompt, return_tensors="pt").to(torch_device)
+        inputs = self.processor(images=raw_image, text=prompt, return_tensors="pt").to(torch_device, dtype=model.dtype)
 
         output = model.generate(**inputs, max_new_tokens=20)
         expected_decoded_texts = "user\n\nWhat are the things I should be cautious about when I visit this place?\nassistant\n\nWhen visiting this place, there are a few things you should be cautious about:\n\n1. **"  # fmt: skip
@@ -272,7 +272,8 @@ class FastVlmForConditionalGenerationIntegrationTest(unittest.TestCase):
         image2 = Image.open(requests.get("http://images.cocodataset.org/val2017/000000039769.jpg", stream=True).raw)
 
         inputs = self.processor(images=[image1, image2], text=prompts, return_tensors="pt", padding=True).to(
-            torch_device
+            torch_device,
+            dtype=model.dtype,
         )
 
         output = model.generate(**inputs, max_new_tokens=20)


### PR DESCRIPTION
# What does this PR do?

Fixes these failing [FastVlmForConditionalGenerationIntegrationTest](https://github.com/huggingface/transformers/actions/runs/20706072009/job/59437072515#step:14:4472)

<img width="1396" height="279" alt="image" src="https://github.com/user-attachments/assets/72879321-0225-4d15-a880-890c21bb8caa" />


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@Rocketknight1 @vasqu