### PR TITLE
fix(models): Add tie_word_embeddings parameter to AyaVisionConfig for proper weight tying

### DIFF
--- a/src/transformers/models/aya_vision/configuration_aya_vision.py
+++ b/src/transformers/models/aya_vision/configuration_aya_vision.py
@@ -48,6 +48,8 @@ class AyaVisionConfig(PreTrainedConfig):
             The epsilon value used for layer normalization in the adapter.
         image_token_index (`int`, *optional*, defaults to 255036):
             The image token index to encode the image prompt.
+        tie_word_embeddings (`bool`, *optional*, defaults to `True`):
+            Whether to tie weight embeddings.
     """
 
     model_type = "aya_vision"
@@ -65,11 +67,13 @@ class AyaVisionConfig(PreTrainedConfig):
         downsample_factor=2,
         adapter_layer_norm_eps=1e-6,
         image_token_index=255036,
+        tie_word_embeddings=True,
         **kwargs,
     ):
         self.image_token_index = image_token_index
         self.downsample_factor = downsample_factor
         self.adapter_layer_norm_eps = adapter_layer_norm_eps
+        self.tie_word_embeddings = tie_word_embeddings
         if vision_feature_select_strategy not in ["default", "full"]:
             raise ValueError(
                 "vision_feature_select_strategy should be one of 'default', 'full'."


### PR DESCRIPTION
### What does the PR do?

Fixes weight tying between `lm_head` and `embed_tokens` by exposing `tie_word_embeddings` at the top-level config, following the canonical repo pattern. Upon inspecting both presets from the [AyaVision collection](https://huggingface.co/collections/CohereLabs/cohere-labs-aya-vision), both presets have `text_config.tie_word_embeddings` set to `True`, but this was not being surfaced on the top-level config.

```python
from transformers import AutoConfig

models = [
    "CohereForAI/aya-vision-32b",
    "CohereLabs/aya-vision-8b",
]
for model_id in models:
    config = AutoConfig.from_pretrained(model_id)
    print(f"{model_id} tie_word_embeddings:", config.text_config.tie_word_embeddings)
```

Fixes #43454.

**Output:**

```
CohereForAI/aya-vision-32b tie_word_embeddings: True
CohereLabs/aya-vision-8b tie_word_embeddings: True
```

Accordingly, I’ve added `tie_word_embeddings` to `AyaVisionConfig`, with its default value set to `True`. As a consequence, the CI failures are also fixed. Run the following command to check the previously failing tests, which should now pass after the weight tying.

```
!RUN_SLOW=1 pytest -v tests/models/aya_vision/test_modeling_aya_vision.py::AyaVisionIntegrationTest::test_small_model_integration_batched_generate tests/models/aya_vision/test_modeling_aya_vision.py::AyaVisionIntegrationTest::test_small_model_integration_batched_generate_multi_image tests/models/aya_vision/test_modeling_aya_vision.py::AyaVisionIntegrationTest::test_small_model_integration_forward tests/models/aya_vision/test_modeling_aya_vision.py::AyaVisionIntegrationTest::test_small_model_integration_generate_chat_template tests/models/aya_vision/test_modeling_aya_vision.py::AyaVisionIntegrationTest::test_small_model_integration_generate_text_only -s
```

### Before submitting

* [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that’s the case).
* [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
  Pull Request section?
* [x] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link
  to it if that’s the case.
* [x] Did you make sure to update the documentation with your changes? Here are the
  [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
  [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).