### PR TITLE
add openAI style `image_url` content support in `apply_chat_template`

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1728,6 +1728,23 @@ class ProcessorMixin(PushToHubMixin):
             is_batched = False
             conversations = [conversation]
 
+        # Normalize OpenAI-style "image_url" content blocks to HuggingFace-style "image" blocks
+        # OpenAI format: {"type": "image_url", "image_url": {"url": "..."}}
+        # HuggingFace format: {"type": "image", "url": "..."}
+        for conversation_idx, conversation in enumerate(conversations):
+            for message in conversation:
+                if not isinstance(message.get("content"), list):
+                    continue
+                new_content = []
+                for content in message["content"]:
+                    if content.get("type") == "image_url" and "image_url" in content:
+                        image_url_info = content["image_url"]
+                        url = image_url_info.get("url", "") if isinstance(image_url_info, dict) else image_url_info
+                        new_content.append({"type": "image", "url": url})
+                    else:
+                        new_content.append(content)
+                message["content"] = new_content
+
         tokenize = template_kwargs.pop("tokenize", False)
         return_dict = template_kwargs.pop("return_dict", True)
 

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1737,7 +1737,7 @@ class ProcessorMixin(PushToHubMixin):
                     continue
                 new_content = []
                 for content in message["content"]:
-                    if content.get("type") == "image_url" and "image_url" in content:
+                    if isinstance(content, dict) and content.get("type") == "image_url" and "image_url" in content:
                         image_url_info = content["image_url"]
                         url = image_url_info.get("url", "") if isinstance(image_url_info, dict) else image_url_info
                         new_content.append({"type": "image", "url": url})

--- a/tests/pipelines/test_pipelines_image_text_to_text.py
+++ b/tests/pipelines/test_pipelines_image_text_to_text.py
@@ -272,7 +272,7 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
             {
                 ("rocm", (9, 4)): "The first image shows a statue of the Statue of",
                 ("cuda", 8): "The first image shows a statue of Liberty in the",
-                ("xpu", 3): "The first image shows a statue of Liberty in the"
+                ("xpu", 3): "The first image shows a statue of Liberty in the",
             }
         ).get_expectation()
 

--- a/tests/pipelines/test_pipelines_image_text_to_text.py
+++ b/tests/pipelines/test_pipelines_image_text_to_text.py
@@ -20,6 +20,7 @@ from transformers.pipelines import ImageTextToTextPipeline, pipeline
 from transformers.testing_utils import (
     Expectations,
     is_pipeline_test,
+    require_deterministic_for_xpu,
     require_torch,
     require_vision,
     slow,
@@ -112,6 +113,10 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
                     "rocm",
                     (9, 4),
                 ): "Hugging Face, a company of minds\nWith tools and services that make our lives easier\nFrom natural language processing\nTo machine learning and more, they do it all\n\nThey help us to create and share\nContent that is both true and true\nAnd make the world a better place\nWith their tools and services, we can do it all\n\nFrom image and video to text and speech\nThey make it all possible\nWith their tools and services, we can do it all\nAnd make the world a better place\n\nSo let us embrace and use\nHugging Face's tools and services\nTo create and share\nContent that is true and true\nAnd make the world a better place.",
+                (
+                    "xpu",
+                    3,
+                ): "Hugging Face, a company of minds\nWith tools and services that make our lives easier\nFrom natural language processing\nTo machine learning and more, they do it all\n\nThey help us to create and share\nContent that's both engaging and informative\nWith their tools, we can write\nAnd create stories that are both true and true\n\nThey help us to analyze\nAnd make sense of data that's hard to see\nWith their tools, we can see\nAnd make sense of the world around us\n\nThey help us to create\nAnd share content that's both true and true\nWith their tools, we can see\nAnd make sense of the world around us\n\nSo here's to Hugging Face, a company of minds\nWith tools and services that make our lives easier\nFrom natural language processing\nTo machine learning and more, they do it all\n\nThank you, Hugging Face, for all you do\nWith tools and services that make our lives easier\nSo here's to you, and all the great things you do",
             }
         ).get_expectation()
         self.assertEqual(
@@ -158,6 +163,7 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
         )
 
     @require_torch
