### PR TITLE
Refactor trainer data_collator and callbacks tests

### DIFF
--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -536,6 +536,21 @@ class TestDataCollatorForSeq2Seq(DataCollatorTestMixin, unittest.TestCase):
 
         self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -1, -1, -1])
 
+    def test_do_not_pad(self):
+        """Test DO_NOT_PAD raises on unequal lengths, works on equal."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
+
+        # Unequal lengths should raise
+        with self.assertRaises(ValueError):
+            collator(self._get_features())
+
+        # Equal lengths should work
+        features = [{"input_ids": list(range(3)), "labels": list(range(3))}] * 2
+        batch = collator(features)
+        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)))
+        self.assertEqual(batch["labels"][0].tolist(), list(range(3)))
+
     def test_without_labels(self):
         """Test collator works without labels."""
         tokenizer = BertTokenizer(self.vocab_file)
@@ -625,9 +640,53 @@ class TestDataCollatorForLanguageModeling(DataCollatorTestMixin, unittest.TestCa
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
         self.assertEqual(batch["labels"].shape, torch.Size([2, 10]))
 
-        # Check that masking occurred
+        # Check that masking occurred and non-masked tokens have -100 labels
         masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
         self.assertTrue(torch.any(masked_tokens))
+        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
+
+    def test_mlm_with_padding(self):
+        """Test MLM mode with different-length sequences requiring padding."""
+        set_seed(42)
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=True)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
+        self.assertTrue(torch.any(masked_tokens))
+        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
+
+    def test_mlm_pad_to_multiple_of(self):
+        """Test MLM mode with pad_to_multiple_of."""
+        set_seed(42)
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=True, pad_to_multiple_of=8)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 16]))
+        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
+        self.assertTrue(torch.any(masked_tokens))
+        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
+
+    def test_with_raw_list_features(self):
+        """Test LM collator with raw list features (not dicts)."""
+        tokenizer = BertTokenizer(self.vocab_file)
+
+        # CLM with raw lists
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+        features = [list(range(10)), list(range(10))]
+        batch = collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+
+        # CLM with raw lists requiring padding
+        features = [list(range(5)), list(range(10))]
+        batch = collator(features)
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
 
     def test_mlm_seed_reproducibility(self):
         """Test that masking is reproducible with seed."""
@@ -880,6 +939,42 @@ class TestDataCollatorForWholeWordMask(DataCollatorTestMixin, unittest.TestCase)
         collator3 = DataCollatorForWholeWordMask(tokenizer, seed=43, return_tensors="np")
         batch3 = collator3(features)
         self.assertFalse(np.all(batch1["input_ids"] == batch3["input_ids"]))
+
+    def test_seed_multiworker_dataloader(self):
+        """Test seed reproducibility with multi-worker DataLoader."""
+        tokenizer = BertTokenizerFast(self.vocab_file)
+        input_tokens = [f"token_{i}" for i in range(998)]
+        tokenizer.add_tokens(input_tokens)
+        features = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(10)]
+
+        dataloader1 = torch.utils.data.DataLoader(
+            features,
+            batch_size=2,
+            num_workers=2,
+            generator=torch.Generator().manual_seed(42),
+            collate_fn=DataCollatorForWholeWordMask(tokenizer, seed=42),
+        )
+        batches1 = torch.stack([batch["input_ids"] for batch in dataloader1])
+
+        dataloader2 = torch.utils.data.DataLoader(
+            features,
+            batch_size=2,
+            num_workers=2,
+            collate_fn=DataCollatorForWholeWordMask(tokenizer, seed=42),
+        )
+        batches2 = torch.stack([batch["input_ids"] for batch in dataloader2])
+
+        self.assertTrue(torch.all(batches1 == batches2))
+
+        # Different seed -> different results
+        dataloader3 = torch.utils.data.DataLoader(
+            features,
+            batch_size=2,
+            num_workers=2,
+            collate_fn=DataCollatorForWholeWordMask(tokenizer, seed=43),
+        )
+        batches3 = torch.stack([batch["input_ids"] for batch in dataloader3])
+        self.assertFalse(torch.all(batches1 == batches3))
 
     def test_numpy_output(self):
         """Test with NumPy output."""

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -11,7 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""
+Tests for data collators.
 
+Tests are organized by collator type, with each test class containing:
+- Functionality tests (PyTorch and NumPy variants)
+- Immutability tests (verifying inputs are not mutated)
+"""
+
+import copy
 import os
 import shutil
 import tempfile
@@ -41,11 +49,11 @@ if is_torch_available():
     import torch
 
 
-@require_torch
-class DataCollatorIntegrationTest(unittest.TestCase):
+class DataCollatorTestMixin:
+    """Mixin providing common setup and utility methods for data collator tests."""
+
     def setUp(self):
         self.tmpdirname = tempfile.mkdtemp()
-
         vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
         self.vocab_file = os.path.join(self.tmpdirname, "vocab.txt")
         with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
@@ -54,417 +62,590 @@ class DataCollatorIntegrationTest(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdirname)
 
-    def test_default_with_dict(self):
-        features = [{"label": i, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
+    def _check_immutability(self, collator, features):
+        """Verify that collator does not mutate input data."""
+        original = copy.deepcopy(features)
+        collator(features)
+
+        for orig, feat in zip(original, features):
+            for key in orig:
+                orig_val, feat_val = orig[key], feat[key]
+                if isinstance(orig_val, np.ndarray):
+                    self.assertEqual(orig_val.tolist(), feat_val.tolist())
+                elif is_torch_available() and isinstance(orig_val, torch.Tensor):
+                    self.assertEqual(orig_val.tolist(), feat_val.tolist())
+                else:
+                    self.assertEqual(orig_val, feat_val)
+
+
+# =============================================================================
+# default_data_collator tests
+# =============================================================================
+
+
+@require_torch
+class TestDefaultDataCollator(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for default_data_collator.
+
+    The default collator handles basic batching of dict features, converting
+    lists and arrays to tensors and properly handling labels.
+    """
+
+    def test_basic_collation(self):
+        """Test basic dict collation with lists."""
+        features = [{"label": i, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(4)]
         batch = default_data_collator(features)
-        self.assertTrue(batch["labels"].equal(torch.tensor(list(range(8)))))
-        self.assertEqual(batch["labels"].dtype, torch.long)
-        self.assertEqual(batch["inputs"].shape, torch.Size([8, 6]))
 
-        # With label_ids
-        features = [{"label_ids": [0, 1, 2], "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
+        self.assertEqual(batch["labels"].tolist(), list(range(4)))
+        self.assertEqual(batch["labels"].dtype, torch.long)
+        self.assertEqual(batch["inputs"].shape, torch.Size([4, 6]))
+
+    def test_multi_label(self):
+        """Test collation with multiple labels per sample."""
+        features = [{"label_ids": [0, 1, 2], "inputs": [0, 1, 2, 3]} for _ in range(4)]
         batch = default_data_collator(features)
-        self.assertTrue(batch["labels"].equal(torch.tensor([[0, 1, 2]] * 8)))
-        self.assertEqual(batch["labels"].dtype, torch.long)
-        self.assertEqual(batch["inputs"].shape, torch.Size([8, 6]))
 
-        # Features can already be tensors
-        features = [{"label": i, "inputs": np.random.randint(0, 10, [10])} for i in range(8)]
+        self.assertEqual(batch["labels"].tolist(), [[0, 1, 2]] * 4)
+        self.assertEqual(batch["labels"].dtype, torch.long)
+
+    def test_numpy_array_inputs(self):
+        """Test collation when features are numpy arrays."""
+        features = [{"label": i, "inputs": np.random.randint(0, 10, [10])} for i in range(4)]
         batch = default_data_collator(features)
-        self.assertTrue(batch["labels"].equal(torch.tensor(list(range(8)))))
-        self.assertEqual(batch["labels"].dtype, torch.long)
-        self.assertEqual(batch["inputs"].shape, torch.Size([8, 10]))
 
-        # Labels can already be tensors
-        features = [{"label": torch.tensor(i), "inputs": np.random.randint(0, 10, [10])} for i in range(8)]
+        self.assertEqual(batch["labels"].tolist(), list(range(4)))
+        self.assertEqual(batch["inputs"].shape, torch.Size([4, 10]))
+
+    def test_tensor_labels(self):
+        """Test collation when labels are already tensors."""
+        features = [{"label": torch.tensor(i), "inputs": [0, 1, 2]} for i in range(4)]
+        batch = default_data_collator(features)
+
+        self.assertEqual(batch["labels"].dtype, torch.long)
+        self.assertEqual(batch["labels"].tolist(), list(range(4)))
+
+    def test_dtype_inference(self):
+        """Test that int labels become long, float labels become float."""
+        # Classification: int -> long
+        features = [{"input_ids": [0, 1, 2], "label": i} for i in range(4)]
         batch = default_data_collator(features)
         self.assertEqual(batch["labels"].dtype, torch.long)
-        self.assertTrue(batch["labels"].equal(torch.tensor(list(range(8)))))
-        self.assertEqual(batch["labels"].dtype, torch.long)
-        self.assertEqual(batch["inputs"].shape, torch.Size([8, 10]))
 
-    def test_default_classification_and_regression(self):
-        data_collator = default_data_collator
-
-        features = [{"input_ids": [0, 1, 2, 3, 4], "label": i} for i in range(4)]
-        batch = data_collator(features)
-        self.assertEqual(batch["labels"].dtype, torch.long)
-
-        features = [{"input_ids": [0, 1, 2, 3, 4], "label": float(i)} for i in range(4)]
-        batch = data_collator(features)
+        # Regression: float -> float
+        features = [{"input_ids": [0, 1, 2], "label": float(i)} for i in range(4)]
+        batch = default_data_collator(features)
         self.assertEqual(batch["labels"].dtype, torch.float)
 
-    def test_default_with_no_labels(self):
-        features = [{"label": None, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
+    def test_none_labels_excluded(self):
+        """Test that None labels are excluded from batch."""
+        features = [{"label": None, "inputs": [0, 1, 2, 3]} for _ in range(4)]
         batch = default_data_collator(features)
-        self.assertTrue("labels" not in batch)
-        self.assertEqual(batch["inputs"].shape, torch.Size([8, 6]))
+        self.assertNotIn("labels", batch)
 
         # With label_ids
-        features = [{"label_ids": None, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
+        features = [{"label_ids": None, "inputs": [0, 1, 2, 3]} for _ in range(4)]
         batch = default_data_collator(features)
-        self.assertTrue("labels" not in batch)
-        self.assertEqual(batch["inputs"].shape, torch.Size([8, 6]))
+        self.assertNotIn("labels", batch)
 
-    def test_data_collator_with_padding(self):
+    def test_numpy_output(self):
+        """Test collation with NumPy output."""
+        features = [{"label": i, "inputs": [0, 1, 2, 3]} for i in range(4)]
+        batch = default_data_collator(features, return_tensors="np")
+
+        self.assertEqual(batch["labels"].tolist(), list(range(4)))
+        self.assertEqual(batch["labels"].dtype, np.int64)
+        self.assertEqual(batch["inputs"].shape, (4, 4))
+
+    def test_numpy_dtype_inference(self):
+        """Test dtype inference with NumPy output."""
+        # Int labels
+        features = [{"input_ids": [0, 1, 2], "label": i} for i in range(4)]
+        batch = default_data_collator(features, return_tensors="np")
+        self.assertEqual(batch["labels"].dtype, np.int64)
+
+        # Float labels
+        features = [{"input_ids": [0, 1, 2], "label": float(i)} for i in range(4)]
+        batch = default_data_collator(features, return_tensors="np")
+        self.assertEqual(batch["labels"].dtype, np.float32)
+
+    def test_immutability(self):
+        """Test that collation does not mutate input data."""
+        for return_tensors in ["pt", "np"]:
+            collator = lambda x, rt=return_tensors: default_data_collator(x, return_tensors=rt)
+
+            # Test with various input types
+            for features in [
+                [{"label": i, "inputs": [0, 1, 2, 3]} for i in range(4)],
+                [{"label": float(i), "inputs": [0, 1, 2, 3]} for i in range(4)],
+                [{"label": None, "inputs": [0, 1, 2, 3]} for _ in range(4)],
+                [{"label_ids": [0, 1, 2], "inputs": [0, 1, 2, 3]} for _ in range(4)],
+            ]:
+                self._check_immutability(collator, features)
+
+
+# =============================================================================
+# DataCollatorWithPadding tests
+# =============================================================================
+
+
+@require_torch
+class TestDataCollatorWithPadding(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorWithPadding.
+
+    This collator pads sequences to the same length within a batch, supporting
+    dynamic padding, max_length, and pad_to_multiple_of options.
+    """
+
+    def test_dynamic_padding(self):
+        """Test padding to longest sequence in batch."""
         tokenizer = BertTokenizer(self.vocab_file)
         features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
 
-        data_collator = DataCollatorWithPadding(tokenizer)
-        batch = data_collator(features)
+        collator = DataCollatorWithPadding(tokenizer)
+        batch = collator(features)
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
         self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
 
-        data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10)
-        batch = data_collator(features)
+    def test_max_length_padding(self):
+        """Test padding to specified max_length."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
+
+        collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10)
+        batch = collator(features)
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
 
-        data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
-        batch = data_collator(features)
+    def test_pad_to_multiple_of(self):
+        """Test padding to multiple of specified value."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
+
+        collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
+        batch = collator(features)
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
 
-    def test_data_collator_with_flattening(self):
-        features = [
+    def test_numpy_output(self):
+        """Test padding with NumPy output."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
+
+        collator = DataCollatorWithPadding(tokenizer, return_tensors="np")
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
+
+    def test_attention_mask_generated(self):
+        """Test that attention_mask is properly generated."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
+
+        collator = DataCollatorWithPadding(tokenizer)
+        batch = collator(features)
+
+        self.assertIn("attention_mask", batch)
+        self.assertEqual(batch["attention_mask"][0].tolist(), [1, 1, 1, 0, 0, 0])
+        self.assertEqual(batch["attention_mask"][1].tolist(), [1, 1, 1, 1, 1, 1])
+
+    def test_immutability(self):
+        """Test that padding does not mutate input data."""
+        tokenizer = BertTokenizer(self.vocab_file)
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorWithPadding(tokenizer, return_tensors=return_tensors)
+            features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
+            self._check_immutability(collator, features)
+
+
+# =============================================================================
+# DataCollatorWithFlattening tests
+# =============================================================================
+
+
+@require_torch
+class TestDataCollatorWithFlattening(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorWithFlattening.
+
+    This collator concatenates multiple sequences into a single sequence,
+    useful for packing multiple examples efficiently. It generates position_ids
+    that reset for each original sequence.
+    """
+
+    def _get_features(self):
+        return [
             {"input_ids": [10, 11, 12]},
             {"input_ids": [20, 21, 22, 23, 24, 25]},
             {"input_ids": [30, 31, 32, 33, 34, 35, 36]},
         ]
 
-        data_collator = DataCollatorWithFlattening(return_tensors="pt")
-        batch = data_collator(features)
-
-        for unexpected_key in [
-            "attention_mask",
-            "cu_seq_lens_k",
-            "cu_seq_lens_q",
-            "max_length_k",
-            "max_length_q",
-            "seq_idx",
-        ]:
-            self.assertNotIn(unexpected_key, batch)
-        self.assertIn("position_ids", batch)
+    def test_basic_flattening(self):
+        """Test that sequences are concatenated with per-sequence position_ids."""
+        collator = DataCollatorWithFlattening(return_tensors="pt")
+        batch = collator(self._get_features())
 
         self.assertEqual(batch["input_ids"].shape, torch.Size([1, 16]))
         self.assertEqual(
-            batch["input_ids"][0].tolist(), [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36]
+            batch["input_ids"][0].tolist(),
+            [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36],
         )
-        self.assertEqual(batch["position_ids"].shape, torch.Size([1, 16]))
         self.assertEqual(batch["position_ids"][0].tolist(), [0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6])
 
-    def test_data_collator_with_flattening_flash_attn_kwargs(self):
-        features = [
-            {"input_ids": [10, 11, 12]},
-            {"input_ids": [20, 21, 22, 23, 24, 25]},
-            {"input_ids": [30, 31, 32, 33, 34, 35, 36]},
-        ]
-        data_collator = DataCollatorWithFlattening(return_tensors="pt", return_flash_attn_kwargs=True)
-        batch = data_collator(features)
+        # Should not include attention_mask or flash attn kwargs by default
+        for key in ["attention_mask", "cu_seq_lens_k", "cu_seq_lens_q", "seq_idx"]:
+            self.assertNotIn(key, batch)
 
-        for unexpected_key in [
-            "attention_mask",
-            "seq_idx",
-        ]:
-            self.assertNotIn(unexpected_key, batch)
-        for expected_key in [
-            "position_ids",
-            "cu_seq_lens_k",
-            "cu_seq_lens_q",
-            "max_length_k",
-            "max_length_q",
-        ]:
-            self.assertIn(expected_key, batch)
+    def test_flash_attn_kwargs(self):
+        """Test flattening with Flash Attention kwargs."""
+        collator = DataCollatorWithFlattening(return_tensors="pt", return_flash_attn_kwargs=True)
+        batch = collator(self._get_features())
 
-        self.assertEqual(batch["input_ids"].shape, torch.Size([1, 16]))
-        self.assertEqual(
-            batch["input_ids"][0].tolist(), [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36]
-        )
-        self.assertEqual(batch["position_ids"].shape, torch.Size([1, 16]))
-        self.assertEqual(batch["position_ids"][0].tolist(), [0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6])
-
-        self.assertEqual(batch["cu_seq_lens_k"].shape, torch.Size([4]))
         self.assertEqual(batch["cu_seq_lens_k"].tolist(), [0, 3, 9, 16])
-        self.assertEqual(batch["cu_seq_lens_q"].shape, torch.Size([4]))
         self.assertEqual(batch["cu_seq_lens_q"].tolist(), [0, 3, 9, 16])
-        # The flash attn max_length_{k,q} are simple python ints
         self.assertEqual(batch["max_length_k"], 7)
         self.assertEqual(batch["max_length_q"], 7)
 
-    def test_data_collator_with_flattening_seq_idx(self):
-        features = [
-            {"input_ids": [10, 11, 12]},
-            {"input_ids": [20, 21, 22, 23, 24, 25]},
-            {"input_ids": [30, 31, 32, 33, 34, 35, 36]},
-        ]
-        data_collator = DataCollatorWithFlattening(return_tensors="pt", return_seq_idx=True)
-        batch = data_collator(features)
+    def test_seq_idx(self):
+        """Test flattening with seq_idx for sequence identification."""
+        collator = DataCollatorWithFlattening(return_tensors="pt", return_seq_idx=True)
+        batch = collator(self._get_features())
 
-        for unexpected_key in [
-            "attention_mask",
-            "cu_seq_lens_k",
-            "cu_seq_lens_q",
-            "max_length_k",
-            "max_length_q",
-        ]:
-            self.assertNotIn(unexpected_key, batch)
-        for expected_key in [
-            "position_ids",
-            "seq_idx",
-        ]:
-            self.assertIn(expected_key, batch)
-
-        self.assertEqual(batch["input_ids"].shape, torch.Size([1, 16]))
-        self.assertEqual(
-            batch["input_ids"][0].tolist(), [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36]
-        )
-        self.assertEqual(batch["position_ids"].shape, torch.Size([1, 16]))
-        self.assertEqual(batch["position_ids"][0].tolist(), [0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6])
-        self.assertEqual(batch["seq_idx"].shape, batch["input_ids"].shape)
         self.assertEqual(batch["seq_idx"][0].tolist(), [0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2])
 
-    def test_data_collator_for_token_classification(self):
-        tokenizer = BertTokenizer(self.vocab_file)
+    def test_with_labels(self):
+        """Test flattening with tensor and list labels."""
+        # Tensor labels
         features = [
+            {"input_ids": torch.tensor([1, 2, 3]), "labels": torch.tensor([10, 11, 12])},
+            {"input_ids": torch.tensor([4, 5]), "labels": torch.tensor([13, 14])},
+        ]
+        collator = DataCollatorWithFlattening(return_tensors="pt")
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (1, 5))
+        self.assertEqual(batch["labels"].shape, (1, 5))
+
+        # List labels
+        features = [
+            {"input_ids": [1, 2, 3], "labels": [10, 11, 12]},
+            {"input_ids": [4, 5], "labels": [13, 14]},
+        ]
+        batch = collator(features)
+        self.assertEqual(batch["labels"].shape, (1, 5))
+
+    def test_numpy_output(self):
+        """Test flattening with NumPy output."""
+        collator = DataCollatorWithFlattening(return_tensors="np")
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["input_ids"].shape, (1, 16))
+        self.assertEqual(batch["position_ids"].shape, (1, 16))
+
+    def test_numpy_flash_attn_kwargs(self):
+        """Test flattening with Flash Attention kwargs and NumPy output."""
+        collator = DataCollatorWithFlattening(return_tensors="np", return_flash_attn_kwargs=True)
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["cu_seq_lens_k"].tolist(), [0, 3, 9, 16])
+        self.assertEqual(batch["max_length_k"], 7)
+
+    def test_immutability(self):
+        """Test that flattening does not mutate input data."""
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorWithFlattening(return_tensors=return_tensors)
+            self._check_immutability(collator, self._get_features())
+
+
+# =============================================================================
+# DataCollatorForTokenClassification tests
+# =============================================================================
+
+
+@require_torch
+class TestDataCollatorForTokenClassification(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorForTokenClassification.
+
+    This collator pads both input_ids and labels for token classification tasks,
+    using -100 as the default label padding value (ignored by loss functions).
+    """
+
+    def _get_features(self):
+        return [
             {"input_ids": [0, 1, 2], "labels": [0, 1, 2]},
             {"input_ids": [0, 1, 2, 3, 4, 5], "labels": [0, 1, 2, 3, 4, 5]},
         ]
 
-        data_collator = DataCollatorForTokenClassification(tokenizer)
-        batch = data_collator(features)
+    def test_padding(self):
+        """Test that both input_ids and labels are padded correctly."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForTokenClassification(tokenizer)
+        batch = collator(self._get_features())
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
         self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
         self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-100] * 3)
+        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -100, -100, -100])
 
-        data_collator = DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10)
-        batch = data_collator(features)
+    def test_max_length_padding(self):
+        """Test padding to max_length."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10)
+        batch = collator(self._get_features())
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
         self.assertEqual(batch["labels"].shape, torch.Size([2, 10]))
 
-        data_collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8)
-        batch = data_collator(features)
+    def test_pad_to_multiple_of(self):
+        """Test padding to multiple of 8."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8)
+        batch = collator(self._get_features())
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
         self.assertEqual(batch["labels"].shape, torch.Size([2, 8]))
 
-        data_collator = DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1)
-        batch = data_collator(features)
+    def test_custom_label_pad_token(self):
+        """Test custom label padding token."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1)
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -1, -1, -1])
+
+    def test_without_labels(self):
+        """Test collator works without labels (inference mode)."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
+
+        collator = DataCollatorForTokenClassification(tokenizer)
+        batch = collator(features)
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-1] * 3)
+        self.assertNotIn("labels", batch)
 
-        for feature in features:
-            feature.pop("labels")
-
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-
-    def test_data_collator_for_token_classification_works_with_pt_tensors(self):
+    def test_with_tensor_inputs(self):
+        """Test with PyTorch tensor inputs."""
         tokenizer = BertTokenizer(self.vocab_file)
         features = [
             {"input_ids": torch.tensor([0, 1, 2]), "labels": torch.tensor([0, 1, 2])},
             {"input_ids": torch.tensor([0, 1, 2, 3, 4, 5]), "labels": torch.tensor([0, 1, 2, 3, 4, 5])},
         ]
 
-        data_collator = DataCollatorForTokenClassification(tokenizer)
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-100] * 3)
+        collator = DataCollatorForTokenClassification(tokenizer)
+        batch = collator(features)
 
-        data_collator = DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10)
-        batch = data_collator(features)
+        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -100, -100, -100])
+
+    def test_numpy_output(self):
+        """Test with NumPy output."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForTokenClassification(tokenizer, return_tensors="np")
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -100, -100, -100])
+
+    def test_immutability(self):
+        """Test that collation does not mutate input data."""
+        tokenizer = BertTokenizer(self.vocab_file)
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForTokenClassification(tokenizer, return_tensors=return_tensors)
+            self._check_immutability(collator, self._get_features())
+
+
+# =============================================================================
+# DataCollatorForSeq2Seq tests
+# =============================================================================
+
+
+@require_torch
+class TestDataCollatorForSeq2Seq(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorForSeq2Seq.
+
+    This collator handles encoder-decoder models, padding both input sequences
+    and labels (decoder input) appropriately.
+    """
+
+    def _get_features(self):
+        return [
+            {"input_ids": list(range(3)), "labels": list(range(3))},
+            {"input_ids": list(range(6)), "labels": list(range(6))},
+        ]
+
+    def test_padding(self):
+        """Test basic padding behavior."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST)
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
+        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -100, -100, -100])
+
+    def test_with_tensor_inputs(self):
+        """Test with PyTorch tensor inputs."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [
+            {"input_ids": torch.tensor(list(range(3))), "labels": torch.tensor(list(range(3)))},
+            {"input_ids": torch.tensor(list(range(6))), "labels": torch.tensor(list(range(6)))},
+        ]
+
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
+
+    def test_max_length_padding(self):
+        """Test padding to max_length."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=10)
+        batch = collator(self._get_features())
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
         self.assertEqual(batch["labels"].shape, torch.Size([2, 10]))
 
