### PR TITLE
fix(cli): Fix TypeAdapter NameError when pydantic is not installed

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -54,6 +54,8 @@ from ..utils import logging
 
 
 if TYPE_CHECKING:
+    from pydantic import TypeAdapter
+
     from transformers import (
         PreTrainedModel,
         PreTrainedTokenizerFast,
@@ -585,7 +587,7 @@ class Serve:
         self,
         request: dict,
         schema: TypedDict,
-        validator: TypeAdapter,
+        validator: "TypeAdapter",
         unused_fields: set,
     ):
         """


### PR DESCRIPTION
## What does this PR do?

Fixes a `NameError: name 'TypeAdapter' is not defined` error when importing transformers without pydantic installed.

## Problem

The `TypeAdapter` class from pydantic was used as a type annotation in `_validate_request()` at line 588:

```python
def _validate_request(
    self,
    request: dict,
    schema: TypedDict,
    validator: TypeAdapter,  # <-- NameError here
    unused_fields: set,
):
```

However, `TypeAdapter` is only imported inside an `if serve_dependencies_available:` block, which requires pydantic to be installed. When pydantic is not installed, Python raises `NameError` when parsing the class definition.

## Solution

1. Added `TypeAdapter` to the `TYPE_CHECKING` imports block
2. Changed the type annotation to use a string literal `"TypeAdapter"` for forward reference

This ensures the type annotation is only evaluated during static type checking, not at runtime.

Fixes #43824