### PR TITLE
delete unnecessary code to make moe compatible to full graph compile

### DIFF
--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -113,10 +113,6 @@ def batched_mm_experts_forward(
     # Reshape for easier indexing
     # S is the number of selected tokens-experts pairs (S = num_tokens * num_top_k)
     token_idx = torch.arange(num_tokens, device=device).unsqueeze(1).expand(-1, num_top_k).reshape(-1)  # (S,)
-    if top_k_weights.sum() == torch.tensor(0.0, device=top_k_weights.device):
-        # If all routing weights are zero local experts are not selected
-        return torch.zeros_like(hidden_states)
-
     sample_weights = top_k_weights.reshape(-1)  # (S,)
     expert_ids = top_k_index.reshape(-1)  # (S,)
 


### PR DESCRIPTION
When all routing weights are zero, in this line [out_per_sample = out_per_sample * sample_weights.unsqueeze(-1)](https://github.com/huggingface/transformers/blob/main/src/transformers/integrations/moe.py#L153) , it will also output all zero tensor for this func, we can delete theses lines of code to make it work for full graph compile. Here is a test case:
`tests/models/glm4_moe_lite/test_modeling_glm4_moe_lite.py::Glm4MoeModelTest::test_generate_compile_model_forward_fullgraph`