### PR TITLE
Fix SwitchTransformers creating sparse layer when num_sparse_*_layers=0

### DIFF
--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -148,13 +148,13 @@ class SwitchTransformersConfig(PreTrainedConfig):
         if self.num_sparse_encoder_layers > 0:
             self.encoder_sparse_step = self.num_layers // self.num_sparse_encoder_layers
         else:
-            self.encoder_sparse_step = self.num_layers  # HACK: this will create 0 sparse layers
+            self.encoder_sparse_step = 0  # 0 means no sparse layers
 
-        # This tells us, each how many encoder layer we'll have to set a sparse layer.
+        # This tells us, each how many decoder layer we'll have to set a sparse layer.
         if self.num_sparse_decoder_layers > 0:
             self.decoder_sparse_step = self.num_decoder_layers // self.num_sparse_decoder_layers
         else:
-            self.decoder_sparse_step = self.num_decoder_layers  # HACK: this will create 0 sparse layers
+            self.decoder_sparse_step = 0  # 0 means no sparse layers
 
         self.num_heads = num_heads
         self.num_experts = num_experts


### PR DESCRIPTION
## What does this PR do?

Fixes #43335

### Problem

When configuring a SwitchTransformers model with `num_sparse_encoder_layers=0` (intending to have zero sparse layers), a sparse layer is still incorrectly created when `num_layers=1`:

```python
config = SwitchTransformersConfig(
    num_layers=1,
    num_sparse_encoder_layers=0,  # Want 0 sparse layers
    ...
)
model = SwitchTransformersModel(config)
encoder_sparse_count = sum(1 for block in model.encoder.block if block.is_sparse)
print(f"Encoder sparse layers: {encoder_sparse_count}")  # Prints 1, expected 0
```

### Root Cause

In `configuration_switch_transformers.py`, when `num_sparse_encoder_layers=0`:
```python
self.encoder_sparse_step = self.num_layers  # HACK: this will create 0 sparse layers
```

This works for most cases, but fails when `num_layers=1` because:
- `encoder_sparse_step = 1`
- In the modeling code: `is_sparse = (i % sparse_step == 1 or sparse_step == 1) if sparse_step > 0 else False`
- When `sparse_step == 1`: `is_sparse = True` (because of the `sparse_step == 1` condition)

### Solution

Set `*_sparse_step = 0` instead of `num_layers` when no sparse layers are desired. The modeling code already handles `sparse_step=0` correctly:
```python
is_sparse = ... if sparse_step > 0 else False  # sparse_step=0 → always False
```

This is a minimal change that correctly handles all edge cases.

## Who can review?

@Rocketknight1 @sayakpaul