### PR TITLE
Improve error message for PEFT adapter without peft

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -93,6 +93,7 @@ from .quantizers.auto import get_hf_quantizer
 from .quantizers.quantizers_utils import get_module_from_name
 from .safetensors_conversion import auto_conversion
 from .utils import (
+    ADAPTER_CONFIG_NAME,
     ADAPTER_SAFE_WEIGHTS_NAME,
     DUMMY_INPUTS,
     SAFE_WEIGHTS_INDEX_NAME,
@@ -105,6 +106,7 @@ from .utils import (
     cached_file,
     check_torch_load_is_safe,
     copy_func,
+    find_adapter_config_file,
     has_file,
     is_accelerate_available,
     is_bitsandbytes_available,
@@ -113,6 +115,7 @@ from .utils import (
     is_flash_attn_3_available,
     is_grouped_mm_available,
     is_kernels_available,
+    is_peft_available,
     is_torch_flex_attn_available,
     is_torch_greater_or_equal,
     is_torch_mlu_available,
@@ -697,6 +700,25 @@ def _get_resolved_checkpoint_files(
 
                 # If no match, raise appropriare errors
                 else:
+                    # Helpful error when the repo is actually a PEFT adapter but `peft` isn't installed.
+                    if not is_peft_available():
+                        adapter_config = find_adapter_config_file(
+                            pretrained_model_name_or_path,
+                            cache_dir=cache_dir,
+                            force_download=force_download,
+                            proxies=proxies,
+                            token=token,
+                            revision=revision,
+                            local_files_only=local_files_only,
+                            subfolder=subfolder,
+                            _commit_hash=commit_hash,
+                        )
+                        if adapter_config is not None:
+                            raise OSError(
+                                f"{pretrained_model_name_or_path} appears to be a PEFT adapter repository (found"
+                                f" {ADAPTER_CONFIG_NAME}). To load it, please install peft with `pip install peft`"
+                                " and load the adapter with PEFT (e.g. `peft.PeftModel.from_pretrained(...)`)."
+                            )
                     # Otherwise, no PyTorch file was found
                     if variant is not None and has_file(
                         pretrained_model_name_or_path, WEIGHTS_NAME, **has_file_kwargs

--- a/tests/utils/test_peft_missing_error_message.py
+++ b/tests/utils/test_peft_missing_error_message.py
@@ -1,0 +1,23 @@
+import pytest
+
+from transformers import AutoModel, BertConfig
+from transformers.testing_utils import require_torch
+from transformers.utils import ADAPTER_CONFIG_NAME, is_peft_available
+
+
+@require_torch
+def test_adapter_repo_without_peft_has_helpful_error(tmp_path):
+    if is_peft_available():
+        pytest.skip("peft is installed in this environment")
+
+    BertConfig().save_pretrained(tmp_path)
+    (tmp_path / ADAPTER_CONFIG_NAME).write_text("{}", encoding="utf-8")
+
+    with pytest.raises(OSError) as excinfo:
+        AutoModel.from_pretrained(tmp_path)
+
+    msg = str(excinfo.value).lower()
+    assert "peft" in msg
+    assert "pip install peft" in msg
+    assert "adapter" in msg
+


### PR DESCRIPTION
## Summary
Detect adapter repositories (via `adapter_config.json`) and raise a clear, actionable error when `peft` is not installed, instead of the generic "missing pytorch_model.bin/model.safetensors" message.

## Changes
- Check for `adapter_config.json` before raising the generic missing-weights error.
- Suggest `pip install peft` and link to PEFT docs.

## Test plan
- Added unit test `tests/utils/test_peft_missing_error_message.py`.

Ref: #34733