### PR TITLE
Docs: fix typo in weight converter guide

### DIFF
--- a/docs/source/en/weightconverter.md
+++ b/docs/source/en/weightconverter.md
@@ -134,7 +134,7 @@ At a high level, the contract looks like this:
    You can do mostly 3 things:
     - add operations to the list of converters: these will be applied on all weights except for the ones collected in any of the `WeightConverter`. These in general should be `WeightRenaming` operations
     - add operations to the list of operations of each converter: this is what happens for `Quantization`, where we just add a quantization operation after the list of operations of any `WeightConverter`.
-    - replace / map operations to your custom operations: this is what happens with `peft`. We replace the `Concatenate` operation of say `mixtral`, to be `PeftConcatenate`. This way, when the adapter checkpoint is read, the weights to be concatenated are collected, and are properly formated for `peft`
+    - replace / map operations to your custom operations: this is what happens with `peft`. We replace the `Concatenate` operation of say `mixtral`, to be `PeftConcatenate`. This way, when the adapter checkpoint is read, the weights to be concatenated are collected, and are properly formatted for `peft`
 3. **Load + finalize + report.** Use the core loader to perform the conversion and populate tensors, then finalize and
    log results. Concretely, this flow is:
    - `LoadStateDictConfig(...)` + `_load_pretrained_model(...)` to load and convert.


### PR DESCRIPTION
## Summary
Fix a spelling typo in the dynamic weight loading / weight converter documentation.

**Change**: `formated` → `formatted` in `docs/source/en/weightconverter.md`

## Test plan
- N/A (documentation-only change)

Made with [Cursor](https://cursor.com)