### PR TITLE
[Quantization] Fix triton_kernels name after being renamed to gpt-oss-triton-kernels

### DIFF
--- a/src/transformers/integrations/mxfp4.py
+++ b/src/transformers/integrations/mxfp4.py
@@ -619,7 +619,7 @@ def replace_with_mxfp4_linear(model, quantization_config=None, modules_to_not_co
     from .hub_kernels import get_kernel
 
     global triton_kernels_hub
-    triton_kernels_hub = get_kernel("kernels-community/triton_kernels")
+    triton_kernels_hub = get_kernel("kernels-community/gpt-oss-triton-kernels")
 
     has_been_replaced = False
     for module_name, module in model.named_modules():

--- a/src/transformers/quantizers/quantizer_mxfp4.py
+++ b/src/transformers/quantizers/quantizer_mxfp4.py
@@ -55,7 +55,7 @@ class Mxfp4HfQuantizer(HfQuantizer):
             try:
                 from ..integrations.hub_kernels import get_kernel
 
-                self.triton_kernels_hub = get_kernel("kernels-community/triton_kernels")
+                self.triton_kernels_hub = get_kernel("kernels-community/gpt-oss-triton-kernels")
             except ImportError:
                 raise ImportError("kernels package is required for MXFP4 quantization")
         return self.triton_kernels_hub


### PR DESCRIPTION
# What does this PR do?

change `triton_kernels` name to `gpt-oss-triton-kernels`, no new failling tests related to this change