### PR TITLE
skip torch export tests for lighton_ocr model

### DIFF
--- a/tests/models/lighton_ocr/test_modeling_lighton_ocr.py
+++ b/tests/models/lighton_ocr/test_modeling_lighton_ocr.py
@@ -227,6 +227,8 @@ class LightOnOcrForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
     pipeline_model_mapping = {"image-text-to-text": LightOnOcrForConditionalGeneration} if is_torch_available() else {}
     # LightOnOcr uses a PixtralVisionModel, which merges batch_size and num_patches in index 1, with index 0 hardcoded to 1
     skip_test_image_features_output_shape = True
+    # Pixtral vision encoder uses dynamic slicing, which is incompatible with torch.export's requirement
+    test_torch_exportable = False
 
     _is_composite = True
 


### PR DESCRIPTION
We meet 2 failed test cases for lighton_ocr model:
```
tests/models/lighton_ocr/test_modeling_lighton_ocr.py::LightOnOcrForConditionalGenerationModelTest::test_torch_export
tests/models/lighton_ocr/test_modeling_lighton_ocr.py::LightOnOcrForConditionalGenerationModelTest::test_torch_export
```
These 2 failed cases are root caused as the vision encoder model(Pixtral) is not suitbale for torch.export in [L498](https://github.com/huggingface/transformers/blob/main/src/transformers/models/pixtral/modeling_pixtral.py#L498), we should skip the tests. 