### PR TITLE
[loading] Fix forced upcasting to fp32

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -40,7 +40,7 @@ _torch_distributed_available = torch.distributed.is_available()
 
 if TYPE_CHECKING:
     from .integrations.tensor_parallel import TensorParallelLayer
-    from .modeling_utils import PreTrainedModel
+    from .modeling_utils import LoadStateDictConfig, PreTrainedModel
     from .quantizers import HfQuantizer
 
 
@@ -967,9 +967,8 @@ def rename_source_key(
 def convert_and_load_state_dict_in_model(
     model: PreTrainedModel,
     state_dict: dict[str, Any],
-    load_config: Any,
+    load_config: LoadStateDictConfig,
     tp_plan: dict[str, str] | None,
-    dtype_plan: dict | None = None,
     disk_offload_index: dict | None = None,
 ):
     r"""

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1066,7 +1066,7 @@ def convert_and_load_state_dict_in_model(
     device_mesh = load_config.device_mesh
     disk_offload_folder = load_config.disk_offload_folder
     offload_buffers = load_config.offload_buffers
-    dtype_plan = dtype_plan or {}
+    dtype_plan = load_config.dtype_plan or {}
     weight_mapping = load_config.weight_mapping or []
     meta_model_state_dict = model.state_dict()
     model_buffers = {k for k, _ in model.named_buffers()}

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3595,7 +3595,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         return init_contexts
 
-    def _get_dtype_plan(self, dtype: torch.dtype) -> dict | None:
+    def _get_dtype_plan(self, dtype: torch.dtype) -> dict:
         """Create the dtype_plan describing modules/parameters that should use the `keep_in_fp32` flag."""
         dtype_plan = {}
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -177,7 +177,7 @@ class LoadStateDictConfig:
     disk_offload_folder: str | None = None
     offload_buffers: bool = False
     dtype: torch.dtype | None = None
-    dtype_plan: dict | None = None
+    dtype_plan: dict = field(default_factory=dict)
     hf_quantizer: HfQuantizer | None = None
     device_mesh: Optional["torch.distributed.device_mesh.DeviceMesh"] = None
     weights_only: bool = True

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3594,17 +3594,19 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             init_contexts.append(torch.device("meta"))
 
         return init_contexts
-    
+
     def _get_dtype_plan(self, dtype: torch.dtype) -> dict | None:
         """Create the dtype_plan describing modules/parameters that should use the `keep_in_fp32` flag."""
         dtype_plan = {}
 
-        # Add _keep_in_fp32_modules only for FP16 loading
-        if isinstance(self._keep_in_fp32_modules, list) and dtype == torch.float16:
+        # The _keep_in_fp32_modules flag is only used to avoid bf16 -> fp16 casting precision issues. It was introduced
+        # in case of force loading a model that should stay in bf16 in fp16
+        # See https://github.com/huggingface/transformers/issues/20287 for details.
+        if self._keep_in_fp32_modules is not None and dtype == torch.float16:
             dtype_plan.update(dict.fromkeys(self._keep_in_fp32_modules, torch.float32))
 
-        # Add _keep_in_fp32_modules_strict for both FP16 and BF16
-        if isinstance(self._keep_in_fp32_modules_strict, list) and dtype in (torch.float16, torch.bfloat16):
+        # The _keep_in_fp32_modules_strict was introduced to always force upcast to fp32, for both fp16 and bf16
+        if self._keep_in_fp32_modules_strict is not None and dtype in (torch.float16, torch.bfloat16):
             dtype_plan.update(dict.fromkeys(self._keep_in_fp32_modules_strict, torch.float32))
 
         return dtype_plan

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -177,6 +177,7 @@ class LoadStateDictConfig:
     disk_offload_folder: str | None = None
     offload_buffers: bool = False
     dtype: torch.dtype | None = None
+    dtype_plan: dict | None = None
     hf_quantizer: HfQuantizer | None = None
     device_mesh: Optional["torch.distributed.device_mesh.DeviceMesh"] = None
     weights_only: bool = True
@@ -1125,8 +1126,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
     # to also prevent bfloat16 casting, use the _keep_in_fp32_modules_strict flag
     _keep_in_fp32_modules_strict = None
 
-    dtype_plan: dict[str, torch.dtype] | None = None
-
     # a list of `re` patterns of `state_dict` keys that should be removed from the list of missing
     # keys we find (keys inside the model but not in the checkpoint) and avoid unnecessary warnings.
     _keys_to_ignore_on_load_missing = None
@@ -1304,12 +1303,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         self._keep_in_fp32_modules = copy.copy(self.__class__._keep_in_fp32_modules)
         self._keep_in_fp32_modules_strict = copy.copy(self.__class__._keep_in_fp32_modules_strict)
         self._tied_weights_keys = copy.copy(self.__class__._tied_weights_keys)
-        self.dtype_plan = {}
-
-        if isinstance(self._keep_in_fp32_modules, list):
-            self.dtype_plan.update(dict.fromkeys(self._keep_in_fp32_modules, torch.float32))
-        if isinstance(self._keep_in_fp32_modules_strict, list):
-            self.dtype_plan.update(dict.fromkeys(self._keep_in_fp32_modules_strict, torch.float32))
 
         self._no_split_modules = self._no_split_modules or []
         _CAN_RECORD_REGISTRY[str(self.__class__)] = self._can_record_outputs  # added for executorch support only
@@ -3601,6 +3594,20 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             init_contexts.append(torch.device("meta"))
 
         return init_contexts
+    
+    def _get_dtype_plan(self, dtype: torch.dtype) -> dict | None:
+        """Create the dtype_plan describing modules/parameters that should use the `keep_in_fp32` flag."""
+        dtype_plan = {}
+
+        # Add _keep_in_fp32_modules only for FP16 loading
+        if isinstance(self._keep_in_fp32_modules, list) and dtype == torch.float16:
+            dtype_plan.update(dict.fromkeys(self._keep_in_fp32_modules, torch.float32))
+
+        # Add _keep_in_fp32_modules_strict for both FP16 and BF16
+        if isinstance(self._keep_in_fp32_modules_strict, list) and dtype in (torch.float16, torch.bfloat16):
+            dtype_plan.update(dict.fromkeys(self._keep_in_fp32_modules_strict, torch.float32))
+
+        return dtype_plan
 
     def set_use_kernels(self, use_kernels, kernel_config: KernelConfig | None = None):
         """
@@ -4052,6 +4059,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                     use_kernels=use_kernels,
                 )
 
