### PR TITLE
Add Claude Skill for PEFT/LoRA fine-tuning guidance

### DIFF
--- a/.claude/skills/peft-lora/SKILL.md
+++ b/.claude/skills/peft-lora/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: peft-lora
+description: Guides efficient fine-tuning with PEFT (Parameter-Efficient Fine-Tuning) methods, especially LoRA and QLoRA. Use when questions involve LoRA adapters, QLoRA quantized fine-tuning, PEFT configurations (LoraConfig, r, lora_alpha), adapter loading/merging, memory-efficient training, or troubleshooting PEFT-related issues.
+---
+
+# PEFT & LoRA Navigator (Claude Code)
+
+## Purpose
+This Skill is an **operating playbook** for working with Parameter-Efficient Fine-Tuning (PEFT), focusing on LoRA (Low-Rank Adaptation) and QLoRA methods within the Hugging Face ecosystem.
+
+It optimizes for:
+- correct PEFT configuration (LoraConfig parameters, target modules)
+- memory-efficient fine-tuning (QLoRA, 4-bit/8-bit quantization)
+- adapter management (loading, merging, stacking)
+- troubleshooting common PEFT pitfalls
+- integration with Transformers Trainer
+
+This file is intentionally **high-level**. Detailed breakdowns live in individual markdown files under `reference/areas/*`.
+
+---
+
+## When to activate
+Activate this Skill if **any** of the following are true:
+- The user mentions PEFT, LoRA, QLoRA, adapters, or parameter-efficient fine-tuning
+- They reference PEFT artifacts (`adapter_config.json`, `adapter_model.safetensors`, `lora_config`)
+- They show code importing `peft` or stack traces mentioning `peft/`
+- They need memory-efficient training decisions (LoRA vs full fine-tuning vs QLoRA)
+- They ask about adapter operations: merge, save, load, switch, combine
+- They mention `LoraConfig`, `r`, `lora_alpha`, `target_modules`, `modules_to_save`
+- They want to fine-tune large LLMs on consumer hardware
+
+Do **not** activate if the request is mostly:
+- Full fine-tuning without PEFT, or
+- Hub/Datasets usage with no PEFT/adapter context, or
+- General Transformers inference without adapters
+
+Do activate if it's **PEFT integration with Transformers** (training/inference with adapters).
+
+---
+
+## Reference entry points 
+
+### Buckets (open exactly ONE first)
+- LoRA Basics → `reference/areas/lora-basics.md`
+- QLoRA & Quantization → `reference/areas/qlora-quantization.md`
+- Adapter Operations → `reference/areas/adapter-operations.md`
+- Training Integration → `reference/areas/training-integration.md`
+- Troubleshooting → `reference/areas/troubleshooting.md`
+
+### Debug template
+- Minimal repro form → `templates/minimal_repro.md`
+
+---
+
+## Exact sequential process (always follow this order)
+
+### Step 1 — Classify the request (pick ONE bucket)
+- **LoRA Basics** (LoraConfig, r, lora_alpha, target_modules, getting started)
+- **QLoRA & Quantization** (4-bit/8-bit, BitsAndBytesConfig, memory-constrained training)
+- **Adapter Operations** (load, save, merge, switch, combine adapters)
+- **Training Integration** (Trainer with PEFT, SFTTrainer, custom loops)
+- **Troubleshooting** (dtype issues, loading errors, wrong outputs)
+
+### Step 2 — Ask only what's missing (0–5 questions, only if ambiguous)
+Ask only the minimum to proceed:
+1) Goal/outcome in one sentence (only if unclear)
+2) Model id or local path (and revision if pinned)
+3) PEFT method (LoRA / QLoRA / other) and config (r, lora_alpha, target_modules)
+4) Environment: `peft` version + `transformers` version + device (CPU/CUDA/MPS) + VRAM
+5) If blocked: full stack trace + minimal repro snippet (use `templates/minimal_repro.md`)
+
+### Step 3 — Route first (deterministic router embedded here)
+Follow this router and open **exactly one** bucket file from the list above.
+
+#### Routing rules
+- If the user is blocked by an exception/traceback → open **Troubleshooting** first
+- If multiple buckets match, prioritize the user's **desired outcome** over the first keyword seen.
+- If still tied, use this fixed priority order:
+  **Troubleshooting > Training Integration > QLoRA & Quantization > LoRA Basics > Adapter Operations**
+
+#### Routing table (open exactly ONE file first)
+
+| User intent / signal | Open this first | Common keywords / symptoms |
+|---|---|---|
+| New to LoRA / setting up first adapter | `reference/areas/lora-basics.md` | `LoraConfig`, `r`, `lora_alpha`, `target_modules`, `get_peft_model`, first time, basics |
+| Memory-constrained / 4-bit / 8-bit training | `reference/areas/qlora-quantization.md` | QLoRA, `BitsAndBytesConfig`, `load_in_4bit`, quantization, OOM, consumer GPU |
+| Loading / saving / merging adapters | `reference/areas/adapter-operations.md` | `merge_and_unload`, `save_pretrained`, `PeftModel.from_pretrained`, multiple adapters |
+| Training with Trainer / SFTTrainer | `reference/areas/training-integration.md` | `Trainer`, `SFTTrainer`, `prepare_model_for_kbit_training`, training loop |
+| Errors, crashes, wrong outputs | `reference/areas/troubleshooting.md` | traceback, dtype, mismatch, `ValueError`, loading fails, outputs wrong |
+
+#### Fallback (if nothing matches)
+- Open `reference/areas/lora-basics.md` to establish fundamentals
+- Then route to the nearest bucket in the table above and continue
+
+### Step 4 — If blocked by an error: reproduce/triage first
+If the user cannot proceed due to an exception or incorrect outputs:
+- prioritize minimal repro + full stack trace + versions
+- classify the failure: **config** vs **loading** vs **training** vs **dtype** vs **merging**
+- apply a targeted fix + propose the smallest next diagnostic step
+
+### Step 5 — Verify only when uncertain (never guess)
+Only consult documentation when you are unsure about a parameter/behavior/default.
+
+Verification order:
+1) PEFT documentation: https://huggingface.co/docs/peft
+2) Transformers PEFT integration docs
+3) Fallback if needed: inspect `peft` source or repo search
+
+If you cannot verify, say so and point to the most likely source to inspect next.
+
+### Step 6 — Respond using the output contract
+Every answer must include:
+- **Steps** (numbered)
+- **Minimal runnable snippet** (copy/paste)
+- **Pitfalls & fixes** ("If X → do Y")
+- **What to change** (3–8 knobs likely to matter)
+
+---
+
+## Key PEFT concepts (quick reference)
+
+### LoRA parameters
+| Parameter | Description | Typical values |
+|---|---|---|
+| `r` | Rank of low-rank matrices | 8, 16, 32, 64 |
+| `lora_alpha` | Scaling factor (effective = lora_alpha/r) | 16, 32 (often 2x of r) |
+| `lora_dropout` | Dropout for LoRA layers | 0.05, 0.1 |
+| `target_modules` | Which layers to apply LoRA | `["q_proj", "v_proj"]`, `"all-linear"` |
+| `modules_to_save` | Layers to fully train (e.g., classifier head) | `["classifier"]`, `["lm_head"]` |
+| `task_type` | Task for proper head handling | `CAUSAL_LM`, `SEQ_CLS`, `SEQ_2_SEQ_LM` |
+
+### Memory comparison (typical 7B model)
+| Method | VRAM (16GB GPU) | Trainable % |
+|---|---|---|
+| Full fine-tuning | 60+ GB (OOM) | 100% |
+| LoRA (fp16) | ~14 GB | 0.1-0.5% |
+| QLoRA (4-bit) | ~6-8 GB | 0.1-0.5% |
+
+---
+
+## Guardrails (non-negotiable)
+- Do not invent PEFT parameters/behavior. Verify if uncertain.
+- Do not recommend full fine-tuning when PEFT solves the memory constraint.
+- Always specify `task_type` in LoraConfig for proper head handling.
+- When using quantization, always use `prepare_model_for_kbit_training()`.
+- Keep PEFT responsibilities separate from Transformers core unless integration is the blocker.

