### PR TITLE
fix: AttributeError for Qwen3_omni_moe

### DIFF
--- a/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
@@ -582,8 +582,6 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(PreTrainedConfig, RotaryEmbeddingCon
         eos_token_id: int | None = None,
         **kwargs,
     ):
-        self.sliding_window = sliding_window
-        self.max_window_layers = max_window_layers
         self.num_code_groups = num_code_groups
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings

--- a/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/configuration_qwen3_omni_moe.py
@@ -573,6 +573,7 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(PreTrainedConfig, RotaryEmbeddingCon
         rope_parameters: int | None = None,
         attention_bias: bool | None = False,
         sliding_window: int | None = None,
+        max_window_layers: int | None = 28,
         layer_types: list[str] | None = None,
         attention_dropout: int | None = 0,
         num_code_groups: int | None = 32,
@@ -582,6 +583,7 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(PreTrainedConfig, RotaryEmbeddingCon
         **kwargs,
     ):
         self.sliding_window = sliding_window
+        self.max_window_layers = max_window_layers
         self.num_code_groups = num_code_groups
         self.vocab_size = vocab_size
         self.max_position_embeddings = max_position_embeddings
@@ -589,7 +591,8 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(PreTrainedConfig, RotaryEmbeddingCon
         self.intermediate_size = intermediate_size
         self.num_hidden_layers = num_hidden_layers
         self.num_attention_heads = num_attention_heads
-        self.sliding_window = sliding_window if self.use_sliding_window else None
+        self.sliding_window = sliding_window
+        self.max_window_layers = max_window_layers
 
         # for backward compatibility
         if num_key_value_heads is None:

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -474,8 +474,6 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(Qwen3Config):
         eos_token_id: int | None = None,
         **kwargs,
     ):
-        self.sliding_window = sliding_window
-        self.max_window_layers = max_window_layers
         self.num_code_groups = num_code_groups
         super().__init__(
             vocab_size,
@@ -505,6 +503,7 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(Qwen3Config):
         )
         del self.use_sliding_window
         self.sliding_window = sliding_window
+        self.max_window_layers = max_window_layers
 
 
 class Qwen3OmniMoeTalkerTextConfig(Qwen3MoeConfig):

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -465,6 +465,7 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(Qwen3Config):
         rope_parameters: int | None = None,
         attention_bias: bool | None = False,
         sliding_window: int | None = None,
+        max_window_layers: int | None = 28,
         layer_types: list[str] | None = None,
         attention_dropout: int | None = 0,
         num_code_groups: int | None = 32,
@@ -474,6 +475,7 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(Qwen3Config):
         **kwargs,
     ):
         self.sliding_window = sliding_window
+        self.max_window_layers = max_window_layers
         self.num_code_groups = num_code_groups
         super().__init__(
             vocab_size,
@@ -502,7 +504,7 @@ class Qwen3OmniMoeTalkerCodePredictorConfig(Qwen3Config):
             **kwargs,
         )
         del self.use_sliding_window
-        del self.max_window_layers
+        self.sliding_window = sliding_window
 
 
 class Qwen3OmniMoeTalkerTextConfig(Qwen3MoeConfig):

--- a/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
@@ -649,6 +649,31 @@ class Qwen3OmniMoeThinkerForConditionalGenerationModelTest(ModelTesterMixin, Gen
             model_tester = self.model_tester
         return model_tester.vision_config["depth"] + 1
 
+    def test_code_predictor_config_init(self):
+        """
+        Test that Qwen3OmniMoeTalkerCodePredictorConfig initializes correctly
+        and accepts max_window_layers while removing use_sliding_window.
+        """
+
+        config = Qwen3OmniMoeTalkerCodePredictorConfig(
+            vocab_size=100,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            max_window_layers=28,
+            sliding_window=2048,
+        )
+
+        # 1. Check max_window_layers is present
+        self.assertEqual(config.max_window_layers, 28)
+
+        # 2. Check sliding_window is present
+        self.assertEqual(config.sliding_window, 2048)
+
+        # 3. Check use_sliding_window is removed
+        with self.assertRaises(AttributeError):
+            _ = config.use_sliding_window
+
 
 @require_torch
 class Qwen3OmniModelIntegrationTest(unittest.TestCase):
@@ -912,30 +937,3 @@ class Qwen3OmniModelIntegrationTest(unittest.TestCase):
         decoded_texts = self.processor.batch_decode(output, skip_special_tokens=True)
         self.assertEqual(decoded_texts[0], EXPECTED_DECODED_TEXT)
         self.assertEqual(decoded_texts[1], EXPECTED_DECODED_TEXT)
-
-
-class TestQwen3OmniMoeCodePredictorConfig(unittest.TestCase):
-    def test_code_predictor_config_init(self):
-        """
-        Test that Qwen3OmniMoeTalkerCodePredictorConfig initializes correctly
-        and accepts max_window_layers while removing use_sliding_window.
-        """
-
-        config = Qwen3OmniMoeTalkerCodePredictorConfig(
-            vocab_size=100,
-            hidden_size=32,
-            num_hidden_layers=2,
-            num_attention_heads=4,
-            max_window_layers=28,
-            sliding_window=2048,
-        )
-
-        # 1. Check max_window_layers is present
-        self.assertEqual(config.max_window_layers, 28)
-
-        # 2. Check sliding_window is present
-        self.assertEqual(config.sliding_window, 2048)
-
-        # 3. Check use_sliding_window is removed
-        with self.assertRaises(AttributeError):
-            _ = config.use_sliding_window

--- a/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
+++ b/tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py
@@ -31,6 +31,7 @@ from transformers import (
     is_torch_available,
     is_vision_available,
 )
+from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import Qwen3OmniMoeTalkerCodePredictorConfig
 from transformers.testing_utils import (
     Expectations,
     cleanup,
@@ -911,3 +912,30 @@ class Qwen3OmniModelIntegrationTest(unittest.TestCase):
         decoded_texts = self.processor.batch_decode(output, skip_special_tokens=True)
         self.assertEqual(decoded_texts[0], EXPECTED_DECODED_TEXT)
         self.assertEqual(decoded_texts[1], EXPECTED_DECODED_TEXT)
+
+
+class TestQwen3OmniMoeCodePredictorConfig(unittest.TestCase):
+    def test_code_predictor_config_init(self):
+        """
+        Test that Qwen3OmniMoeTalkerCodePredictorConfig initializes correctly
+        and accepts max_window_layers while removing use_sliding_window.
+        """
+
+        config = Qwen3OmniMoeTalkerCodePredictorConfig(
+            vocab_size=100,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            max_window_layers=28,
+            sliding_window=2048,
+        )
+
+        # 1. Check max_window_layers is present
+        self.assertEqual(config.max_window_layers, 28)
+
+        # 2. Check sliding_window is present
+        self.assertEqual(config.sliding_window, 2048)
+
+        # 3. Check use_sliding_window is removed
+        with self.assertRaises(AttributeError):
+            _ = config.use_sliding_window


### PR DESCRIPTION
# What does this PR do?

This PR fixes a crash when initializing `Qwen3OmniMoeTalkerCodePredictorConfig` due to a missing attribute reference.

Specifically, it:
1.  **Removes** the reference to the non-existent `use_sliding_window` attribute, which was causing an `AttributeError`.
2.  **Adds** the missing `max_window_layers` initialization (defaulting to `28`). The existing `layer_types` logic relies on this attribute, and without it, `sliding_window` causes a secondary crash.
3.  **Adds** a new test case (`test_code_predictor_config_init`) to ensure the configuration initializes correctly. 

Fixes #43531


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (Issue #43531)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review? 
