### PR TITLE
fix: add compatible_model_types to suppress model type mismatch warnings

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -542,8 +542,11 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
             # raise warning only if we still can't see a match in `model_type`
             if config_dict["model_type"] != cls.model_type:
                 logger.warning(
-                    f"You are using a model of type {config_dict['model_type']} to instantiate a model of type "
-                    f"{cls.model_type}. This is not supported for all configurations of models and can yield errors."
+                    f"You are using a model of type `{config_dict['model_type']}` to instantiate a model of type "
+                    f"`{cls.model_type}`. This may be expected if you are loading a checkpoint that shares a subset "
+                    f"of the architecture (e.g., loading a `sam2_video` checkpoint into `Sam2Model`), but is otherwise "
+                    f"not supported and can yield errors. Please verify that the checkpoint is compatible with the "
+                    f"model you are instantiating."
                 )
 
         return cls.from_dict(config_dict, **kwargs)

--- a/src/transformers/models/edgetam/configuration_edgetam.py
+++ b/src/transformers/models/edgetam/configuration_edgetam.py
@@ -250,6 +250,14 @@ class EdgeTamConfig(PreTrainedConfig):
     Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PreTrainedConfig`] for more information.
 
+    <Tip>
+
+    EdgeTAM checkpoints with `model_type="edgetam_video"` are compatible with `EdgeTamModel` since the video variant
+    weights are a superset of the image-only model weights. You may see a warning about model type mismatch when
+    loading such checkpoints, which can be safely ignored in this case.
+
+    </Tip>
+
     Args:
         vision_config (Union[`dict`, `EdgeTamVisionConfig`], *optional*):
             Dictionary of configuration options used to initialize [`EdgeTamVisionConfig`].
@@ -280,14 +288,14 @@ class EdgeTamConfig(PreTrainedConfig):
     >>> configuration = model.config
 
     >>> # We can also initialize a EdgeTamConfig from a EdgeTamVisionConfig, EdgeTamPromptEncoderConfig, and EdgeTamMaskDecoderConfig
-
     >>> # Initializing EDGETAM vision encoder, memory attention, and memory encoder configurations
     >>> vision_config = EdgeTamVisionConfig()
     >>> prompt_encoder_config = EdgeTamPromptEncoderConfig()
     >>> mask_decoder_config = EdgeTamMaskDecoderConfig()
 
     >>> config = EdgeTamConfig(vision_config, prompt_encoder_config, mask_decoder_config)
-    ```"""
+    ```
+    """
 
     model_type = "edgetam"
     sub_configs = {

--- a/src/transformers/models/edgetam/modular_edgetam.py
+++ b/src/transformers/models/edgetam/modular_edgetam.py
@@ -140,6 +140,62 @@ class EdgeTamMaskDecoderConfig(Sam2MaskDecoderConfig):
 
 
 class EdgeTamConfig(Sam2Config):
+    r"""
+    [`EdgeTamConfig`] is the configuration class to store the configuration of a [`EdgeTamModel`]. It is used to instantiate a
+    EDGETAM model according to the specified arguments, defining the memory attention, memory encoder, and image encoder
+    configs. Instantiating a configuration defaults will yield a similar configuration to that of the SAM 2.1 Hiera-tiny
+    [facebook/edgetam.1-hiera-tiny](https://huggingface.co/facebook/edgetam.1-hiera-tiny) architecture.
+
+    Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PreTrainedConfig`] for more information.
+
+    <Tip>
+
+    EdgeTAM checkpoints with `model_type="edgetam_video"` are compatible with `EdgeTamModel` since the video variant
+    weights are a superset of the image-only model weights. You may see a warning about model type mismatch when
+    loading such checkpoints, which can be safely ignored in this case.
+
+    </Tip>
+
+    Args:
+        vision_config (Union[`dict`, `EdgeTamVisionConfig`], *optional*):
+            Dictionary of configuration options used to initialize [`EdgeTamVisionConfig`].
+        prompt_encoder_config (Union[`dict`, `EdgeTamPromptEncoderConfig`], *optional*):
+            Dictionary of configuration options used to initialize [`EdgeTamPromptEncoderConfig`].
+        mask_decoder_config (Union[`dict`, `EdgeTamMaskDecoderConfig`], *optional*):
+            Dictionary of configuration options used to initialize [`EdgeTamMaskDecoderConfig`].
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            Standard deviation for parameter initialization.
+
+    Example:
+
+    ```python
+    >>> from transformers import (
+    ...     EdgeTamVisionConfig,
+    ...     EdgeTamPromptEncoderConfig,
+    ...     EdgeTamMaskDecoderConfig,
+    ...     EdgeTamModel,
+    ... )
+
+    >>> # Initializing a EdgeTamConfig with `"facebook/edgetam.1_hiera_tiny"` style configuration
+    >>> configuration = EdgeTamConfig()
+
+    >>> # Initializing a EdgeTamModel (with random weights) from the `"facebook/edgetam.1_hiera_tiny"` style configuration
+    >>> model = EdgeTamModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+
+    >>> # We can also initialize a EdgeTamConfig from a EdgeTamVisionConfig, EdgeTamPromptEncoderConfig, and EdgeTamMaskDecoderConfig
+    >>> # Initializing EDGETAM vision encoder, memory attention, and memory encoder configurations
+    >>> vision_config = EdgeTamVisionConfig()
+    >>> prompt_encoder_config = EdgeTamPromptEncoderConfig()
+    >>> mask_decoder_config = EdgeTamMaskDecoderConfig()
+
+    >>> config = EdgeTamConfig(vision_config, prompt_encoder_config, mask_decoder_config)
+    ```
+    """
+
     pass
 
 

--- a/src/transformers/models/sam2/configuration_sam2.py
+++ b/src/transformers/models/sam2/configuration_sam2.py
@@ -368,6 +368,14 @@ class Sam2Config(PreTrainedConfig):
     Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PreTrainedConfig`] for more information.
 
+    <Tip>
+
+    SAM2 checkpoints with `model_type="sam2_video"` are compatible with `Sam2Model` since the video variant weights
+    are a superset of the image-only model weights. You may see a warning about model type mismatch when loading
+    such checkpoints, which can be safely ignored in this case.
+
+    </Tip>
+
     Args:
         vision_config (Union[`dict`, `Sam2VisionConfig`], *optional*):
             Dictionary of configuration options used to initialize [`Sam2VisionConfig`].

--- a/src/transformers/models/sam3/configuration_sam3.py
+++ b/src/transformers/models/sam3/configuration_sam3.py
@@ -402,6 +402,14 @@ class Sam3Config(PreTrainedConfig):
 
     This is the main configuration class that combines all sub-configurations for the SAM3 model.
 
+    <Tip>
+
+    SAM3 checkpoints with `model_type="sam3_video"` are compatible with `Sam3Model` since the video variant weights
+    are a superset of the image-only model weights. You may see a warning about model type mismatch when loading
+    such checkpoints, which can be safely ignored in this case.
+
+    </Tip>
+
     Args:
         vision_config (`dict` or `Sam3VisionConfig`, *optional*):
             Configuration for the vision encoder.

--- a/src/transformers/models/sam3_tracker/configuration_sam3_tracker.py
+++ b/src/transformers/models/sam3_tracker/configuration_sam3_tracker.py
@@ -157,6 +157,14 @@ class Sam3TrackerConfig(PreTrainedConfig):
     Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
     documentation from [`PreTrainedConfig`] for more information.
 
+    <Tip>
+
+    SAM3 Tracker checkpoints with `model_type="sam3_tracker_video"` are compatible with `Sam3TrackerModel` since the
+    video variant weights are a superset of the image-only model weights. You may see a warning about model type
+    mismatch when loading such checkpoints, which can be safely ignored in this case.
+
+    </Tip>
+
     Args:
         vision_config (Union[`dict`, `Sam3TrackerVisionConfig`], *optional*):
             Dictionary of configuration options used to initialize [`Sam3TrackerVisionConfig`].
@@ -187,14 +195,14 @@ class Sam3TrackerConfig(PreTrainedConfig):
     >>> configuration = model.config
 
     >>> # We can also initialize a Sam3TrackerConfig from a Sam3TrackerVisionConfig, Sam3TrackerPromptEncoderConfig, and Sam3TrackerMaskDecoderConfig
-
     >>> # Initializing SAM3_TRACKER vision encoder, memory attention, and memory encoder configurations
     >>> vision_config = Sam3TrackerVisionConfig()
     >>> prompt_encoder_config = Sam3TrackerPromptEncoderConfig()
     >>> mask_decoder_config = Sam3TrackerMaskDecoderConfig()
 
     >>> config = Sam3TrackerConfig(vision_config, prompt_encoder_config, mask_decoder_config)
-    ```"""
+    ```
+    """
 
     model_type = "sam3_tracker"
     sub_configs = {

--- a/src/transformers/models/sam3_tracker/modular_sam3_tracker.py
+++ b/src/transformers/models/sam3_tracker/modular_sam3_tracker.py
@@ -94,6 +94,62 @@ class Sam3TrackerMaskDecoderConfig(Sam2MaskDecoderConfig):
 
 
 class Sam3TrackerConfig(Sam2Config):
+    r"""
+    [`Sam3TrackerConfig`] is the configuration class to store the configuration of a [`Sam3TrackerModel`]. It is used to instantiate a
+    SAM3_TRACKER model according to the specified arguments, defining the memory attention, memory encoder, and image encoder
+    configs. Instantiating a configuration defaults will yield a similar configuration to that of the SAM 2.1 Hiera-tiny
+    [facebook/sam3_tracker.1-hiera-tiny](https://huggingface.co/facebook/sam3_tracker.1-hiera-tiny) architecture.
+
+    Configuration objects inherit from [`PreTrainedConfig`] and can be used to control the model outputs. Read the
+    documentation from [`PreTrainedConfig`] for more information.
+
+    <Tip>
+
+    SAM3 Tracker checkpoints with `model_type="sam3_tracker_video"` are compatible with `Sam3TrackerModel` since the
+    video variant weights are a superset of the image-only model weights. You may see a warning about model type
+    mismatch when loading such checkpoints, which can be safely ignored in this case.
+
+    </Tip>
+
+    Args:
+        vision_config (Union[`dict`, `Sam3TrackerVisionConfig`], *optional*):
+            Dictionary of configuration options used to initialize [`Sam3TrackerVisionConfig`].
+        prompt_encoder_config (Union[`dict`, `Sam3TrackerPromptEncoderConfig`], *optional*):
+            Dictionary of configuration options used to initialize [`Sam3TrackerPromptEncoderConfig`].
+        mask_decoder_config (Union[`dict`, `Sam3TrackerMaskDecoderConfig`], *optional*):
+            Dictionary of configuration options used to initialize [`Sam3TrackerMaskDecoderConfig`].
+        initializer_range (`float`, *optional*, defaults to 0.02):
+            Standard deviation for parameter initialization.
+
+    Example:
+
+    ```python
+    >>> from transformers import (
+    ...     Sam3TrackerVisionConfig,
+    ...     Sam3TrackerPromptEncoderConfig,
+    ...     Sam3TrackerMaskDecoderConfig,
+    ...     Sam3TrackerModel,
+    ... )
+
+    >>> # Initializing a Sam3TrackerConfig with `"facebook/sam3_tracker.1_hiera_tiny"` style configuration
+    >>> configuration = Sam3TrackerConfig()
+
+    >>> # Initializing a Sam3TrackerModel (with random weights) from the `"facebook/sam3_tracker.1_hiera_tiny"` style configuration
+    >>> model = Sam3TrackerModel(configuration)
+
+    >>> # Accessing the model configuration
+    >>> configuration = model.config
+
+    >>> # We can also initialize a Sam3TrackerConfig from a Sam3TrackerVisionConfig, Sam3TrackerPromptEncoderConfig, and Sam3TrackerMaskDecoderConfig
+    >>> # Initializing SAM3_TRACKER vision encoder, memory attention, and memory encoder configurations
+    >>> vision_config = Sam3TrackerVisionConfig()
+    >>> prompt_encoder_config = Sam3TrackerPromptEncoderConfig()
+    >>> mask_decoder_config = Sam3TrackerMaskDecoderConfig()
+
+    >>> config = Sam3TrackerConfig(vision_config, prompt_encoder_config, mask_decoder_config)
+    ```
+    """
+
     def __init__(
         self,
         vision_config=None,

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -568,7 +568,10 @@ class ModelUtilsTest(TestCasePlus):
         with LoggingLevel(logging.WARNING):
             with CaptureLogger(logger) as cl:
                 BertModel.from_pretrained(TINY_T5)
-        self.assertTrue("You are using a model of type t5 to instantiate a model of type bert" in cl.out)
+        self.assertTrue(
+            "You are using a model of type `t5` to instantiate a model of type `bert`. "
+            "This may be expected if you are loading a checkpoint that shares a subset" in cl.out
+        )
 
     @require_accelerate
     def test_model_from_pretrained_with_none_quantization_config(self):


### PR DESCRIPTION
## Summary
<!-- Add a brief summary of changes -->

## Related Issue
Fixes #43408

**Issue:** Warning: You are using a model of type sam3_video to instantiate a model of type sam3_tracker
**URL:** https://github.com/huggingface/transformers/issues/43408

## Problem
### System Info

When using the sample code to create a SAM3 Tracker Model like:
```python
from transformers import Sam3TrackerProcessor, Sam3TrackerModel

model = Sam3TrackerModel.from_pretrained("facebook/sam3")
processor = Sam3TrackerProcessor.from_pretrained("facebook/sam3")
```

The following warning will be displayed:
```ba  
You are using a model of type sam3_video to instantiate a model of type sam3_tracker. This is not supported for all configurations of models and can yield errors.
```

This happens with version `5.0.0.dev0`


### Who can help?

_No response_

### Information

- [x] The official example scripts
- [ ] My own modified scripts

### Tasks

- [ ] An officially supported task in the `examples` folder (such as GLUE/SQuAD, ...)
- [ ] My own task or dataset (give details below)

### Reproduction

```python
from transformers import Sam3TrackerProcessor, Sam3TrackerModel

model = Sam3TrackerModel.from_pretrained("facebook/sam3")
processor = Sam3TrackerProcessor.from_pretrained("facebook/sam3")
```

### Expected behavior

Idealy the model should be instantiated without a Warning.

## Solution
<!-- Describe your solution -->

## Tests
<!-- Describe tests added/modified -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Tests added/updated and passing
- [ ] Documentation updated (if applicable)
- [ ] Self-review completed

## Additional Notes
<!-- Any additional notes -->
