### PR TITLE
fix(qwen3_vl): Use temporal_patch_size for timestamp calculation

### DIFF
--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -1509,7 +1509,7 @@ class Qwen3VLProcessor(Qwen2VLProcessor):
                     curr_timestamp = self._calculate_timestamps(
                         metadata.frames_indices,
                         metadata.fps,
-                        self.video_processor.merge_size,
+                        self.video_processor.temporal_patch_size,
                     )
 
                     video_placeholder = ""

--- a/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
@@ -152,7 +152,7 @@ class Qwen3VLProcessor(ProcessorMixin):
                     curr_timestamp = self._calculate_timestamps(
                         metadata.frames_indices,
                         metadata.fps,
-                        self.video_processor.merge_size,
+                        self.video_processor.temporal_patch_size,
                     )
 
                     video_placeholder = ""


### PR DESCRIPTION
## What does this PR do?

Fixes incorrect timestamp calculation in Qwen3VL Processor by using `temporal_patch_size` instead of `merge_size`.

## Problem

The `_calculate_timestamps()` method was being called with `self.video_processor.merge_size` when it should use `self.video_processor.temporal_patch_size`. 

The `temporal_patch_size` represents the temporal stride of video patches (how many frames are grouped into a single temporal patch), which is the correct value for calculating frame timestamps. The `merge_size` is used for spatial merging and is unrelated to temporal calculations.

## Changes

Updated both `processing_qwen3_vl.py` and `modular_qwen3_vl.py` to use `temporal_patch_size` instead of `merge_size`.

Fixes #43519