### PR TITLE
Fix: adding pad_token_id in Qwen3VLTextConfig

### DIFF
--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -168,7 +168,6 @@ class Qwen3VLTextConfig(PreTrainedConfig):
         self.attention_dropout = attention_dropout
         self.rope_parameters = rope_parameters
 
-        # Passing standard token ids through PreTrainedConfig so they're serialized/deserialized properly.
         super().__init__(
             ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"},
             pad_token_id=pad_token_id,

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -109,7 +109,7 @@ class Qwen3VLTextConfig(PreTrainedConfig):
             Whether to use a bias in the query, key, value and output projection layers during self-attention.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
-        pad_token_id (`int`, *optional*, defaults to `None`):
+        pad_token_id (`int`, *optional*):
             The id of the padding token. If unset, the config is treated as not having a dedicated padding token.
 
     ```python

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -109,6 +109,8 @@ class Qwen3VLTextConfig(PreTrainedConfig):
             Whether to use a bias in the query, key, value and output projection layers during self-attention.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
+        pad_token_id (`int`, *optional*, defaults to `None`):
+            The id of the padding token. If unset, the config is treated as not having a dedicated padding token.
 
     ```python
     >>> from transformers import Qwen3VLTextModel, Qwen3VLTextConfig

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -169,10 +169,10 @@ class Qwen3VLTextConfig(PreTrainedConfig):
         self.attention_bias = attention_bias
         self.attention_dropout = attention_dropout
         self.rope_parameters = rope_parameters
+        self.pad_token_id = pad_token_id
 
         super().__init__(
             ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"},
-            pad_token_id=pad_token_id,
             **kwargs,
         )
 

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -144,6 +144,7 @@ class Qwen3VLTextConfig(PreTrainedConfig):
         rope_parameters: RopeParameters | dict[str, RopeParameters] | None = None,
         attention_bias: bool | None = False,
         attention_dropout: float | None = 0.0,
+        pad_token_id: int | None = None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -167,8 +168,10 @@ class Qwen3VLTextConfig(PreTrainedConfig):
         self.attention_dropout = attention_dropout
         self.rope_parameters = rope_parameters
 
+        # Passing standard token ids through PreTrainedConfig so they're serialized/deserialized properly.
         super().__init__(
             ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"},
+            pad_token_id=pad_token_id,
             **kwargs,
         )
 

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -213,10 +213,10 @@ class Qwen3VLTextConfig(PreTrainedConfig):
         self.attention_bias = attention_bias
         self.attention_dropout = attention_dropout
         self.rope_parameters = rope_parameters
+        self.pad_token_id = pad_token_id
 
         super().__init__(
             ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"},
-            pad_token_id=pad_token_id,
             **kwargs,
         )
 

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -153,7 +153,7 @@ class Qwen3VLTextConfig(PreTrainedConfig):
             Whether to use a bias in the query, key, value and output projection layers during self-attention.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
-        pad_token_id (`int`, *optional*, defaults to `None`):
+        pad_token_id (`int`, *optional*):
             The id of the padding token. If unset, the config is treated as not having a dedicated padding token.
 
     ```python

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -188,6 +188,7 @@ class Qwen3VLTextConfig(PreTrainedConfig):
         rope_parameters: RopeParameters | dict[str, RopeParameters] | None = None,
         attention_bias: bool | None = False,
         attention_dropout: float | None = 0.0,
+        pad_token_id: int | None = None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -213,6 +214,7 @@ class Qwen3VLTextConfig(PreTrainedConfig):
 
         super().__init__(
             ignore_keys_at_rope_validation={"mrope_section", "mrope_interleaved"},
+            pad_token_id=pad_token_id,
             **kwargs,
         )
 

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -153,6 +153,8 @@ class Qwen3VLTextConfig(PreTrainedConfig):
             Whether to use a bias in the query, key, value and output projection layers during self-attention.
         attention_dropout (`float`, *optional*, defaults to 0.0):
             The dropout ratio for the attention probabilities.
+        pad_token_id (`int`, *optional*, defaults to `None`):
+            The id of the padding token. If unset, the config is treated as not having a dedicated padding token.
 
     ```python
     >>> from transformers import Qwen3VLTextModel, Qwen3VLTextConfig

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -20,8 +20,6 @@ from transformers import (
     Qwen3VLConfig,
     Qwen3VLForConditionalGeneration,
     Qwen3VLModel,
-    Qwen3VLTextConfig,
-    Qwen3VLTextModel,
     is_torch_available,
 )
 from transformers.testing_utils import (
@@ -192,34 +190,6 @@ class Qwen3VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
     def test_config(self):
         self.config_tester.run_common_tests()
 
-    def test_nested_text_config_missing_pad_token_id(self):
-        """
-        Mirrors the from_pretrained failure when loading a Qwen3VLModel:
-        a text_config dict loaded from config.json may omit pad_token_id, but should still
-        results in a Qwen3VLTextConfig with pad_token_id=None and allow Qwen3VLModel init.
-        """
-        config = self.model_tester.get_config()  # Qwen3VLConfig
-
-        # remove pad_token_id from config.json like dict
-        text_cfg_dict = (
-            config.text_config.to_dict() if hasattr(config.text_config, "to_dict") else dict(config.text_config)
-        )
-        text_cfg_dict.pop("pad_token_id", None)
-
-        # nested-config normalization: build a Qwen3VLTextConfig from that dict
-        config.text_config = Qwen3VLTextConfig(**text_cfg_dict)
-
-        for model_class in self.all_model_classes:
-            model = model_class(config).to(torch_device)
-
-            language_model = getattr(model, "language_model", None)
-            if language_model is None and hasattr(model, "model"):
-                language_model = getattr(model.model, "language_model", None)
-
-            self.assertIsNotNone(language_model)
-            self.assertTrue(hasattr(language_model.config, "pad_token_id"))
-            self.assertIsNone(language_model.config.pad_token_id)
-
     def test_mismatching_num_image_tokens(self):
         """
         Tests that VLMs through an error with explicit message saying what is wrong
@@ -326,115 +296,3 @@ class Qwen3VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
                 video_grid_thw=video_grid_thw,
             )
             self.assertIsNotNone(outputs)
-
-
-class Qwen3VLTextModelTester:
-    def __init__(
-        self,
-        parent,
-        batch_size=3,
-        seq_length=7,
-        is_training=True,
-        vocab_size=99,
-        hidden_size=32,
-        intermediate_size=37,
-        num_hidden_layers=2,
-        num_attention_heads=4,
-        num_key_value_heads=2,
-        head_dim=8,
-        max_position_embeddings=128,
-        hidden_act="silu",
-        rms_norm_eps=1e-6,
-        attention_bias=False,
-        attention_dropout=0.0,
-        rope_parameters={"rope_type": "default", "mrope_section": [16, 8, 8], "mrope_interleaved": True},
-    ):
-        self.parent = parent
-        self.batch_size = batch_size
-        self.seq_length = seq_length
-        self.is_training = is_training
-
-        self.vocab_size = vocab_size
-        self.hidden_size = hidden_size
-        self.intermediate_size = intermediate_size
-        self.num_hidden_layers = num_hidden_layers
-        self.num_attention_heads = num_attention_heads
-        self.num_key_value_heads = num_key_value_heads
-        self.head_dim = head_dim
-        self.max_position_embeddings = max_position_embeddings
-        self.hidden_act = hidden_act
-        self.rms_norm_eps = rms_norm_eps
-        self.attention_bias = attention_bias
-        self.attention_dropout = attention_dropout
-        self.rope_parameters = rope_parameters
-
-    def get_config(self, **kwargs):
-        # regression case (pad_token_id should default to None)
-        return Qwen3VLTextConfig(
-            vocab_size=self.vocab_size,
-            hidden_size=self.hidden_size,
-            intermediate_size=self.intermediate_size,
-            num_hidden_layers=self.num_hidden_layers,
-            num_attention_heads=self.num_attention_heads,
-            num_key_value_heads=self.num_key_value_heads,
-            head_dim=self.head_dim,
-            hidden_act=self.hidden_act,
-            max_position_embeddings=self.max_position_embeddings,
-            rms_norm_eps=self.rms_norm_eps,
-            attention_bias=self.attention_bias,
-            attention_dropout=self.attention_dropout,
-            rope_parameters=self.rope_parameters,
-            **kwargs,
-        )
-
-    def prepare_config_and_inputs(self):
-        config = self.get_config()
-        input_ids = ids_tensor([self.batch_size, self.seq_length], self.vocab_size)
-        attention_mask = torch.ones(input_ids.shape, dtype=torch.long, device=torch_device)
-        return config, input_ids, attention_mask
-
-    def prepare_config_and_inputs_for_common(self):
-        config, input_ids, attention_mask = self.prepare_config_and_inputs()
-        inputs_dict = {
-            "input_ids": input_ids,
-            "attention_mask": attention_mask,
-        }
-        return config, inputs_dict
-
-
-@require_torch
-class Qwen3VLTextModelTest(ModelTesterMixin, unittest.TestCase):
-    """
-    Model tester for `Qwen3VLTextModel`
-    """
-
-    all_model_classes = (Qwen3VLTextModel,) if is_torch_available() else ()
-
-    def setUp(self):
-        self.model_tester = Qwen3VLTextModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=Qwen3VLTextConfig, has_text_modality=False)
-
-    def test_config(self):
-        self.config_tester.run_common_tests()
-
-    def test_model(self):
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        for model_class in self.all_model_classes:
-            model = model_class(config).to(torch_device)
-            model.eval()
-            with torch.no_grad():
-                outputs = model(**inputs_dict)
-            self.assertIsNotNone(outputs)
-
-    def test_init_without_pad_token_id(self):
-        """
-        Regression test for 'Qwen3VLTextConfig' object has no attribute 'pad_token_id'
-        """
-        # pad_token_id intentionally omitted, should be None
-        config = self.model_tester.get_config()
-        model = Qwen3VLTextModel(config).to(torch_device)
-
-        self.assertTrue(hasattr(model.config, "pad_token_id"))
-        self.assertIsNone(model.config.pad_token_id)
-        self.assertIsNone(model.padding_idx)
-        self.assertIsNone(model.embed_tokens.padding_idx)


### PR DESCRIPTION
# What does this PR do?

This PR fixes an initialization error in Qwen3-VL text model construction when loading checkpoints whose nested text_config does not explicitly define pad_token_id.

there are  2 main issues
	•	Qwen3VLTextModel.__init__ unconditionally accesses config.pad_token_id, but Qwen3VLTextConfig did not define this attribute.
	•	When loading via from_pretrained, this resulted in an AttributeError during model initialization.

The fix adds pad_token_id to Qwen3VLTextConfig (defaulting to None) and forwards it through PreTrainedConfig, aligning the config schema with what the model expects. 
A regression test is added to ensure Qwen3VLTextModel can be instantiated when pad_token_id is not provided.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #43393 #43334 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@Rocketknight1 @zucchini-nlp 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