+        # Create the dtype_plan to potentially use the `keep_in_fp32` flags (this needs to be called on the already
+        # instantiated model, as the flags can be modified by instances sometimes)
+        dtype_plan = model._get_dtype_plan(dtype)
+
         # Obtain the weight conversion mapping for this model if any are registered
         weight_conversions = get_model_conversion_mapping(model, key_mapping, hf_quantizer)
 
@@ -4071,6 +4082,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             disk_offload_folder=offload_folder,
             offload_buffers=offload_buffers,
             dtype=dtype,
+            dtype_plan=dtype_plan,
             hf_quantizer=hf_quantizer,
             device_mesh=device_mesh,
             weights_only=weights_only,
@@ -4202,7 +4214,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 state_dict=merged_state_dict,
                 load_config=load_config,
                 tp_plan=model._tp_plan,
-                dtype_plan=model.dtype_plan,
                 disk_offload_index=disk_offload_index,
             )
 

--- a/src/transformers/models/afmoe/modeling_afmoe.py
+++ b/src/transformers/models/afmoe/modeling_afmoe.py
@@ -247,7 +247,7 @@ class AfmoeMoE(nn.Module):
         self.router = AfmoeTokenChoiceRouter(config)
         self.shared_experts = AfmoeMLP(config, config.moe_intermediate_size * config.num_shared_experts)
         self.experts = AfmoeExperts(config)
-        self.expert_bias = nn.Parameter(torch.zeros(config.num_experts, dtype=torch.float32), requires_grad=False)
+        self.expert_bias = nn.Parameter(torch.zeros(config.num_experts), requires_grad=False)
 
     def forward(self, hidden_states):
         batch_size, seq_len, hidden_dim = hidden_states.shape

