### PR TITLE
Allow bi-directional attention for all models

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -865,6 +865,16 @@ def create_causal_mask(
             An optional mask function to combine with the causal mask function (by doing the intersection of both). This is
             useful to easily overlay another mask on top of the causal one, for example for image tokens handling.
     """
+    # Power feature: if `is_causal` is False, then fallback to bi-directional mask for bi-directional attention
+    if not getattr(config, "is_causal", True):
+        return create_bidirectional_mask(
+            config,
+            input_embeds,
+            attention_mask,
+            or_mask_function=or_mask_function,
+            and_mask_function=and_mask_function,
+        )
+
     # If we have an hybrid cache structure, here we want to create the mask for the full layers
     if hasattr(past_key_values, "is_sliding") and False in past_key_values.is_sliding:
         layer_idx = past_key_values.is_sliding.index(False)
@@ -1057,6 +1067,16 @@ def create_sliding_window_causal_mask(
             An optional mask function to combine with the sliding causal mask function (by doing the intersection of both). This is
             useful to easily overlay another mask on top of the sliding causal one, for example for image tokens handling.
     """
+    # Power feature: if `is_causal` is False, then fallback to bi-directional mask for bi-directional attention
+    if not getattr(config, "is_causal", True):
+        return create_bidirectional_sliding_window_mask(
+            config,
+            input_embeds,
+            attention_mask,
+            or_mask_function=or_mask_function,
+            and_mask_function=and_mask_function,
+        )
+
     # If we have an hybrid cache structure, here we want to create the mask for the sliding layers
     if hasattr(past_key_values, "is_sliding") and True in past_key_values.is_sliding:
         layer_idx = past_key_values.is_sliding.index(True)

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -865,7 +865,8 @@ def create_causal_mask(
             An optional mask function to combine with the causal mask function (by doing the intersection of both). This is
             useful to easily overlay another mask on top of the causal one, for example for image tokens handling.
     """
-    # Power feature: if `is_causal` is False, then fallback to bi-directional mask for bi-directional attention
+    # Power feature: if `is_causal` is False, then fallback to bi-directional mask for bi-directional attention.
+    # It allows to use decoder-only models with bi-directional attention as well
     if not getattr(config, "is_causal", True):
         return create_bidirectional_mask(
             config,
@@ -1068,6 +1069,7 @@ def create_sliding_window_causal_mask(
             useful to easily overlay another mask on top of the sliding causal one, for example for image tokens handling.
     """
     # Power feature: if `is_causal` is False, then fallback to bi-directional mask for bi-directional attention
+    # It allows to use decoder-only models with bi-directional attention as well
     if not getattr(config, "is_causal", True):
         return create_bidirectional_sliding_window_mask(
             config,

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -924,7 +924,7 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 return_dict = getattr(self.config, "return_dict", True)
 
             # Maybe temporarily overwrite config value to create the correct mask - kwarg takes precedence
-            is_causal = kwargs.pop("is_causal", True)
+            is_causal = kwargs.get("is_causal", True)
             if not is_causal:
                 is_causal_in_config = hasattr(self.config, "is_causal")
                 if is_causal_in_config:

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -924,7 +924,7 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 return_dict = getattr(self.config, "return_dict", True)
 
             # Maybe temporarily overwrite config value to create the correct mask - kwarg takes precedence
-            is_causal = kwargs.pop("is_causal", True) and getattr(self.config, "is_causal", True)
+            is_causal = kwargs.get("is_causal", True) and getattr(self.config, "is_causal", True)
             if not is_causal:
                 is_causal_in_config = hasattr(self.config, "is_causal")
                 if is_causal_in_config:

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -924,12 +924,14 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 return_dict = getattr(self.config, "return_dict", True)
 
             # Maybe temporarily overwrite config value to create the correct mask - kwarg takes precedence
-            is_causal = kwargs.get("is_causal", True)
+            is_causal = kwargs.pop("is_causal", True) and getattr(self.config, "is_causal", True)
             if not is_causal:
                 is_causal_in_config = hasattr(self.config, "is_causal")
                 if is_causal_in_config:
                     is_causal_original_value = self.config.is_causal
+                # Set it to both config and kwargs (it's needed in both, and can come from only 1 of the sources)
                 self.config.is_causal = False
+                kwargs["is_causal"] = False
 
             all_args = kwargs.copy()
             if "kwargs" in all_args:

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -924,14 +924,17 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 return_dict = getattr(self.config, "return_dict", True)
 
             # Maybe temporarily overwrite config value to create the correct mask - kwarg takes precedence
-            is_causal = kwargs.get("is_causal", True) and getattr(self.config, "is_causal", True)
-            if not is_causal:
+            is_causal = kwargs.get("is_causal")
+            if is_causal is None:
+                is_causal = getattr(self.config, "is_causal", None)
+
+            if is_causal is not None:
                 is_causal_in_config = hasattr(self.config, "is_causal")
                 if is_causal_in_config:
                     is_causal_original_value = self.config.is_causal
                 # Set it to both config and kwargs (it's needed in both, and can come from only 1 of the sources)
-                self.config.is_causal = False
-                kwargs["is_causal"] = False
+                self.config.is_causal = is_causal
+                kwargs["is_causal"] = is_causal
 
             all_args = kwargs.copy()
             if "kwargs" in all_args:
@@ -1032,7 +1035,7 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 module.forward = original_forward
 
             # Restore original config value
-            if not is_causal:
+            if is_causal is not None:
                 if is_causal_in_config:
                     self.config.is_causal = is_causal_original_value
                 else:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2326,17 +2326,25 @@ class ModelUtilsTest(TestCasePlus):
         self.assertEqual(model._keep_in_fp32_modules, {"linear", "head"})  # language model + composite model
         self.assertEqual(model._keep_in_fp32_modules_strict, {"simple"})  # vision model
 
-    def test_decoder_only_model_can_be_used_as_encoder(self):
+    @parameterized.expand([("sdpa",), ("flash_attention_2",)])
+    def test_decoder_only_model_can_be_used_as_encoder(self, attn_implementation: str):
         """Test that most well-behaved decoder models can be used as encoders through the `is_causal` kwarg/config.
         Note that it's enough to test it on Llama, as the entry points are all through general code
         (masking_utils.py + `check_model_inputs` decorator). This makes it easier as the model need to use both the
         mask API from masking_utils.py and the decorator as mentionned above, and we don't know what models follow that
         standard exactly (so we cannot make it easily a common model test)."""
+        if attn_implementation == "flash_attention_2" and not is_flash_attn_2_available():
+            self.skipTest("FA2 not available")
+
         from transformers import LlamaConfig, LlamaModel
         from transformers.masking_utils import create_bidirectional_mask
 
         config = LlamaConfig(
-            num_hidden_layers=2, hidden_size=32, intermediate_size=64, vocab_size=100, attn_implementation="sdpa"
+            num_hidden_layers=2,
+            hidden_size=32,
+            intermediate_size=64,
+            vocab_size=100,
+            attn_implementation=attn_implementation,
         )
         model = LlamaModel(copy.deepcopy(config))
 
@@ -2370,7 +2378,13 @@ class ModelUtilsTest(TestCasePlus):
 
         # Here, since we have padding, the mask created should never be None. Since the mask is never None, the sdpa
         # backend will always use `is_causal=False`, so both should be strictly equivalent
-        torch.testing.assert_close(reference, without_kwarg)
+        if attn_implementation == "sdpa":
+            torch.testing.assert_close(reference, without_kwarg)
+        # But FA2 relies solely on the `is_causal` kwarg to decide how to dispatch, as it will use varlen since we
+        # have padding, so both won't be equivalent at all
+        else:
+            # Everything should be different (we only test the maximum of the diff to avoid flakyness)
+            self.assertTrue(torch.abs(reference - without_kwarg).max() >= 1e-1)
 
         # Now if we simply forward the kwarg with the usual mask function, it should still work the exact same
         with_kwarg_only = model(input_ids, attention_mask=attention_mask, is_causal=False).last_hidden_state

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2326,6 +2326,67 @@ class ModelUtilsTest(TestCasePlus):
         self.assertEqual(model._keep_in_fp32_modules, {"linear", "head"})  # language model + composite model
         self.assertEqual(model._keep_in_fp32_modules_strict, {"simple"})  # vision model
 
+    def test_decoder_only_model_can_be_used_as_encoder(self):
+        """Test that most well-behaved decoder models can be used as encoders through the `is_causal` kwarg/config.
+        Note that it's enough to test it on Llama, as the entry points are all through general code
+        (masking_utils.py + `check_model_inputs` decorator). This makes it easier as the model need to use both the
+        mask API from masking_utils.py and the decorator as mentionned above, and we don't know what models follow that
+        standard exactly (so we cannot make it easily a common model test)."""
+        from transformers import LlamaConfig, LlamaModel
+        from transformers.masking_utils import create_bidirectional_mask
+
+        config = LlamaConfig(
+            num_hidden_layers=2, hidden_size=32, intermediate_size=64, vocab_size=100, attn_implementation="sdpa"
+        )
+        model = LlamaModel(copy.deepcopy(config))
+
+        # Create inputs, making sure we use padding to verify that mask creation accounts for it correctly
+        input_ids = torch.randint(5, 95, (2, 17))
+        attention_mask = torch.ones_like(input_ids)
+        attention_mask[1, 0:3] = 0
+
+        # The original `create_causal_mask` used in modeling_llama forward more kwargs than `create_bidirectional_mask`,
+        # so we need this one instead to absorb them
+        def create_bidirectional_mask_with_kwargs(
+            config,
+            input_embeds,
+            attention_mask,
+            encoder_hidden_states=None,
+            or_mask_function=None,
+            and_mask_function=None,
+            **kwargs,
+        ):
+            return create_bidirectional_mask(
+                config, input_embeds, attention_mask, encoder_hidden_states, or_mask_function, and_mask_function
+            )
+
+        # Explicitly monkey patch the mask creation function + forward the is_causal kwarg to get the expected result
+        # from the model behaving as encoder instead of decoder
+        with patch(
+            "transformers.models.llama.modeling_llama.create_causal_mask", new=create_bidirectional_mask_with_kwargs
+        ):
+            reference = model(input_ids, attention_mask=attention_mask, is_causal=False).last_hidden_state
+            without_kwarg = model(input_ids, attention_mask=attention_mask).last_hidden_state
+
+        # Here, since we have padding, the mask created should never be None. Since the mask is never None, the sdpa
+        # backend will always use `is_causal=False`, so both should be strictly equivalent
+        torch.testing.assert_close(reference, without_kwarg)
+
+        # Now if we simply forward the kwarg with the usual mask function, it should still work the exact same
+        with_kwarg_only = model(input_ids, attention_mask=attention_mask, is_causal=False).last_hidden_state
+        torch.testing.assert_close(reference, with_kwarg_only)
+
+        # Now, if we use the usual forward, the model should behave normally as a decoder, and output should be
+        # completely different
+        as_decoder = model(input_ids, attention_mask=attention_mask).last_hidden_state
+        # Everything should be different (we only test the maximum of the diff to avoid flakyness)
+        self.assertTrue(torch.abs(reference - as_decoder).max() >= 1e-1)
+
+        # It should also work with it in the config
+        model.config.is_causal = False
+        with_config_only = model(input_ids, attention_mask=attention_mask).last_hidden_state
+        torch.testing.assert_close(reference, with_config_only)
+
 
 @slow
 @require_torch

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2346,11 +2346,11 @@ class ModelUtilsTest(TestCasePlus):
             vocab_size=100,
             attn_implementation=attn_implementation,
         )
-        model = LlamaModel(copy.deepcopy(config))
+        model = LlamaModel(copy.deepcopy(config)).to(device=torch_device, dtype=torch.bfloat16)
 
         # Create inputs, making sure we use padding to verify that mask creation accounts for it correctly
-        input_ids = torch.randint(5, 95, (2, 17))
-        attention_mask = torch.ones_like(input_ids)
+        input_ids = torch.randint(5, 95, (2, 17), device=torch_device)
+        attention_mask = torch.ones_like(input_ids, device=torch_device)
         attention_mask[1, 0:3] = 0
 
         # The original `create_causal_mask` used in modeling_llama forward more kwargs than `create_bidirectional_mask`,


### PR DESCRIPTION
# What does this PR do?

Allow the `is_causal` kwarg and config attribute to make well-behaved decoder-only models act as encoders