### PR TITLE
Avoid hard failure for gpt-oss GGUF architecture by falling back to g…

### DIFF
--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -462,6 +462,13 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
         updated_architecture = "qwen2_moe"
     elif "qwen3moe" in architecture:
         updated_architecture = "qwen3_moe"
+    elif architecture == "gpt-oss":
+        logger.warning(
+            "GGUF architecture 'gpt-oss' is not fully supported yet. "
+            "Falling back to 'gpt-neox' configuration. "
+            "MoE layers are not supported and inference correctness is not guaranteed."
+        )
+        updated_architecture = "gpt-neox"
 
     # For stablelm architecture, we need to set qkv_bias and use_parallel_residual from tensors
     # If `qkv_bias=True`, qkv_proj with bias will be present in the tensors

--- a/src/transformers/models/grounding_dino/processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/processing_grounding_dino.py
@@ -117,8 +117,6 @@ class GroundingDinoProcessorKwargs(ProcessingKwargs, total=False):
 class GroundingDinoProcessor(ProcessorMixin):
     valid_processor_kwargs = GroundingDinoProcessorKwargs
 
-    valid_processor_kwargs = GroundingDinoProcessorKwargs
-
     model_input_names = [
         "input_ids",
         "attention_mask",

--- a/src/transformers/models/grounding_dino/processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/processing_grounding_dino.py
@@ -117,6 +117,16 @@ class GroundingDinoProcessorKwargs(ProcessingKwargs, total=False):
 class GroundingDinoProcessor(ProcessorMixin):
     valid_processor_kwargs = GroundingDinoProcessorKwargs
 
+    valid_processor_kwargs = GroundingDinoProcessorKwargs
+
+    model_input_names = [
+        "input_ids",
+        "attention_mask",
+        "token_type_ids",
+        "pixel_values",
+        "pixel_mask",
+    ]
+
     def __init__(self, image_processor, tokenizer):
         super().__init__(image_processor, tokenizer)
 


### PR DESCRIPTION


# What does this PR do?

This PR avoids a hard failure when loading GGUF models that declare the
`gpt-oss` architecture.

Currently, such models raise a `ValueError` during GGUF config loading.
This change maps `gpt-oss` to the closest supported architecture
(`gpt-neox`) and emits a clear warning to communicate current limitations.

The goal is to allow GGUF checkpoints using `gpt-oss` to be loaded without
crashing, enabling downstream tools (e.g. vLLM) to proceed.

### Notes / Limitations
- This does **not** implement full GPT-OSS support.
- MoE layers are not supported and inference correctness is **not guaranteed**.
- This is a best-effort fallback to avoid hard failure, not a claim of correctness.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #43366


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

No tests were added as GGUF integration tests require large binary artifacts
and this change only affects architecture handling and error prevention.

## Who can review?

cc @SunMarc @Rocketknight1

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
