### PR TITLE
[`chore`] Add missing r-prefix to Gemma3nAudioEncoderModelOutput

### DIFF
--- a/src/transformers/models/gemma3n/modeling_gemma3n.py
+++ b/src/transformers/models/gemma3n/modeling_gemma3n.py
@@ -53,7 +53,7 @@ from .configuration_gemma3n import Gemma3nAudioConfig, Gemma3nConfig, Gemma3nTex
 @dataclass
 @auto_docstring
 class Gemma3nAudioEncoderModelOutput(BaseModelOutputWithPooling):
-    """
+    r"""
     audio_mel_mask (`torch.FloatTensor`, *optional*):
         A torch.BoolTensor of shape `(batch_size, num_frames)`
     """

--- a/src/transformers/models/gemma3n/modular_gemma3n.py
+++ b/src/transformers/models/gemma3n/modular_gemma3n.py
@@ -634,7 +634,7 @@ class Gemma3nConfig(PreTrainedConfig):
 @dataclass
 @auto_docstring
 class Gemma3nAudioEncoderModelOutput(BaseModelOutputWithPooling):
-    """
+    r"""
     audio_mel_mask (`torch.FloatTensor`, *optional*):
         A torch.BoolTensor of shape `(batch_size, num_frames)`
     """


### PR DESCRIPTION
# What does this PR do?

This PR adds a required `r`-prefix to a docstring. It'll be added automatically via `utils/check_docstrings.py` if you've made changes in gemma3n, but we should just get ahead of that and fix it now.

It wasn't spotted previously as I believe the `check_docstrings.py` might only run on files that have local changes?

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@vasqu

- Tom Aarsen