### PR TITLE
fix(switch_transformers): Fix sparse layer creation when num_sparse_*_layers=0

### DIFF
--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -148,13 +148,17 @@ class SwitchTransformersConfig(PreTrainedConfig):
         if self.num_sparse_encoder_layers > 0:
             self.encoder_sparse_step = self.num_layers // self.num_sparse_encoder_layers
         else:
-            self.encoder_sparse_step = self.num_layers  # HACK: this will create 0 sparse layers
+            # Set to 0 to disable sparse layers. The modeling code checks `if sparse_step > 0`
+            # to determine whether to create sparse layers.
+            self.encoder_sparse_step = 0
 
-        # This tells us, each how many encoder layer we'll have to set a sparse layer.
+        # This tells us, each how many decoder layer we'll have to set a sparse layer.
         if self.num_sparse_decoder_layers > 0:
             self.decoder_sparse_step = self.num_decoder_layers // self.num_sparse_decoder_layers
         else:
-            self.decoder_sparse_step = self.num_decoder_layers  # HACK: this will create 0 sparse layers
+            # Set to 0 to disable sparse layers. The modeling code checks `if sparse_step > 0`
+            # to determine whether to create sparse layers.
+            self.decoder_sparse_step = 0
 
         self.num_heads = num_heads
         self.num_experts = num_experts


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where `SwitchTransformersConfig` incorrectly creates sparse layers when `num_sparse_encoder_layers=0` or `num_sparse_decoder_layers=0` is set with a single-layer model.

## Problem

When `num_sparse_encoder_layers=0`, the config was setting:
```python
self.encoder_sparse_step = self.num_layers  # HACK: this will create 0 sparse layers
```

But when `num_layers=1`, this sets `sparse_step=1`. The modeling code then checks:
```python
is_sparse = (i % sparse_step == 1 or sparse_step == 1) if sparse_step > 0 else False
```

The `sparse_step == 1` condition is True, causing a sparse layer to be incorrectly created.

## Solution

Set `encoder_sparse_step = 0` (and `decoder_sparse_step = 0`) when `num_sparse_*_layers=0`. The modeling code's existing `if sparse_step > 0 else False` check correctly handles this case, ensuring no sparse layers are created.

## Reproduction

```python
from transformers import SwitchTransformersConfig, SwitchTransformersModel

config = SwitchTransformersConfig(
    num_layers=1,
    num_sparse_encoder_layers=0,  # Should create 0 sparse layers
    num_decoder_layers=1,
    num_sparse_decoder_layers=0,
    vocab_size=100, d_model=64, d_ff=128, num_heads=4, d_kv=16
)
model = SwitchTransformersModel(config)
encoder_sparse_count = sum(1 for block in model.encoder.block if block.is_sparse)
print(f"Encoder sparse layers: {encoder_sparse_count}")  # Before: 1, After: 0
```

Fixes #43335