### PR TITLE
Revert utils files changes from db1e6f1e

### DIFF
--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -20,7 +20,7 @@ import re
 import subprocess
 
 import git
-import httpx
+import requests
 
 
 def create_script(target_test):
@@ -194,19 +194,19 @@ def get_commit_info(commit):
     merged_author = None
 
     url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit}/pulls"
-    pr_info_for_commit = httpx.get(url).json()
+    pr_info_for_commit = requests.get(url).json()
 
     if len(pr_info_for_commit) > 0:
         pr_number = pr_info_for_commit[0]["number"]
 
         url = f"https://api.github.com/repos/huggingface/transformers/pulls/{pr_number}"
-        pr_for_commit = httpx.get(url).json()
+        pr_for_commit = requests.get(url).json()
         author = pr_for_commit["user"]["login"]
         if pr_for_commit["merged_by"] is not None:
             merged_author = pr_for_commit["merged_by"]["login"]
 
     url = f"https://api.github.com/repos/huggingface/transformers/commits/{commit}"
-    commit_info = httpx.get(url).json()
+    commit_info = requests.get(url).json()
     parent = commit_info["parents"][0]["sha"]
     if author is None:
         author = commit_info["author"]["login"]
@@ -226,7 +226,7 @@ if __name__ == "__main__":
     print(f"start_commit: {args.start_commit}")
     print(f"end_commit: {args.end_commit}")
 
-    # `get_commit_info` uses `httpx.get()` to request info. via `api.github.com` without using token.
+    # `get_commit_info` uses `requests.get()` to request info. via `api.github.com` without using token.
     # If there are many new failed tests in a workflow run, this script may fail at some point with `KeyError` at
     # `pr_number = pr_info_for_commit[0]["number"]` due to the rate limit.
     # Let's cache the commit info. and reuse them whenever possible.

--- a/utils/get_ci_error_statistics.py
+++ b/utils/get_ci_error_statistics.py
@@ -7,7 +7,7 @@ import traceback
 import zipfile
 from collections import Counter
 
-import httpx
+import requests
 
 
 def get_jobs(workflow_run_id, token=None):
@@ -18,7 +18,7 @@ def get_jobs(workflow_run_id, token=None):
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
-    result = httpx.get(url, headers=headers).json()
+    result = requests.get(url, headers=headers).json()
     jobs = []
 
     try:
