### PR TITLE
fix(models): Rename fpn_position_encoding to fpn_position_embeddings

### DIFF
--- a/src/transformers/models/edgetam/modular_edgetam.py
+++ b/src/transformers/models/edgetam/modular_edgetam.py
@@ -204,15 +204,15 @@ class EdgeTamVisionModel(Sam2VisionModel):
         intermediate_hidden_states = backbone_output.last_hidden_state
         intermediate_hidden_states = [hidden_state.permute(0, 2, 3, 1) for hidden_state in intermediate_hidden_states]
 
-        fpn_hidden_states, fpn_position_encoding = self.neck(intermediate_hidden_states)
+        fpn_hidden_states, fpn_position_embeddings = self.neck(intermediate_hidden_states)
         # Select last `num_feature_levels` feature levels from FPN and reverse order to get features from high to low resolution
         fpn_hidden_states = fpn_hidden_states[-self.num_feature_levels :][::-1]
-        fpn_position_encoding = fpn_position_encoding[-self.num_feature_levels :][::-1]
+        fpn_position_embeddings = fpn_position_embeddings[-self.num_feature_levels :][::-1]
 
         return EdgeTamVisionEncoderOutput(
             last_hidden_state=intermediate_hidden_states[-1],
             fpn_hidden_states=fpn_hidden_states,
-            fpn_position_encoding=fpn_position_encoding,
+            fpn_position_embeddings=fpn_position_embeddings,
             hidden_states=backbone_output.hidden_states,
         )
 

