### PR TITLE
Fix CLIPOutput attentions not being returned

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -587,6 +587,8 @@ class CLIPTextTransformer(nn.Module):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
         )
 
 
@@ -682,6 +684,8 @@ class CLIPVisionTransformer(nn.Module):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
         )
 
 

--- a/src/transformers/models/metaclip_2/modeling_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modeling_metaclip_2.py
@@ -984,6 +984,8 @@ class MetaClip2VisionTransformer(nn.Module):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
+            hidden_states=encoder_outputs.hidden_states,
+            attentions=encoder_outputs.attentions,
         )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #43618

### Problem

Since v5, `CLIPVisionModel` and `CLIPTextModel` no longer return attention weights when `output_attentions=True`:

```python
model = CLIPModel.from_pretrained(model_path, attn_implementation="eager")
vision_outputs = model.vision_model(pixel_values=pixel_values, output_attentions=True)
assert vision_outputs.attentions is not None  # FAILS - attentions is None
```

### Root Cause

`CLIPVisionTransformer.forward()` and `CLIPTextTransformer.forward()` both call their respective encoders which return a `BaseModelOutput` containing `hidden_states` and `attentions`. However, when constructing the `BaseModelOutputWithPooling` return value, only `last_hidden_state` and `pooler_output` were being passed - the `hidden_states` and `attentions` fields were omitted.

### Solution

Pass through `hidden_states` and `attentions` from the encoder outputs to the return value in both transformers:

```python
return BaseModelOutputWithPooling(
    last_hidden_state=last_hidden_state,
    pooler_output=pooled_output,
    hidden_states=encoder_outputs.hidden_states,  # NEW
    attentions=encoder_outputs.attentions,        # NEW
)
```

## Who can review?

@yonigozlan @molbap