### PR TITLE
fix(models) : string mutation bug in from_proteinnet_string

### DIFF
--- a/src/transformers/models/esm/openfold_utils/protein.py
+++ b/src/transformers/models/esm/openfold_utils/protein.py
@@ -81,9 +81,8 @@ def from_proteinnet_string(proteinnet_str: str) -> Protein:
     for g in groups:
         if g[0] == "[PRIMARY]":
             seq = g[1][0].strip()
-            for i in range(len(seq)):
-                if seq[i] not in residue_constants.restypes:
-                    seq[i] = "X"  # FIXME: strings are immutable
+            # Replace unknown residues with "X" (strings are immutable, so convert to list first)
+            seq = [char if char in residue_constants.restypes else "X" for char in seq]
             aatype = np.array(
                 [residue_constants.restype_order.get(res_symbol, residue_constants.restype_num) for res_symbol in seq]
             )


### PR DESCRIPTION
### what does this PR do?

fixes a `TypeError` in `openfold_utils/protein.py` where `from_proteinnet_string` attempts to mutate an immutable string in-place.

the original code tried to assign seq[i] = "X" to handle unknown residues, which crashes. this pr replaces that logic with a list comprehension to safely sanitize the sequence, resolving the existing `FIXME`.

### before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


### who can review?

@ArthurZucker 