--- a/src/transformers/models/afmoe/modular_afmoe.py
+++ b/src/transformers/models/afmoe/modular_afmoe.py
@@ -160,7 +160,7 @@ class AfmoeMoE(nn.Module):
         self.router = AfmoeTokenChoiceRouter(config)
         self.shared_experts = AfmoeMLP(config, config.moe_intermediate_size * config.num_shared_experts)
         self.experts = AfmoeExperts(config)
-        self.expert_bias = nn.Parameter(torch.zeros(config.num_experts, dtype=torch.float32), requires_grad=False)
+        self.expert_bias = nn.Parameter(torch.zeros(config.num_experts), requires_grad=False)
 
     def forward(self, hidden_states):
         batch_size, seq_len, hidden_dim = hidden_states.shape

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -878,24 +878,103 @@ class ModelTesterMixin:
                 with self.subTest(k):
                     torch.testing.assert_close(v, new_params[k], msg=f"failed on {k}")
 
-    def test_keep_in_fp32_modules(self):
+    def test_keep_in_fp32_modules_exist(self):
+        """Test that both the `_keep_in_fp32` and `_keep_in_fp32_strict` targets match some layers, to avoid any typo"""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:
-            if model_class._keep_in_fp32_modules is None:
-                self.skipTest(reason="Model class has no _keep_in_fp32_modules attribute defined")
-
             model = model_class(copy.deepcopy(config))
-            with tempfile.TemporaryDirectory() as tmpdirname:
-                model.save_pretrained(tmpdirname)
+            # Make sure the modules correctly exist if the flag is active
+            if model._keep_in_fp32_modules is None and model._keep_in_fp32_modules_strict is None:
+                self.skipTest(
+                    reason=f"{model_class.__name__} has no _keep_in_fp32_modules nor _keep_in_fp32_modules_strict attribute defined"
+                )
 
-                model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
+            all_parameters = {name for name, _ in self.named_parameters() if len(name) > 0}
+            unique_module_names = set()
+            # Get all unique module names in the module graph, without the prefixes
+            for param in all_parameters:
+                unique_module_names.update(
+                    [name for name in param.split(".") if not name.isnumeric() and name not in ["weight", "bias"]]
+                )
+            # Check that every module in the keep_in_fp32 list is part of the module graph
+            if model._keep_in_fp32_modules is not None:
+                non_existent = []
+                for module in model._keep_in_fp32_modules:
+                    if module not in unique_module_names:
+                        non_existent.append(module)
+                self.assertEmpty(
+                    non_existent,
+                    f"{non_existent} were specified in the `_keep_in_fp32_modules` list, but are not part of the modules in"
+                    f" {model_class.__name__}",
+                )
 
