### PR TITLE
Fix Mxfp4 dequantize

### DIFF
--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -249,8 +249,8 @@ def convert_moe_packed_tensors(
         blk = blocks[r0:r1]
         exp = scales[r0:r1]
 
-        idx_lo = blk & 0x0F
-        idx_hi = blk >> 4
+        idx_lo = (blk & 0x0F).to(torch.uint8)
+        idx_hi = (blk >> 4).to(torch.uint8)
 
         sub = out[r0:r1]
         sub[:, 0::2] = lut[idx_lo]

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utils import is_torch_available, is_torch_xpu_available, logging
+from ..utils import is_torch_available, logging
 
 
 if is_torch_available():

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -447,10 +447,6 @@ def dequantize(module, param_name, param_value, target_device, dq_param_name, **
             setattr(module, param_name.rsplit(".", 1)[1], param_value)
             if hasattr(module, blocks_attr) and hasattr(module, scales_attr):
                 dequantized = convert_moe_packed_tensors(getattr(module, blocks_attr), getattr(module, scales_attr))
-                if target_device == "cpu" and torch.cuda.is_available():
-                    torch.cuda.empty_cache()
-                elif target_device == "cpu" and is_torch_xpu_available():
-                    torch.xpu.empty_cache()
                 setattr(module, proj, torch.nn.Parameter(dequantized.to(target_device)))
                 delattr(module, blocks_attr)
                 delattr(module, scales_attr)

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -249,15 +249,19 @@ def convert_moe_packed_tensors(
         blk = blocks[r0:r1]
         exp = scales[r0:r1]
 
+        # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
         idx_lo = (blk & 0x0F).to(torch.int)
+        out[r0:r1, 0::2] = lut[idx_lo]
+        del idx_lo
+
+        # This vector is only used to index into `lut`, but is hugeee in GPU memory so we delete it immediately
         idx_hi = (blk >> 4).to(torch.int)
+        out[r0:r1, 1::2] = lut[idx_hi]
+        del idx_hi
 
-        sub = out[r0:r1]
-        sub[:, 0::2] = lut[idx_lo]
-        sub[:, 1::2] = lut[idx_hi]
-
-        torch.ldexp(sub, exp, out=sub)
-        del idx_lo, idx_hi, blk, exp, sub
+        # Perform op
+        torch.ldexp(out[r0:r1], exp, out=out[r0:r1])
+        del blk, exp
 
     out = out.reshape(*prefix_shape, G, B * 2).view(*prefix_shape, G * B * 2)
 

--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -249,8 +249,8 @@ def convert_moe_packed_tensors(
         blk = blocks[r0:r1]
         exp = scales[r0:r1]
 
-        idx_lo = (blk & 0x0F).to(torch.uint8)
-        idx_hi = (blk >> 4).to(torch.uint8)
+        idx_lo = (blk & 0x0F).to(torch.int)
+        idx_hi = (blk >> 4).to(torch.int)
 
         sub = out[r0:r1]
         sub[:, 0::2] = lut[idx_lo]


### PR DESCRIPTION
# What does this PR do?

As per the title. Fix https://github.com/huggingface/transformers/issues/43317.
They move the devices without being asked to do it, resulting in OOMs when using with a device_map="auto". Also, no need to upscale the dtype to int64 as they are only used to indexing and it takes up more memory in constrained device_map="auto" settings