### PR TITLE
[Bugfix] Extract pad_token_id from text config for Llama-4

### DIFF
--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -1187,7 +1187,9 @@ class Llama4ForConditionalGeneration(Llama4PreTrainedModel, GenerationMixin):
         self.multi_modal_projector = Llama4MultiModalProjector(config)
         self.language_model = Llama4ForCausalLM(config.text_config)
         self.vocab_size = config.text_config.vocab_size
-        self.pad_token_id = self.config.pad_token_id if self.config.pad_token_id is not None else -1
+        self.pad_token_id = (
+            self.config.text_config.pad_token_id if self.config.text_config.pad_token_id is not None else -1
+        )
 
         self.post_init()
 


### PR DESCRIPTION
# What does this PR do?

Loading Llama-4 model with `Llama4ForConditionalGeneration` fails because `self.config.pad_token_id` doesn't exist. For Llama-4 models, `pad_token_id` is inside `text_config` not the general config.

