### PR TITLE
Fix translation task validation when translation pipeline is unavailable

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1345,7 +1345,8 @@ class PipelineRegistry:
             targeted_task = self.supported_tasks[task]
             return task, targeted_task, None
 
-        if task.startswith("translation"):
+        supports_translation = "translation" in self.supported_tasks
+        if supports_translation and task.startswith("translation"):
             tokens = task.split("_")
             if len(tokens) == 4 and tokens[0] == "translation" and tokens[2] == "to":
                 targeted_task = self.supported_tasks["translation"]
@@ -1353,8 +1354,11 @@ class PipelineRegistry:
                 return task, targeted_task, (tokens[1], tokens[3])
             raise KeyError(f"Invalid translation task {task}, use 'translation_XX_to_YY' format")
 
+        available_tasks = self.get_supported_tasks()
+        if supports_translation:
+            available_tasks.append("translation_XX_to_YY")
         raise KeyError(
-            f"Unknown task {task}, available tasks are {self.get_supported_tasks() + ['translation_XX_to_YY']}"
+            f"Unknown task {task}, available tasks are {available_tasks}"
         )
 
     def register_pipeline(

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1357,9 +1357,7 @@ class PipelineRegistry:
         available_tasks = self.get_supported_tasks()
         if supports_translation:
             available_tasks.append("translation_XX_to_YY")
-        raise KeyError(
-            f"Unknown task {task}, available tasks are {available_tasks}"
-        )
+        raise KeyError(f"Unknown task {task}, available tasks are {available_tasks}")
 
     def register_pipeline(
         self,

--- a/tests/pipelines/test_pipelines_common.py
+++ b/tests/pipelines/test_pipelines_common.py
@@ -36,7 +36,7 @@ from transformers import (
     pipeline,
 )
 from transformers.pipelines import PIPELINE_REGISTRY, get_task
-from transformers.pipelines.base import Pipeline, _pad
+from transformers.pipelines.base import Pipeline, PipelineRegistry, _pad
 from transformers.testing_utils import (
     TOKEN,
     USER,
@@ -788,6 +788,7 @@ class CustomPipelineTest(unittest.TestCase):
         )
 
         self.assertEqual(old_classifier.__class__.__name__, "TextClassificationPipeline")
+
         self.assertEqual(old_classifier.task, "text-classification")
         results = old_classifier("I hate you", text_pair="I love you")
         self.assertListEqual(
@@ -864,6 +865,40 @@ class CustomPipelineTest(unittest.TestCase):
         )
 
         self.assertIsInstance(mask_generator, MaskGenerationPipeline)  # Assert successful loading
+
+
+@is_pipeline_test
+class PipelineRegistryTest(unittest.TestCase):
+    def test_check_task_without_translation_pipeline(self):
+        registry = PipelineRegistry(supported_tasks={"text-classification": {}}, task_aliases={})
+
+        with self.assertRaises(KeyError) as exc:
+            registry.check_task("translation")
+        self.assertIn("Unknown task translation", str(exc.exception))
+        self.assertNotIn("translation_XX_to_YY", str(exc.exception))
+
+        with self.assertRaises(KeyError) as exc:
+            registry.check_task("translation_en_to_de")
+        self.assertIn("Unknown task translation_en_to_de", str(exc.exception))
+        self.assertNotIn("translation_XX_to_YY", str(exc.exception))
+
+    def test_check_task_with_translation_pipeline(self):
+        translation_task = {"impl": object()}
+        registry = PipelineRegistry(supported_tasks={"translation": translation_task}, task_aliases={})
+
+        normalized_task, targeted_task, task_options = registry.check_task("translation_en_to_de")
+        self.assertEqual(normalized_task, "translation")
+        self.assertIs(targeted_task, translation_task)
+        self.assertEqual(task_options, ("en", "de"))
+
+        normalized_task, targeted_task, task_options = registry.check_task("translation")
+        self.assertEqual(normalized_task, "translation")
+        self.assertIs(targeted_task, translation_task)
+        self.assertIsNone(task_options)
+
+        with self.assertRaises(KeyError) as exc:
+            registry.check_task("unknown-task")
+        self.assertIn("translation_XX_to_YY", str(exc.exception))
 
 
 @require_torch


### PR DESCRIPTION
## Summary
- only treat `translation_XX_to_YY` as a special task when the `translation` pipeline is actually registered
- stop advertising `translation_XX_to_YY` in unknown-task error messages when translation is not supported
- add regression tests for both modes of `PipelineRegistry` (with and without translation support)

## Reproduction
Issue: #43825

With v5 defaults, `pipeline("translation_en_to_de")` currently raises `KeyError: 'translation'` and unknown-task messages still list `translation_XX_to_YY` although `translation` is unavailable.

## Validation
- `PYTHONPATH=src uv run --with pytest --with datasets pytest -q tests/pipelines/test_pipelines_common.py -k PipelineRegistryTest`
- `uvx ruff check src/transformers/pipelines/base.py tests/pipelines/test_pipelines_common.py`

Fixes #43825
