### PR TITLE
fix: Correct ESM TrunkConfig self-modulo in validation

### DIFF
--- a/src/transformers/models/esm/configuration_esm.py
+++ b/src/transformers/models/esm/configuration_esm.py
@@ -101,16 +101,6 @@ class TrunkConfig:
 
         if self.max_recycles <= 0:
             raise ValueError(f"`max_recycles` should be positive, got {self.max_recycles}.")
-        if self.sequence_state_dim % self.sequence_head_width != 0:
-            raise ValueError(
-                "`sequence_state_dim` should be a round multiple of `sequence_head_width`, got"
-                f" {self.sequence_state_dim} and {self.sequence_head_width}."
-            )
-        if self.pairwise_state_dim % self.pairwise_head_width != 0:
-            raise ValueError(
-                "`pairwise_state_dim` should be a round multiple of `pairwise_head_width`, got"
-                f" {self.pairwise_state_dim} and {self.pairwise_head_width}."
-            )
 
         sequence_num_heads = self.sequence_state_dim // self.sequence_head_width
         pairwise_num_heads = self.pairwise_state_dim // self.pairwise_head_width

--- a/src/transformers/models/esm/configuration_esm.py
+++ b/src/transformers/models/esm/configuration_esm.py
@@ -101,15 +101,15 @@ class TrunkConfig:
 
         if self.max_recycles <= 0:
             raise ValueError(f"`max_recycles` should be positive, got {self.max_recycles}.")
-        if self.sequence_state_dim % self.sequence_state_dim != 0:
+        if self.sequence_state_dim % self.sequence_head_width != 0:
             raise ValueError(
-                "`sequence_state_dim` should be a round multiple of `sequence_state_dim`, got"
-                f" {self.sequence_state_dim} and {self.sequence_state_dim}."
+                "`sequence_state_dim` should be a round multiple of `sequence_head_width`, got"
+                f" {self.sequence_state_dim} and {self.sequence_head_width}."
             )
-        if self.pairwise_state_dim % self.pairwise_state_dim != 0:
+        if self.pairwise_state_dim % self.pairwise_head_width != 0:
             raise ValueError(
-                "`pairwise_state_dim` should be a round multiple of `pairwise_state_dim`, got"
-                f" {self.pairwise_state_dim} and {self.pairwise_state_dim}."
+                "`pairwise_state_dim` should be a round multiple of `pairwise_head_width`, got"
+                f" {self.pairwise_state_dim} and {self.pairwise_head_width}."
             )
 
         sequence_num_heads = self.sequence_state_dim // self.sequence_head_width


### PR DESCRIPTION
### What does this PR do?

`TrunkConfig` validation contained a self-modulo check that would never trigger (dead code). This PR corrects the divisibility check to use the head width instead.

Fixes #43347.

### Before submitting

* [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
* [x] Did you read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
  Pull Request section?
* [x] Was this discussed/approved via a GitHub issue or the [[forum](https://discuss.huggingface.co/)](https://discuss.huggingface.co/)? Please add a link
  to it if that's the case.
* [x] Did you make sure to update the documentation with your changes? Here are the
  [[documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs)](https://github.com/huggingface/transformers/tree/main/docs), and
  [[here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation)](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).

cc: @sayakpaul @Rocketknight1