### PR TITLE
Fix `process_bad_commit_report.py`: avoid items to appear in `null` author in the report

### DIFF
--- a/utils/process_bad_commit_report.py
+++ b/utils/process_bad_commit_report.py
@@ -105,7 +105,8 @@ if __name__ == "__main__":
             for failed_test in failed_tests:
                 author = failed_test["author"]
 
-                if author not in team_members:
+                # If author is not a team member, and the PR is already merged: change to the one who merged the PR
+                if author not in team_members and failed_test["merged_by"] is not None:
                     author = failed_test["merged_by"]
 
                 if author not in new_data:
@@ -119,7 +120,11 @@ if __name__ == "__main__":
     for author, _data in new_data_full.items():
         for model, model_result in _data.items():
             for device, failed_tests in model_result.items():
-                failed_tests = [x for x in failed_tests if x["author"] == author or x["merged_by"] == author]
+                failed_tests = [
+                    x
+                    for x in failed_tests
+                    if x["author"] == author or (x["merged_by"] is not None and x["merged_by"] == author)
+                ]
                 model_result[device] = failed_tests
             _data[model] = {k: v for k, v in model_result.items() if len(v) > 0}
         new_data_full[author] = {k: v for k, v in _data.items() if len(v) > 0}


### PR DESCRIPTION
# What does this PR do?

The file `utils/process_bad_commit_report.py` tried to get a team member to ping on slack, including someone merged a PR despite they are not the author of that PR.

However, that part was written before we have PR comment CI. After this is implemented, we might have "merged_by" being `None` (i.e. `null`) for a PR comment CI.

The previous condition (before this PR)

> failed_tests = [x for x in failed_tests if x["author"] == author or x["merged_by"] == author]

gave confusing results: 

https://huggingface.co/datasets/hf-internal-testing/transformers_pr_ci/blob/main/2026-01-31/runs/27920-21546006888/ci_results_run_models_gpu/new_failures_with_bad_commit_grouped_by_authors.json

(where some items with `author`, so not flaky ones, appeared in 2 top level keys with one being `null` - coming from the fact of  `x["merged_by"] being null`).

v.s.

https://huggingface.co/datasets/hf-internal-testing/transformers_pr_ci/blob/main/2026-01-31/runs/27924-21550696166/ci_results_run_models_gpu/new_failures_with_bad_commit_grouped_by_authors.json

This PR fixes this confusing.