### PR TITLE
fix failed unit test for glm_moe_lite model

### DIFF
--- a/tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py
+++ b/tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py
@@ -47,6 +47,7 @@ class Glm4MoeLiteModelTester(CausalLMModelTester):
         q_lora_rank=16,
         qk_nope_head_dim=64,
         qk_rope_head_dim=64,
+        v_head_dim=64,
     ):
         super().__init__(parent=parent)
         self.n_routed_experts = n_routed_experts
@@ -54,6 +55,7 @@ class Glm4MoeLiteModelTester(CausalLMModelTester):
         self.q_lora_rank = q_lora_rank
         self.qk_nope_head_dim = qk_nope_head_dim
         self.qk_rope_head_dim = qk_rope_head_dim
+        self.v_head_dim = v_head_dim
 
 
 @require_torch

--- a/tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py
+++ b/tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py
@@ -47,7 +47,7 @@ class Glm4MoeLiteModelTester(CausalLMModelTester):
         q_lora_rank=16,
         qk_nope_head_dim=64,
         qk_rope_head_dim=64,
-        v_head_dim=64,
+        v_head_dim=128,
     ):
         super().__init__(parent=parent)
         self.n_routed_experts = n_routed_experts


### PR DESCRIPTION
This PR fixes following failed test cases:
```
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_eager_matches_fa2_generate
 - RuntimeError: mat1 and mat2 shapes cannot be multiplied (14x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attention_2_continue
_generate_with_position_ids - RuntimeError: mat1 and mat2 shapes cannot be multiplied (91x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attention_2_padding_
matches_padding_free_with_position_ids - RuntimeError: mat1 and mat2 shapes cannot be multiplied (91x256 and 512x32
)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attention_2_padding_matches_padding_free_with_position_ids_and_fa_kwargs - RuntimeError: mat1 and mat2 shapes cannot be multiplied (91$256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attn_2_equivalence $ RuntimeError: mat1 and mat2 shapes cannot be multiplied (91x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attn_2_fp32_ln - Ru$timeError: mat1 and mat2 shapes cannot be multiplied (91x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attn_2_from_config $ RuntimeError: mat1 and mat2 shapes cannot be multiplied (91x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attn_2_inference_eq$ivalence - RuntimeError: mat1 and mat2 shapes cannot be multiplied (7x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attn_2_inference_eq$ivalence_right_padding - RuntimeError: mat1 and mat2 shapes cannot be multiplied (7x256 and 512x32)
FAILED tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_flash_attn_kernels_infere$ce_equivalence - RuntimeError: mat1 and mat2 shapes cannot be multiplied (7x256 and 512x32)
```
This is because the test configuration used the default value of 256 for v_head_dim, which caused a dimension mismatch when padding and slicing in flash attention. After this PR all above cases can get passed.