### PR TITLE
Fix: Add missing pad_token_id to StableLmConfig

### DIFF
--- a/src/transformers/models/stablelm/configuration_stablelm.py
+++ b/src/transformers/models/stablelm/configuration_stablelm.py
@@ -87,7 +87,9 @@ class StableLmConfig(PreTrainedConfig, RotaryEmbeddingConfigMixin):
             The id of the `BOS` token in the vocabulary.
         eos_token_id (int, *optional*, defaults to 0):
             The id of the `EOS` token in the vocabulary.
-
+        pad_token_id (int, *optional*):
+            The id of the `PAD` token in the vocabulary.
+    
     Example:
 
     ```python
@@ -122,6 +124,7 @@ class StableLmConfig(PreTrainedConfig, RotaryEmbeddingConfigMixin):
         attention_dropout: float | None = 0.0,
         bos_token_id: int | None = 0,
         eos_token_id: int | None = 0,
+        pad_token_id: int | None = None,
         **kwargs,
     ):
         self.vocab_size = vocab_size
@@ -147,6 +150,7 @@ class StableLmConfig(PreTrainedConfig, RotaryEmbeddingConfigMixin):
 
         self.bos_token_id = bos_token_id
         self.eos_token_id = eos_token_id
+        self.pad_token_id = pad_token_id
         self.tie_word_embeddings = tie_word_embeddings
         super().__init__(**kwargs)
 

--- a/src/transformers/models/stablelm/configuration_stablelm.py
+++ b/src/transformers/models/stablelm/configuration_stablelm.py
@@ -89,7 +89,7 @@ class StableLmConfig(PreTrainedConfig, RotaryEmbeddingConfigMixin):
             The id of the `EOS` token in the vocabulary.
         pad_token_id (int, *optional*):
             The id of the `PAD` token in the vocabulary.
-    
+
     Example:
 
     ```python

--- a/tests/models/stablelm/test_modeling_stablelm.py
+++ b/tests/models/stablelm/test_modeling_stablelm.py
@@ -47,6 +47,16 @@ class StableLmModelTester(CausalLMModelTester):
 @require_torch
 class StableLmModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = StableLmModelTester
+    def test_config_has_pad_token_id(self):
+        """Test that StableLmConfig includes pad_token_id attribute (fixes #43572)"""
+        from transformers import StableLmConfig
+        
+        config = StableLmConfig()
+        self.assertTrue(hasattr(config, "pad_token_id"))
+        
+        # Verify model can be instantiated from config without AttributeError
+        model = StableLmModel(config)
+        self.assertIsNotNone(model)
 
 
 @require_torch


### PR DESCRIPTION
## What does this PR do?

Fixes #43572

Adds the missing `pad_token_id` parameter to `StableLmConfig` to resolve the `AttributeError` when creating StableLM models from config.

## Changes made:
- Added `pad_token_id` parameter to `__init__` method (defaults to `None`)
- Added `self.pad_token_id = pad_token_id` assignment
- Updated docstring to document the new parameter

## Testing:
Verified that `AutoModelForCausalLM.from_config(StableLmConfig())` now works without errors.

## Before submitting
- [x] This PR fixes a bug
- [x] Code follows existing patterns (matches bos_token_id and eos_token_id)
- [x] Documentation updated in docstring

cc @ArthurZucker @Cyrilvallez @itazap