@@ -26,7 +26,7 @@ def get_jobs(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = httpx.get(url + f"&page={i + 2}", headers=headers).json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             jobs.extend(result["jobs"])
 
         return jobs
@@ -44,7 +44,7 @@ def get_job_links(workflow_run_id, token=None):
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
-    result = httpx.get(url, headers=headers).json()
+    result = requests.get(url, headers=headers).json()
     job_links = {}
 
     try:
@@ -52,7 +52,7 @@ def get_job_links(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = httpx.get(url + f"&page={i + 2}", headers=headers).json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             job_links.update({job["name"]: job["html_url"] for job in result["jobs"]})
 
         return job_links
@@ -72,7 +72,7 @@ def get_artifacts_links(workflow_run_id, token=None):
     url = (
         f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/artifacts?per_page=100"
     )
-    result = httpx.get(url, headers=headers).json()
+    result = requests.get(url, headers=headers).json()
     artifacts = {}
 
     try:
@@ -80,7 +80,7 @@ def get_artifacts_links(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = httpx.get(url + f"&page={i + 2}", headers=headers).json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             artifacts.update({artifact["name"]: artifact["archive_download_url"] for artifact in result["artifacts"]})
 
         return artifacts
@@ -101,9 +101,9 @@ def download_artifact(artifact_name, artifact_url, output_dir, token):
     if token is not None:
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
-    result = httpx.get(artifact_url, headers=headers, follow_redirects=False)
+    result = requests.get(artifact_url, headers=headers, allow_redirects=False)
     download_url = result.headers["Location"]
-    response = httpx.get(download_url, follow_redirects=True)
+    response = requests.get(download_url, allow_redirects=True)
     file_path = os.path.join(output_dir, f"{artifact_name}.zip")
     with open(file_path, "wb") as fp:
         fp.write(response.content)

--- a/utils/get_github_job_time.py
+++ b/utils/get_github_job_time.py
@@ -3,7 +3,7 @@ import math
 import traceback
 
 import dateutil.parser as date_parser
-import httpx
+import requests
 
 
 def extract_time_from_single_job(job):
@@ -34,7 +34,7 @@ def get_job_time(workflow_run_id, token=None):
         headers = {"Accept": "application/vnd.github+json", "Authorization": f"Bearer {token}"}
 
     url = f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}/jobs?per_page=100"
-    result = httpx.get(url, headers=headers).json()
+    result = requests.get(url, headers=headers).json()
     job_time = {}
 
     try:
@@ -42,7 +42,7 @@ def get_job_time(workflow_run_id, token=None):
         pages_to_iterate_over = math.ceil((result["total_count"] - 100) / 100)
 
         for i in range(pages_to_iterate_over):
-            result = httpx.get(url + f"&page={i + 2}", headers=headers).json()
+            result = requests.get(url + f"&page={i + 2}", headers=headers).json()
             job_time.update({job["name"]: extract_time_from_single_job(job) for job in result["jobs"]})
 
         return job_time

--- a/utils/get_previous_daily_ci.py
+++ b/utils/get_previous_daily_ci.py
@@ -1,7 +1,7 @@
 import os
 import zipfile
 
-import httpx
+import requests
 from get_ci_error_statistics import download_artifact, get_artifacts_links
 
 
@@ -21,7 +21,7 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
 
     if not workflow_id:
         workflow_run_id = os.environ["GITHUB_RUN_ID"]
-        workflow_run = httpx.get(
+        workflow_run = requests.get(
             f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}", headers=headers
         ).json()
         workflow_id = workflow_run["workflow_id"]
@@ -30,10 +30,10 @@ def get_daily_ci_runs(token, num_runs=7, workflow_id=None):
     # On `main` branch + event being `schedule` + not returning PRs + only `num_runs` results
     url += f"?branch=main&exclude_pull_requests=true&per_page={num_runs}"
 
-    result = httpx.get(f"{url}&event=schedule", headers=headers).json()
+    result = requests.get(f"{url}&event=schedule", headers=headers).json()
     workflow_runs = result["workflow_runs"]
     if len(workflow_runs) == 0:
-        result = httpx.get(f"{url}&event=workflow_run", headers=headers).json()
+        result = requests.get(f"{url}&event=workflow_run", headers=headers).json()
         workflow_runs = result["workflow_runs"]
 
     return workflow_runs
@@ -47,7 +47,7 @@ def get_last_daily_ci_run(token, workflow_run_id=None, workflow_id=None, commit_
 
     workflow_run = None
     if workflow_run_id is not None and workflow_run_id != "":
-        workflow_run = httpx.get(
+        workflow_run = requests.get(
             f"https://api.github.com/repos/huggingface/transformers/actions/runs/{workflow_run_id}", headers=headers
         ).json()
         return workflow_run

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -23,7 +23,7 @@ import sys
 import time
 from typing import Any
 
-import httpx
+import requests
 from compare_test_runs import compare_job_sets
 from get_ci_error_statistics import get_jobs
 from get_previous_daily_ci import get_last_daily_ci_reports, get_last_daily_ci_run, get_last_daily_ci_workflow_run_id
@@ -1092,7 +1092,7 @@ if __name__ == "__main__":
         # Retrieve the PR title and author login to complete the report
         commit_number = ci_url.split("/")[-1]
         ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/commits/{commit_number}"
-        ci_details = httpx.get(ci_detail_url).json()
+        ci_details = requests.get(ci_detail_url).json()
         ci_author = ci_details["author"]["login"]
 
         merged_by = None
@@ -1101,7 +1101,7 @@ if __name__ == "__main__":
         if len(numbers) > 0:
             pr_number = numbers[0]
             ci_detail_url = f"https://api.github.com/repos/{repository_full_name}/pulls/{pr_number}"
-            ci_details = httpx.get(ci_detail_url).json()
+            ci_details = requests.get(ci_detail_url).json()
 
             ci_author = ci_details["user"]["login"]
             ci_url = f"https://github.com/{repository_full_name}/pull/{pr_number}"

--- a/utils/process_circleci_workflow_test_reports.py
+++ b/utils/process_circleci_workflow_test_reports.py
@@ -17,7 +17,7 @@ import os
 import re
 from collections import Counter
 
-import httpx
+import requests
 
 
 if __name__ == "__main__":
@@ -25,7 +25,7 @@ if __name__ == "__main__":
     parser.add_argument("--workflow_id", type=str, required=True)
     args = parser.parse_args()
 
-    r = httpx.get(
+    r = requests.get(
         f"https://circleci.com/api/v2/workflow/{args.workflow_id}/job",
         headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")},
     )
@@ -38,7 +38,7 @@ if __name__ == "__main__":
     for job in jobs:
         if job["name"].startswith(("tests_", "examples_", "pipelines_")):
             url = f"https://circleci.com/api/v2/project/{job['project_slug']}/{job['job_number']}/artifacts"
-            r = httpx.get(url, headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")})
+            r = requests.get(url, headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")})
             job_artifacts = r.json()["items"]
 
             os.makedirs(f"outputs/{job['name']}", exist_ok=True)
@@ -49,10 +49,10 @@ if __name__ == "__main__":
             for artifact in job_artifacts:
                 url = artifact["url"]
                 if artifact["path"].endswith("/summary_short.txt"):
-                    r = httpx.get(url, headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")})
+                    r = requests.get(url, headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")})
                     job_test_summaries[artifact["node_index"]] = r.text
                 elif artifact["path"].endswith("/failures_line.txt"):
-                    r = httpx.get(url, headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")})
+                    r = requests.get(url, headers={"Circle-Token": os.environ.get("CIRCLE_TOKEN", "")})
                     job_failure_lines[artifact["node_index"]] = r.text
 
             summary = {}


### PR DESCRIPTION
# What does this PR do?

PR #42845 fails some workflow runs

```
File "/home/runner/work/transformers/transformers/utils/get_ci_error_statistics.py", line 29, in get_jobs
    result = httpx.get(url + f"&page={i + 2}", headers=headers).json()
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_api.py", line 195, in get
    return request(
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_api.py", line 109, in request
    return client.request(
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_client.py", line 825, in request
    return self.send(request, auth=auth, follow_redirects=follow_redirects)
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_client.py", line 914, in send
    response = self._send_handling_auth(
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_client.py", line 942, in _send_handling_auth
    response = self._send_handling_redirects(
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_client.py", line 979, in _send_handling_redirects
    response = self._send_single_request(request)
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_client.py", line 1014, in _send_single_request
    response = transport.handle_request(request)
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_transports/default.py", line 249, in handle_request
    with map_httpcore_exceptions():
  File "/usr/lib/python3.10/contextlib.py", line 153, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/home/runner/.local/lib/python3.10/site-packages/httpx/_transports/default.py", line 118, in map_httpcore_exceptions
    raise mapped_exc(message) from exc
httpx.ReadTimeout: The read operation timed out
```

revert some changes from that PR for now