--- a/.claude/skills/peft-lora/reference/areas/adapter-operations.md
+++ b/.claude/skills/peft-lora/reference/areas/adapter-operations.md
@@ -1,0 +1,348 @@
+# Adapter Operations (Load, Save, Merge, Switch)
+
+## Contents
+- [Scope](#scope)
+- [Minimum questions to ask](#minimum-questions-to-ask)
+- [Quickstarts](#quickstarts)
+  - [1) Save a trained adapter](#1-save-a-trained-adapter)
+  - [2) Load an adapter for inference](#2-load-an-adapter-for-inference)
+  - [3) Merge adapter into base model](#3-merge-adapter-into-base-model)
+  - [4) Load multiple adapters](#4-load-multiple-adapters)
+  - [5) Switch between adapters](#5-switch-between-adapters)
+  - [6) Combine adapters with weights](#6-combine-adapters-with-weights)
+  - [7) Push adapter to Hub](#7-push-adapter-to-hub)
+- [Knobs that matter (3–8)](#knobs-that-matter-38)
+- [Pitfalls & fixes](#pitfalls--fixes)
+
+---
+
+## Scope
+
+Use this page when the user wants to:
+- Save or load trained LoRA adapters
+- Merge adapters into base model
+- Work with multiple adapters
+- Push/pull adapters from Hugging Face Hub
+- Understand adapter file structure
+
+---
+
+## Minimum questions to ask
+
+Ask only what you need (0–5 questions):
+1) **Operation**: save, load, merge, or multi-adapter?
+2) **Adapter path**: local directory or Hub repo
+3) **Base model**: model id (must match adapter's base)
+4) **Merge goal**: inference-only or save merged model?
+5) If blocked: **full traceback + adapter_config.json contents**
+
+---
+
+## Quickstarts
+
+### 1. Save a trained adapter
+
+After training, save only the adapter weights (not full model):
+
+```python
+# After training
+model.save_pretrained("./my-lora-adapter")
+
+# This creates:
+# ./my-lora-adapter/
+#   ├── adapter_config.json    # LoRA configuration
+#   ├── adapter_model.safetensors  # Adapter weights (~10-50 MB)
+#   └── README.md (optional)
+```
+
+**Important**: This saves ONLY the adapter (a few MB), not the base model (several GB).
+
+To also save the tokenizer:
+```python
+model.save_pretrained("./my-lora-adapter")
+tokenizer.save_pretrained("./my-lora-adapter")
+```
+
+---
+
+### 2. Load an adapter for inference
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+# Load base model first
+base_model_id = "meta-llama/Llama-3.1-8B"
+base_model = AutoModelForCausalLM.from_pretrained(
+    base_model_id,
+    torch_dtype=torch.float16,
+    device_map="auto",
+)
+tokenizer = AutoTokenizer.from_pretrained(base_model_id)
+
+# Load adapter on top
+adapter_path = "./my-lora-adapter"  # or "username/adapter-repo" from Hub
+model = PeftModel.from_pretrained(base_model, adapter_path)
+model.eval()
+
+# Inference
+inputs = tokenizer("Hello, how are you?", return_tensors="pt").to(model.device)
+outputs = model.generate(**inputs, max_new_tokens=50)
+print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+```
+
+---
+
+### 3. Merge adapter into base model
+
+Merging creates a standalone model without adapter overhead:
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import PeftModel
+
+# Load base + adapter
+base_model = AutoModelForCausalLM.from_pretrained(
+    "meta-llama/Llama-3.1-8B",
+    torch_dtype=torch.float16,
+    device_map="auto",
+)
+model = PeftModel.from_pretrained(base_model, "./my-lora-adapter")
+
+# Merge adapter weights into base model
+merged_model = model.merge_and_unload()
+
+# Save merged model (full size, no adapter dependency)
+merged_model.save_pretrained("./merged-model")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.1-8B")
+tokenizer.save_pretrained("./merged-model")
+```
+
+**When to merge**:
+- Serving without PEFT dependency
+- Faster inference (no adapter overhead)
+- Creating a standalone checkpoint
+
+**When NOT to merge**:
+- Using multiple adapters
+- Quantized models (can cause precision loss)
+- Need to switch adapters dynamically
+
+---
+
+### 4. Load multiple adapters
+
+```python
+import torch
+from transformers import AutoModelForCausalLM
+from peft import PeftModel
+
+# Load base model
+base_model = AutoModelForCausalLM.from_pretrained(
+    "meta-llama/Llama-3.1-8B",
+    torch_dtype=torch.float16,
+    device_map="auto",
+)
+
+# Load first adapter
+model = PeftModel.from_pretrained(
+    base_model,
+    "./adapter-style",
+    adapter_name="style",  # Give it a name
+)
+
+# Load additional adapter
+model.load_adapter("./adapter-code", adapter_name="code")
+
+# List available adapters
+print(model.peft_config.keys())  # Output: dict_keys(['style', 'code'])
+```
+
+---
+
+### 5. Switch between adapters
+
+```python
+# Continue from multi-adapter setup
+
+# Set active adapter
+model.set_adapter("style")
+output_style = model.generate(...)
+
+model.set_adapter("code")
+output_code = model.generate(...)
+
+# Disable adapter (use base model)
+model.disable_adapter_layers()
+output_base = model.generate(...)
+
+# Re-enable adapters
+model.enable_adapter_layers()
+```
+
+---
+
+### 6. Combine adapters with weights
+
+Use multiple adapters simultaneously with weighted combination:
+
+```python
+# Activate multiple adapters at once
+model.set_adapter(["style", "code"])
+
+# With custom weights (add_weighted_adapter)
+model.add_weighted_adapter(
+    adapters=["style", "code"],
+    weights=[0.7, 0.3],  # 70% style, 30% code
+    adapter_name="combined",
+)
+model.set_adapter("combined")
+```
+
+**Alternative: Linear combination**
+```python
+from peft import add_weighted_adapter
+
+# Create new adapter from combination
+add_weighted_adapter(
+    model,
+    adapters=["style", "code"],
+    weights=[0.5, 0.5],
+    combination_type="linear",  # or "cat", "ties", etc.
+    adapter_name="mixed",
+)
+```
+
+---
+
+### 7. Push adapter to Hub
+
+```python
+from huggingface_hub import login
+
+# Authenticate
+login()  # or login(token="your_token")
+
+# Push adapter
+model.push_to_hub("your-username/my-lora-adapter")
+
+# With additional files
+tokenizer.push_to_hub("your-username/my-lora-adapter")
+```
+
+Loading from Hub:
+```python
+from peft import PeftModel
+
+model = PeftModel.from_pretrained(
+    base_model,
+    "your-username/my-lora-adapter",  # Hub path
+)
+```
+
+---
+
+## Knobs that matter (3–8)
+
+1) **`adapter_name`**
+   - Name for identifying adapter when loading multiple
+   - Default: `"default"`
+
+2) **`merge_and_unload()` vs keeping adapter**
+   - Merge: faster inference, no PEFT dependency, but loses flexibility
+   - Keep: can switch adapters, required for quantized models
+
+3) **`safe_serialization`**
+   - `True` (default): saves as `.safetensors` (recommended)
+   - `False`: saves as `.bin` (legacy)
+
+4) **Base model compatibility**
+   - Adapter MUST match base model architecture
+   - Check `adapter_config.json` → `base_model_name_or_path`
+
+5) **Revision pinning**
+   - Pin base model revision for reproducibility
+   - Adapter + base model versions should match
+
+6) **`low_cpu_mem_usage`**
+   - Speed up loading for large adapters
+   ```python
+   PeftModel.from_pretrained(base, adapter, low_cpu_mem_usage=True)
+   ```
+
+---
+
+## Pitfalls & fixes
+
+- **"Base model mismatch" or wrong outputs**
+  - Adapter trained on different base model version
+  - **Fix**: Check `adapter_config.json` and use matching base model
+
+- **Merged quantized model has bad outputs**
+  - Merging with 4-bit/8-bit causes precision loss
+  - **Fix**: Keep adapter separate or merge before quantization:
+  ```python
+  # Load in fp16 for merging
+  base = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16)
+  merged = PeftModel.from_pretrained(base, adapter).merge_and_unload()
+  # Then quantize the merged model if needed
+  ```
+
+- **"RuntimeError: Expected all tensors on same device"**
+  - Adapter and base on different devices
+  - **Fix**: Use `device_map="auto"` for both or manually move
+
+- **Adapter not applying / unchanged outputs**
+  - Adapter might be disabled
+  - **Fix**: Check adapter state:
+  ```python
+  from peft import get_model_status
+  print(get_model_status(model))  # Shows active adapters, merged status
+  ```
+
+- **OOM when loading adapter**
+  - Full model + adapter exceeds VRAM
+  - **Fix**: Use quantized base model or `low_cpu_mem_usage=True`
+
+- **Multiple adapters conflict**
+  - Both adapters target same layers differently
+  - **Fix**: Use weighted combination or train single multi-task adapter
+
+- **"ValueError: Cannot add a new adapter when adapter is merged"**
+  - Called `merge_and_unload()` then tried to add adapter
+  - **Fix**: Reload base model, or use `merge_adapter()` (doesn't unload):
+  ```python
+  # Merge in place (can still add more adapters)
+  model.merge_adapter()
+  # vs merge_and_unload() which removes adapter infrastructure
+  ```
+
+---
+
+## Adapter file structure
+
+Understanding what's saved:
+
+```
+my-lora-adapter/
+├── adapter_config.json      # LoRA config (r, alpha, target_modules, etc.)
+├── adapter_model.safetensors  # Trained LoRA weights
+└── README.md                # Auto-generated model card
+
+# adapter_config.json example:
+{
+  "base_model_name_or_path": "meta-llama/Llama-3.1-8B",
+  "r": 16,
+  "lora_alpha": 32,
+  "lora_dropout": 0.05,
+  "target_modules": ["q_proj", "v_proj"],
+  "task_type": "CAUSAL_LM",
+  "peft_type": "LORA"
+}
+```
+
+The adapter is typically **very small** compared to the base model:
+- 7B base model: ~14 GB
+- Typical LoRA adapter: 10-50 MB

--- a/.claude/skills/peft-lora/reference/areas/lora-basics.md
+++ b/.claude/skills/peft-lora/reference/areas/lora-basics.md
@@ -1,0 +1,241 @@
+# LoRA Basics (Low-Rank Adaptation)
+
+## Contents
+- [Scope](#scope)
+- [Minimum questions to ask](#minimum-questions-to-ask)
+- [How LoRA works](#how-lora-works)
+- [Quickstarts](#quickstarts)
+  - [1) Basic LoRA setup for causal LM](#1-basic-lora-setup-for-causal-lm)
+  - [2) LoRA for sequence classification](#2-lora-for-sequence-classification)
+  - [3) LoRA with automatic target module detection](#3-lora-with-automatic-target-module-detection)
+  - [4) Print trainable parameters](#4-print-trainable-parameters)
+- [Knobs that matter (3–8)](#knobs-that-matter-38)
+- [Pitfalls & fixes](#pitfalls--fixes)
+
+---
+
+## Scope
+
+Use this page when the user wants to:
+- Understand LoRA fundamentals
+- Set up their first LoRA configuration
+- Choose appropriate `r`, `lora_alpha`, and `target_modules`
+- Apply LoRA to a pretrained model
+
+---
+
+## Minimum questions to ask
+
+Ask only what you need to produce a runnable snippet (0–5 questions):
+1) **Task** (causal LM, classification, seq2seq, etc.)
+2) **Model id or local path** (and `revision` if pinned)
+3) **Available VRAM** (determines if QLoRA is needed)
+4) **Backend + device** (PyTorch; CPU/CUDA/MPS)
+5) If blocked: **full traceback + exact versions**
+
+---
+
+## How LoRA works
+
+LoRA (Low-Rank Adaptation) freezes the pretrained model weights and injects trainable rank decomposition matrices into specified layers. Instead of updating a weight matrix `W`, LoRA learns two smaller matrices `A` and `B` such that:
+
+```
+W' = W + BA
+```
+
+Where:
+- `W` is the original frozen weight (e.g., 4096 × 4096)
+- `B` has shape (4096 × r) and `A` has shape (r × 4096)
+- `r` (rank) is typically 8-64, making trainable parameters << original
+
+**Key insight**: The update `BA` captures task-specific adaptations with minimal parameters.
+
+---
+
+## Quickstarts
+
+### 1. Basic LoRA setup for causal LM
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from peft import LoraConfig, get_peft_model, TaskType
+
+model_id = "Qwen/Qwen2.5-0.5B-Instruct"
+
+# Load base model
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    torch_dtype=torch.float16,
+    device_map="auto",
+)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+# Configure LoRA
+lora_config = LoraConfig(
+    r=16,                           # Rank of the low-rank matrices
+    lora_alpha=32,                  # Scaling factor (effective_alpha = lora_alpha/r)
+    lora_dropout=0.05,              # Dropout for LoRA layers
+    target_modules=["q_proj", "v_proj"],  # Which layers to adapt
+    task_type=TaskType.CAUSAL_LM,   # Important for proper head handling
+)
+
+# Wrap model with LoRA
+model = get_peft_model(model, lora_config)
+
+# Check trainable parameters
+model.print_trainable_parameters()
+# Output: trainable params: X || all params: Y || trainable%: Z%
+```
+
+---
+
+### 2. LoRA for sequence classification
+
+```python
+import torch
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from peft import LoraConfig, get_peft_model, TaskType
+
+model_id = "distilbert/distilbert-base-uncased"
+
+model = AutoModelForSequenceClassification.from_pretrained(
+    model_id,
+    num_labels=2,
+)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+lora_config = LoraConfig(
+    r=8,
+    lora_alpha=16,
+    lora_dropout=0.1,
+    target_modules=["q_lin", "v_lin"],  # DistilBERT uses different names
+    modules_to_save=["classifier"],      # Train the classification head fully
+    task_type=TaskType.SEQ_CLS,
+)
+
+model = get_peft_model(model, lora_config)
+model.print_trainable_parameters()
+```
+
+**Note**: `modules_to_save` ensures the randomly initialized classifier head is trainable and saved with the adapter.
+
+---
+
+### 3. LoRA with automatic target module detection
+
+For many models, you can use `"all-linear"` to automatically target all linear layers:
+
+```python
+from peft import LoraConfig, TaskType
+
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    target_modules="all-linear",  # Auto-detect all linear layers
+    task_type=TaskType.CAUSAL_LM,
+)
+```
+
+Or let PEFT infer appropriate modules:
+
+```python
+# Omit target_modules to use PEFT's default inference
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    task_type=TaskType.CAUSAL_LM,
+)
+```
+
+---
+
+### 4. Print trainable parameters
+
+Always verify your configuration worked:
+
+```python
+model = get_peft_model(model, lora_config)
+
+# Method 1: Built-in method
+model.print_trainable_parameters()
+
+# Method 2: Manual calculation
+trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+total = sum(p.numel() for p in model.parameters())
+print(f"Trainable: {trainable:,} ({100 * trainable / total:.2f}%)")
+```
+
+Expected output for a 7B model with LoRA:
+```
+trainable params: 4,194,304 || all params: 6,742,609,920 || trainable%: 0.0622
+```
+
+---
+
+## Knobs that matter (3–8)
+
+Prioritize these knobs:
+
+1) **`r` (rank)**
+   - Higher = more expressive but more parameters
+   - Start with 8-16, increase if underfitting
+   
+2) **`lora_alpha`**
+   - Scaling factor: effective learning = lora_alpha / r
+   - Common: 2× the rank (if r=16, use lora_alpha=32)
+   
+3) **`target_modules`**
+   - Which layers to adapt
+   - Common patterns:
+     - LLMs: `["q_proj", "v_proj"]` or `["q_proj", "k_proj", "v_proj", "o_proj"]`
+     - All attention + MLP: `"all-linear"`
+   
+4) **`task_type`**
+   - Must match your model head
+   - `CAUSAL_LM`, `SEQ_CLS`, `SEQ_2_SEQ_LM`, `TOKEN_CLS`, `QUESTION_ANS`, `FEATURE_EXTRACTION`
+   
+5) **`modules_to_save`**
+   - Fully train these layers (not LoRA)
+   - Use for: classifier heads, newly added tokens, embedding layers
+   
+6) **`lora_dropout`**
+   - Regularization for LoRA layers
+   - 0.05-0.1 is typical; 0.0 for inference
+
+7) **`bias`**
+   - `"none"` (default): Don't train biases
+   - `"all"`: Train all biases
+   - `"lora_only"`: Train only LoRA layer biases
+
+---
+
+## Pitfalls & fixes
+
+- **Wrong target_modules for model architecture**
+  - Different models use different layer names
+  - Llama/Mistral: `q_proj`, `v_proj`, `k_proj`, `o_proj`
+  - GPT-2: `c_attn`, `c_proj`
+  - BERT: `query`, `value`, `key`
+  - **Fix**: Use `"all-linear"` or inspect model with `print(model)`
+
+- **Classification head not training**
+  - Add `modules_to_save=["classifier"]` (or appropriate head name)
+  - Ensure `task_type=TaskType.SEQ_CLS` is set
+
+- **OOM even with LoRA**
+  - LoRA reduces trainable params but still loads full model
+  - **Fix**: Use QLoRA (4-bit quantization) - see `qlora-quantization.md`
+
+- **"LoRA layers not found" / empty adapter**
+  - `target_modules` didn't match any layers
+  - **Fix**: Print model architecture and check layer names
+
+- **Merged model behaves differently**
+  - Merging with quantization can cause precision loss
+  - **Fix**: Compare outputs before/after merge on fixed inputs
+
+- **Forgetting to set eval mode**
+  - LoRA dropout applies during training
+  - **Fix**: Call `model.eval()` before inference

--- a/.claude/skills/peft-lora/reference/areas/qlora-quantization.md
+++ b/.claude/skills/peft-lora/reference/areas/qlora-quantization.md
@@ -1,0 +1,297 @@
+# QLoRA & Quantization (Memory-Efficient Fine-Tuning)
+
+## Contents
+- [Scope](#scope)
+- [Minimum questions to ask](#minimum-questions-to-ask)
+- [How QLoRA works](#how-qlora-works)
+- [Quickstarts](#quickstarts)
+  - [1) QLoRA 4-bit training setup](#1-qlora-4-bit-training-setup)
+  - [2) 8-bit LoRA training](#2-8-bit-lora-training)
+  - [3) NF4 vs FP4 quantization](#3-nf4-vs-fp4-quantization)
+  - [4) Compute dtype selection](#4-compute-dtype-selection)
+- [Knobs that matter (3–8)](#knobs-that-matter-38)
+- [Pitfalls & fixes](#pitfalls--fixes)
+- [Memory comparison](#memory-comparison)
+
+---
+
+## Scope
+
+Use this page when the user wants to:
+- Fine-tune large models on consumer GPUs (8-24GB VRAM)
+- Use 4-bit or 8-bit quantization with LoRA
+- Understand QLoRA configuration options
+- Troubleshoot memory issues during training
+
+---
+
+## Minimum questions to ask
+
+Ask only what you need (0–5 questions):
+1) **Model size** (7B, 13B, 70B, etc.)
+2) **Available VRAM** (determines 4-bit vs 8-bit)
+3) **GPU type** (affects compute dtype choice)
+4) **Model id or local path**
+5) If blocked: **full OOM traceback + batch size + sequence length**
+
+---
+
+## How QLoRA works
+
+QLoRA combines three techniques:
+1. **4-bit NormalFloat (NF4)** quantization for base model weights
+2. **Double quantization** to reduce memory from quantization constants
+3. **LoRA adapters** trained in higher precision (bf16/fp16)
+
+The base model stays frozen in 4-bit, while LoRA adapters train in 16-bit precision, achieving near-full-precision quality with ~75% less memory.
+
+---
+
+## Quickstarts
+
+### 1. QLoRA 4-bit training setup
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
+
+model_id = "meta-llama/Llama-3.1-8B"
+
+# 4-bit quantization config
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",           # NormalFloat4 (recommended)
+    bnb_4bit_compute_dtype=torch.bfloat16,  # Compute dtype for LoRA
+    bnb_4bit_use_double_quant=True,      # Double quantization saves more memory
+)
+
+# Load quantized model
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    quantization_config=bnb_config,
+    device_map="auto",
+)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+# CRITICAL: Prepare model for k-bit training
+model = prepare_model_for_kbit_training(model)
+
+# Configure LoRA
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+    task_type=TaskType.CAUSAL_LM,
+)
+
+# Apply LoRA
+model = get_peft_model(model, lora_config)
+model.print_trainable_parameters()
+```
+
+**Critical**: Always call `prepare_model_for_kbit_training()` before `get_peft_model()` for quantized models.
+
+---
+
+### 2. 8-bit LoRA training
+
+For more precision at slightly higher memory cost:
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, BitsAndBytesConfig
+from peft import LoraConfig, get_peft_model, prepare_model_for_kbit_training, TaskType
+
+model_id = "meta-llama/Llama-3.1-8B"
+
+# 8-bit config
+bnb_config = BitsAndBytesConfig(
+    load_in_8bit=True,
+)
+
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    quantization_config=bnb_config,
+    device_map="auto",
+)
+
+model = prepare_model_for_kbit_training(model)
+
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules="all-linear",
+    task_type=TaskType.CAUSAL_LM,
+)
+
+model = get_peft_model(model, lora_config)
+```
+
+---
+
+### 3. NF4 vs FP4 quantization
+
+```python
+from transformers import BitsAndBytesConfig
+import torch
+
+# NF4 (recommended for most cases)
+bnb_config_nf4 = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",  # NormalFloat4: optimized for normally-distributed weights
+    bnb_4bit_compute_dtype=torch.bfloat16,
+)
+
+# FP4 (alternative, sometimes faster)
+bnb_config_fp4 = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="fp4",  # Standard 4-bit float
+    bnb_4bit_compute_dtype=torch.bfloat16,
+)
+```
+
+**When to use each**:
+- **NF4**: Default choice, better for transformer weights (normally distributed)
+- **FP4**: Try if NF4 causes issues or for non-standard architectures
+
+---
+
+### 4. Compute dtype selection
+
+```python
+import torch
+from transformers import BitsAndBytesConfig
+
+# For Ampere+ GPUs (RTX 3000/4000, A100, H100)
+bnb_config_bf16 = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",
+    bnb_4bit_compute_dtype=torch.bfloat16,  # Native bf16 support
+    bnb_4bit_use_double_quant=True,
+)
+
+# For older GPUs (V100, RTX 2000, etc.)
+bnb_config_fp16 = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",
+    bnb_4bit_compute_dtype=torch.float16,   # Use fp16 instead
+    bnb_4bit_use_double_quant=True,
+)
+```
+
+**Check GPU capability**:
+```python
+import torch
+if torch.cuda.is_bf16_supported():
+    print("Use bfloat16")
+else:
+    print("Use float16")
+```
+
+---
+
+## Knobs that matter (3–8)
+
+1) **`load_in_4bit` vs `load_in_8bit`**
+   - 4-bit: Maximum memory savings (~50% of 8-bit)
+   - 8-bit: Better precision, still significant savings
+
+2) **`bnb_4bit_quant_type`**
+   - `"nf4"`: NormalFloat4, optimized for neural network weights
+   - `"fp4"`: Standard 4-bit float
+
+3) **`bnb_4bit_compute_dtype`**
+   - Dtype for LoRA computations (not storage)
+   - `torch.bfloat16`: Preferred for Ampere+ GPUs
+   - `torch.float16`: For older GPUs
+
+4) **`bnb_4bit_use_double_quant`**
+   - Quantizes quantization constants (saves ~0.4 bits/param)
+   - Recommended: `True`
+
+5) **`prepare_model_for_kbit_training()`**
+   - REQUIRED for quantized training
+   - Handles gradient checkpointing and layer norms
+
+6) **LoRA `r` with quantization**
+   - May need higher `r` to compensate for quantization
+   - Start with r=16-32 for QLoRA (vs r=8-16 for fp16 LoRA)
+
+7) **Gradient checkpointing**
+   - Automatically enabled by `prepare_model_for_kbit_training()`
+   - Can disable if VRAM allows: `model.gradient_checkpointing_disable()`
+
+---
+
+## Pitfalls & fixes
+
+- **"ValueError: Attempting to unscale FP16 gradients"**
+  - Caused by fp16 model + mixed precision training
+  - **Fix**: Cast trainable params to fp32:
+  ```python
+  from peft import cast_mixed_precision_params
+  cast_mixed_precision_params(model, dtype=torch.float16)
+  ```
+
+- **Forgot `prepare_model_for_kbit_training()`**
+  - Training may fail or produce bad results
+  - **Fix**: Always call before `get_peft_model()`:
+  ```python
+  model = prepare_model_for_kbit_training(model)
+  model = get_peft_model(model, lora_config)
+  ```
+
+- **OOM even with 4-bit**
+  - Reduce batch size first
+  - Enable gradient checkpointing (default with prepare_model_for_kbit_training)
+  - Reduce sequence length
+  - Use gradient accumulation:
+  ```python
+  training_args = TrainingArguments(
+      per_device_train_batch_size=1,
+      gradient_accumulation_steps=16,  # Effective batch = 16
+  )
+  ```
+
+- **Training loss explodes or NaN**
+  - Check compute dtype matches GPU capability
+  - Try different learning rate (lower for QLoRA, e.g., 1e-4 to 2e-4)
+  - Ensure optimizer compatible with 4-bit:
+  ```python
+  # Use paged AdamW for memory efficiency
+  training_args = TrainingArguments(
+      optim="paged_adamw_8bit",
+  )
+  ```
+
+- **bitsandbytes not installed or CUDA issues**
+  ```bash
+  pip install bitsandbytes>=0.43.0
+  ```
+  - Ensure CUDA toolkit matches PyTorch CUDA version
+
+- **Model outputs are wrong after quantization**
+  - Compare outputs on same inputs with fp16 model
+  - Try `bnb_4bit_quant_type="fp4"` if `nf4` causes issues
+  - Check if model architecture is supported by bitsandbytes
+
+---
+
+## Memory comparison
+
+Approximate VRAM usage for fine-tuning:
+
+| Model Size | Full FT (fp16) | LoRA (fp16) | LoRA (8-bit) | QLoRA (4-bit) |
+|---|---|---|---|---|
+| 7B | 28+ GB | 14-16 GB | 10-12 GB | 6-8 GB |
+| 13B | 52+ GB | 28-32 GB | 18-22 GB | 10-14 GB |
+| 70B | 280+ GB | 140+ GB | 80-100 GB | 40-50 GB |
+
+*Values vary based on sequence length, batch size, and gradient accumulation.*
+
+### Recommended GPU per model size (QLoRA):
+- **7B**: RTX 3090/4090 (24GB), A10 (24GB)
+- **13B**: A100-40GB, 2x RTX 3090
+- **70B**: A100-80GB, 4x A100-40GB

--- a/.claude/skills/peft-lora/reference/areas/training-integration.md
+++ b/.claude/skills/peft-lora/reference/areas/training-integration.md
@@ -1,0 +1,431 @@
+# Training Integration (Trainer, SFTTrainer, Custom Loops)
+
+## Contents
+- [Scope](#scope)
+- [Minimum questions to ask](#minimum-questions-to-ask)
+- [Decision guide: Trainer vs SFTTrainer vs custom loop](#decision-guide-trainer-vs-sfttrainer-vs-custom-loop)
+- [Quickstarts](#quickstarts)
+  - [1) PEFT with Transformers Trainer](#1-peft-with-transformers-trainer)
+  - [2) QLoRA with TRL SFTTrainer](#2-qlora-with-trl-sfttrainer)
+  - [3) Custom training loop with Accelerate](#3-custom-training-loop-with-accelerate)
+  - [4) Resume training from checkpoint](#4-resume-training-from-checkpoint)
+  - [5) Multi-GPU training with PEFT](#5-multi-gpu-training-with-peft)
+- [Knobs that matter (3–8)](#knobs-that-matter-38)
+- [Pitfalls & fixes](#pitfalls--fixes)
+
+---
+
+## Scope
+
+Use this page when the user wants to:
+- Train LoRA/QLoRA with Transformers Trainer
+- Use TRL's SFTTrainer for instruction fine-tuning
+- Write custom training loops with PEFT
+- Resume training from checkpoints
+- Scale PEFT training to multiple GPUs
+
+---
+
+## Minimum questions to ask
+
+Ask only what you need (0–6 questions):
+1) **Task** (instruction tuning, classification, causal LM, etc.)
+2) **Training framework** (Trainer, SFTTrainer, custom loop)
+3) **Model + PEFT config** (which model, LoRA or QLoRA)
+4) **Hardware** (single GPU, multi-GPU, VRAM)
+5) **Dataset format** (already tokenized, needs preprocessing)
+6) If blocked: **full traceback + training args**
+
+---
+
+## Decision guide: Trainer vs SFTTrainer vs custom loop
+
+### Prefer `Trainer` when…
+- Standard supervised fine-tuning
+- Classification or sequence tasks
+- Need full control over preprocessing
+- Already familiar with Trainer API
+
+### Prefer `SFTTrainer` (from TRL) when…
+- Instruction fine-tuning / chat models
+- Want automatic chat template handling
+- Using datasets with conversational format
+- Want RLHF-ready training setup
+
+### Prefer custom loop when…
+- Non-standard objectives (RL, multi-stage, etc.)
+- Very custom batching or optimization
+- Research experimentation
+- Full control over every step
+
+---
+
+## Quickstarts
+
+### 1. PEFT with Transformers Trainer
+
+```python
+import torch
+from datasets import load_dataset
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    TrainingArguments,
+    Trainer,
+    DataCollatorForLanguageModeling,
+)
+from peft import LoraConfig, get_peft_model, TaskType
+
+# Model setup
+model_id = "Qwen/Qwen2.5-0.5B-Instruct"
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    torch_dtype=torch.float16,
+    device_map="auto",
+)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+tokenizer.pad_token = tokenizer.eos_token
+
+# Apply LoRA
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    target_modules="all-linear",
+    task_type=TaskType.CAUSAL_LM,
+)
+model = get_peft_model(model, lora_config)
+model.print_trainable_parameters()
+
+# Dataset
+dataset = load_dataset("wikitext", "wikitext-2-raw-v1", split="train[:1000]")
+
+def tokenize(examples):
+    return tokenizer(
+        examples["text"],
+        truncation=True,
+        max_length=512,
+        padding="max_length",
+    )
+
+tokenized = dataset.map(tokenize, batched=True, remove_columns=dataset.column_names)
+
+# Training
+training_args = TrainingArguments(
+    output_dir="./lora-output",
+    num_train_epochs=1,
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=4,
+    learning_rate=2e-4,
+    fp16=True,
+    logging_steps=10,
+    save_strategy="epoch",
+    report_to="none",
+)
+
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=tokenized,
+    data_collator=DataCollatorForLanguageModeling(tokenizer, mlm=False),
+)
+
+trainer.train()
+trainer.save_model("./lora-output/final")
+```
+
+---
+
+### 2. QLoRA with TRL SFTTrainer
+
+Best for instruction fine-tuning:
+
+```python
+import torch
+from datasets import load_dataset
+from transformers import AutoModelForCausalLM, AutoTokenizer, BitsAndBytesConfig
+from peft import LoraConfig, prepare_model_for_kbit_training
+from trl import SFTTrainer, SFTConfig
+
+# Model with 4-bit quantization
+model_id = "meta-llama/Llama-3.1-8B"
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",
+    bnb_4bit_compute_dtype=torch.bfloat16,
+    bnb_4bit_use_double_quant=True,
+)
+
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    quantization_config=bnb_config,
+    device_map="auto",
+)
+model = prepare_model_for_kbit_training(model)
+
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+tokenizer.pad_token = tokenizer.eos_token
+tokenizer.padding_side = "right"
+
+# LoRA config
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    lora_dropout=0.05,
+    target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+    task_type="CAUSAL_LM",
+)
+
+# Dataset with instruction format
+dataset = load_dataset("timdettmers/openassistant-guanaco", split="train[:1000]")
+
+# SFT Training
+training_args = SFTConfig(
+    output_dir="./qlora-sft",
+    num_train_epochs=1,
+    per_device_train_batch_size=1,
+    gradient_accumulation_steps=16,
+    learning_rate=2e-4,
+    optim="paged_adamw_8bit",  # Memory-efficient optimizer
+    fp16=True,
+    logging_steps=10,
+    save_strategy="epoch",
+    max_seq_length=512,
+    report_to="none",
+)
+
+trainer = SFTTrainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset,
+    processing_class=tokenizer,
+    peft_config=lora_config,  # SFTTrainer handles PEFT integration
+)
+
+trainer.train()
+trainer.save_model("./qlora-sft/final")
+```
+
+---
+
+### 3. Custom training loop with Accelerate
+
+```python
+import torch
+from torch.utils.data import DataLoader
+from transformers import AutoModelForCausalLM, AutoTokenizer, get_scheduler
+from peft import LoraConfig, get_peft_model, TaskType
+from accelerate import Accelerator
+
+# Setup
+accelerator = Accelerator()
+model_id = "Qwen/Qwen2.5-0.5B-Instruct"
+
+model = AutoModelForCausalLM.from_pretrained(model_id, torch_dtype=torch.float16)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+tokenizer.pad_token = tokenizer.eos_token
+
+# Apply LoRA
+lora_config = LoraConfig(
+    r=16, lora_alpha=32,
+    target_modules="all-linear",
+    task_type=TaskType.CAUSAL_LM,
+)
+model = get_peft_model(model, lora_config)
+
+# Optimizer (only for trainable params)
+optimizer = torch.optim.AdamW(
+    filter(lambda p: p.requires_grad, model.parameters()),
+    lr=2e-4,
+)
+
+# Prepare with Accelerate
+model, optimizer = accelerator.prepare(model, optimizer)
+
+# Training loop (simplified)
+model.train()
+for epoch in range(3):
+    for batch in dataloader:  # Your DataLoader
+        outputs = model(**batch)
+        loss = outputs.loss
+        
+        accelerator.backward(loss)
+        optimizer.step()
+        optimizer.zero_grad()
+
+# Save (unwrap from accelerate)
+unwrapped = accelerator.unwrap_model(model)
+unwrapped.save_pretrained("./custom-lora")
+```
+
+---
+
+### 4. Resume training from checkpoint
+
+```python
+from transformers import Trainer, TrainingArguments
+from peft import PeftModel
+
+# Option 1: Resume with Trainer (automatic)
+training_args = TrainingArguments(
+    output_dir="./lora-output",
+    resume_from_checkpoint=True,  # Auto-find latest checkpoint
+    # or: resume_from_checkpoint="./lora-output/checkpoint-500"
+)
+
+# Option 2: Manual checkpoint loading
+base_model = AutoModelForCausalLM.from_pretrained(model_id)
+model = PeftModel.from_pretrained(base_model, "./lora-output/checkpoint-500")
+# Continue training with new Trainer instance...
+```
+
+---
+
+### 5. Multi-GPU training with PEFT
+
+PEFT works seamlessly with distributed training:
+
+```bash
+# With accelerate (recommended)
+accelerate config  # Interactive setup
+accelerate launch train.py
+
+# With torchrun
+torchrun --nproc_per_node 4 train.py
+```
+
+**FSDP with PEFT** (for very large models):
+
+```python
+from transformers import TrainingArguments
+
+training_args = TrainingArguments(
+    output_dir="./fsdp-lora",
+    fsdp="full_shard auto_wrap",
+    fsdp_config={
+        "fsdp_transformer_layer_cls_to_wrap": ["LlamaDecoderLayer"],
+    },
+    # ... other args
+)
+```
+
+---
+
+## Knobs that matter (3–8)
+
+1) **Learning rate**
+   - LoRA typically needs higher LR than full fine-tuning
+   - Start: 1e-4 to 3e-4 (vs 1e-5 to 5e-5 for full FT)
+
+2) **`gradient_accumulation_steps`**
+   - Critical for memory-constrained training
+   - Effective batch = per_device_batch × accumulation × num_gpus
+
+3) **`optim`**
+   - `"paged_adamw_8bit"`: Memory-efficient for QLoRA
+   - `"adamw_torch"`: Standard choice
+
+4) **`fp16` vs `bf16`**
+   - `bf16=True`: For Ampere+ GPUs, better numerical stability
+   - `fp16=True`: For older GPUs
+
+5) **`max_grad_norm`**
+   - Gradient clipping for stability
+   - Default: 1.0, can lower to 0.3 if loss spikes
+
+6) **`warmup_ratio` or `warmup_steps`**
+   - Helps stability at training start
+   - 0.03-0.1 warmup_ratio is common
+
+7) **`save_strategy` and checkpointing**
+   - Save frequently (e.g., "steps", save_steps=100)
+   - Adapters are small, so saving is cheap
+
+8) **`prepare_model_for_kbit_training()`**
+   - REQUIRED for quantized training
+   - Handles gradient checkpointing automatically
+
+---
+
+## Pitfalls & fixes
+
+- **"RuntimeError: element 0 of tensors does not require grad"**
+  - No trainable parameters (LoRA not applied correctly)
+  - **Fix**: Check `model.print_trainable_parameters()` shows > 0
+
+- **Loss is NaN or explodes**
+  - Learning rate too high
+  - **Fix**: Lower LR (try 1e-4), add gradient clipping:
+  ```python
+  training_args = TrainingArguments(
+      learning_rate=1e-4,
+      max_grad_norm=0.3,
+  )
+  ```
+
+- **OOM during training (even with LoRA)**
+  - Batch size too large or sequence too long
+  - **Fix**: 
+    - Reduce `per_device_train_batch_size` to 1
+    - Increase `gradient_accumulation_steps`
+    - Use QLoRA (4-bit)
+    - Reduce `max_seq_length`
+
+- **Trainer not saving adapter correctly**
+  - Using old `save_model()` behavior
+  - **Fix**: PEFT auto-integrates; check output has `adapter_config.json`
+
+- **Checkpoints are huge (full model size)**
+  - Might be saving full model instead of adapter
+  - **Fix**: Ensure you're calling `model.save_pretrained()` on PeftModel
+
+- **"ValueError: You are attempting to train a model on a text generation task"**
+  - Task type mismatch in LoRA config
+  - **Fix**: Set `task_type=TaskType.CAUSAL_LM` explicitly
+
+- **Multi-GPU: adapters not synced**
+  - Should work automatically with DDP/FSDP
+  - **Fix**: Ensure `device_map="auto"` or proper FSDP wrapping
+
+- **Training slow despite small trainable params**
+  - Full model still does forward pass
+  - LoRA reduces trainable params, not forward pass cost
+  - **Fix**: Use gradient checkpointing, reduce sequence length
+
+---
+
+## Common training configurations
+
+### Instruction Fine-Tuning (QLoRA, 7B model)
+```python
+training_args = TrainingArguments(
+    output_dir="./instruction-ft",
+    num_train_epochs=3,
+    per_device_train_batch_size=1,
+    gradient_accumulation_steps=16,
+    learning_rate=2e-4,
+    optim="paged_adamw_8bit",
+    bf16=True,  # or fp16=True for older GPUs
+    max_grad_norm=0.3,
+    warmup_ratio=0.03,
+    lr_scheduler_type="cosine",
+    logging_steps=10,
+    save_strategy="steps",
+    save_steps=100,
+)
+```
+
+### Classification Fine-Tuning (LoRA)
+```python
+training_args = TrainingArguments(
+    output_dir="./classification-ft",
+    num_train_epochs=5,
+    per_device_train_batch_size=8,
+    learning_rate=1e-4,
+    fp16=True,
+    eval_strategy="epoch",
+    save_strategy="epoch",
+    load_best_model_at_end=True,
+    metric_for_best_model="accuracy",
+)
+```

--- a/.claude/skills/peft-lora/reference/areas/troubleshooting.md
+++ b/.claude/skills/peft-lora/reference/areas/troubleshooting.md
@@ -1,0 +1,364 @@
+# Troubleshooting (PEFT Errors, Wrong Outputs, Common Issues)
+
+## Contents
+- [Scope](#scope)
+- [Minimum questions to ask](#minimum-questions-to-ask)
+- [Decision guide: classify the failure](#decision-guide-classify-the-failure)
+- [Quickstarts](#quickstarts)
+  - [1) "ValueError: Attempting to unscale FP16 gradients"](#1-valueerror-attempting-to-unscale-fp16-gradients)
+  - [2) Loaded adapter produces wrong/random outputs](#2-loaded-adapter-produces-wrongrandom-outputs)
+  - [3) "Target modules not found" / empty adapter](#3-target-modules-not-found--empty-adapter)
+  - [4) OOM even with LoRA](#4-oom-even-with-lora)
+  - [5) Loss is None / labels not passed](#5-loss-is-none--labels-not-passed)
+  - [6) Adapter loading version mismatch](#6-adapter-loading-version-mismatch)
+  - [7) Check model and layer status](#7-check-model-and-layer-status)
+- [Pitfalls & fixes (quick reference)](#pitfalls--fixes-quick-reference)
+- [Triage flow (repeatable checklist)](#triage-flow-repeatable-checklist)
+
+---
+
+## Scope
+
+Use this page when the user is **blocked** by:
+- Exceptions during PEFT training/inference
+- Wrong outputs from trained adapters
+- Memory issues despite using PEFT
+- Adapter loading/saving failures
+- Dtype mismatches
+
+---
+
+## Minimum questions to ask
+
+Ask only what you need (0–5 questions). If already provided, don't re-ask:
+1) **Exact error**: full traceback
+2) **Minimal repro**: smallest code that fails
+3) **Versions**: `peft`, `transformers`, `torch`, `bitsandbytes` versions
+4) **Model + adapter config**: model id, LoraConfig settings
+5) **Hardware**: CUDA/CPU, VRAM if memory-related
+
+---
+
+## Decision guide: classify the failure
+
+Classify before fixing:
+
+1) **Dtype/precision issues**
+   - FP16 gradient errors, mixed precision conflicts
+   - NaN loss, overflow
+
+2) **Configuration issues**
+   - Wrong target_modules, task_type mismatch
+   - Adapter not applying
+
+3) **Loading issues**
+   - Version mismatch, missing files
+   - Base model incompatibility
+
+4) **Training issues**
+   - Loss is None, labels not used
+   - Training but no improvement
+
+5) **Memory issues**
+   - OOM despite LoRA/QLoRA
+   - Slow due to wrong settings
+
+---
+
+## Quickstarts
+
+### 1. "ValueError: Attempting to unscale FP16 gradients"
+
+**Symptom**: Error during training with fp16 and quantized model.
+
+**Cause**: Model loaded in fp16, used with AMP, but trainable weights should be fp32.
+
+**Fix**: Cast trainable parameters:
+
+```python
+from peft import get_peft_model, cast_mixed_precision_params
+
+# After creating PEFT model
+model = get_peft_model(model, lora_config)
+
+# Cast trainable params to appropriate dtype
+cast_mixed_precision_params(model, dtype=torch.float16)
+
+# Now training with fp16=True works
+trainer = Trainer(model=model, args=TrainingArguments(fp16=True, ...))
+```
+
+**Alternative** (manual):
+```python
+for param in model.parameters():
+    if param.requires_grad:
+        param.data = param.data.float()
+```
+
+---
+
+### 2. Loaded adapter produces wrong/random outputs
+
+**Symptom**: Adapter loads without error but outputs are garbage.
+
+**Possible causes and fixes**:
+
+**A) Wrong base model**
+```python
+# Check adapter_config.json for expected base
+import json
+with open("./my-adapter/adapter_config.json") as f:
+    config = json.load(f)
+print(config["base_model_name_or_path"])  # Must match!
+```
+
+**B) Forgot to set eval mode**
+```python
+model = PeftModel.from_pretrained(base, adapter)
+model.eval()  # IMPORTANT: disable dropout
+```
+
+**C) Adapter not active**
+```python
+from peft import get_model_status
+print(get_model_status(model))
+# Check: enabled=True, active_adapters=['default']
+```
+
+**D) Random deviations**
+```python
+# Set deterministic mode
+import torch
+torch.manual_seed(42)
+model.eval()
+with torch.inference_mode():
+    outputs = model.generate(...)
+```
+
+---
+
+### 3. "Target modules not found" / empty adapter
+
+**Symptom**: LoRA not applied, 0 trainable parameters.
+
+**Cause**: `target_modules` don't match model's layer names.
+
+**Fix**: Inspect model architecture:
+
+```python
+# Print all named modules
+for name, module in model.named_modules():
+    print(name, type(module).__name__)
+
+# Common patterns:
+# Llama/Mistral: q_proj, k_proj, v_proj, o_proj, gate_proj, up_proj, down_proj
+# GPT-2: c_attn, c_proj, c_fc
+# BERT: query, key, value, dense
+# DistilBERT: q_lin, k_lin, v_lin, out_lin
+```
+
+**Safe approach** - use auto-detection:
+```python
+lora_config = LoraConfig(
+    r=16,
+    lora_alpha=32,
+    target_modules="all-linear",  # Auto-detect all Linear layers
+    task_type=TaskType.CAUSAL_LM,
+)
+```
+
+---
+
+### 4. OOM even with LoRA
+
+**Symptom**: CUDA out of memory during training.
+
+**LoRA reduces trainable params, NOT forward pass memory.**
+
+**Fixes (in order)**:
+
+```python
+# 1. Use QLoRA (4-bit quantization)
+from transformers import BitsAndBytesConfig
+bnb_config = BitsAndBytesConfig(
+    load_in_4bit=True,
+    bnb_4bit_quant_type="nf4",
+    bnb_4bit_compute_dtype=torch.bfloat16,
+)
+
+# 2. Reduce batch size + increase accumulation
+training_args = TrainingArguments(
+    per_device_train_batch_size=1,  # Minimum
+    gradient_accumulation_steps=16,  # Effective batch = 16
+)
+
+# 3. Enable gradient checkpointing (auto with QLoRA)
+model.gradient_checkpointing_enable()
+
+# 4. Reduce sequence length
+max_length = 256  # vs 512 or 1024
+
+# 5. Use paged optimizer
+training_args = TrainingArguments(
+    optim="paged_adamw_8bit",
+)
+```
+
+---
+
+### 5. Loss is None / labels not passed
+
+**Symptom**: Training runs but loss shows `None` or model doesn't improve.
+
+**Cause**: Labels not passed to model forward.
+
+**Fixes**:
+
+```python
+# For causal LM: labels = input_ids (shifted internally)
+def tokenize(examples):
+    tokenized = tokenizer(examples["text"], truncation=True, max_length=512)
+    tokenized["labels"] = tokenized["input_ids"].copy()  # Labels = inputs
+    return tokenized
+
+# For classification: ensure labels column exists
+dataset = dataset.rename_column("label", "labels")
+
+# Check during forward
+outputs = model(input_ids=input_ids, labels=labels)
+print(outputs.loss)  # Should be a tensor, not None
+```
+
+---
+
+### 6. Adapter loading version mismatch
+
+**Symptom**: `TypeError: LoraConfig.__init__() got an unexpected keyword argument`
+
+**Cause**: Adapter saved with newer PEFT than installed version.
+
+**Fix**:
+```bash
+# Upgrade PEFT
+pip install -U peft
+
+# Or from source for latest
+pip install git+https://github.com/huggingface/peft
+```
+
+**Workaround** (if can't upgrade):
+```python
+# Edit adapter_config.json and remove the unknown field
+# This works if it's a default value, may cause issues otherwise
+```
+
+---
+
+### 7. Check model and layer status
+
+Use these to debug adapter state:
+
+```python
+from peft import get_model_status, get_layer_status
+
+# Overall model status
+status = get_model_status(model)
+print(status)
+# TunerModelStatus(
+#     base_model_type='LlamaForCausalLM',
+#     adapter_model_type='LoraModel',
+#     trainable_params=4194304,
+#     total_params=6738415616,
+#     enabled=True,
+#     active_adapters=['default'],
+#     merged_adapters=[],
+# )
+
+# Per-layer status
+for layer in get_layer_status(model)[:5]:
+    print(layer)
+# Shows: name, module_type, enabled, active_adapters, merged_adapters
+
+# Check for "irregular" status (inconsistent state)
+if "irregular" in str(status):
+    print("WARNING: Model in inconsistent state, reload!")
+```
+
+---
+
+## Pitfalls & fixes (quick reference)
+
+| Symptom | Likely Cause | Fix |
+|---------|--------------|-----|
+| "Attempting to unscale FP16 gradients" | Trainable params in fp16 with AMP | `cast_mixed_precision_params()` |
+| 0 trainable parameters | Wrong target_modules | Use `"all-linear"` or inspect model |
+| Loaded model gives garbage | Wrong base model / not in eval mode | Check adapter_config.json, call `.eval()` |
+| OOM with LoRA | Forward pass still full size | Use QLoRA, reduce batch/seq length |
+| Loss is None | Labels not passed | Add `labels=input_ids` for LM |
+| "unexpected keyword argument" | PEFT version mismatch | Upgrade: `pip install -U peft` |
+| NaN loss | Learning rate too high / dtype issues | Lower LR, check compute dtype |
+| Training slow | Gradient checkpointing off | Enable with `prepare_model_for_kbit_training()` |
+| Merged model worse | Quantization precision loss | Merge in fp16, then quantize |
+| Multiple adapters conflict | Same layers, different configs | Use weighted combination |
+
+---
+
+## Triage flow (repeatable checklist)
+
+1) **Freeze the environment**
+   - Record: peft, transformers, torch, bitsandbytes versions
+   - Record: model id, LoraConfig
+   - Record: hardware (GPU, VRAM)
+
+2) **Minimize**
+   - One model
+   - One input
+   - One forward/generate call
+   - Print shapes, dtypes, devices
+
+3) **Classify**
+   - Dtype → Configuration → Loading → Training → Memory
+
+4) **Check adapter state**
+   ```python
+   from peft import get_model_status
+   print(get_model_status(model))
+   model.print_trainable_parameters()
+   ```
+
+5) **Apply smallest fix**
+   - One change at a time
+   - Re-run minimal repro
+
+6) **Verify fix worked**
+   - Check trainable params > 0
+   - Check loss is decreasing
+   - Check outputs are sensible
+
+---
+
+## Common version requirements
+
+For most PEFT functionality:
+```bash
+pip install peft>=0.10.0 transformers>=4.38.0 bitsandbytes>=0.43.0
+```
+
+For latest features:
+```bash
+pip install git+https://github.com/huggingface/peft
+pip install git+https://github.com/huggingface/transformers
+```
+
+Check installed versions:
+```python
+import peft, transformers, torch
+print(f"peft: {peft.__version__}")
+print(f"transformers: {transformers.__version__}")
+print(f"torch: {torch.__version__}")
+try:
+    import bitsandbytes as bnb
+    print(f"bitsandbytes: {bnb.__version__}")
+except ImportError:
+    print("bitsandbytes: not installed")
+```

--- a/.claude/skills/peft-lora/templates/minimal_repro.md
+++ b/.claude/skills/peft-lora/templates/minimal_repro.md
@@ -1,0 +1,160 @@
+# Minimal Repro Template (PEFT/LoRA)
+
+Use this template to produce a **copy/paste runnable** repro that someone else can run and see the same issue.
+
+## 0. One-line goal
+**Goal:** <What should happen?>
+
+## 1. What is happening (actual)
+**Actual:** <What happens instead? Include exact error message or wrong output>
+
+## 2. Environment (must be exact)
+Fill in all that apply.
+
+- OS: Windows / Linux / macOS (include version)
+- Python: `python -V`
+- PEFT: `python -c "import peft; print(peft.__version__)"`
+- Transformers: `python -c "import transformers; print(transformers.__version__)"`
+- PyTorch: `python -c "import torch; print(torch.__version__)"`
+- bitsandbytes: `python -c "import bitsandbytes; print(bitsandbytes.__version__)"`
+- Device: CPU / CUDA (include GPU model + VRAM)
+- CUDA version: `nvcc --version` or `torch.version.cuda`
+
+## 3. Installation commands (exact)
+```bash
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install -U pip
+pip install torch transformers peft bitsandbytes accelerate
+```
+
+## 4. Minimal script (single file)
+
+Create `repro.py` with the smallest code that still fails.
+
+```python
+import os
+import sys
+
+def print_env():
+    print("== ENV ==")
+    print("python:", sys.version.replace("\n", " "))
+    try:
+        import peft
+        print("peft:", peft.__version__)
+    except Exception as e:
+        print("peft import failed:", repr(e))
+    try:
+        import transformers
+        print("transformers:", transformers.__version__)
+    except Exception as e:
+        print("transformers import failed:", repr(e))
+    try:
+        import torch
+        print("torch:", torch.__version__)
+        print("cuda available:", torch.cuda.is_available())
+        if torch.cuda.is_available():
+            print("cuda device:", torch.cuda.get_device_name(0))
+            print("cuda memory:", torch.cuda.get_device_properties(0).total_memory / 1e9, "GB")
+    except Exception as e:
+        print("torch import failed:", repr(e))
+    try:
+        import bitsandbytes as bnb
+        print("bitsandbytes:", bnb.__version__)
+    except Exception as e:
+        print("bitsandbytes:", repr(e))
+    print()
+
+def main():
+    print_env()
+    
+    import torch
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+    from peft import LoraConfig, get_peft_model, TaskType
+    
+    # TODO: Replace with your exact setup
+    model_id = "Qwen/Qwen2.5-0.5B-Instruct"
+    
+    model = AutoModelForCausalLM.from_pretrained(
+        model_id,
+        torch_dtype=torch.float16,
+        device_map="auto",
+    )
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    
+    # TODO: Replace with your LoRA config
+    lora_config = LoraConfig(
+        r=16,
+        lora_alpha=32,
+        lora_dropout=0.05,
+        target_modules=["q_proj", "v_proj"],
+        task_type=TaskType.CAUSAL_LM,
+    )
+    
+    model = get_peft_model(model, lora_config)
+    model.print_trainable_parameters()
+    
+    # TODO: Add the failing operation
+    # ...
+
+if __name__ == "__main__":
+    main()
+```
+
+## 5. Run command + full output
+
+Command used:
+```bash
+python repro.py
+```
+
+Paste the **full output** here (don't truncate).
+
+## 6. Expected vs actual (explicit)
+
+* **Expected:** <exact>
+* **Actual:** <exact>
+
+## 7. LoRA config details
+
+```python
+LoraConfig(
+    r=...,
+    lora_alpha=...,
+    lora_dropout=...,
+    target_modules=...,
+    modules_to_save=...,
+    task_type=...,
+)
+```
+
+## 8. For quantized models (QLoRA)
+
+```python
+BitsAndBytesConfig(
+    load_in_4bit=True/False,
+    load_in_8bit=True/False,
+    bnb_4bit_quant_type="nf4"/"fp4",
+    bnb_4bit_compute_dtype=torch.bfloat16/torch.float16,
+    bnb_4bit_use_double_quant=True/False,
+)
+```
+
+## 9. Knobs to try (only relevant ones)
+
+* LoRA rank: r=8 vs r=16 vs r=32
+* Target modules: specific vs `"all-linear"`
+* Quantization: None vs 8-bit vs 4-bit
+* Compute dtype: fp16 vs bf16
+* `prepare_model_for_kbit_training()`: called / not called
+* Batch size: 1 / 4 / 8
+* Sequence length: 128 / 256 / 512
+
+## 10. If it's a PEFT bug
+
+* Suspected module/file in peft repo:
+  * `src/peft/...`
+* Related issues on GitHub:
+  * Link if found
+* Does it work with older peft version?
+  * Last known working: `pip install peft==X.Y.Z`


### PR DESCRIPTION
## What does this PR do?

Adds a Claude SKILL for PEFT (Parameter-Efficient Fine-Tuning) and LoRA guidance, complementing the transformers-api skill in #43340.

## Why is this needed?

PEFT/LoRA is one of the most popular integrations with Transformers for memory-efficient fine-tuning. This skill helps Claude Code users with:
- LoRA configuration (r, lora_alpha, target_modules)
- QLoRA setup for consumer GPUs
- Adapter operations (save, load, merge, multi-adapter)
- Training integration with Trainer/SFTTrainer
- Common troubleshooting patterns

## Structure
.claude/skills/peft-lora/
├── SKILL.md # Main entry point
├── reference/areas/
│ ├── lora-basics.md # LoRA fundamentals
│ ├── qlora-quantization.md # 4-bit/8-bit training
│ ├── adapter-operations.md # Load/save/merge
│ ├── training-integration.md # Trainer & SFTTrainer
│ └── troubleshooting.md # Common errors
└── templates/
└── minimal_repro.md # Bug report template

## Related PRs

- #43340 - Claude code skills for transformers-api (this complements that PR)
- Addresses issue #42971