--- a/src/transformers/models/edgetam_video/modeling_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modeling_edgetam_video.py
@@ -134,13 +134,13 @@ class EdgeTamVideoVisionEncoderOutput(BaseModelOutputWithPooling):
     fpn_hidden_states (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Feature maps from the Feature Pyramid Network neck.
-    fpn_position_encoding (`tuple(torch.FloatTensor)`):
+    fpn_position_embeddings (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Positional encodings corresponding to the `fpn_hidden_states`.
     """
 
     fpn_hidden_states: torch.FloatTensor | None = None
-    fpn_position_encoding: torch.FloatTensor | None = None
+    fpn_position_embeddings: torch.FloatTensor | None = None
 
 
 class EdgeTamVideoVisionRotaryEmbedding(nn.Module):
@@ -2244,7 +2244,7 @@ class EdgeTamVideoModel(EdgeTamVideoPreTrainedModel):
         vision_outputs: EdgeTamVideoVisionEncoderOutput = self.vision_encoder(pixel_values, return_dict=True, **kwargs)
 
         feature_maps = vision_outputs.fpn_hidden_states
-        feature_maps_position_embeddings = vision_outputs.fpn_position_encoding
+        feature_maps_position_embeddings = vision_outputs.fpn_position_embeddings
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -2259,7 +2259,7 @@ class EdgeTamVideoModel(EdgeTamVideoPreTrainedModel):
             for feature_map_position_embedding in feature_maps_position_embeddings
         ]
         vision_outputs.fpn_hidden_states = feature_maps
-        vision_outputs.fpn_position_encoding = feature_maps_position_embeddings
+        vision_outputs.fpn_position_embeddings = feature_maps_position_embeddings
 
         return vision_outputs
 

--- a/src/transformers/models/sam2/modeling_sam2.py
+++ b/src/transformers/models/sam2/modeling_sam2.py
@@ -74,13 +74,13 @@ class Sam2VisionEncoderOutput(BaseModelOutputWithPooling):
     fpn_hidden_states (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Feature maps from the Feature Pyramid Network neck.
-    fpn_position_encoding (`tuple(torch.FloatTensor)`):
+    fpn_position_embeddings (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Positional encodings corresponding to the `fpn_hidden_states`.
     """
 
     fpn_hidden_states: torch.FloatTensor | None = None
-    fpn_position_encoding: torch.FloatTensor | None = None
+    fpn_position_embeddings: torch.FloatTensor | None = None
 
 
 @dataclass
@@ -218,7 +218,7 @@ class Sam2VisionNeck(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> tuple[tuple[torch.Tensor, ...], tuple[torch.Tensor, ...]]:
         fpn_hidden_states = ()
-        fpn_position_encoding = ()
+        fpn_position_embeddings = ()
 
         # forward in top-down order (from low to high resolution)
         n = len(self.convs) - 1
@@ -242,9 +242,9 @@ class Sam2VisionNeck(nn.Module):
             ).to(prev_features.dtype)
 
             fpn_hidden_states += (prev_features,)
-            fpn_position_encoding += (prev_position_encoding,)
+            fpn_position_embeddings += (prev_position_encoding,)
 
-        return fpn_hidden_states, fpn_position_encoding
+        return fpn_hidden_states, fpn_position_embeddings
 
 
 def eager_attention_forward(
@@ -684,15 +684,15 @@ class Sam2VisionModel(Sam2PreTrainedModel):
         hidden_states = backbone_output.last_hidden_state
         intermediate_hidden_states = backbone_output.intermediate_hidden_states
 
-        fpn_hidden_states, fpn_position_encoding = self.neck(intermediate_hidden_states)
+        fpn_hidden_states, fpn_position_embeddings = self.neck(intermediate_hidden_states)
         # Select last `num_feature_levels` feature levels from FPN and reverse order to get features from high to low resolution
         fpn_hidden_states = fpn_hidden_states[-self.num_feature_levels :][::-1]
-        fpn_position_encoding = fpn_position_encoding[-self.num_feature_levels :][::-1]
+        fpn_position_embeddings = fpn_position_embeddings[-self.num_feature_levels :][::-1]
 
         return Sam2VisionEncoderOutput(
             last_hidden_state=hidden_states,
             fpn_hidden_states=fpn_hidden_states,
-            fpn_position_encoding=fpn_position_encoding,
+            fpn_position_embeddings=fpn_position_embeddings,
         )
 
 
@@ -1580,7 +1580,7 @@ class Sam2Model(Sam2PreTrainedModel):
         vision_outputs: Sam2VisionEncoderOutput = self.vision_encoder(pixel_values, return_dict=True, **kwargs)
 
         feature_maps = vision_outputs.fpn_hidden_states
-        feature_maps_position_embeddings = vision_outputs.fpn_position_encoding
+        feature_maps_position_embeddings = vision_outputs.fpn_position_embeddings
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -1595,7 +1595,7 @@ class Sam2Model(Sam2PreTrainedModel):
             for feature_map_position_embedding in feature_maps_position_embeddings
         ]
         vision_outputs.fpn_hidden_states = feature_maps
-        vision_outputs.fpn_position_encoding = feature_maps_position_embeddings
+        vision_outputs.fpn_position_embeddings = feature_maps_position_embeddings
 
         return vision_outputs
 

--- a/src/transformers/models/sam2_video/modeling_sam2_video.py
+++ b/src/transformers/models/sam2_video/modeling_sam2_video.py
@@ -1167,13 +1167,13 @@ class Sam2VideoVisionEncoderOutput(BaseModelOutputWithPooling):
     fpn_hidden_states (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Feature maps from the Feature Pyramid Network neck.
-    fpn_position_encoding (`tuple(torch.FloatTensor)`):
+    fpn_position_embeddings (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Positional encodings corresponding to the `fpn_hidden_states`.
     """
 
     fpn_hidden_states: torch.FloatTensor | None = None
-    fpn_position_encoding: torch.FloatTensor | None = None
+    fpn_position_embeddings: torch.FloatTensor | None = None
 
 
 class Sam2VideoMaskEmbedding(nn.Module):
@@ -1848,7 +1848,7 @@ class Sam2VideoModel(Sam2VideoPreTrainedModel):
         vision_outputs: Sam2VideoVisionEncoderOutput = self.vision_encoder(pixel_values, return_dict=True, **kwargs)
 
         feature_maps = vision_outputs.fpn_hidden_states
-        feature_maps_position_embeddings = vision_outputs.fpn_position_encoding
+        feature_maps_position_embeddings = vision_outputs.fpn_position_embeddings
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -1863,7 +1863,7 @@ class Sam2VideoModel(Sam2VideoPreTrainedModel):
             for feature_map_position_embedding in feature_maps_position_embeddings
         ]
         vision_outputs.fpn_hidden_states = feature_maps
-        vision_outputs.fpn_position_encoding = feature_maps_position_embeddings
+        vision_outputs.fpn_position_embeddings = feature_maps_position_embeddings
 
         return vision_outputs
 

--- a/src/transformers/models/sam3_tracker/modeling_sam3_tracker.py
+++ b/src/transformers/models/sam3_tracker/modeling_sam3_tracker.py
@@ -752,13 +752,13 @@ class Sam3TrackerVisionEncoderOutput(BaseModelOutputWithPooling):
     fpn_hidden_states (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Feature maps from the Feature Pyramid Network neck.
-    fpn_position_encoding (`tuple(torch.FloatTensor)`):
+    fpn_position_embeddings (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Positional encodings corresponding to the `fpn_hidden_states`.
     """
 
     fpn_hidden_states: torch.FloatTensor | None = None
-    fpn_position_encoding: torch.FloatTensor | None = None
+    fpn_position_embeddings: torch.FloatTensor | None = None
 
 
 @auto_docstring(
@@ -1076,7 +1076,7 @@ class Sam3TrackerModel(Sam3TrackerPreTrainedModel):
         vision_outputs: Sam3TrackerVisionEncoderOutput = self.vision_encoder(pixel_values, return_dict=True, **kwargs)
 
         feature_maps = vision_outputs.fpn_hidden_states
-        feature_maps_position_embeddings = vision_outputs.fpn_position_encoding
+        feature_maps_position_embeddings = vision_outputs.fpn_position_embeddings
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -1091,7 +1091,7 @@ class Sam3TrackerModel(Sam3TrackerPreTrainedModel):
             for feature_map_position_embedding in feature_maps_position_embeddings
         ]
         vision_outputs.fpn_hidden_states = feature_maps
-        vision_outputs.fpn_position_encoding = feature_maps_position_embeddings
+        vision_outputs.fpn_position_embeddings = feature_maps_position_embeddings
 
         return vision_outputs
 

--- a/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
@@ -1151,13 +1151,13 @@ class Sam3TrackerVideoVisionEncoderOutput(BaseModelOutputWithPooling):
     fpn_hidden_states (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Feature maps from the Feature Pyramid Network neck.
-    fpn_position_encoding (`tuple(torch.FloatTensor)`):
+    fpn_position_embeddings (`tuple(torch.FloatTensor)`):
         Tuple of `torch.FloatTensor` (one for each feature level, from high to low resolution) of shape
         `(batch_size, hidden_size, height, width)`. Positional encodings corresponding to the `fpn_hidden_states`.
     """
 
     fpn_hidden_states: torch.FloatTensor | None = None
-    fpn_position_encoding: torch.FloatTensor | None = None
+    fpn_position_embeddings: torch.FloatTensor | None = None
 
 
 class Sam3TrackerVideoPositionalEmbedding(nn.Module):
@@ -1873,7 +1873,7 @@ class Sam3TrackerVideoModel(Sam3TrackerVideoPreTrainedModel):
         )
 
         feature_maps = vision_outputs.fpn_hidden_states
-        feature_maps_position_embeddings = vision_outputs.fpn_position_encoding
+        feature_maps_position_embeddings = vision_outputs.fpn_position_embeddings
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -1888,7 +1888,7 @@ class Sam3TrackerVideoModel(Sam3TrackerVideoPreTrainedModel):
             for feature_map_position_embedding in feature_maps_position_embeddings[:-1]
         ]
         vision_outputs.fpn_hidden_states = feature_maps
-        vision_outputs.fpn_position_encoding = feature_maps_position_embeddings
+        vision_outputs.fpn_position_embeddings = feature_maps_position_embeddings
 
         return vision_outputs
 

--- a/src/transformers/models/sam3_tracker_video/modular_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modular_sam3_tracker_video.py
@@ -560,7 +560,7 @@ class Sam3TrackerVideoModel(Sam2VideoModel):
         )
 
         feature_maps = vision_outputs.fpn_hidden_states
-        feature_maps_position_embeddings = vision_outputs.fpn_position_encoding
+        feature_maps_position_embeddings = vision_outputs.fpn_position_embeddings
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -575,7 +575,7 @@ class Sam3TrackerVideoModel(Sam2VideoModel):
             for feature_map_position_embedding in feature_maps_position_embeddings[:-1]
         ]
         vision_outputs.fpn_hidden_states = feature_maps
-        vision_outputs.fpn_position_encoding = feature_maps_position_embeddings
+        vision_outputs.fpn_position_embeddings = feature_maps_position_embeddings
 
         return vision_outputs
 

--- a/src/transformers/models/sam3_video/modeling_sam3_video.py
+++ b/src/transformers/models/sam3_video/modeling_sam3_video.py
@@ -547,7 +547,7 @@ class Sam3VideoModel(Sam3VideoPreTrainedModel):
         height, width = self.tracker_model.prompt_encoder.image_embedding_size
         hidden_states_spatial = hidden_states.view(batch_size, height, width, -1).permute(0, 3, 1, 2)
 
-        fpn_hidden_states, fpn_position_encoding = self.tracker_neck(hidden_states_spatial)
+        fpn_hidden_states, fpn_position_embeddings = self.tracker_neck(hidden_states_spatial)
 
         # precompute projected level 0 and level 1 features in SAM decoder
         # to avoid running it again on every SAM click
@@ -559,7 +559,7 @@ class Sam3VideoModel(Sam3VideoPreTrainedModel):
         feature_maps = [feature_map.flatten(2).permute(2, 0, 1) for feature_map in feature_maps]
         feature_maps_position_embeddings = [
             feature_map_position_embedding.flatten(2).permute(2, 0, 1)
-            for feature_map_position_embedding in fpn_position_encoding[:-1]
+            for feature_map_position_embedding in fpn_position_embeddings[:-1]
         ]
         return feature_maps, feature_maps_position_embeddings
 

--- a/tests/models/sam3/test_modeling_sam3.py
+++ b/tests/models/sam3/test_modeling_sam3.py
@@ -125,7 +125,7 @@ class Sam3VisionModelTester:
 
         # Check FPN outputs
         self.parent.assertEqual(len(result.fpn_hidden_states), len(self.scale_factors))
-        self.parent.assertEqual(len(result.fpn_position_encoding), len(self.scale_factors))
+        self.parent.assertEqual(len(result.fpn_position_embeddings), len(self.scale_factors))
 
         # Check last hidden state shape
         expected_seq_len = (self.image_size // self.patch_size) ** 2
@@ -223,7 +223,7 @@ class Sam3VisionModelTest(ModelTesterMixin, unittest.TestCase):
                 outputs = model(**self._prepare_for_class(inputs_dict, model_class))
 
             # SAM3VisionModel doesn't return hidden_states in the same way as SAM2
-            # It returns last_hidden_state, fpn_hidden_states, and fpn_position_encoding
+            # It returns last_hidden_state, fpn_hidden_states, and fpn_position_embeddings
             self.assertIsNotNone(outputs.last_hidden_state)
             self.assertIsNotNone(outputs.fpn_hidden_states)
 


### PR DESCRIPTION
# What does this PR do?


The dataclass output attribute was named `fpn_position_encoding` but code in `_prepare_vision_features` was accessing `fpn_position_embeddings`, causing an AttributeError. Renamed to `fpn_position_embeddings` across all SAM2, SAM3, and EdgeTAM models for consistency with transformers naming conventions.

Affected models: sam2, sam2_video, sam3, sam3_tracker, sam3_tracker_video, sam3_video, edgetam, edgetam_video

Maybe the other changes where unnecessary, but I like to have consistent naming scheme through similar modules.

I could have just modified 

transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py", line 1912  to 
```python
vision_pos_embeds = image_outputs.fpn_position_embeddings 

->

vision_pos_embeds = image_outputs.fpn_position_encodings
```


If you all just want the minimal change I can go back and undo the other changes

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- I ran `doc-builder build transformers docs/source/en --build_dir ~/tmp/test-build` Nothing seemed to change. I think the docs for this get automatically updated.

```bash
Building docs for transformers docs/source/en /home/lllang/tmp/test-build/transformers/main/en
Building the MDX files:  13%|████████████████████████                                                                                                                                                                | 81/618 [00:00<00:00, 797.15it/s]use_kernel_func_from_hub is not available in the installed kernels version. Please upgrade kernels to use this feature.
Building the MDX files: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 618/618 [00:47<00:00, 13.12it/s]
Resolving internal links: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 605/605 [00:01<00:00, 584.87it/s]

```

- [ x] Did you write any new necessary tests? 
  - Due to the name change, a test had to be modified `tests/models/sam3/test_modeling_sam3.py`


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
