### PR TITLE
[docs] Remove pipeline() examples from summarization/translation tasks

### DIFF
--- a/docs/source/en/tasks/summarization.md
+++ b/docs/source/en/tasks/summarization.md
@@ -230,18 +230,6 @@ Come up with some text you'd like to summarize. For T5, you need to prefix your 
 >>> text = "summarize: The Inflation Reduction Act lowers prescription drug costs, health care costs, and energy costs. It's the most aggressive action on tackling the climate crisis in American history, which will lift up American workers and create good-paying, union jobs across the country. It'll lower the deficit and ask the ultra-wealthy and corporations to pay their fair share. And no one making under $400,000 per year will pay a penny more in taxes."
 ```
 
-The simplest way to try out your finetuned model for inference is to use it in a [`pipeline`]. Instantiate a `pipeline` for summarization with your model, and pass your text to it:
-
-```py
->>> from transformers import pipeline
-
->>> summarizer = pipeline("summarization", model="username/my_awesome_billsum_model")
->>> summarizer(text)
-[{"summary_text": "The Inflation Reduction Act lowers prescription drug costs, health care costs, and energy costs. It's the most aggressive action on tackling the climate crisis in American history, which will lift up American workers and create good-paying, union jobs across the country."}]
-```
-
-You can also manually replicate the results of the `pipeline` if you'd like:
-
 Tokenize the text and return the `input_ids` as PyTorch tensors:
 
 ```py

--- a/docs/source/en/tasks/translation.md
+++ b/docs/source/en/tasks/translation.md
@@ -238,21 +238,6 @@ Come up with some text you'd like to translate to another language. For T5, you 
 >>> text = "translate English to French: Legumes share resources with nitrogen-fixing bacteria."
 ```
 
-The simplest way to try out your finetuned model for inference is to use it in a [`pipeline`]. Instantiate a `pipeline` for translation with your model, and pass your text to it:
-
-```py
->>> from transformers import pipeline
-
-# Change `xx` to the language of the input and `yy` to the language of the desired output.
-# Examples: "en" for English, "fr" for French, "de" for German, "es" for Spanish, "zh" for Chinese, etc; translation_en_to_fr translates English to French
-# You can view all the lists of languages here - https://huggingface.co/languages
->>> translator = pipeline("translation_xx_to_yy", model="username/my_awesome_opus_books_model")
->>> translator(text)
-[{'translation_text': 'Legumes partagent des ressources avec des bactéries azotantes.'}]
-```
-
-You can also manually replicate the results of the `pipeline` if you'd like:
-
 Tokenize the text and return the `input_ids` as PyTorch tensors:
 
 ```py


### PR DESCRIPTION
## Summary
- Removes `pipeline()`-based inference examples from summarization and translation task documentation
- These examples no longer work in v5 since `SummarizationPipeline` and `TranslationPipeline` were removed

## Background
According to the [v5 migration guide](https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md#pipelines), `SummarizationPipeline` and `TranslationPipeline` were removed in transformers v5.

The documentation still contained inference examples using these pipelines, which is confusing for users on v5 since the examples no longer work.

## Changes
- Removed `pipeline()` examples from `docs/source/en/tasks/summarization.md`
- Removed `pipeline()` examples from `docs/source/en/tasks/translation.md`
- The manual tokenize/generate/decode workflow remains as the recommended approach

Fixes #43827

🤖 Generated with [Claude Code](https://claude.com/claude-code)