### PR TITLE
Migrate RegNet to standardized output tracing

### DIFF
--- a/src/transformers/models/regnet/modeling_regnet.py
+++ b/src/transformers/models/regnet/modeling_regnet.py
@@ -21,7 +21,6 @@ from torch import Tensor, nn
 from ... import initialization as init
 from ...activations import ACT2FN
 from ...modeling_outputs import (
-    BaseModelOutputWithNoAttention,
     BaseModelOutputWithPoolingAndNoAttention,
     ImageClassifierOutputWithNoAttention,
 )
@@ -274,7 +273,6 @@ class RegNetPreTrainedModel(PreTrainedModel):
 
 
 @auto_docstring
-# Copied from transformers.models.resnet.modeling_resnet.ResNetModel with RESNET->REGNET,ResNet->RegNet
 class RegNetModel(RegNetPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)
@@ -310,7 +308,6 @@ class RegNetModel(RegNetPreTrainedModel):
     ImageNet.
     """
 )
-# Copied from transformers.models.resnet.modeling_resnet.ResNetForImageClassification with RESNET->REGNET,ResNet->RegNet,resnet->regnet
 class RegNetForImageClassification(RegNetPreTrainedModel):
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/regnet/modeling_regnet.py
+++ b/src/transformers/models/regnet/modeling_regnet.py
@@ -26,7 +26,8 @@ from ...modeling_outputs import (
     ImageClassifierOutputWithNoAttention,
 )
 from ...modeling_utils import PreTrainedModel
-from ...utils import auto_docstring, logging
+from ...utils import auto_docstring, can_return_tuple, logging
+from ...utils.output_capturing import capture_outputs
 from .configuration_regnet import RegNetConfig
 
 
@@ -235,24 +236,11 @@ class RegNetEncoder(nn.Module):
         for (in_channels, out_channels), depth in zip(in_out_channels, config.depths[1:]):
             self.stages.append(RegNetStage(config, in_channels, out_channels, depth=depth))
 
-    def forward(
-        self, hidden_state: Tensor, output_hidden_states: bool = False, return_dict: bool = True
-    ) -> BaseModelOutputWithNoAttention:
-        hidden_states = () if output_hidden_states else None
-
+    def forward(self, hidden_state: Tensor) -> Tensor:
         for stage_module in self.stages:
-            if output_hidden_states:
-                hidden_states = hidden_states + (hidden_state,)
-
             hidden_state = stage_module(hidden_state)
 
-        if output_hidden_states:
-            hidden_states = hidden_states + (hidden_state,)
-
-        if not return_dict:
-            return tuple(v for v in [hidden_state, hidden_states] if v is not None)
-
-        return BaseModelOutputWithNoAttention(last_hidden_state=hidden_state, hidden_states=hidden_states)
+        return hidden_state
 
 
 @auto_docstring
@@ -261,6 +249,9 @@ class RegNetPreTrainedModel(PreTrainedModel):
     base_model_prefix = "regnet"
     main_input_name = "pixel_values"
     _no_split_modules = ["RegNetYLayer"]
+    _can_record_outputs = {
+        "hidden_states": RegNetStage,
+    }
 
     @torch.no_grad()
     def _init_weights(self, module):
@@ -294,36 +285,22 @@ class RegNetModel(RegNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @capture_outputs
     @auto_docstring
     def forward(
         self,
         pixel_values: Tensor,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> BaseModelOutputWithPoolingAndNoAttention:
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
         embedding_output = self.embedder(pixel_values)
 
-        encoder_outputs = self.encoder(
-            embedding_output, output_hidden_states=output_hidden_states, return_dict=return_dict
-        )
-
-        last_hidden_state = encoder_outputs[0]
+        last_hidden_state = self.encoder(embedding_output)
 
         pooled_output = self.pooler(last_hidden_state)
-
-        if not return_dict:
-            return (last_hidden_state, pooled_output) + encoder_outputs[1:]
 
         return BaseModelOutputWithPoolingAndNoAttention(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
         )
 
 
@@ -347,13 +324,12 @@ class RegNetForImageClassification(RegNetPreTrainedModel):
         # initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> ImageClassifierOutputWithNoAttention:
         r"""
@@ -361,11 +337,9 @@ class RegNetForImageClassification(RegNetPreTrainedModel):
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        outputs = self.regnet(pixel_values, **kwargs)
 
-        outputs = self.regnet(pixel_values, output_hidden_states=output_hidden_states, return_dict=return_dict)
-
-        pooled_output = outputs.pooler_output if return_dict else outputs[1]
+        pooled_output = outputs.pooler_output
 
         logits = self.classifier(pooled_output)
 
@@ -373,10 +347,6 @@ class RegNetForImageClassification(RegNetPreTrainedModel):
 
         if labels is not None:
             loss = self.loss_function(labels, logits, self.config)
-
-        if not return_dict:
-            output = (logits,) + outputs[2:]
-            return (loss,) + output if loss is not None else output
 
         return ImageClassifierOutputWithNoAttention(loss=loss, logits=logits, hidden_states=outputs.hidden_states)
 


### PR DESCRIPTION
# What does this PR do?

This PR migrates the **RegNet** model to the standardized output collection interface as part of the ongoing refactoring effort in issue #43979.

Specifically:
- Adds the `_can_record_outputs` dictionary to `RegNetPreTrainedModel`.
- Adds the `@capture_outputs` decorator to the base `RegNetModel` forward pass.
- Adds the `@can_return_tuple` decorator to the `RegNetForImageClassification` forward pass.
- Removes manual handling of `output_attentions`, `output_hidden_states`, and `return_dict` logic, delegating this to the decorators.
- Simplifies the code by removing manual loops for collecting hidden states.

Ref #43979 

## Who can review?

@molbap (Reviewer - tracking issue #43979)
@yonigozlan (Vision models)