### PR TITLE
Add regression test for ViT dynamic resolution with interpolate_pos_encoding

### DIFF
--- a/tests/models/vit/test_modeling_vit.py
+++ b/tests/models/vit/test_modeling_vit.py
@@ -330,3 +330,32 @@ class ViTModelIntegrationTest(unittest.TestCase):
         # forward pass to make sure inference works in fp16
         with torch.no_grad():
             _ = model(pixel_values)
+
+
+def test_vit_interpolate_pos_encoding_allows_different_resolution():
+    import torch
+    from transformers import ViTConfig, ViTModel
+
+    config = ViTConfig(
+        image_size=224,
+        patch_size=16,
+        hidden_size=64,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        intermediate_size=128,
+    )
+
+    model = ViTModel(config)
+    model.eval()
+
+    pixel_values = torch.randn(1, 3, 256, 256)
+
+    with torch.no_grad():
+        outputs = model(
+            pixel_values=pixel_values,
+            interpolate_pos_encoding=True,
+        )
+
+    assert outputs.last_hidden_state is not None
+    assert outputs.last_hidden_state.shape[0] == 1
+

--- a/tests/models/vit/test_modeling_vit.py
+++ b/tests/models/vit/test_modeling_vit.py
@@ -17,27 +17,22 @@ import unittest
 from functools import cached_property
 
 from transformers import ViTConfig
-from transformers.testing_utils import (
-    require_accelerate,
-    require_torch,
-    require_torch_accelerator,
-    require_torch_fp16,
-    require_vision,
-    slow,
-    torch_device,
-)
+from transformers.testing_utils import (require_accelerate, require_torch,
+                                        require_torch_accelerator,
+                                        require_torch_fp16, require_vision,
+                                        slow, torch_device)
 from transformers.utils import is_torch_available, is_vision_available
 
 from ...test_configuration_common import ConfigTester
 from ...test_modeling_common import ModelTesterMixin, floats_tensor, ids_tensor
 from ...test_pipeline_mixin import PipelineTesterMixin
 
-
 if is_torch_available():
     import torch
     from torch import nn
 
-    from transformers import ViTForImageClassification, ViTForMaskedImageModeling, ViTModel
+    from transformers import (ViTForImageClassification,
+                              ViTForMaskedImageModeling, ViTModel)
 
 
 if is_vision_available():
@@ -98,7 +93,9 @@ class ViTModelTester:
         self.mask_length = num_patches
 
     def prepare_config_and_inputs(self):
-        pixel_values = floats_tensor([self.batch_size, self.num_channels, self.image_size, self.image_size])
+        pixel_values = floats_tensor(
+            [self.batch_size, self.num_channels, self.image_size, self.image_size]
+        )
 
         labels = None
         if self.use_labels:
@@ -131,7 +128,10 @@ class ViTModelTester:
         model.to(torch_device)
         model.eval()
         result = model(pixel_values)
-        self.parent.assertEqual(result.last_hidden_state.shape, (self.batch_size, self.seq_length, self.hidden_size))
+        self.parent.assertEqual(
+            result.last_hidden_state.shape,
+            (self.batch_size, self.seq_length, self.hidden_size),
+        )
 
     def create_and_check_for_masked_image_modeling(self, config, pixel_values, labels):
         model = ViTForMaskedImageModeling(config=config)
@@ -139,7 +139,8 @@ class ViTModelTester:
         model.eval()
         result = model(pixel_values)
         self.parent.assertEqual(
-            result.reconstruction.shape, (self.batch_size, self.num_channels, self.image_size, self.image_size)
+            result.reconstruction.shape,
+            (self.batch_size, self.num_channels, self.image_size, self.image_size),
         )
 
         # test greyscale images
@@ -148,9 +149,14 @@ class ViTModelTester:
         model.to(torch_device)
         model.eval()
 
-        pixel_values = floats_tensor([self.batch_size, 1, self.image_size, self.image_size])
+        pixel_values = floats_tensor(
+            [self.batch_size, 1, self.image_size, self.image_size]
+        )
         result = model(pixel_values)
-        self.parent.assertEqual(result.reconstruction.shape, (self.batch_size, 1, self.image_size, self.image_size))
+        self.parent.assertEqual(
+            result.reconstruction.shape,
+            (self.batch_size, 1, self.image_size, self.image_size),
+        )
 
     def create_and_check_for_image_classification(self, config, pixel_values, labels):
         config.num_labels = self.type_sequence_label_size
@@ -158,7 +164,9 @@ class ViTModelTester:
         model.to(torch_device)
         model.eval()
         result = model(pixel_values, labels=labels)
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.type_sequence_label_size))
+        self.parent.assertEqual(
+            result.logits.shape, (self.batch_size, self.type_sequence_label_size)
+        )
 
         # test greyscale images
         config.num_channels = 1
@@ -166,9 +174,13 @@ class ViTModelTester:
         model.to(torch_device)
         model.eval()
 
-        pixel_values = floats_tensor([self.batch_size, 1, self.image_size, self.image_size])
+        pixel_values = floats_tensor(
+            [self.batch_size, 1, self.image_size, self.image_size]
+        )
         result = model(pixel_values)
-        self.parent.assertEqual(result.logits.shape, (self.batch_size, self.type_sequence_label_size))
+        self.parent.assertEqual(
+            result.logits.shape, (self.batch_size, self.type_sequence_label_size)
+        )
 
     def prepare_config_and_inputs_for_common(self):
         config_and_inputs = self.prepare_config_and_inputs()
