### PR TITLE
Fix ZeRO-3 conversion-mapped checkpoint loading

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -383,11 +383,15 @@ def _apply_weight_conversions_to_state_dict(model, state_dict, weight_mapping):
             # Only WeightConverter needs convert(); WeightRenaming is just a simple rename
             if not isinstance(mapping, WeightConverter):
                 continue
-            realized_value, _ = mapping.convert(
+            converted = mapping.convert(
                 renamed_key,
                 model=model,
                 config=model.config,
             )
+            # Be robust to both conversion APIs:
+            # - legacy: (converted_tensors, conversion_errors)
+            # - current: converted_tensors
+            realized_value = converted[0] if isinstance(converted, tuple) else converted
             for target_name, param in realized_value.items():
                 param = param[0] if isinstance(param, list) else param
                 new_state_dict[target_name] = param

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -511,6 +511,73 @@ class CoreIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
                         self.assertEqual(len(param.shape), 3, f"down_proj should be 3D, got {param.shape}")
                         self.assertEqual(param.shape[0], 8, f"Should have 8 experts, got {param.shape[0]}")
 
+    def test_init_zero3_qwen3next_loads_checkpoint_weights(self):
+        # Regression test: ZeRO-3 + conversion mapping must not drop non-converted keys when loading
+        # checkpoints already saved in the new packed-expert format.
+        import tempfile
+
+        from transformers import Qwen3NextConfig, Qwen3NextForCausalLM
+
+        tiny_config = Qwen3NextConfig(
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            max_position_embeddings=256,
+            linear_conv_kernel_dim=4,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_num_key_heads=4,
+            linear_num_value_heads=4,
+            decoder_sparse_step=1,
+            moe_intermediate_size=32,
+            shared_expert_intermediate_size=32,
+            num_experts_per_tok=2,
+            num_experts=8,
+        )
+
+        ds_config = {
+            "train_batch_size": 1,
+            "zero_optimization": {
+                "stage": 3,
+            },
+        }
+
+        dschf = HfDeepSpeedConfig(ds_config)
+        self.assertTrue(dschf.is_zero3())
+        self.assertTrue(is_deepspeed_zero3_enabled())
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            with LoggingLevel(logging.INFO):
+                with mockenv_context(**self.dist_env_1_gpu):
+                    model = Qwen3NextForCausalLM(tiny_config)
+                    model.save_pretrained(tmpdirname)
+
+            with LoggingLevel(logging.INFO):
+                with mockenv_context(**self.dist_env_1_gpu):
+                    loaded_model, loading_info = Qwen3NextForCausalLM.from_pretrained(
+                        tmpdirname, output_loading_info=True, dtype=torch.float32
+                    )
+
+            self.assertEqual(len(loading_info["missing_keys"]), 0)
+            self.assertEqual(len(loading_info["unexpected_keys"]), 0)
+            self.assertEqual(len(loading_info["mismatched_keys"]), 0)
+
+            import deepspeed
+
+            packed_params = [
+                param
+                for name, param in loaded_model.named_parameters()
+                if "mlp.experts.gate_up_proj" in name or "mlp.experts.down_proj" in name
+            ]
+            self.assertGreater(len(packed_params), 0)
+            with deepspeed.zero.GatheredParameters(packed_params, modifier_rank=0):
+                for param in packed_params:
+                    self.assertEqual(len(param.shape), 3)
+
     def test_init_zero3_variance_scaling(self):
         """
         Tests whether variance scaling initializations (`lecun_normal_`, `default_flax_embed_init_`) work correctly

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -511,6 +511,73 @@ class CoreIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
                         self.assertEqual(len(param.shape), 3, f"down_proj should be 3D, got {param.shape}")
                         self.assertEqual(param.shape[0], 8, f"Should have 8 experts, got {param.shape[0]}")
 
+    def test_init_zero3_qwen3next_no_spurious_missing_keys(self):
+        # Regression test: ZeRO-3 + conversion mapping must not drop non-converted keys when loading
+        # checkpoints already saved in the new packed-expert format.
+        import tempfile
+
+        from transformers import Qwen3NextConfig, Qwen3NextForCausalLM
+
+        tiny_config = Qwen3NextConfig(
+            vocab_size=128,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=4,
+            head_dim=16,
+            max_position_embeddings=256,
+            linear_conv_kernel_dim=4,
+            linear_key_head_dim=16,
+            linear_value_head_dim=16,
+            linear_num_key_heads=4,
+            linear_num_value_heads=4,
+            decoder_sparse_step=1,
+            moe_intermediate_size=32,
+            shared_expert_intermediate_size=32,
+            num_experts_per_tok=2,
+            num_experts=8,
+        )
+
+        ds_config = {
+            "train_batch_size": 1,
+            "zero_optimization": {
+                "stage": 3,
+            },
+        }
+
+        dschf = HfDeepSpeedConfig(ds_config)
+        self.assertTrue(dschf.is_zero3())
+        self.assertTrue(is_deepspeed_zero3_enabled())
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            with LoggingLevel(logging.INFO):
+                with mockenv_context(**self.dist_env_1_gpu):
+                    model = Qwen3NextForCausalLM(tiny_config)
+                    model.save_pretrained(tmpdirname)
+
+            with LoggingLevel(logging.INFO):
+                with mockenv_context(**self.dist_env_1_gpu):
+                    loaded_model, loading_info = Qwen3NextForCausalLM.from_pretrained(
+                        tmpdirname, output_loading_info=True, dtype=torch.float32
+                    )
+
+            self.assertEqual(len(loading_info["missing_keys"]), 0)
+            self.assertEqual(len(loading_info["unexpected_keys"]), 0)
+            self.assertEqual(len(loading_info["mismatched_keys"]), 0)
+
+            import deepspeed
+
+            packed_params = [
+                param
+                for name, param in loaded_model.named_parameters()
+                if "mlp.experts.gate_up_proj" in name or "mlp.experts.down_proj" in name
+            ]
+            self.assertGreater(len(packed_params), 0)
+            with deepspeed.zero.GatheredParameters(packed_params, modifier_rank=0):
+                for param in packed_params:
+                    self.assertEqual(len(param.shape), 3)
+
     def test_init_zero3_variance_scaling(self):
         """
         Tests whether variance scaling initializations (`lecun_normal_`, `default_flax_embed_init_`) work correctly


### PR DESCRIPTION
This PR fixes a ZeRO-3 checkpoint loading failure in Transformers’ conversion-mapped loading path. In affected cases, many parameters are reported as missing and are actually not restored from checkpoint (they get reinitialized).

`transformers/integrations/deepspeed.py` used a `WeightConverter.convert()` return assumption that is no longer stable across versions (legacy tuple vs current dict), which broke correctness/compatibility in the ZeRO-3 conversion helper path.

Chages:
  - Made ZeRO-3 conversion loading robust to both WeightConverter.convert() return shapes:
      - legacy: (converted_tensors, conversion_errors)
      - current: converted_tensors
  - Added a regression test:

Links: huggingface/transformers#43940, deepspeedai/DeepSpeed#7848