### PR TITLE
Fix tie_word_embedding issue for llava_onevision model

### DIFF
--- a/src/transformers/models/llava_next_video/configuration_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/configuration_llava_next_video.py
@@ -162,5 +162,11 @@ class LlavaNextVideoConfig(PreTrainedConfig):
 
         super().__init__(**kwargs)
 
+        # Due to a mismatch at model addition-time, the `tie_word_embeddings` was saved in the text config, even
+        # though it concerns the main model, while it was set to False by default in the main model... So we hardcode a fix here
+        if not self.tie_word_embeddings and self.text_config.tie_word_embeddings:
+            self.tie_word_embeddings = True
+            self.text_config.tie_word_embeddings = False
+
 
 __all__ = ["LlavaNextVideoConfig"]

--- a/src/transformers/models/llava_next_video/modular_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/modular_llava_next_video.py
@@ -181,6 +181,12 @@ class LlavaNextVideoConfig(PreTrainedConfig):
 
         super().__init__(**kwargs)
 
+        # Due to a mismatch at model addition-time, the `tie_word_embeddings` was saved in the text config, even
+        # though it concerns the main model, while it was set to False by default in the main model... So we hardcode a fix here
+        if not self.tie_word_embeddings and self.text_config.tie_word_embeddings:
+            self.tie_word_embeddings = True
+            self.text_config.tie_word_embeddings = False
+
 
 class LlavaNextVideoModelOutputWithPast(LlavaNextModelOutputWithPast):
     r"""

--- a/src/transformers/models/llava_onevision/configuration_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/configuration_llava_onevision.py
@@ -190,5 +190,10 @@ class LlavaOnevisionConfig(PreTrainedConfig):
 
         super().__init__(**kwargs)
 
+        # Due to a mismatch at model addition-time, the `tie_word_embeddings` was saved in the text config, even
+        # though it concerns the main model, while it was set to False by default in the main model... So we hardcode a fix here
+        self.tie_word_embeddings = self.tie_word_embeddings or self.text_config.tie_word_embeddings
+        self.text_config.tie_word_embeddings = False
+
 
 __all__ = ["LlavaOnevisionConfig"]


### PR DESCRIPTION
@zucchini-nlp pls help review, thx! We have to add back the changes in https://github.com/huggingface/transformers/pull/42523. As for llava_onevision model, in its checkpoint config file, the model's `tie_word_embeddings` is Flase, and model's text_config's `tie_word_embeddings` is True: [L171](https://huggingface.co/llava-hf/llava-onevision-qwen2-0.5b-ov-hf/blob/main/config.json#L171),  which causes when loading the model, the `lm_head.weight` of the model will get missing, hence cause totally wrong output. You can run this unit test to reproduce:
`RUN_SLOW=1 pytest -rA tests/models/llava_onevision/test_modeling_llava_onevision.py::LlavaOnevisionForConditionalGenerationIntegrationTest::test_small_model_integration_test_multi_image_nested`