### PR TITLE
[kernels] Update cv_utils name

### DIFF
--- a/src/transformers/models/sam3_video/modeling_sam3_video.py
+++ b/src/transformers/models/sam3_video/modeling_sam3_video.py
@@ -54,7 +54,7 @@ def _load_cv_utils_kernel_once():
         return
 
     try:
-        cv_utils_kernel = get_kernel("kernels-community/cv_utils")
+        cv_utils_kernel = get_kernel("kernels-community/cv-utils")
     except Exception as e:
         logger.warning_once(
             f"Failed to load cv_utils kernel (your torch/cuda setup may not be supported): {e}. "


### PR DESCRIPTION
# What does this PR do?

We are standardizing kernel names in `kernels-community` to use `-` instead of `_`, this pr simply updates `cv_utils`
new kernel is here with the latest torch version 2.10: https://huggingface.co/kernels-community/cv-utils