### PR TITLE
Fix unintended Hub metadata calls from _patch_mistral_regex

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1828,6 +1828,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         init_kwargs["name_or_path"] = pretrained_model_name_or_path
         init_kwargs["is_local"] = _is_local
+        init_kwargs["local_files_only"] = local_files_only
 
         #### Handle tokenizer serialization of added and special tokens
         added_tokens_decoder: dict[int, AddedToken] = {}

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1285,7 +1285,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
         if local_files_only or is_offline_mode():
             return tokenizer
-        
+
         if not is_local and isinstance(pretrained_model_name_or_path, str):
             _id = pretrained_model_name_or_path.lower()
             # Only continue for likely Mistral repos/ids; otherwise no-op.

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1283,21 +1283,15 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
         from transformers.utils.hub import cached_file
 
-        if local_files_only or is_offline_mode():
-            return tokenizer
-
-        if not is_local and isinstance(pretrained_model_name_or_path, str):
-            _id = pretrained_model_name_or_path.lower()
-            # Only continue for likely Mistral repos/ids; otherwise no-op.
-            if not (_id.startswith("mistralai/") or "mistral" in _id):
-                return tokenizer
-
         def is_base_mistral(model_id: str) -> bool:
             model = model_info(model_id)
             if model.tags is not None:
                 if re.search("base_model:.*mistralai", "".join(model.tags)):
                     return True
             return False
+
+        if local_files_only or is_offline_mode():
+            is_local = True
 
         if pretrained_model_name_or_path is not None and (
             is_local or (not is_local and is_base_mistral(pretrained_model_name_or_path))

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1283,15 +1283,21 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
         from transformers.utils.hub import cached_file
 
+        if local_files_only or is_offline_mode():
+            return tokenizer
+        
+        if not is_local and isinstance(pretrained_model_name_or_path, str):
+            _id = pretrained_model_name_or_path.lower()
+            # Only continue for likely Mistral repos/ids; otherwise no-op.
+            if not (_id.startswith("mistralai/") or "mistral" in _id):
+                return tokenizer
+
         def is_base_mistral(model_id: str) -> bool:
             model = model_info(model_id)
             if model.tags is not None:
                 if re.search("base_model:.*mistralai", "".join(model.tags)):
                     return True
             return False
-
-        if is_offline_mode():
-            is_local = True
 
         if pretrained_model_name_or_path is not None and (
             is_local or (not is_local and is_base_mistral(pretrained_model_name_or_path))

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1277,14 +1277,20 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 >> Tags including `base_model:.*mistralai`
         """
         import re
+        from functools import lru_cache
 
         from huggingface_hub import model_info
         from packaging import version
 
         from transformers.utils.hub import cached_file
 
+        @lru_cache(maxsize=128)
         def is_base_mistral(model_id: str) -> bool:
-            model = model_info(model_id)
+            try:
+                model = model_info(model_id)
+            except Exception:
+                # Never block tokenizer init on a Hub error — assume non-Mistral.
+                return False
             if model.tags is not None:
                 if re.search("base_model:.*mistralai", "".join(model.tags)):
                     return True

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -287,3 +287,47 @@ class ReduceMutableBorrowTests(unittest.TestCase):
 
     def fetch(self, tokenizer, text):
         return tokenizer.encode(text, truncation="longest_first", padding="longest")
+
+
+@require_tokenizers
+class PatchMistralRegexHubCallTests(unittest.TestCase):
+    """
+    Regression tests for https://github.com/huggingface/transformers/issues/44749 /
+    https://github.com/huggingface/transformers/issues/43502
+
+    `_patch_mistral_regex` used to unconditionally call `huggingface_hub.model_info`
+    for any tokenizer with vocab > 100k (e.g. Qwen3), causing a large slowdown
+    and breaking offline / local-path loading.
+    """
+
+    def _dummy_backend_tokenizer(self):
+        tok = Tokenizer(WordLevel({"[UNK]": 0, "a": 1}, unk_token="[UNK]"))
+        tok.pre_tokenizer = pre_tokenizers.Whitespace()
+        return tok
+
+    def test_local_files_only_skips_model_info(self):
+        from unittest.mock import patch
+
+        tok = self._dummy_backend_tokenizer()
+        with patch(
+            "huggingface_hub.model_info",
+            side_effect=AssertionError("model_info must not be called when local_files_only=True"),
+        ):
+            result = PreTrainedTokenizerFast._patch_mistral_regex(
+                tok,
+                "some/non-mistral-repo-id",
+                local_files_only=True,
+            )
+        self.assertIsNotNone(result)
+
+    def test_hub_error_does_not_break_init(self):
+        from unittest.mock import patch
+
+        tok = self._dummy_backend_tokenizer()
+        with patch("huggingface_hub.model_info", side_effect=RuntimeError("hub down")):
+            # Must not raise — a Hub failure should be swallowed for non-Mistral models.
+            result = PreTrainedTokenizerFast._patch_mistral_regex(
+                tok,
+                "not-a-real/hub-id",
+            )
+        self.assertIsNotNone(result)


### PR DESCRIPTION
# What does this PR do?

`TokenizersBackend._patch_mistral_regex()` is a Mistral-specific tokenizer patch, but the current implementation may call `huggingface_hub.model_info()` during detection. That triggers an HTTP request to `/api/models/<repo_id>` and can occur even for non-Mistral repos in environments where outbound network calls are blocked.

This PR adds minimal guardrails:
- Return early when `local_files_only=True` or in offline mode.
- Return early for non-Mistral repo ids before calling `model_info()`.

This keeps the Mistral behavior unchanged while preventing unnecessary metadata network requests for non-Mistral models.



<!-- Remove if not applicable -->

Fixes #43502 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@zucchini-nlp @ArthurZucker 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
