### PR TITLE
Fix float16 inference for Sam2 Video / Sam3 Video / Sam3 Video Tracker + add tests

### DIFF
--- a/src/transformers/models/sam2_video/modeling_sam2_video.py
+++ b/src/transformers/models/sam2_video/modeling_sam2_video.py
@@ -2495,7 +2495,7 @@ class Sam2VideoModel(Sam2VideoPreTrainedModel):
                 num_object_pointer_tokens = object_pointers.shape[0]
 
         # Step 4: Concatenate all retrieved memories and their positional embeddings
-        combined_memory = torch.cat(memories_to_concatenate, dim=0)
+        combined_memory = torch.cat(memories_to_concatenate, dim=0).to(dtype=inference_session.dtype)
         combined_memory_positional_embeddings = torch.cat(memory_positional_embeddings_to_concatenate, dim=0)
 
         # Step 5: Forward through the memory attention mechanism

--- a/src/transformers/models/sam2_video/modular_sam2_video.py
+++ b/src/transformers/models/sam2_video/modular_sam2_video.py
@@ -2132,7 +2132,7 @@ class Sam2VideoModel(Sam2Model):
                 num_object_pointer_tokens = object_pointers.shape[0]
 
         # Step 4: Concatenate all retrieved memories and their positional embeddings
-        combined_memory = torch.cat(memories_to_concatenate, dim=0)
+        combined_memory = torch.cat(memories_to_concatenate, dim=0).to(dtype=inference_session.dtype)
         combined_memory_positional_embeddings = torch.cat(memory_positional_embeddings_to_concatenate, dim=0)
 
         # Step 5: Forward through the memory attention mechanism

--- a/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
@@ -2518,7 +2518,7 @@ class Sam3TrackerVideoModel(Sam3TrackerVideoPreTrainedModel):
                 num_object_pointer_tokens = object_pointers.shape[0]
 
         # Step 4: Concatenate all retrieved memories and their positional embeddings
-        combined_memory = torch.cat(memories_to_concatenate, dim=0)
+        combined_memory = torch.cat(memories_to_concatenate, dim=0).to(dtype=inference_session.dtype)
         combined_memory_positional_embeddings = torch.cat(memory_positional_embeddings_to_concatenate, dim=0)
 
         # Step 5: Forward through the memory attention mechanism

--- a/tests/models/sam2_video/test_modeling_sam2_video.py
+++ b/tests/models/sam2_video/test_modeling_sam2_video.py
@@ -20,6 +20,8 @@ import requests
 
 from transformers.testing_utils import (
     backend_empty_cache,
+    is_torch_bf16_available_on_device,
+    is_torch_fp16_available_on_device,
     slow,
     torch_device,
 )
@@ -543,3 +545,77 @@ class Sam2VideoModelIntegrationTest(unittest.TestCase):
             atol=1e-2,
             rtol=1e-2,
         )
