### PR TITLE
make sure hub errors are surfaced

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1613,29 +1613,26 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             # Check for versioned tokenizer files
             if "tokenizer_file" in vocab_files:
                 fast_tokenizer_file = FULL_TOKENIZER_FILE
-                try:
-                    resolved_config_file = cached_file(
-                        pretrained_model_name_or_path,
-                        TOKENIZER_CONFIG_FILE,
-                        cache_dir=cache_dir,
-                        force_download=force_download,
-                        proxies=proxies,
-                        token=token,
-                        revision=revision,
-                        local_files_only=local_files_only,
-                        subfolder=subfolder,
-                        user_agent=user_agent,
-                        _raise_exceptions_for_missing_entries=False,
-                        _commit_hash=commit_hash,
-                    )
-                    if resolved_config_file is not None:
-                        with open(resolved_config_file, encoding="utf-8") as reader:
-                            tokenizer_config = json.load(reader)
-                            if "fast_tokenizer_files" in tokenizer_config:
-                                fast_tokenizer_file = get_fast_tokenizer_file(tokenizer_config["fast_tokenizer_files"])
-                        commit_hash = extract_commit_hash(resolved_config_file, commit_hash)
-                except Exception:
-                    pass
+                resolved_config_file = cached_file(
+                    pretrained_model_name_or_path,
+                    TOKENIZER_CONFIG_FILE,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    proxies=proxies,
+                    token=token,
+                    revision=revision,
+                    local_files_only=local_files_only,
+                    subfolder=subfolder,
+                    user_agent=user_agent,
+                    _raise_exceptions_for_missing_entries=False,
+                    _commit_hash=commit_hash,
+                )
+                if resolved_config_file is not None:
+                    with open(resolved_config_file, encoding="utf-8") as reader:
+                        tokenizer_config = json.load(reader)
+                        if "fast_tokenizer_files" in tokenizer_config:
+                            fast_tokenizer_file = get_fast_tokenizer_file(tokenizer_config["fast_tokenizer_files"])
+                    commit_hash = extract_commit_hash(resolved_config_file, commit_hash)
                 vocab_files["tokenizer_file"] = fast_tokenizer_file
 
             # This block looks for any extra chat template files

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -152,7 +152,6 @@ class AutoTokenizerTest(unittest.TestCase):
             self.assertEqual(tokenizer.model_max_length, 512)
 
     @require_tokenizers
-    @unittest.skip("Broken right now but not very important")
     def test_tokenizer_identifier_non_existent(self):
         for tokenizer_class in [BertTokenizer, AutoTokenizer]:
             with self.assertRaisesRegex(

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -16,6 +16,7 @@ import inspect
 import unittest
 
 import numpy as np
+import pytest
 
 from transformers.testing_utils import require_av, require_torch, require_torchvision, require_vision
 from transformers.utils import is_torch_available, is_vision_available

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -178,6 +178,7 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         pass
 
     @require_av
+    @pytest.mark.xfail(reason="TODO: see issue #43676")
     def test_apply_chat_template_video_frame_sampling(self):
         processor = self.get_processor()
         if processor.chat_template is None:

--- a/tests/models/qwen3_vl/test_processing_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_processing_qwen3_vl.py
@@ -16,7 +16,6 @@ import inspect
 import unittest
 
 import numpy as np
-import pytest
 
 from transformers.testing_utils import require_av, require_torch, require_torchvision, require_vision
 from transformers.utils import is_torch_available, is_vision_available
@@ -179,7 +178,6 @@ class Qwen3VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         pass
 
     @require_av
-    @pytest.mark.xfail(reason="TODO: see issue #43676")
     def test_apply_chat_template_video_frame_sampling(self):
         processor = self.get_processor()
         if processor.chat_template is None:


### PR DESCRIPTION
# What does this PR do?

in `PreTrainedTokenizerBase.from_pretrained` this commit https://github.com/huggingface/transformers/commit/73a13f86f6d208882d59d1200609986c5a5f49a7#diff-85b29486a884f445b1014[…]f4ae701ee758a754fddcc1L1679 silenced hub errors, this is surfaced by 

```
pytest -sv tests/models/auto/test_tokenization_auto.py::AutoTokenizerTest::test_tokenizer_identifier_non_existent
```

with 

```
E           AssertionError: "julien-c/herlolip-not-exists is not a local folder and is not a valid model identifier" does not match "401 Client Error. (Request ID: Root=1-69806dfe-29b61b47408bd03420a3cdac;e2386594-f169-4d1b-9171-050ec211b4c8)
```

This patch removes the try/except block