### PR TITLE
Fix qwen3-vl-moe weight mapping

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -141,17 +141,14 @@ def _build_checkpoint_conversion_mapping():
         ],
         "qwen3_vl_moe": [
             WeightConverter(
-                source_patterns=[
-                    "mlp.experts.*.gate_proj.weight",
-                    "mlp.experts.*.up_proj.weight",
-                ],
+                source_patterns="mlp.experts.gate_up_proj",
                 target_patterns="mlp.experts.gate_up_proj",
-                operations=[MergeModulelist(dim=0), Concatenate(dim=1), Transpose(1, 2)],
+                operations=[Transpose(1, 2)],
             ),
             WeightConverter(
-                source_patterns="mlp.experts.*.down_proj.weight",
+                source_patterns="mlp.experts.down_proj",
                 target_patterns="mlp.experts.down_proj",
-                operations=[MergeModulelist(dim=0), Transpose(1, 2)],
+                operations=[Transpose(1, 2)],
             ),
         ],
         "phimoe": [

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -141,12 +141,12 @@ def _build_checkpoint_conversion_mapping():
         ],
         "qwen3_vl_moe": [
             WeightConverter(
-                source_patterns="mlp.experts.gate_up_proj",
+                source_patterns="mlp.experts.gate_up_proj$",
                 target_patterns="mlp.experts.gate_up_proj",
                 operations=[Transpose(1, 2)],
             ),
             WeightConverter(
-                source_patterns="mlp.experts.down_proj",
+                source_patterns="mlp.experts.down_proj$",
                 target_patterns="mlp.experts.down_proj",
                 operations=[Transpose(1, 2)],
             ),

--- a/tests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py
+++ b/tests/models/qwen3_vl_moe/test_modeling_qwen3_vl_moe.py
@@ -304,6 +304,10 @@ class Qwen3VLMoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
             )
             self.assertIsNotNone(outputs)
 
+    # Need to be False as we only use a Transpose without modifying the keys
+    def test_reverse_loading_mapping(self, check_keys_were_modified=False):
+        super().test_reverse_loading_mapping(check_keys_were_modified)
+
 
 @require_torch
 class Qwen3VLMoeIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?

Supersedes https://github.com/huggingface/transformers/pull/43913
After scanning the collection [here](https://huggingface.co/collections/Qwen/qwen3-vl), all models already have merged experts but need a transpose