### PR TITLE
Fix flaky test for multimodal LLMs

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1343,7 +1343,10 @@ class GenerationTesterMixin:
             # if there are multimodal data which don't belong anywhere inside `text_tokens`
             keys_to_pop = []
             for key in inputs:
-                if ("pixel" in key or key in ["image_patches", "input_feature"]) and key != model.main_input_name:
+                if (
+                    "pixel" in key
+                    or key in ["image_patches", "input_feature", "input_features", "feature_attention_mask"]
+                ) and key != model.main_input_name:
                     keys_to_pop.append(key)
             for key in keys_to_pop:
                 inputs.pop(key)


### PR DESCRIPTION
We have flaky test failures in `tests/models/qwen3_omni_moe/test_modeling_qwen3_omni_moe.py::Qwen3OmniMoeThinkerForConditionalGenerationModelTest::test_generate_continue_from_past_key_values`. The cause is that the logic in this test drops multimodal inputs (because it's passing `past_key_values` to generate instead), but it fails to drop **audio** inputs correctly. This causes flaky failures in LLMs like Qwen3OmniMoE, which I think occur when the audio encoder creates audio features that overwrite the embeddings for generated tokens (maybe when the tokens have the `audio_token_id` value?)

I'm not 100% sure of the cause, but the test fails 3% of the time without this fix and 0% with it, so I'm pretty sure dropping inputs correctly is the solution!

cc @zucchini-nlp