-        data_collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8)
-        batch = data_collator(features)
+    def test_pad_to_multiple_of(self):
+        """Test padding to multiple of 8."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8)
+        batch = collator(self._get_features())
+
         self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
         self.assertEqual(batch["labels"].shape, torch.Size([2, 8]))
 
-        data_collator = DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1)
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-1] * 3)
-
-        for feature in features:
-            feature.pop("labels")
-
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-
-    def _test_data_collator_for_seq2seq(self, to_torch):
-        def create_features(to_torch):
-            if to_torch:
-                features = [
-                    {"input_ids": torch.tensor(list(range(3))), "labels": torch.tensor(list(range(3)))},
-                    {"input_ids": torch.tensor(list(range(6))), "labels": torch.tensor(list(range(6)))},
-                ]
-            else:
-                features = [
-                    {"input_ids": list(range(3)), "labels": list(range(3))},
-                    {"input_ids": list(range(6)), "labels": list(range(6))},
-                ]
-            return features
-
+    def test_custom_label_pad_token(self):
+        """Test custom label padding token."""
         tokenizer = BertTokenizer(self.vocab_file)
-        features = create_features(to_torch)
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1)
+        batch = collator(self._get_features())
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST)
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 3)
-        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
+        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2, -1, -1, -1])
 
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7)
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 7]))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
-        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)) + [tokenizer.pad_token_id] * 1)
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 7]))
-        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 4)
-        self.assertEqual(batch["labels"][1].tolist(), list(range(6)) + [-100] * 1)
-
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
-        with self.assertRaises(ValueError):
-            # expects an error due to unequal shapes to create tensor
-            data_collator(features)
-        batch = data_collator([features[0], features[0]])
-        input_ids = features[0]["input_ids"] if not to_torch else features[0]["input_ids"].tolist()
-        labels = features[0]["labels"] if not to_torch else features[0]["labels"].tolist()
-        self.assertEqual(batch["input_ids"][0].tolist(), input_ids)
-        self.assertEqual(batch["input_ids"][1].tolist(), input_ids)
-        self.assertEqual(batch["labels"][0].tolist(), labels)
-        self.assertEqual(batch["labels"][1].tolist(), labels)
-
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8)
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 8]))
-
-        # side effects on labels cause mismatch on longest strategy
-        features = create_features(to_torch)
-
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1)
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
-        self.assertEqual(batch["labels"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-1] * 3)
-        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
-
-        for feature in features:
-            feature.pop("labels")
-
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
-
-    def test_data_collator_for_seq2seq_with_lists(self):
-        self._test_data_collator_for_seq2seq(to_torch=False)
-
-    def test_data_collator_for_seq2seq_with_pt(self):
-        self._test_data_collator_for_seq2seq(to_torch=True)
-
-    def _test_no_pad_and_pad(self, no_pad_features, pad_features):
+    def test_without_labels(self):
+        """Test collator works without labels."""
         tokenizer = BertTokenizer(self.vocab_file)
-        data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
+        features = [{"input_ids": list(range(3))}, {"input_ids": list(range(6))}]
 
-        batch = data_collator(pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST)
+        batch = collator(features)
 
-        data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8)
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 16)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 16)))
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 6]))
+        # Labels should either not be present or be None
+        self.assertTrue("labels" not in batch or batch["labels"] is None)
 
-        batch = data_collator(pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 16)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 16)))
-
-        tokenizer.pad_token = None
-        data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
-        with self.assertRaises(ValueError):
-            # Expect error due to padding token missing
-            data_collator(pad_features)
-
-        set_seed(42)  # For reproducibility
+    def test_numpy_output(self):
+        """Test with NumPy output."""
         tokenizer = BertTokenizer(self.vocab_file)
-        data_collator = DataCollatorForLanguageModeling(tokenizer)
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
+        collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="np")
+        batch = collator(self._get_features())
 
+        self.assertEqual(batch["input_ids"].shape, (2, 6))
+        self.assertEqual(batch["labels"].shape, (2, 6))
+
+    def test_immutability(self):
+        """Test that collation does not mutate input data."""
+        tokenizer = BertTokenizer(self.vocab_file)
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors=return_tensors)
+            self._check_immutability(collator, self._get_features())
+
+
+# =============================================================================
+# DataCollatorForLanguageModeling tests
+# =============================================================================
+
+
+@require_torch
+class TestDataCollatorForLanguageModeling(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorForLanguageModeling.
+
+    This collator supports both Masked Language Modeling (MLM) and Causal Language
+    Modeling (CLM). For MLM, it randomly masks tokens; for CLM, it shifts labels.
+    """
+
+    def test_clm_mode(self):
+        """Test CLM mode (no masking)."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 10]))
+
+    def test_clm_with_padding(self):
+        """Test CLM mode with different length sequences."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+
+    def test_clm_pad_to_multiple_of(self):
+        """Test CLM with pad_to_multiple_of."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 16]))
+
+    def test_mlm_mode(self):
+        """Test MLM mode with masking."""
+        set_seed(42)
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=True)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 10]))
+
+        # Check that masking occurred
         masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
         self.assertTrue(torch.any(masked_tokens))
-        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
 
-        batch = data_collator(pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(torch.any(masked_tokens))
-        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-        data_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 16)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 16)))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(torch.any(masked_tokens))
-        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-        batch = data_collator(pad_features)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 16)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 16)))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(torch.any(masked_tokens))
-        self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-    def test_data_collator_for_language_modeling(self):
-        no_pad_features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        pad_features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._test_no_pad_and_pad(no_pad_features, pad_features)
-
-        no_pad_features = [list(range(10)), list(range(10))]
-        pad_features = [list(range(5)), list(range(10))]
-        self._test_no_pad_and_pad(no_pad_features, pad_features)
-
-    def test_data_collator_for_language_modeling_with_seed(self):
+    def test_mlm_seed_reproducibility(self):
+        """Test that masking is reproducible with seed."""
         tokenizer = BertTokenizer(self.vocab_file)
         features = [{"input_ids": list(range(1000))}, {"input_ids": list(range(1000))}]
 
-        # check if seed is respected between two different DataCollatorForLanguageModeling instances
-        data_collator = DataCollatorForLanguageModeling(tokenizer, seed=42)
-        batch_1 = data_collator(features)
-        self.assertEqual(batch_1["input_ids"].shape, torch.Size((2, 1000)))
-        self.assertEqual(batch_1["labels"].shape, torch.Size((2, 1000)))
+        collator1 = DataCollatorForLanguageModeling(tokenizer, seed=42)
+        batch1 = collator1(features)
 
-        data_collator = DataCollatorForLanguageModeling(tokenizer, seed=42)
-        batch_2 = data_collator(features)
-        self.assertEqual(batch_2["input_ids"].shape, torch.Size((2, 1000)))
-        self.assertEqual(batch_2["labels"].shape, torch.Size((2, 1000)))
+        collator2 = DataCollatorForLanguageModeling(tokenizer, seed=42)
+        batch2 = collator2(features)
 
-        self.assertTrue(torch.all(batch_1["input_ids"] == batch_2["input_ids"]))
-        self.assertTrue(torch.all(batch_1["labels"] == batch_2["labels"]))
+        self.assertTrue(torch.all(batch1["input_ids"] == batch2["input_ids"]))
+        self.assertTrue(torch.all(batch1["labels"] == batch2["labels"]))
 
-        # check if seed is respected in multiple workers situation
+        # Different seed -> different results
+        collator3 = DataCollatorForLanguageModeling(tokenizer, seed=43)
+        batch3 = collator3(features)
+        self.assertFalse(torch.all(batch1["input_ids"] == batch3["input_ids"]))
+
+    def test_mlm_multiworker_dataloader(self):
+        """Test seed works with multi-worker DataLoader."""
+        tokenizer = BertTokenizer(self.vocab_file)
         features = [{"input_ids": list(range(1000))} for _ in range(10)]
+
         dataloader = torch.utils.data.DataLoader(
             features,
             batch_size=2,
@@ -473,1547 +654,434 @@ class DataCollatorIntegrationTest(unittest.TestCase):
             collate_fn=DataCollatorForLanguageModeling(tokenizer, seed=42),
         )
 
-        batch_3_input_ids = []
-        batch_3_labels = []
-        for batch in dataloader:
-            batch_3_input_ids.append(batch["input_ids"])
-            batch_3_labels.append(batch["labels"])
+        batches = [batch["input_ids"] for batch in dataloader]
+        result = torch.stack(batches)
+        self.assertEqual(result.shape, torch.Size([5, 2, 1000]))
 
-        batch_3_input_ids = torch.stack(batch_3_input_ids)
-        batch_3_labels = torch.stack(batch_3_labels)
-        self.assertEqual(batch_3_input_ids.shape, torch.Size((5, 2, 1000)))
-        self.assertEqual(batch_3_labels.shape, torch.Size((5, 2, 1000)))
-
-        dataloader = torch.utils.data.DataLoader(
-            features,
-            batch_size=2,
-            num_workers=2,
-            collate_fn=DataCollatorForLanguageModeling(tokenizer, seed=42),
-        )
-
-        batch_4_input_ids = []
-        batch_4_labels = []
-        for batch in dataloader:
-            batch_4_input_ids.append(batch["input_ids"])
-            batch_4_labels.append(batch["labels"])
-        batch_4_input_ids = torch.stack(batch_4_input_ids)
-        batch_4_labels = torch.stack(batch_4_labels)
-        self.assertEqual(batch_4_input_ids.shape, torch.Size((5, 2, 1000)))
-        self.assertEqual(batch_4_labels.shape, torch.Size((5, 2, 1000)))
-
-        self.assertTrue(torch.all(batch_3_input_ids == batch_4_input_ids))
-        self.assertTrue(torch.all(batch_3_labels == batch_4_labels))
-
-        # try with different seed
-        dataloader = torch.utils.data.DataLoader(
-            features,
-            batch_size=2,
-            num_workers=2,
-            collate_fn=DataCollatorForLanguageModeling(tokenizer, seed=43),
-        )
-
-        batch_5_input_ids = []
-        batch_5_labels = []
-        for batch in dataloader:
-            batch_5_input_ids.append(batch["input_ids"])
-            batch_5_labels.append(batch["labels"])
-        batch_5_input_ids = torch.stack(batch_5_input_ids)
-        batch_5_labels = torch.stack(batch_5_labels)
-        self.assertEqual(batch_5_input_ids.shape, torch.Size((5, 2, 1000)))
-        self.assertEqual(batch_5_labels.shape, torch.Size((5, 2, 1000)))
-
-        self.assertFalse(torch.all(batch_3_input_ids == batch_5_input_ids))
-        self.assertFalse(torch.all(batch_3_labels == batch_5_labels))
-
-    def test_data_collator_for_whole_word_mask(self):
-        tokenizer = BertTokenizerFast(self.vocab_file)
-
-        input_tokens = [f"token_{i}" for i in range(8)]
-        tokenizer.add_tokens(input_tokens)
-        features = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
-
-        data_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
-
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        # Features can already be tensors
-        features = [
-            tokenizer(" ".join(input_tokens), return_offsets_mapping=True).convert_to_tensors("np") for _ in range(2)
-        ]
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        if is_torch_available():
-            # Features can already be tensors
-            features = [
-                tokenizer(" ".join(input_tokens), return_offsets_mapping=True).convert_to_tensors("pt")
-                for _ in range(2)
-            ]
-            data_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
-            batch = data_collator(features)
-            self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-            self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
-
-    def test_data_collator_for_whole_word_mask_with_seed(self):
-        tokenizer = BertTokenizerFast(self.vocab_file)
-
-        input_tokens = [f"token_{i}" for i in range(998)]
-        tokenizer.add_tokens(input_tokens)
-        features = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
-
-        # check if seed is respected between two different DataCollatorForWholeWordMask instances
-        data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="np")
-        batch_1 = data_collator(features)
-        self.assertEqual(batch_1["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_1["labels"].shape, (2, 1000))
-
-        data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="np")
-        batch_2 = data_collator(features)
-        self.assertEqual(batch_2["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_2["labels"].shape, (2, 1000))
-
-        self.assertTrue(np.all(batch_1["input_ids"] == batch_2["input_ids"]))
-        self.assertTrue(np.all(batch_1["labels"] == batch_2["labels"]))
-
-        # check if seed is respected in multiple workers situation
-        if is_torch_available():
-            features = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(10)]
-            dataloader = torch.utils.data.DataLoader(
-                features,
-                batch_size=2,
-                num_workers=2,
-                generator=torch.Generator().manual_seed(42),
-                collate_fn=DataCollatorForWholeWordMask(tokenizer, seed=42),
-            )
-
-            batch_3_input_ids = []
-            batch_3_labels = []
-            for batch in dataloader:
-                batch_3_input_ids.append(batch["input_ids"])
-                batch_3_labels.append(batch["labels"])
-
-            batch_3_input_ids = torch.stack(batch_3_input_ids)
-            batch_3_labels = torch.stack(batch_3_labels)
-            self.assertEqual(batch_3_input_ids.shape, torch.Size((5, 2, 1000)))
-            self.assertEqual(batch_3_labels.shape, torch.Size((5, 2, 1000)))
-
-            dataloader = torch.utils.data.DataLoader(
-                features,
-                batch_size=2,
-                num_workers=2,
-                collate_fn=DataCollatorForWholeWordMask(tokenizer, seed=42),
-            )
-
-            batch_4_input_ids = []
-            batch_4_labels = []
-            for batch in dataloader:
-                batch_4_input_ids.append(batch["input_ids"])
-                batch_4_labels.append(batch["labels"])
-            batch_4_input_ids = torch.stack(batch_4_input_ids)
-            batch_4_labels = torch.stack(batch_4_labels)
-            self.assertEqual(batch_4_input_ids.shape, torch.Size((5, 2, 1000)))
-            self.assertEqual(batch_4_labels.shape, torch.Size((5, 2, 1000)))
-
-            self.assertTrue(torch.all(batch_3_input_ids == batch_4_input_ids))
-            self.assertTrue(torch.all(batch_3_labels == batch_4_labels))
-
-            # try with different seed
-            dataloader = torch.utils.data.DataLoader(
-                features,
-                batch_size=2,
-                num_workers=2,
-                collate_fn=DataCollatorForWholeWordMask(tokenizer, seed=43),
-            )
-
-            batch_5_input_ids = []
-            batch_5_labels = []
-            for batch in dataloader:
-                batch_5_input_ids.append(batch["input_ids"])
-                batch_5_labels.append(batch["labels"])
-            batch_5_input_ids = torch.stack(batch_5_input_ids)
-            batch_5_labels = torch.stack(batch_5_labels)
-            self.assertEqual(batch_5_input_ids.shape, torch.Size((5, 2, 1000)))
-            self.assertEqual(batch_5_labels.shape, torch.Size((5, 2, 1000)))
-
-            self.assertFalse(torch.all(batch_3_input_ids == batch_5_input_ids))
-            self.assertFalse(torch.all(batch_3_labels == batch_5_labels))
-
-    def test_plm(self):
+    def test_missing_pad_token_error(self):
+        """Test error when pad token is missing and padding is needed."""
         tokenizer = BertTokenizer(self.vocab_file)
-        no_pad_features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        pad_features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
+        tokenizer.pad_token = None
+        features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
 
-        data_collator = DataCollatorForPermutationLanguageModeling(tokenizer)
-
-        batch = data_collator(pad_features)
-        self.assertIsInstance(batch, dict)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-        self.assertEqual(batch["perm_mask"].shape, torch.Size((2, 10, 10)))
-        self.assertEqual(batch["target_mapping"].shape, torch.Size((2, 10, 10)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
-
-        batch = data_collator(no_pad_features)
-        self.assertIsInstance(batch, dict)
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
-        self.assertEqual(batch["perm_mask"].shape, torch.Size((2, 10, 10)))
-        self.assertEqual(batch["target_mapping"].shape, torch.Size((2, 10, 10)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 10)))
-
-        example = [np.random.randint(0, 5, [5])]
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
         with self.assertRaises(ValueError):
-            # Expect error due to odd sequence length
-            data_collator(example)
+            collator(features)
 
-    def test_nsp(self):
+    def test_numpy_output(self):
+        """Test with NumPy output."""
         tokenizer = BertTokenizer(self.vocab_file)
-        features = [
-            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
-            for i in range(2)
-        ]
-        data_collator = DataCollatorForLanguageModeling(tokenizer)
-        batch = data_collator(features)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
 
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 5)))
-        self.assertEqual(batch["token_type_ids"].shape, torch.Size((2, 5)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 5)))
-        self.assertEqual(batch["next_sentence_label"].shape, torch.Size((2,)))
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="np")
+        batch = collator(features)
 
-        data_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        batch = data_collator(features)
+        self.assertEqual(batch["input_ids"].shape, (2, 10))
+        self.assertEqual(batch["labels"].shape, (2, 10))
 
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 8)))
-        self.assertEqual(batch["token_type_ids"].shape, torch.Size((2, 8)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 8)))
-        self.assertEqual(batch["next_sentence_label"].shape, torch.Size((2,)))
-
-    def test_sop(self):
+    def test_numpy_mlm(self):
+        """Test MLM mode with NumPy output."""
+        set_seed(42)
         tokenizer = BertTokenizer(self.vocab_file)
-        features = [
-            {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "sentence_order_label": i,
-            }
-            for i in range(2)
-        ]
-        data_collator = DataCollatorForLanguageModeling(tokenizer)
-        batch = data_collator(features)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
 
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 5)))
-        self.assertEqual(batch["token_type_ids"].shape, torch.Size((2, 5)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 5)))
-        self.assertEqual(batch["sentence_order_label"].shape, torch.Size((2,)))
+        collator = DataCollatorForLanguageModeling(tokenizer, mlm=True, return_tensors="np")
+        batch = collator(features)
 
-        data_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        batch = data_collator(features)
+        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
+        self.assertTrue(np.any(masked_tokens))
 
-        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 8)))
-        self.assertEqual(batch["token_type_ids"].shape, torch.Size((2, 8)))
-        self.assertEqual(batch["labels"].shape, torch.Size((2, 8)))
-        self.assertEqual(batch["sentence_order_label"].shape, torch.Size((2,)))
+    def test_immutability(self):
+        """Test that collation does not mutate input data."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors=return_tensors)
+            self._check_immutability(collator, copy.deepcopy(features))
+
+    # -------------------- Unit tests for internal methods --------------------
+
+    def test_calc_word_ids_and_prob_mask(self):
+        """Test word ID assignment and probability mask generation."""
+        offsets = np.array([
+            [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (8, 9)],
+            [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (0, 0)],
+            [(0, 0), (0, 3), (3, 4), (0, 0), (6, 7), (0, 0)],
+            [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)],
+            [(1, 1), (2, 2), (3, 4), (5, 6), (7, 8), (9, 10)],
+            [(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0)],
+        ])
+
+        special_tokens_mask = np.array([
+            [1, 0, 0, 0, 0, 0],
+            [1, 0, 0, 0, 0, 1],
+            [1, 0, 0, 1, 0, 1],
+            [0, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1],
+        ])
+
+        word_ids, prob_mask = DataCollatorForLanguageModeling._calc_word_ids_and_prob_mask(offsets, special_tokens_mask)
+
+        expected_word_ids = np.array([
+            [-1, 1, 1, 2, 2, 3],
+            [-1, 1, 1, 2, 2, -1],
+            [-1, 1, 1, -1, 2, -1],
+            [1, 1, 1, 1, 1, 1],
+            [1, 2, 3, 4, 5, 6],
+            [-1, -1, -1, -1, -1, -1],
+        ])
+
+        expected_prob_mask = np.array([
+            [1, 0, 1, 0, 1, 0],
+            [1, 0, 1, 0, 1, 1],
+            [1, 0, 1, 1, 0, 1],
+            [0, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0],
+            [1, 1, 1, 1, 1, 1],
+        ])
+
+        np.testing.assert_array_equal(word_ids, expected_word_ids)
+        np.testing.assert_array_equal(prob_mask, expected_prob_mask)
+
+    def test_whole_word_mask_internal(self):
+        """Test mask expansion to cover all subword tokens of masked words."""
+        word_ids = np.array([
+            [-1, 1, 1, 2, 2, 3],
+            [-1, 1, 1, 2, 2, -1],
+            [-1, 1, 1, -1, 2, -1],
+            [1, 1, 1, 1, 1, 1],
+            [1, 2, 3, 4, 5, 6],
+            [1, 2, 3, 4, 5, 6],
+            [-1, -1, -1, -1, -1, -1],
+        ])
+
+        mask = np.array([
+            [0, 1, 0, 0, 0, 0],
+            [0, 1, 0, 1, 0, 0],
+            [0, 0, 0, 0, 1, 0],
+            [1, 0, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 1, 0, 1],
+            [0, 0, 0, 0, 0, 0],
+        ]).astype(bool)
+
+        output = DataCollatorForLanguageModeling._whole_word_mask(word_ids, mask)
+
+        expected = np.array([
+            [0, 1, 1, 0, 0, 0],
+            [0, 1, 1, 1, 1, 0],
+            [0, 0, 0, 0, 1, 0],
+            [1, 1, 1, 1, 1, 1],
+            [0, 0, 0, 0, 0, 0],
+            [0, 1, 0, 1, 0, 1],
+            [0, 0, 0, 0, 0, 0],
+        ]).astype(bool)
+
+        np.testing.assert_array_equal(output, expected)
+
+
+# =============================================================================
+# DataCollatorForWholeWordMask tests
+# =============================================================================
 
 
 @require_torch
