### PR TITLE
Fix TypeError in dot_natural_key when state_dict keys have mixed types at same position

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -819,9 +819,9 @@ def dot_natural_key(s: str):
     result = []
     for p in s.split("."):
         if p.isdigit():
-            result.append((0, int(p), p))
+            result.append((0, int(p)))
         else:
-            result.append((1, 0, p))
+            result.append((1, p))
     return result
 
 

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -812,12 +812,19 @@ def spawn_tp_materialize(
 
 
 def dot_natural_key(s: str):
-    parts = s.split(".")
-    for i, p in enumerate(parts):
-        # whole-segment digits -> int; otherwise leave as str
+    """Sort key for state-dict names: split on ``"."`` and sort digit
+    segments numerically.  Each element is turned into a ``(type_rank, int_value, str_value)``
+    tuple so that segments that are numeric at one position but textual at
+    the same position in a different key never cause a ``TypeError`` during
+    comparison (ints and strs are not orderable in Python 3).
+    """
+    result = []
+    for p in s.split("."):
         if p.isdigit():
-            parts[i] = int(p)
-    return parts
+            result.append((0, int(p), p))
+        else:
+            result.append((1, 0, p))
+    return result
 
 
 @contextmanager

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -812,11 +812,9 @@ def spawn_tp_materialize(
 
 
 def dot_natural_key(s: str):
-    """Sort key for state-dict names: split on ``"."`` and sort digit
-    segments numerically.  Each element is turned into a ``(type_rank, int_value, str_value)``
-    tuple so that segments that are numeric at one position but textual at
-    the same position in a different key never cause a ``TypeError`` during
-    comparison (ints and strs are not orderable in Python 3).
+    """Sort key for state-dict names: split on ``"."`` and sort digits numerically
+    and strings alphabetically. We emit a tuple at each point to sort ints
+    first and strings second to avoid int-string comparison failures.
     """
     result = []
     for p in s.split("."):


### PR DESCRIPTION
## What does this PR do?

Fixes #43867

When a model has sub-models with different naming conventions (e.g. `model.layers.26.self_attn.o_proj.weight` vs `desc_model.roberta.encoder.layers.7.norm1.weight`), `dot_natural_key` can produce lists where the same index contains an `int` in one key and a `str` in another. Python 3 cannot compare `int` and `str`, so `sorted()` raises:

```
TypeError: '<' not supported between instances of 'str' and 'int'
```

### Fix

Each segment is now returned as a `(type_rank, int_value, str_value)` tuple:
- Digit segments: `(0, int(p), p)` 
- String segments: `(1, 0, p)`

This ensures:
- All comparisons are between same-typed tuples (no `TypeError`)
- Natural numeric ordering is preserved within digit segments  
- Digit segments sort before string segments at the same position

### Test

```python
from transformers.core_model_loading import dot_natural_key

# Previously raised TypeError
keys = [
    'model.layers.26.self_attn.o_proj.weight',
    'desc_model.roberta.encoder.layers.7.norm1.weight',
]
sorted(keys, key=dot_natural_key)  # now works

# Natural numeric sort still works
keys = ['model.layers.10.w', 'model.layers.2.w', 'model.layers.1.w']
sorted(keys, key=dot_natural_key)
# => ['model.layers.1.w', 'model.layers.2.w', 'model.layers.10.w']
```
