### PR TITLE
Increase timeout when preparing CI

### DIFF
--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -7,6 +7,7 @@ from huggingface_hub import hf_hub_download, snapshot_download
 from transformers.testing_utils import _run_pipeline_tests, _run_staging
 from transformers.utils.import_utils import is_mistral_common_available
 
+httpx._config.DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(timeout=60.)
 
 URLS_FOR_TESTING_DATA = [
     "http://images.cocodataset.org/val2017/000000000139.jpg",

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -7,7 +7,8 @@ from huggingface_hub import hf_hub_download, snapshot_download
 from transformers.testing_utils import _run_pipeline_tests, _run_staging
 from transformers.utils.import_utils import is_mistral_common_available
 
-httpx._config.DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(timeout=60.)
+
+httpx._config.DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(timeout=60.0)
 
 URLS_FOR_TESTING_DATA = [
     "http://images.cocodataset.org/val2017/000000000139.jpg",


### PR DESCRIPTION
We switched from `requests`, with no timeout by default, to `httpx`, which does have a read timeout by default. This causes some timeout errors in the CI, so this PR increases the timeout length by following the snippet [here](https://github.com/encode/httpx/discussions/3356)