### PR TITLE
[Qwen2VL] Fix missing min_pixels/max_pixels attributes in fast image processor

### DIFF
--- a/src/transformers/models/glm_image/image_processing_glm_image_fast.py
+++ b/src/transformers/models/glm_image/image_processing_glm_image_fast.py
@@ -115,6 +115,9 @@ class GlmImageImageProcessorFast(BaseImageProcessorFast):
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
         super().__init__(size=size, **kwargs)
+        # Maintain backward compatibility by setting min_pixels/max_pixels attributes
+        self.min_pixels = self.size.get("shortest_edge")
+        self.max_pixels = self.size.get("longest_edge")
 
     def _further_process_kwargs(
         self,

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl_fast.py
@@ -81,6 +81,9 @@ class Qwen2VLImageProcessorFast(BaseImageProcessorFast):
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
         super().__init__(size=size, **kwargs)
+        # Maintain backward compatibility by setting min_pixels/max_pixels attributes
+        self.min_pixels = self.size.get("shortest_edge")
+        self.max_pixels = self.size.get("longest_edge")
 
     def _further_process_kwargs(
         self,

--- a/src/transformers/models/video_llama_3/image_processing_video_llama_3_fast.py
+++ b/src/transformers/models/video_llama_3/image_processing_video_llama_3_fast.py
@@ -103,6 +103,9 @@ class VideoLlama3ImageProcessorFast(BaseImageProcessorFast):
             raise ValueError("size must contain 'shortest_edge' and 'longest_edge' keys.")
 
         super().__init__(size=size, **kwargs)
+        # Maintain backward compatibility by setting min_pixels/max_pixels attributes
+        self.min_pixels = self.size.get("shortest_edge")
+        self.max_pixels = self.size.get("longest_edge")
 
     def _further_process_kwargs(
         self,


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `Qwen2VLImageProcessorFast` doesn't set `min_pixels` and `max_pixels` instance attributes, breaking compatibility with code that expects these attributes.

## The Problem

The slow processor (`Qwen2VLImageProcessor`) sets `self.min_pixels` and `self.max_pixels` as instance attributes. The fast processor converts these to `size["shortest_edge"]` and `size["longest_edge"]` but never sets the original attributes.

This causes vLLM (and potentially other libraries) to fail when loading Qwen2-VL/Qwen2.5-Omni models:

```
File "transformers/models/qwen2_vl/image_processing_qwen2_vl.py", line 92, in smart_resize
    if h_bar * w_bar > max_pixels:
TypeError: '>' not supported between instances of 'int' and 'NoneType'
```

### Why config values don't help

Even if `preprocessor_config.json` contains `min_pixels` and `max_pixels` values, this doesn't fix the issue because:

1. `use_fast: false` in the config is **ignored** - transformers 5.0 always auto-upgrades to the fast processor
2. The fast processor receives these values as kwargs but only stores them in `self.size` dict, not as instance attributes
3. Code accessing `processor.min_pixels` gets `None` instead of the config value

## The Fix

Set `min_pixels` and `max_pixels` attributes after `super().__init__()` to maintain backward compatibility:

```python
super().__init__(size=size, **kwargs)
self.min_pixels = self.size.get("shortest_edge")
self.max_pixels = self.size.get("longest_edge")
```

## Verification

```python
from transformers import AutoProcessor

# Before fix
processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-7B-Instruct")
print(processor.image_processor.min_pixels)  # None
print(processor.image_processor.max_pixels)  # None

# After fix
print(processor.image_processor.min_pixels)  # 3136
print(processor.image_processor.max_pixels)  # 12845056
```