### PR TITLE
Allow Path type in transformers.image_utils.load_image function

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -17,8 +17,8 @@ import os
 from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
-from typing import Optional, Union
 from pathlib import Path
+from typing import Optional, Union
 
 import httpx
 import numpy as np
@@ -456,7 +456,7 @@ def load_image(image: Union[str, Path, "PIL.Image.Image"], timeout: float | None
     requires_backends(load_image, ["vision"])
     if isinstance(image, Path):
         image = str(image)
-        
+
     if isinstance(image, str):
         if image.startswith("http://") or image.startswith("https://"):
             # We need to actually check for a real protocol, otherwise it's impossible to use a local file

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -18,6 +18,7 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from io import BytesIO
 from typing import Optional, Union
+from pathlib import Path
 
 import httpx
 import numpy as np
@@ -439,12 +440,12 @@ def valid_coco_panoptic_annotations(annotations: Iterable[dict[str, list | tuple
     return all(is_valid_annotation_coco_panoptic(ann) for ann in annotations)
 
 
-def load_image(image: Union[str, "PIL.Image.Image"], timeout: float | None = None) -> "PIL.Image.Image":
+def load_image(image: Union[str, Path, "PIL.Image.Image"], timeout: float | None = None) -> "PIL.Image.Image":
     """
     Loads `image` to a PIL Image.
 
     Args:
-        image (`str` or `PIL.Image.Image`):
+        image (`str`, `Path` or `PIL.Image.Image`):
             The image to convert to the PIL Image format.
         timeout (`float`, *optional*):
             The timeout value in seconds for the URL request.
@@ -453,6 +454,11 @@ def load_image(image: Union[str, "PIL.Image.Image"], timeout: float | None = Non
         `PIL.Image.Image`: A PIL Image.
     """
     requires_backends(load_image, ["vision"])
+    
+    # Convert Path to string
+    if isinstance(image, Path):
+        image = str(image)
+        
     if isinstance(image, str):
         if image.startswith("http://") or image.startswith("https://"):
             # We need to actually check for a real protocol, otherwise it's impossible to use a local file

--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -454,8 +454,6 @@ def load_image(image: Union[str, Path, "PIL.Image.Image"], timeout: float | None
         `PIL.Image.Image`: A PIL Image.
     """
     requires_backends(load_image, ["vision"])
-    
-    # Convert Path to string
     if isinstance(image, Path):
         image = str(image)
         


### PR DESCRIPTION
Updated transformers.image_utils.load_image helper function to accept Path type for image input.

I've been extracting images from folders with `pathlib` so added a simple fix to `load_image` to allow Path types as input.