### PR TITLE
Refactor `resnet` to use `@capture_outputs` / `@can_return_tuple` output tracing

### DIFF
--- a/src/transformers/models/resnet/modeling_resnet.py
+++ b/src/transformers/models/resnet/modeling_resnet.py
@@ -28,7 +28,8 @@ from ...modeling_outputs import (
     ImageClassifierOutputWithNoAttention,
 )
 from ...modeling_utils import PreTrainedModel
-from ...utils import auto_docstring, logging
+from ...utils import auto_docstring, can_return_tuple, logging
+from ...utils.output_capturing import capture_outputs
 from .configuration_resnet import ResNetConfig
 
 
@@ -218,27 +219,10 @@ class ResNetEncoder(nn.Module):
         for (in_channels, out_channels), depth in zip(in_out_channels, config.depths[1:]):
             self.stages.append(ResNetStage(config, in_channels, out_channels, depth=depth))
 
-    def forward(
-        self, hidden_state: Tensor, output_hidden_states: bool = False, return_dict: bool = True
-    ) -> BaseModelOutputWithNoAttention:
-        hidden_states = () if output_hidden_states else None
-
+    def forward(self, hidden_state: Tensor) -> Tensor:
         for stage_module in self.stages:
-            if output_hidden_states:
-                hidden_states = hidden_states + (hidden_state,)
-
             hidden_state = stage_module(hidden_state)
-
-        if output_hidden_states:
-            hidden_states = hidden_states + (hidden_state,)
-
-        if not return_dict:
-            return tuple(v for v in [hidden_state, hidden_states] if v is not None)
-
-        return BaseModelOutputWithNoAttention(
-            last_hidden_state=hidden_state,
-            hidden_states=hidden_states,
-        )
+        return hidden_state
 
 
 @auto_docstring
@@ -248,6 +232,10 @@ class ResNetPreTrainedModel(PreTrainedModel):
     main_input_name = "pixel_values"
     input_modalities = ("image",)
     _no_split_modules = ["ResNetConvLayer", "ResNetShortCut"]
+
+    _can_record_outputs = {
+        "hidden_states": ResNetStage,
+    }
 
     @torch.no_grad()
     def _init_weights(self, module):
@@ -281,36 +269,22 @@ class ResNetModel(ResNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @capture_outputs
     @auto_docstring
     def forward(
         self,
         pixel_values: Tensor,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> BaseModelOutputWithPoolingAndNoAttention:
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
         embedding_output = self.embedder(pixel_values)
 
-        encoder_outputs = self.encoder(
-            embedding_output, output_hidden_states=output_hidden_states, return_dict=return_dict
-        )
-
-        last_hidden_state = encoder_outputs[0]
+        last_hidden_state = self.encoder(embedding_output)
 
         pooled_output = self.pooler(last_hidden_state)
-
-        if not return_dict:
-            return (last_hidden_state, pooled_output) + encoder_outputs[1:]
 
         return BaseModelOutputWithPoolingAndNoAttention(
             last_hidden_state=last_hidden_state,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
         )
 
 
@@ -333,13 +307,12 @@ class ResNetForImageClassification(ResNetPreTrainedModel):
         # initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> ImageClassifierOutputWithNoAttention:
         r"""
@@ -347,11 +320,9 @@ class ResNetForImageClassification(ResNetPreTrainedModel):
             Labels for computing the image classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        outputs = self.resnet(pixel_values, **kwargs)
 
-        outputs = self.resnet(pixel_values, output_hidden_states=output_hidden_states, return_dict=return_dict)
-
-        pooled_output = outputs.pooler_output if return_dict else outputs[1]
+        pooled_output = outputs.pooler_output
 
         logits = self.classifier(pooled_output)
 
@@ -359,10 +330,6 @@ class ResNetForImageClassification(ResNetPreTrainedModel):
 
         if labels is not None:
             loss = self.loss_function(labels, logits, self.config)
-
-        if not return_dict:
-            output = (logits,) + outputs[2:]
-            return (loss,) + output if loss is not None else output
 
         return ImageClassifierOutputWithNoAttention(loss=loss, logits=logits, hidden_states=outputs.hidden_states)
 
@@ -385,12 +352,11 @@ class ResNetBackbone(BackboneMixin, ResNetPreTrainedModel):
         # initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
         pixel_values: Tensor,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> BackboneOutput:
         r"""
@@ -419,31 +385,20 @@ class ResNetBackbone(BackboneMixin, ResNetPreTrainedModel):
         >>> list(feature_maps[-1].shape)
         [1, 2048, 7, 7]
         ```"""
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-
         embedding_output = self.embedder(pixel_values)
 
-        outputs = self.encoder(embedding_output, output_hidden_states=True, return_dict=True)
+        outputs = self.encoder(embedding_output)
 
-        hidden_states = outputs.hidden_states
+        hidden_states = kwargs.get("output_collection", {}).get("hidden_states", ())
 
         feature_maps = ()
         for idx, stage in enumerate(self.stage_names):
             if stage in self.out_features:
                 feature_maps += (hidden_states[idx],)
 
-        if not return_dict:
-            output = (feature_maps,)
-            if output_hidden_states:
-                output += (outputs.hidden_states,)
-            return output
-
         return BackboneOutput(
             feature_maps=feature_maps,
-            hidden_states=outputs.hidden_states if output_hidden_states else None,
+            hidden_states=outputs.hidden_states if hasattr(outputs, "hidden_states") else None,
             attentions=None,
         )
 


### PR DESCRIPTION
Refactored the `resnet` model to use the standardized output tracing decorators (`@capture_outputs` and `@can_return_tuple`) as part of the migration

### Changes

| File | Change |
|------|--------|
| `modeling_resnet.py` | Migrated to `@capture_outputs` / `@can_return_tuple` |

**Specifically:**

1. **Added** `_can_record_outputs = {"hidden_states": ResNetStage}` to `ResNetPreTrainedModel` hooks on `ResNetStage` submodules automatically collect hidden states.
2. **Decorated** `ResNetModel.forward()` with `@capture_outputs`  removes manual `output_hidden_states` / `return_dict` parameter resolution and collection loops.
3. **Decorated** `ResNetForImageClassification.forward()` and `ResNetBackbone.forward()` with `@can_return_tuple` handles `return_dict` conversion without hook installation.
4. **Simplified** `ResNetEncoder.forward()` now returns a single `hidden_state` tensor instead of manually building output tuples/dicts.
5. **Removed** explicit `output_hidden_states`, `return_dict` parameters from internal signatures where they are no longer needed.
6. **Added** imports for `can_return_tuple` and `capture_outputs`.

### Reference implementations

Follows the pattern established in `llama`, `mistral`, and `qwen2` models as described in #43979.

### Notes

- ResNet has **no attention layers**, so `_can_record_outputs` only maps `"hidden_states"` (no `"attentions"` entry needed).
- The `ResNetBackbone` class uses `BackboneMixin` which has its own output handling the `@can_return_tuple` decorator is applied for consistency.

Fixes (resnet portion)