-class DataCollatorImmutabilityTest(unittest.TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
+class TestDataCollatorForWholeWordMask(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorForWholeWordMask.
 
-        vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
-        self.vocab_file = os.path.join(self.tmpdirname, "vocab.txt")
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
-            vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
+    This collator extends MLM to ensure that when a token is masked, all other
+    tokens from the same word are also masked (whole word masking).
+    """
 
-    def tearDown(self):
-        shutil.rmtree(self.tmpdirname)
-
-    def _turn_to_none(self, item):
-        """used to convert `item` to `None` type"""
-        return None
-
-    def _validate_original_data_against_collated_data(self, collator, original_data, batch_data):
-        # we only care about side effects, the results are tested elsewhere
-        collator(batch_data)
-
-        # we go through every item and convert to `primitive` datatypes if necessary
-        # then compares for equivalence for the original data and the data that has been passed through the collator
-        for original, batch in zip(original_data, batch_data):
-            for original_val, batch_val in zip(original.values(), batch.values()):
-                if isinstance(original_val, (np.ndarray, torch.Tensor)):
-                    self.assertEqual(original_val.tolist(), batch_val.tolist())
-                else:
-                    self.assertEqual(original_val, batch_val)
-
-    def _validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-        self, collator, base_data, input_key, input_datatype, label_key, label_datatype, ignore_label=False
-    ):
-        # using the arguments to recreate the features with their respective (potentially new) datatypes
-        features_original = [
-            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
-            for sample in base_data
-        ]
-        features_batch = [
-            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
-            for sample in base_data
-        ]
-
-        # some collators do not use labels, or sometimes we want to check if the collator with labels can handle such cases
-        if ignore_label:
-            for original, batch in zip(features_original, features_batch):
-                original.pop(label_key)
-                batch.pop(label_key)
-
-        self._validate_original_data_against_collated_data(
-            collator=collator, original_data=features_original, batch_data=features_batch
-        )
-
-    def test_default_collator_immutability(self):
-        features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
-        features_base_multiple_labels = [{"label": (0, 1, 2), "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
-
-        for datatype_input, datatype_label in [
-            (list, int),
-            (list, float),
-            (np.array, int),
-            (np.array, torch.tensor),
-            (list, self._turn_to_none),
-        ]:
-            self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=default_data_collator,
-                base_data=features_base_single_label,
-                input_key="inputs",
-                input_datatype=datatype_input,
-                label_key="label",
-                label_datatype=datatype_label,
-            )
-
-        for datatype_input, datatype_label in [(list, list), (list, self._turn_to_none)]:
-            self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=default_data_collator,
-                base_data=features_base_multiple_labels,
-                input_key="inputs",
-                input_datatype=datatype_input,
-                label_key="label",
-                label_datatype=datatype_label,
-            )
-
-        features_base_single_label_alt = [{"input_ids": (0, 1, 2, 3, 4), "label": float(i)} for i in range(4)]
-        self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=default_data_collator,
-            base_data=features_base_single_label_alt,
-            input_key="input_ids",
-            input_datatype=list,
-            label_key="label",
-            label_datatype=float,
-        )
-
-    def test_with_padding_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_original = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
-        features_batch = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
-
-        data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10)
-        self._validate_original_data_against_collated_data(
-            collator=data_collator, original_data=features_original, batch_data=features_batch
-        )
-
-        data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8)
-        self._validate_original_data_against_collated_data(
-            collator=data_collator, original_data=features_original, batch_data=features_batch
-        )
-
-    def test_for_token_classification_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_base = [
-            {"input_ids": (0, 1, 2), "labels": (0, 1, 2)},
-            {"input_ids": (0, 1, 2, 3, 4, 5), "labels": (0, 1, 2, 3, 4, 5)},
-        ]
-        token_classification_collators = [
-            DataCollatorForTokenClassification(tokenizer),
-            DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10),
-            DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8),
-            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1),
-        ]
-
-        for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
-            for collator in token_classification_collators:
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                )
-
-        self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=token_classification_collators[-1],
-            base_data=features_base,
-            input_key="input_ids",
-            input_datatype=datatype_input,
-            label_key="labels",
-            label_datatype=datatype_label,
-            ignore_label=True,
-        )
-
-    def test_seq2seq_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_base = [
-            {"input_ids": list(range(3)), "labels": list(range(3))},
-            {"input_ids": list(range(6)), "labels": list(range(6))},
-        ]
-        seq2seq_collators = [
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1),
-        ]
-
-        for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
-            for collator in seq2seq_collators:
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                )
-
-        self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=seq2seq_collators[-1],
-            base_data=features_base,
-            input_key="input_ids",
-            input_datatype=datatype_input,
-            label_key="labels",
-            label_datatype=datatype_label,
-            ignore_label=True,
-        )
-
-        features_base_no_pad = [
-            {"input_ids": list(range(3)), "labels": list(range(3))},
-            {"input_ids": list(range(3)), "labels": list(range(3))},
-        ]
-        seq2seq_no_padding_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD)
-        for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
-            self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=seq2seq_no_padding_collator,
-                base_data=features_base_no_pad,
-                input_key="input_ids",
-                input_datatype=datatype_input,
-                label_key="labels",
-                label_datatype=datatype_label,
-            )
-
-    def test_language_modelling_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_base_no_pad = [
-            {"input_ids": tuple(range(10)), "labels": (1,)},
-            {"input_ids": tuple(range(10)), "labels": (1,)},
-        ]
-        features_base_pad = [
-            {"input_ids": tuple(range(5)), "labels": (1,)},
-            {"input_ids": tuple(range(5)), "labels": (1,)},
-        ]
-        lm_collators = [
-            DataCollatorForLanguageModeling(tokenizer, mlm=False),
-            DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8),
-            DataCollatorForLanguageModeling(tokenizer),
-            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8),
-        ]
-
-        for datatype_input, datatype_label in [(list, list), (torch.tensor, torch.tensor)]:
-            for collator in lm_collators:
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base_no_pad,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                    ignore_label=True,
-                )
-
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base_pad,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                    ignore_label=True,
-                )
-
-    def test_whole_world_masking_collator_immutability(self):
+    def _get_tokenizer_and_features(self):
         tokenizer = BertTokenizerFast(self.vocab_file)
-
-        input_tokens = [f"token_{i}" for i in range(8)]
-        tokenizer.add_tokens(input_tokens)
-        original_data = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
-        for feature in original_data:
-            feature["labels"] = (1,)
-
-        batch_data = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
-        for feature in batch_data:
-            feature["labels"] = (1,)
-
-        whole_word_masking_collator = DataCollatorForWholeWordMask(tokenizer)
-
-        self._validate_original_data_against_collated_data(
-            collator=whole_word_masking_collator, original_data=original_data, batch_data=batch_data
-        )
-
-    def test_permutation_language_modelling_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        plm_collator = DataCollatorForPermutationLanguageModeling(tokenizer)
-
-        no_pad_features_original = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        no_pad_features_batch = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(
-            collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch
-        )
-
-        pad_features_original = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        pad_features_batch = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(
-            collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch
-        )
-
-    def test_next_sentence_prediction_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_original = [
-            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
-            for i in range(2)
-        ]
-        features_batch = [
-            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
-            for i in range(2)
-        ]
-
-        nsp_collator = DataCollatorForLanguageModeling(tokenizer)
-        self._validate_original_data_against_collated_data(
-            collator=nsp_collator, original_data=features_original, batch_data=features_batch
-        )
-
-        nsp_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        self._validate_original_data_against_collated_data(
-            collator=nsp_collator, original_data=features_original, batch_data=features_batch
-        )
-
-    def test_sentence_order_prediction_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_original = [
-            {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "sentence_order_label": i,
-            }
-            for i in range(2)
-        ]
-        features_batch = [
-            {
-                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
-                "sentence_order_label": i,
-            }
-            for i in range(2)
-        ]
-
-        sop_collator = DataCollatorForLanguageModeling(tokenizer)
-        self._validate_original_data_against_collated_data(
-            collator=sop_collator, original_data=features_original, batch_data=features_batch
-        )
-
-        sop_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
-        self._validate_original_data_against_collated_data(
-            collator=sop_collator, original_data=features_original, batch_data=features_batch
-        )
-
-
-class NumpyDataCollatorIntegrationTest(unittest.TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
-
-        vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
-        self.vocab_file = os.path.join(self.tmpdirname, "vocab.txt")
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
-            vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdirname)
-
-    def test_default_with_dict(self):
-        features = [{"label": i, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
-        batch = default_data_collator(features, return_tensors="np")
-        self.assertEqual(batch["labels"].tolist(), list(range(8)))
-        self.assertEqual(batch["labels"].dtype, np.int64)
-        self.assertEqual(batch["inputs"].shape, (8, 6))
-
-        # With label_ids
-        features = [{"label_ids": [0, 1, 2], "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
-        batch = default_data_collator(features, return_tensors="np")
-        self.assertEqual(batch["labels"].tolist(), [[0, 1, 2]] * 8)
-        self.assertEqual(batch["labels"].dtype, np.int64)
-        self.assertEqual(batch["inputs"].shape, (8, 6))
-
-        # Features can already be tensors
-        features = [{"label": i, "inputs": np.random.randint(0, 10, [10])} for i in range(8)]
-        batch = default_data_collator(features, return_tensors="np")
-        self.assertEqual(batch["labels"].tolist(), list(range(8)))
-        self.assertEqual(batch["labels"].dtype, np.int64)
-        self.assertEqual(batch["inputs"].shape, (8, 10))
-
-        # Labels can already be tensors
-        features = [{"label": np.array(i), "inputs": np.random.randint(0, 10, [10])} for i in range(8)]
-        batch = default_data_collator(features, return_tensors="np")
-        self.assertEqual(batch["labels"].dtype, np.int64)
-        self.assertEqual(batch["labels"].tolist(), (list(range(8))))
-        self.assertEqual(batch["labels"].dtype, np.int64)
-        self.assertEqual(batch["inputs"].shape, (8, 10))
-
-    def test_default_classification_and_regression(self):
-        data_collator = default_data_collator
-
-        features = [{"input_ids": [0, 1, 2, 3, 4], "label": i} for i in range(4)]
-        batch = data_collator(features, return_tensors="np")
-        self.assertEqual(batch["labels"].dtype, np.int64)
-
-        features = [{"input_ids": [0, 1, 2, 3, 4], "label": float(i)} for i in range(4)]
-        batch = data_collator(features, return_tensors="np")
-        self.assertEqual(batch["labels"].dtype, np.float32)
-
-    def test_default_with_no_labels(self):
-        features = [{"label": None, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
-        batch = default_data_collator(features, return_tensors="np")
-        self.assertTrue("labels" not in batch)
-        self.assertEqual(batch["inputs"].shape, (8, 6))
-
-        # With label_ids
-        features = [{"label_ids": None, "inputs": [0, 1, 2, 3, 4, 5]} for i in range(8)]
-        batch = default_data_collator(features, return_tensors="np")
-        self.assertTrue("labels" not in batch)
-        self.assertEqual(batch["inputs"].shape, (8, 6))
-
-    def test_data_collator_with_padding(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-        features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
-
-        data_collator = DataCollatorWithPadding(tokenizer, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 6))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-
-        data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-
-        data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 8))
-
-    def test_data_collator_with_flattening(self):
-        features = [
-            {"input_ids": [10, 11, 12]},
-            {"input_ids": [20, 21, 22, 23, 24, 25]},
-            {"input_ids": [30, 31, 32, 33, 34, 35, 36]},
-        ]
-
-        data_collator = DataCollatorWithFlattening(return_tensors="np")
-        batch = data_collator(features)
-
-        for unexpected_key in [
-            "attention_mask",
-            "cu_seq_lens_k",
-            "cu_seq_lens_q",
-            "max_length_k",
-            "max_length_q",
-            "seq_idx",
-        ]:
-            self.assertNotIn(unexpected_key, batch)
-        self.assertIn("position_ids", batch)
-
-        self.assertEqual(batch["input_ids"].shape, (1, 16))
-        self.assertEqual(
-            batch["input_ids"][0].tolist(), [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36]
-        )
-        self.assertEqual(batch["position_ids"].shape, (1, 16))
-        self.assertEqual(batch["position_ids"][0].tolist(), [0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6])
-
-    def test_data_collator_with_flattening_flash_attn_kwargs(self):
-        features = [
-            {"input_ids": [10, 11, 12]},
-            {"input_ids": [20, 21, 22, 23, 24, 25]},
-            {"input_ids": [30, 31, 32, 33, 34, 35, 36]},
-        ]
-
-        data_collator = DataCollatorWithFlattening(return_tensors="np", return_flash_attn_kwargs=True)
-        batch = data_collator(features)
-
-        for unexpected_key in [
-            "attention_mask",
-            "seq_idx",
-        ]:
-            self.assertNotIn(unexpected_key, batch)
-        for expected_key in [
-            "position_ids",
-            "cu_seq_lens_k",
-            "cu_seq_lens_q",
-            "max_length_k",
-            "max_length_q",
-        ]:
-            self.assertIn(expected_key, batch)
-
-        self.assertEqual(batch["input_ids"].shape, (1, 16))
-        self.assertEqual(
-            batch["input_ids"][0].tolist(), [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36]
-        )
-        self.assertEqual(batch["position_ids"].shape, (1, 16))
-        self.assertEqual(batch["position_ids"][0].tolist(), [0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6])
-
-        self.assertEqual(batch["cu_seq_lens_k"].shape, (4,))
-        self.assertEqual(batch["cu_seq_lens_k"].tolist(), [0, 3, 9, 16])
-        self.assertEqual(batch["cu_seq_lens_q"].shape, (4,))
-        self.assertEqual(batch["cu_seq_lens_q"].tolist(), [0, 3, 9, 16])
-        # The flash attn max_length_{k,q} are simple python ints
-        self.assertEqual(batch["max_length_k"], 7)
-        self.assertEqual(batch["max_length_q"], 7)
-
-    def test_data_collator_with_flattening_seq_idx(self):
-        features = [
-            {"input_ids": [10, 11, 12]},
-            {"input_ids": [20, 21, 22, 23, 24, 25]},
-            {"input_ids": [30, 31, 32, 33, 34, 35, 36]},
-        ]
-
-        data_collator = DataCollatorWithFlattening(return_tensors="np", return_seq_idx=True)
-        batch = data_collator(features)
-
-        for unexpected_key in [
-            "attention_mask",
-            "cu_seq_lens_k",
-            "cu_seq_lens_q",
-            "max_length_k",
-            "max_length_q",
-        ]:
-            self.assertNotIn(unexpected_key, batch)
-        for expected_key in [
-            "position_ids",
-            "seq_idx",
-        ]:
-            self.assertIn(expected_key, batch)
-
-        self.assertEqual(batch["input_ids"].shape, (1, 16))
-        self.assertEqual(
-            batch["input_ids"][0].tolist(), [10, 11, 12, 20, 21, 22, 23, 24, 25, 30, 31, 32, 33, 34, 35, 36]
-        )
-        self.assertEqual(batch["position_ids"].shape, (1, 16))
-        self.assertEqual(batch["position_ids"][0].tolist(), [0, 1, 2, 0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5, 6])
-        self.assertEqual(batch["seq_idx"].shape, batch["input_ids"].shape)
-        self.assertEqual(batch["seq_idx"][0].tolist(), [0, 0, 0, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2])
-
-    def test_data_collator_for_token_classification(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-        features = [
-            {"input_ids": [0, 1, 2], "labels": [0, 1, 2]},
-            {"input_ids": [0, 1, 2, 3, 4, 5], "labels": [0, 1, 2, 3, 4, 5]},
-        ]
-
-        data_collator = DataCollatorForTokenClassification(tokenizer, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 6))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["labels"].shape, (2, 6))
-        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-100] * 3)
-
-        data_collator = DataCollatorForTokenClassification(
-            tokenizer, padding="max_length", max_length=10, return_tensors="np"
-        )
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        data_collator = DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 8))
-        self.assertEqual(batch["labels"].shape, (2, 8))
-
-        data_collator = DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 6))
-        self.assertEqual(batch["input_ids"][0].tolist(), [0, 1, 2] + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["labels"].shape, (2, 6))
-        self.assertEqual(batch["labels"][0].tolist(), [0, 1, 2] + [-1] * 3)
-
-    def test_data_collator_for_seq2seq(self):
-        def create_features():
-            return [
-                {"input_ids": list(range(3)), "labels": list(range(3))},
-                {"input_ids": list(range(6)), "labels": list(range(6))},
-            ]
-
-        tokenizer = BertTokenizer(self.vocab_file)
-        features = create_features()
-
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="np")
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 6))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
-        self.assertEqual(batch["labels"].shape, (2, 6))
-        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 3)
-        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
-
-        data_collator = DataCollatorForSeq2Seq(
-            tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="np"
-        )
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 7))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 4)
-        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)) + [tokenizer.pad_token_id] * 1)
-        self.assertEqual(batch["labels"].shape, (2, 7))
-        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-100] * 4)
-        self.assertEqual(batch["labels"][1].tolist(), list(range(6)) + [-100] * 1)
-
-        data_collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="np")
-        # numpy doesn't have issues handling unequal shapes via `dtype=object`
-        # with self.assertRaises(ValueError):
-        #     data_collator(features)
-        batch = data_collator([features[0], features[0]])
-        self.assertEqual(batch["input_ids"][0].tolist(), features[0]["input_ids"])
-        self.assertEqual(batch["input_ids"][1].tolist(), features[0]["input_ids"])
-        self.assertEqual(batch["labels"][0].tolist(), features[0]["labels"])
-        self.assertEqual(batch["labels"][1].tolist(), features[0]["labels"])
-
-        data_collator = DataCollatorForSeq2Seq(
-            tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np"
-        )
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 8))
-        self.assertEqual(batch["labels"].shape, (2, 8))
-
-        # side effects on labels cause mismatch on longest strategy
-        features = create_features()
-
-        data_collator = DataCollatorForSeq2Seq(
-            tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np"
-        )
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 6))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
-        self.assertEqual(batch["input_ids"][1].tolist(), list(range(6)))
-        self.assertEqual(batch["labels"].shape, (2, 6))
-        self.assertEqual(batch["labels"][0].tolist(), list(range(3)) + [-1] * 3)
-        self.assertEqual(batch["labels"][1].tolist(), list(range(6)))
-
-        for feature in features:
-            feature.pop("labels")
-
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 6))
-        self.assertEqual(batch["input_ids"][0].tolist(), list(range(3)) + [tokenizer.pad_token_id] * 3)
-
-    def _test_no_pad_and_pad(self, no_pad_features, pad_features):
-        tokenizer = BertTokenizer(self.vocab_file)
-        data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="np")
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        batch = data_collator(pad_features, return_tensors="np")
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        data_collator = DataCollatorForLanguageModeling(
-            tokenizer, mlm=False, pad_to_multiple_of=8, return_tensors="np"
-        )
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, (2, 16))
-        self.assertEqual(batch["labels"].shape, (2, 16))
-
-        batch = data_collator(pad_features, return_tensors="np")
-        self.assertEqual(batch["input_ids"].shape, (2, 16))
-        self.assertEqual(batch["labels"].shape, (2, 16))
-
-        tokenizer.pad_token = None
-        data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="np")
-        with self.assertRaises(ValueError):
-            # Expect error due to padding token missing
-            data_collator(pad_features)
-
-        set_seed(42)  # For reproducibility
-        tokenizer = BertTokenizer(self.vocab_file)
-        data_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(np.any(masked_tokens))
-        # self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-        batch = data_collator(pad_features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(np.any(masked_tokens))
-        # self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-        data_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        batch = data_collator(no_pad_features)
-        self.assertEqual(batch["input_ids"].shape, (2, 16))
-        self.assertEqual(batch["labels"].shape, (2, 16))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(np.any(masked_tokens))
-        # self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-        batch = data_collator(pad_features)
-        self.assertEqual(batch["input_ids"].shape, (2, 16))
-        self.assertEqual(batch["labels"].shape, (2, 16))
-
-        masked_tokens = batch["input_ids"] == tokenizer.mask_token_id
-        self.assertTrue(np.any(masked_tokens))
-        # self.assertTrue(all(x == -100 for x in batch["labels"][~masked_tokens].tolist()))
-
-    def test_data_collator_for_language_modeling(self):
-        no_pad_features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        pad_features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._test_no_pad_and_pad(no_pad_features, pad_features)
-
-        no_pad_features = [list(range(10)), list(range(10))]
-        pad_features = [list(range(5)), list(range(10))]
-        self._test_no_pad_and_pad(no_pad_features, pad_features)
-
-    def test_data_collator_for_language_modeling_with_seed(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-        features = [{"input_ids": list(range(1000))}, {"input_ids": list(range(1000))}]
-
-        # check if seed is respected between two different DataCollatorForLanguageModeling instances
-        data_collator = DataCollatorForLanguageModeling(tokenizer, seed=42, return_tensors="np")
-        batch_1 = data_collator(features)
-        self.assertEqual(batch_1["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_1["labels"].shape, (2, 1000))
-
-        data_collator = DataCollatorForLanguageModeling(tokenizer, seed=42, return_tensors="np")
-        batch_2 = data_collator(features)
-        self.assertEqual(batch_2["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_2["labels"].shape, (2, 1000))
-
-        self.assertTrue(np.all(batch_1["input_ids"] == batch_2["input_ids"]))
-        self.assertTrue(np.all(batch_1["labels"] == batch_2["labels"]))
-
-        data_collator = DataCollatorForLanguageModeling(tokenizer, seed=43, return_tensors="np")
-        batch_3 = data_collator(features)
-        self.assertEqual(batch_3["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_3["labels"].shape, (2, 1000))
-
-        self.assertFalse(np.all(batch_1["input_ids"] == batch_3["input_ids"]))
-        self.assertFalse(np.all(batch_1["labels"] == batch_3["labels"]))
-
-    def test_data_collator_for_whole_word_mask(self):
-        tokenizer = BertTokenizerFast(self.vocab_file)
-        data_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="np")
-
         input_tokens = [f"token_{i}" for i in range(8)]
         tokenizer.add_tokens(input_tokens)
         features = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
+        return tokenizer, features
 
-        batch = data_collator(features)
+    def test_basic(self):
+        """Test whole word masking masks complete words."""
+        tokenizer, features = self._get_tokenizer_and_features()
+        collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
+        batch = collator(features)
+
         self.assertEqual(batch["input_ids"].shape, (2, 10))
         self.assertEqual(batch["labels"].shape, (2, 10))
 
-        # Features can already be tensors
+    def test_with_numpy_inputs(self):
+        """Test with numpy array inputs."""
+        tokenizer, _ = self._get_tokenizer_and_features()
+        input_tokens = [f"token_{i}" for i in range(8)]
         features = [
             tokenizer(" ".join(input_tokens), return_offsets_mapping=True).convert_to_tensors("np") for _ in range(2)
         ]
-        batch = data_collator(features)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
 
-    def test_data_collator_for_whole_word_mask_with_seed(self):
+        collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
+
+    def test_with_tensor_inputs(self):
+        """Test with PyTorch tensor inputs."""
+        tokenizer, _ = self._get_tokenizer_and_features()
+        input_tokens = [f"token_{i}" for i in range(8)]
+        features = [
+            tokenizer(" ".join(input_tokens), return_offsets_mapping=True).convert_to_tensors("pt") for _ in range(2)
+        ]
+
+        collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="pt")
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size((2, 10)))
+
+    def test_seed_reproducibility(self):
+        """Test reproducibility with seed."""
         tokenizer = BertTokenizerFast(self.vocab_file)
-
         input_tokens = [f"token_{i}" for i in range(998)]
         tokenizer.add_tokens(input_tokens)
         features = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
 
-        # check if seed is respected between two different DataCollatorForWholeWordMask instances
-        data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="np")
-        batch_1 = data_collator(features)
-        self.assertEqual(batch_1["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_1["labels"].shape, (2, 1000))
+        collator1 = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="np")
+        batch1 = collator1(features)
 
-        data_collator = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="np")
-        batch_2 = data_collator(features)
-        self.assertEqual(batch_2["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_2["labels"].shape, (2, 1000))
+        collator2 = DataCollatorForWholeWordMask(tokenizer, seed=42, return_tensors="np")
+        batch2 = collator2(features)
 
-        self.assertTrue(np.all(batch_1["input_ids"] == batch_2["input_ids"]))
-        self.assertTrue(np.all(batch_1["labels"] == batch_2["labels"]))
+        np.testing.assert_array_equal(batch1["input_ids"], batch2["input_ids"])
 
-        data_collator = DataCollatorForWholeWordMask(tokenizer, seed=43, return_tensors="np")
-        batch_3 = data_collator(features)
-        self.assertEqual(batch_3["input_ids"].shape, (2, 1000))
-        self.assertEqual(batch_3["labels"].shape, (2, 1000))
+        # Different seed -> different results
+        collator3 = DataCollatorForWholeWordMask(tokenizer, seed=43, return_tensors="np")
+        batch3 = collator3(features)
+        self.assertFalse(np.all(batch1["input_ids"] == batch3["input_ids"]))
 
-        self.assertFalse(np.all(batch_1["input_ids"] == batch_3["input_ids"]))
-        self.assertFalse(np.all(batch_1["labels"] == batch_3["labels"]))
+    def test_numpy_output(self):
+        """Test with NumPy output."""
+        tokenizer, features = self._get_tokenizer_and_features()
+        collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="np")
+        batch = collator(features)
 
-    def test_plm(self):
+        self.assertEqual(batch["input_ids"].shape, (2, 10))
+        self.assertEqual(batch["labels"].shape, (2, 10))
+
+    def test_immutability(self):
+        """Test that collation does not mutate input data."""
+        tokenizer, features = self._get_tokenizer_and_features()
+        features = [dict(f) for f in features]
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForWholeWordMask(tokenizer, return_tensors=return_tensors)
+            self._check_immutability(collator, copy.deepcopy(features))
+
+
+# =============================================================================
+# DataCollatorForPermutationLanguageModeling tests
+# =============================================================================
+
+
+@require_torch
+class TestDataCollatorForPermutationLanguageModeling(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for DataCollatorForPermutationLanguageModeling.
+
+    This collator implements XLNet-style permutation language modeling,
+    generating perm_mask and target_mapping for each batch.
+    """
+
+    def test_basic(self):
+        """Test basic PLM collation."""
         tokenizer = BertTokenizer(self.vocab_file)
-        no_pad_features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        pad_features = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
 
-        data_collator = DataCollatorForPermutationLanguageModeling(tokenizer, return_tensors="np")
+        collator = DataCollatorForPermutationLanguageModeling(tokenizer)
+        batch = collator(features)
 
-        batch = data_collator(pad_features)
-        self.assertIsInstance(batch, dict)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["perm_mask"].shape, (2, 10, 10))
-        self.assertEqual(batch["target_mapping"].shape, (2, 10, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+        self.assertEqual(batch["perm_mask"].shape, torch.Size([2, 10, 10]))
+        self.assertEqual(batch["target_mapping"].shape, torch.Size([2, 10, 10]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 10]))
 
-        batch = data_collator(no_pad_features)
-        self.assertIsInstance(batch, dict)
-        self.assertEqual(batch["input_ids"].shape, (2, 10))
-        self.assertEqual(batch["perm_mask"].shape, (2, 10, 10))
-        self.assertEqual(batch["target_mapping"].shape, (2, 10, 10))
-        self.assertEqual(batch["labels"].shape, (2, 10))
+    def test_with_padding(self):
+        """Test PLM with different length sequences."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(4))}, {"input_ids": list(range(10))}]
 
-        example = [np.random.randint(0, 5, [5])]
+        collator = DataCollatorForPermutationLanguageModeling(tokenizer)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 10]))
+
+    def test_odd_sequence_error(self):
+        """Test that odd sequence lengths raise an error."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForPermutationLanguageModeling(tokenizer)
+
+        features = [{"input_ids": list(range(5))}]
         with self.assertRaises(ValueError):
-            # Expect error due to odd sequence length
-            data_collator(example)
+            collator(features)
+
+    def test_numpy_output(self):
+        """Test with NumPy output."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        collator = DataCollatorForPermutationLanguageModeling(tokenizer, return_tensors="np")
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, (2, 10))
+        self.assertEqual(batch["perm_mask"].shape, (2, 10, 10))
+        self.assertEqual(batch["target_mapping"].shape, (2, 10, 10))
+
+    def test_immutability(self):
+        """Test that collation does not mutate input data."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
+
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForPermutationLanguageModeling(tokenizer, return_tensors=return_tensors)
+            self._check_immutability(collator, copy.deepcopy(features))
+
+
+# =============================================================================
+# Next Sentence Prediction tests
+# =============================================================================
+
+
+@require_torch
+class TestNextSentencePrediction(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for Next Sentence Prediction (NSP) with DataCollatorForLanguageModeling.
+
+    NSP is used in BERT pretraining where the model predicts if two sentences
+    follow each other in the original text.
+    """
+
+    def _get_features(self):
+        return [
+            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
+            for i in range(2)
+        ]
 
     def test_nsp(self):
+        """Test NSP labels are preserved during collation."""
         tokenizer = BertTokenizer(self.vocab_file)
-        features = [
-            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
-            for i in range(2)
-        ]
-        data_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        batch = data_collator(features)
+        collator = DataCollatorForLanguageModeling(tokenizer)
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 5]))
+        self.assertEqual(batch["token_type_ids"].shape, torch.Size([2, 5]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 5]))
+        self.assertEqual(batch["next_sentence_label"].shape, torch.Size([2]))
+
+    def test_nsp_with_padding(self):
+        """Test NSP with pad_to_multiple_of."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
+        self.assertEqual(batch["next_sentence_label"].shape, torch.Size([2]))
+
+    def test_numpy_output(self):
+        """Test NSP with NumPy output."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
+        batch = collator(self._get_features())
 
         self.assertEqual(batch["input_ids"].shape, (2, 5))
-        self.assertEqual(batch["token_type_ids"].shape, (2, 5))
-        self.assertEqual(batch["labels"].shape, (2, 5))
         self.assertEqual(batch["next_sentence_label"].shape, (2,))
 
-        data_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        batch = data_collator(features)
+    def test_immutability(self):
+        """Test that NSP collation does not mutate input data."""
+        tokenizer = BertTokenizer(self.vocab_file)
 
-        self.assertEqual(batch["input_ids"].shape, (2, 8))
-        self.assertEqual(batch["token_type_ids"].shape, (2, 8))
-        self.assertEqual(batch["labels"].shape, (2, 8))
-        self.assertEqual(batch["next_sentence_label"].shape, (2,))
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForLanguageModeling(tokenizer, return_tensors=return_tensors)
+            self._check_immutability(collator, self._get_features())
+
+
+# =============================================================================
+# Sentence Order Prediction tests
+# =============================================================================
+
+
+@require_torch
+class TestSentenceOrderPrediction(DataCollatorTestMixin, unittest.TestCase):
+    """
+    Tests for Sentence Order Prediction (SOP) with DataCollatorForLanguageModeling.
+
+    SOP is used in ALBERT pretraining where the model predicts if two sentences
+    are in the correct order.
+    """
+
+    def _get_features(self):
+        return [
+            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "sentence_order_label": i}
+            for i in range(2)
+        ]
 
     def test_sop(self):
+        """Test SOP labels are preserved during collation."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForLanguageModeling(tokenizer)
+        batch = collator(self._get_features())
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 5]))
+        self.assertEqual(batch["token_type_ids"].shape, torch.Size([2, 5]))
+        self.assertEqual(batch["labels"].shape, torch.Size([2, 5]))
+        self.assertEqual(batch["sentence_order_label"].shape, torch.Size([2]))
+
+    def test_sop_with_tensor_inputs(self):
+        """Test SOP with PyTorch tensor inputs."""
         tokenizer = BertTokenizer(self.vocab_file)
         features = [
             {
-                "input_ids": np.array([0, 1, 2, 3, 4]),
-                "token_type_ids": np.array([0, 1, 2, 3, 4]),
+                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
                 "sentence_order_label": i,
             }
             for i in range(2)
         ]
