### PR TITLE
docs: fix typos across documentation files

### DIFF
--- a/docs/source/en/glossary.md
+++ b/docs/source/en/glossary.md
@@ -89,7 +89,7 @@ See [causal language modeling](#causal-language-modeling) and [decoder models](#
 
 ### backbone
 
-The backbone is the network (embeddings and layers) that outputs the raw hidden states or features. It is usually connected to a [head](#head) which accepts the features as its input to make a prediction. For example, [`ViTModel`] is a backbone without a specific head on top. Other models can also use [`VitModel`] as a backbone such as [DPT](model_doc/dpt).
+The backbone is the network (embeddings and layers) that outputs the raw hidden states or features. It is usually connected to a [head](#head) which accepts the features as its input to make a prediction. For example, [`ViTModel`] is a backbone without a specific head on top. Other models can also use [`ViTModel`] as a backbone such as [DPT](model_doc/dpt).
 
 ## C
 

--- a/docs/source/en/model_doc/gemma.md
+++ b/docs/source/en/model_doc/gemma.md
@@ -134,7 +134,7 @@ visualizer("LLMs generate text through a process known as")
 
 ## Notes
 
-- The original Gemma models support standard kv-caching used in many transformer-based language models. You can use use the default [`DynamicCache`] instance or a tuple of tensors for past key values during generation. This makes it compatible with typical autoregressive generation workflows.
+- The original Gemma models support standard kv-caching used in many transformer-based language models. You can use the default [`DynamicCache`] instance or a tuple of tensors for past key values during generation. This makes it compatible with typical autoregressive generation workflows.
 
    ```py
    import torch

--- a/docs/source/en/model_doc/shieldgemma2.md
+++ b/docs/source/en/model_doc/shieldgemma2.md
@@ -33,7 +33,7 @@ This model was contributed by [Ryan Mullins](https://huggingface.co/RyanMullins)
 ## Usage Example
 
 - ShieldGemma 2 provides a Processor that accepts a list of `images` and an optional list of `policies` as input, and constructs a batch of prompts as the product of these two lists using the provided chat template.
-- You can extend ShieldGemma's built-in in policies with the `custom_policies` argument to the Processor. Using the same key as one of the built-in policies will overwrite that policy with your custom definition.
+- You can extend ShieldGemma's built-in policies with the `custom_policies` argument to the Processor. Using the same key as one of the built-in policies will overwrite that policy with your custom definition.
 - ShieldGemma 2 does not support the image cropping capabilities used by Gemma 3.
 
 ### Classification against Built-in Policies
@@ -71,8 +71,8 @@ url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/
 image = Image.open(requests.get(url, stream=True).raw)
 
 custom_policies = {
-    "key_a": "descrition_a",
-    "key_b": "descrition_b",
+    "key_a": "description_a",
+    "key_b": "description_b",
 }
 
 inputs = processor(

--- a/docs/source/en/quantization/bitsandbytes.md
+++ b/docs/source/en/quantization/bitsandbytes.md
@@ -138,7 +138,7 @@ model_4bit = AutoModelForCausalLM.from_pretrained(
 )
 ```
 
-By default, all other modules such as [torch.nn.LayerNorm](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html) are converted to `torch.float16`. You can change the data type of these modules with the `dtype` parameter.. Setting `dtype="auto"` loads the model in the data type defined in a model's `config.json` file.
+By default, all other modules such as [torch.nn.LayerNorm](https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html) are converted to `torch.float16`. You can change the data type of these modules with the `dtype` parameter. Setting `dtype="auto"` loads the model in the data type defined in a model's `config.json` file.
 
 ```py
 import torch
@@ -340,4 +340,4 @@ model.dequantize()
 
 Learn more about the details of 8-bit quantization in [A Gentle Introduction to 8-bit Matrix Multiplication for transformers at scale using Hugging Face Transformers, Accelerate and bitsandbytes](https://huggingface.co/blog/hf-bitsandbytes-integration).
 
-Try 4-bit quantization in this [notebook](https://colab.research.google.com/drive/1ge2F1QSK8Q7h0hn3YKuBCOAS0bK8E0wf) and learn more about it's details in [Making LLMs even more accessible with bitsandbytes, 4-bit quantization and QLoRA](https://huggingface.co/blog/4bit-transformers-bitsandbytes).
+Try 4-bit quantization in this [notebook](https://colab.research.google.com/drive/1ge2F1QSK8Q7h0hn3YKuBCOAS0bK8E0wf) and learn more about its details in [Making LLMs even more accessible with bitsandbytes, 4-bit quantization and QLoRA](https://huggingface.co/blog/4bit-transformers-bitsandbytes).

--- a/docs/source/en/quantization/finegrained_fp8.md
+++ b/docs/source/en/quantization/finegrained_fp8.md
@@ -36,7 +36,7 @@ Install Accelerate and upgrade to the latest version of PyTorch.
 pip install --upgrade accelerate torch
 ```
 
-Create a [`FineGrainedFP8Config`] class and pass it to [`~PreTrainedModel.from_pretrained`] to quantize it. The weights are loaded in full precision (`torch.float32`) by default regardless of the actual data type the weights are stored in. Set `dtype="auto"` to load the weights in the data type defined in a models `config.json` file to automatically load the most memory-optiomal data type.
+Create a [`FineGrainedFP8Config`] class and pass it to [`~PreTrainedModel.from_pretrained`] to quantize it. The weights are loaded in full precision (`torch.float32`) by default regardless of the actual data type the weights are stored in. Set `dtype="auto"` to load the weights in the data type defined in a models `config.json` file to automatically load the most memory-optimal data type.
 
 ```py
 from transformers import FineGrainedFP8Config, AutoModelForCausalLM, AutoTokenizer

--- a/docs/source/en/quantization/mxfp4.md
+++ b/docs/source/en/quantization/mxfp4.md
@@ -16,9 +16,9 @@ rendered properly in your Markdown viewer.
 
 # MXFP4
 
-Note: MXFP4 quantisation currently only works for OpenAI GPT-OSS 120b and 20b.
+Note: MXFP4 quantization currently only works for OpenAI GPT-OSS 120b and 20b.
 
-MXFP4 is a 4-bit floating point format that dramatically reduces the memory requirements of large models. Large models (GPT-OSS-120B) can fit on a single 80GB GPU and smaller models (GPT-OSS-20B) only require 16GB of memory. It uses blockwise scaling to preserve it's range and accuracy, which typically becomes degraded at lower precisions.
+MXFP4 is a 4-bit floating point format that dramatically reduces the memory requirements of large models. Large models (GPT-OSS-120B) can fit on a single 80GB GPU and smaller models (GPT-OSS-20B) only require 16GB of memory. It uses blockwise scaling to preserve its range and accuracy, which typically becomes degraded at lower precisions.
 
 To use MXPF4, make sure your hardware meets the following requirements.
 

--- a/docs/source/en/testing.md
+++ b/docs/source/en/testing.md
@@ -458,14 +458,14 @@ Let's depict the GPU requirements in the following table:
 | `< 2`  | `@require_torch_non_multi_gpu` |
 | `< 3`  | `@require_torch_up_to_2_gpus`  |
 
-For example, here is a test that must be run only when there are 2 or more GPUs available and pytorch is installed:
+For example, here is a test that must be run only when there are 2 or more GPUs available and PyTorch is installed:
 
 ```python no-style
 @require_torch_multi_gpu
 def test_example_with_multi_gpu():
 ```
 
-These decorators can be stacked. For example, if a test is slow and requires at least one GPU under pytorch, here is
+These decorators can be stacked. For example, if a test is slow and requires at least one GPU under PyTorch, here is
 how to set it up:
 
 ```python no-style


### PR DESCRIPTION
### Docs: Fix Typos and Standardize Naming

This PR fixes various typos, duplicate words, and capitalization inconsistencies across the documentation to improve readability and ensure professional branding.

| File | Changes Made |
| :--- | :--- |
| `glossary.md` | `VitModel` → **ViTModel** |
| `testing.md` | `pytorch` → **PyTorch** (standardized capitalization) |
| `shieldgemma2.md` | Removed duplicate "in"; fixed "descrition" → **description** |
| `gemma.md` | Removed duplicate "use" |
| `bitsandbytes.md` | Fixed double period; `it's` → **its** |
| `finegrained_fp8.md` | `optiomal` → **optimal** |
| `mxfp4.md` | `quantisation` → **quantization**; `it's` → **its** |