### PR TITLE
Enhance JSON schema generation to support instance, static, and class methods

### DIFF
--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -135,7 +135,7 @@ Another way to define tools is by passing a [JSON schema](https://json-schema.or
 You can also manually call the low-level functions that convert Python functions to JSON schemas, and then check or edit the generated schemas. This is usually not necessary, but is useful for understanding the underlying mechanics. It's particularly important
 for chat template authors who need to access the JSON schema to render the tool definitions.
 
-The  [`~PreTrainedTokenizerBase.apply_chat_template`] method uses the [get_json_schema](https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205) function to convert Python functions to a JSON schema.
+The [`~PreTrainedTokenizerBase.apply_chat_template`] method uses the [get_json_schema](https://github.com/huggingface/transformers/blob/14561209291255e51c55260306c7d00c159381a5/src/transformers/utils/chat_template_utils.py#L205) function to convert Python callables to a JSON schema. This includes methods: `self` and `cls` are treated as implicit receiver arguments and are ignored.
 
 ```py
 from transformers.utils import get_json_schema

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -181,8 +181,21 @@ def _parse_type_hint(hint: str) -> dict:
 def _convert_type_hints_to_json_schema(func: Callable) -> dict:
     type_hints = get_type_hints(func)
     signature = inspect.signature(func)
+    # For methods, we need to ignore the first "self" or "cls" parameter. However, since unbound methods are just
+    # functions, we need to check the signature to see if it looks like a method rather than only relying on 
+    # inspect.ismethod(), which returns False for unbound methods.
+    qualname = getattr(func, "__qualname__", "")
+    qualname_parts = qualname.split(".")
+    has_unbound_method_signature = isfunction(func) and len(qualname_parts) >= 2 and qualname_parts[-2] != "<locals>"
+    first_param_name = next(iter(signature.parameters), None)
+    implicit_arg_name = None
+    if first_param_name in {"self", "cls"} and (inspect.ismethod(func) or has_unbound_method_signature):
+        implicit_arg_name = first_param_name
+
     required = []
     for param_name, param in signature.parameters.items():
+        if param_name == implicit_arg_name:
+            continue
         if param.annotation == inspect.Parameter.empty:
             raise TypeHintParsingException(f"Argument {param.name} is missing a type hint in function {func.__name__}")
         if param.default == inspect.Parameter.empty:
@@ -190,6 +203,8 @@ def _convert_type_hints_to_json_schema(func: Callable) -> dict:
 
     properties = {}
     for param_name, param_type in type_hints.items():
+        if param_name == implicit_arg_name:
+            continue
         properties[param_name] = _parse_type_hint(param_type)
 
     schema = {"type": "object", "properties": properties}
@@ -485,7 +500,7 @@ def render_jinja_template(
         for tool in tools:
             if isinstance(tool, dict):
                 tool_schemas.append(tool)
-            elif isfunction(tool):
+            elif isfunction(tool) or inspect.ismethod(tool):
                 tool_schemas.append(get_json_schema(tool))
             else:
                 raise ValueError(

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -181,16 +181,16 @@ def _parse_type_hint(hint: str) -> dict:
 def _convert_type_hints_to_json_schema(func: Callable) -> dict:
     type_hints = get_type_hints(func)
     signature = inspect.signature(func)
-    # For methods, we need to ignore the first "self" or "cls" parameter. However, since unbound methods are just
-    # functions, we need to check the signature to see if it looks like a method rather than only relying on 
-    # inspect.ismethod(), which returns False for unbound methods.
-    qualname = getattr(func, "__qualname__", "")
-    qualname_parts = qualname.split(".")
-    has_unbound_method_signature = isfunction(func) and len(qualname_parts) >= 2 and qualname_parts[-2] != "<locals>"
+    # For methods, we need to ignore the first "self" or "cls" parameter. Here we assume that if the first parameter
+    # is named "self" or "cls" and has no type hint, it is an implicit receiver argument.
     first_param_name = next(iter(signature.parameters), None)
-    implicit_arg_name = None
-    if first_param_name in {"self", "cls"} and (inspect.ismethod(func) or has_unbound_method_signature):
+    if (
+        first_param_name in {"self", "cls"}
+        and signature.parameters[first_param_name].annotation == inspect.Parameter.empty
+    ):
         implicit_arg_name = first_param_name
+    else:
+        implicit_arg_name = None
 
     required = []
     for param_name, param in signature.parameters.items():
@@ -253,7 +253,8 @@ def get_json_schema(func: Callable) -> dict:
     mostly used for passing lists of tools to a chat template. The JSON schema contains the name and description of
     the function, as well as the names, types and descriptions for each of its arguments. `get_json_schema()` requires
     that the function has a docstring, and that each argument has a description in the docstring, in the standard
-    Google docstring format shown below. It also requires that all the function arguments have a valid Python type hint.
+    Google docstring format shown below. It also requires that all user-facing arguments have valid Python type hints.
+    When passing methods, implicit receiver arguments (`self` or `cls`) are ignored.
 
     Although it is not required, a `Returns` block can also be added, which will be included in the schema. This is
     optional because most chat templates ignore the return value of the function.

--- a/tests/utils/test_chat_template_utils.py
+++ b/tests/utils/test_chat_template_utils.py
@@ -487,6 +487,77 @@ class JsonSchemaGeneratorTest(unittest.TestCase):
         }
         self.assertEqual(schema["function"], expected_schema)
 
+    def test_instance_method(self):
+        class Tool:
+            def fn(self, x: int):
+                """
+                Test function
+
+                Args:
+                    x: The input
+                """
+                return x
+
+        expected_schema = {
+            "name": "fn",
+            "description": "Test function",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer", "description": "The input"}},
+                "required": ["x"],
+            },
+        }
+        self.assertEqual(get_json_schema(Tool.fn)["function"], expected_schema)  # unbound case
+        self.assertEqual(get_json_schema(Tool().fn)["function"], expected_schema)  # bound case
+
+    def test_static_method(self):
+        class Tool:
+            @staticmethod
+            def fn(x: int):
+                """
+                Test function
+
+                Args:
+                    x: The input
+                """
+                return x
+
+        expected_schema = {
+            "name": "fn",
+            "description": "Test function",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer", "description": "The input"}},
+                "required": ["x"],
+            },
+        }
+        self.assertEqual(get_json_schema(Tool.fn)["function"], expected_schema)
+        self.assertEqual(get_json_schema(Tool().fn)["function"], expected_schema)
+
+    def test_class_method(self):
+        class Tool:
+            @classmethod
+            def fn(cls, x: int):
+                """
+                Test function
+
+                Args:
+                    x: The input
+                """
+                return x
+
+        expected_schema = {
+            "name": "fn",
+            "description": "Test function",
+            "parameters": {
+                "type": "object",
+                "properties": {"x": {"type": "integer", "description": "The input"}},
+                "required": ["x"],
+            },
+        }
+        self.assertEqual(get_json_schema(Tool.fn)["function"], expected_schema)
+        self.assertEqual(get_json_schema(Tool().fn)["function"], expected_schema)
+
     def test_everything_all_at_once(self):
         def fn(x: str, y: list[str | int] | None, z: tuple[str | int, str] = (42, "hello")) -> tuple[int, str]:
             """


### PR DESCRIPTION
# What does this PR do?

Enhances `get_json_schema()` and `render_jinja_template()` to support instance methods, class methods, and static methods, not just plain functions.

Previously, `get_json_schema()` only worked with standalone functions. Passing a method (bound or unbound) would either fail or incorrectly include `self`/`cls` as a required parameter in the generated schema. Similarly, `render_jinja_template()` would reject bound methods with a `ValueError` because `inspect.isfunction()` returns `False` for them.

This is needed for stateful tool use, where tools are naturally defined as methods on a class instance. For example, an agent may need tools that share state (e.g., a database connection, a session, or accumulated context), and the idiomatic way to do this in Python is to group them as methods on an object:

```python
class IncrementEnv:
    def __init__(self):
        self._counter = 0

    def increment(self, a: int) -> int:
        """
        Increment the internal counter by the input value.

        Args:
            a: The amount to increment the counter by

        Returns:
            The new value of the counter after incrementing
        """
        self._counter += a
        return self._counter

my_env = IncrementEnv()
schema = get_json_schema(my_env.increment)  # Now works correctly
```


```
{'type': 'function', 'function': {'name': 'increment', 'description': 'Increment the internal counter by the input value.', 'parameters': {'type': 'object', 'properties': {'a': {'type': 'integer', 'description': 'The amount to increment the counter by'}}, 'required': ['a']}, 'return': {'type': 'integer', 'description': 'The new value of the counter after incrementing'}}}
```
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
