### PR TITLE
Fix LASR test layerdrop issue

### DIFF
--- a/tests/models/lasr/test_modeling_lasr.py
+++ b/tests/models/lasr/test_modeling_lasr.py
@@ -54,6 +54,7 @@ class LasrEncoderModelTester:
         subsampling_conv_channels=32,
         subsampling_conv_kernel_size=5,
         subsampling_conv_stride=2,
+        layerdrop=0.0,
     ):
         # testing suite parameters
         self.parent = parent
@@ -71,6 +72,7 @@ class LasrEncoderModelTester:
         self.subsampling_conv_channels = subsampling_conv_channels
         self.subsampling_conv_kernel_size = subsampling_conv_kernel_size
         self.subsampling_conv_stride = subsampling_conv_stride
+        self.layerdrop = layerdrop
 
         self.num_mel_bins = num_mel_bins
 
@@ -108,6 +110,7 @@ class LasrEncoderModelTester:
             subsampling_conv_kernel_size=self.subsampling_conv_kernel_size,
             subsampling_conv_stride=self.subsampling_conv_stride,
             num_mel_bins=self.num_mel_bins,
+            layerdrop=self.layerdrop,
         )
 
     def create_and_check_model(self, config, input_features, attention_mask):


### PR DESCRIPTION
The LASR model uses `layerdrop`, which we forgot to disable in the tests. Since the tests only have 2 hidden layers, and the default layerdrop chance is `0.1`, this means there's a `0.1^2 = 1%` chance in any test that doesn't call `model.eval()` that the model will drop **all** of the hidden layers, which breaks lots of tests (for example, there will be no output attentions when this happens).

This PR disables layerdrop in the test config, which resolves the test flakiness (example failing run: https://app.circleci.com/pipelines/github/huggingface/transformers/163931/workflows/272c0cd9-df40-4b38-8e9b-21b12dff3386/jobs/2160291)

cc @tarekziade 