### PR TITLE
Fix AttributeError in run_classification.py when detecting multi-label data

### DIFF
--- a/examples/pytorch/text-classification/run_classification.py
+++ b/examples/pytorch/text-classification/run_classification.py
@@ -412,8 +412,9 @@ def main():
 
     # Trying to have good defaults here, don't hesitate to tweak to your needs.
 
+    label_feature = raw_datasets["train"].features["label"]
     is_regression = (
-        raw_datasets["train"].features["label"].dtype in ["float32", "float64"]
+        getattr(label_feature, "dtype", None) in ["float32", "float64"]
         if data_args.do_regression is None
         else data_args.do_regression
     )
@@ -439,7 +440,7 @@ def main():
                     raise error
 
     else:  # classification
-        if raw_datasets["train"].features["label"].dtype == "list":  # multi-label classification
+        if isinstance(raw_datasets["train"].features["label"], datasets.Sequence):  # multi-label classification
             is_multi_label = True
             logger.info("Label type is list, doing multi-label classification")
         # Trying to find the number of labels in a multi-label classification task


### PR DESCRIPTION
## What does this PR do?

Fixes the `AttributeError: 'List' object has no attribute 'dtype'` crash in `run_classification.py` when loading JSON data with list-type labels for multi-label classification (reported in #43116).

### Problem

When label data is in list format (e.g. `"labels": ["4359", "5181"]`), the HuggingFace `datasets` library infers the feature type as `Sequence`/`List`, which does **not** have a `dtype` attribute. The existing code crashes in two places:

1. **`is_regression` check** (line 416): `raw_datasets["train"].features["label"].dtype in ["float32", "float64"]` → `AttributeError`
2. **Multi-label detection** (line 442): `...features["label"].dtype == "list"` → `AttributeError`

### Fix

1. Use `getattr(label_feature, "dtype", None)` for the regression check, so list-type features safely return `None` (not regression)
2. Use `isinstance(feature, datasets.Sequence)` for multi-label detection instead of checking `.dtype == "list"`

### Reproduction

```python
# With JSON data like: [{"text": "...", "labels": ["a", "b"]}, ...]
# Before fix:
#   AttributeError: 'List' object has no attribute 'dtype'
# After fix:
#   Correctly detects multi-label classification
```

Note: This PR only fixes the **crash** in multi-label detection. The separate thresholding issue for empty predictions is tracked in #43135.
