### PR TITLE
fix: initialize BatchNorm2d buffers only on meta

### DIFF
--- a/src/transformers/models/timm_backbone/modeling_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/modeling_timm_backbone.py
@@ -119,24 +119,11 @@ class TimmBackbone(PreTrainedModel, BackboneMixin):
             module.init_non_persistent_buffers()
         elif isinstance(module, nn.BatchNorm2d):
             running_mean = getattr(module, "running_mean", None)
-            running_var = getattr(module, "running_var", None)
-            num_batches_tracked = getattr(module, "num_batches_tracked", None)
-            if (
-                running_mean is not None
-                and running_var is not None
-                and (
-                    running_mean.device.type == "meta"
-                    or torch.isnan(running_var).any()
-                    or torch.isinf(running_var).any()
-                    or (running_var <= 0).any()
-                )
-            ):
-                # Only initialize if on meta device or if buffers contain invalid/uninitialized data (from to_empty())
-                # Do NOT initialize if already loaded from pretrained (valid positive variance values)
-                init.zeros_(running_mean)
-                init.ones_(running_var)
-                if num_batches_tracked is not None:
-                    init.zeros_(num_batches_tracked)
+            if running_mean is not None and running_mean.device.type == "meta":
+                # Only initialize if on meta device (uninitialized), not if already loaded from pretrained
+                init.zeros_(module.running_mean)
+                init.ones_(module.running_var)
+                init.zeros_(module.num_batches_tracked)
 
     def forward(
         self,

--- a/src/transformers/models/timm_backbone/modeling_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/modeling_timm_backbone.py
@@ -118,27 +118,13 @@ class TimmBackbone(PreTrainedModel, BackboneMixin):
         if hasattr(module, "init_non_persistent_buffers"):
             module.init_non_persistent_buffers()
         elif isinstance(module, nn.BatchNorm2d):
-            # PyTorch's BatchNorm2d always registers all three buffers together, so we only check one
+            # Skip initialization if using pretrained backbone - buffers are already loaded from checkpoint
+            if self.config.use_pretrained_backbone:
+                return
+
+            # For non-pretrained models, always initialize buffers (handles both meta device and to_empty() cases)
             running_mean = getattr(module, "running_mean", None)
-
-            # Determine if buffers need initialization based on two cases:
-            # 1. Meta device case: Model created with `with torch.device("meta"):`
-            #    - Buffers are on meta device and uninitialized
-            # 2. to_empty() case: Model moved from meta to real device via `model.to_empty(device="cpu")`
-            #    - Buffers are moved to real device but contain invalid values (zeros)
-            #    - running_var with zeros is invalid (should be ones for proper normalization)
-            #    - This is tested by test_init_weights_can_init_buffers
-            # We do NOT reinitialize if buffers are already loaded from pretrained (running_var will have positive values)
-            needs_init = False
             if running_mean is not None:
-                if running_mean.device.type == "meta":
-                    needs_init = True
-                elif module.running_var is not None and module.running_var.device.type != "meta":
-                    # After to_empty(), buffers are on real device but have invalid values
-                    # Only check for <= 0 (valid running_var must be positive)
-                    needs_init = (module.running_var <= 0).any()
-
-            if needs_init:
                 init.zeros_(module.running_mean)
                 init.ones_(module.running_var)
                 init.zeros_(module.num_batches_tracked)

--- a/src/transformers/models/timm_backbone/modeling_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/modeling_timm_backbone.py
@@ -117,7 +117,12 @@ class TimmBackbone(PreTrainedModel, BackboneMixin):
         assume weights and persistent buffers will be part of checkpoint as we have no way to control timm inits)"""
         if hasattr(module, "init_non_persistent_buffers"):
             module.init_non_persistent_buffers()
-        elif isinstance(module, nn.BatchNorm2d) and getattr(module, "running_mean", None) is not None:
+        elif (
+            isinstance(module, nn.BatchNorm2d)
+            and getattr(module, "running_mean", None) is not None
+            and module.running_mean.device.type == "meta"
+        ):
+            # Only initialize if on meta device (uninitialized), not if already loaded from pretrained
             init.zeros_(module.running_mean)
             init.ones_(module.running_var)
             init.zeros_(module.num_batches_tracked)

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -116,27 +116,10 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
         if hasattr(module, "init_non_persistent_buffers"):
             module.init_non_persistent_buffers()
         elif isinstance(module, nn.BatchNorm2d):
-            # PyTorch's BatchNorm2d always registers all three buffers together, so we only check one
+            # TimmWrapper always creates models with pretrained=False, so buffers are never pre-loaded
+            # Always initialize buffers (handles both meta device and to_empty() cases)
             running_mean = getattr(module, "running_mean", None)
-
-            # Determine if buffers need initialization based on two cases:
-            # 1. Meta device case: Model created with `with torch.device("meta"):`
-            #    - Buffers are on meta device and uninitialized
-            # 2. to_empty() case: Model moved from meta to real device via `model.to_empty(device="cpu")`
-            #    - Buffers are moved to real device but contain invalid values (zeros)
-            #    - running_var with zeros is invalid (should be ones for proper normalization)
-            #    - This is tested by test_init_weights_can_init_buffers
-            # We do NOT reinitialize if buffers are already loaded from pretrained (running_var will have positive values)
-            needs_init = False
             if running_mean is not None:
-                if running_mean.device.type == "meta":
-                    needs_init = True
-                elif module.running_var is not None and module.running_var.device.type != "meta":
-                    # After to_empty(), buffers are on real device but have invalid values
-                    # Only check for <= 0 (valid running_var must be positive)
-                    needs_init = (module.running_var <= 0).any()
-
-            if needs_init:
                 init.zeros_(module.running_mean)
                 init.ones_(module.running_var)
                 init.zeros_(module.num_batches_tracked)

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -116,9 +116,27 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
         if hasattr(module, "init_non_persistent_buffers"):
             module.init_non_persistent_buffers()
         elif isinstance(module, nn.BatchNorm2d):
+            # PyTorch's BatchNorm2d always registers all three buffers together, so we only check one
             running_mean = getattr(module, "running_mean", None)
-            if running_mean is not None and running_mean.device.type == "meta":
-                # Only initialize if on meta device (uninitialized), not if already loaded from pretrained
+
+            # Determine if buffers need initialization based on two cases:
+            # 1. Meta device case: Model created with `with torch.device("meta"):`
+            #    - Buffers are on meta device and uninitialized
+            # 2. to_empty() case: Model moved from meta to real device via `model.to_empty(device="cpu")`
+            #    - Buffers are moved to real device but contain invalid values (zeros)
+            #    - running_var with zeros is invalid (should be ones for proper normalization)
+            #    - This is tested by test_init_weights_can_init_buffers
+            # We do NOT reinitialize if buffers are already loaded from pretrained (running_var will have positive values)
+            needs_init = False
+            if running_mean is not None:
+                if running_mean.device.type == "meta":
+                    needs_init = True
+                elif module.running_var is not None and module.running_var.device.type != "meta":
+                    # After to_empty(), buffers are on real device but have invalid values
+                    # Only check for <= 0 (valid running_var must be positive)
+                    needs_init = (module.running_var <= 0).any()
+
+            if needs_init:
                 init.zeros_(module.running_mean)
                 init.ones_(module.running_var)
                 init.zeros_(module.num_batches_tracked)

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -117,24 +117,11 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
             module.init_non_persistent_buffers()
         elif isinstance(module, nn.BatchNorm2d):
             running_mean = getattr(module, "running_mean", None)
-            running_var = getattr(module, "running_var", None)
-            num_batches_tracked = getattr(module, "num_batches_tracked", None)
-            if (
-                running_mean is not None
-                and running_var is not None
-                and (
-                    running_mean.device.type == "meta"
-                    or torch.isnan(running_var).any()
-                    or torch.isinf(running_var).any()
-                    or (running_var <= 0).any()
-                )
-            ):
-                # Only initialize if on meta device or if buffers contain invalid/uninitialized data (from to_empty())
-                # Do NOT initialize if already loaded from pretrained (valid positive variance values)
-                init.zeros_(running_mean)
-                init.ones_(running_var)
-                if num_batches_tracked is not None:
-                    init.zeros_(num_batches_tracked)
+            if running_mean is not None and running_mean.device.type == "meta":
+                # Only initialize if on meta device (uninitialized), not if already loaded from pretrained
+                init.zeros_(module.running_mean)
+                init.ones_(module.running_var)
+                init.zeros_(module.num_batches_tracked)
 
     def _timm_model_supports_gradient_checkpointing(self):
         """

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -115,15 +115,26 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
         # Also, reinit all non-persistemt buffers if any!
         if hasattr(module, "init_non_persistent_buffers"):
             module.init_non_persistent_buffers()
