### PR TITLE
Fix tests to use LoadStateDictConfig

### DIFF
--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -580,8 +580,9 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
             ),
             WeightRenaming("mlp.w2.weight", "mlp.down_proj.weight"),
         ]
+        load_config = LoadStateDictConfig(weight_mapping=weight_mapping)
         missing, unexpected, mismatch, _, misc = convert_and_load_state_dict_in_model(
-            model, state_dict, weight_mapping, tp_plan=None, hf_quantizer=None
+            model, state_dict, load_config, tp_plan=None
         )
 
         self.assertEqual(missing, set())
@@ -704,8 +705,9 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
         ]
 
         # Use the mapping to load
+        load_config = LoadStateDictConfig(weight_mapping=weight_mapping)
         missing, unexpected, mismatch, _, misc = convert_and_load_state_dict_in_model(
-            model, state_dict, weight_mapping, tp_plan=None, hf_quantizer=None
+            model, state_dict, load_config, tp_plan=None
         )
         self.assertTrue(len(missing) == 0)
         self.assertTrue(len(unexpected) == 0)


### PR DESCRIPTION
## Summary
- Update `test_ernie4_5_vl_moe_conversion` and `test_ernie4_5_vl_moe_conversion_reversed` to use `LoadStateDictConfig` instead of passing `hf_quantizer` directly to `convert_and_load_state_dict_in_model`

## Test plan
- [x] Both tests pass locally