### PR TITLE
fix: _get_num_multimodal_tokens video branch (#43329)

### DIFF
--- a/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
@@ -230,6 +230,7 @@ class Ernie4_5_VL_MoeProcessor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = Ernie4_5_VL_MoeProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             temporal_merge_size = (
                 videos_kwargs.get("temporal_patch_size", None) or self.video_processor.temporal_patch_size
             )

--- a/src/transformers/models/glm46v/processing_glm46v.py
+++ b/src/transformers/models/glm46v/processing_glm46v.py
@@ -202,6 +202,7 @@ class Glm46VProcessor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = Glm46VProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/glm46v/video_processing_glm46v.py
+++ b/src/transformers/models/glm46v/video_processing_glm46v.py
@@ -275,5 +275,44 @@ class Glm46VVideoProcessor(BaseVideoProcessor):
 
         return BatchFeature(data=data, tensor_type=return_tensors)
 
+    def get_number_of_video_patches(self, num_frames: int, height: int, width: int, videos_kwargs=None):
+        """
+        A utility that returns number of video patches for a given video size.
+
+        Args:
+            num_frames (`int`):
+                Number of frames in the input video.
+            height (`int`):
+                Height of the input video.
+            width (`int`):
+                Width of the input video.
+            videos_kwargs (`dict`, *optional*):
+                Any kwargs to override defaults of the video processor.
+        Returns:
+            `int`: Number of video patches per video.
+        """
+        size = videos_kwargs.get("size", None) or self.size
+        patch_size = videos_kwargs.get("patch_size", None) or self.patch_size
+        merge_size = videos_kwargs.get("merge_size", None) or self.merge_size
+        temporal_patch_size = videos_kwargs.get("temporal_patch_size", None) or self.temporal_patch_size
+        do_resize = videos_kwargs.get("do_resize", None)
+        do_resize = self.do_resize if do_resize is None else do_resize
+
+        resized_height, resized_width = height, width
+        if do_resize:
+            resized_height, resized_width = smart_resize(
+                num_frames=num_frames,
+                height=height,
+                width=width,
+                temporal_factor=temporal_patch_size,
+                factor=patch_size * merge_size,
+                min_pixels=size["shortest_edge"],
+                max_pixels=size["longest_edge"],
+            )
+
+        grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+        grid_t = (num_frames + temporal_patch_size - 1) // temporal_patch_size
+        return grid_t * grid_h * grid_w
+
 
 __all__ = ["Glm46VVideoProcessor"]

--- a/src/transformers/models/glm4v/processing_glm4v.py
+++ b/src/transformers/models/glm4v/processing_glm4v.py
@@ -201,6 +201,7 @@ class Glm4vProcessor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = Glm4vProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/glm4v/video_processing_glm4v.py
+++ b/src/transformers/models/glm4v/video_processing_glm4v.py
@@ -245,5 +245,44 @@ class Glm4vVideoProcessor(BaseVideoProcessor):
 
         return BatchFeature(data=data, tensor_type=return_tensors)
 
+    def get_number_of_video_patches(self, num_frames: int, height: int, width: int, videos_kwargs=None):
+        """
+        A utility that returns number of video patches for a given video size.
+
+        Args:
+            num_frames (`int`):
+                Number of frames in the input video.
+            height (`int`):
+                Height of the input video.
+            width (`int`):
+                Width of the input video.
+            videos_kwargs (`dict`, *optional*):
+                Any kwargs to override defaults of the video processor.
+        Returns:
+            `int`: Number of video patches per video.
+        """
+        size = videos_kwargs.get("size", None) or self.size
+        patch_size = videos_kwargs.get("patch_size", None) or self.patch_size
+        merge_size = videos_kwargs.get("merge_size", None) or self.merge_size
+        temporal_patch_size = videos_kwargs.get("temporal_patch_size", None) or self.temporal_patch_size
+        do_resize = videos_kwargs.get("do_resize", None)
+        do_resize = self.do_resize if do_resize is None else do_resize
+
+        resized_height, resized_width = height, width
+        if do_resize:
+            resized_height, resized_width = smart_resize(
+                num_frames=num_frames,
+                height=height,
+                width=width,
+                temporal_factor=temporal_patch_size,
+                factor=patch_size * merge_size,
+                min_pixels=size["shortest_edge"],
+                max_pixels=size["longest_edge"],
+            )
+
+        grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+        grid_t = (num_frames + temporal_patch_size - 1) // temporal_patch_size
+        return grid_t * grid_h * grid_w
+
 
 __all__ = ["Glm4vVideoProcessor"]

--- a/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
@@ -974,6 +974,7 @@ class Qwen2_5_VLProcessor(Qwen2VLProcessor):
         if video_sizes is not None:
             videos_kwargs = Qwen2_5_VLProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
@@ -181,6 +181,7 @@ class Qwen2_5_VLProcessor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = Qwen2_5_VLProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/qwen2_vl/processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/processing_qwen2_vl.py
@@ -162,6 +162,7 @@ class Qwen2VLProcessor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = Qwen2VLProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py
@@ -323,5 +323,10 @@ class Qwen2VLVideoProcessor(BaseVideoProcessor):
         grid_t = num_frames // temporal_patch_size
         return grid_t * grid_h * grid_w
 
+    def get_number_of_video_patches(self, num_frames: int, height: int, width: int, videos_kwargs=None):
+        return self.get_num_of_video_patches(
+            num_frames=num_frames, height=height, width=width, videos_kwargs=videos_kwargs
+        )
+
 
 __all__ = ["Qwen2VLVideoProcessor"]

--- a/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
@@ -216,6 +216,7 @@ class Qwen3VLProcessor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = Qwen3VLProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py
@@ -269,5 +269,44 @@ class Qwen3VLVideoProcessor(BaseVideoProcessor):
 
         return BatchFeature(data=data, tensor_type=return_tensors)
 
+    def get_number_of_video_patches(self, num_frames: int, height: int, width: int, videos_kwargs=None):
+        """
+        A utility that returns number of video patches for a given video size.
+
+        Args:
+            num_frames (`int`):
+                Number of frames in the input video.
+            height (`int`):
+                Height of the input video.
+            width (`int`):
+                Width of the input video.
+            videos_kwargs (`dict`, *optional*):
+                Any kwargs to override defaults of the video processor.
+        Returns:
+            `int`: Number of video patches per video.
+        """
+        size = videos_kwargs.get("size", None) or self.size
+        patch_size = videos_kwargs.get("patch_size", None) or self.patch_size
+        merge_size = videos_kwargs.get("merge_size", None) or self.merge_size
+        temporal_patch_size = videos_kwargs.get("temporal_patch_size", None) or self.temporal_patch_size
+        do_resize = videos_kwargs.get("do_resize", None)
+        do_resize = self.do_resize if do_resize is None else do_resize
+
+        resized_height, resized_width = height, width
+        if do_resize:
+            resized_height, resized_width = smart_resize(
+                num_frames=num_frames,
+                height=height,
+                width=width,
+                temporal_factor=temporal_patch_size,
+                factor=patch_size * merge_size,
+                min_pixels=size["shortest_edge"],
+                max_pixels=size["longest_edge"],
+            )
+
+        grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+        grid_t = (num_frames + temporal_patch_size - 1) // temporal_patch_size
+        return grid_t * grid_h * grid_w
+
 
 __all__ = ["Qwen3VLVideoProcessor"]

--- a/src/transformers/models/video_llama_3/processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/processing_video_llama_3.py
@@ -189,6 +189,7 @@ class VideoLlama3Processor(ProcessorMixin):
         if video_sizes is not None:
             videos_kwargs = VideoLlama3ProcessorKwargs._defaults.get("videos_kwargs", {})
             videos_kwargs.update(kwargs)
+            merge_size = videos_kwargs.get("merge_size", None) or self.video_processor.merge_size
             num_video_patches = [
                 self.video_processor.get_number_of_video_patches(*video_size, videos_kwargs)
                 for video_size in video_sizes

--- a/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/video_processing_video_llama_3.py
@@ -345,6 +345,11 @@ class VideoLlama3VideoProcessor(BaseVideoProcessor):
         grid_t = num_frames // temporal_patch_size
         return grid_t * grid_h * grid_w
 
+    def get_number_of_video_patches(self, num_frames: int, height: int, width: int, videos_kwargs=None):
+        return self.get_num_of_video_patches(
+            num_frames=num_frames, height=height, width=width, videos_kwargs=videos_kwargs
+        )
+
     def _get_compression_mask(
         self,
         pixel_values_videos: torch.FloatTensor,

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -67,7 +67,6 @@ class Ernie4_5_VL_MoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     def tearDownClass(cls):
         shutil.rmtree(cls.tmpdirname, ignore_errors=True)
 
-    # Copied from tests.models.llava.test_processing_llava.LlavaProcessorTest.test_get_num_vision_tokens
     def test_get_num_vision_tokens(self):
         "Tests general functionality of the helper used internally in vLLM"
 

--- a/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
+++ b/tests/models/ernie4_5_vl_moe/test_processing_ernie4_5_vl_moe.py
@@ -80,6 +80,10 @@ class Ernie4_5_VL_MoeProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
 
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     def test_save_load_pretrained_default(self):
         tokenizer = self.get_tokenizer()
         image_processor = self.get_image_processor()

--- a/tests/models/glm46v/test_processor_glm46v.py
+++ b/tests/models/glm46v/test_processor_glm46v.py
@@ -50,6 +50,13 @@ class Glm46VProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             **kwargs,
         )
 
+    def test_get_num_vision_tokens_video(self):
+        processor = self.get_processor()
+
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     @require_torch
     @require_av
     def _test_apply_chat_template(

--- a/tests/models/glm4v/test_processor_glm4v.py
+++ b/tests/models/glm4v/test_processor_glm4v.py
@@ -50,6 +50,13 @@ class Glm4vProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             **kwargs,
         )
 
+    def test_get_num_vision_tokens_video(self):
+        processor = self.get_processor()
+
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     @require_torch
     @require_av
     def _test_apply_chat_template(

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -53,6 +53,10 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
 
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     @require_torch
     @require_av
     def _test_apply_chat_template(

--- a/tests/models/qwen2_vl/test_processing_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_processing_qwen2_vl.py
@@ -60,6 +60,10 @@ class Qwen2VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
 
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     @require_torch
     @require_av
     def _test_apply_chat_template(

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -57,6 +57,10 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
 
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     def test_model_input_names(self):
         processor = self.get_processor()
 

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -73,6 +73,10 @@ class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
 
+        output = processor._get_num_multimodal_tokens(video_sizes=[(8, 224, 224)])
+        self.assertTrue("num_video_tokens" in output)
+        self.assertEqual(len(output["num_video_tokens"]), 1)
+
     @require_torch
     @require_av
     def _test_apply_chat_template(

--- a/tests/models/video_llama_3/test_processing_video_llama_3.py
+++ b/tests/models/video_llama_3/test_processing_video_llama_3.py
@@ -60,7 +60,6 @@ class VideoLlama3ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             raise ValueError("batch_size must be greater than 0")
         return prepare_image_inputs() * batch_size
 
-    # Copied from tests.models.llava.test_processing_llava.LlavaProcessorTest.test_get_num_vision_tokens
     def test_get_num_vision_tokens(self):
         "Tests general functionality of the helper used internally in vLLM"
 


### PR DESCRIPTION
# What does this PR do?

Fixes #43329

 ### Summary
  `_get_num_multimodal_tokens(video_sizes=...)` crashed in multiple multimodal processors because the
  video branch called `self.video_processor.get_number_of_video_patches(...)` (not implemented on several video
  processors), and used `merge_size` without initializing it (it was only set in the image branch).

  This meant CI never exercised the video route (tests only covered `image_sizes`).

  ### Changes

  - Initialize merge_size in the video_sizes branch (from videos_kwargs.get("merge_size") fallback to
    self.video_processor.merge_size).
  - Add get_number_of_video_patches() to the relevant *VideoProcessor implementations (either as an
    alias to the existing helper or as a small utility consistent with preprocessing).
  - Add unit coverage that calls _get_num_multimodal_tokens(video_sizes=[(8, 224, 224)]) so the video
    branch is exercised in CI.

  ### Affected processors

  - Ernie4_5_VL_MoeProcessor
  - Glm4vProcessor
  - Glm46VProcessor
  - Qwen2VLProcessor
  - Qwen2_5_VLProcessor
  - Qwen3VLProcessor
  - VideoLlama3Processor

  ### Relevant Tests

  python -m pytest -q \
    tests/models/qwen2_vl/test_processing_qwen2_vl.py::Qwen2VLProcessorTest::test_get_num_vision_tokens
  \
    tests/models/qwen2_5_vl/
  test_processing_qwen2_5_vl.py::Qwen2_5_VLProcessorTest::test_get_num_vision_tokens \
    tests/models/qwen3_vl/test_processing_qwen3_vl.py::Qwen3VLProcessorTest::test_get_num_vision_tokens
  \
    tests/models/video_llama_3/
  test_processing_video_llama_3.py::VideoLlama3ProcessorTest::test_get_num_vision_tokens \
    tests/models/ernie4_5_vl_moe/
  test_processing_ernie4_5_vl_moe.py::Ernie4_5_VL_MoeProcessorTest::test_get_num_vision_tokens \
    tests/models/glm4v/test_processor_glm4v.py::Glm4vProcessorTest::test_get_num_vision_tokens_video \
    tests/models/glm46v/test_processor_glm46v.py::Glm46VProcessorTest::test_get_num_vision_tokens_video
