### PR TITLE
[core] Faster and thread-safe `check_model_inputs` implementation

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -118,7 +118,7 @@ from .utils import (
     is_torch_xpu_available,
     logging,
 )
-from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder, is_flash_attention_requested
+from .utils.generic import GeneralInterface, is_flash_attention_requested
 from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
 from .utils.import_utils import (
     is_huggingface_hub_greater_or_equal,
@@ -126,6 +126,7 @@ from .utils.import_utils import (
     is_tracing,
 )
 from .utils.loading_report import LoadStateDictInfo, log_state_dict_report
+from .utils.output_capturing import _CAN_RECORD_REGISTRY, OutputRecorder
 from .utils.quantization_config import QuantizationMethod
 
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1333,7 +1333,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         self.init_weights()
         self._backward_compatibility_gradient_checkpointing()
 
-        # Install output capturing hooks if needed
+        # Install output capturing hooks if needed, to be able to use the `output_xxx` kwargs together with `check_model_inputs`
         install_all_output_capturing_hooks(self)
 
     @property

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -122,7 +122,6 @@ from .utils.generic import (
     _CAN_RECORD_REGISTRY,
     GeneralInterface,
     OutputRecorder,
-    install_all_output_capturing_hooks,
     is_flash_attention_requested,
 )
 from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
@@ -1332,9 +1331,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         # Maybe initialize the weights and tie the keys
         self.init_weights()
         self._backward_compatibility_gradient_checkpointing()
-
-        # Install output capturing hooks if needed, to be able to use the `output_xxx` kwargs together with `check_model_inputs`
-        install_all_output_capturing_hooks(self)
 
     @property
     def tp_plan(self) -> dict[str, str]:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -118,7 +118,7 @@ from .utils import (
     is_torch_xpu_available,
     logging,
 )
-from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder, is_flash_attention_requested
+from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder, is_flash_attention_requested, install_all_output_capturing_hooks
 from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
 from .utils.import_utils import (
     is_huggingface_hub_greater_or_equal,
@@ -1326,6 +1326,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         # Maybe initialize the weights and tie the keys
         self.init_weights()
         self._backward_compatibility_gradient_checkpointing()
+
+        # Install output capturing hooks if needed
+        install_all_output_capturing_hooks(self)
 
     @property
     def tp_plan(self) -> dict[str, str]:

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -118,12 +118,7 @@ from .utils import (
     is_torch_xpu_available,
     logging,
 )
-from .utils.generic import (
-    _CAN_RECORD_REGISTRY,
-    GeneralInterface,
-    OutputRecorder,
-    is_flash_attention_requested,
-)
+from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder, is_flash_attention_requested
 from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
 from .utils.import_utils import (
     is_huggingface_hub_greater_or_equal,

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -118,7 +118,13 @@ from .utils import (
     is_torch_xpu_available,
     logging,
 )
-from .utils.generic import _CAN_RECORD_REGISTRY, GeneralInterface, OutputRecorder, is_flash_attention_requested, install_all_output_capturing_hooks
+from .utils.generic import (
+    _CAN_RECORD_REGISTRY,
+    GeneralInterface,
+    OutputRecorder,
+    install_all_output_capturing_hooks,
+    is_flash_attention_requested,
+)
 from .utils.hub import DownloadKwargs, create_and_tag_model_card, get_checkpoint_shard_files
 from .utils.import_utils import (
     is_huggingface_hub_greater_or_equal,

--- a/src/transformers/models/aria/modeling_aria.py
+++ b/src/transformers/models/aria/modeling_aria.py
@@ -42,7 +42,7 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
-from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_aria import AriaConfig, AriaTextConfig
 
@@ -915,7 +915,8 @@ class AriaModel(AriaPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )

--- a/src/transformers/models/aria/modular_aria.py
+++ b/src/transformers/models/aria/modular_aria.py
@@ -41,7 +41,6 @@ from ...modeling_utils import PreTrainedModel
 from ...processing_utils import ImagesKwargs, MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_python import PreTokenizedInput, TextInput
 from ...utils import TensorType, TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import check_model_inputs
 from ..auto import CONFIG_MAPPING, AutoConfig, AutoTokenizer
 from ..llama.configuration_llama import LlamaConfig
 from ..llama.modeling_llama import (
@@ -1260,10 +1259,6 @@ class AriaModel(LlavaModel):
         )
         return (patches_subgrid.sum(dim=(-1, -2)) > 0).bool()
 
-    @check_model_inputs(tie_last_hidden_states=False)
-    @auto_docstring(
-        custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
-    )
     def get_image_features(
         self,
         pixel_values: torch.FloatTensor,
@@ -1290,8 +1285,6 @@ class AriaModel(LlavaModel):
 
         return image_outputs
 
-    @can_return_tuple
-    @auto_docstring
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/aya_vision/modeling_aya_vision.py
+++ b/src/transformers/models/aya_vision/modeling_aya_vision.py
@@ -30,7 +30,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import can_return_tuple, check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_aya_vision import AyaVisionConfig
 
@@ -179,7 +179,8 @@ class AyaVisionModel(AyaVisionPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -241,7 +242,7 @@ class AyaVisionModel(AyaVisionPreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/aya_vision/modeling_aya_vision.py
+++ b/src/transformers/models/aya_vision/modeling_aya_vision.py
@@ -30,7 +30,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
 from ..auto import AutoModel
 from .configuration_aya_vision import AyaVisionConfig
 
@@ -339,7 +339,7 @@ class AyaVisionForConditionalGeneration(AyaVisionPreTrainedModel, GenerationMixi
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/aya_vision/modular_aya_vision.py
+++ b/src/transformers/models/aya_vision/modular_aya_vision.py
@@ -29,7 +29,7 @@ from ...cache_utils import Cache
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from .configuration_aya_vision import AyaVisionConfig
 
 
@@ -104,7 +104,8 @@ class AyaVisionModelOutputWithPast(LlavaModelOutputWithPast):
 
 class AyaVisionModel(LlavaModel):
     # Unlike LLaVA, the model doesn't have to deal with Pixtral-style image states
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -142,7 +143,7 @@ class AyaVisionModel(LlavaModel):
 
         return image_outputs
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -47,7 +47,8 @@ from ...utils import (
     logging,
     torch_int,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModelForCausalLM, AutoModelForSeq2SeqLM
 from .configuration_blip_2 import Blip2Config, Blip2QFormerConfig, Blip2VisionConfig
 

--- a/src/transformers/models/blt/modeling_blt.py
+++ b/src/transformers/models/blt/modeling_blt.py
@@ -437,8 +437,8 @@ class BltPreTrainedModel(PreTrainedModel):
     _supports_flex_attn = False
     _supports_attention_backend = False
     _can_record_outputs = {
-        "hidden_states": OutputRecorder(BltTransformerLayer, index=0, layer_name="local_decoder"),
-        "attentions": OutputRecorder(BltSelfAttention, index=1, layer_name="local_decoder"),
+        "hidden_states": OutputRecorder(BltTransformerLayer, index=0),
+        "attentions": OutputRecorder(BltSelfAttention, index=1),
     }
 
     @torch.no_grad()
@@ -741,7 +741,6 @@ class BltLocalDecoder(BltPreTrainedModel):
 
         self.post_init()
 
-    @check_model_inputs
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/blt/modeling_blt.py
+++ b/src/transformers/models/blt/modeling_blt.py
@@ -38,7 +38,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_blt import (
     BltConfig,
     BltGlobalTransformerConfig,

--- a/src/transformers/models/blt/modular_blt.py
+++ b/src/transformers/models/blt/modular_blt.py
@@ -29,7 +29,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from ..cohere2.modeling_cohere2 import rotate_half  # noqa: F401
 from ..llama.modeling_llama import LlamaRotaryEmbedding
 from ..mllama.modeling_mllama import (

--- a/src/transformers/models/blt/modular_blt.py
+++ b/src/transformers/models/blt/modular_blt.py
@@ -355,8 +355,8 @@ class BltPreTrainedModel(MllamaPreTrainedModel):
     _supports_flex_attn = False
     _no_split_modules = ["BltTransformerLayer"]
     _can_record_outputs = {
-        "hidden_states": OutputRecorder(BltTransformerLayer, index=0, layer_name="local_decoder"),
-        "attentions": OutputRecorder(BltSelfAttention, index=1, layer_name="local_decoder"),
+        "hidden_states": OutputRecorder(BltTransformerLayer, index=0),
+        "attentions": OutputRecorder(BltSelfAttention, index=1),
     }
 
     # Weight initialization is adapted from:
@@ -673,7 +673,6 @@ class BltLocalDecoder(BltPreTrainedModel):
 
         self.post_init()
 
-    @check_model_inputs
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -31,11 +31,10 @@ from ...utils import (
     ModelOutput,
     TransformersKwargs,
     auto_docstring,
-    can_return_tuple,
     logging,
     torch_int,
 )
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
 from .configuration_clip import CLIPConfig, CLIPTextConfig, CLIPVisionConfig
 
 
@@ -515,9 +514,14 @@ class CLIPEncoder(nn.Module):
         )
 
 
-class CLIPTextTransformer(nn.Module):
+class CLIPTextTransformer(CLIPPreTrainedModel):
+    config: CLIPTextConfig
+    input_modalities = ("text",)
+
+    _no_split_modules = ["CLIPTextEmbeddings", "CLIPEncoderLayer"]
+
     def __init__(self, config: CLIPTextConfig):
-        super().__init__()
+        super().__init__(config)
         self.config = config
         embed_dim = config.hidden_size
         self.embeddings = CLIPTextEmbeddings(config)
@@ -526,7 +530,9 @@ class CLIPTextTransformer(nn.Module):
 
         # For `pooled_output` computation
         self.eos_token_id = config.eos_token_id
+        self.post_init()
 
+    @check_model_inputs(tie_last_hidden_states=False)
     @auto_docstring
     def forward(
         self,
@@ -587,8 +593,6 @@ class CLIPTextTransformer(nn.Module):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
         )
 
 
@@ -615,7 +619,6 @@ class CLIPTextModel(CLIPPreTrainedModel):
     def set_input_embeddings(self, value):
         self.text_model.embeddings.token_embedding = value
 
-    @check_model_inputs(tie_last_hidden_states=False)
     @auto_docstring
     def forward(
         self,
@@ -648,9 +651,14 @@ class CLIPTextModel(CLIPPreTrainedModel):
         )
 
 
-class CLIPVisionTransformer(nn.Module):
+class CLIPVisionTransformer(CLIPPreTrainedModel):
+    config: CLIPVisionConfig
+    main_input_name = "pixel_values"
+    input_modalities = ("image",)
+    _no_split_modules = ["CLIPEncoderLayer"]
+
     def __init__(self, config: CLIPVisionConfig):
-        super().__init__()
+        super().__init__(config)
         self.config = config
         embed_dim = config.hidden_size
 
@@ -658,7 +666,9 @@ class CLIPVisionTransformer(nn.Module):
         self.pre_layrnorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
         self.encoder = CLIPEncoder(config)
         self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
+        self.post_init()
 
+    @check_model_inputs(tie_last_hidden_states=False)
     @auto_docstring
     def forward(
         self,
@@ -684,8 +694,6 @@ class CLIPVisionTransformer(nn.Module):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
         )
 
 
@@ -709,7 +717,6 @@ class CLIPVisionModel(CLIPPreTrainedModel):
     def get_input_embeddings(self) -> nn.Module:
         return self.vision_model.embeddings.patch_embedding
 
-    @check_model_inputs(tie_last_hidden_states=False)
     @auto_docstring
     def forward(
         self,
@@ -967,7 +974,7 @@ class CLIPTextModelWithProjection(CLIPPreTrainedModel):
     def set_input_embeddings(self, value):
         self.text_model.embeddings.token_embedding = value
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1005,6 +1012,8 @@ class CLIPTextModelWithProjection(CLIPPreTrainedModel):
         return CLIPTextModelOutput(
             text_embeds=text_embeds,
             last_hidden_state=text_outputs.last_hidden_state,
+            hidden_states=text_outputs.hidden_states,
+            attentions=text_outputs.attentions,
         )
 
 
@@ -1028,7 +1037,7 @@ class CLIPVisionModelWithProjection(CLIPPreTrainedModel):
     def get_input_embeddings(self) -> nn.Module:
         return self.vision_model.embeddings.patch_embedding
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1068,6 +1077,8 @@ class CLIPVisionModelWithProjection(CLIPPreTrainedModel):
         return CLIPVisionModelOutput(
             image_embeds=image_embeds,
             last_hidden_state=vision_outputs.last_hidden_state,
+            hidden_states=vision_outputs.hidden_states,
+            attentions=vision_outputs.attentions,
         )
 
 
@@ -1096,7 +1107,7 @@ class CLIPForImageClassification(CLIPPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1127,6 +1138,8 @@ class CLIPForImageClassification(CLIPPreTrainedModel):
         return ImageClassifierOutput(
             loss=loss,
             logits=logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
 

--- a/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/modeling_cohere2_vision.py
@@ -29,7 +29,6 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
-from ...utils.generic import check_model_inputs
 from ..auto import AutoModel
 from .configuration_cohere2_vision import Cohere2VisionConfig
 
@@ -202,7 +201,7 @@ class Cohere2VisionModel(Cohere2VisionPreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -279,7 +278,7 @@ class Cohere2VisionForConditionalGeneration(Cohere2VisionPreTrainedModel, Genera
     ) -> tuple | BaseModelOutputWithPooling:
         return self.model.get_image_features(pixel_values=pixel_values, **kwargs)
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/cohere2_vision/modular_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/modular_cohere2_vision.py
@@ -35,7 +35,6 @@ from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import check_model_inputs
 from .configuration_cohere2_vision import Cohere2VisionConfig
 
 
@@ -109,8 +108,6 @@ class Cohere2VisionModel(AyaVisionModel):
 
         return image_outputs
 
-    @check_model_inputs
-    @auto_docstring
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,
@@ -165,8 +162,6 @@ class Cohere2VisionForConditionalGeneration(AyaVisionForConditionalGeneration):
     ) -> tuple | BaseModelOutputWithPooling:
         return self.model.get_image_features(pixel_values=pixel_values, **kwargs)
 
-    @check_model_inputs
-    @auto_docstring
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/conditional_detr/modeling_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modeling_conditional_detr.py
@@ -34,7 +34,8 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_conditional_detr import ConditionalDetrConfig
 
 

--- a/src/transformers/models/conditional_detr/modular_conditional_detr.py
+++ b/src/transformers/models/conditional_detr/modular_conditional_detr.py
@@ -32,7 +32,8 @@ from ...utils import (
     auto_docstring,
     logging,
 )
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..deformable_detr.modeling_deformable_detr import inverse_sigmoid
 from ..detr.image_processing_detr_fast import DetrImageProcessorFast
 from ..detr.modeling_detr import (

--- a/src/transformers/models/deformable_detr/modeling_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modeling_deformable_detr.py
@@ -37,7 +37,8 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import compile_compatible_method_lru_cache, meshgrid
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_deformable_detr import DeformableDetrConfig
 
 

--- a/src/transformers/models/deformable_detr/modular_deformable_detr.py
+++ b/src/transformers/models/deformable_detr/modular_deformable_detr.py
@@ -36,7 +36,8 @@ from ...utils import (
     logging,
     torch_compilable_check,
 )
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..detr.image_processing_detr_fast import DetrImageProcessorFast
 from ..detr.modeling_detr import (
     DetrConvEncoder,

--- a/src/transformers/models/depth_pro/modeling_depth_pro.py
+++ b/src/transformers/models/depth_pro/modeling_depth_pro.py
@@ -279,9 +279,12 @@ class DepthProPatchEncoder(nn.Module):
             patches,
             # required for intermediate features
             output_hidden_states=self.n_intermediate_hooks > 0,
+            return_dict=True,
         )
 
-        scaled_images_last_hidden_state = torch.split_with_sizes(encodings[0], n_patches_per_scaled_image[::-1])
+        scaled_images_last_hidden_state = torch.split_with_sizes(
+            encodings.last_hidden_state, n_patches_per_scaled_image[::-1]
+        )
         # -1 (reverse list) as patch encoder returns high res patches first, we need low res first
         scaled_images_last_hidden_state = scaled_images_last_hidden_state[::-1]
 
@@ -312,7 +315,7 @@ class DepthProPatchEncoder(nn.Module):
         intermediate_features = []
         for i in range(self.n_intermediate_hooks):
             # +1 to correct index position as hidden_states contain embedding output as well
-            hidden_state = encodings[2][self.intermediate_hook_ids[i] + 1]
+            hidden_state = encodings.hidden_states[self.intermediate_hook_ids[i] + 1]
             padding = torch_int(self.merge_padding_value * (1 / self.scaled_images_ratios[-1]))
             output_height = base_height * 2 ** (self.n_scaled_images - 1)
             output_width = base_width * 2 ** (self.n_scaled_images - 1)

--- a/src/transformers/models/doge/modeling_doge.py
+++ b/src/transformers/models/doge/modeling_doge.py
@@ -41,7 +41,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import AttentionInterface, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_torch_flex_attn_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_doge import DogeConfig
 
 

--- a/src/transformers/models/doge/modular_doge.py
+++ b/src/transformers/models/doge/modular_doge.py
@@ -34,7 +34,7 @@ from ...modeling_rope_utils import RopeParameters
 from ...modeling_utils import AttentionInterface, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, is_torch_flex_attn_available, logging
-from ...utils.generic import OutputRecorder
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import (
     LlamaForSequenceClassification,
     LlamaMLP,

--- a/src/transformers/models/edgetam/modeling_edgetam.py
+++ b/src/transformers/models/edgetam/modeling_edgetam.py
@@ -28,8 +28,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from transformers.utils.generic import OutputRecorder
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_layers import GradientCheckpointingLayer
@@ -39,6 +37,7 @@ from ...processing_utils import Unpack
 from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import ModelOutput, auto_docstring, can_return_tuple, logging
 from ...utils.generic import TransformersKwargs, check_model_inputs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_edgetam import (
     EdgeTamConfig,

--- a/src/transformers/models/edgetam_video/modeling_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modeling_edgetam_video.py
@@ -31,8 +31,6 @@ import torch.nn.functional as F
 from torch import Tensor
 from tqdm import tqdm
 
-from transformers.utils.generic import OutputRecorder
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
@@ -43,6 +41,7 @@ from ...processing_utils import Unpack
 from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import ModelOutput, auto_docstring, can_return_tuple, logging
 from ...utils.generic import TransformersKwargs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_edgetam_video import (
     EdgeTamVideoConfig,

--- a/src/transformers/models/edgetam_video/modular_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modular_edgetam_video.py
@@ -21,12 +21,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from transformers.models.sam2.modeling_sam2 import (
-    eager_attention_forward,
-    window_partition,
-)
-from transformers.utils.generic import OutputRecorder
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...configuration_utils import PreTrainedConfig
@@ -37,7 +31,9 @@ from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import (
     auto_docstring,
 )
+from ...utils.output_capturing import OutputRecorder
 from ..auto import CONFIG_MAPPING, AutoConfig
+from ..sam2.modeling_sam2 import eager_attention_forward, window_partition
 from ..sam2_video.configuration_sam2_video import (
     Sam2VideoConfig,
     Sam2VideoMaskDecoderConfig,

--- a/src/transformers/models/ernie4_5_moe/modeling_ernie4_5_moe.py
+++ b/src/transformers/models/ernie4_5_moe/modeling_ernie4_5_moe.py
@@ -37,7 +37,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_ernie4_5_moe import Ernie4_5_MoeConfig
 
 

--- a/src/transformers/models/ernie4_5_moe/modular_ernie4_5_moe.py
+++ b/src/transformers/models/ernie4_5_moe/modular_ernie4_5_moe.py
@@ -24,7 +24,8 @@ from ...modeling_outputs import MoeModelOutputWithPast
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from ..ernie4_5.modeling_ernie4_5 import Ernie4_5RotaryEmbedding, apply_rotary_pos_emb, rotate_half  # noqa: F401
 from ..llama.modeling_llama import LlamaAttention, LlamaRMSNorm
 from ..mixtral.modeling_mixtral import (

--- a/src/transformers/models/ernie4_5_vl_moe/modeling_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/modeling_ernie4_5_vl_moe.py
@@ -45,7 +45,8 @@ from ...utils import (
     is_torchdynamo_compiling,
     torch_compilable_check,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.generic import check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_ernie4_5_vl_moe import (
     Ernie4_5_VL_MoeConfig,
     Ernie4_5_VL_MoeTextConfig,

--- a/src/transformers/models/ernie4_5_vl_moe/modular_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/modular_ernie4_5_vl_moe.py
@@ -60,7 +60,8 @@ from ...utils import (
     is_torchdynamo_compiling,
     logging,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from ..ernie4_5_moe.configuration_ernie4_5_moe import Ernie4_5_MoeConfig
 from ..ernie4_5_moe.modeling_ernie4_5_moe import (
     Ernie4_5_MoeAttention,

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -34,7 +34,8 @@ from ...modeling_outputs import (
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_esm import EsmConfig
 
 

--- a/src/transformers/models/evolla/modeling_evolla.py
+++ b/src/transformers/models/evolla/modeling_evolla.py
@@ -44,7 +44,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_evolla import EvollaConfig, SaProtConfig
 
 

--- a/src/transformers/models/evolla/modular_evolla.py
+++ b/src/transformers/models/evolla/modular_evolla.py
@@ -33,7 +33,8 @@ from ...utils import (
     can_return_tuple,
     logging,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..esm.modeling_esm import (
     EsmAttention,
     EsmEmbeddings,

--- a/src/transformers/models/fast_vlm/modeling_fast_vlm.py
+++ b/src/transformers/models/fast_vlm/modeling_fast_vlm.py
@@ -30,7 +30,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_fast_vlm import FastVlmConfig
 
@@ -114,7 +114,8 @@ class FastVlmModel(FastVlmPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -169,7 +170,7 @@ class FastVlmModel(FastVlmPreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -297,7 +298,7 @@ class FastVlmForConditionalGeneration(FastVlmPreTrainedModel, GenerationMixin):
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/fast_vlm/modular_fast_vlm.py
+++ b/src/transformers/models/fast_vlm/modular_fast_vlm.py
@@ -21,7 +21,7 @@ from ...configuration_utils import PreTrainedConfig
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import CONFIG_MAPPING
 from ..llava.configuration_llava import LlavaConfig
 from ..llava.modeling_llava import (
@@ -180,7 +180,8 @@ class FastVlmModel(LlavaModel):
     def __init__(self, config: FastVlmConfig):
         super().__init__(config)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -211,7 +212,7 @@ class FastVlmModel(LlavaModel):
 
         return image_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -282,7 +283,7 @@ class FastVlmCausalLMOutputWithPast(LlavaCausalLMOutputWithPast):
 class FastVlmForConditionalGeneration(LlavaForConditionalGeneration):
     _checkpoint_conversion_mapping = {}
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/flex_olmo/modeling_flex_olmo.py
+++ b/src/transformers/models/flex_olmo/modeling_flex_olmo.py
@@ -38,7 +38,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_flex_olmo import FlexOlmoConfig
 
 

--- a/src/transformers/models/flex_olmo/modular_flex_olmo.py
+++ b/src/transformers/models/flex_olmo/modular_flex_olmo.py
@@ -23,7 +23,8 @@ from ...modeling_outputs import MoeModelOutputWithPast
 from ...modeling_rope_utils import RopeParameters
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..mixtral.modeling_mixtral import MixtralModel, MixtralPreTrainedModel
 from ..olmo2.modeling_olmo2 import Olmo2Attention, Olmo2RMSNorm, Olmo2RotaryEmbedding
 from ..olmoe.modeling_olmoe import (

--- a/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
@@ -46,13 +46,8 @@ from ...utils import (
     is_torchdynamo_compiling,
     torch_compilable_check,
 )
-from ...utils.generic import (
-    OutputRecorder,
-    can_return_tuple,
-    check_model_inputs,
-    is_flash_attention_requested,
-    maybe_autocast,
-)
+from ...utils.generic import can_return_tuple, check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_glm4v_moe import Glm4vMoeConfig, Glm4vMoeTextConfig, Glm4vMoeVisionConfig
 
 

--- a/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
@@ -42,12 +42,17 @@ from ...processing_utils import Unpack
 from ...utils import (
     TransformersKwargs,
     auto_docstring,
-    can_return_tuple,
     is_grouped_mm_available,
     is_torchdynamo_compiling,
     torch_compilable_check,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.generic import (
+    OutputRecorder,
+    can_return_tuple,
+    check_model_inputs,
+    is_flash_attention_requested,
+    maybe_autocast,
+)
 from .configuration_glm4v_moe import Glm4vMoeConfig, Glm4vMoeTextConfig, Glm4vMoeVisionConfig
 
 
@@ -1651,7 +1656,7 @@ class Glm4vMoeForConditionalGeneration(Glm4vMoePreTrainedModel, GenerationMixin)
         return self.model.get_image_features(pixel_values=pixel_values, image_grid_thw=image_grid_thw, **kwargs)
 
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
@@ -26,7 +26,8 @@ from ...modeling_rope_utils import RopeParameters
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import OutputRecorder, can_return_tuple
+from ...utils.generic import can_return_tuple
+from ...utils.output_capturing import OutputRecorder
 from ..deepseek_v3.modeling_deepseek_v3 import DeepseekV3NaiveMoe
 from ..glm4.modeling_glm4 import Glm4Attention
 from ..glm4_moe.configuration_glm4_moe import Glm4MoeConfig

--- a/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
@@ -26,7 +26,7 @@ from ...modeling_rope_utils import RopeParameters
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import OutputRecorder, can_return_tuple
 from ..deepseek_v3.modeling_deepseek_v3 import DeepseekV3NaiveMoe
 from ..glm4.modeling_glm4 import Glm4Attention
 from ..glm4_moe.configuration_glm4_moe import Glm4MoeConfig
@@ -493,7 +493,7 @@ class Glm4vMoeTextModel(Glm4vTextModel):
 
 class Glm4vMoeForConditionalGeneration(Glm4vForConditionalGeneration):
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/got_ocr2/modeling_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/modeling_got_ocr2.py
@@ -25,8 +25,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-from transformers.utils.generic import check_model_inputs
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...cache_utils import Cache
@@ -36,6 +34,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
+from ...utils.generic import check_model_inputs
 from ..auto import AutoModel
 from .configuration_got_ocr2 import GotOcr2Config, GotOcr2VisionConfig
 

--- a/src/transformers/models/got_ocr2/modeling_got_ocr2.py
+++ b/src/transformers/models/got_ocr2/modeling_got_ocr2.py
@@ -25,6 +25,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from transformers.utils.generic import check_model_inputs
+
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...cache_utils import Cache
@@ -34,7 +36,6 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
-from ...utils.generic import check_model_inputs
 from ..auto import AutoModel
 from .configuration_got_ocr2 import GotOcr2Config, GotOcr2VisionConfig
 
@@ -587,7 +588,7 @@ class GotOcr2Model(GotOcr2PreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/gpt_neox/modeling_gpt_neox.py
+++ b/src/transformers/models/gpt_neox/modeling_gpt_neox.py
@@ -13,7 +13,6 @@ from torch import nn
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
-from ...integrations import use_kernel_forward_from_hub
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GradientCheckpointingLayer
@@ -270,12 +269,11 @@ class GPTNeoXLayer(GradientCheckpointingLayer):
         position_ids: torch.LongTensor | None = None,
         use_cache: bool | None = False,
         layer_past: Cache | None = None,
-        output_attentions: bool | None = False,
         cache_position: torch.LongTensor | None = None,
         position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ):
-        attn_output, attn_weights = self.attention(
+        attn_output, _ = self.attention(
             self.input_layernorm(hidden_states),
             attention_mask=attention_mask,
             position_ids=position_ids,
@@ -302,76 +300,6 @@ class GPTNeoXLayer(GradientCheckpointingLayer):
             mlp_output = self.post_mlp_dropout(mlp_output)
             hidden_states = mlp_output + attn_output
 
-        outputs = (hidden_states,)
-        if output_attentions:
-            outputs += (attn_weights,)
-
-        return outputs
-
-
-@use_kernel_forward_from_hub("RMSNorm")
-class GPTNeoXRMSNorm(nn.Module):
-    def __init__(self, hidden_size, eps: float = 1e-6) -> None:
-        """
-        GPTNeoXRMSNorm is equivalent to T5LayerNorm
-        """
-        super().__init__()
-        self.weight = nn.Parameter(torch.ones(hidden_size))
-        self.variance_epsilon = eps
-
-    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        input_dtype = hidden_states.dtype
-        hidden_states = hidden_states.to(torch.float32)
-        variance = hidden_states.pow(2).mean(-1, keepdim=True)
-        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
-        return self.weight * hidden_states.to(input_dtype)
-
-    def extra_repr(self):
-        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
-
-
-class GPTNeoXDecoderLayer(GradientCheckpointingLayer):
-    def __init__(self, config: GPTNeoXConfig, layer_idx: int):
-        super().__init__()
-        self.hidden_size = config.hidden_size
-
-        self.self_attn = GPTNeoXAttention(config=config, layer_idx=layer_idx)
-
-        self.mlp = GPTNeoXMLP(config)
-        self.input_layernorm = GPTNeoXRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.post_attention_layernorm = GPTNeoXRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-
-    def forward(
-        self,
-        hidden_states: torch.Tensor,
-        attention_mask: torch.Tensor | None = None,
-        position_ids: torch.LongTensor | None = None,
-        past_key_values: Cache | None = None,
-        use_cache: bool | None = False,
-        cache_position: torch.LongTensor | None = None,
-        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
-        **kwargs: Unpack[TransformersKwargs],
-    ) -> torch.Tensor:
-        residual = hidden_states
-        hidden_states = self.input_layernorm(hidden_states)
-        # Self Attention
-        hidden_states, _ = self.self_attn(
-            hidden_states=hidden_states,
-            attention_mask=attention_mask,
-            position_ids=position_ids,
-            past_key_values=past_key_values,
-            use_cache=use_cache,
-            cache_position=cache_position,
-            position_embeddings=position_embeddings,
-            **kwargs,
-        )
-        hidden_states = residual + hidden_states
-
-        # Fully Connected
-        residual = hidden_states
-        hidden_states = self.post_attention_layernorm(hidden_states)
-        hidden_states = self.mlp(hidden_states)
-        hidden_states = residual + hidden_states
         return hidden_states
 
 
@@ -389,7 +317,7 @@ class GPTNeoXPreTrainedModel(PreTrainedModel):
     _can_compile_fullgraph = True
     _supports_attention_backend = True
     _can_record_outputs = {
-        "hidden_states": GPTNeoXDecoderLayer,
+        "hidden_states": GPTNeoXLayer,
         "attentions": GPTNeoXAttention,
     }
     _keys_to_ignore_on_load_unexpected = [r"attention.bias", r"attention.masked_bias"]
@@ -421,26 +349,11 @@ class GPTNeoXModel(GPTNeoXPreTrainedModel):
         inputs_embeds: torch.FloatTensor | None = None,
         past_key_values: Cache | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
         cache_position: torch.LongTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPast:
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        use_cache = use_cache if use_cache is not None else self.config.use_cache
-
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
-
-        if self.gradient_checkpointing and self.training:
-            if use_cache:
-                logger.warning_once(
-                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
-                )
-                use_cache = False
 
         if inputs_embeds is None:
             inputs_embeds = self.embed_in(input_ids)
@@ -468,39 +381,23 @@ class GPTNeoXModel(GPTNeoXPreTrainedModel):
 
         hidden_states = self.emb_dropout(inputs_embeds)
         position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
-
-        all_attentions = () if output_attentions else None
-        all_hidden_states = () if output_hidden_states else None
-        for i, layer in enumerate(self.layers):
-            if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_states,)
-
-            outputs = layer(
+        for layer in self.layers:
+            hidden_states = layer(
                 hidden_states,
                 attention_mask=causal_mask,
                 position_ids=position_ids,
                 layer_past=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,
-                output_attentions=output_attentions,
                 cache_position=cache_position,
                 **kwargs,
             )
-            hidden_states = outputs[0]
-
-            if output_attentions:
-                all_attentions = all_attentions + (outputs[1],)
 
         hidden_states = self.final_layer_norm(hidden_states)
-        # Add last hidden state
-        if output_hidden_states:
-            all_hidden_states = all_hidden_states + (hidden_states,)
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
-            hidden_states=all_hidden_states,
-            attentions=all_attentions,
         )
 
     def get_input_embeddings(self):
@@ -546,8 +443,6 @@ class GPTNeoXForCausalLM(GPTNeoXPreTrainedModel, GenerationMixin):
         past_key_values: Cache | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
         cache_position: torch.LongTensor | None = None,
         logits_to_keep: int | torch.Tensor = 0,
         **kwargs: Unpack[TransformersKwargs],
@@ -582,8 +477,6 @@ class GPTNeoXForCausalLM(GPTNeoXPreTrainedModel, GenerationMixin):
             inputs_embeds=inputs_embeds,
             past_key_values=past_key_values,
             use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
             cache_position=cache_position,
             **kwargs,
         )
@@ -641,8 +534,6 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
         past_key_values: Cache | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> SequenceClassifierOutputWithPast:
         r"""
@@ -659,8 +550,7 @@ class GPTNeoXForSequenceClassification(GPTNeoXPreTrainedModel):
             inputs_embeds=inputs_embeds,
             past_key_values=past_key_values,
             use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
+            **kwargs,
         )
         hidden_states = outputs.last_hidden_state
         logits = self.score(hidden_states)
@@ -721,8 +611,6 @@ class GPTNeoXForTokenClassification(GPTNeoXPreTrainedModel):
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> TokenClassifierOutput:
         r"""
@@ -739,8 +627,7 @@ class GPTNeoXForTokenClassification(GPTNeoXPreTrainedModel):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
+            **kwargs,
         )
 
         hidden_states = outputs.last_hidden_state
@@ -781,8 +668,6 @@ class GPTNeoXForQuestionAnswering(GPTNeoXPreTrainedModel):
         inputs_embeds: torch.FloatTensor | None = None,
         start_positions: torch.LongTensor | None = None,
         end_positions: torch.LongTensor | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> QuestionAnsweringModelOutput:
         outputs: BaseModelOutputWithPast = self.gpt_neox(
@@ -790,8 +675,7 @@ class GPTNeoXForQuestionAnswering(GPTNeoXPreTrainedModel):
             attention_mask=attention_mask,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
+            **kwargs,
         )
 
         sequence_output = outputs.last_hidden_state

--- a/src/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -39,7 +39,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_gpt_oss import GptOssConfig
 
 

--- a/src/transformers/models/gpt_oss/modular_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modular_gpt_oss.py
@@ -32,7 +32,8 @@ from ...utils import (
     auto_docstring,
     logging,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import (
     LlamaDecoderLayer,
     LlamaPreTrainedModel,

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -36,7 +36,8 @@ from ...modeling_outputs import ModelOutput
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedConfig, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_idefics import IdeficsConfig
 from .perceiver import IdeficsPerceiverResampler
 from .vision import IdeficsVisionEmbeddings, IdeficsVisionTransformer

--- a/src/transformers/models/instructblip/modeling_instructblip.py
+++ b/src/transformers/models/instructblip/modeling_instructblip.py
@@ -38,7 +38,8 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import apply_chunking_to_forward
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, can_return_tuple, logging, torch_int
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM
 from .configuration_instructblip import InstructBlipConfig, InstructBlipQFormerConfig, InstructBlipVisionConfig
 

--- a/src/transformers/models/instructblipvideo/modeling_instructblipvideo.py
+++ b/src/transformers/models/instructblipvideo/modeling_instructblipvideo.py
@@ -44,7 +44,8 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import apply_chunking_to_forward
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, can_return_tuple, logging, torch_int
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel, AutoModelForCausalLM, AutoModelForSeq2SeqLM
 from .configuration_instructblipvideo import (
     InstructBlipVideoConfig,

--- a/src/transformers/models/internvl/modeling_internvl.py
+++ b/src/transformers/models/internvl/modeling_internvl.py
@@ -36,7 +36,7 @@ from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPast, BaseMo
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, torch_compilable_check, torch_int
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_internvl import InternVLConfig, InternVLVisionConfig
 
@@ -544,7 +544,8 @@ class InternVLModel(InternVLPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -618,7 +619,7 @@ class InternVLModel(InternVLPreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -779,7 +780,7 @@ class InternVLForConditionalGeneration(InternVLPreTrainedModel, GenerationMixin)
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/internvl/modular_internvl.py
+++ b/src/transformers/models/internvl/modular_internvl.py
@@ -28,7 +28,7 @@ from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_int
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs, merge_with_config_defaults
 from ..clip.modeling_clip import CLIPMLP
 from ..janus.modeling_janus import JanusVisionAttention
 from ..llama.modeling_llama import LlamaRMSNorm
@@ -484,7 +484,8 @@ class InternVLModel(LlavaModel):
 
         return vision_features
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -534,7 +535,7 @@ class InternVLModel(LlavaModel):
 
         return vision_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -44,7 +44,8 @@ from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPas
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_jamba import JambaConfig
 
 

--- a/src/transformers/models/jamba/modular_jamba.py
+++ b/src/transformers/models/jamba/modular_jamba.py
@@ -31,7 +31,8 @@ from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPas
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import LlamaAttention, LlamaRMSNorm, eager_attention_forward
 from ..mistral.modeling_mistral import MistralMLP
 from ..mixtral.modeling_mixtral import MixtralExperts, MixtralForCausalLM

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -37,7 +37,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_jetmoe import JetMoeConfig
 
 

--- a/src/transformers/models/jetmoe/modular_jetmoe.py
+++ b/src/transformers/models/jetmoe/modular_jetmoe.py
@@ -31,7 +31,8 @@ from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPas
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import LlamaDecoderLayer
 from ..mixtral.modeling_mixtral import (
     MixtralModel,

--- a/src/transformers/models/lighton_ocr/modeling_lighton_ocr.py
+++ b/src/transformers/models/lighton_ocr/modeling_lighton_ocr.py
@@ -29,7 +29,6 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
-from ...utils.generic import check_model_inputs
 from ..auto import AutoModel
 from .configuration_lighton_ocr import LightOnOcrConfig
 
@@ -334,7 +333,7 @@ class LightOnOcrForConditionalGeneration(LightOnOcrPreTrainedModel, GenerationMi
     ) -> tuple | BaseModelOutputWithPooling:
         return self.model.get_image_features(pixel_values=pixel_values, image_sizes=image_sizes, **kwargs)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/llava/modeling_llava.py
+++ b/src/transformers/models/llava/modeling_llava.py
@@ -25,7 +25,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_llava import LlavaConfig
 
@@ -146,7 +146,8 @@ class LlavaModel(LlavaPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -221,7 +222,7 @@ class LlavaModel(LlavaPreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -319,7 +320,7 @@ class LlavaForConditionalGeneration(LlavaPreTrainedModel, GenerationMixin):
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/llava_next/modeling_llava_next.py
+++ b/src/transformers/models/llava_next/modeling_llava_next.py
@@ -29,8 +29,8 @@ from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling, ModelOutput
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils import TransformersKwargs, auto_docstring, logging, torch_compilable_check
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_llava_next import LlavaNextConfig
 
@@ -344,7 +344,8 @@ class LlavaNextModel(LlavaNextPreTrainedModel):
         feature_lens = torch.tensor(feature_lens, dtype=torch.long, device=image_features[0].device)
         return new_image_features, feature_lens
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -583,7 +584,7 @@ class LlavaNextForConditionalGeneration(LlavaNextPreTrainedModel, GenerationMixi
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/llava_next_video/modeling_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/modeling_llava_next_video.py
@@ -35,7 +35,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_llava_next_video import LlavaNextVideoConfig
 
@@ -396,7 +396,8 @@ class LlavaNextVideoModel(LlavaNextVideoPreTrainedModel):
         feature_lens = torch.tensor(feature_lens, dtype=torch.long, device=image_features[0].device)
         return new_image_features, feature_lens
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -509,7 +510,7 @@ class LlavaNextVideoModel(LlavaNextVideoPreTrainedModel):
             )
         return special_image_mask, special_video_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -602,7 +603,8 @@ class LlavaNextVideoModel(LlavaNextVideoPreTrainedModel):
             video_hidden_states=video_features if pixel_values_videos is not None else None,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains video last hidden states from the vision tower and apply multimodal projection."
     )
@@ -722,7 +724,7 @@ class LlavaNextVideoForConditionalGeneration(LlavaNextVideoPreTrainedModel, Gene
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/llava_next_video/modular_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/modular_llava_next_video.py
@@ -34,7 +34,7 @@ from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import auto_docstring, logging, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import CONFIG_MAPPING, AutoConfig
 
 
@@ -276,7 +276,8 @@ class LlavaNextVideoModel(LlavaNextModel):
         self.vision_resampler = LlavaNextVideoPooler(config)
         self.post_init()
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -348,7 +349,8 @@ class LlavaNextVideoModel(LlavaNextModel):
 
         return image_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains video last hidden states from the vision tower and apply multimodal projection."
     )
@@ -440,7 +442,7 @@ class LlavaNextVideoModel(LlavaNextModel):
             )
         return special_image_mask, special_video_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -555,7 +557,7 @@ class LlavaNextVideoForConditionalGeneration(LlavaNextForConditionalGeneration):
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/llava_onevision/modeling_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/modeling_llava_onevision.py
@@ -35,7 +35,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_llava_onevision import LlavaOnevisionConfig
 
@@ -353,7 +353,8 @@ class LlavaOnevisionModel(LlavaOnevisionPreTrainedModel):
         feature_lens = torch.tensor(feature_lens, dtype=torch.long, device=image_features[0].device)
         return new_image_features, feature_lens
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -470,7 +471,7 @@ class LlavaOnevisionModel(LlavaOnevisionPreTrainedModel):
             )
         return special_image_mask, special_video_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -572,7 +573,8 @@ class LlavaOnevisionModel(LlavaOnevisionPreTrainedModel):
             video_hidden_states=video_features if pixel_values_videos is not None else None,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains video last hidden states from the vision tower, apply multimodal projection and pooling."
     )
@@ -704,7 +706,7 @@ class LlavaOnevisionForConditionalGeneration(LlavaOnevisionPreTrainedModel, Gene
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/llava_onevision/modular_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/modular_llava_onevision.py
@@ -48,7 +48,7 @@ from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import TensorType, auto_docstring, logging
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from .image_processing_llava_onevision import LlavaOnevisionImageProcessorKwargs
 
 
@@ -310,7 +310,8 @@ class LlavaOnevisionModel(LlavaNextVideoModel):
         image_features = image_features.view(batch_frames, -1, dim)
         return image_features
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -386,7 +387,8 @@ class LlavaOnevisionModel(LlavaNextVideoModel):
 
         return image_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains video last hidden states from the vision tower, apply multimodal projection and pooling."
     )
@@ -436,7 +438,7 @@ class LlavaOnevisionModel(LlavaNextVideoModel):
 
         return vision_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -540,7 +542,7 @@ class LlavaOnevisionModel(LlavaNextVideoModel):
 
 
 class LlavaOnevisionForConditionalGeneration(LlavaNextVideoForConditionalGeneration):
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/lw_detr/modeling_lw_detr.py
+++ b/src/transformers/models/lw_detr/modeling_lw_detr.py
@@ -1197,6 +1197,7 @@ class LwDetrModelOutput(ModelOutput):
     enc_outputs_coord_logits: torch.FloatTensor | None = None
     hidden_states: tuple[torch.FloatTensor, ...] | None = None
     attentions: tuple[torch.FloatTensor, ...] | None = None
+    cross_attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 def refine_bboxes(reference_points, deltas):
@@ -1483,6 +1484,7 @@ class LwDetrModel(LwDetrPreTrainedModel):
             enc_outputs_coord_logits=enc_outputs_coord_logits,
             hidden_states=decoder_outputs.hidden_states,
             attentions=decoder_outputs.attentions,
+            cross_attentions=decoder_outputs.cross_attentions,
         )
 
 
@@ -1557,6 +1559,7 @@ class LwDetrObjectDetectionOutput(ModelOutput):
     enc_outputs_coord_logits: torch.FloatTensor | None = None
     hidden_states: tuple[torch.FloatTensor, ...] | None = None
     attentions: tuple[torch.FloatTensor, ...] | None = None
+    cross_attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring(
@@ -1694,6 +1697,7 @@ class LwDetrForObjectDetection(LwDetrPreTrainedModel):
             enc_outputs_coord_logits=enc_outputs_boxes_logits,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
+            cross_attentions=outputs.cross_attentions,
         )
 
 

--- a/src/transformers/models/lw_detr/modeling_lw_detr.py
+++ b/src/transformers/models/lw_detr/modeling_lw_detr.py
@@ -38,7 +38,7 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import meshgrid
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
 from .configuration_lw_detr import LwDetrConfig, LwDetrViTConfig
 
 
@@ -1120,6 +1120,7 @@ class LwDetrDecoder(LwDetrPreTrainedModel):
         query_pos = self.ref_point_head(query_sine_embed)
         return reference_points_inputs, query_pos
 
+    @check_model_inputs
     def forward(
         self,
         inputs_embeds: torch.Tensor | None = None,
@@ -1194,6 +1195,8 @@ class LwDetrModelOutput(ModelOutput):
     intermediate_reference_points: torch.FloatTensor | None = None
     enc_outputs_class: torch.FloatTensor | None = None
     enc_outputs_coord_logits: torch.FloatTensor | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 def refine_bboxes(reference_points, deltas):
@@ -1335,7 +1338,7 @@ class LwDetrModel(LwDetrPreTrainedModel):
         object_query = object_query.masked_fill(~output_proposals_valid, float(0))
         return object_query, output_proposals
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1478,6 +1481,8 @@ class LwDetrModel(LwDetrPreTrainedModel):
             intermediate_reference_points=decoder_outputs.intermediate_reference_points,
             enc_outputs_class=enc_outputs_class,
             enc_outputs_coord_logits=enc_outputs_coord_logits,
+            hidden_states=decoder_outputs.hidden_states,
+            attentions=decoder_outputs.attentions,
         )
 
 
@@ -1550,6 +1555,8 @@ class LwDetrObjectDetectionOutput(ModelOutput):
     intermediate_reference_points: torch.FloatTensor | None = None
     enc_outputs_class: Any = None
     enc_outputs_coord_logits: torch.FloatTensor | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring(
@@ -1572,7 +1579,7 @@ class LwDetrForObjectDetection(LwDetrPreTrainedModel):
 
         self.post_init()
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1685,6 +1692,8 @@ class LwDetrForObjectDetection(LwDetrPreTrainedModel):
             init_reference_points=outputs.init_reference_points,
             enc_outputs_class=enc_outputs_class_logits,
             enc_outputs_coord_logits=enc_outputs_boxes_logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
 

--- a/src/transformers/models/lw_detr/modular_lw_detr.py
+++ b/src/transformers/models/lw_detr/modular_lw_detr.py
@@ -29,7 +29,7 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import meshgrid
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, logging
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
 from ..auto import AutoConfig
 from ..convnext.modeling_convnext import ConvNextLayerNorm
 from ..dab_detr.modeling_dab_detr import gen_sine_position_embeddings
@@ -1095,6 +1095,7 @@ class LwDetrDecoder(LwDetrPreTrainedModel):
         query_pos = self.ref_point_head(query_sine_embed)
         return reference_points_inputs, query_pos
 
+    @check_model_inputs
     def forward(
         self,
         inputs_embeds: torch.Tensor | None = None,
@@ -1169,6 +1170,8 @@ class LwDetrModelOutput(ModelOutput):
     intermediate_reference_points: torch.FloatTensor | None = None
     enc_outputs_class: torch.FloatTensor | None = None
     enc_outputs_coord_logits: torch.FloatTensor | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring(
@@ -1263,7 +1266,7 @@ class LwDetrModel(DeformableDetrModel):
         object_query = object_query.masked_fill(~output_proposals_valid, float(0))
         return object_query, output_proposals
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1406,6 +1409,8 @@ class LwDetrModel(DeformableDetrModel):
             intermediate_reference_points=decoder_outputs.intermediate_reference_points,
             enc_outputs_class=enc_outputs_class,
             enc_outputs_coord_logits=enc_outputs_coord_logits,
+            hidden_states=decoder_outputs.hidden_states,
+            attentions=decoder_outputs.attentions,
         )
 
 
@@ -1463,6 +1468,8 @@ class LwDetrObjectDetectionOutput(ModelOutput):
     intermediate_reference_points: torch.FloatTensor | None = None
     enc_outputs_class: Any = None
     enc_outputs_coord_logits: torch.FloatTensor | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring(
@@ -1482,7 +1489,7 @@ class LwDetrForObjectDetection(DeformableDetrForObjectDetection):
 
         self.post_init()
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1595,6 +1602,8 @@ class LwDetrForObjectDetection(DeformableDetrForObjectDetection):
             init_reference_points=outputs.init_reference_points,
             enc_outputs_class=enc_outputs_class_logits,
             enc_outputs_coord_logits=enc_outputs_boxes_logits,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
 

--- a/src/transformers/models/lw_detr/modular_lw_detr.py
+++ b/src/transformers/models/lw_detr/modular_lw_detr.py
@@ -1172,6 +1172,7 @@ class LwDetrModelOutput(ModelOutput):
     enc_outputs_coord_logits: torch.FloatTensor | None = None
     hidden_states: tuple[torch.FloatTensor, ...] | None = None
     attentions: tuple[torch.FloatTensor, ...] | None = None
+    cross_attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring(
@@ -1411,6 +1412,7 @@ class LwDetrModel(DeformableDetrModel):
             enc_outputs_coord_logits=enc_outputs_coord_logits,
             hidden_states=decoder_outputs.hidden_states,
             attentions=decoder_outputs.attentions,
+            cross_attentions=decoder_outputs.cross_attentions,
         )
 
 
@@ -1470,6 +1472,7 @@ class LwDetrObjectDetectionOutput(ModelOutput):
     enc_outputs_coord_logits: torch.FloatTensor | None = None
     hidden_states: tuple[torch.FloatTensor, ...] | None = None
     attentions: tuple[torch.FloatTensor, ...] | None = None
+    cross_attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring(
@@ -1604,6 +1607,7 @@ class LwDetrForObjectDetection(DeformableDetrForObjectDetection):
             enc_outputs_coord_logits=enc_outputs_boxes_logits,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
+            cross_attentions=outputs.cross_attentions,
         )
 
 

--- a/src/transformers/models/metaclip_2/modular_metaclip_2.py
+++ b/src/transformers/models/metaclip_2/modular_metaclip_2.py
@@ -6,7 +6,6 @@ from ...masking_utils import create_causal_mask
 from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import check_model_inputs
 from ..clip.configuration_clip import CLIPConfig, CLIPTextConfig, CLIPVisionConfig
 from ..clip.modeling_clip import (
     CLIPMLP,
@@ -277,7 +276,6 @@ class MetaClip2PreTrainedModel(CLIPPreTrainedModel):
 
 
 class MetaClip2TextTransformer(CLIPTextTransformer):
-    @auto_docstring
     def forward(
         self,
         input_ids,
@@ -354,8 +352,6 @@ class MetaClip2TextModel(CLIPTextModel):
     >>> pooled_output = outputs.pooler_output  # pooled (EOS token) states
     ```"""
 
-    @check_model_inputs(tie_last_hidden_states=False)
-    @auto_docstring
     def forward(
         self,
         input_ids: torch.Tensor | None = None,
@@ -417,8 +413,6 @@ class MetaClip2TextModelWithProjection(CLIPTextModelWithProjection):
     >>> text_embeds = outputs.text_embeds
     ```"""
 
-    @check_model_inputs(tie_last_hidden_states=False)
-    @auto_docstring
     def forward(
         self,
         input_ids: torch.Tensor | None = None,
@@ -510,8 +504,6 @@ class MetaClip2Model(CLIPModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @can_return_tuple
-    @auto_docstring
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,
@@ -663,8 +655,6 @@ class MetaClip2VisionModel(CLIPVisionModel):
     >>> pooled_output = outputs.pooler_output  # pooled CLS states
     ```"""
 
-    @check_model_inputs(tie_last_hidden_states=False)
-    @auto_docstring
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
@@ -738,8 +728,6 @@ class MetaClip2VisionModelWithProjection(CLIPVisionModelWithProjection):
     >>> image_embeds = outputs.image_embeds
     ```"""
 
-    @check_model_inputs(tie_last_hidden_states=False)
-    @auto_docstring
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,

--- a/src/transformers/models/minimax/modeling_minimax.py
+++ b/src/transformers/models/minimax/modeling_minimax.py
@@ -49,7 +49,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_minimax import MiniMaxConfig
 
 

--- a/src/transformers/models/minimax/modular_minimax.py
+++ b/src/transformers/models/minimax/modular_minimax.py
@@ -29,7 +29,8 @@ from ...modeling_outputs import MoeModelOutputWithPast
 from ...modeling_rope_utils import RopeParameters
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..gemma2.modeling_gemma2 import Gemma2RotaryEmbedding
 from ..mixtral.modeling_mixtral import (
     MixtralAttention,

--- a/src/transformers/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/modeling_minimax_m2.py
@@ -38,7 +38,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_minimax_m2 import MiniMaxM2Config
 
 

--- a/src/transformers/models/mistral3/modeling_mistral3.py
+++ b/src/transformers/models/mistral3/modeling_mistral3.py
@@ -32,7 +32,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_mistral3 import Mistral3Config
 
@@ -215,7 +215,8 @@ class Mistral3Model(Mistral3PreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -278,7 +279,7 @@ class Mistral3Model(Mistral3PreTrainedModel):
         )
         return special_image_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -388,7 +389,7 @@ class Mistral3ForConditionalGeneration(Mistral3PreTrainedModel, GenerationMixin)
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/mistral3/modular_mistral3.py
+++ b/src/transformers/models/mistral3/modular_mistral3.py
@@ -21,7 +21,7 @@ from ...cache_utils import Cache
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import auto_docstring, logging
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..llava.modeling_llava import (
     LlavaCausalLMOutputWithPast,
     LlavaForConditionalGeneration,
@@ -120,7 +120,8 @@ class Mistral3PreTrainedModel(LlavaPreTrainedModel):
 
 
 class Mistral3Model(LlavaModel):
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -159,7 +160,7 @@ class Mistral3Model(LlavaModel):
 
         return image_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -55,7 +55,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, maybe_autocast
+from ...utils.generic import maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_mixtral import MixtralConfig
 
 

--- a/src/transformers/models/mixtral/modular_mixtral.py
+++ b/src/transformers/models/mixtral/modular_mixtral.py
@@ -32,7 +32,7 @@ from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPas
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, is_grouped_mm_available, logging
-from ...utils.generic import OutputRecorder
+from ...utils.output_capturing import OutputRecorder
 from ..mistral.modeling_mistral import (
     MistralAttention,
     MistralForCausalLM,

--- a/src/transformers/models/mlcd/modeling_mlcd.py
+++ b/src/transformers/models/mlcd/modeling_mlcd.py
@@ -29,7 +29,6 @@ from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_int
-from ...utils.generic import check_model_inputs
 from .configuration_mlcd import MLCDVisionConfig
 
 
@@ -453,9 +452,14 @@ class MLCDPreTrainedModel(PreTrainedModel):
             init.copy_(module.inv_freq, inv_freq)
 
 
-class MLCDVisionTransformer(nn.Module):
+class MLCDVisionTransformer(MLCDPreTrainedModel):
+    config: MLCDVisionConfig
+    main_input_name = "pixel_values"
+    input_modalities = ("image",)
+    _no_split_modules = ["MLCDEncoderLayer"]
+
     def __init__(self, config: MLCDVisionConfig):
-        super().__init__()
+        super().__init__(config)
         self.config = config
         embed_dim = config.hidden_size
 
@@ -465,6 +469,7 @@ class MLCDVisionTransformer(nn.Module):
         self.post_layernorm = nn.LayerNorm(embed_dim, eps=config.layer_norm_eps)
         self.vision_rotary_embedding = MLCDRotaryEmbedding(config.hidden_size // config.num_attention_heads // 2)
         self.class_pos_emb = nn.Parameter(torch.randn(1, config.hidden_size // config.num_attention_heads // 2))
+        self.post_init()
 
     @auto_docstring
     def forward(
@@ -522,7 +527,6 @@ class MLCDVisionModel(MLCDPreTrainedModel):
     def get_input_embeddings(self) -> nn.Module:
         return self.vision_model.embeddings.patch_embedding
 
-    @check_model_inputs(tie_last_hidden_states=False)
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/mlcd/modeling_mlcd.py
+++ b/src/transformers/models/mlcd/modeling_mlcd.py
@@ -29,6 +29,7 @@ from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_int
+from ...utils.generic import check_model_inputs
 from .configuration_mlcd import MLCDVisionConfig
 
 
@@ -471,6 +472,7 @@ class MLCDVisionTransformer(MLCDPreTrainedModel):
         self.class_pos_emb = nn.Parameter(torch.randn(1, config.hidden_size // config.num_attention_heads // 2))
         self.post_init()
 
+    @check_model_inputs(tie_last_hidden_states=False)
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/mlcd/modular_mlcd.py
+++ b/src/transformers/models/mlcd/modular_mlcd.py
@@ -395,7 +395,6 @@ class MLCDVisionTransformer(CLIPVisionTransformer):
         self.vision_rotary_embedding = MLCDRotaryEmbedding(config.hidden_size // config.num_attention_heads // 2)
         self.class_pos_emb = nn.Parameter(torch.randn(1, config.hidden_size // config.num_attention_heads // 2))
 
-    @auto_docstring
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,

--- a/src/transformers/models/mlcd/modular_mlcd.py
+++ b/src/transformers/models/mlcd/modular_mlcd.py
@@ -22,7 +22,6 @@ from ...modeling_outputs import BaseModelOutput, BaseModelOutputWithPooling
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import check_model_inputs
 from ..clip.modeling_clip import (
     CLIPMLP,
     CLIPAttention,
@@ -433,8 +432,6 @@ class MLCDVisionTransformer(CLIPVisionTransformer):
 
 
 class MLCDVisionModel(CLIPVisionModel):
-    @check_model_inputs(tie_last_hidden_states=False)
-    @auto_docstring
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,

--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -1469,7 +1469,6 @@ class MllamaModel(MllamaPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs
     @can_return_tuple
     @auto_docstring
     def forward(

--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -36,7 +36,8 @@ from ...modeling_rope_utils import (
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_torch_flex_attn_available, logging
-from ...utils.generic import OutputRecorder, check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.generic import check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_mllama import MllamaConfig, MllamaTextConfig, MllamaVisionConfig
 
 

--- a/src/transformers/models/moonshine/modeling_moonshine.py
+++ b/src/transformers/models/moonshine/modeling_moonshine.py
@@ -25,8 +25,6 @@ from typing import Optional
 import torch
 import torch.nn as nn
 
-from transformers.utils.generic import OutputRecorder, check_model_inputs
-
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -45,7 +43,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_moonshine import MoonshineConfig
 
 

--- a/src/transformers/models/moonshine/modular_moonshine.py
+++ b/src/transformers/models/moonshine/modular_moonshine.py
@@ -18,8 +18,6 @@ from dataclasses import dataclass
 import torch
 import torch.nn as nn
 
-from transformers.utils.generic import OutputRecorder, check_model_inputs
-
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...configuration_utils import PreTrainedConfig
@@ -38,6 +36,8 @@ from ...modeling_rope_utils import RopeParameters
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..glm.modeling_glm import GlmAttention, GlmRotaryEmbedding, apply_rotary_pos_emb
 from ..llama.modeling_llama import LlamaDecoderLayer, LlamaModel, eager_attention_forward
 from ..whisper.modeling_whisper import WhisperModel, shift_tokens_right

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -26,8 +26,6 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from transformers.utils.generic import OutputRecorder, check_model_inputs
-
 from ...activations import ACT2FN
 from ...cache_utils import Cache, DynamicCache, EncoderDecoderCache
 from ...generation import GenerationMixin
@@ -46,7 +44,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_moonshine_streaming import MoonshineStreamingConfig, MoonshineStreamingEncoderConfig
 
 

--- a/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modular_moonshine_streaming.py
@@ -19,8 +19,6 @@ import torch
 import torch.nn as nn
 from torch import Tensor
 
-from transformers.utils.generic import OutputRecorder, check_model_inputs
-
 from ...cache_utils import Cache
 from ...masking_utils import create_bidirectional_mask
 from ...modeling_outputs import (
@@ -30,6 +28,8 @@ from ...modeling_outputs import (
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS
 from ...processing_utils import ProcessingKwargs, Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import LlamaMLP, eager_attention_forward
 from ..moonshine.modeling_moonshine import (
     MoonshineDecoder,

--- a/src/transformers/models/nanochat/modeling_nanochat.py
+++ b/src/transformers/models/nanochat/modeling_nanochat.py
@@ -36,8 +36,8 @@ from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, can_return_tuple
-from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils import TransformersKwargs, auto_docstring
+from ...utils.generic import can_return_tuple, check_model_inputs, maybe_autocast
 from .configuration_nanochat import NanoChatConfig
 
 

--- a/src/transformers/models/nllb_moe/modeling_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/modeling_nllb_moe.py
@@ -38,7 +38,8 @@ from ...modeling_outputs import (
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs
+from ...utils.generic import can_return_tuple, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_nllb_moe import NllbMoeConfig
 
 

--- a/src/transformers/models/olmoe/modeling_olmoe.py
+++ b/src/transformers/models/olmoe/modeling_olmoe.py
@@ -40,7 +40,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_olmoe import OlmoeConfig
 
 

--- a/src/transformers/models/olmoe/modular_olmoe.py
+++ b/src/transformers/models/olmoe/modular_olmoe.py
@@ -24,7 +24,7 @@ from ...modeling_outputs import MoeModelOutputWithPast
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, is_grouped_mm_available, logging
-from ...utils.generic import OutputRecorder
+from ...utils.output_capturing import OutputRecorder
 from ..gemma.modeling_gemma import GemmaMLP
 from ..llama.modeling_llama import (
     LlamaAttention,

--- a/src/transformers/models/paddleocr_vl/modeling_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/modeling_paddleocr_vl.py
@@ -833,6 +833,7 @@ class PaddleOCRVisionEncoder(nn.Module):
         cu_seqlens: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         image_grid_thw: list[tuple[int, int, int] | list[tuple[int, int, int]]] | None = None,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutput:
         r"""
         inputs_embeds (`torch.FloatTensor` of shape `(sequence_length, hidden_size)`, *optional*):
@@ -876,6 +877,7 @@ class PaddleOCRVisionEncoder(nn.Module):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 position_embeddings=position_embeddings,
+                **kwargs,
             )
 
         return BaseModelOutput(
@@ -910,7 +912,7 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
         cu_seqlens: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         image_grid_thw: list[tuple[int, int, int] | list[tuple[int, int, int]]] | None = None,
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         """
         Args:
@@ -930,6 +932,7 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
             cu_seqlens=cu_seqlens,
             attention_mask=attention_mask,
             image_grid_thw=image_grid_thw,
+            **kwargs,
         )
 
         last_hidden_state = encoder_outputs.last_hidden_state
@@ -959,7 +962,7 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
         pixel_values: torch.FloatTensor,
         cu_seqlens: torch.Tensor,
         image_grid_thw: list[tuple[int, int, int] | list[tuple[int, int, int]]] | None = None,
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | BaseModelOutputWithPooling:
         """
         Args:
@@ -974,6 +977,7 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
             pixel_values=pixel_values,
             cu_seqlens=cu_seqlens,
             image_grid_thw=image_grid_thw,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/paddleocr_vl/modeling_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/modeling_paddleocr_vl.py
@@ -884,6 +884,14 @@ class PaddleOCRVisionEncoder(nn.Module):
 
 
 class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
+    config: PaddleOCRVisionConfig
+    main_input_name = "pixel_values"
+    input_modalities = "image"
+    _can_record_outputs = {
+        "hidden_states": PaddleOCRVisionEncoderLayer,
+        "attentions": PaddleOCRVisionAttention,
+    }
+
     def __init__(self, config: PaddleOCRVisionConfig):
         super().__init__(config)
         self.config = config
@@ -895,6 +903,7 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
 
         self.post_init()
 
+    @check_model_inputs(tie_last_hidden_states=False)
     def forward(
         self,
         pixel_values: torch.FloatTensor,
@@ -929,8 +938,6 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=None,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
         )
 
 
@@ -938,10 +945,6 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
     config: PaddleOCRVisionConfig
     main_input_name = "pixel_values"
     input_modalities = "image"
-    _can_record_outputs = {
-        "hidden_states": PaddleOCRVisionEncoderLayer,
-        "attentions": PaddleOCRVisionAttention,
-    }
 
     def __init__(self, config: PaddleOCRVisionConfig):
         super().__init__(config)
@@ -951,7 +954,6 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs(tie_last_hidden_states=False)
     def forward(
         self,
         pixel_values: torch.FloatTensor,

--- a/src/transformers/models/paddleocr_vl/modular_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/modular_paddleocr_vl.py
@@ -960,6 +960,7 @@ class PaddleOCRVisionEncoder(VideoLlama3VisionEncoder):
         cu_seqlens: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         image_grid_thw: list[tuple[int, int, int] | list[tuple[int, int, int]]] | None = None,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutput:
         r"""
         inputs_embeds (`torch.FloatTensor` of shape `(sequence_length, hidden_size)`, *optional*):
@@ -1003,6 +1004,7 @@ class PaddleOCRVisionEncoder(VideoLlama3VisionEncoder):
                 hidden_states,
                 cu_seqlens=cu_seqlens,
                 position_embeddings=position_embeddings,
+                **kwargs,
             )
 
         return BaseModelOutput(
@@ -1037,7 +1039,7 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
         cu_seqlens: torch.Tensor,
         attention_mask: torch.Tensor | None = None,
         image_grid_thw: list[tuple[int, int, int] | list[tuple[int, int, int]]] | None = None,
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         """
         Args:
@@ -1057,6 +1059,7 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
             cu_seqlens=cu_seqlens,
             attention_mask=attention_mask,
             image_grid_thw=image_grid_thw,
+            **kwargs,
         )
 
         last_hidden_state = encoder_outputs.last_hidden_state
@@ -1086,7 +1089,7 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
         pixel_values: torch.FloatTensor,
         cu_seqlens: torch.Tensor,
         image_grid_thw: list[tuple[int, int, int] | list[tuple[int, int, int]]] | None = None,
-        **kwargs,
+        **kwargs: Unpack[TransformersKwargs],
     ) -> tuple | BaseModelOutputWithPooling:
         """
         Args:
@@ -1101,6 +1104,7 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
             pixel_values=pixel_values,
             cu_seqlens=cu_seqlens,
             image_grid_thw=image_grid_thw,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/paddleocr_vl/modular_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/modular_paddleocr_vl.py
@@ -1011,6 +1011,14 @@ class PaddleOCRVisionEncoder(VideoLlama3VisionEncoder):
 
 
 class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
+    config: PaddleOCRVisionConfig
+    main_input_name = "pixel_values"
+    input_modalities = "image"
+    _can_record_outputs = {
+        "hidden_states": PaddleOCRVisionEncoderLayer,
+        "attentions": PaddleOCRVisionAttention,
+    }
+
     def __init__(self, config: PaddleOCRVisionConfig):
         super().__init__(config)
         self.config = config
@@ -1022,6 +1030,7 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
 
         self.post_init()
 
+    @check_model_inputs(tie_last_hidden_states=False)
     def forward(
         self,
         pixel_values: torch.FloatTensor,
@@ -1056,8 +1065,6 @@ class PaddleOCRVisionTransformer(PaddleOCRVLPreTrainedModel):
         return BaseModelOutputWithPooling(
             last_hidden_state=last_hidden_state,
             pooler_output=None,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
         )
 
 
@@ -1065,10 +1072,6 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
     config: PaddleOCRVisionConfig
     main_input_name = "pixel_values"
     input_modalities = "image"
-    _can_record_outputs = {
-        "hidden_states": PaddleOCRVisionEncoderLayer,
-        "attentions": PaddleOCRVisionAttention,
-    }
 
     def __init__(self, config: PaddleOCRVisionConfig):
         super().__init__(config)
@@ -1078,7 +1081,6 @@ class PaddleOCRVisionModel(PaddleOCRVLPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
-    @check_model_inputs(tie_last_hidden_states=False)
     def forward(
         self,
         pixel_values: torch.FloatTensor,

--- a/src/transformers/models/phi/modeling_phi.py
+++ b/src/transformers/models/phi/modeling_phi.py
@@ -24,8 +24,8 @@ from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils import TransformersKwargs, auto_docstring, logging
+from ...utils.generic import can_return_tuple, check_model_inputs, maybe_autocast
 from .configuration_phi import PhiConfig
 
 

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -37,7 +37,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_phimoe import PhimoeConfig
 
 

--- a/src/transformers/models/phimoe/modular_phimoe.py
+++ b/src/transformers/models/phimoe/modular_phimoe.py
@@ -23,7 +23,8 @@ from ...modeling_layers import (
     GenericForSequenceClassification,
 )
 from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS
-from ...utils.generic import OutputRecorder, maybe_autocast
+from ...utils.generic import maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import LlamaAttention
 from ..mixtral.modeling_mixtral import (
     MixtralDecoderLayer,

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -52,7 +52,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_qwen2_moe import Qwen2MoeConfig
 
 

--- a/src/transformers/models/qwen2_moe/modular_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modular_qwen2_moe.py
@@ -34,7 +34,8 @@ from ...modeling_layers import (
 from ...modeling_outputs import MoeModelOutputWithPast
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..gemma.modeling_gemma import GemmaMLP
 from ..gemma2.modeling_gemma2 import Gemma2RotaryEmbedding
 from ..llama.modeling_llama import LlamaAttention, LlamaDecoderLayer, LlamaRMSNorm

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -48,7 +48,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, is_grouped_mm_available
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_qwen3_moe import Qwen3MoeConfig
 
 

--- a/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modular_qwen3_moe.py
@@ -20,7 +20,7 @@ from ...cache_utils import Cache
 from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPast
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, logging
-from ...utils.generic import OutputRecorder
+from ...utils.output_capturing import OutputRecorder
 from ..llama.modeling_llama import (
     LlamaForQuestionAnswering,
     LlamaForSequenceClassification,

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -43,8 +43,9 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
 from ...utils.import_utils import is_causal_conv1d_available, is_flash_linear_attention_available
+from ...utils.output_capturing import OutputRecorder
 from .configuration_qwen3_next import Qwen3NextConfig
 
 

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -29,11 +29,12 @@ from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPas
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
 from ...utils.import_utils import (
     is_causal_conv1d_available,
     is_flash_linear_attention_available,
 )
+from ...utils.output_capturing import OutputRecorder
 from ..bamba.modeling_bamba import apply_mask_to_padding_states, apply_rotary_pos_emb
 from ..gemma2.modeling_gemma2 import Gemma2RotaryEmbedding
 from ..gemma3.modeling_gemma3 import Gemma3RMSNorm

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -54,13 +54,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import auto_docstring, can_return_tuple, is_grouped_mm_available, torch_compilable_check
-from ...utils.generic import (
-    OutputRecorder,
-    TransformersKwargs,
-    check_model_inputs,
-    is_flash_attention_requested,
-    maybe_autocast,
-)
+from ...utils.generic import TransformersKwargs, check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_qwen3_omni_moe import (
     Qwen3OmniMoeAudioEncoderConfig,
     Qwen3OmniMoeCode2WavConfig,

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -45,7 +45,8 @@ from ...modeling_utils import PreTrainedModel
 from ...processing_utils import ProcessorMixin, Unpack
 from ...tokenization_utils_base import TextInput
 from ...utils import auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, TransformersKwargs, check_model_inputs
+from ...utils.generic import TransformersKwargs, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ...video_utils import VideoInput, make_batched_videos
 from ..mimi.modeling_mimi import MimiLayerScale
 from ..qwen2_5_omni.configuration_qwen2_5_omni import (

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -1172,7 +1172,7 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
         return special_image_mask, special_video_mask
 
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -1287,6 +1287,8 @@ class Qwen3VLModel(Qwen3VLPreTrainedModel):
             last_hidden_state=outputs.last_hidden_state,
             past_key_values=outputs.past_key_values,
             rope_deltas=self.rope_deltas,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
 

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -1005,7 +1005,7 @@ class Qwen3VLModel(Qwen2_5_VLModel):
         return self.get_image_features(pixel_values_videos, video_grid_thw, **kwargs)
 
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -1120,6 +1120,8 @@ class Qwen3VLModel(Qwen2_5_VLModel):
             last_hidden_state=outputs.last_hidden_state,
             past_key_values=outputs.past_key_values,
             rope_deltas=self.rope_deltas,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
 

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1305,7 +1305,7 @@ class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
         return special_image_mask, special_video_mask
 
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor = None,
@@ -1420,6 +1420,8 @@ class Qwen3VLMoeModel(Qwen3VLMoePreTrainedModel):
             last_hidden_state=outputs.last_hidden_state,
             past_key_values=outputs.past_key_values,
             rope_deltas=self.rope_deltas,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
         )
 
 

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -50,7 +50,8 @@ from ...utils import (
     is_grouped_mm_available,
     torch_compilable_check,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.generic import check_model_inputs, is_flash_attention_requested, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_qwen3_vl_moe import Qwen3VLMoeConfig, Qwen3VLMoeTextConfig, Qwen3VLMoeVisionConfig
 
 

--- a/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modular_qwen3_vl_moe.py
@@ -24,7 +24,7 @@ from ...modeling_rope_utils import RopeParameters
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, can_return_tuple, logging
-from ...utils.generic import OutputRecorder
+from ...utils.output_capturing import OutputRecorder
 from ..qwen3_moe.modeling_qwen3_moe import (
     Qwen3MoeDecoderLayer,
     Qwen3MoeExperts,

--- a/src/transformers/models/sam/modeling_sam.py
+++ b/src/transformers/models/sam/modeling_sam.py
@@ -22,8 +22,6 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
-from transformers.utils.generic import OutputRecorder, TransformersKwargs, check_model_inputs
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_layers import GradientCheckpointingLayer
@@ -31,6 +29,8 @@ from ...modeling_outputs import BaseModelOutput
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import ModelOutput, auto_docstring, logging
+from ...utils.generic import TransformersKwargs, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_sam import SamConfig, SamMaskDecoderConfig, SamPromptEncoderConfig, SamVisionConfig
 
 

--- a/src/transformers/models/sam2/modeling_sam2.py
+++ b/src/transformers/models/sam2/modeling_sam2.py
@@ -548,6 +548,8 @@ class Sam2HieraDetModelOutput(ModelOutput):
 
     last_hidden_state: torch.FloatTensor | None = None
     intermediate_hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring
@@ -670,7 +672,7 @@ class Sam2VisionModel(Sam2PreTrainedModel):
     def get_input_embeddings(self):
         return self.backbone.get_input_embeddings()
 
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
@@ -693,6 +695,8 @@ class Sam2VisionModel(Sam2PreTrainedModel):
             last_hidden_state=hidden_states,
             fpn_hidden_states=fpn_hidden_states,
             fpn_position_encoding=fpn_position_encoding,
+            hidden_states=backbone_output.hidden_states,
+            attentions=backbone_output.attentions,
         )
 
 

--- a/src/transformers/models/sam2/modeling_sam2.py
+++ b/src/transformers/models/sam2/modeling_sam2.py
@@ -28,8 +28,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from transformers.utils.generic import OutputRecorder
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_layers import GradientCheckpointingLayer
@@ -44,6 +42,7 @@ from ...utils import (
     logging,
 )
 from ...utils.generic import TransformersKwargs, check_model_inputs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_sam2 import (
     Sam2Config,

--- a/src/transformers/models/sam2/modular_sam2.py
+++ b/src/transformers/models/sam2/modular_sam2.py
@@ -653,6 +653,8 @@ class Sam2HieraDetModelOutput(ModelOutput):
 
     last_hidden_state: torch.FloatTensor | None = None
     intermediate_hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
 
 
 @auto_docstring
@@ -775,7 +777,7 @@ class Sam2VisionModel(Sam2PreTrainedModel):
     def get_input_embeddings(self):
         return self.backbone.get_input_embeddings()
 
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
@@ -798,6 +800,8 @@ class Sam2VisionModel(Sam2PreTrainedModel):
             last_hidden_state=hidden_states,
             fpn_hidden_states=fpn_hidden_states,
             fpn_position_encoding=fpn_position_encoding,
+            hidden_states=backbone_output.hidden_states,
+            attentions=backbone_output.attentions,
         )
 
 

--- a/src/transformers/models/sam2_video/modeling_sam2_video.py
+++ b/src/transformers/models/sam2_video/modeling_sam2_video.py
@@ -40,7 +40,8 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import ModelOutput, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, TransformersKwargs, is_flash_attention_requested
+from ...utils.generic import TransformersKwargs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_sam2_video import Sam2VideoConfig, Sam2VideoMaskDecoderConfig, Sam2VideoPromptEncoderConfig
 

--- a/src/transformers/models/sam2_video/modular_sam2_video.py
+++ b/src/transformers/models/sam2_video/modular_sam2_video.py
@@ -38,7 +38,8 @@ from ...utils import (
     auto_docstring,
     logging,
 )
-from ...utils.generic import OutputRecorder, TransformersKwargs
+from ...utils.generic import TransformersKwargs
+from ...utils.output_capturing import OutputRecorder
 from ...video_utils import VideoInput
 from ..auto import CONFIG_MAPPING, AutoConfig
 from ..sam2.configuration_sam2 import (

--- a/src/transformers/models/sam3/modeling_sam3.py
+++ b/src/transformers/models/sam3/modeling_sam3.py
@@ -788,6 +788,11 @@ class Sam3PreTrainedModel(PreTrainedModel):
 
 @auto_docstring
 class Sam3ViTModel(Sam3PreTrainedModel):
+    _can_record_outputs = {
+        "hidden_states": Sam3ViTLayer,
+        "attentions": Sam3ViTRoPEAttention,
+    }
+
     def __init__(self, config: Sam3ViTConfig):
         super().__init__(config)
         self.config = config
@@ -1010,10 +1015,6 @@ class Sam3VisionNeck(nn.Module):
 class Sam3VisionModel(Sam3PreTrainedModel):
     config_class = Sam3VisionConfig
     main_input_name = "pixel_values"
-    _can_record_outputs = {
-        "hidden_states": Sam3ViTLayer,
-        "attentions": Sam3ViTRoPEAttention,
-    }
 
     def __init__(self, config: Sam3VisionConfig):
         super().__init__(config)
@@ -1026,7 +1027,7 @@ class Sam3VisionModel(Sam3PreTrainedModel):
     def get_input_embeddings(self):
         return self.backbone.get_input_embeddings()
 
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
@@ -1049,6 +1050,8 @@ class Sam3VisionModel(Sam3PreTrainedModel):
             last_hidden_state=hidden_states,
             fpn_hidden_states=fpn_hidden_states,
             fpn_position_encoding=fpn_position_encoding,
+            hidden_states=backbone_output.hidden_states,
+            attentions=backbone_output.attentions,
         )
 
 
@@ -2213,7 +2216,7 @@ class Sam3Model(Sam3PreTrainedModel):
         vision_outputs = self.vision_encoder(pixel_values, **kwargs)
         return vision_outputs
 
-    @check_model_inputs
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/sam3_tracker/modeling_sam3_tracker.py
+++ b/src/transformers/models/sam3_tracker/modeling_sam3_tracker.py
@@ -27,8 +27,6 @@ import torch.nn as nn
 import torch.nn.functional as F
 from torch import Tensor
 
-from transformers.utils.generic import OutputRecorder
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_layers import GradientCheckpointingLayer
@@ -37,6 +35,7 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import ModelOutput, auto_docstring, can_return_tuple, logging
 from ...utils.generic import TransformersKwargs, check_model_inputs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_sam3_tracker import Sam3TrackerConfig, Sam3TrackerMaskDecoderConfig, Sam3TrackerPromptEncoderConfig
 

--- a/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modeling_sam3_tracker_video.py
@@ -41,7 +41,8 @@ from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...pytorch_utils import compile_compatible_method_lru_cache
 from ...utils import ModelOutput, TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, is_flash_attention_requested
+from ...utils.generic import is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_sam3_tracker_video import (
     Sam3TrackerVideoConfig,

--- a/src/transformers/models/sam_hq/modeling_sam_hq.py
+++ b/src/transformers/models/sam_hq/modeling_sam_hq.py
@@ -27,9 +27,6 @@ import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
 
-from transformers.modeling_outputs import ModelOutput
-from transformers.utils.generic import OutputRecorder, TransformersKwargs, check_model_inputs
-
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_layers import GradientCheckpointingLayer
@@ -37,6 +34,8 @@ from ...modeling_outputs import BaseModelOutput
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import auto_docstring, logging
+from ...utils.generic import ModelOutput, TransformersKwargs, check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from .configuration_sam_hq import SamHQConfig, SamHQMaskDecoderConfig, SamHQPromptEncoderConfig, SamHQVisionConfig
 
 

--- a/src/transformers/models/sam_hq/modular_sam_hq.py
+++ b/src/transformers/models/sam_hq/modular_sam_hq.py
@@ -17,11 +17,9 @@ from dataclasses import dataclass
 import torch
 from torch import nn
 
-from transformers.modeling_outputs import ModelOutput
-from transformers.utils.generic import TransformersKwargs, check_model_inputs
-
 from ...processing_utils import Unpack
 from ...utils import auto_docstring, logging
+from ...utils.generic import ModelOutput, TransformersKwargs, check_model_inputs
 from ..sam.configuration_sam import SamConfig, SamMaskDecoderConfig, SamPromptEncoderConfig, SamVisionConfig
 from ..sam.modeling_sam import (
     SamFeedForward,

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -47,7 +47,8 @@ from ...utils import (
     is_torchdynamo_compiling,
     logging,
 )
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs, is_flash_attention_requested
+from ...utils.generic import can_return_tuple, check_model_inputs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from .configuration_switch_transformers import SwitchTransformersConfig
 
 

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -1210,11 +1210,6 @@ class SwitchTransformersEncoderModel(SwitchTransformersPreTrainedModel):
     _tied_weights_keys = {
         "encoder.embed_tokens.weight": "shared.weight",
     }
-    _can_record_outputs = {
-        "hidden_states": SwitchTransformersBlock,
-        "attentions": OutputRecorder(SwitchTransformersAttention, index=-1, layer_name="layer.0"),
-        "router_logits": SwitchTransformersTop1Router,
-    }
 
     def __init__(self, config: SwitchTransformersConfig):
         super().__init__(config)
@@ -1234,7 +1229,7 @@ class SwitchTransformersEncoderModel(SwitchTransformersPreTrainedModel):
         self.encoder.set_input_embeddings(new_embeddings)
 
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -901,11 +901,6 @@ class SwitchTransformersEncoderModel(SwitchTransformersPreTrainedModel):
     _tied_weights_keys = {
         "encoder.embed_tokens.weight": "shared.weight",
     }
-    _can_record_outputs = {
-        "hidden_states": SwitchTransformersBlock,
-        "attentions": OutputRecorder(SwitchTransformersAttention, index=-1, layer_name="layer.0"),
-        "router_logits": SwitchTransformersTop1Router,
-    }
 
     def __init__(self, config: SwitchTransformersConfig):
         super().__init__(config)
@@ -925,7 +920,7 @@ class SwitchTransformersEncoderModel(SwitchTransformersPreTrainedModel):
         self.encoder.set_input_embeddings(new_embeddings)
 
     @auto_docstring
-    @check_model_inputs
+    @can_return_tuple
     def forward(
         self,
         input_ids: torch.LongTensor | None = None,

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -40,7 +40,8 @@ from ...utils import (
     is_torchdynamo_compiling,
     logging,
 )
-from ...utils.generic import OutputRecorder, can_return_tuple, check_model_inputs, is_flash_attention_requested
+from ...utils.generic import can_return_tuple, check_model_inputs, is_flash_attention_requested
+from ...utils.output_capturing import OutputRecorder
 from ..t5.modeling_t5 import T5Attention, T5DenseActDense, T5LayerCrossAttention, T5LayerNorm, T5LayerSelfAttention
 from .configuration_switch_transformers import SwitchTransformersConfig
 

--- a/src/transformers/models/t5gemma/modeling_t5gemma.py
+++ b/src/transformers/models/t5gemma/modeling_t5gemma.py
@@ -44,7 +44,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from .configuration_t5gemma import T5GemmaConfig, T5GemmaModuleConfig
 
 

--- a/src/transformers/models/t5gemma/modular_t5gemma.py
+++ b/src/transformers/models/t5gemma/modular_t5gemma.py
@@ -41,7 +41,8 @@ from ...utils import (
     can_return_tuple,
     logging,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..gemma2.configuration_gemma2 import Gemma2Config
 from ..gemma2.modeling_gemma2 import (
     Gemma2Attention,

--- a/src/transformers/models/t5gemma2/modeling_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modeling_t5gemma2.py
@@ -46,7 +46,8 @@ from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
-from ...utils.generic import OutputRecorder, check_model_inputs, maybe_autocast
+from ...utils.generic import check_model_inputs, maybe_autocast
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from .configuration_t5gemma2 import T5Gemma2Config, T5Gemma2DecoderConfig, T5Gemma2EncoderConfig, T5Gemma2TextConfig
 

--- a/src/transformers/models/t5gemma2/modular_t5gemma2.py
+++ b/src/transformers/models/t5gemma2/modular_t5gemma2.py
@@ -44,7 +44,8 @@ from ...utils import (
     logging,
     torch_compilable_check,
 )
-from ...utils.generic import OutputRecorder, check_model_inputs
+from ...utils.generic import check_model_inputs
+from ...utils.output_capturing import OutputRecorder
 from ..auto import AutoModel
 from ..gemma3.configuration_gemma3 import Gemma3Config, Gemma3TextConfig
 from ..gemma3.modeling_gemma3 import (

--- a/src/transformers/models/video_llava/modeling_video_llava.py
+++ b/src/transformers/models/video_llava/modeling_video_llava.py
@@ -27,7 +27,7 @@ from ...modeling_outputs import BaseModelOutputWithPooling, ModelOutput
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_video_llava import VideoLlavaConfig
 
@@ -170,7 +170,8 @@ class VideoLlavaModel(VideoLlavaPreTrainedModel):
     def set_input_embeddings(self, value):
         self.language_model.set_input_embeddings(value)
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -218,7 +219,8 @@ class VideoLlavaModel(VideoLlavaPreTrainedModel):
 
         return image_outputs
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains video last hidden states from the vision tower and apply multimodal projection."
     )
@@ -301,7 +303,7 @@ class VideoLlavaModel(VideoLlavaPreTrainedModel):
             )
         return special_image_mask, special_video_mask
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -441,7 +443,7 @@ class VideoLlavaForConditionalGeneration(VideoLlavaPreTrainedModel, GenerationMi
             **kwargs,
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/vipllava/modeling_vipllava.py
+++ b/src/transformers/models/vipllava/modeling_vipllava.py
@@ -30,7 +30,7 @@ from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPool
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
-from ...utils.generic import can_return_tuple, merge_with_config_defaults
+from ...utils.generic import can_return_tuple
 from ..auto import AutoModel
 from .configuration_vipllava import VipLlavaConfig
 
@@ -151,7 +151,6 @@ class VipLlavaModel(VipLlavaPreTrainedModel):
         self.language_model.set_input_embeddings(value)
 
     @can_return_tuple
-    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )

--- a/src/transformers/models/vipllava/modeling_vipllava.py
+++ b/src/transformers/models/vipllava/modeling_vipllava.py
@@ -29,8 +29,8 @@ from ...generation import GenerationMixin
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling, ModelOutput
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, torch_compilable_check
-from ...utils.generic import check_model_inputs
+from ...utils import TransformersKwargs, auto_docstring, torch_compilable_check
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..auto import AutoModel
 from .configuration_vipllava import VipLlavaConfig
 
@@ -151,6 +151,7 @@ class VipLlavaModel(VipLlavaPreTrainedModel):
         self.language_model.set_input_embeddings(value)
 
     @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )
@@ -332,7 +333,7 @@ class VipLlavaForConditionalGeneration(VipLlavaPreTrainedModel, GenerationMixin)
             pixel_values=pixel_values, vision_feature_layers=vision_feature_layers, **kwargs
         )
 
-    @check_model_inputs(tie_last_hidden_states=False)
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,

--- a/src/transformers/models/vipllava/modular_vipllava.py
+++ b/src/transformers/models/vipllava/modular_vipllava.py
@@ -28,7 +28,7 @@ from ...cache_utils import Cache
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, logging
-from ...utils.generic import can_return_tuple, merge_with_config_defaults
+from ...utils.generic import can_return_tuple
 from .configuration_vipllava import VipLlavaConfig
 
 
@@ -73,7 +73,6 @@ class VipLlavaPreTrainedModel(LlavaPreTrainedModel):
 
 class VipLlavaModel(LlavaModel):
     @can_return_tuple
-    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )

--- a/src/transformers/models/vipllava/modular_vipllava.py
+++ b/src/transformers/models/vipllava/modular_vipllava.py
@@ -27,7 +27,8 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache
 from ...modeling_outputs import BaseModelOutputWithPooling
 from ...processing_utils import Unpack
-from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
+from ...utils import TransformersKwargs, auto_docstring, logging
+from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from .configuration_vipllava import VipLlavaConfig
 
 
@@ -72,6 +73,7 @@ class VipLlavaPreTrainedModel(LlavaPreTrainedModel):
 
 class VipLlavaModel(LlavaModel):
     @can_return_tuple
+    @merge_with_config_defaults
     @auto_docstring(
         custom_intro="Obtains image last hidden states from the vision tower and apply multimodal projection."
     )

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -851,6 +851,60 @@ def can_return_tuple(func):
     return wrapper
 
 
+def merge_with_config_defaults(func):
+    """
+    Decorator using config field (if they exist) as default value for some args and kwargs. Precedence is always
+    given to the args/kwargs that are explicitly passed.
+    """
+
+    @wraps(func)
+    def wrapper(self, *args, **kwargs):
+        args_with_config_defaults = [
+            "use_cache",
+            "vision_feature_layer",
+            "vision_feature_select_strategy",
+            "vision_aspect_ratio",
+        ]
+        for arg_name in args_with_config_defaults:
+            arg_index = None
+            if arg_name in func.__code__.co_varnames:
+                arg_index = func.__code__.co_varnames.index(arg_name) - 1  # -1 for self
+
+            if arg_index is not None and len(args) > arg_index and args[arg_index] is not None:
+                arg_value = args[arg_index]
+            elif kwargs.get(arg_name) is not None:
+                arg_value = kwargs[arg_name]
+            else:
+                arg_value = getattr(self.config, arg_name, None)
+
+            if arg_value is not None:
+                # Arg-specific handling
+                if arg_name == "use_cache":
+                    if getattr(self, "gradient_checkpointing", False) and self.training and arg_value:
+                        logger.warning_once(
+                            "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
+                        )
+                        arg_value = False
+                elif arg_name == "vision_feature_select_strategy":
+                    valid_strategies = ["default", "full"]
+                    if arg_value not in valid_strategies:
+                        raise ValueError(
+                            f"`Unexpected select feature strategy: {arg_value}. Please select from {valid_strategies}."
+                        )
+
+                if arg_index is not None and len(args) > arg_index:
+                    args = list(args)
+                    args[arg_index] = arg_value
+                    args = tuple(args)
+                else:
+                    kwargs[arg_name] = arg_value
+
+        output = func(self, *args, **kwargs)
+        return output
+
+    return wrapper
+
+
 @dataclass
 @requires(backends=("torch",))
 class OutputRecorder:

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -981,11 +981,11 @@ def install_output_capuring_hook(module: nn.Module, key: str, index: int) -> Non
             return
 
         if key == "hidden_states" and len(collected_outputs[key]) == 0:
-            collected_outputs[key] += (args[0],)
+            collected_outputs[key].append(args[0])
         if not isinstance(output, tuple):
-            collected_outputs[key] += (output,)
+            collected_outputs[key].append(output)
         elif output[index] is not None:
-            collected_outputs[key] += (output[index],)
+            collected_outputs[key].append(output[index])
 
     module.register_forward_hook(output_capturing_hook)
 
@@ -1171,7 +1171,7 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
             if "output_attentions" in recordable_keys:
                 recordable_keys["output_cross_attentions"] = recordable_keys["output_attentions"]
 
-            collected_outputs = {k.replace("output_", ""): () for k, v in recordable_keys.items() if v}
+            collected_outputs = {k.replace("output_", ""): [] for k, v in recordable_keys.items() if v}
             # Make sure hooks are installed if we need to collect outputs
             if len(collected_outputs) > 0:
                 maybe_install_capturing_hooks(self)
@@ -1217,20 +1217,21 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                         pass
                     elif hasattr(outputs, "vision_hidden_states"):
                         collected_outputs[key] = collected_outputs[key][:-1]
-                        collected_outputs[key] += (outputs.vision_hidden_states,)
+                        collected_outputs[key].append(outputs.vision_hidden_states)
                     elif hasattr(outputs, "last_hidden_state"):
                         collected_outputs[key] = collected_outputs[key][:-1]
-                        collected_outputs[key] += (outputs.last_hidden_state,)
+                        collected_outputs[key].append(outputs.last_hidden_state)
 
-                    outputs[key] = collected_outputs[key]
+                    outputs[key] = tuple(collected_outputs[key])
                 elif key == "attentions":
                     if isinstance(capture_flags[key], list) and len(capture_flags[key]) == 2:
-                        outputs[key] = collected_outputs[key][0::2]
-                        outputs["cross_" + key] = collected_outputs[key][1::2]
+                        outputs[key] = tuple(collected_outputs[key][0::2])
+                        outputs["cross_" + key] = tuple(collected_outputs[key][1::2])
                     else:
-                        outputs[key] = collected_outputs[key]
+                        outputs[key] = tuple(collected_outputs[key])
                 else:
-                    outputs[key] = collected_outputs[key]
+                    outputs[key] = tuple(collected_outputs[key])
+
             if return_dict is False:
                 outputs = outputs.to_tuple()
             return outputs

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -21,7 +21,7 @@ import inspect
 import json
 import os
 import warnings
-from collections import OrderedDict, UserDict, defaultdict
+from collections import OrderedDict, UserDict
 from collections.abc import Callable, Iterable, MutableMapping
 from contextlib import AbstractContextManager, ExitStack, nullcontext
 from contextvars import ContextVar
@@ -967,20 +967,17 @@ class CompileableContextVar:
 
 # Thread-safe global variables
 _active_collector = CompileableContextVar("output_collector", default=None)
-_active_keys = CompileableContextVar("keys_to_capture", default=None)
 
 
 def install_output_capuring_hook(module: nn.Module, key: str, index: int) -> None:
     """Install the forward hook needed to capture the output described by `key` and `index` in `module`."""
 
     def output_capturing_hook(module, args, output):
-        keys_to_capture = _active_keys.get()
-        # If it's None or not a key we want to capture, simply return, the hook is inactive
-        if keys_to_capture is None or key not in keys_to_capture:
-            return
-
         # Get the current thread-local collector
         collected_outputs = _active_collector.get()
+        # If it's None or not a key we want to capture, simply return, the hook is inactive
+        if collected_outputs is None or key not in collected_outputs.keys():
+            return
 
         if key == "hidden_states" and len(collected_outputs[key]) == 0:
             collected_outputs[key] += (args[0],)
@@ -1142,11 +1139,9 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
             if "output_attentions" in recordable_keys:
                 recordable_keys["output_cross_attentions"] = recordable_keys["output_attentions"]
 
-            keys_to_capture = {k.replace("output_", "") for k, v in recordable_keys.items() if v}
-            collected_outputs = defaultdict(tuple)
+            collected_outputs = {k.replace("output_", ""): () for k, v in recordable_keys.items() if v}
             # Let's activate the output collector hooks if needed!
             output_token = _active_collector.set(collected_outputs)
-            keys_token = _active_keys.set(keys_to_capture)
 
             try:
                 if kwargs.get("debug_io", False):
@@ -1172,7 +1167,6 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
             finally:
                 # Reset the states
                 _active_collector.reset(output_token)
-                _active_keys.reset(keys_token)
 
             # Restore original config value
             if is_causal is not None:

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -1210,6 +1210,11 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 else:
                     del self.config.is_causal
 
+            # Need to drop it if empty as it will be set using the `attentions` key - otherwise it resets it when
+            # re-iterating over it
+            if (cross := collected_outputs.get("cross_attentions")) is not None and len(cross) == 0:
+                del collected_outputs["cross_attentions"]
+
             # Inject collected outputs into model output
             for key in collected_outputs:
                 if key == "hidden_states":

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -15,29 +15,26 @@
 Generic utilities
 """
 
+from __future__ import annotations
+
 import inspect
 import json
-from contextvars import ContextVar
 import os
 import warnings
 from collections import OrderedDict, UserDict, defaultdict
 from collections.abc import Callable, Iterable, MutableMapping
 from contextlib import AbstractContextManager, ExitStack, nullcontext
+from contextvars import ContextVar
 from dataclasses import dataclass, fields, is_dataclass
 from enum import Enum
 from functools import partial, wraps
-from typing import Any, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import numpy as np
 
 from ..utils import logging
-from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy, requires, is_torchdynamo_compiling
+from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy, is_torchdynamo_compiling, requires
 
-
-_CAN_RECORD_REGISTRY = {}
-
-
-logger = logging.get_logger(__name__)
 
 _is_torch_available = False
 if is_torch_available():
@@ -48,6 +45,17 @@ if is_torch_available():
     from ..model_debugging_utils import model_addition_debugger_context
 
     _is_torch_available = True
+
+
+if TYPE_CHECKING:
+    from torch import nn
+
+    from ..modeling_utils import PreTrainedModel
+
+_CAN_RECORD_REGISTRY = {}
+
+
+logger = logging.get_logger(__name__)
 
 
 # required for @can_return_tuple decorator to work with torchdynamo
@@ -178,7 +186,7 @@ def _is_tensor_or_array_like(value):
 
 def maybe_autocast(
     device_type: str,
-    dtype: Optional["_dtype"] = None,
+    dtype: _dtype | None = None,
     enabled: bool = True,
     cache_enabled: bool | None = None,
 ):
@@ -452,12 +460,12 @@ class ModelOutput(OrderedDict):
 if _is_torch_available:
     import torch.utils._pytree as _torch_pytree
 
-    def _model_output_flatten(output: ModelOutput) -> tuple[list[Any], "_torch_pytree.Context"]:
+    def _model_output_flatten(output: ModelOutput) -> tuple[list[Any], _torch_pytree.Context]:
         return list(output.values()), list(output.keys())
 
     def _model_output_unflatten(
         values: Iterable[Any],
-        context: "_torch_pytree.Context",
+        context: _torch_pytree.Context,
         output_type=None,
     ) -> ModelOutput:
         return output_type(**dict(zip(context, values)))
@@ -754,15 +762,15 @@ class TransformersKwargs(TypedDict, total=False):
             Can be set to False to enable bi-directional attention, i.e. use decoder Attention modules as encoders.
     """
 
-    num_items_in_batch: Optional["torch.Tensor"]
+    num_items_in_batch: torch.Tensor | None
     output_hidden_states: bool | None
     output_attentions: bool | None
     output_router_logits: bool | None
-    cu_seq_lens_q: Optional["torch.LongTensor"]
-    cu_seq_lens_k: Optional["torch.LongTensor"]
+    cu_seq_lens_q: torch.LongTensor | None
+    cu_seq_lens_k: torch.LongTensor | None
     max_length_q: int | None
     max_length_k: int | None
-    position_ids: Optional["torch.LongTensor"]
+    position_ids: torch.LongTensor | None
     is_causal: bool | None
 
 
@@ -799,7 +807,7 @@ def is_timm_local_checkpoint(pretrained_model_path: str) -> bool:
     return False
 
 
-def set_attribute_for_modules(module: "torch.nn.Module", key: str, value: Any):
+def set_attribute_for_modules(module: torch.nn.Module, key: str, value: Any):
     """
     Set a value to a module and all submodules.
     """
@@ -808,7 +816,7 @@ def set_attribute_for_modules(module: "torch.nn.Module", key: str, value: Any):
         set_attribute_for_modules(submodule, key, value)
 
 
-def del_attribute_from_modules(module: "torch.nn.Module", key: str):
+def del_attribute_from_modules(module: torch.nn.Module, key: str):
     """
     Delete a value from a module and all submodules.
     """
@@ -842,12 +850,15 @@ def can_return_tuple(func):
 
     return wrapper
 
+
 class CompileableContextVar:
     """
     Convenience wrapper around a ContextVar for usage with `torch.compile`.
     This behaves exactly as a `ContextVar`, except when compilation is triggered in which case it behaves as a simple
     global variable. This is useful as `torch.compile` cannot trace the `get` method of `ContextVar`. This however means
-    that the access to the underlying variable is not thread-safe when compilation is triggered."""
+    that the access to the underlying variable is not thread-safe when compilation is triggered.
+    """
+
     def __init__(self, name, default):
         self.context_var = ContextVar(name, default=default)
         self.global_var = default
@@ -864,7 +875,7 @@ class CompileableContextVar:
                 return self.global_var
             else:
                 return self.context_var.get()
-        
+
     def set(self, value):
         if is_torchdynamo_compiling():
             self.global_var = value
@@ -880,18 +891,21 @@ class CompileableContextVar:
         else:
             self.context_var.reset(token)
 
+
+# Thread-safe global variables
 _active_collector = CompileableContextVar("output_collector", default=None)
 _active_keys = CompileableContextVar("keys_to_capture", default=None)
 
 
-def install_hook(module, key, index):
+def install_output_capuring_hook(module: nn.Module, key: str, index: int) -> None:
+    """Install the forward hook needed to capture the output described by `key` and `index` in `module`."""
 
     def output_capturing_hook(module, args, output):
         keys_to_capture = _active_keys.get()
         # If it's None or not a key we want to capture, simply return, the hook is inactive
         if keys_to_capture is None or key not in keys_to_capture:
             return
-        
+
         # Get the current thread-local collector
         collected_outputs = _active_collector.get()
 
@@ -905,8 +919,37 @@ def install_hook(module, key, index):
     module.register_forward_hook(output_capturing_hook)
 
 
-def install_all_output_capturing_hooks(model):
+def recursively_install_hooks(parent_module: nn.Module, capture_tasks: list[tuple[str, OutputRecorder]]) -> None:
+    """
+    Recursively install all output capturing hooks on all submodules of `parent_module`.
+    Note that we need to use this recursive approach instead of simply iteratating over all modules, because we want
+    to skip installing them on all parts of the graph that are submodels (`PreTrainedModel` instances), to avoid installing
+    then twice in case of composite models (we cannot skip the submodel module itself, as we also need to skip all its
+    children).
+    """
     from ..modeling_utils import PreTrainedModel
+
+    # First dispatch to children if needed
+    for name, module in parent_module.named_children():
+        if not isinstance(module, PreTrainedModel):
+            recursively_install_hooks(module, capture_tasks)
+
+    # Potentially install the hook on current `parent_module`
+    for key, specs in capture_tasks:
+        # The second check is for multimodals where only backbone layer suffix is available
+        if (specs.target_class is not None and isinstance(parent_module, specs.target_class)) or (
+            specs.class_name is not None and name.endswith(specs.class_name)
+        ):
+            if specs.layer_name is not None and specs.layer_name not in name:
+                continue
+            install_output_capuring_hook(parent_module, key, specs.index)
+
+
+def install_all_output_capturing_hooks(model: PreTrainedModel) -> None:
+    """
+    Install the output recording hooks on all the modules in `model`. This is designed to be called in
+    `post_init` for every `PreTrainedModel`, and will take care of only installing them once for composite models.
+    """
     # _can_record_outputs is None by default
     capture_flags = _CAN_RECORD_REGISTRY.get(str(model.__class__)) or {}  # there is a weak ref for executorch
 
@@ -922,22 +965,8 @@ def install_all_output_capturing_hooks(model):
                 specs = OutputRecorder(target_class=target_class, index=index, class_name=class_name)
             capture_tasks.append((key, specs))
 
-    # Install all hooks (we need to use this approach instead of only iterate over all modules so that composite models
-    # do not install them several time)
-    def install_all(parent_module):
-        for name, module in parent_module.named_children():
-            if not isinstance(module, PreTrainedModel):
-                install_all(module)
-            for key, specs in capture_tasks:
-                # The second check is for multimodals where only backbone layer suffix is available
-                if (specs.target_class is not None and isinstance(module, specs.target_class)) or (
-                    specs.class_name is not None and name.endswith(specs.class_name)
-                ):
-                    if specs.layer_name is not None and specs.layer_name not in name:
-                        continue
-                    install_hook(module, key, specs.index)
-    
-    install_all(model)
+    # Install the hooks
+    recursively_install_hooks(model, capture_tasks)
 
 
 @dataclass
@@ -953,7 +982,7 @@ class OutputRecorder:
         class_name (Optional[str]): Name of the class to which the hook will be attached. Could be the suffix of class name in some cases.
     """
 
-    target_class: "type[torch.nn.Module]"
+    target_class: type[torch.nn.Module]
     index: int = 0
     layer_name: str | None = None
     class_name: str | None = None
@@ -1056,10 +1085,10 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
             # when certain condtions are met. Let's output cross attention if attentions are requested (for BC)
             if "output_attentions" in recordable_keys:
                 recordable_keys["output_cross_attentions"] = recordable_keys["output_attentions"]
-            
+
             keys_to_capture = {k.replace("output_", "") for k, v in recordable_keys.items() if v}
             collected_outputs = defaultdict(tuple)
-            # If we need to capture any output, let's activate the hooks!
+            # Let's activate the output collector hooks if needed!
             output_token = _active_collector.set(collected_outputs)
             keys_token = _active_keys.set(keys_to_capture)
 
@@ -1084,8 +1113,8 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                     "Missing `**kwargs` in the signature of the `@check_model_inputs`-decorated function "
                     f"({func.__qualname__})"
                 )
-            # Reset the collector
             finally:
+                # Reset the states
                 _active_collector.reset(output_token)
                 _active_keys.reset(keys_token)
 

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -851,6 +851,25 @@ def can_return_tuple(func):
     return wrapper
 
 
+@dataclass
+@requires(backends=("torch",))
+class OutputRecorder:
+    """
+    Configuration for recording outputs from a model via hooks.
+
+    Attributes:
+        target_class (Type): The class (e.g., nn.Module) to which the hook will be attached.
+        index (Optional[int]): If the output is a tuple/list, optionally record only at a specific index.
+        layer_name (Optional[str]): Name of the submodule to target (if needed), e.g., "transformer.layer.3.attn".
+        class_name (Optional[str]): Name of the class to which the hook will be attached. Could be the suffix of class name in some cases.
+    """
+
+    target_class: type[torch.nn.Module]
+    index: int = 0
+    layer_name: str | None = None
+    class_name: str | None = None
+
+
 class CompileableContextVar:
     """
     Convenience wrapper around a ContextVar for usage with `torch.compile`.
@@ -967,25 +986,6 @@ def install_all_output_capturing_hooks(model: PreTrainedModel) -> None:
 
     # Install the hooks
     recursively_install_hooks(model, capture_tasks)
-
-
-@dataclass
-@requires(backends=("torch",))
-class OutputRecorder:
-    """
-    Configuration for recording outputs from a model via hooks.
-
-    Attributes:
-        target_class (Type): The class (e.g., nn.Module) to which the hook will be attached.
-        index (Optional[int]): If the output is a tuple/list, optionally record only at a specific index.
-        layer_name (Optional[str]): Name of the submodule to target (if needed), e.g., "transformer.layer.3.attn".
-        class_name (Optional[str]): Name of the class to which the hook will be attached. Could be the suffix of class name in some cases.
-    """
-
-    target_class: type[torch.nn.Module]
-    index: int = 0
-    layer_name: str | None = None
-    class_name: str | None = None
 
 
 def check_model_inputs(func=None, *, tie_last_hidden_states=True):

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -807,7 +807,7 @@ def is_timm_local_checkpoint(pretrained_model_path: str) -> bool:
     return False
 
 
-def set_attribute_for_modules(module: torch.nn.Module, key: str, value: Any):
+def set_attribute_for_modules(module: nn.Module, key: str, value: Any):
     """
     Set a value to a module and all submodules.
     """
@@ -816,7 +816,7 @@ def set_attribute_for_modules(module: torch.nn.Module, key: str, value: Any):
         set_attribute_for_modules(submodule, key, value)
 
 
-def del_attribute_from_modules(module: torch.nn.Module, key: str):
+def del_attribute_from_modules(module: nn.Module, key: str):
     """
     Delete a value from a module and all submodules.
     """
@@ -864,7 +864,7 @@ class OutputRecorder:
         class_name (Optional[str]): Name of the class to which the hook will be attached. Could be the suffix of class name in some cases.
     """
 
-    target_class: type[torch.nn.Module]
+    target_class: type[nn.Module]
     index: int = 0
     layer_name: str | None = None
     class_name: str | None = None
@@ -938,7 +938,9 @@ def install_output_capuring_hook(module: nn.Module, key: str, index: int) -> Non
     module.register_forward_hook(output_capturing_hook)
 
 
-def recursively_install_hooks(parent_module: nn.Module, capture_tasks: list[tuple[str, OutputRecorder]]) -> None:
+def recursively_install_hooks(
+    parent_module: nn.Module, module_name: str, capture_tasks: list[tuple[str, OutputRecorder]]
+) -> None:
     """
     Recursively install all output capturing hooks on all submodules of `parent_module`.
     Note that we need to use this recursive approach instead of simply iteratating over all modules, because we want
@@ -951,15 +953,15 @@ def recursively_install_hooks(parent_module: nn.Module, capture_tasks: list[tupl
     # First dispatch to children if needed
     for name, module in parent_module.named_children():
         if not isinstance(module, PreTrainedModel):
-            recursively_install_hooks(module, capture_tasks)
+            recursively_install_hooks(module, f"{module_name}.{name}", capture_tasks)
 
     # Potentially install the hook on current `parent_module`
     for key, specs in capture_tasks:
         # The second check is for multimodals where only backbone layer suffix is available
         if (specs.target_class is not None and isinstance(parent_module, specs.target_class)) or (
-            specs.class_name is not None and name.endswith(specs.class_name)
+            specs.class_name is not None and module_name.endswith(specs.class_name)
         ):
-            if specs.layer_name is not None and specs.layer_name not in name:
+            if specs.layer_name is not None and specs.layer_name not in module_name:
                 continue
             install_output_capuring_hook(parent_module, key, specs.index)
 
@@ -985,7 +987,7 @@ def install_all_output_capturing_hooks(model: PreTrainedModel) -> None:
             capture_tasks.append((key, specs))
 
     # Install the hooks
-    recursively_install_hooks(model, capture_tasks)
+    recursively_install_hooks(model, "", capture_tasks)
 
 
 def check_model_inputs(func=None, *, tie_last_hidden_states=True):

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -17,6 +17,7 @@ Generic utilities
 
 import inspect
 import json
+from contextvars import ContextVar
 import os
 import warnings
 from collections import OrderedDict, UserDict, defaultdict
@@ -30,7 +31,7 @@ from typing import Any, Optional, TypedDict
 import numpy as np
 
 from ..utils import logging
-from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy, requires
+from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy, requires, is_torchdynamo_compiling
 
 
 _CAN_RECORD_REGISTRY = {}
@@ -841,6 +842,103 @@ def can_return_tuple(func):
 
     return wrapper
 
+class CompileableContextVar:
+    """
+    Convenience wrapper around a ContextVar for usage with `torch.compile`.
+    This behaves exactly as a `ContextVar`, except when compilation is triggered in which case it behaves as a simple
+    global variable. This is useful as `torch.compile` cannot trace the `get` method of `ContextVar`. This however means
+    that the access to the underlying variable is not thread-safe when compilation is triggered."""
+    def __init__(self, name, default):
+        self.context_var = ContextVar(name, default=default)
+        self.global_var = default
+        self.compiling = False
+
+    def get(self):
+        # Set was called before and compilation was already detected
+        if self.compiling:
+            return self.global_var
+        else:
+            # Set was maybe never called, so still check it here
+            if is_torchdynamo_compiling():
+                self.is_compiling = True
+                return self.global_var
+            else:
+                return self.context_var.get()
+        
+    def set(self, value):
+        if is_torchdynamo_compiling():
+            self.global_var = value
+            self.compiling = True
+            return None
+        else:
+            return self.context_var.set(value)
+
+    def reset(self, token):
+        if self.compiling:
+            self.global_var = None
+            self.compiling = False
+        else:
+            self.context_var.reset(token)
+
+_active_collector = CompileableContextVar("output_collector", default=None)
+_active_keys = CompileableContextVar("keys_to_capture", default=None)
+
+
+def install_hook(module, key, index):
+
+    def output_capturing_hook(module, args, output):
+        keys_to_capture = _active_keys.get()
+        # If it's None or not a key we want to capture, simply return, the hook is inactive
+        if keys_to_capture is None or key not in keys_to_capture:
+            return
+        
+        # Get the current thread-local collector
+        collected_outputs = _active_collector.get()
+
+        if key == "hidden_states" and len(collected_outputs[key]) == 0:
+            collected_outputs[key] += (args[0],)
+        if not isinstance(output, tuple):
+            collected_outputs[key] += (output,)
+        elif output[index] is not None:
+            collected_outputs[key] += (output[index],)
+
+    module.register_forward_hook(output_capturing_hook)
+
+
+def install_all_output_capturing_hooks(model):
+    from ..modeling_utils import PreTrainedModel
+    # _can_record_outputs is None by default
+    capture_flags = _CAN_RECORD_REGISTRY.get(str(model.__class__)) or {}  # there is a weak ref for executorch
+
+    capture_tasks = []
+    for key, layer_specs in capture_flags.items():
+        if not isinstance(layer_specs, list):
+            layer_specs = [layer_specs]
+        for specs in layer_specs:
+            if not isinstance(specs, OutputRecorder):
+                index = 0 if "hidden_states" in key else 1
+                class_name = None if not isinstance(specs, str) else specs
+                target_class = specs if not isinstance(specs, str) else None
+                specs = OutputRecorder(target_class=target_class, index=index, class_name=class_name)
+            capture_tasks.append((key, specs))
+
+    # Install all hooks (we need to use this approach instead of only iterate over all modules so that composite models
+    # do not install them several time)
+    def install_all(parent_module):
+        for name, module in parent_module.named_children():
+            if not isinstance(module, PreTrainedModel):
+                install_all(module)
+            for key, specs in capture_tasks:
+                # The second check is for multimodals where only backbone layer suffix is available
+                if (specs.target_class is not None and isinstance(module, specs.target_class)) or (
+                    specs.class_name is not None and name.endswith(specs.class_name)
+                ):
+                    if specs.layer_name is not None and specs.layer_name not in name:
+                        continue
+                    install_hook(module, key, specs.index)
+    
+    install_all(model)
+
 
 @dataclass
 @requires(backends=("torch",))
@@ -958,54 +1056,12 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
             # when certain condtions are met. Let's output cross attention if attentions are requested (for BC)
             if "output_attentions" in recordable_keys:
                 recordable_keys["output_cross_attentions"] = recordable_keys["output_attentions"]
-
+            
+            keys_to_capture = {k.replace("output_", "") for k, v in recordable_keys.items() if v}
             collected_outputs = defaultdict(tuple)
-            monkey_patched_layers = []
-
-            def make_capture_wrapper(module, orig_forward, key, index):
-                @wraps(orig_forward)
-                def wrapped_forward(*args, **kwargs):
-                    if key == "hidden_states" and len(collected_outputs[key]) == 0:
-                        collected_outputs[key] += (args[0],)
-                    output = orig_forward(*args, **kwargs)
-                    if not isinstance(output, tuple):
-                        collected_outputs[key] += (output,)
-                    elif output[index] is not None:
-                        if key not in collected_outputs:
-                            collected_outputs[key] = (output[index],)
-                        else:
-                            collected_outputs[key] += (output[index],)
-                    return output
-
-                return wrapped_forward
-
-            if any(recordable_keys.values()):
-                capture_tasks = []
-                for key, layer_specs in capture_flags.items():
-                    if not recordable_keys.get(f"output_{key}", False):
-                        continue
-                    if not isinstance(layer_specs, list):
-                        layer_specs = [layer_specs]
-                    for specs in layer_specs:
-                        if not isinstance(specs, OutputRecorder):
-                            index = 0 if "hidden_states" in key else 1
-                            class_name = None if not isinstance(specs, str) else specs
-                            target_class = specs if not isinstance(specs, str) else None
-                            specs = OutputRecorder(target_class=target_class, index=index, class_name=class_name)
-                        capture_tasks.append((key, specs))
-
-                for name, module in self.named_modules():
-                    for key, specs in capture_tasks:
-                        # The second check is for multimodals where only backbone layer suffix is available
-                        if (specs.target_class is not None and isinstance(module, specs.target_class)) or (
-                            specs.class_name is not None and name.endswith(specs.class_name)
-                        ):
-                            if specs.layer_name is not None and specs.layer_name not in name:
-                                continue
-                            # Monkey patch forward
-                            original_forward = module.forward
-                            module.forward = make_capture_wrapper(module, original_forward, key, specs.index)
-                            monkey_patched_layers.append((module, original_forward))
+            # If we need to capture any output, let's activate the hooks!
+            output_token = _active_collector.set(collected_outputs)
+            keys_token = _active_keys.set(keys_to_capture)
 
             try:
                 if kwargs.get("debug_io", False):
@@ -1028,10 +1084,10 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                     "Missing `**kwargs` in the signature of the `@check_model_inputs`-decorated function "
                     f"({func.__qualname__})"
                 )
-
-            # Restore original forward methods
-            for module, original_forward in monkey_patched_layers:
-                module.forward = original_forward
+            # Reset the collector
+            finally:
+                _active_collector.reset(output_token)
+                _active_keys.reset(keys_token)
 
             # Restore original config value
             if is_causal is not None:

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -20,13 +20,11 @@ from __future__ import annotations
 import inspect
 import json
 import os
-import threading
 import warnings
 from collections import OrderedDict, UserDict
 from collections.abc import Callable, Iterable, MutableMapping
 from contextlib import AbstractContextManager, ExitStack, nullcontext
-from contextvars import ContextVar
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import fields, is_dataclass
 from enum import Enum
 from functools import partial, wraps
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -34,7 +32,8 @@ from typing import TYPE_CHECKING, Any, TypedDict
 import numpy as np
 
 from ..utils import logging
-from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy, is_torchdynamo_compiling, requires
+from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy
+from .output_capturing import _CAN_RECORD_REGISTRY, _active_collector, maybe_install_capturing_hooks
 
 
 _is_torch_available = False
@@ -50,10 +49,6 @@ if is_torch_available():
 
 if TYPE_CHECKING:
     from torch import nn
-
-    from ..modeling_utils import PreTrainedModel
-
-_CAN_RECORD_REGISTRY = {}
 
 
 logger = logging.get_logger(__name__)
@@ -904,173 +899,6 @@ def merge_with_config_defaults(func):
         return output
 
     return wrapper
-
-
-@dataclass
-@requires(backends=("torch",))
-class OutputRecorder:
-    """
-    Configuration for recording outputs from a model via hooks.
-
-    Attributes:
-        target_class (Type): The class (e.g., nn.Module) to which the hook will be attached.
-        index (Optional[int]): If the output is a tuple/list, optionally record only at a specific index.
-        layer_name (Optional[str]): Name of the submodule to target (if needed), e.g., "transformer.layer.3.attn".
-        class_name (Optional[str]): Name of the class to which the hook will be attached. Could be the suffix of class name in some cases.
-    """
-
-    target_class: type[nn.Module]
-    index: int = 0
-    layer_name: str | None = None
-    class_name: str | None = None
-
-
-class CompileableContextVar:
-    """
-    Convenience wrapper around a ContextVar for usage with `torch.compile`.
-    This behaves exactly as a `ContextVar`, except when compilation is triggered in which case it behaves as a simple
-    global variable. This is useful as `torch.compile` cannot trace the `get` method of `ContextVar`. This however means
-    that the access to the underlying variable is not thread-safe when compilation is triggered.
-    """
-
-    def __init__(self, name, default):
-        self.context_var = ContextVar(name, default=default)
-        self.global_var = default
-        self.compiling = False
-
-    def get(self):
-        # Set was called before and compilation was already detected
-        if self.compiling:
-            return self.global_var
-        else:
-            # Set was maybe never called, so still check it here
-            if is_torchdynamo_compiling():
-                self.is_compiling = True
-                return self.global_var
-            else:
-                return self.context_var.get()
-
-    def set(self, value):
-        if is_torchdynamo_compiling():
-            self.global_var = value
-            self.compiling = True
-            return None
-        else:
-            return self.context_var.set(value)
-
-    def reset(self, token):
-        if self.compiling:
-            self.global_var = None
-            self.compiling = False
-        else:
-            self.context_var.reset(token)
-
-
-# Thread-safe global variables
-_active_collector = CompileableContextVar("output_collector", default=None)
-
-
-def install_output_capuring_hook(module: nn.Module, key: str, index: int) -> None:
-    """Install the forward hook needed to capture the output described by `key` and `index` in `module`."""
-
-    def output_capturing_hook(module, args, output):
-        # Get the current thread-local collector
-        collected_outputs = _active_collector.get()
-        # If it's None or not a key we want to capture, simply return, the hook is inactive
-        if collected_outputs is None or key not in collected_outputs.keys():
-            return
-
-        if key == "hidden_states" and len(collected_outputs[key]) == 0:
-            collected_outputs[key].append(args[0])
-        if not isinstance(output, tuple):
-            collected_outputs[key].append(output)
-        elif output[index] is not None:
-            collected_outputs[key].append(output[index])
-
-    module.register_forward_hook(output_capturing_hook)
-
-
-def recursively_install_hooks(
-    parent_module: nn.Module, module_name: str, capture_tasks: list[tuple[str, OutputRecorder]]
-) -> None:
-    """
-    Recursively install all output capturing hooks on all submodules of `parent_module`.
-    Note that we need to use this recursive approach instead of simply iterating over all modules, because we want
-    to respect the `capture_tasks` of all individual submodels (`PreTrainedModel` instances) in the graph. That is, once
-    we reach a submodel in the graph, its children should use this submodel's `capture_tasks`, but other parts of the graph
-    should not.
-    """
-    from ..modeling_utils import PreTrainedModel
-
-    # First dispatch to children if needed
-    for name, module in parent_module.named_children():
-        # Keep dispatching the same `capture_tasks`
-        if not isinstance(module, PreTrainedModel):
-            recursively_install_hooks(module, f"{module_name}.{name}", capture_tasks)
-        # New Submodel: we need to dispatch its own `capture_tasks`
-        else:
-            install_all_output_capturing_hooks(module, prefix=f"{module_name}.{name}")
-
-    # Potentially install the hook on current `parent_module`
-    for key, specs in capture_tasks:
-        # The second check is for multimodals where only backbone layer suffix is available
-        if (specs.target_class is not None and isinstance(parent_module, specs.target_class)) or (
-            specs.class_name is not None and module_name.endswith(specs.class_name)
-        ):
-            if specs.layer_name is not None and specs.layer_name not in module_name:
-                continue
-            install_output_capuring_hook(parent_module, key, specs.index)
-
-
-def install_all_output_capturing_hooks(model: PreTrainedModel, prefix: str | None = None) -> None:
-    """
-    Install the output recording hooks on all the modules in `model`. Tis will take care of correctly dispatching
-    the `_can_record_outputs` property of each individual submodels in case of composite models.
-    """
-    # _can_record_outputs is None by default
-    capture_flags = _CAN_RECORD_REGISTRY.get(str(model.__class__)) or {}  # there is a weak ref for executorch
-
-    capture_tasks = []
-    for key, layer_specs in capture_flags.items():
-        if not isinstance(layer_specs, list):
-            layer_specs = [layer_specs]
-        for specs in layer_specs:
-            if not isinstance(specs, OutputRecorder):
-                index = 0 if "hidden_states" in key else 1
-                class_name = None if not isinstance(specs, str) else specs
-                target_class = specs if not isinstance(specs, str) else None
-                specs = OutputRecorder(target_class=target_class, index=index, class_name=class_name)
-            capture_tasks.append((key, specs))
-
-    # Install the hooks
-    prefix = prefix if prefix is not None else ""
-    recursively_install_hooks(model, prefix, capture_tasks)
-    # Mark the model as already hooked
-    model._output_capturing_hooks_installed = True
-
-
-# We need this to make sure we don't have race conditions when installing hooks, resulting in them being installed
-# several times
-_hook_installation_lock = threading.Lock()
-
-
-def maybe_install_capturing_hooks(model: PreTrainedModel) -> None:
-    """
-    Check if the model already has output capturing hooks installed, and install them if it is not already the
-    case.
-    Note that this is thread-safe, in case 2 (ore more) threads want to install them concurrently.
-    """
-    # First check
-    if getattr(model, "_output_capturing_hooks_installed", False):
-        return
-
-    with _hook_installation_lock:
-        # Second check, in case several threads entered this function concurrently and did not return on the
-        # previous check
-        if getattr(model, "_output_capturing_hooks_installed", False):
-            return
-        # This will install the hooks and mark the model as hooked
-        install_all_output_capturing_hooks(model)
 
 
 def check_model_inputs(func=None, *, tie_last_hidden_states=True):

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import inspect
 import json
 import os
+import threading
 import warnings
 from collections import OrderedDict, UserDict
 from collections.abc import Callable, Iterable, MutableMapping
@@ -994,17 +995,21 @@ def recursively_install_hooks(
 ) -> None:
     """
     Recursively install all output capturing hooks on all submodules of `parent_module`.
-    Note that we need to use this recursive approach instead of simply iteratating over all modules, because we want
-    to skip installing them on all parts of the graph that are submodels (`PreTrainedModel` instances), to avoid installing
-    then twice in case of composite models (we cannot skip the submodel module itself, as we also need to skip all its
-    children).
+    Note that we need to use this recursive approach instead of simply iterating over all modules, because we want
+    to respect the `capture_tasks` of all individual submodels (`PreTrainedModel` instances) in the graph. That is, once
+    we reach a submodel in the graph, its children should use this submodel's `capture_tasks`, but other parts of the graph
+    should not.
     """
     from ..modeling_utils import PreTrainedModel
 
     # First dispatch to children if needed
     for name, module in parent_module.named_children():
+        # Keep dispatching the same `capture_tasks`
         if not isinstance(module, PreTrainedModel):
             recursively_install_hooks(module, f"{module_name}.{name}", capture_tasks)
+        # New Submodel: we need to dispatch its own `capture_tasks`
+        else:
+            install_all_output_capturing_hooks(module, prefix=f"{module_name}.{name}")
 
     # Potentially install the hook on current `parent_module`
     for key, specs in capture_tasks:
@@ -1017,10 +1022,10 @@ def recursively_install_hooks(
             install_output_capuring_hook(parent_module, key, specs.index)
 
 
-def install_all_output_capturing_hooks(model: PreTrainedModel) -> None:
+def install_all_output_capturing_hooks(model: PreTrainedModel, prefix: str | None = None) -> None:
     """
-    Install the output recording hooks on all the modules in `model`. This is designed to be called in
-    `post_init` for every `PreTrainedModel`, and will take care of only installing them once for composite models.
+    Install the output recording hooks on all the modules in `model`. Tis will take care of correctly dispatching
+    the `_can_record_outputs` property of each individual submodels in case of composite models.
     """
     # _can_record_outputs is None by default
     capture_flags = _CAN_RECORD_REGISTRY.get(str(model.__class__)) or {}  # there is a weak ref for executorch
@@ -1038,7 +1043,34 @@ def install_all_output_capturing_hooks(model: PreTrainedModel) -> None:
             capture_tasks.append((key, specs))
 
     # Install the hooks
-    recursively_install_hooks(model, "", capture_tasks)
+    prefix = prefix if prefix is not None else ""
+    recursively_install_hooks(model, prefix, capture_tasks)
+    # Mark the model as already hooked
+    model._output_capturing_hooks_installed = True
+
+
+# We need this to make sure we don't have race conditions when installing hooks, resulting in them being installed
+# several times
+_hook_installation_lock = threading.Lock()
+
+
+def maybe_install_capturing_hooks(model: PreTrainedModel) -> None:
+    """
+    Check if the model already has output capturing hooks installed, and install them if it is not already the
+    case.
+    Note that this is thread-safe, in case 2 (ore more) threads want to install them concurrently.
+    """
+    # First check
+    if getattr(model, "_output_capturing_hooks_installed", False):
+        return
+
+    with _hook_installation_lock:
+        # Second check, in case several threads entered this function concurrently and did not return on the
+        # previous check
+        if getattr(model, "_output_capturing_hooks_installed", False):
+            return
+        # This will install the hooks and mark the model as hooked
+        install_all_output_capturing_hooks(model)
 
 
 def check_model_inputs(func=None, *, tie_last_hidden_states=True):
@@ -1140,6 +1172,9 @@ def check_model_inputs(func=None, *, tie_last_hidden_states=True):
                 recordable_keys["output_cross_attentions"] = recordable_keys["output_attentions"]
 
             collected_outputs = {k.replace("output_", ""): () for k, v in recordable_keys.items() if v}
+            # Make sure hooks are installed if we need to collect outputs
+            if len(collected_outputs) > 0:
+                maybe_install_capturing_hooks(self)
             # Let's activate the output collector hooks if needed!
             output_token = _active_collector.set(collected_outputs)
 

--- a/src/transformers/utils/output_capturing.py
+++ b/src/transformers/utils/output_capturing.py
@@ -1,0 +1,201 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Contains the logic for automatic additional output capture with our forward decorators.
+"""
+
+from __future__ import annotations
+
+import threading
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .import_utils import is_torchdynamo_compiling, requires
+
+
+if TYPE_CHECKING:
+    from torch import nn
+
+    from ..modeling_utils import PreTrainedModel
+
+
+_CAN_RECORD_REGISTRY = {}
+
+
+@dataclass
+@requires(backends=("torch",))
+class OutputRecorder:
+    """
+    Configuration for recording outputs from a model via hooks.
+
+    Attributes:
+        target_class (Type): The class (e.g., nn.Module) to which the hook will be attached.
+        index (Optional[int]): If the output is a tuple/list, optionally record only at a specific index.
+        layer_name (Optional[str]): Name of the submodule to target (if needed), e.g., "transformer.layer.3.attn".
+        class_name (Optional[str]): Name of the class to which the hook will be attached. Could be the suffix of class name in some cases.
+    """
+
+    target_class: type[nn.Module]
+    index: int = 0
+    layer_name: str | None = None
+    class_name: str | None = None
+
+
+class CompileableContextVar:
+    """
+    Convenience wrapper around a ContextVar for usage with `torch.compile`.
+    This behaves exactly as a `ContextVar`, except when compilation is triggered in which case it behaves as a simple
+    global variable. This is useful as `torch.compile` cannot trace the `get` method of `ContextVar`. This however means
+    that the access to the underlying variable is not thread-safe when compilation is triggered.
+    """
+
+    def __init__(self, name, default):
+        self.context_var = ContextVar(name, default=default)
+        self.global_var = default
+        self.compiling = False
+
+    def get(self):
+        # Set was called before and compilation was already detected
+        if self.compiling:
+            return self.global_var
+        else:
+            # Set was maybe never called, so still check it here
+            if is_torchdynamo_compiling():
+                self.is_compiling = True
+                return self.global_var
+            else:
+                return self.context_var.get()
+
+    def set(self, value):
+        if is_torchdynamo_compiling():
+            self.global_var = value
+            self.compiling = True
+            return None
+        else:
+            return self.context_var.set(value)
+
+    def reset(self, token):
+        if self.compiling:
+            self.global_var = None
+            self.compiling = False
+        else:
+            self.context_var.reset(token)
+
+
+# Thread-safe global variables
+_active_collector = CompileableContextVar("output_collector", default=None)
+
+
+def install_output_capuring_hook(module: nn.Module, key: str, index: int) -> None:
+    """Install the forward hook needed to capture the output described by `key` and `index` in `module`."""
+
+    def output_capturing_hook(module, args, output):
+        # Get the current thread-local collector
+        collected_outputs = _active_collector.get()
+        # If it's None or not a key we want to capture, simply return, the hook is inactive
+        if collected_outputs is None or key not in collected_outputs.keys():
+            return
+
+        if key == "hidden_states" and len(collected_outputs[key]) == 0:
+            collected_outputs[key].append(args[0])
+        if not isinstance(output, tuple):
+            collected_outputs[key].append(output)
+        elif output[index] is not None:
+            collected_outputs[key].append(output[index])
+
+    module.register_forward_hook(output_capturing_hook)
+
+
+def recursively_install_hooks(
+    parent_module: nn.Module, module_name: str, capture_tasks: list[tuple[str, OutputRecorder]]
+) -> None:
+    """
+    Recursively install all output capturing hooks on all submodules of `parent_module`.
+    Note that we need to use this recursive approach instead of simply iterating over all modules, because we want
+    to respect the `capture_tasks` of all individual submodels (`PreTrainedModel` instances) in the graph. That is, once
+    we reach a submodel in the graph, its children should use this submodel's `capture_tasks`, but other parts of the graph
+    should not.
+    """
+    from ..modeling_utils import PreTrainedModel
+
+    # First dispatch to children if needed
+    for name, module in parent_module.named_children():
+        # Keep dispatching the same `capture_tasks`
+        if not isinstance(module, PreTrainedModel):
+            recursively_install_hooks(module, f"{module_name}.{name}", capture_tasks)
+        # New Submodel: we need to dispatch its own `capture_tasks`
+        else:
+            install_all_output_capturing_hooks(module, prefix=f"{module_name}.{name}")
+
+    # Potentially install the hook on current `parent_module`
+    for key, specs in capture_tasks:
+        # The second check is for multimodals where only backbone layer suffix is available
+        if (specs.target_class is not None and isinstance(parent_module, specs.target_class)) or (
+            specs.class_name is not None and module_name.endswith(specs.class_name)
+        ):
+            if specs.layer_name is not None and specs.layer_name not in module_name:
+                continue
+            install_output_capuring_hook(parent_module, key, specs.index)
+
+
+def install_all_output_capturing_hooks(model: PreTrainedModel, prefix: str | None = None) -> None:
+    """
+    Install the output recording hooks on all the modules in `model`. Tis will take care of correctly dispatching
+    the `_can_record_outputs` property of each individual submodels in case of composite models.
+    """
+    # _can_record_outputs is None by default
+    capture_flags = _CAN_RECORD_REGISTRY.get(str(model.__class__)) or {}  # there is a weak ref for executorch
+
+    capture_tasks = []
+    for key, layer_specs in capture_flags.items():
+        if not isinstance(layer_specs, list):
+            layer_specs = [layer_specs]
+        for specs in layer_specs:
+            if not isinstance(specs, OutputRecorder):
+                index = 0 if "hidden_states" in key else 1
+                class_name = None if not isinstance(specs, str) else specs
+                target_class = specs if not isinstance(specs, str) else None
+                specs = OutputRecorder(target_class=target_class, index=index, class_name=class_name)
+            capture_tasks.append((key, specs))
+
+    # Install the hooks
+    prefix = prefix if prefix is not None else ""
+    recursively_install_hooks(model, prefix, capture_tasks)
+    # Mark the model as already hooked
+    model._output_capturing_hooks_installed = True
+
+
+# We need this to make sure we don't have race conditions when installing hooks, resulting in them being installed
+# several times
+_hook_installation_lock = threading.Lock()
+
+
+def maybe_install_capturing_hooks(model: PreTrainedModel) -> None:
+    """
+    Check if the model already has output capturing hooks installed, and install them if it is not already the
+    case.
+    Note that this is thread-safe, in case 2 (ore more) threads want to install them concurrently.
+    """
+    # First check
+    if getattr(model, "_output_capturing_hooks_installed", False):
+        return
+
+    with _hook_installation_lock:
+        # Second check, in case several threads entered this function concurrently and did not return on the
+        # previous check
+        if getattr(model, "_output_capturing_hooks_installed", False):
+            return
+        # This will install the hooks and mark the model as hooked
+        install_all_output_capturing_hooks(model)

--- a/src/transformers/utils/output_capturing.py
+++ b/src/transformers/utils/output_capturing.py
@@ -95,7 +95,7 @@ class CompileableContextVar:
             self.context_var.reset(token)
 
 
-# Thread-safe global variables
+# Thread/context-safe global variable
 _active_collector = CompileableContextVar("output_collector", default=None)
 
 

--- a/src/transformers/utils/output_capturing.py
+++ b/src/transformers/utils/output_capturing.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """
 Contains the logic for automatic additional output capture with our forward decorators.
+This mostly describe the hooks used and the logic to make capture thread/context safe.
 """
 
 from __future__ import annotations
@@ -186,7 +187,7 @@ def maybe_install_capturing_hooks(model: PreTrainedModel) -> None:
     """
     Check if the model already has output capturing hooks installed, and install them if it is not already the
     case.
-    Note that this is thread-safe, in case 2 (ore more) threads want to install them concurrently.
+    Note that this is thread-safe, in case 2 (or more) threads want to install them concurrently.
     """
     # First check
     if getattr(model, "_output_capturing_hooks_installed", False):

--- a/tests/models/clip/test_modeling_clip.py
+++ b/tests/models/clip/test_modeling_clip.py
@@ -636,7 +636,6 @@ class CLIPForImageClassificationModelTest(CLIPModelTesterMixin, PipelineTesterMi
 
     test_resize_embeddings = False
     test_attention_outputs = False
-    _is_composite = True
 
     def setUp(self):
         self.model_tester = CLIPForImageClassificationModelTester(self)

--- a/tests/models/metaclip_2/test_modeling_metaclip_2.py
+++ b/tests/models/metaclip_2/test_modeling_metaclip_2.py
@@ -648,7 +648,6 @@ class MetaClip2ForImageClassificationModelTest(MetaClip2ModelTesterMixin, Pipeli
 
     test_resize_embeddings = False
     test_attention_outputs = False
-    _is_composite = True
 
     def setUp(self):
         self.model_tester = MetaClip2ForImageClassificationModelTester(self)

--- a/tests/models/sam2/test_modeling_sam2.py
+++ b/tests/models/sam2/test_modeling_sam2.py
@@ -264,6 +264,7 @@ class Sam2VisionModelTest(ModelTesterMixin, unittest.TestCase):
             # check that output_hidden_states also work using config
             del inputs_dict["output_hidden_states"]
             config.output_hidden_states = True
+            config.backbone_config.output_hidden_states = True
 
             check_hidden_states_output(inputs_dict, config, model_class, image_size)
 

--- a/tests/models/sam2/test_modeling_sam2.py
+++ b/tests/models/sam2/test_modeling_sam2.py
@@ -194,6 +194,7 @@ class Sam2VisionModelTest(ModelTesterMixin, unittest.TestCase):
             # check that output_attentions also work using config
             del inputs_dict["output_attentions"]
             config.output_attentions = True
+            config.backbone_config.output_attentions = True
             window_size = config.backbone_config.window_size_per_stage[0]
             out_dim = config.backbone_config.hidden_size
             patch_stride = config.backbone_config.patch_stride
@@ -514,6 +515,7 @@ class Sam2ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             del inputs_dict["output_attentions"]
             config.mask_decoder_config.output_attentions = True
             config.vision_config.output_attentions = True
+            config.vision_config.backbone_config.output_attentions = True
             config.output_attentions = True
             model = model_class._from_config(config, attn_implementation="eager")
             window_size = config.vision_config.backbone_config.window_size_per_stage[0]

--- a/tests/models/sam3/test_modeling_sam3.py
+++ b/tests/models/sam3/test_modeling_sam3.py
@@ -497,8 +497,12 @@ class Sam3ModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
             del inputs_dict["output_attentions"]
             config.output_attentions = True
             for k in config.sub_configs:
-                if getattr(config, k) is not None:
-                    getattr(config, k).output_attentions = True
+                if (subconfig := getattr(config, k)) is not None:
+                    subconfig.output_attentions = True
+                    # Sam3 has a vision subconfig with itself a sub config....
+                    for k in subconfig.sub_configs:
+                        if (subsubconfig := getattr(subconfig, k)) is not None:
+                            subsubconfig.output_attentions = True
 
             model = model_class(config)
             model.to(torch_device)

--- a/tests/models/sam3_tracker/test_modeling_sam3_tracker.py
+++ b/tests/models/sam3_tracker/test_modeling_sam3_tracker.py
@@ -302,6 +302,7 @@ class Sam3TrackerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestC
             del inputs_dict["output_attentions"]
             config.mask_decoder_config.output_attentions = True
             config.vision_config.output_attentions = True
+            config.vision_config.backbone_config.output_attentions = True
             config.output_attentions = True
             model = model_class(config)
             model.to(torch_device)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -5196,7 +5196,8 @@ class ModelTesterMixin:
         if not self.has_attentions:
             return
 
-        for model_class in self.all_model_classes:
+        for model_class in self.all_model_classes[1:]:
+            print(model_class.__name__)
             if not hasattr(model_class, "get_image_features"):
                 continue
 
@@ -5216,6 +5217,7 @@ class ModelTesterMixin:
 
             set_value_subconfigs(config, "output_attentions", True)
             check_attentions_output(inputs_dict, config, model_class)
+            print("done")
 
     @parameterized.expand([True, False, None])
     def test_get_audio_features_output(self, return_dict: bool | None):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -5196,8 +5196,7 @@ class ModelTesterMixin:
         if not self.has_attentions:
             return
 
-        for model_class in self.all_model_classes[1:]:
-            print(model_class.__name__)
+        for model_class in self.all_model_classes:
             if not hasattr(model_class, "get_image_features"):
                 continue
 
@@ -5217,7 +5216,6 @@ class ModelTesterMixin:
 
             set_value_subconfigs(config, "output_attentions", True)
             check_attentions_output(inputs_dict, config, model_class)
-            print("done")
 
     @parameterized.expand([True, False, None])
     def test_get_audio_features_output(self, return_dict: bool | None):

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -110,6 +110,11 @@ PRIVATE_MODELS = [
     "PeAudioPreTrainedModel",
     "PeAudioVideoPreTrainedModel",
     "PeVideoPreTrainedModel",
+    "CLIPTextTransformer",  # was not a PreTrainedModel originally but needs to be
+    "CLIPVisionTransformer",  # was not a PreTrainedModel originally but needs to be
+    "MetaClip2TextTransformer",  # was not a PreTrainedModel originally but needs to be
+    "MetaClip2VisionTransformer",  # was not a PreTrainedModel originally but needs to be
+    "MLCDVisionTransformer",  # was not a PreTrainedModel originally but needs to be
 ]
 
 # Update this list for models that are not tested with a comment explaining the reason it should not be.


### PR DESCRIPTION
# What does this PR do?

## The problem

Currently, `check_model_inputs` needs to iterate on all modules and monkey-patch all needed submodule's `forward` on-the-fly, before restoring them afterwards. This brings 2 big issues:

- It's NOT thread-safe (see also issue https://github.com/huggingface/transformers/issues/42673): due to the monkey patching, 2 threads running the model's forward concurrently will each try to monkey-patch the global state, resulting in undefined behavior and memory leaks in the collected outputs
- It's not efficient at all: every call to the model's `forward` need to traverse the whole model graph to monkey patch every module

Note that thread-safety is an important aspect for most simple servers, i.e. gradio spaces etc as the model then runs on different threads. So even if the `output_xxx` kwargs are somewhat niche, I believe it's an important issue that we should not overlook.

## The proposal

We can instead use forward hooks, and only activate them when needed. Coupled with `ContextVars` for thread-safety on the `collected_outputs`, this brings a much more safe, clean and efficient implementation. The idea is the following:

- install forward hooks ONCE lazily the first time we need output capture (so we only traverse the graph once) -> no monkey patching of forwards - if we never need output capture (most of the time) the hooks are NOT installed
- These hooks are dormant once installed, and are only awakened when we have the `output_xxx` kwargs
- Since the hooks need to use a global variable to collect the outputs (because we don't want to modify the signature of every module's `forward` of course), use a `ContextVar` inside the hook, so the collected outputs are thread-safe (`ContextVar` basically behaves as a thread-safe global variable and it blazingly fast)
- Since `torch.compile` does not support tracing the `get` of `ContextVar`, use a simple trick to use a simple global variable in those cases. This unfortunately means that `torch.compile` + `return_xxx` are not thread-safe, but works on single thread
- Collect outputs inside lists instead of tuples to avoid creating new objects all the time, and simply append to it

## TLDR - What is solves

|            | Need to traverse the whole graph every time | Thread-safe without compile | Thread-safe with compile |
|-------|:--------------------------------------------:|:-----------------------------:|:-------------------------:|
| Currently |    🚫   |    🚫   |   🚫   |
| This PR |    ✅   |   ✅    |    🚫   | 

## Reproduction code

<details>
<summary>memory_leak.py</summary>

```python
import threading
import time

import torch
from transformers import AutoModelForCausalLM, AutoTokenizer

model_id = "meta-llama/Llama-3.1-8B-Instruct"
device = 0
WARMUP = 3
TOKS = 100
THREADS = 2

model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.bfloat16, device_map=device, attn_implementation="eager")
tokenizer = AutoTokenizer.from_pretrained(model_id)
messages = [
    {"role": "user", "content": "What do you think about life?"},
]
inputs = tokenizer.apply_chat_template(messages, return_tensors="pt").to(device)
input_size = inputs.input_ids.shape[-1]

generation_config = dict(
    min_new_tokens=TOKS,
    max_new_tokens=TOKS,
    do_sample=False,
    eos_token_id=tokenizer.eos_token_id,
    pad_token_id=tokenizer.eos_token_id,
    output_attentions=True,
    output_hidden_states=True,
    return_dict_in_generate=True,
)

def print_memory_peak():
    peak = torch.cuda.max_memory_allocated(device) / 1024 ** 3
    print(f"Memory peak is {peak:.2f} GiB")

def run_a_few():
    t0 = time.time()
    for _ in range(WARMUP):
        output = model.generate(**inputs, **generation_config)
    dt = time.time() - t0
    print_memory_peak()

def run_indefinitely():
    while True:
        output = model.generate(**inputs, **generation_config)
        print_memory_peak()

run_a_few()


threads = []
for _ in range(THREADS):
    threads.append(threading.Thread(target=run_indefinitely))

# Start each thread
for t in threads:
    t.start()

# Wait for all threads to finish
for t in threads:
    t.join()

```

</details>

The above script shows the issue mentionned and the associated memory leak. On current main, memory keeps increasing without bounds with time. On this PR, it is solved and memory is stable.
Moreover, the output gathered are now correct compared to fully random before.

<details>
<summary>benchmark_speed.py</summary>

```python
from transformers import AutoModelForCausalLM
import numpy as np
import torch
import time

model_id = "meta-llama/Llama-3.1-8B-Instruct"
device = 0
WARMUP = 10
EXPERIENCE = 1000
INPUT_SHAPE = (2, 56)


model = AutoModelForCausalLM.from_pretrained(model_id, dtype=torch.bfloat16, device_map=device, attn_implementation="eager")

torch.manual_seed(12)
input_ids = torch.randint(10, 1000, INPUT_SHAPE, device=device)

# Warmup
tot = []
for _ in range(WARMUP):
    torch.cuda.synchronize(device)
    t0 = time.time()
    with torch.no_grad():
        out = model(input_ids, return_dict=True)
    torch.cuda.synchronize(device)
    dt = time.time() - t0
    tot.append(dt)
assert out.attentions is None
print(f"Warmup took {np.mean(tot):.2e} s")

# Actual test
tot = []
for _ in range(EXPERIENCE):
    torch.cuda.synchronize(device)
    t0 = time.time()
    with torch.no_grad():
        out = model(input_ids, return_dict=True)
    torch.cuda.synchronize(device)
    dt = time.time() - t0
    tot.append(dt)
assert out.attentions is None
print(f"Forward took {np.mean(tot):.2e} s")


# Actual test with return_xxx
tot = []
for _ in range(EXPERIENCE):
    torch.cuda.synchronize(device)
    t0 = time.time()
    with torch.no_grad():
        out = model(input_ids, return_dict=True, output_attentions=True)
    torch.cuda.synchronize(device)
    dt = time.time() - t0
    tot.append(dt)
assert out.attentions is not None
print(f"Return attention forward took {np.mean(tot):.2e} s")

```

</details>

The above script was used to benchmark the speed of both approches when using `output_xxx` or not.
Results on 1 small foward of Llama3 8B (input size (2, 56)):

|            | Without output capture | With output capture | 
|-------|:-----------------------:|:---------------------:|
| Currently |    3.37e-02 s   |     3.53e-02 s |  
| This PR |    3.33e-02 s (**1.2% faster**)|   3.41e-02 s (**3.5% faster**) |

So this PR is slightly faster in both cases.

## Note

Some models did not use the decorator correctly or very redundantly, that's why I had to perform some minimal changes on a few.
