### PR TITLE
fix(Phi4Multimodal): Fix incorrect default vision/audio config initialization in Phi4MultimodalConfig

### DIFF
--- a/src/transformers/models/phi4_multimodal/configuration_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/configuration_phi4_multimodal.py
@@ -376,12 +376,12 @@ class Phi4MultimodalConfig(PreTrainedConfig):
         if isinstance(vision_config, dict):
             vision_config = Phi4MultimodalVisionConfig(**vision_config)
         elif vision_config is None:
-            Phi4MultimodalVisionConfig()
+            vision_config = Phi4MultimodalVisionConfig()
         self.vision_config = vision_config
 
         if isinstance(audio_config, dict):
             audio_config = Phi4MultimodalAudioConfig(**audio_config)
-        elif vision_config is None:
+        elif audio_config is None:
             audio_config = Phi4MultimodalAudioConfig()
         self.audio_config = audio_config
         self.vocab_size = vocab_size

--- a/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/modular_phi4_multimodal.py
@@ -399,12 +399,12 @@ class Phi4MultimodalConfig(Phi3Config):
         if isinstance(vision_config, dict):
             vision_config = Phi4MultimodalVisionConfig(**vision_config)
         elif vision_config is None:
-            Phi4MultimodalVisionConfig()
+            vision_config = Phi4MultimodalVisionConfig()
         self.vision_config = vision_config
 
         if isinstance(audio_config, dict):
             audio_config = Phi4MultimodalAudioConfig(**audio_config)
-        elif vision_config is None:
+        elif audio_config is None:
             audio_config = Phi4MultimodalAudioConfig()
         self.audio_config = audio_config
 


### PR DESCRIPTION
## 🐛 Bug Fix: Phi4MultimodalConfig default sub-config initialization

This PR fixes two issues in `Phi4MultimodalConfig.__init__` related to default initialization of multimodal sub-configs. 

Rations in Phi4MultimodalConfig

# What does this PR do?


### ❌ Problems fixed

1. When `vision_config` is `None`, a default `Phi4MultimodalVisionConfig()` was instantiated but **not assigned**, leaving `self.vision_config` as `None`.
2. The `audio_config` default initialization incorrectly checked `vision_config is None` instead of `audio_config is None`.

### ✅ Changes

```python
if isinstance(vision_config, dict):
    vision_config = Phi4MultimodalVisionConfig(**vision_config)
elif vision_config is None:
    vision_config = Phi4MultimodalVisionConfig()
self.vision_config = vision_config

if isinstance(audio_config, dict):
    audio_config = Phi4MultimodalAudioConfig(**audio_config)
elif audio_config is None:
    audio_config = Phi4MultimodalAudioConfig()
self.audio_config = audio_config
```

### 🎯 Impact

- Ensures `vision_config` and `audio_config` are always valid config objects when omitted
    
- Prevents downstream errors caused by unexpected `None` values
    
- Improves consistency with other multimodal config implementations
    

No behavior change for users explicitly passing configs.


Let me know if you'd like tests added or additional adjustments.
This pull request fixes initialization logic for the vision and audio configuration objects in the `Phi4MultimodalModel` constructor. The changes ensure that default configuration objects are correctly assigned when none are provided.

Configuration initialization fixes:

* Corrected the assignment of default `vision_config` and `audio_config` objects in the `__init__` method of `modular_phi4_multimodal.py`, ensuring that they are properly instantiated when not provided.
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #43479 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
     Fixing the issue: #43479
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
      I don't think this PR need to update the documentation. Please correct me and I'll add additional submits to this PR. 
- [x] Did you write any new necessary tests?
      I don't think any additional test is needed. Please let me know if it's reuqired and I'll add additional submits to this PR. 


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@Cyrilvallez
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
> Note: This PR description is refined by AI, I have review this description and report and taken the full responsibility for this PR. 
