### PR TITLE
Revert tokenization regression, add test

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2019,6 +2019,16 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                 "Unable to load vocabulary from file. "
                 "Please check that the provided vocabulary is accessible and not corrupted."
             )
+
+        # If tokenizer_file exists and tokenizer has a TokenizersBackend, replace the blank tokenizer with tokenizer.json
+        if tokenizer_file is not None and hasattr(tokenizer, "_tokenizer"):
+            from tokenizers import Tokenizer as TokenizerFast
+
+            tokenizer._tokenizer = TokenizerFast.from_file(tokenizer_file)
+            # Re-run post-initialization if the tokenizer has it
+            if hasattr(tokenizer, "_post_init"):
+                tokenizer._post_init()
+
         return tokenizer
 
     @classmethod

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -127,30 +127,28 @@ class TokenizerUtilsTest(unittest.TestCase):
 
     @require_tokenizers
     def test_decoding_single_token(self):
-        for tokenizer_class in [BertTokenizer, BertTokenizer]:
-            with self.subTest(f"{tokenizer_class}"):
-                tokenizer = tokenizer_class.from_pretrained("google-bert/bert-base-cased")
+        tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-cased")
 
-                token_id = 2300
-                decoded_flat = tokenizer.decode(token_id)
-                decoded_list = tokenizer.decode([token_id])
+        token_id = 2300
+        decoded_flat = tokenizer.decode(token_id)
+        decoded_list = tokenizer.decode([token_id])
 
-                self.assertEqual(decoded_flat, "Force")
-                self.assertEqual(decoded_list, "Force")
+        self.assertEqual(decoded_flat, "Force")
+        self.assertEqual(decoded_list, "Force")
 
-                token_id = 0
-                decoded_flat = tokenizer.decode(token_id)
-                decoded_list = tokenizer.decode([token_id])
+        token_id = 0
+        decoded_flat = tokenizer.decode(token_id)
+        decoded_list = tokenizer.decode([token_id])
 
-                self.assertEqual(decoded_flat, "[PAD]")
-                self.assertEqual(decoded_list, "[PAD]")
+        self.assertEqual(decoded_flat, "[PAD]")
+        self.assertEqual(decoded_list, "[PAD]")
 
-                last_item_id = tokenizer.vocab_size - 1
-                decoded_flat = tokenizer.decode(last_item_id)
-                decoded_list = tokenizer.decode([last_item_id])
+        last_item_id = tokenizer.vocab_size - 1
+        decoded_flat = tokenizer.decode(last_item_id)
+        decoded_list = tokenizer.decode([last_item_id])
 
