### PR TITLE
Fix incorrect timestamp calculation in Qwen3VL Processor

### DIFF
--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -1507,7 +1507,7 @@ class Qwen3VLProcessor(Qwen2VLProcessor):
                     curr_timestamp = self._calculate_timestamps(
                         metadata.frames_indices,
                         metadata.fps,
-                        self.video_processor.merge_size,
+                        self.video_processor.temporal_patch_size,
                     )
 
                     video_placeholder = ""

--- a/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
@@ -152,7 +152,7 @@ class Qwen3VLProcessor(ProcessorMixin):
                     curr_timestamp = self._calculate_timestamps(
                         metadata.frames_indices,
                         metadata.fps,
-                        self.video_processor.merge_size,
+                        self.video_processor.temporal_patch_size,
                     )
 
                     video_placeholder = ""


### PR DESCRIPTION
## What does this PR do?

Fixes #43519

### Problem

The Qwen3VL processor was incorrectly using `merge_size` (spatial merging) instead of `temporal_patch_size` (temporal grouping) when calculating video frame timestamps.

```python
# Before (incorrect)
curr_timestamp = self._calculate_timestamps(
    metadata.frames_indices,
    metadata.fps,
    self.video_processor.merge_size,  # Wrong! This is for spatial merging
)
```

### Root Cause

The video processor has two different parameters:
- `temporal_patch_size`: Groups consecutive frames together temporally (default 2)
- `merge_size`: Groups pixels spatially (default 2)

When calculating timestamps, we're grouping frames temporally to compute their average timestamp. Using `merge_size` instead of `temporal_patch_size` produces incorrect timestamp values because:
1. The grouping factor could be different between spatial and temporal dimensions
2. Conceptually, we're averaging timestamps across time, not space

### Solution

Use `temporal_patch_size` for timestamp calculation:

```python
# After (correct)
curr_timestamp = self._calculate_timestamps(
    metadata.frames_indices,
    metadata.fps,
    self.video_processor.temporal_patch_size,  # Correct!
)
```

The fix is applied to both `processing_qwen3_vl.py` and `modular_qwen3_vl.py`.

## Who can review?

VLM maintainers