### PR TITLE
Update doc preprocessing regex to prevent ReDoS

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -2757,7 +2757,7 @@ def preprocess_string(string, skip_cuda_tests):
     cuda stuff is detective (with a heuristic), this method will return an empty string so no doctest will be run for
     `string`.
     """
-    codeblock_pattern = r"(```(?:python|py)\s*\n\s*>>> )(.*?```)"
+    codeblock_pattern = r"(```(?:python|py)\s{0,100}\n\s{0,100}>>> )(.*?```)"
     codeblocks = re.split(codeblock_pattern, string, flags=re.DOTALL)
     is_cuda_found = False
     for i, codeblock in enumerate(codeblocks):


### PR DESCRIPTION
# Update doc preprocessing regex to prevent ReDoS

The regular expression for capturing docstrings is vulnerable to a [ReDoS attack](https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS)

The previous change dramatically improved performance, but is still vulnerable to the pattern:
```python
data= "```py" + ("\n" * i)
```

As i grows, the processing time increases in greater than linear time:
```
Execution time: 0.156596 s , iteration (i=10000)
Execution time: 0.615783 s , iteration (i=20000)
Execution time: 1.404632 s , iteration (i=30000)
Execution time: 2.502577 s , iteration (i=40000)
Execution time: 4.122107 s , iteration (i=50000)
Execution time: 6.003960 s , iteration (i=60000)
Execution time: 7.687220 s , iteration (i=70000)
Execution time: 10.054976 s , iteration (i=80000)
Execution time: 12.749450 s , iteration (i=90000)
Execution time: 17.755118 s , iteration (i=100000)
Execution time: 20.584845 s , iteration (i=110000)
Execution time: 24.046818 s , iteration (i=120000)
Execution time: 28.025028 s , iteration (i=130000)
Execution time: 31.564563 s , iteration (i=140000)
Execution time: 36.151067 s , iteration (i=150000)
Execution time: 40.400584 s , iteration (i=160000)
Execution time: 50.993116 s , iteration (i=170000)
Execution time: 66.691314 s , iteration (i=180000)
Execution time: 73.058775 s , iteration (i=190000)
Execution time: 81.073598 s , iteration (i=200000)
Execution time: 89.698897 s , iteration (i=210000)
Execution time: 98.433263 s , iteration (i=220000)
```

The replacement regex, `(```(?:python|py)\s{0,100}\n\s{0,100}>>> )(.*?```)` allows a **generous** 100 whitespace characters after the word python/py, and up to 100 whitespace characters before the `>>>`

This supplements https://github.com/huggingface/transformers/pull/36648

Fixes CVE-2025-2099
 https://nvd.nist.gov/vuln/detail/CVE-2025-2099



I found this tool useful for generating evil strings: https://devina.io/redos-checker
It couldn't seem to find a pattern that can break the new regular expression.


cc @ArthurZucker : Original Author (I think) https://github.com/huggingface/transformers/commit/2fdf0ef3ef3fa57145e8c98828d105143177d42d

@Rocketknight1 @ydshieh Wrote/Reviewed https://github.com/huggingface/transformers/pull/36648 and are hopefully familiar with the issue.
