### PR TITLE
Cleanup rope conversion

### DIFF
--- a/src/transformers/models/minimax_m2/configuration_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/configuration_minimax_m2.py
@@ -184,26 +184,5 @@ class MiniMaxM2Config(PreTrainedConfig):
 
         super().__init__(**kwargs)
 
-    def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation=None, **kwargs):
-        rope_scaling = kwargs.pop("rope_scaling", None)
-        self.rope_parameters = rope_scaling or self.rope_parameters
-        self.rope_parameters = self.rope_parameters if self.rope_parameters is not None else {}
-
-        # Standardize and validate the correctness of rotary position embeddings parameters
-        # Model uses non-standard naming for rope params, overwrite!
-        self.rope_parameters.setdefault("rope_theta", self.default_theta)
-        self.rope_parameters["partial_rotary_factor"] = (
-            kwargs.pop("rotary_dim", self.head_dim // 2) / self.head_dim
-        )  # Default to `0.5`
-        self.standardize_rope_params()
-
-        if ignore_keys_at_rope_validation is None:
-            ignore_keys_at_rope_validation = {"partial_rotary_factor"}
-        else:
-            ignore_keys_at_rope_validation |= {"partial_rotary_factor"}
-
-        self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
-        return kwargs
-
 
 __all__ = ["MiniMaxM2Config"]

--- a/src/transformers/models/minimax_m2/modular_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/modular_minimax_m2.py
@@ -204,27 +204,6 @@ class MiniMaxM2Config(PreTrainedConfig):
 
         super().__init__(**kwargs)
 
-    def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation=None, **kwargs):
-        rope_scaling = kwargs.pop("rope_scaling", None)
-        self.rope_parameters = rope_scaling or self.rope_parameters
-        self.rope_parameters = self.rope_parameters if self.rope_parameters is not None else {}
-
-        # Standardize and validate the correctness of rotary position embeddings parameters
-        # Model uses non-standard naming for rope params, overwrite!
-        self.rope_parameters.setdefault("rope_theta", self.default_theta)
-        self.rope_parameters["partial_rotary_factor"] = (
-            kwargs.pop("rotary_dim", self.head_dim // 2) / self.head_dim
-        )  # Default to `0.5`
-        self.standardize_rope_params()
-
-        if ignore_keys_at_rope_validation is None:
-            ignore_keys_at_rope_validation = {"partial_rotary_factor"}
-        else:
-            ignore_keys_at_rope_validation |= {"partial_rotary_factor"}
-
-        self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
-        return kwargs
-
 
 class MiniMaxM2TopKRouter(MixtralTopKRouter):
     def forward(self, hidden_states, e_score_correction_bias):

--- a/src/transformers/models/solar_open/configuration_solar_open.py
+++ b/src/transformers/models/solar_open/configuration_solar_open.py
@@ -180,27 +180,5 @@ class SolarOpenConfig(PreTrainedConfig):
 
         super().__init__(**kwargs)
 
-    def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation: set | None = None, **kwargs):
-        default_rope_params = RopeParameters(
-            rope_type="yarn",
-            factor=2.0,
-            original_max_position_embeddings=65_536,
-        )
-
-        rope_scaling = kwargs.pop("rope_scaling", None)
-        self.rope_parameters = rope_scaling or self.rope_parameters
-        self.rope_parameters = self.rope_parameters if self.rope_parameters is not None else default_rope_params
-
-        # Standardize and validate the correctness of rotary position embeddings parameters
-        self.rope_parameters.setdefault("rope_theta", kwargs.pop("rope_theta", self.default_theta))
-
-        if "partial_rotary_factor" in kwargs:
-            self.rope_parameters.setdefault("partial_rotary_factor", kwargs["partial_rotary_factor"])
-            ignore_keys_at_rope_validation = {"partial_rotary_factor"}
-
-        self.standardize_rope_params()
-        self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
-        return kwargs
-
 
 __all__ = ["SolarOpenConfig"]

--- a/src/transformers/models/solar_open/modular_solar_open.py
+++ b/src/transformers/models/solar_open/modular_solar_open.py
@@ -183,28 +183,6 @@ class SolarOpenConfig(Glm4MoeConfig):
         del self.first_k_dense_replace
         del self.use_qk_norm
 
-    def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation: set | None = None, **kwargs):
-        default_rope_params = RopeParameters(
-            rope_type="yarn",
-            factor=2.0,
-            original_max_position_embeddings=65_536,
-        )
-
-        rope_scaling = kwargs.pop("rope_scaling", None)
-        self.rope_parameters = rope_scaling or self.rope_parameters
-        self.rope_parameters = self.rope_parameters if self.rope_parameters is not None else default_rope_params
-
-        # Standardize and validate the correctness of rotary position embeddings parameters
-        self.rope_parameters.setdefault("rope_theta", kwargs.pop("rope_theta", self.default_theta))
-
-        if "partial_rotary_factor" in kwargs:
-            self.rope_parameters.setdefault("partial_rotary_factor", kwargs["partial_rotary_factor"])
-            ignore_keys_at_rope_validation = {"partial_rotary_factor"}
-
-        self.standardize_rope_params()
-        self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)
-        return kwargs
-
 
 class SolarOpenDecoderLayer(LlamaDecoderLayer):
     def __init__(self, config: SolarOpenConfig, layer_idx: int):


### PR DESCRIPTION
As per title, cleanup as this overwrite was not necessary

Can be verified by running (with and without this change)
```python
from transformers import AutoConfig


config = AutoConfig.from_pretrained("upstage/Solar-Open-100B")
print(config)
```

cc @oesni for viz