### PR TITLE
fix `pr-repo-consistency-bot.yml`

### DIFF
--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -145,6 +145,10 @@ jobs:
           git fetch --depth=1 pr-origin ${PR_HEAD_SHA}
           git checkout ${PR_HEAD_SHA}
 
+          # Also fetch main branch from upstream for comparison (required by `check_modular_conversion`)
+          git remote add upstream https://github.com/${{ github.repository }}.git
+          git fetch --depth=1 upstream main:main
+
       - name: Run checks with trusted script
         id: run_checks
         run: |


### PR DESCRIPTION
# What does this PR do?

`check_modular_conversion` needs the repo. has the `main` branch info to compare against the PR changes.