### PR TITLE
Remove stale TODO comments in UDOP tied weights

### DIFF
--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -1422,8 +1422,8 @@ class UdopModel(UdopPreTrainedModel):
     _tied_weights_keys = {
         "encoder.embed_tokens.weight": "shared.weight",
         "decoder.embed_tokens.weight": "shared.weight",
-        "encoder.embed_patches.proj.weight": "patch_embed.proj.weight",  # TODO tie weights for patch embeddings not working
-        "encoder.embed_patches.proj.bias": "patch_embed.proj.bias",  # TODO tie weights for patch embeddings not working
+        "encoder.embed_patches.proj.weight": "patch_embed.proj.weight",
+        "encoder.embed_patches.proj.bias": "patch_embed.proj.bias",
     }
 
     def __init__(self, config):


### PR DESCRIPTION
## Summary
Remove outdated TODO comments claiming patch embedding weight tying is "not working".

## Details
Testing confirms the tying mechanism works correctly:
- `patch_embed.proj.weight` and `encoder.embed_patches.proj.weight` share the same tensor
- Only source weights are saved to state_dict
- Weight tying is correctly re-established when loading

The TODO was added during #41580 refactor but the mechanism works identically to token embedding tying.