### PR TITLE
[`Attn`] Fixup interface usage after refactor

### DIFF
--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -490,9 +490,9 @@ class ConditionalDetrSelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -573,9 +573,9 @@ class ConditionalDetrDecoderSelfAttention(nn.Module):
         )
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -696,9 +696,9 @@ class ConditionalDetrDecoderCrossAttention(nn.Module):
         key_states = key_states.view(*kv_input_shape, self.num_attention_heads, expanded_head_dim).transpose(1, 2)
         value_states = value_states.view(kv_hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/conditional_detr/modular_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modular_conditional_detr.py
@@ -307,9 +307,9 @@ class ConditionalDetrDecoderSelfAttention(nn.Module):
         )
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -430,9 +430,9 @@ class ConditionalDetrDecoderCrossAttention(nn.Module):
         key_states = key_states.view(*kv_input_shape, self.num_attention_heads, expanded_head_dim).transpose(1, 2)
         value_states = value_states.view(kv_hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/d_fine/modeling_d_fine.py
+++ b/src/transformers/models/d_fine/modeling_d_fine.py
@@ -519,9 +519,9 @@ class DFineSelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -1586,8 +1586,6 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
                 for _ in range(num_pred)
             ]
         )
-        # Convert to instance attribute before modifying
-        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
             tied_weights_keys = self._tied_weights_keys.copy()
             tied_weights_keys["bbox_embed"] = "model.decoder.bbox_embed"

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -1587,14 +1587,13 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
             ]
         )
         # Convert to instance attribute before modifying
+        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
             self.model.decoder.bbox_embed = self.bbox_embed
-            self._tied_weights_keys = self._tied_weights_keys.copy()
-            self._tied_weights_keys["model.decoder.bbox_embed"] = "bbox_embed"
+            self._tied_weights_keys["bbox_embed"] = "model.decoder.bbox_embed"
         if config.two_stage:
             self.model.decoder.class_embed = self.class_embed
-            self._tied_weights_keys = self._tied_weights_keys.copy()
-            self._tied_weights_keys["model.decoder.class_embed"] = "class_embed"
+            self._tied_weights_keys["class_embed"] = "model.decoder.class_embed"
         self.post_init()
 
     @auto_docstring

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -1586,16 +1586,14 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
                 for _ in range(num_pred)
             ]
         )
+        # Convert to instance attribute before modifying
+        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
-            tied_weights_keys = self._tied_weights_keys.copy()
-            tied_weights_keys["bbox_embed"] = "model.decoder.bbox_embed"
-            self._tied_weights_keys = tied_weights_keys
             self.model.decoder.bbox_embed = self.bbox_embed
+            self._tied_weights_keys["model.decoder.bbox_embed"] = "bbox_embed"
         if config.two_stage:
-            tied_weights_keys = self._tied_weights_keys.copy()
-            tied_weights_keys["class_embed"] = "model.decoder.class_embed"
-            self._tied_weights_keys = tied_weights_keys
             self.model.decoder.class_embed = self.class_embed
+            self._tied_weights_keys["model.decoder.class_embed"] = "class_embed"
         self.post_init()
 
     @auto_docstring

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -1587,12 +1587,13 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
             ]
         )
         # Convert to instance attribute before modifying
-        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
             self.model.decoder.bbox_embed = self.bbox_embed
+            self._tied_weights_keys = self._tied_weights_keys.copy()
             self._tied_weights_keys["model.decoder.bbox_embed"] = "bbox_embed"
         if config.two_stage:
             self.model.decoder.class_embed = self.class_embed
+            self._tied_weights_keys = self._tied_weights_keys.copy()
             self._tied_weights_keys["model.decoder.class_embed"] = "class_embed"
         self.post_init()
 

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -535,9 +535,9 @@ class DeformableDetrSelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -1349,16 +1349,14 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
                 for _ in range(num_pred)
             ]
         )
+        # Convert to instance attribute before modifying
+        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
-            tied_weights_keys = self._tied_weights_keys.copy()
-            tied_weights_keys["bbox_embed"] = "model.decoder.bbox_embed"
-            self._tied_weights_keys = tied_weights_keys
             self.model.decoder.bbox_embed = self.bbox_embed
+            self._tied_weights_keys["model.decoder.bbox_embed"] = "bbox_embed"
         if config.two_stage:
-            tied_weights_keys = self._tied_weights_keys.copy()
-            tied_weights_keys["class_embed"] = "model.decoder.class_embed"
-            self._tied_weights_keys = tied_weights_keys
             self.model.decoder.class_embed = self.class_embed
+            self._tied_weights_keys["model.decoder.class_embed"] = "class_embed"
         self.post_init()
 
     @auto_docstring

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -1350,14 +1350,13 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
             ]
         )
         # Convert to instance attribute before modifying
+        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
             self.model.decoder.bbox_embed = self.bbox_embed
-            self._tied_weights_keys = self._tied_weights_keys.copy()
-            self._tied_weights_keys["model.decoder.bbox_embed"] = "bbox_embed"
+            self._tied_weights_keys["bbox_embed"] = "model.decoder.bbox_embed"
         if config.two_stage:
             self.model.decoder.class_embed = self.class_embed
-            self._tied_weights_keys = self._tied_weights_keys.copy()
-            self._tied_weights_keys["model.decoder.class_embed"] = "class_embed"
+            self._tied_weights_keys["class_embed"] = "model.decoder.class_embed"
         self.post_init()
 
     @auto_docstring

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -1350,12 +1350,13 @@ class DeformableDetrForObjectDetection(DeformableDetrPreTrainedModel):
             ]
         )
         # Convert to instance attribute before modifying
-        self._tied_weights_keys = self._tied_weights_keys.copy()
         if config.with_box_refine:
             self.model.decoder.bbox_embed = self.bbox_embed
+            self._tied_weights_keys = self._tied_weights_keys.copy()
             self._tied_weights_keys["model.decoder.bbox_embed"] = "bbox_embed"
         if config.two_stage:
             self.model.decoder.class_embed = self.class_embed
+            self._tied_weights_keys = self._tied_weights_keys.copy()
             self._tied_weights_keys["model.decoder.class_embed"] = "class_embed"
         self.post_init()
 

--- a/src/transformers/models/detr/modeling_detr.py
+++ b/src/transformers/models/detr/modeling_detr.py
@@ -493,9 +493,9 @@ class DetrSelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,
@@ -573,9 +573,9 @@ class DetrCrossAttention(nn.Module):
         key_states = self.k_proj(key_input).view(kv_hidden_shape).transpose(1, 2)
         value_states = self.v_proj(key_value_states).view(kv_hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/pp_doclayout_v3/modeling_pp_doclayout_v3.py
+++ b/src/transformers/models/pp_doclayout_v3/modeling_pp_doclayout_v3.py
@@ -608,9 +608,9 @@ class PPDocLayoutV3SelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -351,9 +351,9 @@ class RTDetrSelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -316,9 +316,9 @@ class RTDetrV2SelfAttention(nn.Module):
         key_states = self.k_proj(query_key_input).view(hidden_shape).transpose(1, 2)
         value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
 
-        attention_interface: Callable = eager_attention_forward
-        if self.config._attn_implementation != "eager":
-            attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
+            self.config._attn_implementation, eager_attention_forward
+        )
 
         attn_output, attn_weights = attention_interface(
             self,


### PR DESCRIPTION
As per title, the new way to call the attention interface has slipped through a refactor because it's too new and not too well known atm cc @yonigozlan 