+
+    def test_inference_with_different_dtypes(self):
+        """Test that inference works correctly for float32, bfloat16, and float16 dtypes."""
+        raw_video = prepare_video()
+        dtypes_to_test = [
+            (torch.float32, None),  # float32 is always available
+            (torch.bfloat16, is_torch_bf16_available_on_device),
+            (torch.float16, is_torch_fp16_available_on_device),
+        ]
+
+        for dtype, availability_check in dtypes_to_test:
+            with self.subTest(dtype=dtype):
+                # Skip if dtype is not available on device
+                if availability_check is not None and not availability_check(torch_device):
+                    self.skipTest(f"{dtype} not supported on {torch_device}")
+
+                # Load model with specific dtype
+                video_model = Sam2VideoModel.from_pretrained("facebook/sam2.1-hiera-tiny", torch_dtype=dtype).to(
+                    torch_device
+                )
+                video_model.eval()
+
+                # Initialize inference session
+                inference_session = self.processor.init_video_session(
+                    video=raw_video, inference_device=torch_device, dtype=dtype
+                )
+                ann_frame_idx = 0
+                ann_obj_id = 1
+
+                # Add inputs
+                self.processor.add_inputs_to_inference_session(
+                    inference_session=inference_session,
+                    frame_idx=ann_frame_idx,
+                    obj_ids=ann_obj_id,
+                    input_points=[[[[210, 350]]]],
+                    input_labels=[[[1]]],
+                )
+
+                # Run inference on first frame
+                outputs = video_model(inference_session=inference_session, frame_idx=ann_frame_idx)
+                low_res_masks = outputs.pred_masks
+
+                # Verify output shape and dtype
+                self.assertEqual(low_res_masks.shape, (1, 1, 256, 256))
+                self.assertEqual(low_res_masks.dtype, dtype)
+
+                # Post-process masks
+                video_res_masks = self.processor.post_process_masks(
+                    [low_res_masks], [raw_video.shape[-3:-1]], binarize=False
+                )[0]
+                self.assertEqual(video_res_masks.shape, (1, 1, raw_video.shape[-3], raw_video.shape[-2]))
+
+                # Test propagation across multiple frames to test memory handling
+                frames = []
+                max_frame_num_to_track = 2
+                for sam2_video_output in video_model.propagate_in_video_iterator(
+                    inference_session=inference_session,
+                    start_frame_idx=ann_frame_idx,
+                    max_frame_num_to_track=max_frame_num_to_track,
+                ):
+                    video_res_masks = self.processor.post_process_masks(
+                        [sam2_video_output.pred_masks], [raw_video.shape[-3:-1]], binarize=False
+                    )[0]
+                    frames.append(video_res_masks)
+                    # Verify dtype is maintained during propagation
+                    self.assertEqual(sam2_video_output.pred_masks.dtype, dtype)
+
+                frames = torch.stack(frames, dim=0)
+                # Verify we got the expected number of frames (initial frame + max_frame_num_to_track)
+                self.assertEqual(
+                    frames.shape, (max_frame_num_to_track + 1, 1, 1, raw_video.shape[-3], raw_video.shape[-2])
+                )
+                # Verify dtype is maintained in stacked frames
+                self.assertEqual(frames.dtype, dtype)

--- a/tests/models/sam3_tracker_video/test_modeling_sam3_tracker_video.py
+++ b/tests/models/sam3_tracker_video/test_modeling_sam3_tracker_video.py
@@ -20,6 +20,8 @@ import requests
 
 from transformers.testing_utils import (
     backend_empty_cache,
+    is_torch_bf16_available_on_device,
+    is_torch_fp16_available_on_device,
     slow,
     torch_device,
 )
@@ -540,3 +542,77 @@ class Sam3TrackerVideoModelIntegrationTest(unittest.TestCase):
             atol=1e-2,
             rtol=1e-2,
         )
+
+    def test_inference_with_different_dtypes(self):
+        """Test that inference works correctly for float32, bfloat16, and float16 dtypes."""
+        raw_video = prepare_video()
+        dtypes_to_test = [
+            (torch.float32, None),  # float32 is always available
+            (torch.bfloat16, is_torch_bf16_available_on_device),
+            (torch.float16, is_torch_fp16_available_on_device),
+        ]
+
+        for dtype, availability_check in dtypes_to_test:
+            with self.subTest(dtype=dtype):
+                # Skip if dtype is not available on device
+                if availability_check is not None and not availability_check(torch_device):
+                    self.skipTest(f"{dtype} not supported on {torch_device}")
+
+                # Load model with specific dtype
+                video_model = Sam3TrackerVideoModel.from_pretrained("facebook/sam3", torch_dtype=dtype).to(
+                    torch_device
+                )
+                video_model.eval()
+
+                # Initialize inference session
+                inference_session = self.processor.init_video_session(
+                    video=raw_video, inference_device=torch_device, dtype=dtype
+                )
+                ann_frame_idx = 0
+                ann_obj_id = 1
+
+                # Add inputs
+                self.processor.add_inputs_to_inference_session(
+                    inference_session=inference_session,
+                    frame_idx=ann_frame_idx,
+                    obj_ids=ann_obj_id,
+                    input_points=[[[[210, 350]]]],
+                    input_labels=[[[1]]],
+                )
+
+                # Run inference on first frame
+                outputs = video_model(inference_session=inference_session, frame_idx=ann_frame_idx)
+                low_res_masks = outputs.pred_masks
+
+                # Verify output shape and dtype
+                self.assertEqual(low_res_masks.shape, (1, 1, 288, 288))
+                self.assertEqual(low_res_masks.dtype, dtype)
+
+                # Post-process masks
+                video_res_masks = self.processor.post_process_masks(
+                    [low_res_masks], [raw_video.shape[-3:-1]], binarize=False
+                )[0]
+                self.assertEqual(video_res_masks.shape, (1, 1, raw_video.shape[-3], raw_video.shape[-2]))
+
+                # Test propagation across multiple frames to test memory handling
+                frames = []
+                max_frame_num_to_track = 2
+                for sam2_video_output in video_model.propagate_in_video_iterator(
+                    inference_session=inference_session,
+                    start_frame_idx=ann_frame_idx,
+                    max_frame_num_to_track=max_frame_num_to_track,
+                ):
+                    video_res_masks = self.processor.post_process_masks(
+                        [sam2_video_output.pred_masks], [raw_video.shape[-3:-1]], binarize=False
+                    )[0]
+                    frames.append(video_res_masks)
+                    # Verify dtype is maintained during propagation
+                    self.assertEqual(sam2_video_output.pred_masks.dtype, dtype)
+
+                frames = torch.stack(frames, dim=0)
+                # Verify we got the expected number of frames (initial frame + max_frame_num_to_track)
+                self.assertEqual(
+                    frames.shape, (max_frame_num_to_track + 1, 1, 1, raw_video.shape[-3], raw_video.shape[-2])
+                )
+                # Verify dtype is maintained in stacked frames
+                self.assertEqual(frames.dtype, dtype)

