### PR TITLE
feat: Add legacy TrainingArguments logging_dir fallback for TensorBoard

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -611,6 +611,9 @@ class TensorBoardCallback(TrainerCallback):
                 # overwrite logging dir for trials
                 self.logging_dir = os.path.join(args.output_dir, default_logdir(), trial_name)
 
+        if self.logging_dir is None and getattr(args, "logging_dir", None):
+            self.logging_dir = os.path.expanduser(args.logging_dir)
+
         if self.logging_dir is None:
             self.logging_dir = os.path.join(args.output_dir, default_logdir())
 


### PR DESCRIPTION
# What does this PR do?

Restore backward-compatible TensorBoard logging directory behavior. The callback now prefers `TENSORBOARD_LOGGING_DIR` when set, but falls back to `TrainingArguments.logging_dir` if the env var is not provided, preserving legacy workflows while keeping the newer env-first behavior.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc