### PR TITLE
Cast byte_count to int in caching_allocator_warmup for MPS compatibility

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4746,7 +4746,7 @@ def caching_allocator_warmup(model: PreTrainedModel, expanded_device_map: dict, 
             ) - torch_accelerator_module.memory_allocated(index)
             byte_count = int(max(0, byte_count - unused_memory))
         # We divide by 2 here as we allocate in fp16
-        _ = torch.empty(byte_count // 2, dtype=torch.float16, device=device, requires_grad=False)
+        _ = torch.empty(int(byte_count // 2), dtype=torch.float16, device=device, requires_grad=False)
 
 
 class AttentionInterface(GeneralInterface):


### PR DESCRIPTION
…tibility

# What does this PR do?

Fixes #43582

Fixes TypeError on Apple Silicon (MPS) when loading models with quantization by ensuring `byte_count // 2` returns a Python int.

## The Issue

On line 4762 in `modeling_utils.py`, `torch.empty(byte_count // 2, ...)` fails with TypeError on MPS devices because:
1. `byte_count` comes from `total_byte_count` as a torch/numpy scalar
2. For CUDA/XPU: line 4760 casts it to Python int
3. For MPS: this casting is skipped (device type check on line 4748 doesn't include "mps")
4. `byte_count // 2` on a torch scalar returns float
5. `torch.empty()` expects int, receives float → TypeError

## The Fix

Wrap the division in `int()` on line 4762:
```python
_ = torch.empty(int(byte_count // 2), dtype=torch.float16, device=device, requires_grad=False)
```

This defensive fix works for all device types (CUDA, XPU, MPS, and future additions).

## Testing

**Reproduced on main branch:**
- Loading GPT-2 with BitsAndBytes 4-bit quantization on MPS → TypeError

**Verified fix works:**
- Same setup with fix → Model loads successfully without error

Tested on Apple Silicon M3 Pro with PyTorch 2.10.0.

## Before submitting
- [x] This PR fixes a bug
- [x] Tested on actual hardware (M3 Pro MPS)
- [x] Code follows existing patterns

cc @vasqu @Cyrilvallez