-                for name, param in model.named_parameters():
-                    with self.subTest(name):
-                        if re.search("|".join(model_class._keep_in_fp32_modules), name):
-                            self.assertTrue(param.dtype == torch.float32)
+            if model._keep_in_fp32_modules_strict is not None:
+                non_existent = []
+                for module in model._keep_in_fp32_modules_strict:
+                    if module not in unique_module_names:
+                        non_existent.append(module)
+                self.assertEmpty(
+                    non_existent,
+                    f"{non_existent} were specified in the `_keep_in_fp32_modules_strict` list, but are not part of the modules in"
+                    f" {model_class.__name__}",
+                )
+
+    def test_keep_in_fp32_modules(self):
+        """Test that the flag `_keep_in_fp32_modules` is correctly respected."""
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+                model = model_class(copy.deepcopy(config))
+                if model._keep_in_fp32_modules is None:
+                    self.skipTest(
+                        reason=f"{model_class.__name__} class has no _keep_in_fp32_modules attribute defined"
+                    )
+
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    model.save_pretrained(tmpdirname)
+
+                    # Test when reloading in fp16 -> should be upcasted to fp32
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
+                    for name, param in model.named_parameters():
+                        if re.search("|".join(model._keep_in_fp32_modules), name):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
-                            self.assertTrue(param.dtype == torch.float16, name)
+                            self.assertTrue(param.dtype == torch.float16)
+
+                    # Test when reloading in bf16 -> should stay bf16
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
+                    for name, param in model.named_parameters():
+                        self.assertTrue(param.dtype == torch.bfloat16)
+
+    def test_keep_in_fp32_modules_strict(self):
+        """Test that the flag `_keep_in_fp32_modules_strict` is correctly respected."""
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+                model = model_class(copy.deepcopy(config))
+                if model._keep_in_fp32_modules_strict is None:
+                    self.skipTest(
+                        reason=f"{model_class.__name__} class has no _keep_in_fp32_modules_strict attribute defined"
+                    )
+
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    model.save_pretrained(tmpdirname)
+
+                    # Test when reloading in fp16 -> should be upcasted to fp32
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
+                    for name, param in model.named_parameters():
+                        if re.search("|".join(model._keep_in_fp32_modules_strict), name):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
+                        else:
+                            self.assertTrue(param.dtype == torch.float16)
+
+                    # Test when reloading in bf16 -> should also be upcasted to fp32
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
+                    for name, param in model.named_parameters():
+                        if re.search("|".join(model._keep_in_fp32_modules_strict), name):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
+                        else:
+                            self.assertTrue(param.dtype == torch.bfloat16)
 
     def test_save_load_keys_to_ignore_on_save(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -895,7 +895,7 @@ class ModelTesterMixin:
                 if model._keep_in_fp32_modules is not None:
                     non_existent = []
                     for module in model._keep_in_fp32_modules:
-                        if not any(re.search(rf"^|\.{module}\.|$", name) for name in state_dict_names):
+                        if not any(re.search(rf"(?:^|\.){module}(?:\.|$)", name) for name in state_dict_names):
                             non_existent.append(module)
                     self.assertTrue(
                         len(non_existent) == 0,
@@ -906,7 +906,7 @@ class ModelTesterMixin:
                 if model._keep_in_fp32_modules_strict is not None:
                     non_existent = []
                     for module in model._keep_in_fp32_modules_strict:
-                        if not any(re.search(rf"^|\.{module}\.|$", name) for name in state_dict_names):
+                        if not any(re.search(rf"(?:^|\.){module}(?:\.|$)", name) for name in state_dict_names):
                             non_existent.append(module)
                     self.assertTrue(
                         len(non_existent) == 0,
@@ -931,14 +931,14 @@ class ModelTesterMixin:
                     # Test when reloading in fp16 -> should be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
                     for name, param in model.state_dict().items():
-                        if any(re.search(rf"^|\.{k}\.|$", name) for k in model._keep_in_fp32_modules):
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
                             self.assertTrue(param.dtype == torch.float16)
 
                     # Test when reloading in bf16 -> should stay bf16
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
-                    for name, param in model.state_dict().items()():
+                    for name, param in model.state_dict().items():
                         self.assertTrue(param.dtype == torch.bfloat16)
 
     def test_keep_in_fp32_modules_strict(self):
@@ -957,16 +957,16 @@ class ModelTesterMixin:
 
                     # Test when reloading in fp16 -> should be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
-                    for name, param in model.state_dict().items()():
-                        if any(re.search(rf"^|\.{k}\.|$", name) for k in model._keep_in_fp32_modules_strict):
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules_strict):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
                             self.assertTrue(param.dtype == torch.float16)
 
                     # Test when reloading in bf16 -> should also be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
-                    for name, param in model.state_dict().items()():
-                        if any(re.search(rf"^|\.{k}\.|$", name) for k in model._keep_in_fp32_modules_strict):
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules_strict):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
                             self.assertTrue(param.dtype == torch.bfloat16)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -882,42 +882,43 @@ class ModelTesterMixin:
         """Test that both the `_keep_in_fp32` and `_keep_in_fp32_strict` targets match some layers, to avoid any typo"""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
         for model_class in self.all_model_classes:
-            model = model_class(copy.deepcopy(config))
-            # Make sure the modules correctly exist if the flag is active
-            if model._keep_in_fp32_modules is None and model._keep_in_fp32_modules_strict is None:
-                self.skipTest(
-                    reason=f"{model_class.__name__} has no _keep_in_fp32_modules nor _keep_in_fp32_modules_strict attribute defined"
-                )
+            with self.subTest(model_class.__name__):
+                model = model_class(copy.deepcopy(config))
+                # Make sure the modules correctly exist if the flag is active
+                if model._keep_in_fp32_modules is None and model._keep_in_fp32_modules_strict is None:
+                    self.skipTest(
+                        reason=f"{model_class.__name__} has no _keep_in_fp32_modules nor _keep_in_fp32_modules_strict attribute defined"
+                    )
 
-            all_parameters = {name for name, _ in self.named_parameters() if len(name) > 0}
-            unique_module_names = set()
-            # Get all unique module names in the module graph, without the prefixes
-            for param in all_parameters:
-                unique_module_names.update(
-                    [name for name in param.split(".") if not name.isnumeric() and name not in ["weight", "bias"]]
-                )
-            # Check that every module in the keep_in_fp32 list is part of the module graph
-            if model._keep_in_fp32_modules is not None:
-                non_existent = []
-                for module in model._keep_in_fp32_modules:
-                    if module not in unique_module_names:
-                        non_existent.append(module)
-                self.assertEmpty(
-                    non_existent,
-                    f"{non_existent} were specified in the `_keep_in_fp32_modules` list, but are not part of the modules in"
-                    f" {model_class.__name__}",
-                )
+                all_parameters = {name for name, _ in model.named_parameters() if len(name) > 0}
+                unique_module_names = set()
+                # Get all unique module names in the module graph, without the prefixes
+                for param in all_parameters:
+                    unique_module_names.update(
+                        [name for name in param.split(".") if not name.isnumeric() and name not in ["weight", "bias"]]
+                    )
+                # Check that every module in the keep_in_fp32 list is part of the module graph
+                if model._keep_in_fp32_modules is not None:
+                    non_existent = []
+                    for module in model._keep_in_fp32_modules:
+                        if module not in unique_module_names:
+                            non_existent.append(module)
+                    self.assertTrue(
+                        len(non_existent) == 0,
+                        f"{non_existent} were specified in the `_keep_in_fp32_modules` list, but are not part of the modules in"
+                        f" {model_class.__name__}",
+                    )
 
-            if model._keep_in_fp32_modules_strict is not None:
-                non_existent = []
-                for module in model._keep_in_fp32_modules_strict:
-                    if module not in unique_module_names:
-                        non_existent.append(module)
-                self.assertEmpty(
-                    non_existent,
-                    f"{non_existent} were specified in the `_keep_in_fp32_modules_strict` list, but are not part of the modules in"
-                    f" {model_class.__name__}",
-                )
+                if model._keep_in_fp32_modules_strict is not None:
+                    non_existent = []
+                    for module in model._keep_in_fp32_modules_strict:
+                        if module not in unique_module_names:
+                            non_existent.append(module)
+                    self.assertTrue(
+                        len(non_existent) == 0,
+                        f"{non_existent} were specified in the `_keep_in_fp32_modules_strict` list, but are not part of the modules in"
+                        f" {model_class.__name__}",
+                    )
 
     def test_keep_in_fp32_modules(self):
         """Test that the flag `_keep_in_fp32_modules` is correctly respected."""

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -890,18 +890,12 @@ class ModelTesterMixin:
                         reason=f"{model_class.__name__} has no _keep_in_fp32_modules nor _keep_in_fp32_modules_strict attribute defined"
                     )
 
