### PR TITLE
Add GIT support to visual-question-answering pipeline

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -1327,6 +1327,7 @@ MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
         ("blip", "BlipForQuestionAnswering"),
         ("blip-2", "Blip2ForConditionalGeneration"),
+        ("git", "GitForCausalLM"),
         ("vilt", "ViltForQuestionAnswering"),
     ]
 )

--- a/tests/models/git/test_modeling_git.py
+++ b/tests/models/git/test_modeling_git.py
@@ -373,6 +373,7 @@ class GitModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
             "image-to-text": GitForCausalLM,
             "text-generation": GitForCausalLM,
             "image-text-to-text": GitForCausalLM,
+            "visual-question-answering": GitForCausalLM,
             "any-to-any": GitForCausalLM,
         }
         if is_torch_available()


### PR DESCRIPTION
# What does this PR do?

This PR adds GIT to the auto-model mapping for the visual-question-answering pipeline and updates the corresponding GIT pipeline test mapping.

This ensures that GIT models (e.g. GitForCausalLM) are correctly recognized and usable with the visual-question-answering pipeline, consistent with existing generative model support.

## Issue

Partially addresses #21110

## Tests
- pytest tests/models/git/test_modeling_git.py -v -k "pipeline" -x
- pytest tests/pipelines/test_pipelines_visual_question_answering.py -v -x

---

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue or the forum?  
  Issue reference: #21110
- [ ] Did you make sure to update the documentation with your changes?  
  (Not required — registration/test-only change)
- [x] Did you write any new necessary tests?  
  (No new tests required; existing pipeline tests cover this change)

---

## Who can review?

@Rocketknight1