### PR TITLE
Fix: resolve lazy-load ImportError for PreTrainedModel (#42548)

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -133,6 +133,7 @@ _import_structure = {
         "is_wandb_available",
     ],
     "loss": [],
+    "modeling_utils": ["PreTrainedModel", "PushToHubMixin", "unwrap_model"],
     "pipelines": [
         "AnyToAnyPipeline",
         "AudioClassificationPipeline",
@@ -617,6 +618,8 @@ if TYPE_CHECKING:
     from .modeling_rope_utils import dynamic_rope_update as dynamic_rope_update
     from .modeling_utils import AttentionInterface as AttentionInterface
     from .modeling_utils import PreTrainedModel as PreTrainedModel
+    from .modeling_utils import PushToHubMixin as PushToHubMixin
+    from .modeling_utils import unwrap_model as unwrap_model
     from .models import *
     from .models.mamba.modeling_mamba import MambaCache as MambaCache
     from .models.timm_wrapper import TimmWrapperImageProcessor as TimmWrapperImageProcessor


### PR DESCRIPTION
## Description
This PR fixes the `ImportError: cannot import name 'PreTrainedModel' from 'transformers'` reported in #42548. 

**The Issue:**
`PreTrainedModel` was missing from the `_import_structure` in `src/transformers/__init__.py`. This caused the lazy-loading mechanism to fail when core frameworks (like PyTorch) were not present or specifically disabled, even though the source file existed.

**Changes:**
- Added `modeling_utils` mapping to `_import_structure` including `PreTrainedModel`, `PushToHubMixin`, and `unwrap_model`.
- Updated the `TYPE_CHECKING` block to include these exports for IDE/static analysis support.
- Formatted with `ruff` to ensure style compliance.

**Verification:**
Running the following in a minimal environment now succeeds:
`python -c "from transformers import PreTrainedModel; print('Success')"`

Fixes #42548