-                all_parameters = {name for name, _ in model.named_parameters() if len(name) > 0}
-                unique_module_names = set()
-                # Get all unique module names in the module graph, without the prefixes
-                for param in all_parameters:
-                    unique_module_names.update(
-                        [name for name in param.split(".") if not name.isnumeric() and name not in ["weight", "bias"]]
-                    )
+                state_dict_names = {k for k, v in model.state_dict().items()}
                 # Check that every module in the keep_in_fp32 list is part of the module graph
                 if model._keep_in_fp32_modules is not None:
                     non_existent = []
                     for module in model._keep_in_fp32_modules:
-                        if module not in unique_module_names:
+                        if not any(re.search(rf"^|\.{module}\.|$", name) for name in state_dict_names):
                             non_existent.append(module)
                     self.assertTrue(
                         len(non_existent) == 0,
@@ -912,12 +906,12 @@ class ModelTesterMixin:
                 if model._keep_in_fp32_modules_strict is not None:
                     non_existent = []
                     for module in model._keep_in_fp32_modules_strict:
-                        if module not in unique_module_names:
+                        if not any(re.search(rf"^|\.{module}\.|$", name) for name in state_dict_names):
                             non_existent.append(module)
                     self.assertTrue(
                         len(non_existent) == 0,
-                        f"{non_existent} were specified in the `_keep_in_fp32_modules_strict` list, but are not part of the modules in"
-                        f" {model_class.__name__}",
+                        f"{non_existent} were specified in the `_keep_in_fp32_modules_strict` list, but are not part of the "
+                        f"modules in {model_class.__name__}",
                     )
 
     def test_keep_in_fp32_modules(self):
@@ -936,15 +930,15 @@ class ModelTesterMixin:
 
                     # Test when reloading in fp16 -> should be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
-                    for name, param in model.named_parameters():
-                        if re.search("|".join(model._keep_in_fp32_modules), name):
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"^|\.{k}\.|$", name) for k in model._keep_in_fp32_modules):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
                             self.assertTrue(param.dtype == torch.float16)
 
                     # Test when reloading in bf16 -> should stay bf16
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
-                    for name, param in model.named_parameters():
+                    for name, param in model.state_dict().items()():
                         self.assertTrue(param.dtype == torch.bfloat16)
 
     def test_keep_in_fp32_modules_strict(self):
