### PR TITLE
Fix MusicgenForConditionalGeneration config_class inheritance

### DIFF
--- a/src/transformers/models/musicgen/modeling_musicgen.py
+++ b/src/transformers/models/musicgen/modeling_musicgen.py
@@ -1287,6 +1287,7 @@ class MusicgenForCausalLM(MusicgenPreTrainedModel, GenerationMixin):
     """
 )
 class MusicgenForConditionalGeneration(MusicgenPreTrainedModel, GenerationMixin):
+    config_class = MusicgenConfig
     config: MusicgenConfig
     output_modalities = ("audio",)
     base_model_prefix = "encoder_decoder"


### PR DESCRIPTION
## Summary

`MusicgenForConditionalGeneration` inherits from `MusicgenPreTrainedModel` which has `config_class` implicitly set to `MusicgenDecoderConfig` via the type annotation `config: MusicgenDecoderConfig`.

However, `MusicgenForConditionalGeneration` expects a `MusicgenConfig` (which contains `decoder`, `text_encoder`, and `audio_encoder` sub-configs), not a `MusicgenDecoderConfig`. 

This causes an `AttributeError` when loading the model with `from_pretrained()`:

```
File "transformers/models/musicgen/modeling_musicgen.py", line 1384, in __init__
    if config.decoder.cross_attention_hidden_size is not None:
       ^^^^^^^^^^^^^^
AttributeError: 'MusicgenDecoderConfig' object has no attribute 'decoder'. Did you mean: 'is_decoder'?
```

## Fix

Explicitly set `config_class = MusicgenConfig` on `MusicgenForConditionalGeneration` to override the parent class's implicit config_class.

## Test

```python
from transformers import MusicgenForConditionalGeneration
model = MusicgenForConditionalGeneration.from_pretrained('facebook/musicgen-large')
# Previously: AttributeError
# Now: loads successfully
```

🤖 Generated with [Claude Code](https://claude.ai/code)