### PR TITLE
Remove CompressedLinear support for compressed-tensors > 0.13

### DIFF
--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -80,14 +80,14 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
         from compressed_tensors import __version__ as ct_version
         from packaging import version
 
-        if version.parse(ct_version) > version.parse("0.13"):
+        if version.parse(ct_version) >= version.parse("0.14"):
             self.compressor.decompress_model(model=model)
         elif (
             self.quantization_config.is_quantization_compressed and not self.run_compressed
         ) or self.quantization_config.is_sparsification_compressed:
             self.compressor.decompress_model(model=model)
 
-    def _dequantize(self, model):
+    def _dequantize(self, model, dtype=None):
         from compressed_tensors.quantization import QuantizationStatus
 
         self.compressor.decompress_model(model=model)

--- a/src/transformers/quantizers/quantizer_compressed_tensors.py
+++ b/src/transformers/quantizers/quantizer_compressed_tensors.py
@@ -68,8 +68,7 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
 
         ct_quantization_config = self.compressor.quantization_config
 
-        # Always initialize compressed wrappers to match the checkpoint
-        apply_quantization_config(model, ct_quantization_config, self.run_compressed)
+        apply_quantization_config(model, ct_quantization_config)
         if (
             self.quantization_config.is_quantization_compressed
             or self.quantization_config.is_sparsification_compressed
@@ -78,11 +77,26 @@ class CompressedTensorsHfQuantizer(HfQuantizer):
 
     def _process_model_after_weight_loading(self, model, **kwargs):
         """Decompress loaded model if necessary - need for qat"""
+        from compressed_tensors import __version__ as ct_version
+        from packaging import version
 
-        if (
+        if version.parse(ct_version) > version.parse("0.13"):
+            self.compressor.decompress_model(model=model)
+        elif (
             self.quantization_config.is_quantization_compressed and not self.run_compressed
         ) or self.quantization_config.is_sparsification_compressed:
             self.compressor.decompress_model(model=model)
+
+    def _dequantize(self, model):
+        from compressed_tensors.quantization import QuantizationStatus
+
+        self.compressor.decompress_model(model=model)
+
+        for module in model.modules():
+            if hasattr(module, "quantization_status"):
+                module.quantization_status = QuantizationStatus.FROZEN
+
+        return model
 
     # NOTE: TP plan override for compressed tensors removed - unsupported styles were used.
     # TODO: Implement proper TP support for compressed tensors quantization

--- a/tests/quantization/compressed_tensors_integration/test_compressed_models.py
+++ b/tests/quantization/compressed_tensors_integration/test_compressed_models.py
@@ -169,8 +169,66 @@ class RunCompressedTest(unittest.TestCase):
         backend_empty_cache(torch_device)
         gc.collect()
 
+    def test_default_run_compressed__True(self):
+        from compressed_tensors import __version__ as ct_version
+        from packaging import version
+
+        if version.parse(ct_version) >= version.parse("0.14"):
+            self.skipTest("CompressedLinear removed in CT >= 0.14")
+
+        try:
+            from compressed_tensors.linear.compressed_linear import CompressedLinear
+        except ImportError:
+            self.skipTest("CompressedLinear not available in this version of compressed-tensors")
+        from compressed_tensors.quantization.utils import iter_named_leaf_modules
+
+        for stub in self.stubs:
+            model = AutoModelForCausalLM.from_pretrained(
+                stub,
+            )
+            compressed_linear_counts = 0
+
+            for _, submodule in iter_named_leaf_modules(
+                model,
+            ):
+                if isinstance(submodule, CompressedLinear):
+                    compressed_linear_counts += 1
+
+            # some linear models are not compressed - ex. lm_head
+            assert compressed_linear_counts > 0
+
+    def test_model_decompressed_after_loading(self):
+        """Verify that models are properly decompressed after loading for CT >= 0.14"""
+        from compressed_tensors import __version__ as ct_version
+        from compressed_tensors.quantization import QuantizationStatus
+        from compressed_tensors.quantization.utils import iter_named_leaf_modules
+        from packaging import version
+
+        if version.parse(ct_version) < version.parse("0.14"):
+            self.skipTest("Automatic decompression only applies to CT >= 0.14")
+
+        for stub in self.stubs:
+            model = AutoModelForCausalLM.from_pretrained(stub)
+            for _, submodule in iter_named_leaf_modules(model):
+                if hasattr(submodule, "quantization_status"):
+                    self.assertNotEqual(
+                        submodule.quantization_status,
+                        QuantizationStatus.COMPRESSED,
+                        "Module should be decompressed after loading for CT >= 0.14",
+                    )
+
     def test_run_compressed_outputs_match(self):
         """Check that run_compressed=True/False output are the same"""
+        from compressed_tensors import __version__ as ct_version
+        from packaging import version
+
+        if version.parse(ct_version) >= version.parse("0.14"):
+            self.skipTest("run_compressed no longer applies for CT >= 0.14")
+
+        try:
+            from compressed_tensors.linear.compressed_linear import CompressedLinear  # noqa: F401
+        except ImportError:
+            self.skipTest("CompressedLinear not available in this version of compressed-tensors")
 
         from transformers import AutoTokenizer
         from transformers.utils.quantization_config import CompressedTensorsConfig

--- a/tests/quantization/compressed_tensors_integration/test_compressed_models.py
+++ b/tests/quantization/compressed_tensors_integration/test_compressed_models.py
@@ -169,49 +169,6 @@ class RunCompressedTest(unittest.TestCase):
         backend_empty_cache(torch_device)
         gc.collect()
 
-    def test_default_run_compressed__True(self):
-        from compressed_tensors.linear.compressed_linear import CompressedLinear
-        from compressed_tensors.quantization.utils import iter_named_leaf_modules
-
-        for stub in self.stubs:
-            model = AutoModelForCausalLM.from_pretrained(
-                stub,
-            )
-            compressed_linear_counts = 0
-
-            for _, submodule in iter_named_leaf_modules(
-                model,
-            ):
-                if isinstance(submodule, CompressedLinear):
-                    compressed_linear_counts += 1
-
-            # some linear models are not compressed - ex. lm_head
-            assert compressed_linear_counts > 0
-
-    def test_default_run_compressed__False(self):
-        from compressed_tensors.linear.compressed_linear import CompressedLinear
-        from compressed_tensors.quantization.utils import iter_named_leaf_modules
-
-        from transformers.utils.quantization_config import CompressedTensorsConfig
-
-        quantization_config = CompressedTensorsConfig(run_compressed=False)
-
-        for stub in self.stubs:
-            model = AutoModelForCausalLM.from_pretrained(
-                stub,
-                quantization_config=quantization_config,
-            )
-            compressed_linear_counts = 0
-
-            for _, submodule in iter_named_leaf_modules(
-                model,
-            ):
-                if isinstance(submodule, CompressedLinear):
-                    compressed_linear_counts += 1
-
-            # No modules should be CompressedLinear
-            assert compressed_linear_counts == 0
-
     def test_run_compressed_outputs_match(self):
         """Check that run_compressed=True/False output are the same"""
 


### PR DESCRIPTION
Title: Remove CompressedLinear support for compressed-tensors > 0.13

Body:


## What does this PR do?

Prepares transformers for the removal of `CompressedLinear` from compressed-tensors (v0.14+). Users should now call `model.dequantize()` after loading to decompress quantized models.

**Changes:**
- Stop passing `run_compressed` to `apply_quantization_config`
- Always decompress models after loading for compressed-tensors > 0.13
- Add `_dequantize` method to `CompressedTensorsHfQuantizer`
- Remove tests that reference deleted `CompressedLinear` class (`test_default_run_compressed__True`, `test_default_run_compressed__False`)

Backwards compatibility is maintained for compressed-tensors ≤ 0.13.

Related to vllm-project/llm-compressor#2279
Companion PR: vllm-project/compressed-tensors#564

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. → vllm-project/llm-compressor#2279
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc @MekkCyber (quantization)