### PR TITLE
Fix broken SAM and SAM-HQ due to tie weights and type validation

### DIFF
--- a/src/transformers/models/edgetam/modeling_edgetam.py
+++ b/src/transformers/models/edgetam/modeling_edgetam.py
@@ -926,6 +926,7 @@ class EdgeTamMaskDecoder(nn.Module):
 class EdgeTamModel(EdgeTamPreTrainedModel):
     input_modalities = ("image", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(EdgeTamTwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {}
     _keys_to_ignore_on_load_unexpected = [
         r"^memory_.*",
         r"^mask_downsample.*",

--- a/src/transformers/models/edgetam_video/modeling_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modeling_edgetam_video.py
@@ -2003,6 +2003,7 @@ def get_1d_sine_pe(pos_inds, dim, temperature=10000):
 class EdgeTamVideoModel(EdgeTamVideoPreTrainedModel):
     input_modalities = ("video", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(EdgeTamVideoTwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {}
     _keys_to_ignore_on_load_unexpected = []
 
     def __init__(self, config: EdgeTamVideoConfig):

--- a/src/transformers/models/sam/configuration_sam.py
+++ b/src/transformers/models/sam/configuration_sam.py
@@ -314,6 +314,7 @@ class SamConfig(PreTrainedConfig):
         prompt_encoder_config=None,
         mask_decoder_config=None,
         initializer_range=0.02,
+        tie_word_embeddings=True,
         **kwargs,
     ):
         vision_config = vision_config if vision_config is not None else {}
@@ -331,6 +332,7 @@ class SamConfig(PreTrainedConfig):
         self.prompt_encoder_config = SamPromptEncoderConfig(**prompt_encoder_config)
         self.mask_decoder_config = SamMaskDecoderConfig(**mask_decoder_config)
         self.initializer_range = initializer_range
+        self.tie_word_embeddings = tie_word_embeddings
         super().__init__(**kwargs)
 
 

--- a/src/transformers/models/sam/modeling_sam.py
+++ b/src/transformers/models/sam/modeling_sam.py
@@ -547,7 +547,7 @@ class SamPositionalEmbedding(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.scale = config.scale
-        self.register_buffer("positional_embedding", self.scale * torch.randn((2, config.num_pos_feats)))
+        self.positional_embedding = nn.Parameter(self.scale * torch.randn((2, config.num_pos_feats)))
 
     def forward(self, input_coords, input_shape=None):
         """Positionally encode points that are normalized to [0,1]."""
@@ -1106,6 +1106,9 @@ class SamVisionModel(SamPreTrainedModel):
 class SamModel(SamPreTrainedModel):
     input_modalities = ("image", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(SamTwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {
+        "prompt_encoder.shared_embedding.positional_embedding": "shared_image_embedding.positional_embedding"
+    }
 
     def __init__(self, config: SamConfig):
         super().__init__(config)

--- a/src/transformers/models/sam/processing_sam.py
+++ b/src/transformers/models/sam/processing_sam.py
@@ -61,9 +61,9 @@ class SamImagesKwargs(ImagesKwargs, total=False):
     """
 
     segmentation_maps: ImageInput | None
-    input_points: NestedList | None
-    input_labels: NestedList | None
-    input_boxes: NestedList | None
+    input_points: NestedList | torch.Tensor | None
+    input_labels: NestedList | torch.Tensor | None
+    input_boxes: NestedList | torch.Tensor | None
     point_pad_value: int | None
     mask_size: dict[str, int]
     mask_pad_size: dict[str, int]

--- a/src/transformers/models/sam/processing_sam.py
+++ b/src/transformers/models/sam/processing_sam.py
@@ -62,7 +62,7 @@ class SamImagesKwargs(ImagesKwargs, total=False):
 
     segmentation_maps: ImageInput | None
     input_points: NestedList | torch.Tensor | None
-    input_labels: NestedList | torch.Tensor | None
+    input_labels: NestedList | int | torch.Tensor | None
     input_boxes: NestedList | torch.Tensor | None
     point_pad_value: int | None
     mask_size: dict[str, int]

--- a/src/transformers/models/sam2/modeling_sam2.py
+++ b/src/transformers/models/sam2/modeling_sam2.py
@@ -1284,6 +1284,7 @@ class Sam2MaskDecoder(nn.Module):
 class Sam2Model(Sam2PreTrainedModel):
     input_modalities = ("image", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(Sam2TwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {}
     _keys_to_ignore_on_load_unexpected = [
         r"^memory_.*",
         r"^mask_downsample.*",

--- a/src/transformers/models/sam2/modular_sam2.py
+++ b/src/transformers/models/sam2/modular_sam2.py
@@ -1188,6 +1188,7 @@ class Sam2Model(SamModel):
         "no_object_pointer",
         "occlusion_spatial_embedding_parameter",
     ]
+    _tied_weights_keys = {}
 
     def __init__(self, config: Sam2Config):
         PreTrainedModel.__init__(self, config)

--- a/src/transformers/models/sam2_video/modeling_sam2_video.py
+++ b/src/transformers/models/sam2_video/modeling_sam2_video.py
@@ -1582,6 +1582,7 @@ def get_1d_sine_pe(pos_inds, dim, temperature=10000):
 class Sam2VideoModel(Sam2VideoPreTrainedModel):
     input_modalities = ("video", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(Sam2VideoTwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {}
     _keys_to_ignore_on_load_unexpected = []
 
     def __init__(self, config: Sam2VideoConfig):

--- a/src/transformers/models/sam3_tracker/modeling_sam3_tracker.py
+++ b/src/transformers/models/sam3_tracker/modeling_sam3_tracker.py
@@ -774,6 +774,7 @@ class Sam3TrackerVisionEncoderOutput(ModelOutput):
 class Sam3TrackerModel(Sam3TrackerPreTrainedModel):
     input_modalities = ("image", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(Sam3TrackerTwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {}
     _keys_to_ignore_on_load_unexpected = [
         r"^detector_model.",
         r"^memory_.*",

--- a/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
@@ -1591,6 +1591,7 @@ def get_1d_sine_pe(pos_inds, dim, temperature=10000):
 class Sam3TrackerVideoModel(Sam3TrackerVideoPreTrainedModel):
     input_modalities = ("video", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(Sam3TrackerVideoTwoWayAttentionBlock, index=2)}
+    _tied_weights_keys = {}
     _keys_to_ignore_on_load_unexpected = [r"^detector_model."]
     _checkpoint_conversion_mapping = {
         r"tracker_model.(.+)": r"\1",  # the regex allows to remove the prefix, and add it back in revert mode

--- a/src/transformers/models/sam_hq/configuration_sam_hq.py
+++ b/src/transformers/models/sam_hq/configuration_sam_hq.py
@@ -290,6 +290,7 @@ class SamHQConfig(PreTrainedConfig):
         prompt_encoder_config=None,
         mask_decoder_config=None,
         initializer_range=0.02,
+        tie_word_embeddings=True,
         **kwargs,
     ):
         vision_config = vision_config if vision_config is not None else {}
@@ -307,6 +308,7 @@ class SamHQConfig(PreTrainedConfig):
         self.prompt_encoder_config = SamHQPromptEncoderConfig(**prompt_encoder_config)
         self.mask_decoder_config = SamHQMaskDecoderConfig(**mask_decoder_config)
         self.initializer_range = initializer_range
+        self.tie_word_embeddings = tie_word_embeddings
         super().__init__(**kwargs)
 
 

--- a/src/transformers/models/sam_hq/modeling_sam_hq.py
+++ b/src/transformers/models/sam_hq/modeling_sam_hq.py
@@ -415,7 +415,7 @@ class SamHQPositionalEmbedding(nn.Module):
     def __init__(self, config):
         super().__init__()
         self.scale = config.scale
-        self.register_buffer("positional_embedding", self.scale * torch.randn((2, config.num_pos_feats)))
+        self.positional_embedding = nn.Parameter(self.scale * torch.randn((2, config.num_pos_feats)))
 
     def forward(self, input_coords, input_shape=None):
         """Positionally encode points that are normalized to [0,1]."""
@@ -1233,7 +1233,9 @@ class SamHQPromptEncoder(nn.Module):
 class SamHQModel(SamHQPreTrainedModel):
     input_modalities = ("image", "text")
     _can_record_outputs = {"mask_decoder_attentions": OutputRecorder(SamHQTwoWayAttentionBlock, index=2)}
-    _keys_to_ignore_on_load_missing = ["prompt_encoder.shared_embedding.positional_embedding"]
+    _tied_weights_keys = {
+        "prompt_encoder.shared_embedding.positional_embedding": "shared_image_embedding.positional_embedding"
+    }
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/sam_hq/modular_sam_hq.py
+++ b/src/transformers/models/sam_hq/modular_sam_hq.py
@@ -440,8 +440,6 @@ class SamHQVisionModel(SamVisionModel):
     """
 )
 class SamHQModel(SamModel):
-    _keys_to_ignore_on_load_missing = ["prompt_encoder.shared_embedding.positional_embedding"]
-
     def __init__(self, config):
         super().__init__(config)
         self.vision_encoder = SamHQVisionEncoder(config.vision_config)

--- a/src/transformers/models/sam_hq/processing_sam_hq.py
+++ b/src/transformers/models/sam_hq/processing_sam_hq.py
@@ -19,9 +19,9 @@ from copy import deepcopy
 
 import numpy as np
 
+from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
 from ...processing_utils import ImagesKwargs, ProcessingKwargs, ProcessorMixin, Unpack
-from ...tokenization_utils_base import BatchEncoding
 from ...utils import auto_docstring, is_torch_available
 
 
@@ -29,6 +29,8 @@ if is_torch_available():
     import torch
 
 NestedList = list[float | int | None | list[float | int | None]]
+NestedList2 = list[NestedList]
+NestedList3 = list[NestedList2]
 
 
 class SamHQImagesKwargs(ImagesKwargs, total=False):
@@ -61,9 +63,9 @@ class SamHQImagesKwargs(ImagesKwargs, total=False):
     """
 
     segmentation_maps: ImageInput | None
-    input_points: NestedList | None
-    input_labels: NestedList | None
-    input_boxes: NestedList | None
+    input_points: NestedList3 | NestedList2 | NestedList | torch.Tensor | None
+    input_labels: NestedList2 | NestedList | int | torch.Tensor | None
+    input_boxes: NestedList3 | NestedList2 | NestedList | torch.Tensor | None
     point_pad_value: int | None
     mask_size: dict[str, int]
     mask_pad_size: dict[str, int]
@@ -94,7 +96,7 @@ class SamHQProcessor(ProcessorMixin):
         self,
         images: ImageInput | None = None,
         **kwargs: Unpack[SamHQProcessorKwargs],
-    ) -> BatchEncoding:
+    ) -> BatchFeature:
         output_kwargs = self._merge_kwargs(
             SamHQProcessorKwargs,
             tokenizer_init_kwargs={},

--- a/src/transformers/models/sam_hq/processing_sam_hq.py
+++ b/src/transformers/models/sam_hq/processing_sam_hq.py
@@ -16,6 +16,7 @@ Processor class for SAMHQ.
 """
 
 from copy import deepcopy
+from typing import Union
 
 import numpy as np
 
@@ -28,9 +29,7 @@ from ...utils import auto_docstring, is_torch_available
 if is_torch_available():
     import torch
 
-NestedList = list[float | int | None | list[float | int | None]]
-NestedList2 = list[NestedList]
-NestedList3 = list[NestedList2]
+NestedList = list[Union[float | int | None, "NestedList"]]
 
 
 class SamHQImagesKwargs(ImagesKwargs, total=False):
@@ -63,9 +62,9 @@ class SamHQImagesKwargs(ImagesKwargs, total=False):
     """
 
     segmentation_maps: ImageInput | None
-    input_points: NestedList3 | NestedList2 | NestedList | torch.Tensor | None
-    input_labels: NestedList2 | NestedList | int | torch.Tensor | None
-    input_boxes: NestedList3 | NestedList2 | NestedList | torch.Tensor | None
+    input_points: NestedList | torch.Tensor | None
+    input_labels: NestedList | int | torch.Tensor | None
+    input_boxes: NestedList | torch.Tensor | None
     point_pad_value: int | None
     mask_size: dict[str, int]
     mask_pad_size: dict[str, int]

--- a/tests/models/sam/test_modeling_sam.py
+++ b/tests/models/sam/test_modeling_sam.py
@@ -991,7 +991,7 @@ class SamModelIntegrationTest(unittest.TestCase):
         iou_scores = outputs.iou_scores.cpu()
         self.assertTrue(iou_scores.shape == (1, 2, 3))
         torch.testing.assert_close(
-            iou_scores, torch.tensor([[[0.9105, 0.9825, 0.9675], [0.7646, 0.7943, 0.7774]]]), atol=1e-4, rtol=1e-4
+            iou_scores, torch.tensor([[[0.9105, 0.9825, 0.9675], [0.7646, 0.7944, 0.7769]]]), atol=1e-4, rtol=1e-4
         )
 
     def test_inference_mask_generation_three_boxes_point_batch(self):
@@ -1003,14 +1003,8 @@ class SamModelIntegrationTest(unittest.TestCase):
 
         raw_image = prepare_image()
 
-        # fmt: off
-        input_boxes = torch.Tensor([[[620, 900, 1000, 1255]], [[75, 275, 1725, 850]],  [[75, 275, 1725, 850]]]).cpu()
-        EXPECTED_IOU = torch.tensor([[
-            [0.9773, 0.9881, 0.9522],
-            [0.5996, 0.7661, 0.7937],
-            [0.5996, 0.7661, 0.7937],
-        ]])
-        # fmt: on
+        input_boxes = torch.Tensor([[[620, 900, 1000, 1255]], [[75, 275, 1725, 850]], [[75, 275, 1725, 850]]]).cpu()
+        EXPECTED_IOU = torch.tensor([[[0.9773, 0.9880, 0.9522], [0.5995, 0.7658, 0.7936], [0.5995, 0.7658, 0.7936]]])
         input_boxes = input_boxes.unsqueeze(0)
 
         inputs = processor(raw_image, input_boxes=input_boxes, return_tensors="pt").to(torch_device)

--- a/tests/models/sam_hq/test_modeling_sam_hq.py
+++ b/tests/models/sam_hq/test_modeling_sam_hq.py
@@ -1004,15 +1004,15 @@ class SamHQModelIntegrationTest(unittest.TestCase):
             images=[raw_image, raw_image],
             input_points=input_points,
             input_labels=input_labels,
-            images_kwargs={"point_pad_value": -10},
+            point_pad_value=-10,
             return_tensors="pt",
         ).to(torch_device)
 
         with torch.no_grad():
             outputs = model(**inputs)
         scores = outputs.iou_scores.squeeze()
-        self.assertTrue(torch.allclose(scores[0][-1], torch.tensor(0.4482), atol=1e-4))
-        self.assertTrue(torch.allclose(scores[1][-1], torch.tensor(0.4482), atol=1e-4))
+        self.assertTrue(torch.allclose(scores[0][-1], torch.tensor(0.8858), atol=1e-4))
+        self.assertTrue(torch.allclose(scores[1][-1], torch.tensor(0.9092), atol=1e-4))
 
     def test_inference_mask_generation_one_box(self):
         model = SamHQModel.from_pretrained("syscv-community/sam-hq-vit-base")


### PR DESCRIPTION
It looks like these models have been broken for a while due to incorrectly tie weights after the tie weight refactor, and more recently due to enforced typing in the processors

This PR replaces buffers that we can't tie anymore by nn.Parameters, and fixed the typing in processors