### PR TITLE
Decorate cache updates with no_grad, just in case

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -96,6 +96,7 @@ class DynamicLayer(CacheLayerMixin):
         self.values = torch.tensor([], dtype=self.dtype, device=self.device)
         self.is_initialized = True
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -183,6 +184,7 @@ class DynamicSlidingWindowLayer(DynamicLayer):
         super().lazy_initialization(key_states, value_states)
         self._sliding_window_tensor = self._sliding_window_tensor.to(self.device)
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -307,6 +309,7 @@ class StaticLayer(CacheLayerMixin):
 
         self.is_initialized = True
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -382,6 +385,7 @@ class StaticSlidingWindowLayer(StaticLayer):
         super().__init__(max_cache_len=effective_max_cache_len)
         self.cumulative_length = 0
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -515,6 +519,7 @@ class QuantizedLayer(DynamicLayer):
         self.residual_length = residual_length
         self.cumulative_length = 0
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,
@@ -755,6 +760,7 @@ class Cache:
         if not (only_non_sliding and self.is_sliding[layer_idx]):
             self.layers[layer_idx].offload()
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/models/bamba/modeling_bamba.py
+++ b/src/transformers/models/bamba/modeling_bamba.py
@@ -134,6 +134,7 @@ class HybridMambaAttentionDynamicCache:
     def __getitem__(self, layer_idx):
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/models/falcon_h1/modeling_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modeling_falcon_h1.py
@@ -131,6 +131,7 @@ class FalconHybridMambaAttentionDynamicCache:
     def __getitem__(self, layer_idx):
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/models/falcon_mamba/modeling_falcon_mamba.py
+++ b/src/transformers/models/falcon_mamba/modeling_falcon_mamba.py
@@ -121,6 +121,7 @@ class FalconMambaCache:
             self.conv_states.append(conv_state)
             self.ssm_states.append(ssm_state)
 
+    @torch.no_grad()
     def update_conv_state(
         self, layer_idx: int, new_conv_state: torch.Tensor, cache_position: torch.LongTensor
     ) -> torch.Tensor:
@@ -138,6 +139,7 @@ class FalconMambaCache:
         self.conv_states[layer_idx] += conv_state
         return self.conv_states[layer_idx]
 
+    @torch.no_grad()
     def update_ssm_state(self, layer_idx: int, new_ssm_state: torch.Tensor):
         self.ssm_states[layer_idx].zero_()
         self.ssm_states[layer_idx] += new_ssm_state.to(self.ssm_states[layer_idx].device)

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -248,6 +248,7 @@ class HybridMambaAttentionDynamicCache:
     def __getitem__(self, layer_idx):
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/models/jamba/modeling_jamba.py
+++ b/src/transformers/models/jamba/modeling_jamba.py
@@ -121,6 +121,7 @@ class HybridMambaAttentionDynamicCache:
     def __getitem__(self, layer_idx):
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/models/jamba/modular_jamba.py
+++ b/src/transformers/models/jamba/modular_jamba.py
@@ -94,6 +94,7 @@ class HybridMambaAttentionDynamicCache:
     def __getitem__(self, layer_idx):
         return self.key_cache[layer_idx], self.value_cache[layer_idx]
 
+    @torch.no_grad()
     def update(
         self,
         key_states: torch.Tensor,

--- a/src/transformers/models/mamba/modeling_mamba.py
+++ b/src/transformers/models/mamba/modeling_mamba.py
@@ -119,6 +119,7 @@ class MambaCache:
             self.conv_states.append(conv_state)
             self.ssm_states.append(ssm_state)
 
+    @torch.no_grad()
     def update_conv_state(
         self, layer_idx: int, new_conv_state: torch.Tensor, cache_position: torch.LongTensor
     ) -> torch.Tensor:
@@ -136,6 +137,7 @@ class MambaCache:
         self.conv_states[layer_idx] += conv_state
         return self.conv_states[layer_idx]
 
+    @torch.no_grad()
     def update_ssm_state(self, layer_idx: int, new_ssm_state: torch.Tensor):
         self.ssm_states[layer_idx].zero_()
         self.ssm_states[layer_idx] += new_ssm_state.to(self.ssm_states[layer_idx].device)

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -156,6 +156,7 @@ class Mamba2Cache:
             dtype=dtype,
         )
 
+    @torch.no_grad()
     def update_conv_state(
         self, layer_idx: int, new_conv_state: torch.Tensor, cache_init: bool = False
     ) -> torch.Tensor:
@@ -166,6 +167,7 @@ class Mamba2Cache:
             self.conv_states[layer_idx][:, :, -1] = new_conv_state[:, 0, :].to(self.conv_states.device)
         return self.conv_states[layer_idx]
 
+    @torch.no_grad()
     def update_ssm_state(self, layer_idx: int, new_ssm_state: torch.Tensor):
         self.ssm_states[layer_idx] = new_ssm_state.to(self.ssm_states.device)
         return self.ssm_states[layer_idx]


### PR DESCRIPTION
Although our cache update methods are usually used in inference, when grad is disabled anyway, there seem to be some edge cases where they cause problems with compilation and gradient computation. Since we never want to propagate gradient through these steps, adding `@no_grad` decorators shouldn't hurt, and fixes the edge cases.

Fixes #43010