### PR TITLE
fix `ShieldGemma2IntegrationTest::test_model`

### DIFF
--- a/src/transformers/models/shieldgemma2/modeling_shieldgemma2.py
+++ b/src/transformers/models/shieldgemma2/modeling_shieldgemma2.py
@@ -58,16 +58,16 @@ class ShieldGemma2ForImageClassification(PreTrainedModel):
         self.post_init()
 
     def get_input_embeddings(self):
-        return self.model.language_model.get_input_embeddings()
+        return self.model.get_decoder().get_input_embeddings()
 
     def set_input_embeddings(self, value):
-        self.model.language_model.set_input_embeddings(value)
+        self.model.get_decoder().set_input_embeddings(value)
 
     def get_output_embeddings(self):
-        return self.model.language_model.get_output_embeddings()
+        return self.model.get_decoder().get_output_embeddings()
 
     def set_output_embeddings(self, new_embeddings):
-        self.model.language_model.set_output_embeddings(new_embeddings)
+        self.model.get_decoder().set_output_embeddings(new_embeddings)
 
     @auto_docstring
     def forward(


### PR DESCRIPTION
…y::ShieldGemma2IntegrationTest::test_model crash

crash calltrack is
```
tests/models/shieldgemma2/test_modeling_shieldgemma2.py:49:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
src/transformers/modeling_utils.py:4023: in from_pretrained
    hf_quantizer.preprocess_model(
src/transformers/quantizers/base.py:167: in preprocess_model
    self._process_model_before_weight_loading(model, **kwargs)
src/transformers/quantizers/quantizer_bnb_4bit.py:127: in _process_model_before_weight_loading
    self.modules_to_not_convert = self.get_modules_to_not_convert(
src/transformers/quantizers/base.py:237: in get_modules_to_not_convert
    modules_to_not_convert = get_keys_to_not_convert(model)
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/transformers/quantizers/base.py:48: in get_keys_to_not_convert
    output_emb_module = model.get_output_embeddings()
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
src/transformers/models/shieldgemma2/modeling_shieldgemma2.py:67: in get_output_embeddings
    return self.model.language_model.get_output_embeddings()
           ^^^^^^^^^^^^^^^^^^^^^^^^^
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = Gemma3ForConditionalGeneration(
  (model): Gemma3Model(
    (vision_tower): SiglipVisionModel(
      (vision_model): S...rotary_emb): Gemma3RotaryEmbedding()
    )
  )
  (lm_head): Linear(in_features=2560, out_features=262208, bias=False)
)
name = 'language_model'

    def __getattr__(self, name: str) -> Union[Tensor, "Module"]:
        if "_parameters" in self.__dict__:
            _parameters = self.__dict__["_parameters"]
            if name in _parameters:
                return _parameters[name]
        if "_buffers" in self.__dict__:
            _buffers = self.__dict__["_buffers"]
            if name in _buffers:
                return _buffers[name]
        if "_modules" in self.__dict__:
            modules = self.__dict__["_modules"]
            if name in modules:
                return modules[name]
>       raise AttributeError(
            f"'{type(self).__name__}' object has no attribute '{name}'"
        )
E       AttributeError: 'Gemma3ForConditionalGeneration' object has no attribute 'language_model'

/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py:1967: AttributeError

```