### PR TITLE
Make DataCollatorMixin handle BatchFeature

### DIFF
--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -46,7 +46,7 @@ class DataCollatorMixin:
         else:
             raise ValueError(f"Framework '{return_tensors}' not recognized!")
 
-        if not isinstance(batch, BatchFeature):
+        if isinstance(batch, dict):
             batch = BatchFeature(batch, return_tensors)
 
         return batch

--- a/src/transformers/data/data_collator.py
+++ b/src/transformers/data/data_collator.py
@@ -21,6 +21,7 @@ from typing import Any
 
 import numpy as np
 
+from ..feature_extraction_utils import BatchFeature
 from ..tokenization_utils_base import PreTrainedTokenizerBase
 from ..utils import PaddingStrategy
 
@@ -39,11 +40,16 @@ class DataCollatorMixin:
         if return_tensors is None:
             return_tensors = self.return_tensors
         if return_tensors == "pt":
-            return self.torch_call(features)
+            batch = self.torch_call(features)
         elif return_tensors == "np":
-            return self.numpy_call(features)
+            batch = self.numpy_call(features)
         else:
             raise ValueError(f"Framework '{return_tensors}' not recognized!")
+
+        if not isinstance(batch, BatchFeature):
+            batch = BatchFeature(batch, return_tensors)
+
+        return batch
 
 
 def pad_without_fast_tokenizer_warning(tokenizer, *pad_args, **pad_kwargs):


### PR DESCRIPTION
# What does this PR do?

Modify so that if the batch returned from DataCollatorMixin is a dict, it is converted to BatchFeature and output.
In most learning and projects, instead of returning the value returned from processing_class performed in pt_call or np_call as is, there are many cases where an additional dict is made and returned, and there are many times when the functionality provided by BatchFeature cannot be used.
So, I tweaked the collator so that if the batch is a simple dict, it can be converted to BatchFeature.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@SunMarc
