### PR TITLE
Add missing GPURawMetrics.from_dict() method in benchmark_v2

### DIFF
--- a/benchmark_v2/framework/data_classes.py
+++ b/benchmark_v2/framework/data_classes.py
@@ -136,7 +136,7 @@ class BenchmarkResult:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, None | int | float]) -> "BenchmarkResult":
+    def from_dict(cls, data: dict[str, Any]) -> "BenchmarkResult":
         # Handle GPU metrics, which is saved as None if it contains only None values
         if data["gpu_metrics"] is None:
             gpu_metrics = [None for _ in range(len(data["e2e_latency"]))]

--- a/benchmark_v2/framework/hardware_metrics.py
+++ b/benchmark_v2/framework/hardware_metrics.py
@@ -154,6 +154,17 @@ class GPURawMetrics:
             "monitoring_status": self.monitoring_status.value,
         }
 
+    @classmethod
+    def from_dict(cls, data: dict[str, None | int | float | str]) -> "GPURawMetrics":
+        """Create a GPURawMetrics instance from a dictionary."""
+        return cls(
+            utilization=data["utilization"],
+            memory_used=data["memory_used"],
+            timestamps=data["timestamps"],
+            timestamp_0=data["timestamp_0"],
+            monitoring_status=GPUMonitoringStatus(data["monitoring_status"]),
+        )
+
 
 # Main class, used to monitor the GPU utilization during benchmark execution
 class GPUMonitor:


### PR DESCRIPTION
  Adds the missing `from_dict()` classmethod to the `GPURawMetrics` dataclass in `benchmark_v2/framework/hardware_metrics.py`.      
  
 (`BenchmarkResult.from_dict()` is used at line 144 of `data_classes.py`)
                                                                                                                                                              