### PR TITLE
SwanLab: Add support for id and resume arguments in SwanLabCallback

### DIFF
--- a/src/transformers/integrations/integration_utils.py
+++ b/src/transformers/integrations/integration_utils.py
@@ -2227,7 +2227,7 @@ class SwanLabCallback(TrainerCallback):
     A [`TrainerCallback`] that logs metrics, media, model checkpoints to [SwanLab](https://swanlab.cn/).
     """
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         if not is_swanlab_available():
             raise RuntimeError("SwanLabCallback requires swanlab to be installed. Run `pip install swanlab`.")
         import swanlab
@@ -2235,6 +2235,7 @@ class SwanLabCallback(TrainerCallback):
         self._swanlab = swanlab
         self._initialized = False
         self._log_model = os.getenv("SWANLAB_LOG_MODEL", None)
+        self._init_kwargs = kwargs
 
     def setup(self, args, state, model, **kwargs):
         """
@@ -2302,6 +2303,7 @@ class SwanLabCallback(TrainerCallback):
             init_args["project"] = os.getenv("SWANLAB_PROJECT", None)
 
             if self._swanlab.get_run() is None:
+                init_args.update(self._init_kwargs)
                 self._swanlab.init(
                     **init_args,
                 )


### PR DESCRIPTION
# Summary

This PR updates `SwanLabCallback` to accept `**kwargs` in its `__init__` method and passes them to `swanlab.init()` during setup.

Previously, the SwanLab integration did not expose important initialization arguments like `experiment_id`, `id`, or `resume`. This made it impossible to properly resume training runs (e.g., when using `Trainer.train(resume_from_checkpoint=...)`) because SwanLab would create a new experiment instead of continuing the existing one. 

By allowing `**kwargs` to be passed through, users can now maintain experiment continuity across restarts by explicitly passing the run ID.

**Changes:**
- Updated `SwanLabCallback.__init__` to store `**kwargs`.
- Updated `SwanLabCallback.setup` to merge these user-provided arguments into `init_args` before calling `swanlab.init`.

Fixes #43698 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed.
