### PR TITLE
fix: replace mutable default argument in _read_h5_weights

### DIFF
--- a/src/transformers/models/moonshine/convert_usefulsensors_to_hf.py
+++ b/src/transformers/models/moonshine/convert_usefulsensors_to_hf.py
@@ -32,7 +32,9 @@ def _get_weights(model_name):
     )
 
 
-def _read_h5_weights(group, current_key="", weights={}):
+def _read_h5_weights(group, current_key="", weights=None):
+    if weights is None:
+        weights = {}
     for key in group:
         full_key = f"{current_key}.{key}" if current_key else key
         if isinstance(group[key], h5py.Dataset):


### PR DESCRIPTION
Replaces mutable default dict `weights={}` with `weights=None` and initializes inside the function. The dict is mutated via `weights[full_key] = w`, which can cause unexpected behavior across multiple calls.