### PR TITLE
Make the CI Green Round 3

### DIFF
--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -287,6 +287,7 @@ class ProcessorTesterMixin:
 
             if component_class is None and is_tokenizers_available():
                 from transformers.tokenization_utils_tokenizers import TokenizersBackend
+
                 component_class = TokenizersBackend
         elif mapping_name == "image_processor":
             from transformers.models.auto.image_processing_auto import IMAGE_PROCESSOR_MAPPING

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -276,13 +276,17 @@ class ProcessorTesterMixin:
 
         # Get the appropriate Auto mapping for this component type
         if mapping_name == "tokenizer":
-            from transformers.models.auto.tokenization_auto import TOKENIZER_MAPPING
+            from transformers.models.auto.tokenization_auto import TOKENIZER_MAPPING_NAMES, tokenizer_class_from_name
             from transformers.utils import is_tokenizers_available
 
-            component_class = TOKENIZER_MAPPING.get(config_class, None)
+            tokenizer_class_name = TOKENIZER_MAPPING_NAMES.get(model_type)
+            if tokenizer_class_name:
+                component_class = tokenizer_class_from_name(tokenizer_class_name)
+            else:
+                component_class = None
+
             if component_class is None and is_tokenizers_available():
                 from transformers.tokenization_utils_tokenizers import TokenizersBackend
-
                 component_class = TokenizersBackend
         elif mapping_name == "image_processor":
             from transformers.models.auto.image_processing_auto import IMAGE_PROCESSOR_MAPPING


### PR DESCRIPTION
This time I'm focusing on `_get_component_class_from_processor` in the tests. I'm not sure if the way this operates can sometimes result in Tokenizer classes going missing.