### PR TITLE
Fix TypeAdapter NameError in transformers CLI

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -30,7 +30,7 @@ from contextlib import asynccontextmanager
 from functools import lru_cache
 from io import BytesIO
 from threading import Thread
-from typing import TYPE_CHECKING, Annotated, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Annotated, TypedDict
 
 import typer
 from huggingface_hub import scan_cache_dir
@@ -315,9 +315,9 @@ class TimedModel:
 
     def __init__(
         self,
-        model: "PreTrainedModel",
+        model: PreTrainedModel,
         timeout_seconds: int,
-        processor: Union["ProcessorMixin", "PreTrainedTokenizerFast"] | None = None,
+        processor: ProcessorMixin | PreTrainedTokenizerFast | None = None,
     ):
         self.model = model
         self._name_or_path = str(model.name_or_path)
@@ -665,7 +665,7 @@ class Serve:
         finish_reason: str | None = None,
         tool_calls: list[ChoiceDeltaToolCall] | None = None,
         decode_stream: DecodeStream | None = None,
-        tokenizer: Optional["PreTrainedTokenizerFast"] = None,
+        tokenizer: PreTrainedTokenizerFast | None = None,
     ) -> ChatCompletionChunk:
         """
         Builds a chunk of a streaming OpenAI Chat Completion response.
@@ -931,7 +931,7 @@ class Serve:
             return JSONResponse(json_chunk, media_type="application/json")
 
     @staticmethod
-    def get_model_modality(model: "PreTrainedModel", processor=None) -> Modality:
+    def get_model_modality(model: PreTrainedModel, processor=None) -> Modality:
         if processor is not None:
             if isinstance(processor, PreTrainedTokenizerBase):
                 return Modality.LLM
@@ -1843,9 +1843,7 @@ class Serve:
         logger.info(f"Loaded model {model_id_and_revision}")
         return model, data_processor
 
-    def load_model_and_processor(
-        self, model_id_and_revision: str
-    ) -> tuple["PreTrainedModel", "PreTrainedTokenizerFast"]:
+    def load_model_and_processor(self, model_id_and_revision: str) -> tuple[PreTrainedModel, PreTrainedTokenizerFast]:
         """
         Loads the text model and processor from the given model ID and revision into the ServeCommand instance.
 
@@ -1870,7 +1868,7 @@ class Serve:
 
         return model, processor
 
-    def load_audio_model_and_processor(self, model_id_and_revision: str) -> tuple["PreTrainedModel", "ProcessorMixin"]:
+    def load_audio_model_and_processor(self, model_id_and_revision: str) -> tuple[PreTrainedModel, ProcessorMixin]:
         """
         Loads the audio model and processor from the given model ID and revision into the ServeCommand instance.
 

--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from __future__ import annotations
+
 import asyncio
 import base64
 import copy


### PR DESCRIPTION
## What does this PR do?

Fixes #43576

The `transformers env` command was failing with:
```
NameError: name 'TypeAdapter' is not defined
```

### Root Cause

The `Serve` class in `serve.py` uses `TypeAdapter` (from pydantic) as a type annotation in its `_validate_request` method signature. However, `TypeAdapter` is only imported when `serve_dependencies_available` is True (i.e., when pydantic, fastapi, uvicorn, and openai are all installed).

When any of these dependencies are missing:
1. `serve_dependencies_available` is False
2. The `TypeAdapter` import is skipped
3. Python still evaluates the annotation `validator: TypeAdapter` when parsing the class
4. This raises a `NameError`

### Solution

Add `from __future__ import annotations` to defer annotation evaluation. This is a standard Python pattern that makes annotations evaluated lazily (as strings) rather than eagerly.

This is a minimal, non-breaking fix that allows all CLI commands (including `transformers env`) to work regardless of whether the serve dependencies are installed.

## Who can review?

@Rocketknight1