### PR TITLE
Docs: fix Training step by removing tokenizer from trainer initialization

### DIFF
--- a/docs/source/en/quicktour.md
+++ b/docs/source/en/quicktour.md
@@ -252,7 +252,6 @@ trainer = Trainer(
     args=training_args,
     train_dataset=dataset["train"],
     eval_dataset=dataset["test"],
-    tokenizer=tokenizer,
     data_collator=data_collator,
 )
 

--- a/docs/source/en/quicktour.md
+++ b/docs/source/en/quicktour.md
@@ -252,6 +252,7 @@ trainer = Trainer(
     args=training_args,
     train_dataset=dataset["train"],
     eval_dataset=dataset["test"],
+    processing_class=tokenizer,
     data_collator=data_collator,
 )
 

--- a/docs/source/en/tasks/language_modeling.md
+++ b/docs/source/en/tasks/language_modeling.md
@@ -235,7 +235,7 @@ At this point, only three steps remain:
 ...     train_dataset=lm_dataset["train"],
 ...     eval_dataset=lm_dataset["test"],
 ...     data_collator=data_collator,
-...     tokenizer=tokenizer,
+...     processing_class=tokenizer,
 ... )
 
 >>> trainer.train()

--- a/docs/source/en/tasks/masked_language_modeling.md
+++ b/docs/source/en/tasks/masked_language_modeling.md
@@ -229,7 +229,7 @@ At this point, only three steps remain:
 ...     train_dataset=lm_dataset["train"],
 ...     eval_dataset=lm_dataset["test"],
 ...     data_collator=data_collator,
-...     tokenizer=tokenizer,
+...     processing_class=tokenizer,
 ... )
 
 >>> trainer.train()


### PR DESCRIPTION
# Summary
This PR removes the deprecated tokenizer parameter from the Quicktour documentation examples.

As of the v5.0.0 release, the tokenizer argument was officially replaced from the Trainer constructor. Currently, the documentation example fails with a TypeError, preventing users from completing the introductory tutorial.

# Changes
Location: 
- docs/source/en/quicktour.md
- docs/source/en/tasks/language_modelin.md
- docs/source/en/tasks/masked_language_modeling.md

Action: Replaced tokenizer=tokenizer from the Trainer initialization by processing_class=tokenizer

Reasoning: The tokenizer is officially replaced by processing_class:

TypeError: Trainer.__init__() got an unexpected keyword argument 'tokenizer'

# Related Resources
Breaking Change Reference: [Transformers v5.0.0 Release Notes](https://github.com/huggingface/transformers/releases/tag/v5.0.0)

Affected Doc Page: [Quicktour - Training Step](https://huggingface.co/docs/transformers/quicktour?pipeline-tasks=text+generation)

Checklist
[x] This PR fixes a typo or improves the docs.

cc @stevhliu @SunMarc 