-                self.assertEqual(decoded_flat, "##：")
-                self.assertEqual(decoded_list, "##：")
+        self.assertEqual(decoded_flat, "##：")
+        self.assertEqual(decoded_list, "##：")
 
     def test_extra_special_tokens_multimodal(self):
         attribute_special_tokens_list = [
@@ -200,41 +198,39 @@ class TokenizerUtilsTest(unittest.TestCase):
 
     @require_tokenizers
     def test_decoding_skip_special_tokens(self):
-        for tokenizer_class in [BertTokenizer, BertTokenizer]:
-            with self.subTest(f"{tokenizer_class}"):
-                tokenizer = tokenizer_class.from_pretrained("google-bert/bert-base-cased")
-                tokenizer.add_tokens(["ஐ"], special_tokens=True)
+        tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-cased")
+        tokenizer.add_tokens(["ஐ"], special_tokens=True)
 
-                # test special token with other tokens, skip the special tokens
-                sentence = "This is a beautiful flower ஐ"
-                ids = tokenizer(sentence)["input_ids"]
-                decoded_sent = tokenizer.decode(ids, skip_special_tokens=True)
-                self.assertEqual(decoded_sent, "This is a beautiful flower")
+        # test special token with other tokens, skip the special tokens
+        sentence = "This is a beautiful flower ஐ"
+        ids = tokenizer(sentence)["input_ids"]
+        decoded_sent = tokenizer.decode(ids, skip_special_tokens=True)
+        self.assertEqual(decoded_sent, "This is a beautiful flower")
 
-                # test special token with other tokens, do not skip the special tokens
-                ids = tokenizer(sentence)["input_ids"]
-                decoded_sent = tokenizer.decode(ids, skip_special_tokens=False)
-                self.assertEqual(decoded_sent, "[CLS] This is a beautiful flower ஐ [SEP]")
+        # test special token with other tokens, do not skip the special tokens
+        ids = tokenizer(sentence)["input_ids"]
+        decoded_sent = tokenizer.decode(ids, skip_special_tokens=False)
+        self.assertEqual(decoded_sent, "[CLS] This is a beautiful flower ஐ [SEP]")
 
-                # test special token stand alone, skip the special tokens
-                sentence = "ஐ"
-                ids = tokenizer(sentence)["input_ids"]
-                decoded_sent = tokenizer.decode(ids, skip_special_tokens=True)
-                self.assertEqual(decoded_sent, "")
+        # test special token stand alone, skip the special tokens
+        sentence = "ஐ"
+        ids = tokenizer(sentence)["input_ids"]
+        decoded_sent = tokenizer.decode(ids, skip_special_tokens=True)
+        self.assertEqual(decoded_sent, "")
 
-                # test special token stand alone, do not skip the special tokens
-                ids = tokenizer(sentence)["input_ids"]
-                decoded_sent = tokenizer.decode(ids, skip_special_tokens=False)
-                self.assertEqual(decoded_sent, "[CLS] ஐ [SEP]")
+        # test special token stand alone, do not skip the special tokens
+        ids = tokenizer(sentence)["input_ids"]
+        decoded_sent = tokenizer.decode(ids, skip_special_tokens=False)
+        self.assertEqual(decoded_sent, "[CLS] ஐ [SEP]")
 
-                # test single special token alone, skip
-                pad_id = 0
-                decoded_sent = tokenizer.decode(pad_id, skip_special_tokens=True)
-                self.assertEqual(decoded_sent, "")
+        # test single special token alone, skip
+        pad_id = 0
+        decoded_sent = tokenizer.decode(pad_id, skip_special_tokens=True)
+        self.assertEqual(decoded_sent, "")
 
-                # test single special token alone, do not skip
-                decoded_sent = tokenizer.decode(pad_id, skip_special_tokens=False)
-                self.assertEqual(decoded_sent, "[PAD]")
+        # test single special token alone, do not skip
+        decoded_sent = tokenizer.decode(pad_id, skip_special_tokens=False)
+        self.assertEqual(decoded_sent, "[PAD]")
 
     @require_torch
     def test_padding_accepts_tensors_pt(self):
@@ -283,16 +279,14 @@ class TokenizerUtilsTest(unittest.TestCase):
             self.assertEqual(tokenizer._tokenizer.model.token_to_id("token"), 2)
 
     def test_len_tokenizer(self):
-        for tokenizer_class in [BertTokenizer, BertTokenizer]:
-            with self.subTest(f"{tokenizer_class}"):
-                tokenizer = tokenizer_class.from_pretrained("bert-base-uncased")
-                added_tokens_size = len(tokenizer.added_tokens_decoder)
-                self.assertEqual(len(tokenizer), tokenizer.vocab_size)
+        tokenizer = BertTokenizer.from_pretrained("bert-base-uncased")
+        added_tokens_size = len(tokenizer.added_tokens_decoder)
+        self.assertEqual(len(tokenizer), tokenizer.vocab_size)
 
-                tokenizer.add_tokens(["<test_token>"])
-                self.assertEqual(len(tokenizer), tokenizer.vocab_size + 1)
-                self.assertEqual(len(tokenizer.added_tokens_decoder), added_tokens_size + 1)
-                self.assertEqual(len(tokenizer.added_tokens_encoder), added_tokens_size + 1)
+        tokenizer.add_tokens(["<test_token>"])
+        self.assertEqual(len(tokenizer), tokenizer.vocab_size + 1)
+        self.assertEqual(len(tokenizer.added_tokens_decoder), added_tokens_size + 1)
+        self.assertEqual(len(tokenizer.added_tokens_encoder), added_tokens_size + 1)
 
     @require_sentencepiece
     def test_sentencepiece_cohabitation(self):


### PR DESCRIPTION
# What does this PR do?

This PR fixes the following regression:
```python
from transformers import AutoTokenizer

tokenizer = AutoTokenizer.from_pretrained("sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2")
sentences = ["C'est une belle journée.", "Das ist ein schöner Tag.", "It's a beautiful day."]

tokenized = tokenizer(sentences, padding=True, truncation=True, return_tensors="pt")
decoded = tokenizer.batch_decode(tokenized["input_ids"])
print(decoded)
# `main` before #42563 or with this PR:
["<s> C'est une belle journée.</s>", '<s> Das ist ein schöner Tag.</s><pad>', "<s> It's a beautiful day.</s>"]
# `main` since #42563:
["<s> c ' est une belle <unk>. </s>", '<s> das ist ein <unk> tag. </s> <pad>', "<s> it ' s a <unk> day. </s>"]
```

The issue was introduced in #42563. In essence, alongside removing a lot of sentencepiece conversion code, this PR also removed this code (https://github.com/huggingface/transformers/pull/42563/files#r2727583533) that loads the `tokenizer_file` if it exists:
```python
        # If tokenizer_file exists and tokenizer has a TokenizersBackend, replace the blank tokenizer with tokenizer.json if tokenizer_file is not None and hasattr(tokenizer, "_tokenizer"):
            from tokenizers import Tokenizer as TokenizerFast

            tokenizer._tokenizer = TokenizerFast.from_file(tokenizer_file)
            # Re-run post-initialization if the tokenizer has it
            if hasattr(tokenizer, "_post_init"):
                tokenizer._post_init()
```

Because this code was removed, the tokenizer from https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 loads with the default WordPiece model, instead of the Unigram that the model was trained for. I've added a test that fails on `main` that's resolved by reintroducing this code.

This is currently heavily affecting the performance of the https://huggingface.co/sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2 embedding model, causing test failures on my side.

### Note
I also simplified some
```python
        for tokenizer_class in [BertTokenizer, BertTokenizer]:
            with self.subTest(f"{tokenizer_class}"):
```
test cases. This is likely a leftover from replacing BertTokenizerFast.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @itazap

- Tom Aarsen