### PR TITLE
fix(moe): normalize auxiliary loss by top_k for correct load balancing

### DIFF
--- a/src/transformers/models/dbrx/modeling_dbrx.py
+++ b/src/transformers/models/dbrx/modeling_dbrx.py
@@ -614,7 +614,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -631,8 +633,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/ernie4_5_moe/modeling_ernie4_5_moe.py
+++ b/src/transformers/models/ernie4_5_moe/modeling_ernie4_5_moe.py
@@ -624,7 +624,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -641,8 +643,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/ernie4_5_vl_moe/modeling_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/modeling_ernie4_5_vl_moe.py
@@ -1548,7 +1548,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -1565,8 +1567,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/flex_olmo/modeling_flex_olmo.py
+++ b/src/transformers/models/flex_olmo/modeling_flex_olmo.py
@@ -567,7 +567,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -584,8 +586,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
@@ -1561,7 +1561,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -1578,8 +1580,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -556,7 +556,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -573,8 +575,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/granitemoe/modeling_granitemoe.py
+++ b/src/transformers/models/granitemoe/modeling_granitemoe.py
@@ -595,7 +595,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -612,8 +614,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -1398,7 +1398,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -1415,8 +1417,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/granitemoeshared/modeling_granitemoeshared.py
+++ b/src/transformers/models/granitemoeshared/modeling_granitemoeshared.py
@@ -664,7 +664,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -681,8 +683,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -923,7 +923,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -940,8 +942,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/jetmoe/modeling_jetmoe.py
+++ b/src/transformers/models/jetmoe/modeling_jetmoe.py
@@ -718,7 +718,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -735,8 +737,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/minimax/modeling_minimax.py
+++ b/src/transformers/models/minimax/modeling_minimax.py
@@ -759,7 +759,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -776,8 +778,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/minimax_m2/modeling_minimax_m2.py
+++ b/src/transformers/models/minimax_m2/modeling_minimax_m2.py
@@ -558,7 +558,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -575,8 +577,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -552,7 +552,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -569,8 +571,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/mixtral/modular_mixtral.py
+++ b/src/transformers/models/mixtral/modular_mixtral.py
@@ -94,7 +94,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -111,8 +113,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/olmoe/modeling_olmoe.py
+++ b/src/transformers/models/olmoe/modeling_olmoe.py
@@ -575,7 +575,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -592,8 +594,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/phimoe/modeling_phimoe.py
+++ b/src/transformers/models/phimoe/modeling_phimoe.py
@@ -742,7 +742,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -759,8 +761,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
+++ b/src/transformers/models/qwen2_moe/modeling_qwen2_moe.py
@@ -588,7 +588,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -605,8 +607,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/modeling_qwen3_moe.py
@@ -579,7 +579,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -596,8 +598,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -1135,7 +1135,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -1152,8 +1154,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1903,7 +1903,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -1920,8 +1922,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -1467,7 +1467,9 @@ def load_balancing_loss_func(
 
     if attention_mask is None:
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.mean(expert_mask.float(), dim=0)
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.mean(expert_mask.float(), dim=0) / top_k
 
         # Compute the average probability of routing to these experts
         router_prob_per_expert = torch.mean(routing_weights, dim=0)
@@ -1484,8 +1486,10 @@ def load_balancing_loss_func(
         )
 
         # Compute the percentage of tokens routed to each experts
-        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / torch.sum(
-            expert_attention_mask, dim=0
+        # Normalize by top_k so that sum(f_i) = 1, matching the distribution of P_i
+        # See: https://github.com/huggingface/transformers/issues/43688
+        tokens_per_expert = torch.sum(expert_mask.float() * expert_attention_mask, dim=0) / (
+            torch.sum(expert_attention_mask, dim=0) * top_k
         )
 
         # Compute the mask that masks all padding tokens as 0 with the same shape of tokens_per_expert

--- a/tests/models/ernie4_5_moe/test_modeling_ernie4_5_moe.py
+++ b/tests/models/ernie4_5_moe/test_modeling_ernie4_5_moe.py
@@ -105,7 +105,7 @@ class Ernie4_5_MoeModelTest(CausalLMModelTest, unittest.TestCase):
         result = model(input_ids, attention_mask=attention_mask)
         bs, seqlen = input_ids.shape
         self.assertEqual(result.router_logits[0].shape, (bs * seqlen, config.num_experts))
-        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(2, dtype=torch.float32), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(1, dtype=torch.float32), rtol=1e-2, atol=1e-2)
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)

