### PR TITLE
Simplify loading structure

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -20,7 +20,7 @@ import os
 import re
 from abc import abstractmethod
 from collections import defaultdict
-from collections.abc import Callable, MutableMapping, MutableSet
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import deepcopy
@@ -33,6 +33,7 @@ import torch
 from .integrations.accelerate import get_device, offload_weight
 from .integrations.tensor_parallel import ALL_PARALLEL_STYLES
 from .utils import is_env_variable_true, logging
+from .utils.loading_report import LoadStateDictInfo
 
 
 _torch_distributed_available = torch.distributed.is_available()
@@ -656,8 +657,7 @@ class WeightRenaming(WeightTransform):
         model=None,
         config=None,
         hf_quantizer=None,
-        missing_keys: MutableSet[str] | None = None,
-        conversion_errors: MutableMapping[str, str] | None = None,
+        loading_info: LoadStateDictInfo | None = None,
     ):
         # Collect the tensors here - we use a new dictionary to avoid keeping them in memory in the internal
         # attribute during the whole process
@@ -670,7 +670,7 @@ class WeightRenaming(WeightTransform):
 
         if hf_quantizer is not None and self.quantization_operation is not None:
             with log_conversion_errors(
-                layer_name, conversion_errors, (len(collected_tensors), layer_name), self.quantization_operation
+                layer_name, loading_info, (len(collected_tensors), layer_name), self.quantization_operation
             ):
                 collected_tensors = self.quantization_operation.convert(
                     collected_tensors,
@@ -679,10 +679,10 @@ class WeightRenaming(WeightTransform):
                     full_layer_name=target_key,
                     model=model,
                     config=config,
-                    missing_keys=missing_keys,
+                    missing_keys=loading_info.missing_keys if loading_info else None,
                 )
 
-        return collected_tensors, conversion_errors
+        return collected_tensors
 
 
 # List of classes that are known to be able to use m:n
@@ -713,15 +713,14 @@ class WeightConverter(WeightTransform):
         model=None,
         config=None,
         hf_quantizer=None,
-        missing_keys: MutableSet[str] | None = None,
-        conversion_errors: MutableMapping[str, str] | None = None,
+        loading_info: LoadStateDictInfo | None = None,
     ):
         # Collect the tensors here - we use a new dictionary to avoid keeping them in memory in the internal
         # attribute during the whole process
         collected_tensors = self.materialize_tensors()
 
         for op in self.operations:
-            with log_conversion_errors(layer_name, conversion_errors, (len(collected_tensors), layer_name), op):
+            with log_conversion_errors(layer_name, loading_info, (len(collected_tensors), layer_name), op):
                 collected_tensors = op.convert(
                     collected_tensors,
                     source_patterns=self.source_patterns,
@@ -730,7 +729,7 @@ class WeightConverter(WeightTransform):
                     full_layer_name=layer_name,
                     model=model,
                     config=config,
-                    missing_keys=missing_keys,
+                    missing_keys=loading_info.missing_keys if loading_info else None,
                 )
 
         # Tensors are returned from ops with the target patterns, we need to expand them to full name.
@@ -749,7 +748,7 @@ class WeightConverter(WeightTransform):
 
         if hf_quantizer is not None and self.quantization_operation is not None:
             with log_conversion_errors(
-                layer_name, conversion_errors, (len(collected_tensors), layer_name), self.quantization_operation
+                layer_name, loading_info, (len(collected_tensors), layer_name), self.quantization_operation
             ):
                 collected_tensors = self.quantization_operation.convert(
                     collected_tensors,
@@ -758,9 +757,9 @@ class WeightConverter(WeightTransform):
                     full_layer_name=layer_name,
                     config=config,
                     model=model,
-                    missing_keys=missing_keys,
+                    missing_keys=loading_info.missing_keys if loading_info else None,
                 )
-        return collected_tensors, conversion_errors
+        return collected_tensors
 
 
 # For I/O bound operations (i.e. here reading files), it is better to have fewer threads, e.g. 4 is a good default.
@@ -823,7 +822,7 @@ def dot_natural_key(s: str):
 @contextmanager
 def log_conversion_errors(
     first_target_key: str,
-    conversion_errors: MutableMapping[str, str] | None,
+    loading_info: LoadStateDictInfo | None,
     extras: Any = None,
     op: list[ConversionOps] | ConversionOps | None = None,
 ):