@@ -198,7 +210,10 @@ class ViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         else ()
     )
     pipeline_model_mapping = (
-        {"image-feature-extraction": ViTModel, "image-classification": ViTForImageClassification}
+        {
+            "image-feature-extraction": ViTModel,
+            "image-classification": ViTForImageClassification,
+        }
         if is_torch_available()
         else {}
     )
@@ -208,7 +223,9 @@ class ViTModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
 
     def setUp(self):
         self.model_tester = ViTModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=ViTConfig, has_text_modality=False, hidden_size=37)
+        self.config_tester = ConfigTester(
+            self, config_class=ViTConfig, has_text_modality=False, hidden_size=37
+        )
 
     @unittest.skip(
         "Since `torch==2.3+cu121`, although this test passes, many subsequent tests have `CUDA error: misaligned address`."
@@ -263,11 +280,17 @@ def prepare_img():
 class ViTModelIntegrationTest(unittest.TestCase):
     @cached_property
     def default_image_processor(self):
-        return ViTImageProcessor.from_pretrained("google/vit-base-patch16-224") if is_vision_available() else None
+        return (
+            ViTImageProcessor.from_pretrained("google/vit-base-patch16-224")
+            if is_vision_available()
+            else None
+        )
 
     @slow
     def test_inference_image_classification_head(self):
-        model = ViTForImageClassification.from_pretrained("google/vit-base-patch16-224").to(torch_device)
+        model = ViTForImageClassification.from_pretrained(
+            "google/vit-base-patch16-224"
+        ).to(torch_device)
 
         image_processor = self.default_image_processor
         image = prepare_img()
@@ -283,7 +306,9 @@ class ViTModelIntegrationTest(unittest.TestCase):
 
         expected_slice = torch.tensor([-0.2744, 0.8215, -0.0836]).to(torch_device)
 
-        torch.testing.assert_close(outputs.logits[0, :3], expected_slice, rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(
+            outputs.logits[0, :3], expected_slice, rtol=1e-4, atol=1e-4
+        )
 
     @slow
     def test_inference_interpolate_pos_encoding(self):
@@ -293,7 +318,9 @@ class ViTModelIntegrationTest(unittest.TestCase):
         # to visualize self-attention on higher resolution images.
         model = ViTModel.from_pretrained("facebook/dino-vits8").to(torch_device)
 
-        image_processor = ViTImageProcessor.from_pretrained("facebook/dino-vits8", size=480)
+        image_processor = ViTImageProcessor.from_pretrained(
+            "facebook/dino-vits8", size=480
+        )
         image = prepare_img()
         inputs = image_processor(images=image, return_tensors="pt")
         pixel_values = inputs.pixel_values.to(torch_device)
@@ -307,10 +334,16 @@ class ViTModelIntegrationTest(unittest.TestCase):
         self.assertEqual(outputs.last_hidden_state.shape, expected_shape)
 
         expected_slice = torch.tensor(
-            [[4.2325, 4.3882, -6.6678], [4.5372, 1.8933, -6.7355], [4.4454, 0.8514, -5.8747]]
+            [
+                [4.2325, 4.3882, -6.6678],
+                [4.5372, 1.8933, -6.7355],
+                [4.4454, 0.8514, -5.8747],
+            ]
         ).to(torch_device)
 
-        torch.testing.assert_close(outputs.last_hidden_state[0, :3, :3], expected_slice, rtol=1e-3, atol=1e-3)
+        torch.testing.assert_close(
+            outputs.last_hidden_state[0, :3, :3], expected_slice, rtol=1e-3, atol=1e-3
+        )
 
     @slow
     @require_accelerate
@@ -320,7 +353,9 @@ class ViTModelIntegrationTest(unittest.TestCase):
         r"""
         A small test to make sure that inference work in half precision without any problem.
         """
-        model = ViTModel.from_pretrained("facebook/dino-vits8", dtype=torch.float16, device_map="auto")
+        model = ViTModel.from_pretrained(
+            "facebook/dino-vits8", dtype=torch.float16, device_map="auto"
+        )
         image_processor = self.default_image_processor
 
         image = prepare_img()
@@ -334,6 +369,7 @@ class ViTModelIntegrationTest(unittest.TestCase):
 
 def test_vit_interpolate_pos_encoding_allows_different_resolution():
     import torch
+
     from transformers import ViTConfig, ViTModel
 
     config = ViTConfig(
@@ -358,4 +394,3 @@ def test_vit_interpolate_pos_encoding_allows_different_resolution():
 
     assert outputs.last_hidden_state is not None
     assert outputs.last_hidden_state.shape[0] == 1
-


### PR DESCRIPTION
# What does this PR do?

This PR adds a regression test to [tests/models/vit/test_modeling_vit.py](cci:7://file:///c:/Users/HP/Downloads/huggingface/transformers/tests/models/vit/test_modeling_vit.py:0:0-0:0). 

It checks that [ViTModel](cci:2://file:///c:/Users/HP/Downloads/huggingface/transformers/tests/models/vit/test_modeling_vit.py:183:0-251:35) correctly handles input images with resolutions different from the model configuration when `interpolate_pos_encoding=True` is passed during the forward pass. This asserts that the model can dynamically interpolate position embeddings for larger or smaller images without error.

# Fixes
N/A (Adds missing test coverage for dynamic resolution support)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@yonigozlan @molbap