-        data_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        batch = data_collator(features)
+
+        collator = DataCollatorForLanguageModeling(tokenizer)
+        batch = collator(features)
+
+        self.assertEqual(batch["sentence_order_label"].shape, torch.Size([2]))
+
+    def test_sop_with_padding(self):
+        """Test SOP with pad_to_multiple_of."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        features = [
+            {
+                "input_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "token_type_ids": torch.tensor([0, 1, 2, 3, 4]),
+                "sentence_order_label": i,
+            }
+            for i in range(2)
+        ]
+
+        collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8)
+        batch = collator(features)
+
+        self.assertEqual(batch["input_ids"].shape, torch.Size([2, 8]))
+        self.assertEqual(batch["sentence_order_label"].shape, torch.Size([2]))
+
+    def test_numpy_output(self):
+        """Test SOP with NumPy output."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
+        batch = collator(self._get_features())
 
         self.assertEqual(batch["input_ids"].shape, (2, 5))
-        self.assertEqual(batch["token_type_ids"].shape, (2, 5))
-        self.assertEqual(batch["labels"].shape, (2, 5))
         self.assertEqual(batch["sentence_order_label"].shape, (2,))
 
-        data_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        batch = data_collator(features)
-
-        self.assertEqual(batch["input_ids"].shape, (2, 8))
-        self.assertEqual(batch["token_type_ids"].shape, (2, 8))
-        self.assertEqual(batch["labels"].shape, (2, 8))
-        self.assertEqual(batch["sentence_order_label"].shape, (2,))
-
-
-class NumpyDataCollatorImmutabilityTest(unittest.TestCase):
-    def setUp(self):
-        self.tmpdirname = tempfile.mkdtemp()
-
-        vocab_tokens = ["[UNK]", "[CLS]", "[SEP]", "[PAD]", "[MASK]"]
-        self.vocab_file = os.path.join(self.tmpdirname, "vocab.txt")
-        with open(self.vocab_file, "w", encoding="utf-8") as vocab_writer:
-            vocab_writer.write("".join([x + "\n" for x in vocab_tokens]))
-
-    def tearDown(self):
-        shutil.rmtree(self.tmpdirname)
-
-    def _turn_to_none(self, item):
-        """used to convert `item` to `None` type"""
-        return None
-
-    def _validate_original_data_against_collated_data(self, collator, original_data, batch_data):
-        # we only care about side effects, the results are tested elsewhere
-        collator(batch_data)
-
-        # we go through every item and convert to `primitive` datatypes if necessary
-        # then compares for equivalence for the original data and the data that has been passed through the collator
-        for original, batch in zip(original_data, batch_data):
-            for original_val, batch_val in zip(original.values(), batch.values()):
-                if isinstance(original_val, np.ndarray):
-                    self.assertEqual(original_val.tolist(), batch_val.tolist())
-                else:
-                    self.assertEqual(original_val, batch_val)
-
-    def _validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-        self, collator, base_data, input_key, input_datatype, label_key, label_datatype, ignore_label=False
-    ):
-        # using the arguments to recreate the features with their respective (potentially new) datatypes
-        features_original = [
-            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
-            for sample in base_data
-        ]
-        features_batch = [
-            {label_key: label_datatype(sample[label_key]), input_key: input_datatype(sample[input_key])}
-            for sample in base_data
-        ]
-
-        # some collators do not use labels, or sometimes we want to check if the collator with labels can handle such cases
-        if ignore_label:
-            for original, batch in zip(features_original, features_batch):
-                original.pop(label_key)
-                batch.pop(label_key)
-
-        self._validate_original_data_against_collated_data(
-            collator=collator, original_data=features_original, batch_data=features_batch
-        )
-
-    def test_default_collator_immutability(self):
-        features_base_single_label = [{"label": i, "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
-        features_base_multiple_labels = [{"label": (0, 1, 2), "inputs": (0, 1, 2, 3, 4, 5)} for i in range(4)]
-
-        for datatype_input, datatype_label in [
-            (list, int),
-            (list, float),
-            (np.array, int),
-            (np.array, np.array),
-            (list, self._turn_to_none),
-        ]:
-            self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=lambda x: default_data_collator(x, return_tensors="np"),
-                base_data=features_base_single_label,
-                input_key="inputs",
-                input_datatype=datatype_input,
-                label_key="label",
-                label_datatype=datatype_label,
-            )
-
-        for datatype_input, datatype_label in [(list, list), (list, self._turn_to_none)]:
-            self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=lambda x: default_data_collator(x, return_tensors="np"),
-                base_data=features_base_multiple_labels,
-                input_key="inputs",
-                input_datatype=datatype_input,
-                label_key="label",
-                label_datatype=datatype_label,
-            )
-
-        features_base_single_label_alt = [{"input_ids": (0, 1, 2, 3, 4), "label": float(i)} for i in range(4)]
-        self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=lambda x: default_data_collator(x, return_tensors="np"),
-            base_data=features_base_single_label_alt,
-            input_key="input_ids",
-            input_datatype=list,
-            label_key="label",
-            label_datatype=float,
-        )
-
-    def test_with_padding_collator_immutability(self):
+    def test_immutability(self):
+        """Test that SOP collation does not mutate input data."""
         tokenizer = BertTokenizer(self.vocab_file)
 
