### PR TITLE
More flaky generate tests

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1250,6 +1250,7 @@ class GenerationTesterMixin:
             self._check_past_key_values_for_generate(batch_size, outputs.past_key_values, max_length, text_config)
 
     @pytest.mark.generate
+    @is_flaky
     def test_generate_continue_from_past_key_values(self):
         # Tests that we can continue generating from past key values, returned from a previous `generate` call
         for model_class in self.all_generative_model_classes:

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -635,6 +635,7 @@ class GenerationTesterMixin:
 
     @parameterized.expand([("random",), ("same",)])
     @pytest.mark.generate
+    @is_flaky  # Matt: These tests have some inherent variability. It'd be cool to make them deterministic!
     def test_assisted_decoding_matches_greedy_search(self, assistant_type):
         # This test ensures that the assisted generation does not introduce output changes over greedy search.
         # See https://github.com/huggingface/transformers/issues/25420#issuecomment-1775317535 for more info.
@@ -732,7 +733,7 @@ class GenerationTesterMixin:
                 self._check_generate_outputs(output, model.config, use_cache=True)
 
     @pytest.mark.generate
-    @is_flaky
+    @is_flaky  # Matt: These tests have some inherent variability. It'd be cool to make them deterministic!
     def test_prompt_lookup_decoding_matches_greedy_search(self):
         # This test ensures that the prompt lookup generation does not introduce output changes over greedy search.
         # This test is mostly a copy of test_assisted_decoding_matches_greedy_search


### PR DESCRIPTION
The generate tests that compare prompt lookup or speculative decoding to the base model have an extremely high rate of flakiness, I guess because of inherent non-determinism. The actual generation works, but the test frequently sees divergence from this non-determinism at some point and throws an error.

It'd be cool to make a more reliable version of these tests at some point, but for now I'm just marking them as flaky to clean up the CI!

Example failing job here: https://app.circleci.com/jobs/github/huggingface/transformers/2143338