### PR TITLE
[`Docs`] Minimax M2 add release date

### DIFF
--- a/docs/source/en/model_doc/minimax_m2.md
+++ b/docs/source/en/model_doc/minimax_m2.md
@@ -16,7 +16,7 @@ limitations under the License.
 ⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be rendered properly in your Markdown viewer.
 
 -->
-*This model was released on {release_date} and added to Hugging Face Transformers on 2026-01-09.*
+*This model was released on 2025-10-27 and added to Hugging Face Transformers on 2026-01-09.*
 
 
 # MiniMax-M2


### PR DESCRIPTION
New make automatically added the correct line but there was no original release date