-        features_original = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
-        features_batch = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
-
-        data_collator = DataCollatorWithPadding(tokenizer, padding="max_length", max_length=10, return_tensors="np")
-        self._validate_original_data_against_collated_data(
-            collator=data_collator, original_data=features_original, batch_data=features_batch
-        )
-
-        data_collator = DataCollatorWithPadding(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        self._validate_original_data_against_collated_data(
-            collator=data_collator, original_data=features_original, batch_data=features_batch
-        )
-
-    def test_for_token_classification_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_base = [
-            {"input_ids": (0, 1, 2), "labels": (0, 1, 2)},
-            {"input_ids": (0, 1, 2, 3, 4, 5), "labels": (0, 1, 2, 3, 4, 5)},
-        ]
-        token_classification_collators = [
-            DataCollatorForTokenClassification(tokenizer, return_tensors="np"),
-            DataCollatorForTokenClassification(tokenizer, padding="max_length", max_length=10, return_tensors="np"),
-            DataCollatorForTokenClassification(tokenizer, pad_to_multiple_of=8, return_tensors="np"),
-            DataCollatorForTokenClassification(tokenizer, label_pad_token_id=-1, return_tensors="np"),
-        ]
-
-        for datatype_input, datatype_label in [(list, list)]:
-            for collator in token_classification_collators:
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                )
-
-        self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=token_classification_collators[-1],
-            base_data=features_base,
-            input_key="input_ids",
-            input_datatype=datatype_input,
-            label_key="labels",
-            label_datatype=datatype_label,
-            ignore_label=True,
-        )
-
-    def test_seq2seq_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_base = [
-            {"input_ids": list(range(3)), "labels": list(range(3))},
-            {"input_ids": list(range(6)), "labels": list(range(6))},
-        ]
-        seq2seq_collators = [
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors="np"),
-            DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.MAX_LENGTH, max_length=7, return_tensors="np"),
-            DataCollatorForSeq2Seq(
-                tokenizer, padding=PaddingStrategy.LONGEST, pad_to_multiple_of=8, return_tensors="np"
-            ),
-            DataCollatorForSeq2Seq(
-                tokenizer, padding=PaddingStrategy.LONGEST, label_pad_token_id=-1, return_tensors="np"
-            ),
-        ]
-
-        for datatype_input, datatype_label in [(list, list)]:
-            for collator in seq2seq_collators:
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                )
-
-        self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-            collator=seq2seq_collators[-1],
-            base_data=features_base,
-            input_key="input_ids",
-            input_datatype=datatype_input,
-            label_key="labels",
-            label_datatype=datatype_label,
-            ignore_label=True,
-        )
-
-        features_base_no_pad = [
-            {"input_ids": list(range(3)), "labels": list(range(3))},
-            {"input_ids": list(range(3)), "labels": list(range(3))},
-        ]
-        seq2seq_no_padding_collator = DataCollatorForSeq2Seq(
-            tokenizer, padding=PaddingStrategy.DO_NOT_PAD, return_tensors="np"
-        )
-        for datatype_input, datatype_label in [(list, list)]:
-            self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                collator=seq2seq_no_padding_collator,
-                base_data=features_base_no_pad,
-                input_key="input_ids",
-                input_datatype=datatype_input,
-                label_key="labels",
-                label_datatype=datatype_label,
-            )
-
-    def test_language_modelling_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_base_no_pad = [
-            {"input_ids": tuple(range(10)), "labels": (1,)},
-            {"input_ids": tuple(range(10)), "labels": (1,)},
-        ]
-        features_base_pad = [
-            {"input_ids": tuple(range(5)), "labels": (1,)},
-            {"input_ids": tuple(range(5)), "labels": (1,)},
-        ]
-        lm_collators = [
-            DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="np"),
-            DataCollatorForLanguageModeling(tokenizer, mlm=False, pad_to_multiple_of=8, return_tensors="np"),
-            DataCollatorForLanguageModeling(tokenizer, return_tensors="np"),
-            DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np"),
-        ]
-
-        for datatype_input, datatype_label in [(list, list)]:
-            for collator in lm_collators:
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base_no_pad,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                    ignore_label=True,
-                )
-
-                self._validate_original_data_against_collated_data_on_specified_keys_and_datatypes(
-                    collator=collator,
-                    base_data=features_base_pad,
-                    input_key="input_ids",
-                    input_datatype=datatype_input,
-                    label_key="labels",
-                    label_datatype=datatype_label,
-                    ignore_label=True,
-                )
-
-    def test_whole_world_masking_collator_immutability(self):
-        tokenizer = BertTokenizerFast(self.vocab_file)
-
-        input_tokens = [f"token_{i}" for i in range(8)]
-        tokenizer.add_tokens(input_tokens)
-        original_data = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
-        for feature in original_data:
-            feature["labels"] = (1,)
-
-        batch_data = [tokenizer(" ".join(input_tokens), return_offsets_mapping=True) for _ in range(2)]
-        for feature in batch_data:
-            feature["labels"] = (1,)
-
-        whole_word_masking_collator = DataCollatorForWholeWordMask(tokenizer, return_tensors="np")
-
-        self._validate_original_data_against_collated_data(
-            collator=whole_word_masking_collator, original_data=original_data, batch_data=batch_data
-        )
-
-    def test_permutation_language_modelling_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        plm_collator = DataCollatorForPermutationLanguageModeling(tokenizer, return_tensors="np")
-
-        no_pad_features_original = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        no_pad_features_batch = [{"input_ids": list(range(10))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(
-            collator=plm_collator, original_data=no_pad_features_original, batch_data=no_pad_features_batch
-        )
-
-        pad_features_original = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        pad_features_batch = [{"input_ids": list(range(5))}, {"input_ids": list(range(10))}]
-        self._validate_original_data_against_collated_data(
-            collator=plm_collator, original_data=pad_features_original, batch_data=pad_features_batch
-        )
-
-    def test_next_sentence_prediction_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_original = [
-            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
-            for i in range(2)
-        ]
-        features_batch = [
-            {"input_ids": [0, 1, 2, 3, 4], "token_type_ids": [0, 1, 2, 3, 4], "next_sentence_label": i}
-            for i in range(2)
-        ]
-
-        nsp_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        self._validate_original_data_against_collated_data(
-            collator=nsp_collator, original_data=features_original, batch_data=features_batch
-        )
-
-        nsp_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        self._validate_original_data_against_collated_data(
-            collator=nsp_collator, original_data=features_original, batch_data=features_batch
-        )
-
-    def test_sentence_order_prediction_collator_immutability(self):
-        tokenizer = BertTokenizer(self.vocab_file)
-
-        features_original = [
-            {
-                "input_ids": np.array([0, 1, 2, 3, 4]),
-                "token_type_ids": np.array([0, 1, 2, 3, 4]),
-                "sentence_order_label": i,
-            }
-            for i in range(2)
-        ]
-        features_batch = [
-            {
-                "input_ids": np.array([0, 1, 2, 3, 4]),
-                "token_type_ids": np.array([0, 1, 2, 3, 4]),
-                "sentence_order_label": i,
-            }
-            for i in range(2)
-        ]
-
-        sop_collator = DataCollatorForLanguageModeling(tokenizer, return_tensors="np")
-        self._validate_original_data_against_collated_data(
-            collator=sop_collator, original_data=features_original, batch_data=features_batch
-        )
-
-        sop_collator = DataCollatorForLanguageModeling(tokenizer, pad_to_multiple_of=8, return_tensors="np")
-        self._validate_original_data_against_collated_data(
-            collator=sop_collator, original_data=features_original, batch_data=features_batch
-        )
-
-
-class DataCollatorForLanguageModelingUnitTest(unittest.TestCase):
-    def test__calc_word_ids_and_prob_mask(self):
-        offsets = np.array(
-            [
-                [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (8, 9)],
-                [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (0, 0)],
-                [(0, 0), (0, 3), (3, 4), (0, 0), (6, 7), (0, 0)],
-                [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)],
-                [(1, 1), (2, 2), (3, 4), (5, 6), (7, 8), (9, 10)],
-                [(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0)],
-            ]
-        )
-
-        special_tokens_mask = np.array(
-            [
-                [1, 0, 0, 0, 0, 0],
-                [1, 0, 0, 0, 0, 1],
-                [1, 0, 0, 1, 0, 1],
-                [0, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 1, 1, 1],
-            ]
-        )
-
-        output_word_ids, output_prob_mask = DataCollatorForLanguageModeling._calc_word_ids_and_prob_mask(
-            offsets, special_tokens_mask
-        )
-
-        expected_word_ids = np.array(
-            [
-                [-1, 1, 1, 2, 2, 3],
-                [-1, 1, 1, 2, 2, -1],
-                [-1, 1, 1, -1, 2, -1],
-                [1, 1, 1, 1, 1, 1],
-                [1, 2, 3, 4, 5, 6],
-                [-1, -1, -1, -1, -1, -1],
-            ]
-        )
-
-        expected_prob_mask = np.array(
-            [
-                [1, 0, 1, 0, 1, 0],
-                [1, 0, 1, 0, 1, 1],
-                [1, 0, 1, 1, 0, 1],
-                [0, 1, 1, 1, 1, 1],
-                [0, 0, 0, 0, 0, 0],
-                [1, 1, 1, 1, 1, 1],
-            ]
-        )
-
-        np.testing.assert_array_equal(output_word_ids, expected_word_ids)
-        np.testing.assert_array_equal(output_prob_mask, expected_prob_mask)
-
-    def test__whole_word_mask(self):
-        word_ids = np.array(
-            [
-                [-1, 1, 1, 2, 2, 3],
-                [-1, 1, 1, 2, 2, -1],
-                [-1, 1, 1, -1, 2, -1],
-                [1, 1, 1, 1, 1, 1],
-                [1, 2, 3, 4, 5, 6],
-                [1, 2, 3, 4, 5, 6],
-                [-1, -1, -1, -1, -1, -1],
-            ]
-        )
-
-        mask = np.array(
-            [
-                [0, 1, 0, 0, 0, 0],
-                [0, 1, 0, 1, 0, 0],
-                [0, 0, 0, 0, 1, 0],
-                [1, 0, 0, 0, 0, 0],
-                [0, 0, 0, 0, 0, 0],
-                [0, 1, 0, 1, 0, 1],
-                [0, 0, 0, 0, 0, 0],
-            ]
-        ).astype(bool)
-
-        output_mask = DataCollatorForLanguageModeling._whole_word_mask(word_ids, mask)
-
-        expected_mask = np.array(
-            [
-                [0, 1, 1, 0, 0, 0],
-                [0, 1, 1, 1, 1, 0],
-                [0, 0, 0, 0, 1, 0],
-                [1, 1, 1, 1, 1, 1],
-                [0, 0, 0, 0, 0, 0],
-                [0, 1, 0, 1, 0, 1],
-                [0, 0, 0, 0, 0, 0],
-            ]
-        ).astype(bool)
-
-        np.testing.assert_array_equal(output_mask, expected_mask)
-
-
-class DataCollatorWithFlatteningTest(unittest.TestCase):
-    """Tests for DataCollatorWithFlattening"""
-
-    def test_flattening_with_tensor_labels(self):
-        """Test that DataCollatorWithFlattening supports tensor labels (fixes issue #42599)."""
-        features = [
-            {
-                "input_ids": torch.tensor([1, 2, 3, 4]),
-                "labels": torch.tensor([10, 11, 12, 13]),
-            },
-            {
-                "input_ids": torch.tensor([5, 6, 7]),
-                "labels": torch.tensor([14, 15, 16]),
-            },
-        ]
-        collator = DataCollatorWithFlattening(return_tensors="pt")
-
-        # This should not raise TypeError anymore
-        batch = collator(features)
-
-        # Verify the output
-        self.assertIsInstance(batch, dict)
-        self.assertIn("input_ids", batch)
-        self.assertIn("labels", batch)
-        self.assertIn("position_ids", batch)
-
-        # Check shapes
-        self.assertEqual(batch["input_ids"].shape, (1, 7))  # 4 + 3 tokens
-        self.assertEqual(batch["labels"].shape, (1, 7))
-        self.assertEqual(batch["position_ids"].shape, (1, 7))
-
-    def test_flattening_with_list_labels(self):
-        """Test that DataCollatorWithFlattening still works with list labels."""
-        features = [
-            {
-                "input_ids": torch.tensor([1, 2, 3, 4]),
-                "labels": [10, 11, 12, 13],
-            },
-            {
-                "input_ids": torch.tensor([5, 6, 7]),
-                "labels": [14, 15, 16],
-            },
-        ]
-        collator = DataCollatorWithFlattening(return_tensors="pt")
-        batch = collator(features)
-
-        # Verify it still works with lists
-        self.assertIsInstance(batch, dict)
-        self.assertEqual(batch["input_ids"].shape, (1, 7))
-        self.assertEqual(batch["labels"].shape, (1, 7))
+        for return_tensors in ["pt", "np"]:
+            collator = DataCollatorForLanguageModeling(tokenizer, return_tensors=return_tensors)
+            self._check_immutability(collator, self._get_features())

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -171,9 +171,14 @@ class TestDefaultDataCollator(DataCollatorTestMixin, unittest.TestCase):
 
     def test_immutability(self):
         """Test that collation does not mutate input data."""
-        for return_tensors in ["pt", "np"]:
-            collator = lambda x, rt=return_tensors: default_data_collator(x, return_tensors=rt)
 
+        def collator_pt(x):
+            return default_data_collator(x, return_tensors="pt")
+
+        def collator_np(x):
+            return default_data_collator(x, return_tensors="np")
+
+        for collator in [collator_pt, collator_np]:
             # Test with various input types
             for features in [
                 [{"label": i, "inputs": [0, 1, 2, 3]} for i in range(4)],
@@ -557,7 +562,9 @@ class TestDataCollatorForSeq2Seq(DataCollatorTestMixin, unittest.TestCase):
         tokenizer = BertTokenizer(self.vocab_file)
 
         for return_tensors in ["pt", "np"]:
-            collator = DataCollatorForSeq2Seq(tokenizer, padding=PaddingStrategy.LONGEST, return_tensors=return_tensors)
+            collator = DataCollatorForSeq2Seq(
+                tokenizer, padding=PaddingStrategy.LONGEST, return_tensors=return_tensors
+            )
             self._check_immutability(collator, self._get_features())
 
 
@@ -704,80 +711,96 @@ class TestDataCollatorForLanguageModeling(DataCollatorTestMixin, unittest.TestCa
 
     def test_calc_word_ids_and_prob_mask(self):
         """Test word ID assignment and probability mask generation."""
-        offsets = np.array([
-            [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (8, 9)],
-            [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (0, 0)],
-            [(0, 0), (0, 3), (3, 4), (0, 0), (6, 7), (0, 0)],
-            [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)],
-            [(1, 1), (2, 2), (3, 4), (5, 6), (7, 8), (9, 10)],
-            [(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0)],
-        ])
+        offsets = np.array(
+            [
+                [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (8, 9)],
+                [(0, 0), (0, 3), (3, 4), (5, 6), (6, 7), (0, 0)],
+                [(0, 0), (0, 3), (3, 4), (0, 0), (6, 7), (0, 0)],
+                [(1, 2), (2, 3), (3, 4), (4, 5), (5, 6), (6, 7)],
+                [(1, 1), (2, 2), (3, 4), (5, 6), (7, 8), (9, 10)],
+                [(0, 0), (0, 0), (0, 0), (0, 0), (0, 0), (0, 0)],
+            ]
+        )
 
-        special_tokens_mask = np.array([
-            [1, 0, 0, 0, 0, 0],
-            [1, 0, 0, 0, 0, 1],
-            [1, 0, 0, 1, 0, 1],
-            [0, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [1, 1, 1, 1, 1, 1],
-        ])
+        special_tokens_mask = np.array(
+            [
+                [1, 0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0, 1],
+                [1, 0, 0, 1, 0, 1],
+                [0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1],
+            ]
+        )
 
-        word_ids, prob_mask = DataCollatorForLanguageModeling._calc_word_ids_and_prob_mask(offsets, special_tokens_mask)
+        word_ids, prob_mask = DataCollatorForLanguageModeling._calc_word_ids_and_prob_mask(
+            offsets, special_tokens_mask
+        )
 
-        expected_word_ids = np.array([
-            [-1, 1, 1, 2, 2, 3],
-            [-1, 1, 1, 2, 2, -1],
-            [-1, 1, 1, -1, 2, -1],
-            [1, 1, 1, 1, 1, 1],
-            [1, 2, 3, 4, 5, 6],
-            [-1, -1, -1, -1, -1, -1],
-        ])
+        expected_word_ids = np.array(
+            [
+                [-1, 1, 1, 2, 2, 3],
+                [-1, 1, 1, 2, 2, -1],
+                [-1, 1, 1, -1, 2, -1],
+                [1, 1, 1, 1, 1, 1],
+                [1, 2, 3, 4, 5, 6],
+                [-1, -1, -1, -1, -1, -1],
+            ]
+        )
 
-        expected_prob_mask = np.array([
-            [1, 0, 1, 0, 1, 0],
-            [1, 0, 1, 0, 1, 1],
-            [1, 0, 1, 1, 0, 1],
-            [0, 1, 1, 1, 1, 1],
-            [0, 0, 0, 0, 0, 0],
-            [1, 1, 1, 1, 1, 1],
-        ])
+        expected_prob_mask = np.array(
+            [
+                [1, 0, 1, 0, 1, 0],
+                [1, 0, 1, 0, 1, 1],
+                [1, 0, 1, 1, 0, 1],
+                [0, 1, 1, 1, 1, 1],
+                [0, 0, 0, 0, 0, 0],
+                [1, 1, 1, 1, 1, 1],
+            ]
+        )
 
         np.testing.assert_array_equal(word_ids, expected_word_ids)
         np.testing.assert_array_equal(prob_mask, expected_prob_mask)
 
     def test_whole_word_mask_internal(self):
         """Test mask expansion to cover all subword tokens of masked words."""
-        word_ids = np.array([
-            [-1, 1, 1, 2, 2, 3],
-            [-1, 1, 1, 2, 2, -1],
-            [-1, 1, 1, -1, 2, -1],
-            [1, 1, 1, 1, 1, 1],
-            [1, 2, 3, 4, 5, 6],
-            [1, 2, 3, 4, 5, 6],
-            [-1, -1, -1, -1, -1, -1],
-        ])
+        word_ids = np.array(
+            [
+                [-1, 1, 1, 2, 2, 3],
+                [-1, 1, 1, 2, 2, -1],
+                [-1, 1, 1, -1, 2, -1],
+                [1, 1, 1, 1, 1, 1],
+                [1, 2, 3, 4, 5, 6],
+                [1, 2, 3, 4, 5, 6],
+                [-1, -1, -1, -1, -1, -1],
+            ]
+        )
 
-        mask = np.array([
-            [0, 1, 0, 0, 0, 0],
-            [0, 1, 0, 1, 0, 0],
-            [0, 0, 0, 0, 1, 0],
-            [1, 0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0, 0],
-            [0, 1, 0, 1, 0, 1],
-            [0, 0, 0, 0, 0, 0],
-        ]).astype(bool)
+        mask = np.array(
+            [
+                [0, 1, 0, 0, 0, 0],
+                [0, 1, 0, 1, 0, 0],
+                [0, 0, 0, 0, 1, 0],
+                [1, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 1, 0, 1],
+                [0, 0, 0, 0, 0, 0],
+            ]
+        ).astype(bool)
 
         output = DataCollatorForLanguageModeling._whole_word_mask(word_ids, mask)
 
-        expected = np.array([
-            [0, 1, 1, 0, 0, 0],
-            [0, 1, 1, 1, 1, 0],
-            [0, 0, 0, 0, 1, 0],
-            [1, 1, 1, 1, 1, 1],
-            [0, 0, 0, 0, 0, 0],
-            [0, 1, 0, 1, 0, 1],
-            [0, 0, 0, 0, 0, 0],
-        ]).astype(bool)
+        expected = np.array(
+            [
+                [0, 1, 1, 0, 0, 0],
+                [0, 1, 1, 1, 1, 0],
+                [0, 0, 0, 0, 1, 0],
+                [1, 1, 1, 1, 1, 1],
+                [0, 0, 0, 0, 0, 0],
+                [0, 1, 0, 1, 0, 1],
+                [0, 0, 0, 0, 0, 0],
+            ]
+        ).astype(bool)
 
         np.testing.assert_array_equal(output, expected)
 

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -12,6 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Tests for trainer callbacks.
+
+This module tests:
+- Callback registration (add, remove, pop)
+- Event firing order during training
+- Stateful callback persistence across checkpoints
+- TrainerState and TrainerControl behavior
+- Built-in callbacks (DefaultFlowCallback, EarlyStoppingCallback, etc.)
+"""
 
 import os
 import shutil
@@ -22,7 +32,6 @@ from unittest.mock import patch
 from transformers import (
     DefaultFlowCallback,
     EarlyStoppingCallback,
-    IntervalStrategy,
     PrinterCallback,
     ProgressCallback,
     Trainer,
@@ -32,7 +41,7 @@ from transformers import (
     is_torch_available,
 )
 from transformers.testing_utils import require_torch
-from transformers.trainer_callback import ExportableState
+from transformers.trainer_callback import CallbackHandler, ExportableState, TrainerControl
 
 
 if is_torch_available():
@@ -41,24 +50,21 @@ if is_torch_available():
     from .test_trainer import RegressionDataset, RegressionModelConfig, RegressionPreTrainedModel
 
 
-class MyTestExportableCallback(TrainerCallback, ExportableState):
-    def __init__(self, my_test_state="test"):
-        self.my_test_state = my_test_state
-
-    def state(self):
-        return {
-            "args": {
-                "my_test_state": self.my_test_state,
-            },
-        }
+# =============================================================================
+# Test Callback Implementations
+# =============================================================================
 
 
-class MyTestTrainerCallback(TrainerCallback):
-    "A callback that registers the events that goes through."
+class EventRecorderCallback(TrainerCallback):
+    """
+    A callback that records all events it receives.
 
-    def __init__(self, my_test_state="test"):
+    Used to verify that callbacks are called at the right times
+    and in the right order during training.
+    """
+
+    def __init__(self):
         self.events = []
-        self.my_test_state = my_test_state
 
     def on_init_end(self, args, state, control, **kwargs):
         self.events.append("on_init_end")
@@ -84,6 +90,9 @@ class MyTestTrainerCallback(TrainerCallback):
     def on_optimizer_step(self, args, state, control, **kwargs):
         self.events.append("on_optimizer_step")
 
+    def on_substep_end(self, args, state, control, **kwargs):
+        self.events.append("on_substep_end")
+
     def on_step_end(self, args, state, control, **kwargs):
         self.events.append("on_step_end")
 
@@ -106,23 +115,103 @@ class MyTestTrainerCallback(TrainerCallback):
         self.events.append("on_push_begin")
 
 
+class StatefulTestCallback(TrainerCallback, ExportableState):
+    """
+    A stateful callback that can save and restore its state.
+
+    Used to test checkpoint persistence of callback state.
+    """
+
+    def __init__(self, my_value="default"):
+        self.my_value = my_value
+
+    def state(self):
+        return {
+            "args": {"my_value": self.my_value},
+            "attributes": {},
+        }
+
+
+class StopTrainingCallback(TrainerCallback):
+    """A callback that stops training after a specified number of steps."""
+
+    def __init__(self, stop_after_steps=1):
+        self.stop_after_steps = stop_after_steps
+
+    def on_step_end(self, args, state, control, **kwargs):
+        if state.global_step >= self.stop_after_steps:
+            control.should_training_stop = True
+        return control
+
+
+class ModifyControlCallback(TrainerCallback):
+    """A callback that modifies control flags to test control flow."""
+
+    def __init__(self):
+        self.control_modifications = []
+
+    def on_step_end(self, args, state, control, **kwargs):
+        self.control_modifications.append({
+            "step": state.global_step,
+            "should_log": control.should_log,
+            "should_save": control.should_save,
+            "should_evaluate": control.should_evaluate,
+        })
+        return control
+
+
+# =============================================================================
+# Helper Functions
+# =============================================================================
+
+
+def get_callback_names(callbacks):
+    """Extract callback class names from a list of callbacks (classes or instances)."""
+    names = []
+    for cb in callbacks:
+        if isinstance(cb, type):
+            names.append(cb.__name__)
+        else:
+            names.append(cb.__class__.__name__)
+    return sorted(names)
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
 @require_torch
 class TrainerCallbackTest(unittest.TestCase):
+    """Tests for callback registration and lifecycle with Trainer."""
+
     def setUp(self):
         self.output_dir = tempfile.mkdtemp()
 
     def tearDown(self):
         shutil.rmtree(self.output_dir)
 
-    def get_trainer(self, a=0, b=0, train_len=64, eval_len=64, callbacks=None, disable_tqdm=False, **kwargs):
-        # disable_tqdm in TrainingArguments has a flaky default since it depends on the level of logging. We make sure
-        # its set to False since the tests later on depend on its value.
-        train_dataset = RegressionDataset(length=train_len)
-        eval_dataset = RegressionDataset(length=eval_len)
-        config = RegressionModelConfig(a=a, b=b)
+    def _create_trainer(self, callbacks=None, **kwargs):
+        """
+        Create a Trainer instance with a simple regression model.
+
+        Args:
+            callbacks: List of callbacks to add to the trainer.
+            **kwargs: Additional arguments passed to TrainingArguments.
+
+        Returns:
+            A configured Trainer instance.
+        """
+        train_dataset = RegressionDataset(length=64)
+        eval_dataset = RegressionDataset(length=64)
+        config = RegressionModelConfig(a=0, b=0)
         model = RegressionPreTrainedModel(config)
 
-        args = TrainingArguments(self.output_dir, disable_tqdm=disable_tqdm, report_to=[], **kwargs)
+        # disable_tqdm must be explicit since it depends on logging level
+        kwargs.setdefault("disable_tqdm", False)
+        kwargs.setdefault("report_to", [])
+
+        args = TrainingArguments(self.output_dir, **kwargs)
         return Trainer(
             model,
             args,
@@ -131,151 +220,348 @@ class TrainerCallbackTest(unittest.TestCase):
             callbacks=callbacks,
         )
 
-    def check_callbacks_equality(self, cbs1, cbs2):
-        self.assertEqual(len(cbs1), len(cbs2))
+    def _get_callback(self, trainer, callback_class):
+        """Get a callback instance from the trainer by class type."""
+        for cb in trainer.callback_handler.callbacks:
+            if isinstance(cb, callback_class):
+                return cb
+        return None
 
-        # Order doesn't matter
-        cbs1 = sorted(cbs1, key=lambda cb: cb.__name__ if isinstance(cb, type) else cb.__class__.__name__)
-        cbs2 = sorted(cbs2, key=lambda cb: cb.__name__ if isinstance(cb, type) else cb.__class__.__name__)
+    # -------------------------------------------------------------------------
+    # Callback Registration Tests
+    # -------------------------------------------------------------------------
 
-        for cb1, cb2 in zip(cbs1, cbs2):
-            if isinstance(cb1, type) and isinstance(cb2, type):
-                self.assertEqual(cb1, cb2)
-            elif isinstance(cb1, type) and not isinstance(cb2, type):
-                self.assertEqual(cb1, cb2.__class__)
-            elif not isinstance(cb1, type) and isinstance(cb2, type):
-                self.assertEqual(cb1.__class__, cb2)
-            else:
-                self.assertEqual(cb1, cb2)
+    def test_default_callbacks_are_present(self):
+        """Trainer should have default callbacks plus ProgressCallback."""
+        trainer = self._create_trainer()
 
-    def get_expected_events(self, trainer):
-        expected_events = ["on_init_end", "on_train_begin"]
-        step = 0
-        train_dl_len = len(trainer.get_eval_dataloader())
-        evaluation_events = ["on_prediction_step"] * len(trainer.get_eval_dataloader()) + ["on_log", "on_evaluate"]
-        for _ in range(trainer.state.num_train_epochs):
-            expected_events.append("on_epoch_begin")
-            for _ in range(train_dl_len):
-                step += 1
-                expected_events += ["on_step_begin", "on_pre_optimizer_step", "on_optimizer_step", "on_step_end"]
-                if step % trainer.args.logging_steps == 0:
-                    expected_events.append("on_log")
-                if trainer.args.eval_strategy == IntervalStrategy.STEPS and step % trainer.args.eval_steps == 0:
-                    expected_events += evaluation_events.copy()
-                if step % trainer.args.save_steps == 0 or step == trainer.state.max_steps:
-                    expected_events.append("on_save")
-            expected_events.append("on_epoch_end")
-            if trainer.args.eval_strategy == IntervalStrategy.EPOCH:
-                expected_events += evaluation_events.copy()
-        expected_events += ["on_log", "on_train_end"]
-        return expected_events
+        expected = get_callback_names(DEFAULT_CALLBACKS + [ProgressCallback])
+        actual = get_callback_names(trainer.callback_handler.callbacks)
 
-    def test_init_callback(self):
-        trainer = self.get_trainer()
-        expected_callbacks = DEFAULT_CALLBACKS.copy() + [ProgressCallback]
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+        self.assertEqual(actual, expected)
 
-        # Callbacks passed at init are added to the default callbacks
-        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback])
-        expected_callbacks.append(MyTestTrainerCallback)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+    def test_custom_callback_added_at_init(self):
+        """Custom callbacks passed at init should be added to defaults."""
+        trainer = self._create_trainer(callbacks=[EventRecorderCallback])
 
-        # TrainingArguments.disable_tqdm controls if use ProgressCallback or PrinterCallback
-        trainer = self.get_trainer(disable_tqdm=True)
-        expected_callbacks = DEFAULT_CALLBACKS.copy() + [PrinterCallback]
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+        expected = get_callback_names(DEFAULT_CALLBACKS + [ProgressCallback, EventRecorderCallback])
+        actual = get_callback_names(trainer.callback_handler.callbacks)
 
-    def test_add_remove_callback(self):
-        expected_callbacks = DEFAULT_CALLBACKS.copy() + [ProgressCallback]
-        trainer = self.get_trainer()
+        self.assertEqual(actual, expected)
 
-        # We can add, pop, or remove by class name
+    def test_printer_callback_when_tqdm_disabled(self):
+        """PrinterCallback should replace ProgressCallback when tqdm is disabled."""
+        trainer = self._create_trainer(disable_tqdm=True)
+
+        expected = get_callback_names(DEFAULT_CALLBACKS + [PrinterCallback])
+        actual = get_callback_names(trainer.callback_handler.callbacks)
+
+        self.assertEqual(actual, expected)
+
+    def test_add_callback_by_class(self):
+        """Adding a callback by class should instantiate and add it."""
+        trainer = self._create_trainer()
+        initial_count = len(trainer.callback_handler.callbacks)
+
+        trainer.add_callback(EventRecorderCallback)
+
+        self.assertEqual(len(trainer.callback_handler.callbacks), initial_count + 1)
+        self.assertIsNotNone(self._get_callback(trainer, EventRecorderCallback))
+
+    def test_add_callback_by_instance(self):
+        """Adding a callback instance should add that exact instance."""
+        trainer = self._create_trainer()
+        callback = EventRecorderCallback()
+
+        trainer.add_callback(callback)
+
+        self.assertIn(callback, trainer.callback_handler.callbacks)
+
+    def test_remove_callback_by_class(self):
+        """Removing by class should remove the first matching callback."""
+        trainer = self._create_trainer()
+        self.assertIsNotNone(self._get_callback(trainer, DefaultFlowCallback))
+
         trainer.remove_callback(DefaultFlowCallback)
-        expected_callbacks.remove(DefaultFlowCallback)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
 
-        trainer = self.get_trainer()
-        cb = trainer.pop_callback(DefaultFlowCallback)
-        self.assertEqual(cb.__class__, DefaultFlowCallback)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+        self.assertIsNone(self._get_callback(trainer, DefaultFlowCallback))
 
-        trainer.add_callback(DefaultFlowCallback)
-        expected_callbacks.insert(0, DefaultFlowCallback)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+    def test_remove_callback_by_instance(self):
+        """Removing by instance should remove that exact callback."""
+        trainer = self._create_trainer()
+        callback = trainer.callback_handler.callbacks[0]
 
-        # We can also add, pop, or remove by instance
-        trainer = self.get_trainer()
-        cb = trainer.callback_handler.callbacks[0]
-        trainer.remove_callback(cb)
-        expected_callbacks.remove(DefaultFlowCallback)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+        trainer.remove_callback(callback)
 
-        trainer = self.get_trainer()
-        cb1 = trainer.callback_handler.callbacks[0]
-        cb2 = trainer.pop_callback(cb1)
-        self.assertEqual(cb1, cb2)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+        self.assertNotIn(callback, trainer.callback_handler.callbacks)
 
-        trainer.add_callback(cb1)
-        expected_callbacks.insert(0, DefaultFlowCallback)
-        self.check_callbacks_equality(trainer.callback_handler.callbacks, expected_callbacks)
+    def test_pop_callback_returns_instance(self):
+        """Pop should remove and return the callback instance."""
+        trainer = self._create_trainer()
+        original_callback = self._get_callback(trainer, DefaultFlowCallback)
 
-    def test_event_flow(self):
+        popped = trainer.pop_callback(DefaultFlowCallback)
+
+        self.assertEqual(popped, original_callback)
+        self.assertIsNone(self._get_callback(trainer, DefaultFlowCallback))
+
+    def test_duplicate_callback_warning(self):
+        """Adding a duplicate callback class should emit a warning."""
+        with patch("transformers.trainer_callback.logger.warning") as warn_mock:
+            self._create_trainer(callbacks=[EventRecorderCallback, EventRecorderCallback])
+
+            self.assertTrue(warn_mock.called)
+            self.assertIn("EventRecorderCallback", warn_mock.call_args[0][0])
+
+    # -------------------------------------------------------------------------
+    # Event Flow Tests
+    # -------------------------------------------------------------------------
+
+    def test_basic_training_events(self):
+        """Basic training should fire events in the correct order."""
         import warnings
 
-        # XXX: for now ignore scatter_gather warnings in this test since it's not relevant to what's being tested
         with warnings.catch_warnings():
             warnings.simplefilter(action="ignore", category=UserWarning)
 
-            trainer = self.get_trainer(callbacks=[MyTestTrainerCallback])
-            trainer.train()
-            events = trainer.callback_handler.callbacks[-2].events
-            self.assertEqual(events, self.get_expected_events(trainer))
-
-            # Independent log/save/eval
-            trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], logging_steps=5)
-            trainer.train()
-            events = trainer.callback_handler.callbacks[-2].events
-            self.assertEqual(events, self.get_expected_events(trainer))
-
-            trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], save_steps=5)
-            trainer.train()
-            events = trainer.callback_handler.callbacks[-2].events
-            self.assertEqual(events, self.get_expected_events(trainer))
-
-            trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], eval_steps=5, eval_strategy="steps")
-            trainer.train()
-            events = trainer.callback_handler.callbacks[-2].events
-            self.assertEqual(events, self.get_expected_events(trainer))
-
-            trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], eval_strategy="epoch")
-            trainer.train()
-            events = trainer.callback_handler.callbacks[-2].events
-            self.assertEqual(events, self.get_expected_events(trainer))
-
-            # A bit of everything
-            trainer = self.get_trainer(
-                callbacks=[MyTestTrainerCallback],
-                logging_steps=3,
-                save_steps=10,
-                eval_steps=5,
-                eval_strategy="steps",
+            trainer = self._create_trainer(
+                callbacks=[EventRecorderCallback],
+                max_steps=2,
+                logging_steps=1,
+                save_strategy="no",
             )
             trainer.train()
-            events = trainer.callback_handler.callbacks[-2].events
-            self.assertEqual(events, self.get_expected_events(trainer))
 
-            # warning should be emitted for duplicated callbacks
-            with patch("transformers.trainer_callback.logger.warning") as warn_mock:
-                trainer = self.get_trainer(
-                    callbacks=[MyTestTrainerCallback, MyTestTrainerCallback],
-                )
-                assert str(MyTestTrainerCallback) in warn_mock.call_args[0][0]
+        callback = self._get_callback(trainer, EventRecorderCallback)
+        events = callback.events
 
-    def test_stateful_callbacks(self):
-        # Use something with non-defaults
+        # Check essential events are present and in order
+        self.assertEqual(events[0], "on_init_end")
+        self.assertEqual(events[1], "on_train_begin")
+        self.assertIn("on_epoch_begin", events)
+        self.assertIn("on_step_begin", events)
+        self.assertIn("on_step_end", events)
+        self.assertIn("on_epoch_end", events)
+        self.assertEqual(events[-1], "on_train_end")
+
+    def test_evaluation_events_with_steps_strategy(self):
+        """Evaluation events should fire when using steps strategy."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            trainer = self._create_trainer(
+                callbacks=[EventRecorderCallback],
+                max_steps=2,
+                eval_strategy="steps",
+                eval_steps=2,
+                logging_steps=1,
+                save_strategy="no",
+            )
+            trainer.train()
+
+        callback = self._get_callback(trainer, EventRecorderCallback)
+
+        self.assertIn("on_evaluate", callback.events)
+        self.assertIn("on_prediction_step", callback.events)
+
+    def test_evaluation_events_with_epoch_strategy(self):
+        """Evaluation events should fire when using epoch strategy."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            trainer = self._create_trainer(
+                callbacks=[EventRecorderCallback],
+                num_train_epochs=1,
+                eval_strategy="epoch",
+                logging_steps=1,
+                save_strategy="no",
+            )
+            trainer.train()
+
+        callback = self._get_callback(trainer, EventRecorderCallback)
+
+        self.assertIn("on_evaluate", callback.events)
+
+    def test_save_events(self):
+        """Save events should fire according to save strategy."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            trainer = self._create_trainer(
+                callbacks=[EventRecorderCallback],
+                max_steps=2,
+                save_strategy="steps",
+                save_steps=2,
+                logging_steps=1,
+            )
+            trainer.train()
+
+        callback = self._get_callback(trainer, EventRecorderCallback)
+
+        self.assertIn("on_save", callback.events)
+
+    def test_log_events(self):
+        """Log events should fire according to logging steps."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            trainer = self._create_trainer(
+                callbacks=[EventRecorderCallback],
+                max_steps=4,
+                logging_steps=2,
+                save_strategy="no",
+            )
+            trainer.train()
+
+        callback = self._get_callback(trainer, EventRecorderCallback)
+
+        # Should have multiple log events (at step 2 and 4)
+        log_count = callback.events.count("on_log")
+        self.assertGreaterEqual(log_count, 2)
+
+    def test_optimizer_step_events(self):
+        """Optimizer events should fire on each training step."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            trainer = self._create_trainer(
+                callbacks=[EventRecorderCallback],
+                max_steps=2,
+                logging_steps=1,
+                save_strategy="no",
+            )
+            trainer.train()
+
+        callback = self._get_callback(trainer, EventRecorderCallback)
+
+        self.assertIn("on_pre_optimizer_step", callback.events)
+        self.assertIn("on_optimizer_step", callback.events)
+
+    def test_on_push_begin_event(self):
+        """on_push_begin should be callable and fire correctly."""
+        trainer = self._create_trainer(callbacks=[EventRecorderCallback], max_steps=1)
+        trainer.train()
+
+        callback = self._get_callback(trainer, EventRecorderCallback)
+        initial_count = len(callback.events)
+
+        # Manually trigger push_begin event
+        trainer.callback_handler.on_push_begin(trainer.args, trainer.state, trainer.control)
+
+        self.assertIn("on_push_begin", callback.events)
+        self.assertEqual(callback.events.count("on_push_begin"), 1)
+        self.assertEqual(len(callback.events), initial_count + 1)
+
+    def test_no_duplicate_save_on_epoch_strategy(self):
+        """Save should only happen once per epoch with epoch strategy."""
+        save_count = 0
+
+        class SaveCounterCallback(TrainerCallback):
+            def on_step_end(self, args, state, control, **kwargs):
+                nonlocal save_count
+                if control.should_save:
+                    save_count += 1
+
+            def on_epoch_end(self, args, state, control, **kwargs):
+                nonlocal save_count
+                if control.should_save:
+                    save_count += 1
+
+        trainer = self._create_trainer(
+            callbacks=[SaveCounterCallback()],
+            max_steps=2,
+            save_strategy="epoch",
+        )
+        trainer.train()
+
+        self.assertEqual(save_count, 1)
+
+    # -------------------------------------------------------------------------
+    # Control Flow Tests
+    # -------------------------------------------------------------------------
+
+    def test_callback_can_stop_training(self):
+        """A callback should be able to stop training by setting control flag."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            trainer = self._create_trainer(
+                callbacks=[StopTrainingCallback(stop_after_steps=1)],
+                max_steps=10,
+                logging_steps=1,
+                save_strategy="no",
+            )
+            trainer.train()
+
+        # Training should have stopped after 1 step, not 10
+        self.assertEqual(trainer.state.global_step, 1)
+
+    def test_callback_receives_control_flags(self):
+        """Callbacks should receive current control flags."""
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter(action="ignore", category=UserWarning)
+
+            callback = ModifyControlCallback()
+            trainer = self._create_trainer(
+                callbacks=[callback],
+                max_steps=2,
+                logging_steps=1,
+                save_strategy="no",
+            )
+            trainer.train()
+
+        # Should have recorded control state for each step
+        self.assertEqual(len(callback.control_modifications), 2)
+
+
+@require_torch
+class StatefulCallbackTest(unittest.TestCase):
+    """Tests for stateful callback persistence across checkpoints."""
+
+    def setUp(self):
+        self.output_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.output_dir)
+
+    def _create_trainer(self, callbacks=None, **kwargs):
+        """Create a Trainer for stateful callback tests."""
+        train_dataset = RegressionDataset(length=64)
+        eval_dataset = RegressionDataset(length=64)
+        config = RegressionModelConfig(a=0, b=0)
+        model = RegressionPreTrainedModel(config)
+
+        kwargs.setdefault("disable_tqdm", False)
+        kwargs.setdefault("report_to", [])
+
+        args = TrainingArguments(self.output_dir, **kwargs)
+        return Trainer(
+            model,
+            args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            callbacks=callbacks,
+        )
+
+    def test_early_stopping_state_persists(self):
+        """EarlyStoppingCallback state should persist across checkpoint resume."""
+        # First training run with custom patience
         cb = EarlyStoppingCallback(early_stopping_patience=5, early_stopping_threshold=0.2)
-        trainer = self.get_trainer(
+        trainer = self._create_trainer(
             callbacks=[cb],
             load_best_model_at_end=True,
             save_strategy="steps",
@@ -286,8 +572,8 @@ class TrainerCallbackTest(unittest.TestCase):
         )
         trainer.train()
 
-        # Create a new trainer with defaults
-        trainer = self.get_trainer(
+        # Resume with default callback - should load saved state
+        trainer = self._create_trainer(
             callbacks=[EarlyStoppingCallback()],
             load_best_model_at_end=True,
             save_strategy="steps",
@@ -297,23 +583,27 @@ class TrainerCallbackTest(unittest.TestCase):
             max_steps=2,
             restore_callback_states_from_checkpoint=True,
         )
-        # Load it back in and verify values
         checkpoint = os.path.join(self.output_dir, "checkpoint-2")
         trainer.train(resume_from_checkpoint=checkpoint)
-        cb = [
-            callback for callback in trainer.callback_handler.callbacks if isinstance(callback, EarlyStoppingCallback)
-        ][0]
-        assert cb.early_stopping_patience == 5
-        assert cb.early_stopping_threshold == 0.2
 
-    def test_stateful_mixed_callbacks(self):
-        # Use two callbacks, one stateful one not
-        # Use something with non-defaults
+        # Find the callback and verify state was restored
+        restored_cb = None
+        for callback in trainer.callback_handler.callbacks:
+            if isinstance(callback, EarlyStoppingCallback):
+                restored_cb = callback
+                break
+
+        self.assertIsNotNone(restored_cb)
+        self.assertEqual(restored_cb.early_stopping_patience, 5)
+        self.assertEqual(restored_cb.early_stopping_threshold, 0.2)
+
+    def test_mixed_stateful_and_regular_callbacks(self):
+        """Stateful and regular callbacks should coexist correctly."""
         cbs = [
-            MyTestTrainerCallback(my_test_state="another value"),
+            EventRecorderCallback(),
             EarlyStoppingCallback(early_stopping_patience=5, early_stopping_threshold=0.2),
         ]
-        trainer = self.get_trainer(
+        trainer = self._create_trainer(
             callbacks=cbs,
             load_best_model_at_end=True,
             save_strategy="steps",
@@ -324,9 +614,9 @@ class TrainerCallbackTest(unittest.TestCase):
         )
         trainer.train()
 
-        # Create a new trainer with defaults
-        trainer = self.get_trainer(
-            callbacks=[EarlyStoppingCallback(), MyTestTrainerCallback()],
+        # Resume with fresh callbacks
+        trainer = self._create_trainer(
+            callbacks=[EarlyStoppingCallback(), EventRecorderCallback()],
             load_best_model_at_end=True,
             save_strategy="steps",
             eval_strategy="steps",
@@ -335,24 +625,22 @@ class TrainerCallbackTest(unittest.TestCase):
             max_steps=2,
             restore_callback_states_from_checkpoint=True,
         )
-        # Load it back in and verify values
         checkpoint = os.path.join(self.output_dir, "checkpoint-2")
         trainer.train(resume_from_checkpoint=checkpoint)
-        cbs = [
-            callback
-            for callback in trainer.callback_handler.callbacks
-            if isinstance(callback, (EarlyStoppingCallback, MyTestTrainerCallback))
-        ]
-        assert len(cbs) == 2
-        my_test, early_stopping = cbs
-        assert early_stopping.early_stopping_patience == 5
-        assert early_stopping.early_stopping_threshold == 0.2
-        assert my_test.my_test_state == "test"
 
-    def test_stateful_duplicate_callbacks(self):
-        # Use something with non-defaults
-        cbs = [MyTestExportableCallback("first"), MyTestExportableCallback("second")]
-        trainer = self.get_trainer(
+        # Stateful callback should be restored
+        early_stopping = None
+        for callback in trainer.callback_handler.callbacks:
+            if isinstance(callback, EarlyStoppingCallback):
+                early_stopping = callback
+                break
+
+        self.assertEqual(early_stopping.early_stopping_patience, 5)
+
+    def test_multiple_instances_of_same_stateful_callback(self):
+        """Multiple instances of the same stateful callback should each persist."""
+        cbs = [StatefulTestCallback("first"), StatefulTestCallback("second")]
+        trainer = self._create_trainer(
             callbacks=cbs,
             load_best_model_at_end=True,
             save_strategy="steps",
@@ -363,9 +651,9 @@ class TrainerCallbackTest(unittest.TestCase):
         )
         trainer.train()
 
-        # Create a new trainer with defaults
-        trainer = self.get_trainer(
-            callbacks=[MyTestExportableCallback(), MyTestExportableCallback()],
+        # Resume with default values
+        trainer = self._create_trainer(
+            callbacks=[StatefulTestCallback(), StatefulTestCallback()],
             load_best_model_at_end=True,
             save_strategy="steps",
             eval_strategy="steps",
@@ -374,21 +662,22 @@ class TrainerCallbackTest(unittest.TestCase):
             max_steps=2,
             restore_callback_states_from_checkpoint=True,
         )
-        # Load it back in and verify values
         checkpoint = os.path.join(self.output_dir, "checkpoint-2")
         trainer.train(resume_from_checkpoint=checkpoint)
-        cbs = [
-            callback
-            for callback in trainer.callback_handler.callbacks
-            if isinstance(callback, MyTestExportableCallback)
-        ]
-        assert len(cbs) == 2
-        assert cbs[0].my_test_state == "first"
-        assert cbs[1].my_test_state == "second"
 
-    def test_missing_stateful_callback(self):
+        restored = [
+            cb for cb in trainer.callback_handler.callbacks
+            if isinstance(cb, StatefulTestCallback)
+        ]
+
+        self.assertEqual(len(restored), 2)
+        self.assertEqual(restored[0].my_value, "first")
+        self.assertEqual(restored[1].my_value, "second")
+
+    def test_missing_stateful_callback_warning(self):
+        """Warning should be emitted when a stateful callback is missing on resume."""
         cb = EarlyStoppingCallback()
-        trainer = self.get_trainer(
+        trainer = self._create_trainer(
             callbacks=[cb],
             load_best_model_at_end=True,
             save_strategy="steps",
@@ -399,8 +688,8 @@ class TrainerCallbackTest(unittest.TestCase):
         )
         trainer.train()
 
-        # Create a new trainer with defaults
-        trainer = self.get_trainer(
+        # Resume WITHOUT the EarlyStoppingCallback
+        trainer = self._create_trainer(
             save_strategy="steps",
             eval_strategy="steps",
             save_steps=2,
@@ -408,52 +697,329 @@ class TrainerCallbackTest(unittest.TestCase):
             max_steps=2,
             restore_callback_states_from_checkpoint=True,
         )
-        # Load it back in and verify values
         checkpoint = os.path.join(self.output_dir, "checkpoint-2")
-        # warning should be emitted for not-present callbacks
+
         with patch("transformers.trainer.logger.warning") as warn_mock:
             trainer.train(resume_from_checkpoint=checkpoint)
-            assert "EarlyStoppingCallback" in warn_mock.call_args[0][0]
 
-    def test_stateful_control(self):
-        trainer = self.get_trainer(
+            self.assertTrue(warn_mock.called)
+            self.assertIn("EarlyStoppingCallback", warn_mock.call_args[0][0])
+
+    def test_trainer_control_state_persists(self):
+        """TrainerControl state should persist across checkpoint resume."""
+        trainer = self._create_trainer(
             max_steps=2,
             save_strategy="steps",
             save_steps=2,
         )
         trainer.train()
-        # Load it back in and verify values
-        trainer = self.get_trainer(max_steps=2, restore_callback_states_from_checkpoint=True)
+
+        # Load state and verify
+        trainer = self._create_trainer(max_steps=2, restore_callback_states_from_checkpoint=True)
         checkpoint = os.path.join(self.output_dir, "checkpoint-2")
         trainer.state = TrainerState.load_from_json(os.path.join(checkpoint, TRAINER_STATE_NAME))
         trainer._load_callback_state()
-        assert trainer.control.should_training_stop
 
-    def test_no_duplicate_save_on_epoch_save_strategy(self):
-        times_saved = 0
+        self.assertTrue(trainer.control.should_training_stop)
 
-        class OnEndCallback(TrainerCallback):
-            def on_step_end(self, args: TrainingArguments, state: TrainerState, control, **kwargs):
-                nonlocal times_saved
-                if control.should_save:
-                    times_saved += 1
 
-            def on_epoch_end(self, args: TrainingArguments, state: TrainerState, control, **kwargs):
-                nonlocal times_saved
-                if control.should_save:
-                    times_saved += 1
+class TrainerStateTest(unittest.TestCase):
+    """Tests for TrainerState functionality."""
 
-        trainer = self.get_trainer(max_steps=2, save_strategy="epoch", callbacks=[OnEndCallback])
-        trainer.train()
-        assert times_saved == 1
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
 
-    def test_on_push_begin(self):
-        trainer = self.get_trainer(callbacks=[MyTestTrainerCallback], max_steps=1)
-        trainer.train()
-        callback = [cb for cb in trainer.callback_handler.callbacks if isinstance(cb, MyTestTrainerCallback)][0]
-        initial_event_count = len(callback.events)
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir)
 
-        trainer.callback_handler.on_push_begin(trainer.args, trainer.state, trainer.control)
-        assert "on_push_begin" in callback.events
-        assert callback.events.count("on_push_begin") == 1
-        assert len(callback.events) == initial_event_count + 1
+    def test_save_and_load_json(self):
+        """TrainerState should serialize and deserialize to JSON."""
+        state = TrainerState(
+            epoch=1.5,
+            global_step=100,
+            max_steps=200,
+            best_metric=0.95,
+        )
+        json_path = os.path.join(self.temp_dir, "state.json")
+
+        state.save_to_json(json_path)
+        loaded = TrainerState.load_from_json(json_path)
+
+        self.assertEqual(loaded.epoch, 1.5)
+        self.assertEqual(loaded.global_step, 100)
+        self.assertEqual(loaded.max_steps, 200)
+        self.assertEqual(loaded.best_metric, 0.95)
+
+    def test_log_history_initialized(self):
+        """log_history should be initialized as empty list."""
+        state = TrainerState()
+
+        self.assertEqual(state.log_history, [])
+
+    def test_stateful_callbacks_initialized(self):
+        """stateful_callbacks should be initialized as empty dict."""
+        state = TrainerState()
+
+        self.assertEqual(state.stateful_callbacks, {})
+
+    def test_compute_steps_from_proportion(self):
+        """compute_steps should convert proportions to absolute values."""
+        state = TrainerState()
+
+        class MockArgs:
+            logging_steps = 0.1  # 10% of max_steps
+            eval_steps = 0.2    # 20% of max_steps
+            save_steps = 0.5    # 50% of max_steps
+
+        state.compute_steps(MockArgs(), max_steps=100)
+
+        self.assertEqual(state.logging_steps, 10)
+        self.assertEqual(state.eval_steps, 20)
+        self.assertEqual(state.save_steps, 50)
+
+    def test_compute_steps_from_integers(self):
+        """compute_steps should preserve integer values."""
+        state = TrainerState()
+
+        class MockArgs:
+            logging_steps = 10
+            eval_steps = 20
+            save_steps = 50
+
+        state.compute_steps(MockArgs(), max_steps=100)
+
+        self.assertEqual(state.logging_steps, 10)
+        self.assertEqual(state.eval_steps, 20)
+        self.assertEqual(state.save_steps, 50)
+
+
+class TrainerControlTest(unittest.TestCase):
+    """Tests for TrainerControl functionality."""
+
+    def test_default_values(self):
+        """TrainerControl should have all flags False by default."""
+        control = TrainerControl()
+
+        self.assertFalse(control.should_training_stop)
+        self.assertFalse(control.should_epoch_stop)
+        self.assertFalse(control.should_save)
+        self.assertFalse(control.should_evaluate)
+        self.assertFalse(control.should_log)
+
+    def test_new_training_resets_stop_flag(self):
+        """_new_training should reset should_training_stop."""
+        control = TrainerControl(should_training_stop=True)
+
+        control._new_training()
+
+        self.assertFalse(control.should_training_stop)
+
+    def test_new_epoch_resets_epoch_stop_flag(self):
+        """_new_epoch should reset should_epoch_stop."""
+        control = TrainerControl(should_epoch_stop=True)
+
+        control._new_epoch()
+
+        self.assertFalse(control.should_epoch_stop)
+
+    def test_new_step_resets_step_flags(self):
+        """_new_step should reset save, evaluate, and log flags."""
+        control = TrainerControl(
+            should_save=True,
+            should_evaluate=True,
+            should_log=True,
+        )
+
+        control._new_step()
+
+        self.assertFalse(control.should_save)
+        self.assertFalse(control.should_evaluate)
+        self.assertFalse(control.should_log)
+
+    def test_state_export(self):
+        """state() should return all control flags."""
+        control = TrainerControl(
+            should_training_stop=True,
+            should_save=True,
+        )
+
+        state = control.state()
+
+        self.assertEqual(state["args"]["should_training_stop"], True)
+        self.assertEqual(state["args"]["should_save"], True)
+        self.assertEqual(state["attributes"], {})
+
+
+class CallbackHandlerTest(unittest.TestCase):
+    """Tests for CallbackHandler functionality."""
+
+    def test_callback_list_property(self):
+        """callback_list should return newline-separated callback names."""
+        handler = CallbackHandler(
+            callbacks=[DefaultFlowCallback(), ProgressCallback()],
+            model=None,
+            processing_class=None,
+            optimizer=None,
+            lr_scheduler=None,
+        )
+
+        callback_list = handler.callback_list
+
+        self.assertIn("DefaultFlowCallback", callback_list)
+        self.assertIn("ProgressCallback", callback_list)
+
+    def test_warning_without_default_flow_callback(self):
+        """Warning should be emitted if DefaultFlowCallback is missing."""
+        with patch("transformers.trainer_callback.logger.warning") as warn_mock:
+            CallbackHandler(
+                callbacks=[ProgressCallback()],
+                model=None,
+                processing_class=None,
+                optimizer=None,
+                lr_scheduler=None,
+            )
+
+            self.assertTrue(warn_mock.called)
+            self.assertIn("DefaultFlowCallback", warn_mock.call_args[0][0])
+
+    def test_pop_callback_returns_none_if_not_found(self):
+        """pop_callback should return None if callback not found."""
+        handler = CallbackHandler(
+            callbacks=[DefaultFlowCallback()],
+            model=None,
+            processing_class=None,
+            optimizer=None,
+            lr_scheduler=None,
+        )
+
+        result = handler.pop_callback(ProgressCallback)
+
+        self.assertIsNone(result)
+
+    def test_call_event_passes_kwargs(self):
+        """call_event should pass kwargs to all callbacks."""
+        received_kwargs = {}
+
+        class KwargsRecorderCallback(TrainerCallback):
+            def on_log(self, args, state, control, **kwargs):
+                received_kwargs.update(kwargs)
+
+        handler = CallbackHandler(
+            callbacks=[DefaultFlowCallback(), KwargsRecorderCallback()],
+            model="test_model",
+            processing_class="test_processor",
+            optimizer="test_optimizer",
+            lr_scheduler="test_scheduler",
+        )
+        handler.train_dataloader = "test_train_dl"
+        handler.eval_dataloader = "test_eval_dl"
+
+        control = TrainerControl()
+        handler.call_event("on_log", None, TrainerState(), control, logs={"loss": 1.0})
+
+        self.assertEqual(received_kwargs["model"], "test_model")
+        self.assertEqual(received_kwargs["processing_class"], "test_processor")
+        self.assertEqual(received_kwargs["logs"], {"loss": 1.0})
+
+
+class EarlyStoppingCallbackTest(unittest.TestCase):
+    """Tests for EarlyStoppingCallback logic."""
+
+    def test_patience_counter_increments_when_metric_does_not_improve(self):
+        """Patience counter should increment when metric doesn't improve."""
+        callback = EarlyStoppingCallback(early_stopping_patience=3)
+        state = TrainerState(best_metric=0.9)
+        control = TrainerControl()
+
+        class MockArgs:
+            greater_is_better = True
+
+        # Metric is worse (0.8 < 0.9), counter should increment
+        callback.check_metric_value(MockArgs(), state, control, 0.8)
+
+        self.assertEqual(callback.early_stopping_patience_counter, 1)
+
+    def test_patience_counter_resets_when_metric_improves(self):
+        """Patience counter should reset when metric improves."""
+        callback = EarlyStoppingCallback(early_stopping_patience=3)
+        callback.early_stopping_patience_counter = 2
+        state = TrainerState(best_metric=0.8)
+        control = TrainerControl()
+
+        class MockArgs:
+            greater_is_better = True
+
+        # Metric is better (0.95 > 0.8), counter should reset
+        callback.check_metric_value(MockArgs(), state, control, 0.95)
+
+        self.assertEqual(callback.early_stopping_patience_counter, 0)
+
+    def test_threshold_prevents_small_improvements(self):
+        """Small improvements within threshold should not reset counter."""
+        callback = EarlyStoppingCallback(
+            early_stopping_patience=3,
+            early_stopping_threshold=0.1,
+        )
+        state = TrainerState(best_metric=0.8)
+        control = TrainerControl()
+
+        class MockArgs:
+            greater_is_better = True
+
+        # Improvement of 0.05 is less than threshold of 0.1
+        callback.check_metric_value(MockArgs(), state, control, 0.85)
+
+        self.assertEqual(callback.early_stopping_patience_counter, 1)
+
+    def test_state_includes_all_attributes(self):
+        """state() should include patience, threshold, and counter."""
+        callback = EarlyStoppingCallback(
+            early_stopping_patience=5,
+            early_stopping_threshold=0.1,
+        )
+        callback.early_stopping_patience_counter = 3
+
+        state = callback.state()
+
+        self.assertEqual(state["args"]["early_stopping_patience"], 5)
+        self.assertEqual(state["args"]["early_stopping_threshold"], 0.1)
+        self.assertEqual(state["attributes"]["early_stopping_patience_counter"], 3)
+
+
+class ExportableStateTest(unittest.TestCase):
+    """Tests for ExportableState interface."""
+
+    def test_from_state_creates_instance(self):
+        """from_state should create instance with correct args and attributes."""
+        state = {
+            "args": {"my_value": "restored"},
+            "attributes": {},
+        }
+
+        instance = StatefulTestCallback.from_state(state)
+
+        self.assertEqual(instance.my_value, "restored")
+
+    def test_from_state_sets_attributes(self):
+        """from_state should set attributes from state dict."""
+
+        class CallbackWithAttributes(TrainerCallback, ExportableState):
+            def __init__(self, name="default"):
+                self.name = name
+                self.counter = 0
+
+            def state(self):
+                return {
+                    "args": {"name": self.name},
+                    "attributes": {"counter": self.counter},
+                }
+
+        state = {
+            "args": {"name": "test"},
+            "attributes": {"counter": 5},
+        }
+
+        instance = CallbackWithAttributes.from_state(state)
+
+        self.assertEqual(instance.name, "test")
+        self.assertEqual(instance.counter, 5)

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -151,12 +151,14 @@ class ModifyControlCallback(TrainerCallback):
         self.control_modifications = []
 
     def on_step_end(self, args, state, control, **kwargs):
