### PR TITLE
Modernize string formatting (f-strings) in conversion scripts

### DIFF
--- a/src/transformers/models/imagegpt/convert_imagegpt_original_tf2_to_pytorch.py
+++ b/src/transformers/models/imagegpt/convert_imagegpt_original_tf2_to_pytorch.py
@@ -66,7 +66,7 @@ def load_tf_weights_in_imagegpt(model, config, imagegpt_checkpoint_path):
             )
             or name[-1] == "_step"
         ):
-            logger.info("Skipping {}".format("/".join(name)))
+            logger.info(f"Skipping {'/'.join(name)}")
             continue
 
         pointer = model

--- a/src/transformers/models/omdet_turbo/convert_omdet_turbo_to_hf.py
+++ b/src/transformers/models/omdet_turbo/convert_omdet_turbo_to_hf.py
@@ -241,7 +241,7 @@ def run_test(model, processor):
         image = Image.open(BytesIO(response.read())).convert("RGB")
 
     classes = ["cat", "remote"]
-    task = "Detect {}.".format(", ".join(classes))
+    task = f"Detect {', '.join(classes)}."
     inputs = processor(image, text=classes, task=task, return_tensors="pt")
 
     # Running forward

--- a/src/transformers/models/omdet_turbo/processing_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/processing_omdet_turbo.py
@@ -215,7 +215,7 @@ class OmDetTurboProcessor(ProcessorMixin):
 
         task = output_kwargs["text_kwargs"].pop("task", None)
         if task is None:
-            task = ["Detect {}.".format(", ".join(text_single)) for text_single in text]
+            task = [f"Detect {', '.join(text_single)}." for text_single in text]
         elif not isinstance(task, (list, tuple)):
             task = [task]
 

--- a/src/transformers/models/rembert/convert_rembert_tf_checkpoint_to_pytorch.py
+++ b/src/transformers/models/rembert/convert_rembert_tf_checkpoint_to_pytorch.py
@@ -89,7 +89,7 @@ def load_tf_weights_in_rembert(model, config, tf_checkpoint_path):
                 try:
                     pointer = getattr(pointer, scope_names[0])
                 except AttributeError:
-                    logger.info("Skipping {}".format("/".join(name)))
+                    logger.info(f"Skipping {'/'.join(name)}")
                     continue
             if len(scope_names) >= 2:
                 num = int(scope_names[1])

--- a/src/transformers/models/swin/convert_swin_timm_to_pytorch.py
+++ b/src/transformers/models/swin/convert_swin_timm_to_pytorch.py
@@ -141,7 +141,7 @@ def convert_swin_checkpoint(swin_name, pytorch_dump_folder_path):
 
     url = "http://images.cocodataset.org/val2017/000000039769.jpg"
 
-    image_processor = AutoImageProcessor.from_pretrained("microsoft/{}".format(swin_name.replace("_", "-")))
+    image_processor = AutoImageProcessor.from_pretrained(f"microsoft/{swin_name.replace('_', '-')}")
     with httpx.stream("GET", url) as response:
         image = Image.open(BytesIO(response.read()))
     inputs = image_processor(images=image, return_tensors="pt")

--- a/src/transformers/models/swinv2/convert_swinv2_timm_to_pytorch.py
+++ b/src/transformers/models/swinv2/convert_swinv2_timm_to_pytorch.py
@@ -179,7 +179,7 @@ def convert_swinv2_checkpoint(swinv2_name, pytorch_dump_folder_path):
 
     url = "http://images.cocodataset.org/val2017/000000039769.jpg"
 
-    image_processor = AutoImageProcessor.from_pretrained("microsoft/{}".format(swinv2_name.replace("_", "-")))
+    image_processor = AutoImageProcessor.from_pretrained(f"microsoft/{swinv2_name.replace('_', '-')}")
     with httpx.stream("GET", url) as response:
         image = Image.open(BytesIO(response.read()))
     inputs = image_processor(images=image, return_tensors="pt")


### PR DESCRIPTION
# What does this PR do?

Replaces legacy `.format()` calls with f-strings in several model conversion scripts (`convert_*.py`).

## Modifications
Used `flynt` to apply safe transformations to string literals in:
- `src/transformers/models/imagegpt/` (Conversion)
- `src/transformers/models/rembert/` (Conversion)
- `src/transformers/models/swin/` / `swinv2` (Conversion)
- `src/transformers/models/omdet_turbo/` (Conversion **and** Processor)

## Verification
- **Manual Check:** Verified that the logic remains identical and only syntax was updated to Python 3.8+ standards.
- **Syntax Check:** Ran `py_compile` on all modified files to ensure no syntax errors were introduced.
- **Scope:** Changes are limited to standalone conversion scripts and do not affect core modeling logic.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@amyeroberts
@ArthurZucker