### PR TITLE
Add pytest-random-order for reproducible test randomization

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -151,6 +151,13 @@ class CircleCIJob:
         pytest_flags.append(
             f"--make-reports={self.name}" if "examples" in self.name else f"--make-reports=tests_{self.name}"
         )
+        # Use CIRCLE_BUILD_NUM as seed for pytest-random-order to ensure:
+        # - Different randomization for each build/PR
+        # - Same seed across all parallel containers in a build (reproducible)
+        # - Deterministic test order for debugging failures
+        # - bucket=module randomizes within each file, works well with --dist=loadfile
+        pytest_flags.append("--random-order-bucket=module")
+        pytest_flags.append("--random-order-seed=${CIRCLE_BUILD_NUM:-0}")
                 # Examples special case: we need to download NLTK files in advance to avoid cuncurrency issues
         timeout_cmd = f"timeout {self.command_timeout} " if self.command_timeout else ""
         marker_cmd = f"-m '{self.marker}'" if self.marker is not None else ""

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -32,7 +32,7 @@ COMMON_ENV_VARIABLES = {
     "DISABLE_SAFETENSORS_CONVERSION": True,
 }
 # Disable the use of {"s": None} as the output is way too long, causing the navigation on CircleCI impractical
-COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "vvv": None, "rsfE":None}
+COMMON_PYTEST_OPTIONS = {"max-worker-restart": 0, "vvv": None, "rsfE":None, "random-order-bucket": "module", "random-order-seed": "${CIRCLE_BUILD_NUM:-0}"}
 DEFAULT_DOCKER_IMAGE = [{"image": "cimg/python:3.8.12"}]
 
 # Strings that commonly appear in the output of flaky tests when they fail. These are used with `pytest-rerunfailures`
@@ -153,13 +153,6 @@ class CircleCIJob:
         pytest_flags.append(
             f"--make-reports={self.name}" if "examples" in self.name else f"--make-reports=tests_{self.name}"
         )
-        # Use CIRCLE_BUILD_NUM as seed for pytest-random-order to ensure:
-        # - Different randomization for each build/PR
-        # - Same seed across all parallel containers in a build (reproducible)
-        # - Deterministic test order for debugging failures
-        # - bucket=module randomizes within each file, works well with --dist=loadfile
-        pytest_flags.append("--random-order-bucket=module")
-        pytest_flags.append("--random-order-seed=${CIRCLE_BUILD_NUM:-0}")
                 # Examples special case: we need to download NLTK files in advance to avoid cuncurrency issues
         timeout_cmd = f"timeout {self.command_timeout} " if self.command_timeout else ""
         marker_cmd = f"-m '{self.marker}'" if self.marker is not None else ""

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -111,6 +111,8 @@ class CircleCIJob:
             self.install_steps = ["uv pip install ."]
         # Use a custom patched pytest to force exit the process at the end, to avoid `Too long with no output (exceeded 10m0s): context deadline exceeded`
         self.install_steps.append("uv pip install git+https://github.com/ydshieh/pytest.git@8.4.1-ydshieh")
+        # Install pytest-random-order plugin for test randomization
+        self.install_steps.append("uv pip install pytest-random-order")
         if self.pytest_options is None:
             self.pytest_options = {}
         if isinstance(self.tests_to_run, str):

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,11 @@ fix-repo: style
 
 # Run tests for the library
 test:
-	python -m pytest -n auto --dist=loadfile -s -v ./tests/
+	python -m pytest -n auto --dist=loadfile -s -v --random-order-bucket=module ./tests/
 
 # Run tests for examples
 test-examples:
-	python -m pytest -n auto --dist=loadfile -s -v ./examples/pytorch/
+	python -m pytest -n auto --dist=loadfile -s -v --random-order-bucket=module ./examples/pytorch/
 
 # Run benchmark
 benchmark:

--- a/Makefile
+++ b/Makefile
@@ -59,13 +59,13 @@ fix-repo: style
 	-python utils/add_dates.py
 
 
-# Run tests for the library
+# Run tests for the library, requires pytest-random-order
 test:
-	python -m pytest -n auto --dist=loadfile -s -v --random-order-bucket=module ./tests/
+	python -m pytest -p random_order -n auto --dist=loadfile -s -v --random-order-bucket=module ./tests/
 
-# Run tests for examples
+# Run tests for examples, requires pytest-random-order
 test-examples:
-	python -m pytest -n auto --dist=loadfile -s -v --random-order-bucket=module ./examples/pytorch/
+	python -m pytest -p random_order -n auto --dist=loadfile -s -v --random-order-bucket=module ./examples/pytorch/
 
 # Run benchmark
 benchmark:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,10 +75,6 @@ markers = [
     "generate: marks tests that use the GenerationTesterMixin",
     "is_training_test: marks tests that use the TrainingTesterMixin (deselect with '-m \"not is_training_test\"')",
 ]
-# pytest-random-order randomizes test order to catch test interdependencies
-# Uses bucket=module to randomize tests within each file (works well with --dist=loadfile)
-# In CI: seed is set to CIRCLE_BUILD_NUM for reproducibility across parallel containers
-# Locally: uses random seed by default, or specify with --random-order-seed=<number>
 log_cli = 1
 log_cli_level = "WARNING"
 asyncio_default_fixture_loop_scope = "function"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,10 @@ markers = [
     "generate: marks tests that use the GenerationTesterMixin",
     "is_training_test: marks tests that use the TrainingTesterMixin (deselect with '-m \"not is_training_test\"')",
 ]
+# pytest-random-order randomizes test order to catch test interdependencies
+# Uses bucket=module to randomize tests within each file (works well with --dist=loadfile)
+# In CI: seed is set to CIRCLE_BUILD_NUM for reproducibility across parallel containers
+# Locally: uses random seed by default, or specify with --random-order-seed=<number>
 log_cli = 1
 log_cli_level = "WARNING"
 asyncio_default_fixture_loop_scope = "function"

--- a/setup.py
+++ b/setup.py
@@ -111,6 +111,7 @@ _deps = [
     "pydantic>=2",
     "pytest>=7.2.0,<9.0.0",
     "pytest-asyncio>=1.2.0",
+    "pytest-random-order",
     "pytest-rerunfailures<16.0",
     "pytest-timeout",
     "pytest-xdist",
@@ -270,6 +271,7 @@ extras["testing"] = (
     deps_list(
         "pytest",
         "pytest-asyncio",
+        "pytest-random-order",
         "pytest-rich",
         "pytest-xdist",
         "pytest-order",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -49,6 +49,7 @@ deps = {
     "pydantic": "pydantic>=2",
     "pytest": "pytest>=7.2.0,<9.0.0",
     "pytest-asyncio": "pytest-asyncio>=1.2.0",
+    "pytest-random-order": "pytest-random-order",
     "pytest-rerunfailures": "pytest-rerunfailures<16.0",
     "pytest-timeout": "pytest-timeout",
     "pytest-xdist": "pytest-xdist",


### PR DESCRIPTION
# What does this PR do?

Uses bucket=module to randomize tests within files, compatible with --dist=loadfile. CI uses CIRCLE_BUILD_NUM as seed for reproducibility across parallel containers. Local runs use random seed to catch order dependencies over time. Enables debugging by reproducing exact test order from failed CI builds.
<!-- Remove if not applicable -->
