### PR TITLE
LiquidAI models: Prevent leaking image information across batched queries

### DIFF
--- a/src/transformers/models/lfm2_vl/image_processing_lfm2_vl_fast.py
+++ b/src/transformers/models/lfm2_vl/image_processing_lfm2_vl_fast.py
@@ -315,8 +315,7 @@ class Lfm2VlImageProcessorFast(BaseImageProcessorFast):
             .unfold(3, size=tile_size, step=tile_size)
             .contiguous()
             .view(batch_size, num_channels, -1, tile_size, tile_size)
-            .permute(2, 0, 1, 3, 4)
-            .reshape(batch_size, -1, num_channels, tile_size, tile_size)
+            .permute(0, 2, 1, 3, 4)
         )
 
         # Re-order processed images to a nested image structure, so it can be reordered back correctly


### PR DESCRIPTION
# What does this PR do?

Currently, there's a bug in the preprocessing logic of images for LiquidAI models: If there are multiple queries batched together, fragments of the image in one query may be swapped with fragments of the image in another query. This degrades the output quality and could leak information from one user to another.

To replicate this issue, run the following code:
```
from transformers import AutoModelForImageTextToText, AutoProcessor
from transformers.image_utils import load_image
from PIL import Image

model_id = "LiquidAI/LFM2-VL-450M"
model = AutoModelForImageTextToText.from_pretrained(
    model_id, device_map="auto", dtype="float64"
)
processor = AutoProcessor.from_pretrained(model_id)

PROMPT = "What colors are in this image? How much of each color is there?"
COLORS = [
    (255, 0, 0),    # Red
    (0, 255, 0),    # Green
]
IMAGE_SIZE = (1024, 1024)

conversations = [
    [
        {
            "role": "user",
            "content": [
                {"type": "image", "image": Image.new("RGB", IMAGE_SIZE, color=color)},
                {"type": "text", "text": PROMPT},
            ]
        },
    ] for color in COLORS
]

inputs = processor.apply_chat_template(
    conversations,
    add_generation_prompt=True,
    return_tensors="pt",
    return_dict=True,
    tokenize=True,
).to(model.device)
outputs = model.generate(**inputs, max_new_tokens=640)
response = processor.batch_decode(outputs, skip_special_tokens=True)

for color, r in zip(COLORS, response):
    print("Response for color", color)
    print(r)
    print()
```

Run this once with both colors, and once with only red and green, respectively.

Expected behavior: If both queries are batched, the output is the same as what you'd get in individual queries (modulo some variability).
Actual behavior: For the individual queries, the response correctly states that the image is green/red (the model may hallucinate that there's also some black/white). For the batched inference run, the model reports "Mostly red + some green" and "Mostly green + some red", clearly demonstrating the leak of information.

This is fixed by applying the change from this PR.


## Before submitting
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@zucchini-nlp, @ankke, @yonigozlan  