### PR TITLE
Fix resume_from_checkpoint ignoring user's batch size configuration

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2146,7 +2146,12 @@ class Trainer:
                 self._load_from_checkpoint(resume_from_checkpoint)
             # In case of repeating the find_executable_batch_size, set `self._train_batch_size` properly
             state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
-            if state.train_batch_size is not None:
+            # Only restore the checkpoint's train_batch_size when using auto_find_batch_size,
+            # as that feature needs to resume with the automatically-found batch size.
+            # Otherwise, use the current args batch size to allow users to change batch configuration
+            # while keeping the same global batch size (e.g., changing per_device_train_batch_size
+            # and gradient_accumulation_steps proportionally).
+            if state.train_batch_size is not None and args.auto_find_batch_size:
                 self._train_batch_size = state.train_batch_size
 
         # If model was re-initialized, put it on the right device and update self.model_wrapped


### PR DESCRIPTION
# Fix Trainer resume_from_checkpoint incorrectly calculating max_steps when changing batch size

## What does this PR do?

When resuming training from a checkpoint with a different `per_device_train_batch_size` but the same global batch size (by adjusting `gradient_accumulation_steps`), the Trainer was incorrectly recalculating `max_steps`.

**Root cause:** `self._train_batch_size` was unconditionally restored from the checkpoint state at line 2150-2151, causing the dataloader to be created with the OLD batch size. This led to incorrect `len_dataloader` and ultimately wrong `max_steps` calculation.

**Example:**
- Script 1: `per_device_train_batch_size=1`, `gradient_accumulation_steps=4` → `max_steps=8`
- Script 2 (resume): `per_device_train_batch_size=4`, `gradient_accumulation_steps=1` → `max_steps=32` ❌ (should be 8)

**The fix:** Only restore the checkpoint's `train_batch_size` when `auto_find_batch_size` is enabled, since that feature specifically needs the auto-discovered batch size to be preserved. Otherwise, use the current args batch size.

Fixes #43708

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. → #43708
- [ ] Did you make sure to update the documentation with your changes? (N/A - no doc changes needed)
- [ ] Did you write any new necessary tests? (Bugfix with minimal code change)

## Who can review?

@SunMarc (already engaged on the issue)