### PR TITLE
Fix dtype in image-text-to-text pipe

### DIFF
--- a/src/transformers/models/pixtral/modeling_pixtral.py
+++ b/src/transformers/models/pixtral/modeling_pixtral.py
@@ -494,7 +494,7 @@ class PixtralVisionModel(PixtralPreTrainedModel):
 
         # pass images through initial convolution independently
         target_dtype = self.patch_conv.weight.dtype
-        patch_embeds = self.patch_conv(pixel_values.to(dtype=patch_embeds))
+        patch_embeds = self.patch_conv(pixel_values.to(dtype=target_dtype))
         patch_embeds_list = [
             embed[..., : (size[0] // self.patch_size), : (size[1] // self.patch_size)]
             for embed, size in zip(patch_embeds, image_sizes)

--- a/src/transformers/models/pixtral/modeling_pixtral.py
+++ b/src/transformers/models/pixtral/modeling_pixtral.py
@@ -493,7 +493,8 @@ class PixtralVisionModel(PixtralPreTrainedModel):
             image_sizes = [(height, width)] * batch_size
 
         # pass images through initial convolution independently
-        patch_embeds = self.patch_conv(pixel_values)
+        target_dtype = self.patch_conv.weight.dtype
+        patch_embeds = self.patch_conv(pixel_values.to(dtype=patch_embeds))
         patch_embeds_list = [
             embed[..., : (size[0] // self.patch_size), : (size[1] // self.patch_size)]
             for embed, size in zip(patch_embeds, image_sizes)

--- a/src/transformers/pipelines/image_text_to_text.py
+++ b/src/transformers/pipelines/image_text_to_text.py
@@ -334,7 +334,7 @@ class ImageTextToTextPipeline(Pipeline):
                 return_tensors="pt",
                 tokenize=True,
                 return_dict=True,
-            )
+            ).to(dtype=self.dtype)
             model_inputs["text"] = inputs
             return model_inputs
         # In case we only have text inputs


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/43716, as per title

We didn't see errors even if we test `bf16` because most backbone models (e.g. SigLIP) cast pixels to target dtype inside the model code. I fixed it in pipe and also in pixtral model following siglip pattern