### PR TITLE
Replace mutable default arguments with None

### DIFF
--- a/src/transformers/debug_utils.py
+++ b/src/transformers/debug_utils.py
@@ -142,7 +142,9 @@ class DebugUnderflowOverflow:
             Whether to abort after a certain batch number has finished
     """
 
-    def __init__(self, model, max_frames_to_save=21, trace_batch_nums=[], abort_after_batch_num=None):
+    def __init__(self, model, max_frames_to_save=21, trace_batch_nums=None, abort_after_batch_num=None):
+        if trace_batch_nums is None:
+            trace_batch_nums = []
         self.model = model
         self.trace_batch_nums = trace_batch_nums
         self.abort_after_batch_num = abort_after_batch_num

--- a/src/transformers/models/idefics/modeling_idefics.py
+++ b/src/transformers/models/idefics/modeling_idefics.py
@@ -156,7 +156,9 @@ def expand_inputs_for_generation(
     return input_ids, model_kwargs
 
 
-def freeze_model(model, module_exceptions=[]):
+def freeze_model(model, module_exceptions=None):
+    if module_exceptions is None:
+        module_exceptions = []
     mapping = {
         "LayerNorm": nn.LayerNorm,
         "Linear": nn.Linear,
@@ -932,11 +934,15 @@ class IdeficsModel(IdeficsPreTrainedModel):
         if config.freeze_vision_layers:
             freeze_model(self.vision_model, module_exceptions=config.freeze_vision_module_exceptions)
 
-    def freeze_text_layers(self, module_exceptions=[]):
+    def freeze_text_layers(self, module_exceptions=None):
+        if module_exceptions is None:
+            module_exceptions = []
         for module in [self.layers, self.norm]:
             freeze_model(module, module_exceptions=module_exceptions)
 
-    def freeze_vision_layers(self, module_exceptions=[]):
+    def freeze_vision_layers(self, module_exceptions=None):
+        if module_exceptions is None:
+            module_exceptions = []
         freeze_model(self.vision_model, module_exceptions=module_exceptions)
 
     @merge_with_config_defaults


### PR DESCRIPTION
# What does this PR do?

Fixes a common Python pitfall regarding **mutable default arguments**. 

In Python, default arguments are evaluated only once at function definition time. If a mutable object (like a `list`) is used as a default, that same list instance is shared across all calls to the function. This can lead to insidious bugs where the list grows unexpectedly between function calls or instances.

## Modifications
Refactored the following method signatures to use `None` as the default value and initialize the list inside the function:

- **`src/transformers/models/idefics/modeling_idefics.py`**:
  - `freeze_model(..., module_exceptions=[])` -> `module_exceptions=None`
  - `freeze_text_layers(..., module_exceptions=[])` -> `module_exceptions=None`
  - `freeze_vision_layers(..., module_exceptions=[])` -> `module_exceptions=None`

- **`src/transformers/debug_utils.py`**:
  - `DebugUnderflowOverflow.__init__(..., trace_batch_nums=[])` -> `trace_batch_nums=None`

## Verification
- Verified that the logic inside the functions correctly initializes the list if the argument is `None` (`if arg is None: arg = []`).
- Verified that existing calls passing explicit lists are unaffected.

## Who can review?
@sgugger 
@amyeroberts
@ArthurZucker

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?