### PR TITLE
[UMT5] Ignore tied encoder embedding missing-key warning

### DIFF
--- a/src/transformers/models/umt5/modeling_umt5.py
+++ b/src/transformers/models/umt5/modeling_umt5.py
@@ -1161,6 +1161,7 @@ class UMT5EncoderModel(UMT5PreTrainedModel):
 
     model_type = "umt5"
     # config_class = UMT5Config
+    _keys_to_ignore_on_load_missing = [r"encoder.embed_tokens.weight"]
     _tied_weights_keys = {
         "encoder.embed_tokens.weight": "shared.weight",
     }

--- a/tests/models/umt5/test_encoder_missing_keys.py
+++ b/tests/models/umt5/test_encoder_missing_keys.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+
+from transformers import UMT5Config, UMT5EncoderModel
+from transformers.testing_utils import require_torch
+
+
+@require_torch
+class UMT5EncoderMissingKeysTest(unittest.TestCase):
+    def test_encoder_embed_tokens_missing_key_is_ignored_on_load(self):
+        config = UMT5Config(
+            vocab_size=99,
+            d_model=32,
+            d_ff=37,
+            d_kv=8,
+            num_layers=2,
+            num_heads=4,
+            relative_attention_num_buckets=8,
+        )
+        model = UMT5EncoderModel(config).eval()
+        state_dict = model.state_dict()
+        state_dict.pop("encoder.embed_tokens.weight")
+
+        _, loading_info = UMT5EncoderModel.from_pretrained(
+            None,
+            config=config,
+            state_dict=state_dict,
+            output_loading_info=True,
+        )
+
+        self.assertNotIn("encoder.embed_tokens.weight", loading_info["missing_keys"])


### PR DESCRIPTION
## Summary
Fixes #43992 by preventing a false missing-key report for `UMT5EncoderModel` when `encoder.embed_tokens.weight` is tied to `shared.weight`.

`UMT5EncoderModel` already declares tied weights, but loading checkpoints that only carry the shared embedding can still surface a misleading missing key warning for `encoder.embed_tokens.weight`. This change marks that key as ignorable-on-load for this encoder-only class, matching the tied-embedding semantics.

## Changes
- `src/transformers/models/umt5/modeling_umt5.py`
  - Add `_keys_to_ignore_on_load_missing = [r"encoder.embed_tokens.weight"]` to `UMT5EncoderModel`.
- `tests/models/umt5/test_encoder_missing_keys.py`
  - Add a regression test that loads `UMT5EncoderModel` from a state dict missing `encoder.embed_tokens.weight` and asserts the key is not reported in `missing_keys`.

## Validation
- `PYTHONPATH=src python3 -m ruff check src/transformers/models/umt5/modeling_umt5.py tests/models/umt5/test_encoder_missing_keys.py`
- `PYTHONPATH=src /tmp/tfpycheck/bin/pytest -q tests/models/umt5/test_encoder_missing_keys.py`
- `PYTHONPATH=src /tmp/tfpycheck/bin/coverage run -m pytest -q tests/models/umt5/test_encoder_missing_keys.py`
- `PYTHONPATH=src /tmp/tfpycheck/bin/coverage report -m src/transformers/models/umt5/modeling_umt5.py`

Coverage note:
- The added regression test hits the new load-ignore behavior directly; full-file coverage remains low because the model file contains many unrelated execution paths.
