### PR TITLE
Fix model/processor mismatch in SigLIP2 quantization example

### DIFF
--- a/docs/source/en/model_doc/siglip2.md
+++ b/docs/source/en/model_doc/siglip2.md
@@ -125,7 +125,7 @@ from PIL import Image
 from transformers import AutoProcessor, AutoModel, BitsAndBytesConfig
 
 bnb_config = BitsAndBytesConfig(load_in_4bit=True)
-model = AutoModel.from_pretrained("google/siglip2-large-patch16-512", quantization_config=bnb_config, device_map="auto", attn_implementation="sdpa")
+model = AutoModel.from_pretrained("google/siglip2-base-patch16-224", quantization_config=bnb_config, device_map="auto", attn_implementation="sdpa")
 processor = AutoProcessor.from_pretrained("google/siglip2-base-patch16-224")
 
 url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/pipeline-cat-chonk.jpeg"


### PR DESCRIPTION
## What does this PR do?

Fixes the model/processor mismatch in the SigLIP2 documentation quantization example.

Fixes #39692

## The Problem

The quantization example used mismatched model and processor checkpoints:
- Model: `google/siglip2-large-patch16-512`
- Processor: `google/siglip2-base-patch16-224`

This mismatch caused errors because the processor configuration (designed for 224px base model) didn't match the model being used (512px large model).

## The Fix

Updated the example to use matching model and processor:
- Model: `google/siglip2-base-patch16-224`
- Processor: `google/siglip2-base-patch16-224`

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?