### PR TITLE
Fix TypeError in dot_natural_key when sorting mixed structure keys

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -813,11 +813,13 @@ def spawn_tp_materialize(
 
 def dot_natural_key(s: str):
     parts = s.split(".")
-    for i, p in enumerate(parts):
-        # whole-segment digits -> int; otherwise leave as str
+    key = []
+    for p in parts:
         if p.isdigit():
-            parts[i] = int(p)
-    return parts
+            key.append((0, int(p)))
+        else:
+            key.append((1, p))
+    return tuple(key)
 
 
 @contextmanager


### PR DESCRIPTION
# What does this PR do?

Fixes #43867

This PR fixes a `TypeError` in the `dot_natural_key` function in `src/transformers/core_model_loading.py` that occurs when sorting model state dictionary keys with mixed numeric and string structures.

## Problem

The original `dot_natural_key` function returned a list containing mixed `int` and `str` types. When sorting keys like `["model.0.weight", "model.layer.weight"]`, Python's sorting attempted to compare `int` with `str` at the same position, causing:

```
TypeError: '<' not supported between instances of 'str' and 'int'
```

## Solution

Updated the function to return tuples of `(type_flag, value)` where:
- Numeric parts: `(0, int(p))` - sorted numerically
- String parts: `(1, p)` - sorted lexicographically

This ensures consistent type comparison while preserving natural numeric ordering.

## Testing

Tested with a minimal reproduction script that triggers the error on the original code and passes with the fix.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
      
     
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
      
      **Not applicable** - This is an internal utility function fix, no user-facing documentation changes needed.
      
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
