### PR TITLE
Fix for #43530

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1603,9 +1603,7 @@ class GenerationTesterMixin:
                 )
 
             for dynamic_result, compiled_result in zip(dynamic_outputs, compiled_outputs):
-                # Increased tolerance for MoE models where small numerical differences in router scores
-                # can lead to different expert selection between eager and compiled execution
-                self.assertTrue(has_similar_generate_outputs(dynamic_result, compiled_result, atol=1e-3, rtol=1e-3))
+                self.assertTrue(has_similar_generate_outputs(dynamic_result, compiled_result))
 
     @pytest.mark.generate
     def test_generate_compilation_all_outputs(self):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1603,7 +1603,9 @@ class GenerationTesterMixin:
                 )
 
             for dynamic_result, compiled_result in zip(dynamic_outputs, compiled_outputs):
-                self.assertTrue(has_similar_generate_outputs(dynamic_result, compiled_result))
+                # Increased tolerance for MoE models where small numerical differences in router scores
+                # can lead to different expert selection between eager and compiled execution
+                self.assertTrue(has_similar_generate_outputs(dynamic_result, compiled_result, atol=1e-3, rtol=1e-3))
 
     @pytest.mark.generate
     def test_generate_compilation_all_outputs(self):

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -71,10 +71,10 @@ def parse_hf_url(url):
 
 
 def validate_downloaded_content(filepath):
-    with open(filepath, "r") as f:
+    with open(filepath, "rb") as f:
         header = f.read(32)
 
-    for bad_sig in ["<!doctype", "<html", '{"error', '{"message']:
+    for bad_sig in [b"<!doctype", b"<html", b'{"error', b'{"message']:
         if header.lower().startswith(bad_sig):
             raise ValueError(
                 f"Downloaded file appears to be an HTML error page, not a valid media file. "


### PR DESCRIPTION
#43530 fails because the test I wrote for verifying correct downloads fails on image files, which might have UTF-8 illegal bytes. Opening the file in `b` mode fixes it. This doesn't show up in the CI because the script is run when recreating docker workers!