### PR TITLE
fix: ZeRO-3 crash for non-pretrained BERT in _init_weights

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2271,9 +2271,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
             init.normal_(module.weight, mean=0.0, std=std)
-            # Here we need the check explicitly, as we slice the weight in the `zeros_` call, so it looses the flag
+            # Here we need the check explicitly, as we slice the weight in the `zeros_` call, so it loses the flag
             if module.padding_idx is not None and not getattr(module.weight, "_is_hf_initialized", False):
                 # If deepspeed is enabled, the module weight data is not stored, so we need to all gather first
+                # This should not be needed after PR #43847, since _init_weights will just be skipped.
                 if is_deepspeed_zero3_enabled():
                     import deepspeed
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2276,6 +2276,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 # If deepspeed is enabled, the module weight data is not stored, so we need to all gather first
                 if is_deepspeed_zero3_enabled():
                     import deepspeed
+
                     with deepspeed.zero.GatheredParameters(module.weight, modifier_rank=0):
                         init.zeros_(module.weight[module.padding_idx])
                 else:

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -390,7 +390,7 @@ class CoreIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
             # Embedding padding_idx row should be zeroed
             self.assertTrue(torch.allclose(padding_row, torch.zeros_like(padding_row)))
 
-            # Weights should have std=config.initializer_range=0.02, 
+            # Weights should have std=config.initializer_range=0.02,
             # not the _init_weights default of std ≈ 0.5
             self.assertAlmostEqual(embedding.weight.std().item(), std, delta=std)
             self.assertAlmostEqual(linear.weight.std().item(), std, delta=std)


### PR DESCRIPTION
# What does this PR do?

EDIT: see the discussion here https://github.com/huggingface/transformers/pull/43783#discussion_r2795768079

Add a check for deepspeed_zero3 in `_init_weights` for `nn.Embedding`.

When initializing weights for `nn.Embedding`, the code checks for whether there are any indices for padding tokens, and if so, sets their weights to zero. However, when ZeRO3 is enabled, the module weights are not stored, and so indexing fails. To fix, we wrap this line in a `deepspeed.zero.GatheredParameters` context to do an all-gather before indexing.

Fixes #43638 


~~**Note:** After fixing this issue, a separate regression was discovered on main, where ZeRO-3 weights are not gathered during the forward pass (RuntimeError: 'weight' must be 2-D). This affects multiple architectures (BERT, Qwen) and is not present in v5.0.0. I'll open a separate issue for this.~~
EDIT: this has now been fixed elsewhere


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

- text models: @ArthurZucker @Cyrilvallez 
- deepspeed integration: maybe @qgallouedec ?