@@ -833,7 +832,7 @@ def log_conversion_errors(
         yield
     except Exception as e:
         # During reverse mapping, we do not log and skip errors
-        if conversion_errors is None:
+        if loading_info is None:
             raise e
 
         def _format_op_name(curr_op: list[ConversionOps] | ConversionOps | None) -> str | None:
@@ -850,16 +849,16 @@ def log_conversion_errors(
         if isinstance(extras, tuple) and len(extras) == 2:
             length, target_keys = extras
             descriptor = f"{op_name} " if op_name else ""
-            conversion_errors[first_target_key] = (
+            loading_info.conversion_errors[first_target_key] = (
                 f"{e}\nError: {descriptor}on tensors destined for {target_keys}. Ckpt contains: {length}"
             )
         elif isinstance(extras, str):
             suffix = f" via {op_name}" if op_name else ""
-            conversion_errors[first_target_key] = f"{e}\nError{suffix} when processing parameter {extras}"
+            loading_info.conversion_errors[first_target_key] = f"{e}\nError{suffix} when processing parameter {extras}"
         elif extras is None and op_name:
-            conversion_errors[first_target_key] = f"{op_name}: {e}"
+            loading_info.conversion_errors[first_target_key] = f"{op_name}: {e}"
         else:
-            conversion_errors[first_target_key] = f"{extras} |Error: {e}"
+            loading_info.conversion_errors[first_target_key] = f"{extras} |Error: {e}"
 
         # Raise a specific Exception that we can catch easily
         raise SkipParameters()
@@ -869,9 +868,7 @@ def set_param_for_module(
     model: PreTrainedModel,
     target_name: str,
     param_value: torch.Tensor,
-    mismatch_keys: MutableSet[tuple[str, torch.Size, torch.Size]],
-    missing_keys: MutableSet[str],
-    unexpected_keys: MutableSet[str],
+    loading_info: LoadStateDictInfo,
     distributed_operation: TensorParallelLayer | None,
     hf_quantizer: HfQuantizer,
 ):
@@ -880,14 +877,14 @@ def set_param_for_module(
 
     ref = getattr(module_obj, param_name)
     if ref is None:
-        unexpected_keys.add(target_name)
+        loading_info.unexpected_keys.add(target_name)
     else:
         if not isinstance(param_value, torch.nn.Parameter):
             if param_name not in module_obj._buffers:
                 param_value = torch.nn.Parameter(param_value, requires_grad=param_value.is_floating_point())
 
         # Remove from missing keys (it's either mismatched, or all good)
-        missing_keys.discard(target_name)
+        loading_info.missing_keys.discard(target_name)
 
         # Determine expected shape: for TP, use sharded shape; otherwise, use full shape
         if distributed_operation is not None:
@@ -896,7 +893,7 @@ def set_param_for_module(
             expected_shape = ref.shape
 
         if ref is not None and param_value.shape != expected_shape and hf_quantizer is None:
-            mismatch_keys.add((target_name, param_value.shape, expected_shape))
+            loading_info.mismatch_keys.add((target_name, param_value.shape, expected_shape))
         else:
             # super important otherwise _init_weight will re-init the param
             param_value._is_hf_initialized = True
@@ -906,7 +903,7 @@ def set_param_for_module(
 def offload_and_maybe_resave_param(
     target_name: str,
     param: torch.Tensor,
-    missing_keys: MutableSet[str],
+    loading_info: LoadStateDictInfo,
     disk_offload_folder: str,
     disk_offload_index: dict,
     applied_ops: WeightConverter | WeightRenaming,
@@ -915,7 +912,7 @@ def offload_and_maybe_resave_param(
     WeightConverter operations have been applied, it will resave the new parameter. Otherwise, it will use the original
     `disk_offload_index` for this given param."""
     # We need to remove from missing keys
-    missing_keys.discard(target_name)
+    loading_info.missing_keys.discard(target_name)
     # If not already offloaded, or if we applied any special Operation except Renaming, we need to re-save
     if target_name not in disk_offload_index or isinstance(applied_ops, WeightConverter):
         disk_offload_index = offload_weight(param, target_name, disk_offload_folder, disk_offload_index)
@@ -1074,10 +1071,14 @@ def convert_and_load_state_dict_in_model(
     meta_model_state_dict = model.state_dict()
     model_buffers = {k for k, _ in model.named_buffers()}
 
-    missing_keys = set(meta_model_state_dict.keys())
-    conversion_errors = {}
-    mismatch_keys = set()
-    unexpected_keys = set()
+    # We start from all missing keys, and we will remove/add them from the proper containers as loading advances
+    loading_info = LoadStateDictInfo(
+        missing_keys=set(meta_model_state_dict.keys()),
+        unexpected_keys=set(),
+        mismatched_keys=set(),
+        conversion_errors={},
+        error_msgs=[],
+    )
 
     # We use threading by default, if not explicitly deactivated via env variable. If we have to offload,
     # we cannot use it either to control the memory as we are under memory constraints, so we need to be sequential
@@ -1107,7 +1108,7 @@ def convert_and_load_state_dict_in_model(
         )
 
         # 2. finally, collect the tensor into the proper converter
-        if renamed_key in missing_keys:
+        if renamed_key in meta_model_state_dict:
             empty_param = meta_model_state_dict.get(renamed_key)
             # If we enter here, we have a WeightConverter operation to perform
             if source_pattern is not None:
@@ -1168,9 +1169,9 @@ def convert_and_load_state_dict_in_model(
         elif source_pattern is not None:  # add all target keys as unexpected
             mapping = pattern_to_converter[source_pattern]
             for k in mapping.target_patterns:
-                unexpected_keys.add(renamed_key.replace(mapping.target_patterns[0], k))
+                loading_info.unexpected_keys.add(renamed_key.replace(mapping.target_patterns[0], k))
         else:
-            unexpected_keys.add(renamed_key)
+            loading_info.unexpected_keys.add(renamed_key)
 
     try:
         total_entries = len(param_name_to_load)
@@ -1180,13 +1181,12 @@ def convert_and_load_state_dict_in_model(
                 pbar.set_postfix({"Materializing param": first_param_name})
                 pbar.refresh()
                 try:
-                    realized_value, conversion_errors = mapping.convert(
+                    realized_value = mapping.convert(
                         first_param_name,
                         model=model,
                         config=model.config,
                         hf_quantizer=hf_quantizer,
-                        missing_keys=missing_keys,
-                        conversion_errors=conversion_errors,
+                        loading_info=loading_info,
                     )
                     for target_name, param in realized_value.items():
                         param = param[0] if isinstance(param, list) else param
@@ -1194,16 +1194,14 @@ def convert_and_load_state_dict_in_model(
                         # Offloading support
                         if param_device == "disk" and (target_name not in model_buffers or offload_buffers):
                             disk_offload_index = offload_and_maybe_resave_param(
-                                target_name, param, missing_keys, disk_offload_folder, disk_offload_index, mapping
+                                target_name, param, loading_info, disk_offload_folder, disk_offload_index, mapping
                             )
                         else:
                             set_param_for_module(
                                 model,
                                 target_name,
                                 param,
-                                mismatch_keys,
-                                missing_keys,
-                                unexpected_keys,
+                                loading_info,
                                 mapping.distributed_operation,
                                 hf_quantizer,
                             )
@@ -1222,7 +1220,7 @@ def convert_and_load_state_dict_in_model(
 
     # Keep the current weight conversion mapping for later saving (in case it was coming directly from the user)
     model._weight_conversions = weight_mapping
-    return missing_keys, unexpected_keys, mismatch_keys, disk_offload_index, conversion_errors
+    return loading_info, disk_offload_index
 
 
 def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch.Tensor]):
@@ -1269,7 +1267,7 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
     new_state_dict = {}
     for first_param_name, reversed_converter in conversion_mapping.items():
         # Apply the reverse converter
-        realized_value, _ = reversed_converter.convert(first_param_name, model=model, config=model.config)
+        realized_value = reversed_converter.convert(first_param_name, model=model, config=model.config)
         for target_name, param in realized_value.items():
             param = param[0] if isinstance(param, list) else param
             new_state_dict[target_name] = param

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -893,7 +893,7 @@ def set_param_for_module(
             expected_shape = ref.shape
 
         if ref is not None and param_value.shape != expected_shape and hf_quantizer is None:
-            loading_info.mismatch_keys.add((target_name, param_value.shape, expected_shape))
+            loading_info.mismatched_keys.add((target_name, param_value.shape, expected_shape))
         else:
             # super important otherwise _init_weight will re-init the param
             param_value._is_hf_initialized = True

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4079,7 +4079,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             download_kwargs=download_kwargs,
         )
         loading_info, disk_offload_index = cls._load_pretrained_model(model, state_dict, checkpoint_files, load_config)
-        loading_info = cls._finalize_load_state_dict(model, load_config, loading_info)
+        loading_info = cls._finalize_model_loading(model, load_config, loading_info)
         model.eval()  # Set model in evaluation mode to deactivate Dropout modules by default
         model.set_use_kernels(use_kernels, kernel_config)
 
@@ -4213,10 +4213,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         return loading_info, disk_offload_index
 
     @staticmethod
-    def _finalize_load_state_dict(
+    def _finalize_model_loading(
         model, load_config: LoadStateDictConfig, loading_info: LoadStateDictInfo
     ) -> LoadStateDictInfo:
-        """Performs all post processing operations after having loaded some checkpoints into a model, such as moving
+        """Perform all post processing operations after having loaded some checkpoints into a model, such as moving
         missing keys from meta device to their expected device, reinitializing missing weights according to proper
         distributions, tying the weights and logging the loading report."""
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -26,7 +26,7 @@ from abc import abstractmethod
 from collections import defaultdict
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, field
 from enum import Enum
 from functools import partial, wraps
 from itertools import cycle
@@ -126,7 +126,7 @@ from .utils.import_utils import (
     is_sagemaker_mp_enabled,
     is_tracing,
 )
-from .utils.loading_report import log_state_dict_report
+from .utils.loading_report import LoadStateDictInfo, log_state_dict_report
 from .utils.quantization_config import QuantizationMethod
 
 
@@ -170,7 +170,7 @@ class LoadStateDictConfig:
 
     pretrained_model_name_or_path: str | None = None
     download_kwargs: DownloadKwargs | None = field(default_factory=DownloadKwargs)
-    use_safetensors: bool = True
+    use_safetensors: bool | None = None
     ignore_mismatched_sizes: bool = False
     sharded_metadata: dict | None = None
     device_map: dict | None = None
@@ -185,21 +185,6 @@ class LoadStateDictConfig:
     @property
     def is_quantized(self) -> bool:
         return self.hf_quantizer is not None
-
-
-@dataclass
-class LoadStateDictInfo:
-    """
-    Return container for state-dict loading results and diagnostics.
-    This simplifies the code a bit.
-    """
-
-    missing_keys: set[str]
-    unexpected_keys: set[str]
-    mismatched_keys: set[tuple[str, torch.Size]]
-    disk_offload_index: dict[str, str] | None
-    error_msgs: list[str]
-    conversion_errors: set[str]
 
 
 def is_local_dist_rank_0():
@@ -4096,8 +4081,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             use_safetensors=use_safetensors,
             download_kwargs=download_kwargs,
         )
-        load_info = cls._load_pretrained_model(model, state_dict, checkpoint_files, load_config)
-        load_info = cls._finalize_load_state_dict(model, load_config, load_info)
+        loading_info, disk_offload_index = cls._load_pretrained_model(model, state_dict, checkpoint_files, load_config)
         model.eval()  # Set model in evaluation mode to deactivate Dropout modules by default
         model.set_use_kernels(use_kernels, kernel_config)
 
@@ -4116,9 +4100,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         # If the device_map has more than 1 device: dispatch model with hooks on all devices
         if device_map is not None and len(set(device_map.values())) > 1:
-            accelerate_dispatch(
-                model, hf_quantizer, device_map, offload_folder, load_info.disk_offload_index, offload_buffers
-            )
+            accelerate_dispatch(model, hf_quantizer, device_map, offload_folder, disk_offload_index, offload_buffers)
 
         if hf_quantizer is not None:
             model.hf_quantizer = hf_quantizer
@@ -4129,7 +4111,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if _adapter_model_path is not None:
             if token is not None:
                 adapter_kwargs["token"] = token
-            load_info = model.load_adapter(
+            loading_info = model.load_adapter(
                 _adapter_model_path,
                 adapter_name=adapter_name,
                 load_config=load_config,
@@ -4137,13 +4119,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             )
 
         if output_loading_info:
-            loading_info = {
-                "missing_keys": load_info.missing_keys,
-                "unexpected_keys": load_info.unexpected_keys,
-                "mismatched_keys": load_info.mismatched_keys,
-                "error_msgs": load_info.error_msgs,
-            }
-            return model, loading_info
+            return model, loading_info.to_dict()
         return model
 
     @classmethod
@@ -4153,7 +4129,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         state_dict: dict | None,
         checkpoint_files: list[str] | None,
         load_config: LoadStateDictConfig,
-    ) -> LoadStateDictInfo:
+    ) -> tuple[LoadStateDictInfo, dict]:
         is_quantized = load_config.is_quantized
         is_hqq_or_quark = is_quantized and load_config.hf_quantizer.quantization_config.quant_method in {
             QuantizationMethod.HQQ,
@@ -4197,7 +4173,13 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 state_dict = merged_state_dict
             error_msgs, missing_keys = _load_state_dict_into_zero3_model(model, state_dict, load_config)
             # This is not true but for now we assume only best-case scenario with deepspeed, i.e. perfectly matching checkpoints
-            unexpected_keys, mismatched_keys, conversion_errors = set(), set(), set()
+            loading_info = LoadStateDictInfo(
+                missing_keys=missing_keys,
+                error_msgs=error_msgs,
+                unexpected_keys=set(),
+                mismatched_keys=set(),
+                conversion_errors={},
+            )
         else:
             all_pointer = set()
             if state_dict is not None:
@@ -4217,73 +4199,49 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             else:
                 raise ValueError("Neither a state dict nor checkpoint files were found.")
 
-            missing_keys, unexpected_keys, mismatched_keys, disk_offload_index, conversion_errors = (
-                convert_and_load_state_dict_in_model(
-                    model=model,
-                    state_dict=merged_state_dict,
-                    load_config=load_config,
-                    tp_plan=model._tp_plan,
-                    dtype_plan=model.dtype_plan,
-                    disk_offload_index=disk_offload_index,
-                )
+            loading_info, disk_offload_index = convert_and_load_state_dict_in_model(
+                model=model,
+                state_dict=merged_state_dict,
+                load_config=load_config,
+                tp_plan=model._tp_plan,
+                dtype_plan=model.dtype_plan,
+                disk_offload_index=disk_offload_index,
             )
 
             # finally close all opened file pointers
             for k in all_pointer:
                 k.__exit__(None, None, None)
 
-        return LoadStateDictInfo(
-            missing_keys=missing_keys,
-            unexpected_keys=unexpected_keys,
-            mismatched_keys=mismatched_keys,
-            disk_offload_index=disk_offload_index,
-            error_msgs=error_msgs,
-            conversion_errors=conversion_errors,
-        )
-
-    @staticmethod
-    def _finalize_load_state_dict(
-        model,
-        load_config: LoadStateDictConfig,
-        load_info: LoadStateDictInfo,
-    ) -> LoadStateDictInfo:
-        # TODO @ArthurZucker this will be in a separate function to allows people not to run this
-        # for more granularity
-
         # Marks tied weights as `_is_hf_initialized` to avoid initializing them (it's very important for efficiency)
         model.mark_tied_weights_as_initialized()
 
         # Move missing (and potentially mismatched) keys and non-persistent buffers back to their expected device from
         # meta device (because they were not moved when loading the weights as they were not in the loaded state dict)
-        missing_and_mismatched = load_info.missing_keys | {k[0] for k in load_info.mismatched_keys}
         model._move_missing_keys_from_meta_to_device(
-            missing_and_mismatched, load_config.device_map, load_config.device_mesh, load_config.hf_quantizer
+            loading_info.missing_and_mismatched(),
+            load_config.device_map,
+            load_config.device_mesh,
+            load_config.hf_quantizer,
         )
 
         # Correctly initialize the missing (and potentially mismatched) keys (all parameters without the `_is_hf_initialized` flag)
         model._initialize_missing_keys(load_config.is_quantized)
 
         # Tie the weights
-        model.tie_weights(missing_keys=load_info.missing_keys, recompute_mapping=False)
+        model.tie_weights(missing_keys=loading_info.missing_keys, recompute_mapping=False)
 
         # Adjust missing and unexpected keys
-        missing_keys, unexpected_keys = model._adjust_missing_and_unexpected_keys(
-            load_info.missing_keys, load_info.unexpected_keys
-        )
+        model._adjust_missing_and_unexpected_keys(loading_info)
 
         log_state_dict_report(
             model=model,
-            load_config=load_config,
+            pretrained_model_name_or_path=load_config.pretrained_model_name_or_path,
+            ignore_mismatched_sizes=load_config.ignore_mismatched_sizes,
+            loading_info=loading_info,
             logger=logger,
-            error_msgs=load_info.error_msgs,
-            unexpected_keys=unexpected_keys,
-            missing_keys=missing_keys,
-            mismatched_keys=load_info.mismatched_keys,
-            mismatched_shapes=load_info.mismatched_keys,
-            conversion_errors=load_info.conversion_errors,
         )
 
-        return replace(load_info, missing_keys=missing_keys, unexpected_keys=unexpected_keys)
+        return loading_info, disk_offload_index
 
     def retrieve_modules_from_names(self, names, add_prefix=False, remove_prefix=False):
         module_keys = {".".join(key.split(".")[:-1]) for key in names}
@@ -4539,11 +4497,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         else:
             self.initialize_weights()
 
-    def _adjust_missing_and_unexpected_keys(
-        self, missing_keys: set[str], unexpected_keys: set[str]
-    ) -> tuple[set[str], set[str]]:
+    def _adjust_missing_and_unexpected_keys(self, loading_info: LoadStateDictInfo) -> None:
         """Adjust the `missing_keys` and `unexpected_keys` based on current model's exception rules, to avoid
-        raising unneeded warnings/errors.
+        raising unneeded warnings/errors. This is performed in-place.
         """
         # Old checkpoints may have keys for rotary_emb.inv_freq forach layer, however we moved this buffer to the main model
         # (so the buffer name has changed). Remove them in such a case. This is another exception that was not added to
@@ -4561,13 +4517,15 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         # Clean-up missing keys
         if ignore_missing_regex is not None:
-            missing_keys = {key for key in missing_keys if ignore_missing_regex.search(key) is None}
+            loading_info.missing_keys = {
+                key for key in loading_info.missing_keys if ignore_missing_regex.search(key) is None
+            }
 
         # Clean-up unexpected keys
         if ignore_unexpected_regex is not None:
-            unexpected_keys = {key for key in unexpected_keys if ignore_unexpected_regex.search(key) is None}
-
-        return missing_keys, unexpected_keys
+            loading_info.unexpected_keys = {
+                key for key in loading_info.unexpected_keys if ignore_unexpected_regex.search(key) is None
+            }
 
     def mark_tied_weights_as_initialized(self):
         """Adds the `_is_hf_initialized` flag on parameters that will be tied, in order to avoid initializing them

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4079,6 +4079,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             download_kwargs=download_kwargs,
         )
         loading_info, disk_offload_index = cls._load_pretrained_model(model, state_dict, checkpoint_files, load_config)
+        loading_info = cls._finalize_load_state_dict(model, load_config, loading_info)
         model.eval()  # Set model in evaluation mode to deactivate Dropout modules by default
         model.set_use_kernels(use_kernels, kernel_config)
 
@@ -4119,14 +4120,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             return model, loading_info.to_dict()
         return model
 
-    @classmethod
+    @staticmethod
     def _load_pretrained_model(
-        cls,
         model: "PreTrainedModel",
         state_dict: dict | None,
         checkpoint_files: list[str] | None,
         load_config: LoadStateDictConfig,
     ) -> tuple[LoadStateDictInfo, dict]:
+        """Perform the actual loading of some checkpoints into a `model`, by reading them from disk and dispatching them accordingly."""
         is_quantized = load_config.is_quantized
         is_hqq_or_quark = is_quantized and load_config.hf_quantizer.quantization_config.quant_method in {
             QuantizationMethod.HQQ,
@@ -4209,6 +4210,16 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             for k in all_pointer:
                 k.__exit__(None, None, None)
 
+        return loading_info, disk_offload_index
+
+    @staticmethod
+    def _finalize_load_state_dict(
+        model, load_config: LoadStateDictConfig, loading_info: LoadStateDictInfo
+    ) -> LoadStateDictInfo:
+        """Performs all post processing operations after having loaded some checkpoints into a model, such as moving
+        missing keys from meta device to their expected device, reinitializing missing weights according to proper
+        distributions, tying the weights and logging the loading report."""
+
         # Marks tied weights as `_is_hf_initialized` to avoid initializing them (it's very important for efficiency)
         model.mark_tied_weights_as_initialized()
 
@@ -4238,7 +4249,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             logger=logger,
         )
 
-        return loading_info, disk_offload_index
+        return loading_info
 
     def retrieve_modules_from_names(self, names, add_prefix=False, remove_prefix=False):
         module_keys = {".".join(key.split(".")[:-1]) for key in names}

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -14,6 +14,7 @@
 import logging
 import re
 import shutil
+import sys
 from collections import OrderedDict, defaultdict
 from dataclasses import dataclass
 from typing import Any
@@ -118,7 +119,11 @@ PALETTE = {
 
 
 def _color(s, color):
-    return f"{PALETTE[color]}{s}{PALETTE['reset']}"
+    """Return color-formatted input `s` if `sys.stdout` is interactive, e.g. connected to a terminal."""
+    if sys.stdout.isatty():
+        return f"{PALETTE[color]}{s}{PALETTE['reset']}"
+    else:
+        return s
 
 
 def _get_terminal_width(default=80):

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -14,9 +14,8 @@
 import logging
 import re
 import shutil
-import sys
 from collections import OrderedDict, defaultdict
-from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any
 
 
@@ -83,26 +82,6 @@ def update_key_name(mapping: dict[str, Any]) -> dict[str, Any]:
     return out
 
 
-# We have a class to simplify disabling ANSI colors
-class ANSI:
-    palette = {
-        "reset": "[0m",
-        "red": "[31m",
-        "yellow": "[33m",
-        "orange": "[38;5;208m",
-        "purple": "[35m",
-        "bold": "[1m",
-        "italic": "[3m",
-        "dim": "[2m",
-    }
-
-    def __init__(self, enable):
-        self.enable = enable
-
-    def __getitem__(self, key):
-        return self.palette[key] if self.enable else ""
-
-
 _ansi_re = re.compile(r"\x1b\[[0-9;]*m")
 
 
@@ -126,8 +105,20 @@ def _make_table(rows, headers):
     return "\n".join([header_line, sep_line] + body)
 
 
-def _color(s, color, ansi):
-    return f"{ansi[color]}{s}{ansi['reset']}"
+PALETTE = {
+    "reset": "[0m",
+    "red": "[31m",
+    "yellow": "[33m",
+    "orange": "[38;5;208m",
+    "purple": "[35m",
+    "bold": "[1m",
+    "italic": "[3m",
+    "dim": "[2m",
+}
+
+
+def _color(s, color):
+    return f"{PALETTE[color]}{s}{PALETTE['reset']}"
 
 
 def _get_terminal_width(default=80):
@@ -137,20 +128,115 @@ def _get_terminal_width(default=80):
         return default
 
 
+@dataclass
+class LoadStateDictInfo:
+    """
+    Mutable container for state-dict loading results and diagnostics. Each entry in this structure is mutable,
+    and will usually be mutated in-place during the loading pipeline.
+
+    Attributes:
+        missing_keys (`set[str]`):
+            Keys that are missing from the loaded checkpoints but expected in the model's architecture.
+        unexpected_keys (`set[str]`):
+            Keys that are found in the checkpoints, but not expected in the model's architecture.
+        mismatched_keys (`set[tuple[str, tuple[int], tuple[int]]]`):
+            Keys that are found in the checkpoints and are expected in the model's architecture, but with a different shape.
+        error_msgs ( `list[str]`):
+            Some potential error messages.
+        conversion_errors (`dict[str, str]`):
+            Errors happening during the on-the-fly weight conversion process.
+    """
+
+    missing_keys: set[str]
+    unexpected_keys: set[str]
+    mismatched_keys: set[tuple[str, tuple[int], tuple[int]]]
+    error_msgs: list[str]
+    conversion_errors: dict[str, str]
+
+    def missing_and_mismatched(self):
+        """Return all effective missing keys, including `missing` and `mismatched` keys."""
+        return self.missing_keys | {k[0] for k in self.mismatched_keys}
+
+    def to_dict(self):
+        # Does not include the `conversion_errors` to be coherent with legacy reporting in the tests
+        return {
+            "missing_keys": self.missing_keys,
+            "unexpected_keys": self.unexpected_keys,
+            "mismatched_keys": self.mismatched_keys,
+            "error_msgs": self.error_msgs,
+        }
+
+    def create_loading_report(self) -> str | None:
+        """Generate the minimal table of a loading report."""
+        term_w = _get_terminal_width()
+
+        rows = []
+        tips = ""
+        if self.unexpected_keys:
+            tips += (
+                f"\n- {_color('UNEXPECTED', 'orange') + PALETTE['italic']}\t:can be ignored when loading from different "
+                "task/architecture; not ok if you expect identical arch."
+            )
+            for k in update_key_name(self.unexpected_keys):
+                status = _color("UNEXPECTED", "orange")
+                rows.append([k, status, "", ""])
+
+        if self.missing_keys:
+            tips += (
+                f"\n- {_color('MISSING', 'red') + PALETTE['italic']}\t:those params were newly initialized because missing "
+                "from the checkpoint. Consider training on your downstream task."
+            )
+            for k in update_key_name(self.missing_keys):
+                status = _color("MISSING", "red")
+                rows.append([k, status, ""])
+
+        if self.mismatched_keys:
+            tips += (
+                f"\n- {_color('MISMATCH', 'yellow') + PALETTE['italic']}\t:ckpt weights were loaded, but they did not match "
+                "the original empty weight shapes."
+            )
+            iterator = {a: (b, c) for a, b, c in self.mismatched_shapes}
+            for key, (shape_ckpt, shape_model) in update_key_name(iterator).items():
+                status = _color("MISMATCH", "yellow")
+                data = [
+                    key,
+                    status,
+                    f"Reinit due to size mismatch - ckpt: {str(shape_ckpt)} vs model:{str(shape_model)}",
+                ]
+                rows.append(data)
+
+        if self.conversion_errors:
+            tips += f"\n- {_color('CONVERSION', 'purple') + PALETTE['italic']}\t:originate from the conversion scheme"
+            for k, v in update_key_name(self.conversion_errors).items():
+                status = _color("CONVERSION", "purple")
+                _details = v[:term_w]
+                rows.append([k, status, _details])
+
+        # If nothing is wrong, return None
+        if len(rows) == 0:
+            return None
+
+        headers = ["Key", "Status"]
+        if term_w > 200:
+            headers += ["Details"]
+        else:
+            headers += ["", ""]
+        table = _make_table(rows, headers=headers)
+        tips = f"\n\n{PALETTE['italic']}Notes:{tips}{PALETTE['reset']}"
+        report = table + tips
+
+        return report
+
+
 def log_state_dict_report(
-    *,
     model,
-    load_config,
+    pretrained_model_name_or_path: str,
+    ignore_mismatched_sizes: bool,
+    loading_info: LoadStateDictInfo,
     logger: logging.Logger | None = None,
-    error_msgs: Iterable[str] | None = None,
-    unexpected_keys=None,
-    missing_keys=None,
-    mismatched_keys=None,
-    mismatched_shapes=None,
-    conversion_errors=None,
-    color=True,  # allow disabling for plain logs
 ):
-    """Log a readable report about state_dict loading issues.
+    """
+    Log a readable report about state_dict loading issues.
 
     This version is terminal-size aware: for very small terminals it falls back to a compact
     Key | Status view so output doesn't wrap badly.
@@ -158,96 +244,32 @@ def log_state_dict_report(
     if logger is None:
         logger = logging.getLogger(__name__)
 
-    error_msgs = error_msgs or []
-    unexpected_keys = unexpected_keys or []
-    missing_keys = missing_keys or []
-    mismatched_keys = mismatched_keys or []
-    mismatched_shapes = mismatched_shapes or []
-    conversion_errors = conversion_errors or {}
-    pretrained_model_name_or_path = load_config.pretrained_model_name_or_path
-    ignore_mismatched_sizes = load_config.ignore_mismatched_sizes
-
-    # Detect whether the current stdout supports ANSI colors; allow callers to pass `color=False` to force no color
-    color_enabled = bool(color and sys.stdout.isatty())
-    ansi = ANSI(color_enabled)
-
     # Re-raise errors early if needed
-    if error_msgs:
-        error_msg = "\n\t".join(error_msgs)
+    if loading_info.error_msgs:
+        error_msg = "\n\t".join(loading_info.error_msgs)
         if "size mismatch" in error_msg:
             error_msg += (
                 "\n\tYou may consider adding `ignore_mismatched_sizes=True` to `from_pretrained(...)` if appropriate."
             )
         raise RuntimeError(f"Error(s) in loading state_dict for {model.__class__.__name__}:\n\t{error_msg}")
 
-    term_w = _get_terminal_width()
-    rows = []
-    if unexpected_keys:
-        for k in update_key_name(unexpected_keys):
-            status = "UNEXPECTED"
-            status = _color(status, "orange", ansi)
-            rows.append([k, status, "", ""])
-
-    if missing_keys:
-        for k in update_key_name(missing_keys):
-            status = "MISSING"
-            status = _color(status, "red", ansi)
-            rows.append([k, status, ""])
-
-    if mismatched_keys:
-        iterator = {a: (b, c) for a, b, c in mismatched_shapes}
-        for key, (shape_ckpt, shape_model) in update_key_name(iterator).items():
-            status = "MISMATCH"
-            status = _color(status, "yellow", ansi)
-            data = [key, status]
-            data.append(
-                " ".join(["Reinit due to size mismatch", f"ckpt: {str(shape_ckpt)} vs model:{str(shape_model)}"])
-            )
-            rows.append(data)
-
-    if conversion_errors:
-        for k, v in update_key_name(conversion_errors).items():
-            status = "CONVERSION"
-            status = _color(status, "purple", ansi)
-            _details = v[:term_w]
-            rows.append([k, status, _details])
-
-    if not rows:
+    # Create the report table
+    report = loading_info.create_loading_report()
+    if report is None:
         return
 
-    headers = ["Key", "Status"]
-    if term_w > 200:
-        headers += ["Details"]
-    else:
-        headers += ["", ""]
-    table = _make_table(rows, headers=headers)
-
-    prelude = (
-        f"{ansi['bold']}{model.__class__.__name__} LOAD REPORT{ansi['reset']} from: {pretrained_model_name_or_path}\n"
-    )
-    tips = f"\n\n{ansi['italic']}Notes:"
-    if unexpected_keys:
-        tips += f"\n- {_color('UNEXPECTED', 'orange', ansi) + ansi['italic']}\t:can be ignored when loading from different task/architecture; not ok if you expect identical arch."
-    if missing_keys:
-        tips += f"\n- {_color('MISSING', 'red', ansi) + ansi['italic']}\t:those params were newly initialized because missing from the checkpoint. Consider training on your downstream task."
-    if mismatched_keys:
-        tips += f"\n- {_color('MISMATCH', 'yellow', ansi) + ansi['italic']}\t:ckpt weights were loaded, but they did not match the original empty weight shapes."
-    if conversion_errors:
-        tips += f"\n- {_color('CONVERSION', 'purple', ansi) + ansi['italic']}\t:originate from the conversion scheme"
-    tips += f"{ansi['reset']}"
+    prelude = f"{PALETTE['bold']}{model.__class__.__name__} LOAD REPORT{PALETTE['reset']} from: {pretrained_model_name_or_path}\n"
 
     # Log the report as warning
-    logger.warning(prelude + table + tips)
+    logger.warning(prelude + report)
 
     # Re-raise in those case, after the report
-    if conversion_errors:
+    if loading_info.conversion_errors:
         raise RuntimeError(
             "We encountered some issues during automatic conversion of the weights. For details look at the `CONVERSION` entries of "
             "the above report!"
         )
-    if not ignore_mismatched_sizes and mismatched_keys:
+    if not ignore_mismatched_sizes and loading_info.mismatched_keys:
         raise RuntimeError(
             "You set `ignore_mismatched_sizes` to `False`, thus raising an error. For details look at the above report!"
         )
-
-    return prelude + table + tips

--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -195,7 +195,7 @@ class LoadStateDictInfo:
                 f"\n- {_color('MISMATCH', 'yellow') + PALETTE['italic']}\t:ckpt weights were loaded, but they did not match "
                 "the original empty weight shapes."
             )
-            iterator = {a: (b, c) for a, b, c in self.mismatched_shapes}
+            iterator = {a: (b, c) for a, b, c in self.mismatched_keys}
             for key, (shape_ckpt, shape_model) in update_key_name(iterator).items():
                 status = _color("MISMATCH", "yellow")
                 data = [

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1568,7 +1568,9 @@ class ModelUtilsTest(TestCasePlus):
             with LoggingLevel(logging.WARNING):
                 with CaptureLogger(logger) as cl:
                     _, loading_info = ModelWithHead.from_pretrained(tmp_dir, output_loading_info=True)
-            self.assertIn("added_key | UNEXPECTED", cl.out)
+            # Will be colored if terminal is interactive
+            expected_output = "added_key | [38;5;208mUNEXPECTED" if sys.stdout.isatty() else "added_key | UNEXPECTED"
+            self.assertIn(expected_output, cl.out)
             self.assertEqual(loading_info["unexpected_keys"], {"added_key"})
 
     def test_warn_if_padding_and_no_attention_mask(self):


### PR DESCRIPTION
# What does this PR do?

As per the title. This simplifies the use of `LoadStateDictInfo` a bit everywhere, and makes it clear that the entries within the struct are mutated in-place all the time.