### PR TITLE
[Qwen-VL] min/max pixels gone forever

### DIFF
--- a/src/transformers/models/glm_image/image_processing_glm_image_fast.py
+++ b/src/transformers/models/glm_image/image_processing_glm_image_fast.py
@@ -96,8 +96,6 @@ class GlmImageImageProcessorFast(BaseImageProcessorFast):
     patch_size = 14
     temporal_patch_size = 2
     merge_size = 2
-    min_pixels = None
-    max_pixels = None
     valid_kwargs = GlmImageImageProcessorKwargs
     model_input_names = ["pixel_values", "image_grid_thw"]
 
@@ -116,7 +114,7 @@ class GlmImageImageProcessorFast(BaseImageProcessorFast):
         if "shortest_edge" not in size or "longest_edge" not in size:
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
-        super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        super().__init__(size=size, **kwargs)
 
     def _further_process_kwargs(
         self,
@@ -139,7 +137,7 @@ class GlmImageImageProcessorFast(BaseImageProcessorFast):
         else:
             size = {**self.size}
 
-        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        return super()._further_process_kwargs(size=size, **kwargs)
 
     @auto_docstring
     def preprocess(

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
@@ -62,8 +62,6 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
     patch_size = 14
     temporal_patch_size = 2
     merge_size = 2
-    min_pixels = None
-    max_pixels = None
     valid_kwargs = Qwen2VLImageProcessorKwargs
     model_input_names = ["pixel_values", "image_grid_thw"]
 
@@ -82,7 +80,7 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
         if "shortest_edge" not in size or "longest_edge" not in size:
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
-        super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        super().__init__(size=size, **kwargs)
 
     def _further_process_kwargs(
         self,
@@ -105,7 +103,7 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
         else:
             size = {**self.size}
 
-        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        return super()._further_process_kwargs(size=size, **kwargs)
 
     @auto_docstring
     def preprocess(

--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -79,8 +79,6 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
     do_rescale = True
     do_normalize = True
     do_convert_rgb = True
-    min_pixels = 128 * 28 * 28
-    max_pixels = 28 * 28 * 768
     patch_size = 14
     temporal_patch_size = 2
     merge_size = 2
@@ -105,7 +103,7 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
         if "shortest_edge" not in size or "longest_edge" not in size:
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
-        super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        super().__init__(size=size, **kwargs)
 
     def _further_process_kwargs(
         self,
@@ -128,7 +126,7 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
         else:
             size = {**self.size}
 
-        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        return super()._further_process_kwargs(size=size, **kwargs)
 
     def sample_frames(
         self,

--- a/src/transformers/models/video_llama_3/image_processing_video_llama_3_fast.py
+++ b/src/transformers/models/video_llama_3/image_processing_video_llama_3_fast.py
@@ -80,8 +80,6 @@ class VideoLlama3ImageProcessorFast(BaseImageProcessorFast):
     patch_size = 14
     temporal_patch_size = 1
     merge_size = 1
-    min_pixels = None
-    max_pixels = None
     valid_kwargs = VideoLlama3ImageProcessorKwargs
     model_input_names = [
         "pixel_values",
@@ -104,7 +102,7 @@ class VideoLlama3ImageProcessorFast(BaseImageProcessorFast):
         if "shortest_edge" not in size or "longest_edge" not in size:
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
-        super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        super().__init__(size=size, **kwargs)
 
     def _further_process_kwargs(
         self,
@@ -127,7 +125,7 @@ class VideoLlama3ImageProcessorFast(BaseImageProcessorFast):
         else:
             size = {**self.size}
 
-        return super()._further_process_kwargs(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        return super()._further_process_kwargs(size=size, **kwargs)
 
     @auto_docstring
     def preprocess(

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1473,9 +1473,6 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
     valid_kwargs = VideoLlama3VideoProcessorInitKwargs
     model_input_names = ["pixel_values_videos", "video_grid_thw", "video_merge_sizes", "video_compression_mask"]
 
-    def _further_process_kwargs(self):
-        raise AttributeError("VideoLlama3 never supported min/max pixels, no need to copy from Qwen")
-
     def _get_compression_mask(
         self,
         pixel_values_videos: torch.FloatTensor,
@@ -1532,8 +1529,6 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
         do_normalize: bool,
         image_mean: float | list[float] | None,
         image_std: float | list[float] | None,
-        min_pixels: int | None = None,
-        max_pixels: int | None = None,
         patch_size: int | None = None,
         temporal_patch_size: int | None = None,
         merge_size: int | None = None,
@@ -1553,8 +1548,8 @@ class VideoLlama3VideoProcessor(Qwen2VLVideoProcessor):
                     height,
                     width,
                     factor=patch_size * merge_size,
-                    min_pixels=min_pixels,
-                    max_pixels=max_pixels // shape[0],
+                    min_pixels=size["shortest_edge"],
+                    max_pixels=size["longest_edge"] // shape[0],
                 )
                 stacked_videos = self.resize(
                     image=stacked_videos,

--- a/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
@@ -79,8 +79,6 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
     do_rescale = True
     do_normalize = True
     do_convert_rgb = True
-    min_pixels = 128 * 28 * 28
-    max_pixels = 28 * 28 * 768
     patch_size = 14
     temporal_patch_size = 1
     merge_size = 2
@@ -107,7 +105,7 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
         if "shortest_edge" not in size or "longest_edge" not in size:
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
-        super().__init__(size=size, min_pixels=min_pixels, max_pixels=max_pixels, **kwargs)
+        super().__init__(size=size, **kwargs)
 
     def sample_frames(
         self,

--- a/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
@@ -107,6 +107,29 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
 
         super().__init__(size=size, **kwargs)
 
+    def _further_process_kwargs(
+        self,
+        size: SizeDict | None = None,
+        min_pixels: int | None = None,
+        max_pixels: int | None = None,
+        **kwargs,
+    ) -> dict:
+        """
+        Update kwargs that need further processing before being validated
+        Can be overridden by subclasses to customize the processing of kwargs.
+        """
+        if min_pixels is not None and max_pixels is not None:
+            size = {"shortest_edge": min_pixels, "longest_edge": max_pixels}
+        elif size is not None:
+            if "shortest_edge" not in size or "longest_edge" not in size:
+                raise ValueError("dictionary `size` must contain 'shortest_edge' and 'longest_edge' keys.")
+            min_pixels = size["shortest_edge"]
+            max_pixels = size["longest_edge"]
+        else:
+            size = {**self.size}
+
+        return super()._further_process_kwargs(size=size, **kwargs)
+
     def sample_frames(
         self,
         metadata: VideoMetadata,
@@ -189,8 +212,6 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
         do_normalize: bool,
         image_mean: float | list[float] | None,
         image_std: float | list[float] | None,
-        min_pixels: int | None = None,
-        max_pixels: int | None = None,
         patch_size: int | None = None,
         temporal_patch_size: int | None = None,
         merge_size: int | None = None,
@@ -210,8 +231,8 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
                     height,
                     width,
                     factor=patch_size * merge_size,
-                    min_pixels=min_pixels,
-                    max_pixels=max_pixels // shape[0],
+                    min_pixels=size["shortest_edge"],
+                    max_pixels=size["longest_edge"] // shape[0],
                 )
                 stacked_videos = self.resize(
                     image=stacked_videos,

--- a/tests/models/qwen2_vl/test_image_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_image_processing_qwen2_vl.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+import json
 import tempfile
 import unittest
 
@@ -136,24 +137,18 @@ class Qwen2VLImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase):
             self.assertTrue(hasattr(image_processing, "image_mean"))
             self.assertTrue(hasattr(image_processing, "image_std"))
             self.assertTrue(hasattr(image_processing, "do_resize"))
-            self.assertTrue(hasattr(image_processing, "min_pixels"))
-            self.assertTrue(hasattr(image_processing, "max_pixels"))
             self.assertTrue(hasattr(image_processing, "do_convert_rgb"))
             self.assertTrue(hasattr(image_processing, "patch_size"))
             self.assertTrue(hasattr(image_processing, "temporal_patch_size"))
             self.assertTrue(hasattr(image_processing, "merge_size"))
 
-    def test_image_processor_from_dict_with_kwargs(self):
+    def test_image_processor_to_json_string(self):
         for image_processing_class in self.image_processor_list:
-            image_processor = image_processing_class.from_dict(self.image_processor_dict)
-            self.assertEqual(image_processor.min_pixels, 56 * 56)
-            self.assertEqual(image_processor.max_pixels, 28 * 28 * 1280)
-
-            image_processor = image_processing_class.from_dict(
-                self.image_processor_dict, min_pixels=256 * 256, max_pixels=640 * 640
-            )
-            self.assertEqual(image_processor.min_pixels, 256 * 256)
-            self.assertEqual(image_processor.max_pixels, 640 * 640)
+            image_processor = image_processing_class(**self.image_processor_dict)
+            obj = json.loads(image_processor.to_json_string())
+            for key, value in self.image_processor_dict.items():
+                if key not in ["min_pixels", "max_pixels"]:
+                    self.assertEqual(obj[key], value)
 
     def test_select_best_resolution(self):
         # Test with a final resize resolution

--- a/tests/models/qwen2_vl/test_video_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_video_processing_qwen2_vl.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import tempfile
 import unittest
 
@@ -58,7 +59,7 @@ class Qwen2VLVideoProcessingTester:
         max_pixels=100 * 100,
         merge_size=2,
     ):
-        size = size if size is not None else {"shortest_edge": 20}
+        size = size if size is not None else {"shortest_edge": 400, "longest_edge": 10000}
         self.parent = parent
         self.batch_size = batch_size
         self.num_frames = num_frames
@@ -147,18 +148,22 @@ class Qwen2VLVideoProcessingTest(VideoProcessingTestMixin, unittest.TestCase):
         self.assertTrue(hasattr(video_processing, "image_std"))
         self.assertTrue(hasattr(video_processing, "do_convert_rgb"))
 
-    # OVERRIDDEN BECAUSE QWEN2_VL HAS SPECIAL OUTPUT SHAPES
     def test_video_processor_from_dict_with_kwargs(self):
+        video_processor = self.fast_video_processing_class.from_dict(self.video_processor_dict)
+        self.assertEqual(video_processor.size, {"shortest_edge": 400, "longest_edge": 10000})
+
+        video_processor = self.fast_video_processing_class.from_dict(
+            self.video_processor_dict, size={"shortest_edge": 100, "longest_edge": 200}
+        )
+        self.assertEqual(video_processor.size, {"shortest_edge": 100, "longest_edge": 200})
+
+    def test_video_processor_to_json_string(self):
         for video_processing_class in self.video_processor_list:
             video_processor = video_processing_class(**self.video_processor_dict)
-            self.assertEqual(video_processor.min_pixels, self.video_processor_tester.min_pixels)
-            self.assertEqual(video_processor.max_pixels, self.video_processor_tester.max_pixels)
-
-            video_processor = video_processing_class.from_dict(
-                self.video_processor_dict, min_pixels=256 * 256, max_pixels=640 * 640
-            )
-            self.assertEqual(video_processor.min_pixels, 256 * 256)
-            self.assertEqual(video_processor.max_pixels, 640 * 640)
+            obj = json.loads(video_processor.to_json_string())
+            for key, value in self.video_processor_dict.items():
+                if key not in ["min_pixels", "max_pixels"]:
+                    self.assertEqual(obj[key], value)
 
     def test_call_pil(self):
         for video_processing_class in self.video_processor_list:

--- a/tests/models/video_llama_3/test_image_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_image_processing_video_llama_3.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+import json
 import tempfile
 import unittest
 
@@ -133,23 +134,17 @@ class VideoLlama3ImageProcessingTest(ImageProcessingTestMixin, unittest.TestCase
             self.assertTrue(hasattr(image_processing, "image_mean"))
             self.assertTrue(hasattr(image_processing, "image_std"))
             self.assertTrue(hasattr(image_processing, "do_resize"))
-            self.assertTrue(hasattr(image_processing, "min_pixels"))
-            self.assertTrue(hasattr(image_processing, "max_pixels"))
             self.assertTrue(hasattr(image_processing, "do_convert_rgb"))
             self.assertTrue(hasattr(image_processing, "patch_size"))
             self.assertTrue(hasattr(image_processing, "merge_size"))
 
-    def test_image_processor_from_dict_with_kwargs(self):
+    def test_image_processor_to_json_string(self):
         for image_processing_class in self.image_processor_list:
-            image_processor = image_processing_class.from_dict(self.image_processor_dict)
-            self.assertEqual(image_processor.min_pixels, 14 * 14 * 16)
-            self.assertEqual(image_processor.max_pixels, 14 * 14 * 16384)
-
-            image_processor = image_processing_class.from_dict(
-                self.image_processor_dict, min_pixels=256 * 256, max_pixels=640 * 640
-            )
-            self.assertEqual(image_processor.min_pixels, 256 * 256)
-            self.assertEqual(image_processor.max_pixels, 640 * 640)
+            image_processor = image_processing_class(**self.image_processor_dict)
+            obj = json.loads(image_processor.to_json_string())
+            for key, value in self.image_processor_dict.items():
+                if key not in ["min_pixels", "max_pixels"]:
+                    self.assertEqual(obj[key], value)
 
     def test_select_best_resolution(self):
         # Test with a final resize resolution


### PR DESCRIPTION
# What does this PR do?

As per title, deletes min/max pixels from class attributes, but still allows passing them with kwargs at `__init__` and during `__call__`. 

And fixes https://github.com/huggingface/transformers/pull/43228#issuecomment-3745649304. Caused by us setting `self.min_pixels` to config value and giving it highest priority than `size` in `_further_process_kwargs`, even when `size` is a user-defined argument.