--- a/tests/models/jamba/test_modeling_jamba.py
+++ b/tests/models/jamba/test_modeling_jamba.py
@@ -421,7 +421,7 @@ class JambaModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
         bs, seqlen = input_ids.shape
         self.assertEqual(result.router_logits[0].shape, (bs * seqlen, config.num_experts))
         # After #40617, we still have 0.01 % of failure rate here.
-        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(2, dtype=torch.float32), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(1, dtype=torch.float32), rtol=1e-2, atol=1e-2)
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)

--- a/tests/models/minimax/test_modeling_minimax.py
+++ b/tests/models/minimax/test_modeling_minimax.py
@@ -80,7 +80,7 @@ class MiniMaxModelTest(CausalLMModelTest, unittest.TestCase):
         model.eval()
         result = model(input_ids, attention_mask=attention_mask)
         self.assertEqual(result.router_logits[0].shape, (91, config.num_local_experts))
-        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(2, dtype=torch.float32), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(1, dtype=torch.float32), rtol=1e-2, atol=1e-2)
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)

--- a/tests/models/minimax_m2/test_modeling_minimax_m2.py
+++ b/tests/models/minimax_m2/test_modeling_minimax_m2.py
@@ -64,7 +64,7 @@ class MiniMaxM2ModelTest(CausalLMModelTest, unittest.TestCase):
         result = model(input_ids, attention_mask=attention_mask)
         bs, seqlen = input_ids.shape
         self.assertEqual(result.router_logits[0].shape, (bs * seqlen, config.num_experts))
-        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(2, dtype=torch.float32), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(1, dtype=torch.float32), rtol=1e-2, atol=1e-2)
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -85,7 +85,7 @@ class MixtralModelTest(CausalLMModelTest, unittest.TestCase):
         model.eval()
         result = model(input_ids, attention_mask=attention_mask)
         self.assertEqual(result.router_logits[0].shape, (91, config.num_local_experts))
-        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(2, dtype=torch.float32), rtol=1e-2, atol=1e-2)
+        torch.testing.assert_close(result.aux_loss.cpu(), torch.tensor(1, dtype=torch.float32), rtol=1e-2, atol=1e-2)
 
         # First, we make sure that adding padding tokens doesn't change the loss
         # loss(input_ids, attention_mask=None) == loss(input_ids + padding, attention_mask=attention_mask_with_padding)


### PR DESCRIPTION
## Summary

Fixes #43688

The auxiliary load balancing loss in MoE models was not correctly normalized when `top_k > 1`. The `tokens_per_expert` distribution (f_i) was summing to K instead of 1, while `router_prob_per_expert` (P_i) sums to 1, making the loss calculation incorrect.

**Before (incorrect):**
```
sum(f_i) = K
sum(P_i) = 1
```

**After (correct):**
```
sum(f_i) = 1  
sum(P_i) = 1
```

## Mathematical Background

From the [Switch Transformer paper](https://huggingface.co/papers/2101.03961), the load balancing loss is:

$$L = N \cdot \sum_{i=1}^{N} f_i \cdot P_i$$

Where:
- $f_i$ = fraction of tokens routed to expert $i$
- $P_i$ = average routing probability to expert $i$

For this dot product to work correctly, both $f_i$ and $P_i$ should represent the same scale (probability distributions that sum to 1).

When using top-k routing:
- Each token picks K experts, so without normalization: $\sum f_i = K$
- Router probabilities are softmax: $\sum P_i = 1$

The fix divides `tokens_per_expert` by `top_k` to normalize the distribution.

This matches the [megablocks implementation](https://github.com/Muennighoff/megablocks/blob/4a25bc7b5665bcb9da93d72d5ad0c14d41e1a351/megablocks/layers/moe.py#L31) and the approach described in [DeepSeek-MoE](https://arxiv.org/abs/2401.06066).

## Changes

- Add `/top_k` normalization in `load_balancing_loss_func` for both attention mask and non-attention mask branches

## Affected Models

This fix is in `modular_mixtral.py` which propagates to all MoE models using the mixtral-style load balancing loss:
- OLMoE, GPT-OSS, Qwen2-MoE, Jamba, JetMoE, Phi-MoE, etc.