### PR TITLE
Fix `KeyError` in `check_bad_commit.py`

### DIFF
--- a/utils/check_bad_commit.py
+++ b/utils/check_bad_commit.py
@@ -279,7 +279,7 @@ if __name__ == "__main__":
 
             # TODO: make this script able to deal with both `single-gpu` and `multi-gpu` via a new argument.
             reports[model].pop("multi-gpu", None)
-            failed_tests = reports[model]["single-gpu"]
+            failed_tests = reports[model].get("single-gpu", [])
 
             failed_tests_with_bad_commits = []
             for failure in failed_tests:


### PR DESCRIPTION
# What does this PR do?

The PR #43628 changed a bit the format of `new_failures.json` and causes the `check_bad_commit.py` may fail.

("single-gpu" is no longer guaranteed to be in the dict)