### PR TITLE
Fix mistral checkpoint loading in `utils/fetch_hub_objects_for_ci.py`: avoid too many requests and/or timeout

### DIFF
--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -104,8 +104,8 @@ class CircleCIJob:
         else:
             # BIG HACK WILL REMOVE ONCE FETCHER IS UPDATED
             print(os.environ.get("GIT_COMMIT_MESSAGE"))
-            # if "[build-ci-image]" in os.environ.get("GIT_COMMIT_MESSAGE", "") or os.environ.get("GIT_COMMIT_MESSAGE", "") == "dev-ci":
-            self.docker_image[0]["image"] = f"{self.docker_image[0]['image']}:dev"
+            if "[build-ci-image]" in os.environ.get("GIT_COMMIT_MESSAGE", "") or os.environ.get("GIT_COMMIT_MESSAGE", "") == "dev-ci":
+                self.docker_image[0]["image"] = f"{self.docker_image[0]['image']}:dev"
             print(f"Using {self.docker_image} docker image")
         if self.install_steps is None:
             self.install_steps = ["uv pip install ."]

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+a = 1
+
 import argparse
 import copy
 import os

--- a/.circleci/create_circleci_config.py
+++ b/.circleci/create_circleci_config.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-a = 1
-
 import argparse
 import copy
 import os
@@ -107,8 +104,8 @@ class CircleCIJob:
         else:
             # BIG HACK WILL REMOVE ONCE FETCHER IS UPDATED
             print(os.environ.get("GIT_COMMIT_MESSAGE"))
-            if "[build-ci-image]" in os.environ.get("GIT_COMMIT_MESSAGE", "") or os.environ.get("GIT_COMMIT_MESSAGE", "") == "dev-ci":
-                self.docker_image[0]["image"] = f"{self.docker_image[0]['image']}:dev"
+            # if "[build-ci-image]" in os.environ.get("GIT_COMMIT_MESSAGE", "") or os.environ.get("GIT_COMMIT_MESSAGE", "") == "dev-ci":
+            self.docker_image[0]["image"] = f"{self.docker_image[0]['image']}:dev"
             print(f"Using {self.docker_image} docker image")
         if self.install_steps is None:
             self.install_steps = ["uv pip install ."]

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -285,11 +285,13 @@ if __name__ == "__main__":
                 revision=None,
             )
 
-            MistralTokenizer.from_hf_hub(repo_id)
+            MistralTokenizer.from_hf_hub(repo_id, local_files_only=local_files_only)
 
             repo_id = "mistralai/Voxtral-Mini-3B-2507"
+            local_files_only = len(list_local_hf_repo_files(repo_id, revision=None)) > 0
+
             AutoTokenizer.from_pretrained(repo_id)
-            MistralTokenizer.from_hf_hub(repo_id)
+            MistralTokenizer.from_hf_hub(repo_id, local_files_only=local_files_only)
 
     # Download files from URLs to local directory
     for url in URLS_FOR_TESTING_DATA:

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -279,7 +279,9 @@ if __name__ == "__main__":
 
             # This will go the path `transformers/tokenization_mistral_common.py::MistralCommonBackend::from_pretrained --> mistral_common.tokens.tokenizers.utils.download_tokenizer_from_hf_hub`.
             # No idea at all why we need the statement below again (`MistralCommonBackend.from_pretrained`).
