### PR TITLE
fix(testing): Fix BLOOM tokenizer, CLAP audio features, and CLVP text tester usage in tests

### DIFF
--- a/tests/models/bloom/test_modeling_bloom.py
+++ b/tests/models/bloom/test_modeling_bloom.py
@@ -544,7 +544,7 @@ class BloomIntegrationTest(unittest.TestCase):
 
         input_sentence = ["I enjoy walking with my cute dog", "I enjoy walking with my cute dog"]
 
-        inputs = tokenizer.batch_encode_plus(input_sentence, return_tensors="pt", padding=True)
+        inputs = tokenizer(input_sentence, return_tensors="pt", padding=True)
         input_ids = inputs["input_ids"].to(torch_device)
         attention_mask = inputs["attention_mask"]
         greedy_output = model.generate(input_ids, attention_mask=attention_mask, max_length=50, do_sample=False)
@@ -565,7 +565,7 @@ class BloomIntegrationTest(unittest.TestCase):
         input_sentence = ["I enjoy walking with my cute dog", "Hello my name is"]
         input_sentence_without_pad = "Hello my name is"
 
-        input_ids = tokenizer.batch_encode_plus(input_sentence, return_tensors="pt", padding=True)
+        input_ids = tokenizer(input_sentence, return_tensors="pt", padding=True)
         input_ids_without_pad = tokenizer.encode(input_sentence_without_pad, return_tensors="pt")
 
         input_ids, attention_mask = input_ids["input_ids"].to(torch_device), input_ids["attention_mask"]

--- a/tests/models/clap/test_modeling_clap.py
+++ b/tests/models/clap/test_modeling_clap.py
@@ -538,7 +538,9 @@ class ClapModelIntegrationTest(unittest.TestCase):
             expected_mean = EXPECTED_MEANS_UNFUSED[padding]
 
             self.assertTrue(
-                torch.allclose(audio_embed.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3)
+                torch.allclose(
+                    audio_embed.pooler_output.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3
+                )
             )
 
     def test_integration_fused(self):
@@ -565,7 +567,9 @@ class ClapModelIntegrationTest(unittest.TestCase):
             expected_mean = EXPECTED_MEANS_FUSED[padding]
 
             self.assertTrue(
-                torch.allclose(audio_embed.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3)
+                torch.allclose(
+                    audio_embed.pooler_output.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3
+                )
             )
 
     def test_batched_fused(self):
@@ -592,7 +596,9 @@ class ClapModelIntegrationTest(unittest.TestCase):
             expected_mean = EXPECTED_MEANS_FUSED[padding]
 
             self.assertTrue(
-                torch.allclose(audio_embed.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3)
+                torch.allclose(
+                    audio_embed.pooler_output.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3
+                )
             )
 
     def test_batched_unfused(self):
@@ -617,5 +623,7 @@ class ClapModelIntegrationTest(unittest.TestCase):
             expected_mean = EXPECTED_MEANS_FUSED[padding]
 
             self.assertTrue(
-                torch.allclose(audio_embed.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3)
+                torch.allclose(
+                    audio_embed.pooler_output.cpu().mean(), torch.tensor([expected_mean]), atol=1e-3, rtol=1e-3
+                )
             )

--- a/tests/models/clvp/test_modeling_clvp.py
+++ b/tests/models/clvp/test_modeling_clvp.py
@@ -321,6 +321,7 @@ class ClvpModelForConditionalGenerationTester:
     def __init__(self, parent, is_training=False):
         self.parent = parent
         self.clvp_encoder_tester = ClvpEncoderTester(parent)
+        self.text_model_tester = self.clvp_encoder_tester
         self.is_training = is_training
         self.batch_size = self.clvp_encoder_tester.batch_size  # need bs for batching_equivalence test
 


### PR DESCRIPTION
### What does this PR do?

The following failing tests were identified and fixed in this PR:

→ **BLOOM:** `batch_encode_plus()` method was removed from `PreTrainedTokenizerBase` in commit 05c0e1d390 (the "rm slow tokenizers" refactor, #40936). The functionality was absorbed into `__call__`, so `tokenizer(.)` is the current equivalent.
→  **CLAP:** `ClapModel.get_audio_features()` returns a `BaseModelOutputWithPooling` obj not a tensor. The method internally calls `self.audio_model(.)`, projects & normalizes features, stores them in `audio_outputs.pooler_output`, and returns the full output object. The old code calling `.cpu()` directly on the output object caused `AttributeError`.
→  **CLVP:** `ModelTesterMixin` has inherited tests (a couple are `test_get_text_features_output`, `test_get_text_features_hidden_states`, `test_get_text_features_attentions`) that fire when the model has `get_text_features()`. These tests call `_text_features_prepare_config_and_inputs()` which expects `self.model_tester.text_model_tester` to exist. Again, follows the canonical pattern in other multi-modal models like [BridgeTower](https://github.com/huggingface/transformers/blob/main/tests/models/bridgetower/test_modeling_bridgetower.py#L177), [Kosmos2](https://github.com/huggingface/transformers/blob/main/tests/models/kosmos2/test_modeling_kosmos2.py#L207).

**Before the fix (feel free to cross-check; these errors are reproducible):**

<img alt="before_testing" src="https://github.com/user-attachments/assets/beb5f72e-2e14-41ab-a6e0-449f9fb88b93" />

**After the fix (feel free to cross-check):**

<img alt="after_testing" src="https://github.com/user-attachments/assets/121b2685-c818-4641-9722-020f3cc45c4c" />

### Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you fix any necessary existing tests?