-        self.control_modifications.append({
-            "step": state.global_step,
-            "should_log": control.should_log,
-            "should_save": control.should_save,
-            "should_evaluate": control.should_evaluate,
-        })
+        self.control_modifications.append(
+            {
+                "step": state.global_step,
+                "should_log": control.should_log,
+                "should_save": control.should_save,
+                "should_evaluate": control.should_evaluate,
+            }
+        )
         return control
 
 
@@ -665,10 +667,7 @@ class StatefulCallbackTest(unittest.TestCase):
         checkpoint = os.path.join(self.output_dir, "checkpoint-2")
         trainer.train(resume_from_checkpoint=checkpoint)
 
-        restored = [
-            cb for cb in trainer.callback_handler.callbacks
-            if isinstance(cb, StatefulTestCallback)
-        ]
+        restored = [cb for cb in trainer.callback_handler.callbacks if isinstance(cb, StatefulTestCallback)]
 
         self.assertEqual(len(restored), 2)
         self.assertEqual(restored[0].my_value, "first")
@@ -768,8 +767,8 @@ class TrainerStateTest(unittest.TestCase):
 
         class MockArgs:
             logging_steps = 0.1  # 10% of max_steps
-            eval_steps = 0.2    # 20% of max_steps
-            save_steps = 0.5    # 50% of max_steps
+            eval_steps = 0.2  # 20% of max_steps
+            save_steps = 0.5  # 50% of max_steps
 
         state.compute_steps(MockArgs(), max_steps=100)
 

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -32,6 +32,7 @@ from unittest.mock import patch
 from transformers import (
     DefaultFlowCallback,
     EarlyStoppingCallback,
+    IntervalStrategy,
     PrinterCallback,
     ProgressCallback,
     Trainer,
@@ -319,135 +320,76 @@ class TrainerCallbackTest(unittest.TestCase):
     # Event Flow Tests
     # -------------------------------------------------------------------------
 
-    def test_basic_training_events(self):
-        """Basic training should fire events in the correct order."""
+    def _get_expected_events(self, trainer):
+        """Compute the exact expected event sequence for a training run."""
+        expected_events = ["on_init_end", "on_train_begin"]
+        step = 0
+        train_dl_len = len(trainer.get_eval_dataloader())
+        evaluation_events = ["on_prediction_step"] * len(trainer.get_eval_dataloader()) + ["on_log", "on_evaluate"]
+        for _ in range(trainer.state.num_train_epochs):
+            expected_events.append("on_epoch_begin")
+            for _ in range(train_dl_len):
+                step += 1
+                expected_events += ["on_step_begin", "on_pre_optimizer_step", "on_optimizer_step", "on_step_end"]
+                if step % trainer.args.logging_steps == 0:
+                    expected_events.append("on_log")
+                if trainer.args.eval_strategy == IntervalStrategy.STEPS and step % trainer.args.eval_steps == 0:
+                    expected_events += evaluation_events.copy()
+                if step % trainer.args.save_steps == 0 or step == trainer.state.max_steps:
+                    expected_events.append("on_save")
+            expected_events.append("on_epoch_end")
+            if trainer.args.eval_strategy == IntervalStrategy.EPOCH:
+                expected_events += evaluation_events.copy()
+        expected_events += ["on_log", "on_train_end"]
+        return expected_events
+
+    def test_event_flow(self):
+        """Test exact event sequence across multiple training configurations."""
         import warnings
 
         with warnings.catch_warnings():
             warnings.simplefilter(action="ignore", category=UserWarning)
 
+            # Default configuration
+            trainer = self._create_trainer(callbacks=[EventRecorderCallback])
+            trainer.train()
+            events = self._get_callback(trainer, EventRecorderCallback).events
+            self.assertEqual(events, self._get_expected_events(trainer))
+
+            # Independent log/save/eval steps
+            trainer = self._create_trainer(callbacks=[EventRecorderCallback], logging_steps=5)
+            trainer.train()
+            events = self._get_callback(trainer, EventRecorderCallback).events
+            self.assertEqual(events, self._get_expected_events(trainer))
+
+            trainer = self._create_trainer(callbacks=[EventRecorderCallback], save_steps=5)
+            trainer.train()
+            events = self._get_callback(trainer, EventRecorderCallback).events
+            self.assertEqual(events, self._get_expected_events(trainer))
+
             trainer = self._create_trainer(
-                callbacks=[EventRecorderCallback],
-                max_steps=2,
-                logging_steps=1,
-                save_strategy="no",
+                callbacks=[EventRecorderCallback], eval_steps=5, eval_strategy="steps"
             )
             trainer.train()
+            events = self._get_callback(trainer, EventRecorderCallback).events
+            self.assertEqual(events, self._get_expected_events(trainer))
 
-        callback = self._get_callback(trainer, EventRecorderCallback)
-        events = callback.events
+            trainer = self._create_trainer(callbacks=[EventRecorderCallback], eval_strategy="epoch")
+            trainer.train()
+            events = self._get_callback(trainer, EventRecorderCallback).events
+            self.assertEqual(events, self._get_expected_events(trainer))
 
-        # Check essential events are present and in order
-        self.assertEqual(events[0], "on_init_end")
-        self.assertEqual(events[1], "on_train_begin")
-        self.assertIn("on_epoch_begin", events)
-        self.assertIn("on_step_begin", events)
-        self.assertIn("on_step_end", events)
-        self.assertIn("on_epoch_end", events)
-        self.assertEqual(events[-1], "on_train_end")
-
-    def test_evaluation_events_with_steps_strategy(self):
-        """Evaluation events should fire when using steps strategy."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="ignore", category=UserWarning)
-
+            # A bit of everything
             trainer = self._create_trainer(
                 callbacks=[EventRecorderCallback],
-                max_steps=2,
+                logging_steps=3,
+                save_steps=10,
+                eval_steps=5,
                 eval_strategy="steps",
-                eval_steps=2,
-                logging_steps=1,
-                save_strategy="no",
             )
             trainer.train()
-
-        callback = self._get_callback(trainer, EventRecorderCallback)
-
-        self.assertIn("on_evaluate", callback.events)
-        self.assertIn("on_prediction_step", callback.events)
-
-    def test_evaluation_events_with_epoch_strategy(self):
-        """Evaluation events should fire when using epoch strategy."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="ignore", category=UserWarning)
-
-            trainer = self._create_trainer(
-                callbacks=[EventRecorderCallback],
-                num_train_epochs=1,
-                eval_strategy="epoch",
-                logging_steps=1,
-                save_strategy="no",
-            )
-            trainer.train()
-
-        callback = self._get_callback(trainer, EventRecorderCallback)
-
-        self.assertIn("on_evaluate", callback.events)
-
-    def test_save_events(self):
-        """Save events should fire according to save strategy."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="ignore", category=UserWarning)
-
-            trainer = self._create_trainer(
-                callbacks=[EventRecorderCallback],
-                max_steps=2,
-                save_strategy="steps",
-                save_steps=2,
-                logging_steps=1,
-            )
-            trainer.train()
-
-        callback = self._get_callback(trainer, EventRecorderCallback)
-
-        self.assertIn("on_save", callback.events)
-
-    def test_log_events(self):
-        """Log events should fire according to logging steps."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="ignore", category=UserWarning)
-
-            trainer = self._create_trainer(
-                callbacks=[EventRecorderCallback],
-                max_steps=4,
-                logging_steps=2,
-                save_strategy="no",
-            )
-            trainer.train()
-
-        callback = self._get_callback(trainer, EventRecorderCallback)
-
-        # Should have multiple log events (at step 2 and 4)
-        log_count = callback.events.count("on_log")
-        self.assertGreaterEqual(log_count, 2)
-
-    def test_optimizer_step_events(self):
-        """Optimizer events should fire on each training step."""
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter(action="ignore", category=UserWarning)
-
-            trainer = self._create_trainer(
-                callbacks=[EventRecorderCallback],
-                max_steps=2,
-                logging_steps=1,
-                save_strategy="no",
-            )
-            trainer.train()
-
-        callback = self._get_callback(trainer, EventRecorderCallback)
-
-        self.assertIn("on_pre_optimizer_step", callback.events)
-        self.assertIn("on_optimizer_step", callback.events)
+            events = self._get_callback(trainer, EventRecorderCallback).events
+            self.assertEqual(events, self._get_expected_events(trainer))
 
     def test_on_push_begin_event(self):
         """on_push_begin should be callable and fire correctly."""

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -367,9 +367,7 @@ class TrainerCallbackTest(unittest.TestCase):
             events = self._get_callback(trainer, EventRecorderCallback).events
             self.assertEqual(events, self._get_expected_events(trainer))
 
-            trainer = self._create_trainer(
-                callbacks=[EventRecorderCallback], eval_steps=5, eval_strategy="steps"
-            )
+            trainer = self._create_trainer(callbacks=[EventRecorderCallback], eval_steps=5, eval_strategy="steps")
             trainer.train()
             events = self._get_callback(trainer, EventRecorderCallback).events
             self.assertEqual(events, self._get_expected_events(trainer))


### PR DESCRIPTION
# What does this PR do?

This PR updates and simplifies tests for trainer. We never really had any issues with those tests, just cleaning a bit. 

1) `tests/trainer/test_data_collator.py` 
- Restructured from 4 large classes (PyTorch/NumPy × Integration/Immutability) into 10
  focused classes by collator type
- Each test class now contains PyTorch, NumPy, and immutability tests together
- Added missing tests (attention_mask generation, flattening immutability)

2) `tests/trainer/test_trainer_callback.py`
  - Split monolithic tests into ~30 focused single-purpose tests
  - Added 4 new test classes: `TrainerStateTest`, `TrainerControlTest`, `CallbackHandlerTest`, `EarlyStoppingCallbackTest`
  - Tests now cover: callback registration, event firing, control flow, state,  persistence, and early stopping logic
