### PR TITLE
custom tok init fix

### DIFF
--- a/src/transformers/tokenization_python.py
+++ b/src/transformers/tokenization_python.py
@@ -414,6 +414,9 @@ class PythonBackend(PreTrainedTokenizerBase):
         # 1. Init the parent class
 
         self.tokens_trie = Trie()
+        
+        # Initialize total_vocab_size early to avoid issues if get_vocab() is called early (custom tokenizers)
+        self.total_vocab_size = 0
 
         # 2. init `_added_tokens_decoder` if child class did not
         if not hasattr(self, "_added_tokens_decoder"):
@@ -439,9 +442,6 @@ class PythonBackend(PreTrainedTokenizerBase):
         # 7. init the parent class
         super().__init__(**kwargs)
 
-        if self._added_tokens_decoder:
-            self._update_total_vocab_size()
-
         # 4. If some of the special tokens are not part of the vocab, we add them, at the end.
         # V5: the order of addition follows self.SPECIAL_TOKENS_ATTRIBUTES, then extra special tokens
         # Note: _add_tokens will automatically skip tokens that are already in the base vocab
@@ -449,7 +449,6 @@ class PythonBackend(PreTrainedTokenizerBase):
             [token for token in self.all_special_tokens if token not in self._added_tokens_encoder],
             special_tokens=True,
         )
-        self._update_total_vocab_size()
 
     @property
     def is_fast(self) -> bool:
@@ -501,6 +500,9 @@ class PythonBackend(PreTrainedTokenizerBase):
         """
         Size of the full vocabulary with the added tokens.
         """
+        # Lazy evaluation: compute if not already set (e.g., during initialization)
+        if self.total_vocab_size == 0:
+            self._update_total_vocab_size()
         return self.total_vocab_size
 
     def _update_total_vocab_size(self):

--- a/src/transformers/tokenization_python.py
+++ b/src/transformers/tokenization_python.py
@@ -414,7 +414,7 @@ class PythonBackend(PreTrainedTokenizerBase):
         # 1. Init the parent class
 
         self.tokens_trie = Trie()
-        
+
         # Initialize total_vocab_size early to avoid issues if get_vocab() is called early (custom tokenizers)
         self.total_vocab_size = 0
 

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -461,7 +461,7 @@ class AutoTokenizerTest(unittest.TestCase):
 
     @slow
     def test_custom_tokenizer_init(self):
-        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen-VL", trust_remote_code=True)
+        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen-VL", trust_remote_code=True, revision="0547ed36a86561e2e42fecec8fd0c4f6953e33c4")
         self.assertIsInstance(tokenizer, PythonBackend)
         self.assertGreater(len(tokenizer.get_vocab()), 0)
 

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -33,6 +33,7 @@ from transformers import (
     GPT2Tokenizer,
     HerbertTokenizer,
     PreTrainedTokenizerFast,
+    PythonBackend,
     Qwen2Tokenizer,
     Qwen2TokenizerFast,
     Qwen3MoeConfig,
@@ -457,6 +458,12 @@ class AutoTokenizerTest(unittest.TestCase):
         )
         self.assertIsNot(tokenizer.__class__, reloaded_tokenizer.__class__)
         self.assertTrue(reloaded_tokenizer.special_attribute_present)
+
+    @slow
+    def test_custom_tokenizer_init(self):
+        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen-VL", trust_remote_code=True)
+        self.assertIsInstance(tokenizer, PythonBackend)
+        self.assertGreater(len(tokenizer.get_vocab()), 0)
 
     @require_tokenizers
     def test_from_pretrained_dynamic_tokenizer_conflict(self):

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -461,7 +461,9 @@ class AutoTokenizerTest(unittest.TestCase):
 
     @slow
     def test_custom_tokenizer_init(self):
-        tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen-VL", trust_remote_code=True, revision="0547ed36a86561e2e42fecec8fd0c4f6953e33c4")
+        tokenizer = AutoTokenizer.from_pretrained(
+            "Qwen/Qwen-VL", trust_remote_code=True, revision="0547ed36a86561e2e42fecec8fd0c4f6953e33c4"
+        )
         self.assertIsInstance(tokenizer, PythonBackend)
         self.assertGreater(len(tokenizer.get_vocab()), 0)
 


### PR DESCRIPTION
custom tokenizers fail on super._init_() call that tries to update vocab size before all vocab attrs are defined