-            AutoTokenizer.from_pretrained(repo_id, tokenizer_type="mistral", local_files_only=local_files_only, revision=None)
+            AutoTokenizer.from_pretrained(
+                repo_id, tokenizer_type="mistral", local_files_only=local_files_only, revision=None
+            )
 
             _ = MistralCommonBackend.from_pretrained(
                 repo_id,

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -273,10 +273,14 @@ if __name__ == "__main__":
             from transformers.tokenization_mistral_common import MistralCommonBackend
 
             repo_id = "hf-internal-testing/namespace-mistralai-repo_name-Mistral-Small-3.1-24B-Instruct-2503"
-            AutoTokenizer.from_pretrained(repo_id, tokenizer_type="mistral")
 
             # determine if we already have this downloaded
             local_files_only = len(list_local_hf_repo_files(repo_id, revision=None)) > 0
+
+            # This will go the path `transformers/tokenization_mistral_common.py::MistralCommonBackend::from_pretrained --> mistral_common.tokens.tokenizers.utils.download_tokenizer_from_hf_hub`.
+            # No idea at all why we need the statement below again (`MistralCommonBackend.from_pretrained`).
+            AutoTokenizer.from_pretrained(repo_id, tokenizer_type="mistral", local_files_only=local_files_only, revision=None)
+
             _ = MistralCommonBackend.from_pretrained(
                 repo_id,
                 local_files_only=local_files_only,

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -267,13 +267,24 @@ if __name__ == "__main__":
         # `mistral_common.tokens.tokenizers.utils.download_tokenizer_from_hf_hub` which (probably) doesn't have the cache.
         if is_mistral_common_available():
             from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
+            from mistral_common.tokens.tokenizers.utils import list_local_hf_repo_files
 
             from transformers import AutoTokenizer
             from transformers.tokenization_mistral_common import MistralCommonBackend
 
             repo_id = "hf-internal-testing/namespace-mistralai-repo_name-Mistral-Small-3.1-24B-Instruct-2503"
             AutoTokenizer.from_pretrained(repo_id, tokenizer_type="mistral")
-            MistralCommonBackend.from_pretrained(repo_id)
+
+            # determine if we already have this downloaded
+            local_files_only = len(list_local_hf_repo_files(repo_id, revision=None)) > 0
+            _ = MistralCommonBackend.from_pretrained(
+                repo_id,
+                local_files_only=local_files_only,
+                # This is a hack as `list_local_hf_repo_files` from `mistral_common` has a bug
+                # TODO: Discuss with `mistral-common` maintainers: after a fix being done there, remove this `revision` hack
+                revision=None,
+            )
+
             MistralTokenizer.from_hf_hub(repo_id)
 
             repo_id = "mistralai/Voxtral-Mini-3B-2507"

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -296,7 +296,7 @@ if __name__ == "__main__":
             repo_id = "mistralai/Voxtral-Mini-3B-2507"
             local_files_only = len(list_local_hf_repo_files(repo_id, revision=None)) > 0
 
-            AutoTokenizer.from_pretrained(repo_id)
+            AutoTokenizer.from_pretrained(repo_id, local_files_only=local_files_only)
             MistralTokenizer.from_hf_hub(repo_id, local_files_only=local_files_only)
 
     # Download files from URLs to local directory

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -265,6 +265,7 @@ if __name__ == "__main__":
 
         # For `tests/test_tokenization_mistral_common.py:TestMistralCommonBackend`, which eventually calls
         # `mistral_common.tokens.tokenizers.utils.download_tokenizer_from_hf_hub` which (probably) doesn't have the cache.
+        # For `revision=None`, see https://github.com/huggingface/transformers/pull/40623
         if is_mistral_common_available():
             from mistral_common.tokens.tokenizers.mistral import MistralTokenizer
             from mistral_common.tokens.tokenizers.utils import list_local_hf_repo_files

--- a/utils/fetch_hub_objects_for_ci.py
+++ b/utils/fetch_hub_objects_for_ci.py
@@ -296,7 +296,7 @@ if __name__ == "__main__":
             repo_id = "mistralai/Voxtral-Mini-3B-2507"
             local_files_only = len(list_local_hf_repo_files(repo_id, revision=None)) > 0
 
-            AutoTokenizer.from_pretrained(repo_id, local_files_only=local_files_only)
+            AutoTokenizer.from_pretrained(repo_id, local_files_only=local_files_only, revision=None)
             MistralTokenizer.from_hf_hub(repo_id, local_files_only=local_files_only)
 
     # Download files from URLs to local directory


### PR DESCRIPTION
# What does this PR do?

Just reuse the local files as much as possible