### PR TITLE
Changes to cache_utils should trigger all tests all the time

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -78,6 +78,7 @@ CORE_FILES = (
     ".circleci/create_circleci_config.py",
     "src/transformers/modeling_utils.py",
     "src/transformers/core_model_loading.py",
+    "src/transformers/cache_utils.py",
 )
 
 


### PR DESCRIPTION
# What does this PR do?

As per the title. This is a core file, and we cannot allow to change it without triggering everything - see https://github.com/huggingface/transformers/pull/43897#issuecomment-3885203477 as well