### PR TITLE
Remove unused squeeze from VJEPA2 embeddings rotation

### DIFF
--- a/src/transformers/models/vjepa2/modeling_vjepa2.py
+++ b/src/transformers/models/vjepa2/modeling_vjepa2.py
@@ -189,8 +189,8 @@ def rotate_queries_or_keys(x, pos):
     emb_sin = freq.sin()  # (..., N, D/2)
     emb_cos = freq.cos()  # (..., N, D/2)
 
-    emb_sin = emb_sin.squeeze(-1).repeat(1, 1, 1, 2)
-    emb_cos = emb_cos.squeeze(-1).repeat(1, 1, 1, 2)
+    emb_sin = emb_sin.repeat(1, 1, 1, 2)
+    emb_cos = emb_cos.repeat(1, 1, 1, 2)
 
     # --
     y = x.unflatten(-1, (-1, 2))


### PR DESCRIPTION
# What does this PR do?

Removes unused `.squeeze` from VJEPA2 embeddings rotation. Currently the squeeze does nothing on video input since torch skips it if the dimension is not 1. Exporting to onnx and compiling to TensorRT instead fails because the squeeze is mantained.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@qubvel @yonigozlan @molbap
