### PR TITLE
don't merge check

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -24,6 +24,10 @@ on:
       pr_number:
         required: false
         type: string
+    outputs:
+      is_check_failures_ok:
+        description: "Whether the failure checking infrastructure succeeded"
+        value: ${{ jobs.check_new_failures.result != 'failure' && jobs.process_new_failures_with_commit_info.result != 'failure' }}
 
 env:
   HF_HOME: /mnt/cache

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -390,7 +390,7 @@ jobs:
             # Model CI
             if [[ "$model_ci_result" != "skipped" && "$model_ci_result" != "cancelled" ]]; then
               if [[ "$model_infrastructure_ok" == "false" ]]; then
-                echo "⚠️ **Model CI Infrastructure Error**"
+                echo "⚠️ **Model CI failed to report results**"
                 echo ''
                 infrastructure_error=true
               fi
@@ -399,7 +399,7 @@ jobs:
             # Quantization CI
             if [[ "$quantization_ci_result" != "skipped" && "$quantization_ci_result" != "cancelled" ]]; then
               if [[ "$quant_infrastructure_ok" == "false" ]]; then
-                echo "⚠️ **Quantization CI Infrastructure Error**"
+                echo "⚠️ **Quantization CI failed to report results**"
                 echo ''
                 infrastructure_error=true
               fi

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -363,6 +363,8 @@ jobs:
           main_commit: ${{ needs.get-pr-info.outputs.PR_MERGE_COMMIT_BASE_SHA }}
           model_ci_result: ${{ needs.model-ci.result }}
           quantization_ci_result: ${{ needs.quantization-ci.result }}
+          model_infrastructure_ok: ${{ needs.model-ci.outputs.is_infrastructure_ok }}
+          quant_infrastructure_ok: ${{ needs.quantization-ci.outputs.is_infrastructure_ok }}
         run: |
           # Create commit links (8 chars display, full SHA in URL)
           run_commit_link="[${run_commit:0:8}](https://github.com/${github_repository}/commit/${run_commit})"
@@ -381,9 +383,34 @@ jobs:
             echo "| PR | ${pr_commit_link} | branch commit |"
             echo "| main | ${main_commit_link} | base commit |"
             echo ''
+
+            # Check infrastructure health - simple and clean!
+            infrastructure_error=false
+            
+            # Model CI
+            if [[ "$model_ci_result" != "skipped" && "$model_ci_result" != "cancelled" ]]; then
+              if [[ "$model_infrastructure_ok" == "false" ]]; then
+                echo "⚠️ **Model CI Infrastructure Error**"
+                echo ''
+                infrastructure_error=true
+              fi
+            fi
+            
+            # Quantization CI
+            if [[ "$quantization_ci_result" != "skipped" && "$quantization_ci_result" != "cancelled" ]]; then
+              if [[ "$quant_infrastructure_ok" == "false" ]]; then
+                echo "⚠️ **Quantization CI Infrastructure Error**"
+                echo ''
+                infrastructure_error=true
+              fi
+            fi
+            
+            if [[ "$infrastructure_error" == "true" ]]; then
+              echo 'The test failure analysis could not be completed. Please check the [workflow run]('$GITHUB_RUN_URL') for details.'
+              echo "STATUS=error" >> $GITHUB_ENV
       
             # Check if both jobs were skipped or cancelled
-            if [[ "$model_ci_result" == "skipped" || "$model_ci_result" == "cancelled" ]] && \
+            elif [[ "$model_ci_result" == "skipped" || "$model_ci_result" == "cancelled" ]] && \
                [[ "$quantization_ci_result" == "skipped" || "$quantization_ci_result" == "cancelled" ]]; then
               echo '⚠️ No test being reported (jobs are skipped or cancelled)!'
               echo "STATUS=error" >> $GITHUB_ENV

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -44,6 +44,11 @@ on:
       pr_number:
         required: false
         type: string
+    outputs:
+      is_infrastructure_ok:
+        description: "Whether the CI infrastructure (slack reporting and failure checking) succeeded"
+        value: ${{ jobs.send_results.outputs.is_slack_reporting_job_ok == 'true' && jobs.check_new_failures.outputs.is_check_failures_ok == 'true' }}
+
 
 env:
   HF_HOME: /mnt/cache

--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -27,7 +27,10 @@ on:
       commit_sha:
         required: false
         type: string
-
+    outputs:
+      is_slack_reporting_job_ok:
+        description: "Whether the send_results job succeeded (not failed)"
+        value: ${{ jobs.send_results.result != 'failure' }}
 
 env:
   TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN: ${{ secrets.TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN }}


### PR DESCRIPTION
# What does this PR do?

Currently, if slack reporting (re-usable) workflow or `check new failure` workflow fails, the CI triggered via a comment in a pull request will send a comment back to the PR page with

✅ No failing test specific to this PR 🎉 👏 !


This is very wrong and will cause a lot of issues.

This PR tries to detect such scenario and if this happens, the feedback comment would be something like

 ⚠️ Model CI Infrastructure Error

The test failure analysis could not be completed. Please check the [workflow run](https://github.com/huggingface/transformers/actions/runs/21855542500) for details.