### PR TITLE
add XPU expected output for MixedInt8GPT2Test

### DIFF
--- a/tests/quantization/bnb/test_mixed_int8.py
+++ b/tests/quantization/bnb/test_mixed_int8.py
@@ -930,6 +930,8 @@ class MixedInt8GPT2Test(MixedInt8Test):
     # Expected values on Intel CPU
     EXPECTED_OUTPUTS.add("Hello my name is John Doe. I am a man. I am")
     EXPECTED_OUTPUTS.add("Hello my name is John, and I'm a writer. I'm")
+    # Expected values on Intel XPU
+    EXPECTED_OUTPUTS.add("Hello my name is John Doe and I am a member of the United")
 
     def test_int8_from_pretrained(self):
         r"""


### PR DESCRIPTION
@SunMarc this PR fixes failed case of `tests/quantization/bnb/test_mixed_int8.py::MixedInt8GPT2Test::test_generate_quality_config` for XPU, pls help review, thx!