### PR TITLE
Fix in-place modification of inputs_embeds in Kosmos-2.5 forward

### DIFF
--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -1091,7 +1091,7 @@ class Kosmos2_5TextTransformer(nn.Module):
 
         # Ignore copy
         if image_embeds is not None:
-            inputs_embeds = inputs_embeds.clone() 
+            inputs_embeds = inputs_embeds.clone()
             inputs_embeds[image_embeds_position_mask == 1] = image_embeds.to(inputs_embeds.device).view(
                 -1, image_embeds.shape[-1]
             )

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -1091,8 +1091,9 @@ class Kosmos2_5TextTransformer(nn.Module):
 
         # Ignore copy
         if image_embeds is not None:
+            inputs_embeds = inputs_embeds.clone() 
             inputs_embeds[image_embeds_position_mask == 1] = image_embeds.to(inputs_embeds.device).view(
-                -1, image_embeds.size(-1)
+                -1, image_embeds.shape[-1]
             )
 
         inputs_embeds = inputs_embeds * self.embed_scale


### PR DESCRIPTION
# What does this PR do?

Fixes a PyTorch autograd error when fine-tuning `Kosmos2_5ForConditionalGeneration` with PEFT (LoRA).

The model forward pass performed an in-place assignment on `inputs_embeds`, which can be a leaf tensor with `requires_grad=True` during training. This caused the following runtime error:

RuntimeError: a leaf Variable that requires grad is being used in an in-place operation


This PR avoids the in-place modification by cloning the tensor before assignment, allowing training to proceed correctly while preserving existing behavior.

I have verified the fix using the reproduction script I provided in the issue; the RuntimeError is resolved and training proceeds as expected.

Fixes #43416

cc @zucchini-nlp
