### PR TITLE
Remove unnecessary device synchronizations from finegrained FP8 matmul

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -472,9 +472,6 @@ class FP8Linear(nn.Linear):
                     output_dtype=input.dtype,
                 )
 
-            # Blocks the CPU until all accelerator operations on the specified device are complete. It is used to ensure that the results of the
-            # preceding operations are ready before proceeding
-            torch_accelerator_module.synchronize()
             if self.bias is not None:
                 output = output + self.bias
 
@@ -579,9 +576,7 @@ class FP8Expert(nn.Module):
                     self.block_size,
                     output_dtype=input.dtype,
                 )
-            # Blocks the CPU until all accelerator operations on the specified device are complete. It is used to ensure that the results of the
-            # preceding operations are ready before proceeding
-            torch_accelerator_module.synchronize()
+
             return output.to(dtype=input.dtype)
 
 


### PR DESCRIPTION
The synchronizations are unnecessary and kill performance. Before and after traces
<img width="1073" height="120" alt="image" src="https://github.com/user-attachments/assets/ccbde7ec-9466-40dd-81a0-8f337100739d" />
<img width="912" height="118" alt="image" src="https://github.com/user-attachments/assets/9567f954-e582-4c12-86bd-62e908c6cf28" />

cc @SunMarc