### PR TITLE
Enforce explicit UTF-8 encoding in core Library to prevent Windows crashes

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -770,7 +770,7 @@ def check_python_requirements(path_or_repo_id, requirements_file="requirements.t
     failed = []  # error messages regarding requirements
     try:
         requirements = cached_file(path_or_repo_id=path_or_repo_id, filename=requirements_file, **kwargs)
-        with open(requirements, "r") as f:
+        with open(requirements, "r", encoding="utf-8") as f:
             requirements = f.readlines()
 
         for requirement in requirements:

--- a/src/transformers/model_debugging_utils.py
+++ b/src/transformers/model_debugging_utils.py
@@ -240,7 +240,7 @@ def log_model_debug_trace(debug_path: str | None, model):
 
     prune_outputs_if_children(model._call_tree)
 
-    with open(full_path, "w") as f:
+    with open(full_path, "w", encoding="utf-8") as f:
         json.dump(model._call_tree, f, indent=2)
 
     # summary-only version for readability - traversing the tree again #TODO optimize?
@@ -263,7 +263,7 @@ def log_model_debug_trace(debug_path: str | None, model):
     tree_copy = json.loads(json.dumps(model._call_tree))  # deep copy
     strip_values(tree_copy)
 
-    with open(summary_path, "w") as f:
+    with open(summary_path, "w", encoding="utf-8") as f:
         json.dump(tree_copy, f, indent=2)
 
 

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -517,7 +517,7 @@ class CsvPipelineDataFormat(PipelineDataFormat):
         super().__init__(output_path, input_path, column, overwrite=overwrite)
 
     def __iter__(self):
-        with open(self.input_path, "r") as f:
+        with open(self.input_path, "r", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
                 if self.is_multi_columns:
@@ -532,7 +532,7 @@ class CsvPipelineDataFormat(PipelineDataFormat):
         Args:
             data (`list[dict]`): The data to store.
         """
-        with open(self.output_path, "w") as f:
+        with open(self.output_path, "w", encoding="utf-8") as f:
             if len(data) > 0:
                 writer = csv.DictWriter(f, list(data[0].keys()))
                 writer.writeheader()
@@ -560,7 +560,7 @@ class JsonPipelineDataFormat(PipelineDataFormat):
     ):
         super().__init__(output_path, input_path, column, overwrite=overwrite)
 
-        with open(input_path, "r") as f:
+        with open(input_path, "r", encoding="utf-8") as f:
             self._entries = json.load(f)
 
     def __iter__(self):
@@ -577,7 +577,7 @@ class JsonPipelineDataFormat(PipelineDataFormat):
         Args:
             data (`dict`): The data to store.
         """
-        with open(self.output_path, "w") as f:
+        with open(self.output_path, "w", encoding="utf-8") as f:
             json.dump(data, f)
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -2205,7 +2205,7 @@ def pytest_terminal_summary_main(tr, id):
                 dlist.append(rep)
     if dlist:
         dlist.sort(key=lambda x: x.duration, reverse=True)
-        with open(report_files["durations"], "w") as f:
+        with open(report_files["durations"], "w", encoding="utf-8") as f:
             durations_min = 0.05  # sec
             f.write("slowest durations\n")
             for i, rep in enumerate(dlist):
@@ -2235,25 +2235,25 @@ def pytest_terminal_summary_main(tr, id):
 
     # report failures with line/short/long styles
     config.option.tbstyle = "auto"  # full tb
-    with open(report_files["failures_long"], "w") as f:
+    with open(report_files["failures_long"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         tr.summary_failures()
 
     # config.option.tbstyle = "short" # short tb
-    with open(report_files["failures_short"], "w") as f:
+    with open(report_files["failures_short"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         summary_failures_short(tr)
 
     config.option.tbstyle = "line"  # one line per error
-    with open(report_files["failures_line"], "w") as f:
+    with open(report_files["failures_line"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         tr.summary_failures()
 
-    with open(report_files["errors"], "w") as f:
+    with open(report_files["errors"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         tr.summary_errors()
 
-    with open(report_files["warnings"], "w") as f:
+    with open(report_files["warnings"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         tr.summary_warnings()  # normal warnings
         tr.summary_warnings()  # final warnings
@@ -2267,11 +2267,11 @@ def pytest_terminal_summary_main(tr, id):
     #     tr._tw = create_terminal_writer(config, f)
     #     tr.summary_passes()
 
-    with open(report_files["summary_short"], "w") as f:
+    with open(report_files["summary_short"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         tr.short_test_summary()
 
-    with open(report_files["stats"], "w") as f:
+    with open(report_files["stats"], "w", encoding="utf-8") as f:
         tr._tw = create_terminal_writer(config, f)
         tr.summary_stats()
 
@@ -2416,7 +2416,7 @@ def nested_simplify(obj, decimals=3):
 
 
 def check_json_file_has_correct_format(file_path):
-    with open(file_path) as f:
+    with open(file_path, encoding="utf-8") as f:
         lines = f.readlines()
         if len(lines) == 1:
             # length can only be 1 if dict is empty
@@ -3359,13 +3359,13 @@ def _get_test_info():
     # Get the code context in the test function/method.
     from _pytest._code.source import Source
 
-    with open(actual_test_file) as fp:
+    with open(actual_test_file, encoding="utf-8") as fp:
         s = fp.read()
         source = Source(s)
         test_code_context = "\n".join(source.getstatement(test_lineno - 1).lines)
 
     # Get the code context in the caller (to the patched function/method).
-    with open(caller_path) as fp:
+    with open(caller_path, encoding="utf-8") as fp:
         s = fp.read()
         source = Source(s)
         caller_code_context = "\n".join(source.getstatement(caller_lineno - 1).lines)
@@ -4039,12 +4039,12 @@ def _format_py_obj(obj, indent=0, mode="", cache=None, prefix=""):
 
 
 def write_file(file, content):
-    with open(file, "w") as f:
+    with open(file, "w", encoding="utf-8") as f:
         f.write(content)
 
 
 def read_json_file(file):
-    with open(file, "r") as fh:
+    with open(file, "r", encoding="utf-8") as fh:
         return json.load(fh)
 
 
@@ -4280,7 +4280,7 @@ def convert_all_safetensors_to_bins(folder: str):
         # Adapt the index as well
         elif file == SAFE_WEIGHTS_INDEX_NAME:
             new_path = os.path.join(folder, WEIGHTS_INDEX_NAME)
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 index = json.loads(f.read())
             os.remove(path)
             if "weight_map" in index.keys():
@@ -4289,7 +4289,7 @@ def convert_all_safetensors_to_bins(folder: str):
                 for k, v in weight_map.items():
                     new_weight_map[k] = v.replace(".safetensors", ".bin").replace("model", "pytorch_model")
             index["weight_map"] = new_weight_map
-            with open(new_path, "w") as f:
+            with open(new_path, "w", encoding="utf-8") as f:
                 f.write(json.dumps(index, indent=4))
 
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1768,7 +1768,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             if template_file is None:
                 continue  # I think this should never happen, but just in case
             template_name = extra_chat_template.removeprefix("chat_template_")
-            with open(template_file) as chat_template_handle:
+            with open(template_file, encoding="utf-8") as chat_template_handle:
                 chat_templates[template_name] = chat_template_handle.read()
         if len(chat_templates) == 1 and "default" in chat_templates:
             init_kwargs["chat_template"] = chat_templates["default"]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3829,7 +3829,7 @@ class Trainer:
             dataset_args=dataset_args,
         )
         model_card = training_summary.to_model_card()
-        with open(model_card_filepath, "w") as f:
+        with open(model_card_filepath, "w", encoding="utf-8") as f:
             f.write(model_card)
 
         if is_peft_library:
@@ -3852,7 +3852,7 @@ class Trainer:
             index_path = os.path.join(checkpoint_folder, index_file)
             if os.path.isfile(index_path):
                 modeling_files.append(index_file)
-                with open(index_path) as f:
+                with open(index_path, encoding="utf-8") as f:
                     index = json.loads(f.read())
                 shard_files = list(set(index["weight_map"].values()))
                 modeling_files.extend(shard_files)

--- a/src/transformers/trainer_jit_checkpoint.py
+++ b/src/transformers/trainer_jit_checkpoint.py
@@ -57,7 +57,7 @@ class CheckpointManager:
 
             # Create a sentinel file to indicate checkpointing is in progress
             sentinel_file = os.path.join(output_dir, checkpoint_folder, "checkpoint-is-incomplete.txt")
-                with open(sentinel_file, "w", encoding="utf-8") as f:
+            with open(sentinel_file, "w", encoding="utf-8") as f:
                 f.write(f"Checkpoint started at step {current_step} and in progress...")
             logger.info(f"Created checkpoint progress sentinel marker file: {sentinel_file}")
 

--- a/src/transformers/trainer_jit_checkpoint.py
+++ b/src/transformers/trainer_jit_checkpoint.py
@@ -57,7 +57,7 @@ class CheckpointManager:
 
             # Create a sentinel file to indicate checkpointing is in progress
             sentinel_file = os.path.join(output_dir, checkpoint_folder, "checkpoint-is-incomplete.txt")
-            with open(sentinel_file, "w") as f:
+                with open(sentinel_file, "w", encoding="utf-8") as f:
                 f.write(f"Checkpoint started at step {current_step} and in progress...")
             logger.info(f"Created checkpoint progress sentinel marker file: {sentinel_file}")
 

--- a/src/transformers/trainer_pt_utils.py
+++ b/src/transformers/trainer_pt_utils.py
@@ -940,19 +940,19 @@ def save_metrics(self, split, metrics, combined=True):
         return
 
     path = os.path.join(self.args.output_dir, f"{split}_results.json")
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         json.dump(metrics, f, indent=4, sort_keys=True)
 
     if combined:
         path = os.path.join(self.args.output_dir, "all_results.json")
         if os.path.exists(path):
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 all_metrics = json.load(f)
         else:
             all_metrics = {}
 
         all_metrics.update(metrics)
-        with open(path, "w") as f:
+        with open(path, "w", encoding="utf-8") as f:
             json.dump(all_metrics, f, indent=4, sort_keys=True)
 
 

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -789,13 +789,13 @@ def is_timm_local_checkpoint(pretrained_model_path: str) -> bool:
 
     # pretrained_model_path is a file
     if is_file and pretrained_model_path.endswith(".json"):
-        with open(pretrained_model_path) as f:
+        with open(pretrained_model_path, encoding="utf-8") as f:
             config_dict = json.load(f)
         return is_timm_config_dict(config_dict)
 
     # pretrained_model_path is a directory with a config.json
     if is_dir and os.path.exists(os.path.join(pretrained_model_path, "config.json")):
-        with open(os.path.join(pretrained_model_path, "config.json")) as f:
+        with open(os.path.join(pretrained_model_path, "config.json"), encoding="utf-8") as f:
             config_dict = json.load(f)
         return is_timm_config_dict(config_dict)
 

--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -851,7 +851,7 @@ def get_checkpoint_shard_files(
     if not os.path.isfile(index_filename):
         raise ValueError(f"Can't find a checkpoint index ({index_filename}) in {pretrained_model_name_or_path}.")
 
-    with open(index_filename) as f:
+    with open(index_filename, encoding="utf-8") as f:
         index = json.loads(f.read())
 
     shard_filenames = sorted(set(index["weight_map"].values()))


### PR DESCRIPTION
# What does this PR do?

Fixes potential `UnicodeDecodeError` on Windows (and other environments where the default encoding is not UTF-8) by enforcing `encoding="utf-8"` in standard `open()` calls across the core library.

## Modifications
Added `encoding="utf-8"` to text file operations (JSON, CSV, Python source, Model Cards) in the following core modules:

- **Trainer:** `trainer.py`, `trainer_pt_utils.py`, `trainer_jit_checkpoint.py`
- **Utilities:** `utils/generic.py`, `utils/hub.py`, `dynamic_module_utils.py`, `model_debugging_utils.py`
- **Pipelines:** `pipelines/base.py`
- **Testing:** `testing_utils.py`
- **Tokenization:** `tokenization_utils_base.py`

## Verification
- **Manual Audit:** Verified that binary operations (`"wb"`, `"rb"`) were **not** modified.
- **Safety Check:** Verified that `safe_open` (safetensors) and `subprocess.Popen` were **not** modified.
- **Scope:** Changes are strictly limited to `src/transformers` core files (excluding individual model definitions) to ensure high-impact stability improvements.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@sgugger
@amyeroberts
@ArthurZucker