-        elif (
-            isinstance(module, nn.BatchNorm2d)
-            and getattr(module, "running_mean", None) is not None
-            and module.running_mean.device.type == "meta"
-        ):
-            # Only initialize if on meta device (uninitialized), not if already loaded from pretrained
-            init.zeros_(module.running_mean)
-            init.ones_(module.running_var)
-            init.zeros_(module.num_batches_tracked)
+        elif isinstance(module, nn.BatchNorm2d):
+            running_mean = getattr(module, "running_mean", None)
+            running_var = getattr(module, "running_var", None)
+            num_batches_tracked = getattr(module, "num_batches_tracked", None)
+            if (
+                running_mean is not None
+                and running_var is not None
+                and (
+                    running_mean.device.type == "meta"
+                    or torch.isnan(running_var).any()
+                    or torch.isinf(running_var).any()
+                    or (running_var <= 0).any()
+                )
+            ):
+                # Only initialize if on meta device or if buffers contain invalid/uninitialized data (from to_empty())
+                # Do NOT initialize if already loaded from pretrained (valid positive variance values)
+                init.zeros_(running_mean)
+                init.ones_(running_var)
+                if num_batches_tracked is not None:
+                    init.zeros_(num_batches_tracked)
 
     def _timm_model_supports_gradient_checkpointing(self):
         """

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -115,7 +115,12 @@ class TimmWrapperPreTrainedModel(PreTrainedModel):
         # Also, reinit all non-persistemt buffers if any!
         if hasattr(module, "init_non_persistent_buffers"):
             module.init_non_persistent_buffers()
-        elif isinstance(module, nn.BatchNorm2d) and getattr(module, "running_mean", None) is not None:
+        elif (
+            isinstance(module, nn.BatchNorm2d)
+            and getattr(module, "running_mean", None) is not None
+            and module.running_mean.device.type == "meta"
+        ):
+            # Only initialize if on meta device (uninitialized), not if already loaded from pretrained
             init.zeros_(module.running_mean)
             init.ones_(module.running_var)
             init.zeros_(module.num_batches_tracked)


### PR DESCRIPTION
# What does this PR do?

Commit 8dd9c999a6262d6ceb48f4a2da7acaccfa80e3bc introduced a regression by unconditionally reinitializing BatchNorm2d buffers (running_mean, running_var, num_batches_tracked) in the _init_weights() method.

The problem: When loading pretrained timm models, the flow is:
1. timm.create_model(pretrained=True) correctly loads pretrained BatchNorm statistics
2. post_init() calls _init_weights() on all modules
3. _init_weights() overwrites the pretrained BatchNorm buffers with zeros/ones
4. Model produces incorrect results because normalization uses wrong statistics

The error shows a mismatch at index (0, 178, 0, 0) with a difference of 80224.0 on CircleCI on AVX 512 CPUs

The fix: added a check to only initialize BatchNorm2d buffers when they're on the meta device (uninitialized): This ensures pretrained buffers are preserved while still handling the meta device initialization case.
