### PR TITLE
Skip glm_image integration tests (wrong checkpoint)

### DIFF
--- a/tests/models/glm_image/test_modeling_glm_image.py
+++ b/tests/models/glm_image/test_modeling_glm_image.py
@@ -347,6 +347,12 @@ class GlmImageModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCa
 
 
 @require_torch
+@unittest.skip(
+    reason="Integration tests use wrong checkpoint (zai-org/GLM-4.5V is glm4v_moe, not glm_image). "
+    "The correct checkpoint is zai-org/GLM-Image with subfolder='vision_language_encoder'. "
+    "Tests also need to be rewritten as GlmImage is for image generation, not VLM-style Q&A. "
+    "See https://github.com/huggingface/transformers/issues/43344"
+)
 @slow
 class GlmImageIntegrationTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
# What does this PR do?

The integration tests for `GlmImageForConditionalGeneration` were failing because they load `zai-org/GLM-4.5V` which is a `glm4v_moe` model, not `glm_image`. This causes shape mismatches:

```
lm_head.weight: [151552, 4096] vs [16512, 4096]  
patch_embed.proj.weight: [1536, 3, 2, 14, 14] vs [1536, 3, 14, 14]
```

The correct checkpoint is `zai-org/GLM-Image` with `subfolder='vision_language_encoder'`.

There's also a deeper issue — tests use VLM prompts ("What kind of dog is this?") but GlmImage is for image generation, not visual Q&A. So the test logic itself needs rewriting.

This PR skips the tests until they can be properly fixed.

Fixes #43344

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #43344
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@zucchini-nlp @ydshieh