### PR TITLE
Fix AttributeError in OwlViT conversion script for Python 3.10+

### DIFF
--- a/src/transformers/models/owlvit/convert_owlvit_original_flax_to_hf.py
+++ b/src/transformers/models/owlvit/convert_owlvit_original_flax_to_hf.py
@@ -15,7 +15,7 @@
 https://github.com/google-research/scenic/tree/main/scenic/projects/owl_vit"""
 
 import argparse
-import collections
+from collections.abc import MutableMapping
 
 import jax
 import jax.numpy as jnp
@@ -81,7 +81,7 @@ def flatten_nested_dict(params, parent_key="", sep="/"):
     for k, v in params.items():
         new_key = parent_key + sep + k if parent_key else k
 
-        if isinstance(v, collections.MutableMapping):
+        if isinstance(v, MutableMapping):
             items.extend(flatten_nested_dict(v, new_key, sep=sep).items())
         else:
             items.append((new_key, v))


### PR DESCRIPTION
# What does this PR do?

Fixes a hard crash (`AttributeError`) in `src/transformers/models/owlvit/convert_owlvit_original_flax_to_hf.py` caused by `collections.MutableMapping`, which was removed in Python 3.10.

## The Problem
The script imports `MutableMapping` directly from `collections`. This alias was deprecated in Python 3.3 and **permanently removed in Python 3.10**.
Attempting to run this script on any modern environment results in:
`AttributeError: module 'collections' has no attribute 'MutableMapping'`

## The Fix
Updates the import to use `collections.abc.MutableMapping`. This is the standard location for abstract base classes and is fully backwards compatible.

## Verification
- **Documentation:** Confirmed via [Python 3.10 Release Notes](https://docs.python.org/3/whatsnew/3.10.html#removed) that the alias is removed.
- **Static Analysis:** Verified the import path is updated to `collections.abc`.
- **Linting:** Ran `ruff` locally; no style issues found.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@zucchini-nlp
@yonigozlan