@@ -963,16 +957,16 @@ class ModelTesterMixin:
 
                     # Test when reloading in fp16 -> should be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
-                    for name, param in model.named_parameters():
-                        if re.search("|".join(model._keep_in_fp32_modules_strict), name):
+                    for name, param in model.state_dict().items()():
+                        if any(re.search(rf"^|\.{k}\.|$", name) for k in model._keep_in_fp32_modules_strict):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
                             self.assertTrue(param.dtype == torch.float16)
 
                     # Test when reloading in bf16 -> should also be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
-                    for name, param in model.named_parameters():
-                        if re.search("|".join(model._keep_in_fp32_modules_strict), name):
+                    for name, param in model.state_dict().items()():
+                        if any(re.search(rf"^|\.{k}\.|$", name) for k in model._keep_in_fp32_modules_strict):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
                             self.assertTrue(param.dtype == torch.bfloat16)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -934,12 +934,12 @@ class ModelTesterMixin:
                         if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
-                            self.assertTrue(param.dtype == torch.float16)
+                            self.assertTrue(param.dtype == torch.float16, f"{name} was upcasted but it should NOT")
 
                     # Test when reloading in bf16 -> should stay bf16
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
                     for name, param in model.state_dict().items():
-                        self.assertTrue(param.dtype == torch.bfloat16)
+                        self.assertTrue(param.dtype == torch.bfloat16, f"{name} was upcasted but it should NOT")
 
     def test_keep_in_fp32_modules_strict(self):
         """Test that the flag `_keep_in_fp32_modules_strict` is correctly respected."""
@@ -961,7 +961,7 @@ class ModelTesterMixin:
                         if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules_strict):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
-                            self.assertTrue(param.dtype == torch.float16)
+                            self.assertTrue(param.dtype == torch.float16, f"{name} was upcasted but it should NOT")
 
                     # Test when reloading in bf16 -> should also be upcasted to fp32
                     model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
@@ -969,7 +969,7 @@ class ModelTesterMixin:
                         if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules_strict):
                             self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
                         else:
-                            self.assertTrue(param.dtype == torch.bfloat16)
+                            self.assertTrue(param.dtype == torch.bfloat16, f"{name} was upcasted but it should NOT")
 
     def test_save_load_keys_to_ignore_on_save(self):
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
# What does this PR do?

As per the title. https://github.com/huggingface/transformers/pull/41580 broke the `keep_in_fp32_modules` flag as it's supposed to be used only with fp16, not bf16.
I added very strict tests on this to avoid name clashing/typos etc!