### PR TITLE
Inclusion of process_group in the gather_full_tensor function in tensor_parallel.py

### DIFF
--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -1165,10 +1165,10 @@ def gather_full_tensor(local_tensor: torch.Tensor, shard_dim: int, device_mesh) 
 
     # Gather all shards
     gathered_tensors = [torch.empty_like(local_tensor) for _ in range(world_size)]
-    dist.all_gather(gathered_tensors, local_tensor.contiguous())
+    dist.all_gather(gathered_tensors, local_tensor.contiguous(), group=process_group)
 
     # Concatenate along the shard dimension
-    return torch.cat(gathered_tensors, dim=shard_dim, group=process_group)
+    return torch.cat(gathered_tensors, dim=shard_dim)
 
 
 def gather_state_dict_for_save(


### PR DESCRIPTION
# What does this PR do?

It fixes minor issue in the gather_full_tensor function. The existing implementation tries to perform all_gather across all the ranks of distributed training. But when we talk about the case of TP+DP then we only need to perform all_gather across TP ranks, not the DP ranks. This change makes use of group argument in dist.all_gather API of pytorch to perform it correctly.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

CC: @SunMarc @ArthurZucker @ydshieh 