+    @require_deterministic_for_xpu
     def test_small_model_pt_token(self):
         pipe = pipeline("image-text-to-text", model="llava-hf/llava-interleave-qwen-0.5b-hf")
         image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
@@ -174,6 +180,10 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
                     "rocm",
                     (9, 4),
                 ): "<image> What this is? Assistant: This is a photo of two cats lying on a pink blanket. The cats are facing the camera, and they appear to be sleeping or resting. The blanket is placed on a couch, and the cats are positioned in such a way that they are facing the camera. The image captures a peaceful moment between the two cats, and it's a great way to showcase their cuteness and relaxed demeanor.",
+                (
+                    "xpu",
+                    3,
+                ): "<image> What this is? Assistant: This is a photo of two cats lying on a pink blanket. The cats are facing the camera, and they appear to be sleeping or resting. The blanket is placed on a surface that looks like a couch or a chair, and it is covered with a soft fabric. The cats' fur is a mix of black, white, and brown, and they have a variety of patterns on their bodies. The image captures a moment of tranquility and companionship between the cats.",
             }
         ).get_expectation()
         self.assertEqual(
@@ -197,6 +207,10 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
                     "rocm",
                     (9, 4),
                 ): "<image> What this is? Assistant: This is a photo of two cats lying on a pink blanket. The cats are facing the camera, and they appear to be sleeping or resting. The blanket is placed on a couch, and the overall setting is cozy and comfortable.",
+                (
+                    "xpu",
+                    3,
+                ): "<image> What this is? Assistant: This is a photo of two cats lying on a pink blanket. The cats are facing the camera, and they appear to be sleeping or resting. The blanket is placed on a surface that looks like a couch or a chair, and it is covered with a soft fabric. The cats' fur is a mix of black, white, and brown, and they have a variety of patterns on their bodies. The image captures a moment of tranquility and companionship between the cats.",
             }
         ).get_expectation()
         self.assertEqual(
@@ -258,6 +272,7 @@ class ImageTextToTextPipelineTests(unittest.TestCase):
             {
                 ("rocm", (9, 4)): "The first image shows a statue of the Statue of",
                 ("cuda", 8): "The first image shows a statue of Liberty in the",
+                ("xpu", 3): "The first image shows a statue of Liberty in the"
             }
         ).get_expectation()
 


### PR DESCRIPTION
Many users and tools use the OpenAI chat format for image inputs:
`{"type": "image_url", "image_url": {"url": "https://example.com/image.jpg"}}`

However, apply_chat_template only recognizes the HuggingFace-native format:
`{"type": "image", "url": "https://example.com/image.jpg"}`

This means that when users pass OpenAI-style messages through processor.apply_chat_template(...) (or via the image-text-to-text pipeline), the image_url content blocks are silently skipped during image extraction, resulting in no images being loaded.

This PR adds a normalization step in apply_chat_template that converts OpenAI-style image_url blocks to the HuggingFace image format before image extraction and template rendering, so both formats work seamlessly.

Fix
In ProcessorMixin.apply_chat_template (processing_utils.py), after building the conversations list and before the tokenize block, we normalize:


{"type": "image_url", "image_url": {"url": "..."}}  →  {"type": "image", "url": "..."}
This ensures both the image loading logic and the Jinja chat template rendering see a consistent format.

Test

RUN_SLOW=1 pytest tests/pipelines/test_pipelines_image_text_to_text.py::ImageTextToTextPipelineTests::test_model_pt_chat_template_image_url
Before: ❌ FAILED (no images extracted from image_url blocks)
After: ✅ PASSED