--- a/tests/models/sam3_video/test_modeling_sam3_video.py
+++ b/tests/models/sam3_video/test_modeling_sam3_video.py
@@ -18,6 +18,8 @@ import unittest
 
 from transformers.testing_utils import (
     backend_empty_cache,
+    is_torch_bf16_available_on_device,
+    is_torch_fp16_available_on_device,
     slow,
     torch_device,
 )
@@ -547,3 +549,60 @@ class Sam3VideoModelIntegrationTest(unittest.TestCase):
 
         model = Sam3VideoModel.from_pretrained("facebook/sam3", config=config).to(torch_device).eval()
         self.assertEqual(model.config.image_size, 560)
+
+    def test_inference_with_different_dtypes(self):
+        """Test that inference works correctly for float32, bfloat16, and float16 dtypes."""
+        raw_video = prepare_video()
+        dtypes_to_test = [
+            (torch.float32, None),  # float32 is always available
+            (torch.bfloat16, is_torch_bf16_available_on_device),
+            (torch.float16, is_torch_fp16_available_on_device),
+        ]
+
+        for dtype, availability_check in dtypes_to_test:
+            with self.subTest(dtype=dtype):
+                # Skip if dtype is not available on device
+                if availability_check is not None and not availability_check(torch_device):
+                    self.skipTest(f"{dtype} not supported on {torch_device}")
+
+                # Load model with specific dtype
+                video_model = Sam3VideoModel.from_pretrained("facebook/sam3", torch_dtype=dtype).to(torch_device)
+                video_model.eval()
+
+                # Initialize inference session
+                inference_session = self.processor.init_video_session(
+                    video=raw_video,
+                    inference_device=torch_device,
+                    processing_device="cpu",
+                    video_storage_device="cpu",
+                    dtype=dtype,
+                )
+
+                # Add text prompt
+                text = "person"
+                inference_session = self.processor.add_text_prompt(
+                    inference_session=inference_session,
+                    text=text,
+                )
+
+                # Run inference on first frame
+                outputs_per_frame = {}
+                model_outputs_per_frame = {}
+                max_frame_num_to_track = 2
+                for model_outputs in video_model.propagate_in_video_iterator(
+                    inference_session=inference_session,
+                    max_frame_num_to_track=max_frame_num_to_track,
+                ):
+                    processed_outputs = self.processor.postprocess_outputs(inference_session, model_outputs)
+                    outputs_per_frame[model_outputs.frame_idx] = processed_outputs
+                    model_outputs_per_frame[model_outputs.frame_idx] = model_outputs
+
+                    # Verify dtype is maintained in model outputs
+                    if len(model_outputs.object_ids) > 0:
+                        first_obj_id = model_outputs.object_ids[0]
+                        raw_mask = model_outputs.obj_id_to_mask[first_obj_id]
+                        self.assertEqual(raw_mask.dtype, dtype)
+
+                # Verify we processed frames
+                self.assertGreaterEqual(len(outputs_per_frame), 1)
+                self.assertLessEqual(len(outputs_per_frame), max_frame_num_to_track + 1)


### PR DESCRIPTION
Issue originally raised in https://github.com/huggingface/transformers/pull/43268, but provided fix changes inference values for other dtypes. This keeps memory saved as bf16 and only convert concatenated memory to `inference_session` dtype.