### PR TITLE
Fix `convert_rope_params_to_dict` so it uses `rope_theta` from the config

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -630,9 +630,9 @@ class RotaryEmbeddingConfigMixin:
     default_theta = 10_000.0
 
     def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation: set | None = None, **kwargs):
-        # If `rope_scaling` was present, it will be written to `rope_parameters` automatically by `@rope_scaling.setter`
-        if self.rope_parameters is None:
-            self.rope_parameters = {}
+        rope_scaling = kwargs.pop("rope_scaling", None)
+        self.rope_parameters = rope_scaling or self.rope_parameters
+        self.rope_parameters = self.rope_parameters if self.rope_parameters is not None else {}
 
         # Standardize and validate the correctness of rotary position embeddings parameters. Priority for these parameters is:
         # 1. Values in `rope_parameters` dict (where they should be after standardization)

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -630,15 +630,21 @@ class RotaryEmbeddingConfigMixin:
     default_theta = 10_000.0
 
     def convert_rope_params_to_dict(self, ignore_keys_at_rope_validation: set | None = None, **kwargs):
-        rope_scaling = kwargs.pop("rope_scaling", None)
-        self.rope_parameters = rope_scaling or self.rope_parameters
-        self.rope_parameters = self.rope_parameters if self.rope_parameters is not None else {}
+        # If `rope_scaling` was present, it will be written to `rope_parameters` automatically by `@rope_scaling.setter`
+        if self.rope_parameters is None:
+            self.rope_parameters = {}
 
-        # Standardize and validate the correctness of rotary position embeddings parameters
-        self.rope_parameters.setdefault("rope_theta", kwargs.pop("rope_theta", self.default_theta))
+        # Standardize and validate the correctness of rotary position embeddings parameters. Priority for these parameters is:
+        # 1. Values in `rope_parameters` dict (where they should be after standardization)
+        # 2. Values in `kwargs` (i.e. it's in config.json but not MyConfig.__init__'s args)
+        # 3. Values in the config's attributes (i.e. it's in MyConfig.__init__'s args)
+        # 4. Default values (i.e. not present at all but other RoPE parameters are present)
+        rope_theta = kwargs.pop("rope_theta", getattr(self, "rope_theta", self.default_theta))
+        self.rope_parameters.setdefault("rope_theta", rope_theta)
 
-        if "partial_rotary_factor" in kwargs:
-            self.rope_parameters.setdefault("partial_rotary_factor", kwargs["partial_rotary_factor"])
+        partial_rotary_factor = kwargs.get("partial_rotary_factor", getattr(self, "partial_rotary_factor", None))
+        if partial_rotary_factor is not None:
+            self.rope_parameters.setdefault("partial_rotary_factor", partial_rotary_factor)
             ignore_keys_at_rope_validation = {"partial_rotary_factor"}
 
         self.standardize_rope_params()


### PR DESCRIPTION
`convert_rope_params_to_dict` assumes that `rope_theta` and `partial_rotary_factor` will be present in `kwargs`. This is only true if these parameters are not explicit arguments of the config class's `__init__` method.

i.e. `convert_rope_params_to_dict` will fail for a config which looks like:

```py
class MyConfig(PreTrainedConfig):
    def __init__(self, ..., rope_theta, ..., **kwargs):
        ...
        super().__init__(**kwargs)
```

All custom configs to date will look like this so this is not a safe assumption to make.

This PR updates `convert_rope_params_to_dict` so that it checks for the rope parameters in the following locations in order of priority:

1. Values in `rope_parameters` dict (where they should be after standardization)
2. Values in `kwargs` (i.e. it's in config.json but not MyConfig.__init__'s args)
3. Values in the config's attributes (i.e. it's in MyConfig.__init__'s args)
4. Default values (i.e. not present at all but other RoPE parameters are present)

It also simplifies the fallback to `{}` for `rope_parameters`.