### PR TITLE
SwanLab: add id and resume support for resuming runs (fixes #43698)

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -2278,6 +2278,18 @@ class SwanLabCallback(TrainerCallback):
         - **SWANLAB_API_HOST** (`str`, *optional*, defaults to `None`):
             API address for the SwanLab cloud environment for private version (its free)
 
+        - **SWANLAB_RUN_ID** (`str`, *optional*, defaults to `None`):
+            The SwanLab run ID (21-character string) to resume. When set together with `SWANLAB_RESUME`, enables
+            resuming a previous run so that `trainer.train(resume_from_checkpoint=...)` continues the same
+            experiment instead of creating a new one. The run ID can be found in the experiment's Environment tab
+            or in the URL on the SwanLab dashboard.
+
+        - **SWANLAB_RESUME** (`str` or `bool`, *optional*, defaults to `None`):
+            Resume mode for SwanLab. Use with `SWANLAB_RUN_ID` when resuming training. Accepted values: `"allow"`
+            (resume if run exists, else create new; same as `True`), `"must"` (resume only, error if run missing),
+            `"never"` (always create new run; same as `False`). Set to `"allow"` or `True` when using
+            `trainer.train(resume_from_checkpoint=...)` to continue the same experiment.
+
         """
         self._initialized = True
 
@@ -2300,6 +2312,21 @@ class SwanLabCallback(TrainerCallback):
             elif trial_name is not None:
                 init_args["experiment_name"] = trial_name
             init_args["project"] = os.getenv("SWANLAB_PROJECT", None)
+
+            # Support resuming a previous run (e.g. when using trainer.train(resume_from_checkpoint=...))
+            swanlab_run_id = os.getenv("SWANLAB_RUN_ID", None) or os.getenv("SWANLAB_ID", None)
+            swanlab_resume = os.getenv("SWANLAB_RESUME", None)
+            if swanlab_run_id is not None:
+                init_args["id"] = swanlab_run_id
+            if swanlab_resume is not None:
+                if swanlab_resume.lower() in ("true", "1"):
+                    init_args["resume"] = True
+                elif swanlab_resume.lower() in ("false", "0"):
+                    init_args["resume"] = False
+                elif swanlab_resume.lower() in ("allow", "must", "never"):
+                    init_args["resume"] = swanlab_resume.lower()
+                else:
+                    init_args["resume"] = swanlab_resume
 
             if self._swanlab.get_run() is None:
                 self._swanlab.init(


### PR DESCRIPTION
Fixes #43698

## Summary
When using `Trainer` with SwanLab and resuming training (`trainer.train(resume_from_checkpoint=...)`), the integration previously had no way to pass `id` and `resume` to `swanlab.init()`, so a new experiment was always created instead of continuing the existing one.

This PR adds support for resuming a previous SwanLab run via environment variables (same pattern as MLflow's `MLFLOW_RUN_ID`):

- **SWANLAB_RUN_ID** (or **SWANLAB_ID**): The 21-character SwanLab run ID to resume. Users set this when resuming so the same experiment continues.
- **SWANLAB_RESUME**: Resume mode — `"allow"` / `True` (resume if run exists, else create new), `"must"` (resume only), or `"never"` / `False` (always create new).

## Changes
- In `SwanLabCallback.setup()`, read `SWANLAB_RUN_ID`/`SWANLAB_ID` and `SWANLAB_RESUME` from the environment and pass them to `swanlab.init()`.
- Document the new env vars in the callback docstring.
- Parse `SWANLAB_RESUME` for common values (`true`/`false`, `allow`/`must`/`never`) so both string and boolean-like env values work.

## Usage
When resuming training, set the env vars before calling `trainer.train(resume_from_checkpoint=...)`:

```python
import os
os.environ["SWANLAB_RUN_ID"] = "14pk4qbyav4toobziszli"  # from previous run
os.environ["SWANLAB_RESUME"] = "allow"
trainer.train(resume_from_checkpoint="./checkpoint-100")
```

This keeps metrics and history in a single SwanLab run across restarts.