### PR TITLE
Replace config.get() with getattr(config)

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -716,7 +716,7 @@ class AutoTokenizer:
                 )
             config = config.encoder
 
-        model_type = config_class_to_model_type(type(config).__name__) or config.get("model_type", None)
+        model_type = config_class_to_model_type(type(config).__name__) or getattr(config, "model_type", None)
         if model_type is not None:
             tokenizer_class = TOKENIZER_MAPPING.get(type(config), TokenizersBackend)
             if tokenizer_class is not None:


### PR DESCRIPTION
A buggy line was introduced in #42894 that uses `config.get()`, but `config` classes are not dicts and don't have item access like that. Replaced it with `getattr()`!

Fixes #43272, cc @arthurzucker for review