### PR TITLE
fix: correct typo 'quantizatin_operations' to 'quantization_operations'

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -261,7 +261,7 @@ def _build_peft_weight_mapping(
                     source_patterns=new_source_patterns,
                     target_patterns=new_target_patterns,
                     distributed_operation=orig_conversion.distributed_operation,
-                    quantization_operation=orig_conversion.quantizatin_operations,
+                    quantization_operation=orig_conversion.quantization_operations,
                     operations=new_weight_conversions,
                 )
                 new_weight_conversions.append(new_conversion)
@@ -300,7 +300,7 @@ def _build_peft_weight_mapping(
                     source_patterns=new_source_patterns,
                     target_patterns=new_target_patterns,
                     distributed_operation=orig_conversion.distributed_operation,
-                    quantization_operation=orig_conversion.quantizatin_operations,
+                    quantization_operation=orig_conversion.quantization_operations,
                     operations=new_weight_conversions,
                 )
                 new_weight_conversions.append(new_conversion)


### PR DESCRIPTION
Fixes #43813

Corrects the typo in `src/transformers/integrations/peft.py` on lines 264 and 303 where `quantizatin_operations` should be `quantization_operations`.