### PR TITLE
Look for the pad_token_id in the right place for Llama4

### DIFF
--- a/src/transformers/models/llama4/modeling_llama4.py
+++ b/src/transformers/models/llama4/modeling_llama4.py
@@ -1186,7 +1186,10 @@ class Llama4ForConditionalGeneration(Llama4PreTrainedModel, GenerationMixin):
         self.multi_modal_projector = Llama4MultiModalProjector(config)
         self.language_model = Llama4ForCausalLM(config.text_config)
         self.vocab_size = config.text_config.vocab_size
-        self.pad_token_id = self.config.pad_token_id if self.config.pad_token_id is not None else -1
+        if hasattr(self.config, "pad_token_id"):
+            self.pad_token_id = self.config.pad_token_id
+        else:
+            self.pad_token_id = self.config.text_config.pad_token_id or -1
 
         self.post_init()
 


### PR DESCRIPTION
Llama4 look for `pad_token_id` on `self.config` in some cases, but I think it actually lives on `self.config.text_config`. This PR should fix things! There was a similar issue with Qwen3, but thankfully I couldn't find any other affected models.

Fixes #43525