### PR TITLE
Fix AttributeError for remote models with trust_remote_code=True

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4436,6 +4436,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         If we don't add them back in `self.all_tied_weights_keys`, they will be re-initialized
         and all params in tied group get random weights.
         """
+        if not hasattr(self, "all_tied_weights_keys"):
+            self.all_tied_weights_keys = {}
         param_pointers = defaultdict(list)
         for param_name, param_value in self.state_dict().items():
             param_pointers[param_value.data_ptr()].append(param_name)
@@ -4562,6 +4564,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         later as they will be tied (overwritten) anyway.
         This is very important as most embeddings are tied, and they are huge params (vocabularies are often 256k), so
         running inits on them is very costly."""
+        if not hasattr(self, "all_tied_weights_keys"):
+            return
         for tied_param in self.all_tied_weights_keys.keys():
             param = self.get_parameter(tied_param)
             param._is_hf_initialized = True


### PR DESCRIPTION
# What does this PR do?

Fixes #43883

After #42270, `all_tied_weights_keys` is initialized in `post_init()`, but remote models loaded with `trust_remote_code=True` don't always call `post_init()` properly, causing `AttributeError` when loading models like Molmo.

This fix adds defensive checks in two methods:
- `_adjust_tied_keys_with_tied_pointers()`: Initialize empty dict if missing, then detect tied weights via data pointers
- `mark_tied_weights_as_initialized()`: Return early if attribute missing

This allows remote models to load successfully while maintaining tied weight detection.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you write any new necessary tests?

## Who can review?

@Rocketknight1 @Cyrilvallez
