### PR TITLE
Timm backbone saves and loads `out_features`

### DIFF
--- a/src/transformers/models/timm_backbone/configuration_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/configuration_timm_backbone.py
@@ -78,7 +78,6 @@ class TimmBackboneConfig(BackboneConfigMixin, PreTrainedConfig):
         self.output_stride = output_stride
         self.freeze_batch_norm_2d = freeze_batch_norm_2d
 
-        # self._out_features = kwargs.pop("out_features", None)
         super().__init__(**kwargs)
 
     @property

--- a/src/transformers/models/timm_backbone/modeling_timm_backbone.py
+++ b/src/transformers/models/timm_backbone/modeling_timm_backbone.py
@@ -45,9 +45,6 @@ class TimmBackbone(BackboneMixin, PreTrainedModel):
         if config.backbone is None:
             raise ValueError("backbone is not set in the config. Please set it to a timm model name.")
 
-        if hasattr(config, "out_features") and config.out_features is not None:
-            raise ValueError("out_features is not supported by TimmBackbone. Please use out_indices instead.")
-
         # We just take the final layer by default. This matches the default for the transformers models.
         out_indices = config.out_indices if getattr(config, "out_indices", None) is not None else (-1,)
         pretrained = kwargs.pop("pretrained", False)


### PR DESCRIPTION
Fixes https://github.com/huggingface/transformers/issues/43878

After the refactor we started saving `out_features` and `stage_names` in timm backbone config, because it now also inherits from `BackboneConfigMixin`. But the modeling code would throw an error if `out_features` is already set

This PR deletes the error and instead verifies that the loaded-back config values align with the values obtained from `timm`. Ideally it should always align unless the config was corrupted before being saved, e.g. manually changing fields to un-aligned values