### PR TITLE
Chase TokenizersBackend issue

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4757,3 +4757,7 @@ class PreTrainedAudioTokenizerBase(PreTrainedModel):
     @abstractmethod
     def decode(self, audio_codes: torch.Tensor, *args, **kwargs):
         """Decode from discrete audio codebooks back to raw audio"""
+
+def empty_function(x: int):
+    # This is just here to trigger the full CI by modifying a core file, and should definitely be removed before merging
+    return x + 1

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4758,6 +4758,7 @@ class PreTrainedAudioTokenizerBase(PreTrainedModel):
     def decode(self, audio_codes: torch.Tensor, *args, **kwargs):
         """Decode from discrete audio codebooks back to raw audio"""
 
+
 def empty_function(x: int):
     # This is just here to trigger the full CI by modifying a core file, and should definitely be removed before merging
     return x + 1

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -693,9 +693,11 @@ class AutoTokenizer:
             if tokenizer_class is None and not tokenizer_class_candidate.endswith("Fast"):
                 tokenizer_class = tokenizer_class_from_name(tokenizer_class_candidate + "Fast")
             if tokenizer_class is not None and tokenizer_class.__name__ == "PythonBackend":
+                raise ValueError("Fallback happened here!!")
                 tokenizer_class = TokenizersBackend
             # Fallback to TokenizersBackend if the class wasn't found
             if tokenizer_class is None:
+                raise ValueError("Fallback happened here!!")
                 tokenizer_class = TokenizersBackend
 
             return tokenizer_class.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1432,7 +1432,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         Returns:
             `dict[str, int]`: The vocabulary.
         """
-        raise NotImplementedError()
+        raise NotImplementedError("We got here!")
 
     def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
         """

--- a/tests/models/idefics/test_processing_idefics.py
+++ b/tests/models/idefics/test_processing_idefics.py
@@ -98,6 +98,8 @@ class IdeficsProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         )
 
         self.assertEqual(processor.tokenizer.get_vocab(), tokenizer_add_kwargs.get_vocab())
+        if not isinstance(processor.tokenizer, self._get_component_class_from_processor("tokenizer")):
+            raise ValueError("We got here!")
         self.assertIsInstance(processor.tokenizer, self._get_component_class_from_processor("tokenizer"))
 
         self.assertEqual(processor.image_processor.to_json_string(), image_processor_add_kwargs.to_json_string())


### PR DESCRIPTION
One of the recurring issues we see in the CI is tokenizers occasionally being initialized as instances of `TokenizersBackend` rather than the actual tokenizer class. The error crops up all over, and is annoyingly hard to track down because I can't reproduce it locally. This PR is an attempt to flush it out and run some debug so I can see what's happening in the CI itself.