### PR TITLE
Fix Trainer resume_from_checkpoint to apply checkpoint conversion mappings

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -68,7 +68,7 @@ from .integrations.deepspeed import deepspeed_init, deepspeed_load_checkpoint, i
 from .integrations.peft import MIN_PEFT_VERSION
 from .integrations.tpu import tpu_spmd_dataloader
 from .modelcard import TrainingSummary
-from .modeling_utils import PreTrainedModel, unwrap_model
+from .modeling_utils import LoadStateDictConfig, PreTrainedModel, unwrap_model
 from .models.auto.modeling_auto import (
     MODEL_FOR_CAUSAL_LM_MAPPING_NAMES,
     MODEL_MAPPING_NAMES,
@@ -2814,30 +2814,29 @@ class Trainer:
                     except StopIteration:
                         device_map = {"": "cpu"}
 
-                    missing_keys, unexpected_keys, mismatched_keys, _disk_offload_index, conversion_errors = (
-                        convert_and_load_state_dict_in_model(
-                            model=model,
-                            state_dict=state_dict,
-                            weight_mapping=weight_mapping,
-                            tp_plan=getattr(model, "tp_plan", None),
-                            hf_quantizer=None,
-                            device_map=device_map,
-                        )
+                    load_config = LoadStateDictConfig(
+                        device_map=device_map,
+                        weight_mapping=weight_mapping,
+                        hf_quantizer=None,
+                        weights_only=True,
+                    )
+                    loading_info, _disk_offload_index = convert_and_load_state_dict_in_model(
+                        model=model,
+                        state_dict=state_dict,
+                        load_config=load_config,
+                        tp_plan=getattr(model, "_tp_plan", None),
                     )
 
-                    class _LoadResult:
-                        def __init__(self, missing_keys, unexpected_keys):
-                            self.missing_keys = list(missing_keys)
-                            self.unexpected_keys = list(unexpected_keys)
-
-                    load_result = _LoadResult(missing_keys, unexpected_keys)
-                    if conversion_errors:
+                    load_result = loading_info
+                    if loading_info.conversion_errors:
                         logger.warning(
-                            f"There were errors while applying checkpoint conversion mapping: {list(conversion_errors.keys())}"  # noqa: E501
+                            "There were errors while applying checkpoint conversion mapping: "
+                            f"{list(loading_info.conversion_errors.keys())}"
                         )
-                    if mismatched_keys:
+                    if loading_info.mismatched_keys:
                         logger.warning(
-                            f"There were mismatched keys in the checkpoint model loaded: {sorted(mismatched_keys)}"  # noqa: E501
+                            "There were mismatched keys in the checkpoint model loaded: "
+                            f"{sorted(loading_info.mismatched_keys)}"
                         )
                 else:
                     # workaround for FSDP bug https://github.com/pytorch/pytorch/issues/82963

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -56,6 +56,8 @@ from torch.utils.data import DataLoader, Dataset, IterableDataset, RandomSampler
 
 from . import __version__
 from .configuration_utils import PreTrainedConfig
+from .conversion_mapping import get_model_conversion_mapping
+from .core_model_loading import convert_and_load_state_dict_in_model
 from .data.data_collator import DataCollator, DataCollatorWithPadding, default_data_collator
 from .debug_utils import DebugOption, DebugUnderflowOverflow
 from .feature_extraction_sequence_utils import SequenceFeatureExtractor
@@ -2804,9 +2806,43 @@ class Trainer:
                     check_torch_load_is_safe()
                     state_dict = torch.load(weights_file, map_location="cpu", weights_only=True)
 
-                # workaround for FSDP bug https://github.com/pytorch/pytorch/issues/82963
-                # which takes *args instead of **kwargs
-                load_result = model.load_state_dict(state_dict, False)
+                weight_mapping = get_model_conversion_mapping(model)
+                if weight_mapping:
+                    try:
+                        param_device = next(model.parameters()).device
+                        device_map = {"": str(param_device)}
+                    except StopIteration:
+                        device_map = {"": "cpu"}
+
+                    missing_keys, unexpected_keys, mismatched_keys, _disk_offload_index, conversion_errors = (
+                        convert_and_load_state_dict_in_model(
+                            model=model,
+                            state_dict=state_dict,
+                            weight_mapping=weight_mapping,
+                            tp_plan=getattr(model, "tp_plan", None),
+                            hf_quantizer=None,
+                            device_map=device_map,
+                        )
+                    )
+
+                    class _LoadResult:
+                        def __init__(self, missing_keys, unexpected_keys):
+                            self.missing_keys = list(missing_keys)
+                            self.unexpected_keys = list(unexpected_keys)
+
+                    load_result = _LoadResult(missing_keys, unexpected_keys)
+                    if conversion_errors:
+                        logger.warning(
+                            f"There were errors while applying checkpoint conversion mapping: {list(conversion_errors.keys())}"  # noqa: E501
+                        )
+                    if mismatched_keys:
+                        logger.warning(
+                            f"There were mismatched keys in the checkpoint model loaded: {sorted(mismatched_keys)}"  # noqa: E501
+                        )
+                else:
+                    # workaround for FSDP bug https://github.com/pytorch/pytorch/issues/82963
+                    # which takes *args instead of **kwargs
+                    load_result = model.load_state_dict(state_dict, False)
                 # release memory
                 del state_dict
                 self._issue_warnings_after_load(load_result)

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -183,6 +183,41 @@ def get_dataset(file_path, tokenizer, max_len):
     return tokenized_dataset["train"]
 
 
+@require_torch
+def test_resume_from_checkpoint_applies_checkpoint_conversion_mapping():
+    class TinyLayerNormModel(PreTrainedModel):
+        config_class = PreTrainedConfig
+
+        def __init__(self, config):
+            super().__init__(config)
+            self.LayerNorm = nn.LayerNorm(2, elementwise_affine=True)
+            self.post_init()
+
+        def forward(self, x):
+            return self.LayerNorm(x)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        model = TinyLayerNormModel(PreTrainedConfig())
+        args = TrainingArguments(tmp_dir, report_to="none")
+        trainer = Trainer(model=model, args=args)
+
+        checkpoint_dir = os.path.join(tmp_dir, "checkpoint-1")
+        os.makedirs(checkpoint_dir, exist_ok=True)
+
+        expected_weight = torch.tensor([1.0, 2.0])
+        expected_bias = torch.tensor([3.0, 4.0])
+        state_dict = {
+            "LayerNorm.gamma": expected_weight,
+            "LayerNorm.beta": expected_bias,
+        }
+        torch.save(state_dict, os.path.join(checkpoint_dir, "pytorch_model.bin"))
+
+        trainer._load_from_checkpoint(checkpoint_dir)
+
+        assert torch.allclose(trainer.model.LayerNorm.weight.detach().cpu(), expected_weight)
+        assert torch.allclose(trainer.model.LayerNorm.bias.detach().cpu(), expected_bias)
+
+
 class StoreLossCallback(TrainerCallback):
     """
     Simple callback to store the loss.


### PR DESCRIPTION
# What does this PR do?

Fixes #43701

When resuming training via [Trainer.train(resume_from_checkpoint=...)](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/src/transformers/trainer.py:2070:4-2175:13), the checkpoint loading path now applies registered checkpoint conversion mappings (e.g. legacy key renames) instead of calling [model.load_state_dict()](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/src/transformers/modeling_utils.py:292:0-323:106) directly on the raw checkpoint keys.

This aligns the resume-from-checkpoint behavior with the regular model loading behavior and prevents key mismatch issues for checkpoints saved with legacy/converted parameter names.

## Motivation / context

Some models/checkpoints require key renaming through conversion mappings (including legacy mappings). Previously, the [Trainer](cci:2://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/src/transformers/trainer.py:277:0-5348:9) resume path bypassed that conversion logic, which could lead to missing/unexpected keys and failed/incomplete restores.

## Changes

- Update [Trainer._load_from_checkpoint](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/src/transformers/trainer.py:2718:4-2877:60) to load via [convert_and_load_state_dict_in_model()](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/src/transformers/core_model_loading.py:966:0-1221:43) with a [LoadStateDictConfig](cci:2://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/src/transformers/modeling_utils.py:162:0-186:44) when a conversion mapping exists.
- Add a regression test ensuring resume applies the conversion mapping:
  [test_resume_from_checkpoint_applies_checkpoint_conversion_mapping](cci:1://file:///c:/Users/brass/OneDrive/Desktop/Work/clients/Anthonette/transformers/tests/trainer/test_trainer.py:185:0-217:89).

## Tests

- `python -m pytest -k resume_from_checkpoint_applies_checkpoint_conversion_mapping tests/trainer/test_trainer.py`

