### PR TITLE
Fix always issuing generation deprecation warning

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1812,7 +1812,7 @@ class GenerationMixin(ContinuousMixin):
             generation_config.cache_implementation = None
 
         # It doesn't make sense to allow kwargs and `generation_config`, that should be mutually exclusive
-        if generation_config_provided is not None and set(kwargs.keys()) - set(model_kwargs.keys()):
+        if generation_config_provided and set(kwargs.keys()) - set(model_kwargs.keys()):
             generation_kwargs = set(kwargs.keys()) - set(model_kwargs.keys())
             logger.warning_once(
                 f"Passing `generation_config` together with generation-related "

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2691,6 +2691,46 @@ class GenerationIntegrationTests(unittest.TestCase):
             model.generation_config.use_cache = None
             model.save_pretrained(tmpdirname)
 
+    def test_generation_config_deprecation(self):
+        import logging as pylogging
+
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        input_ids = tokenizer("Hello", return_tensors="pt").input_ids.to(torch_device)
+
+        logger = pylogging.getLogger("transformers")
+
+        class OnWarningHandler(pylogging.Handler):
+            def __init__(self):
+                super().__init__()
+                self.warnings = []
+
+            def emit(self, record):
+                msg = record.getMessage()
+                if "Passing `generation_config` together with" in msg:
+                    self.warnings.append(msg)
+
+        warningHandler = OnWarningHandler()
+        logger.addHandler(warningHandler)
+
+        try:
+            # Providing generation_config and kwargs is deprecated, so we expect a warning here.
+            #
+            # We're using logging_once, make sure that we emit this warning in any case by clearing the
+            # cache on warning_once
+            logging.warning_once.cache_clear()
+            generation_config = GenerationConfig(temperature=1.0)
+            _ = model.generate(input_ids, generation_config=generation_config, do_sample=False)
+            self.assertTrue(len(warningHandler.warnings) == 1)
+
+            # Providing no generation config, only kwargs is not deprecated. No further deprecation warnings
+            # should have been sent.
+            logging.warning_once.cache_clear()
+            _ = model.generate(input_ids, do_sample=False)
+            self.assertTrue(len(warningHandler.warnings) == 1)
+        finally:
+            logger.removeHandler(warningHandler)
+
     # TODO joao, manuel: remove in v4.62.0
     @slow
     def test_diverse_beam_search(self):


### PR DESCRIPTION
# What does this PR do?

**Note:** already discussed with @zucchini-nlp internally

Commit 38e5987 from PR #43194 introduced a minor bug that causes the issuing of a deprecation warning regardless of the user using the deprecated interface.

For example:
```
model.generate(**input_ids, do_sample=False)
```
would issue a deprecation warning not to pass `GenerationConfig` as well as generation kwargs even though we're not passing a `GenerationConfig`.

Along the fix this also introduces a unit test to check both the intended and the bug behavior.


