### PR TITLE
Focalnet standardized outputs

### DIFF
--- a/src/transformers/models/focalnet/modeling_focalnet.py
+++ b/src/transformers/models/focalnet/modeling_focalnet.py
@@ -516,20 +516,53 @@ class FocalNetEncoder(nn.Module):
         )
 
         self.gradient_checkpointing = False
+
     @can_return_tuple
     def forward(
         self,
         hidden_states: torch.Tensor,
         input_dimensions: tuple[int, int],
+        output_hidden_states: bool | None = False,
+        output_hidden_states_before_downsampling: bool | None = False,
     ) -> FocalNetEncoderOutput:
+        all_reshaped_hidden_states = () if output_hidden_states else None
+
+        if output_hidden_states:
+            batch_size, _, hidden_size = hidden_states.shape
+            # rearrange b (h w) c -> b c h w
+            reshaped_hidden_state = hidden_states.view(batch_size, *input_dimensions, hidden_size)
+            reshaped_hidden_state = reshaped_hidden_state.permute(0, 3, 1, 2)
+            all_reshaped_hidden_states += (reshaped_hidden_state,)
 
         for i, stage_module in enumerate(self.stages):
             stage_outputs = stage_module(hidden_states, input_dimensions)
+            hidden_states = stage_outputs[0]
+            hidden_states_before_downsampling = stage_outputs[1]
+            output_dimensions = stage_outputs[2]
+
+            input_dimensions = (output_dimensions[-2], output_dimensions[-1])
+
+            if output_hidden_states and output_hidden_states_before_downsampling:
+                batch_size, _, hidden_size = hidden_states_before_downsampling.shape
+                # rearrange b (h w) c -> b c h w
+                # here we use the original (not downsampled) height and width
+                reshaped_hidden_state = hidden_states_before_downsampling.view(
+                    batch_size, *(output_dimensions[0], output_dimensions[1]), hidden_size
+                )
+                reshaped_hidden_state = reshaped_hidden_state.permute(0, 3, 1, 2)
+                all_reshaped_hidden_states += (reshaped_hidden_state,)
+            elif output_hidden_states and not output_hidden_states_before_downsampling:
+                batch_size, _, hidden_size = hidden_states.shape
+                # rearrange b (h w) c -> b c h w
+                reshaped_hidden_state = hidden_states.view(batch_size, *input_dimensions, hidden_size)
+                reshaped_hidden_state = reshaped_hidden_state.permute(0, 3, 1, 2)
+                all_reshaped_hidden_states += (reshaped_hidden_state,)
 
         return FocalNetEncoderOutput(
-            last_hidden_state=stage_outputs[0],
-
+            last_hidden_state=hidden_states,
+            reshaped_hidden_states=all_reshaped_hidden_states,
         )
+
 
 @auto_docstring
 class FocalNetPreTrainedModel(PreTrainedModel):
@@ -538,9 +571,7 @@ class FocalNetPreTrainedModel(PreTrainedModel):
     main_input_name = "pixel_values"
     supports_gradient_checkpointing = True
     _no_split_modules = ["FocalNetStage"]
-    _can_record_outputs = {
-        "hidden_states": FocalNetStage
-    }
+    _can_record_outputs = {"hidden_states": FocalNetStage}
 
     @torch.no_grad()
     def _init_weights(self, module):
@@ -594,8 +625,6 @@ class FocalNetModel(FocalNetPreTrainedModel):
             Boolean masked positions. Indicates which patches are masked (1) and which aren't (0).
         """
 
-
-
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
@@ -604,6 +633,7 @@ class FocalNetModel(FocalNetPreTrainedModel):
         encoder_outputs = self.encoder(
             embedding_output,
             input_dimensions,
+            output_hidden_states=kwargs.get("output_hidden_states", self.config.output_hidden_states),
         )
 
         sequence_output = encoder_outputs[0]
@@ -614,11 +644,9 @@ class FocalNetModel(FocalNetPreTrainedModel):
             pooled_output = self.pooler(sequence_output.transpose(1, 2))
             pooled_output = torch.flatten(pooled_output, 1)
 
-
         return FocalNetModelOutput(
             last_hidden_state=sequence_output,
             pooler_output=pooled_output,
-            hidden_states=encoder_outputs.hidden_states,
             reshaped_hidden_states=encoder_outputs.reshaped_hidden_states,
         )
 
@@ -656,14 +684,13 @@ class FocalNetForMaskedImageModeling(FocalNetPreTrainedModel):
         self.post_init()
 
     @auto_docstring
+    @can_return_tuple
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
         bool_masked_pos: torch.BoolTensor | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | FocalNetMaskedImageModelingOutput:
+    ) -> FocalNetMaskedImageModelingOutput:
         r"""
         bool_masked_pos (`torch.BoolTensor` of shape `(batch_size, num_patches)`):
             Boolean masked positions. Indicates which patches are masked (1) and which aren't (0).
@@ -694,13 +721,11 @@ class FocalNetForMaskedImageModeling(FocalNetPreTrainedModel):
         >>> list(reconstructed_pixel_values.shape)
         [1, 3, 192, 192]
         ```"""
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         outputs = self.focalnet(
             pixel_values,
             bool_masked_pos=bool_masked_pos,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **kwargs,
         )
 
         sequence_output = outputs[0]
@@ -725,10 +750,6 @@ class FocalNetForMaskedImageModeling(FocalNetPreTrainedModel):
             )
             reconstruction_loss = nn.functional.l1_loss(pixel_values, reconstructed_pixel_values, reduction="none")
             masked_im_loss = (reconstruction_loss * mask).sum() / (mask.sum() + 1e-5) / self.config.num_channels
-
-        if not return_dict:
-            output = (reconstructed_pixel_values,) + outputs[2:]
-            return ((masked_im_loss,) + output) if masked_im_loss is not None else output
 
         return FocalNetMaskedImageModelingOutput(
             loss=masked_im_loss,
@@ -766,7 +787,6 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
         self,
         pixel_values: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
-        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> tuple | FocalNetImageClassifierOutput:
         r"""
@@ -775,10 +795,10 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        
+
         outputs = self.focalnet(
             pixel_values,
-            output_hidden_states=output_hidden_states,
+            **kwargs,
         )
 
         pooled_output = outputs[1]
@@ -819,7 +839,6 @@ class FocalNetBackbone(BackboneMixin, FocalNetPreTrainedModel):
     def forward(
         self,
         pixel_values: torch.Tensor,
-        output_hidden_states: bool | None = None,
         **kwargs,
     ) -> BackboneOutput:
         r"""
@@ -844,7 +863,6 @@ class FocalNetBackbone(BackboneMixin, FocalNetPreTrainedModel):
         ```"""
 
         outputs = self.focalnet(pixel_values, output_hidden_states=True, return_dict=True)
-        print(outputs)
         hidden_states = outputs.reshaped_hidden_states
 
         feature_maps = ()
@@ -852,10 +870,9 @@ class FocalNetBackbone(BackboneMixin, FocalNetPreTrainedModel):
             if stage in self.out_features:
                 feature_maps += (hidden_states[idx],)
 
-
         return BackboneOutput(
             feature_maps=feature_maps,
-            hidden_states=outputs.hidden_states if output_hidden_states else None,
+            hidden_states=outputs.hidden_states if kwargs.get("output_hidden_states") else None,
             attentions=None,
         )
 

--- a/src/transformers/models/focalnet/modeling_focalnet.py
+++ b/src/transformers/models/focalnet/modeling_focalnet.py
@@ -26,7 +26,8 @@ from ...backbone_utils import BackboneMixin
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import BackboneOutput
 from ...modeling_utils import PreTrainedModel
-from ...utils import ModelOutput, auto_docstring, logging
+from ...utils import ModelOutput, auto_docstring, can_return_tuple, logging
+from ...utils.output_capturing import capture_outputs
 from .configuration_focalnet import FocalNetConfig
 
 
@@ -515,62 +516,20 @@ class FocalNetEncoder(nn.Module):
         )
 
         self.gradient_checkpointing = False
-
+    @can_return_tuple
     def forward(
         self,
         hidden_states: torch.Tensor,
         input_dimensions: tuple[int, int],
-        output_hidden_states: bool | None = False,
-        output_hidden_states_before_downsampling: bool | None = False,
-        return_dict: bool | None = True,
-    ) -> tuple | FocalNetEncoderOutput:
-        all_hidden_states = () if output_hidden_states else None
-        all_reshaped_hidden_states = () if output_hidden_states else None
-
-        if output_hidden_states:
-            batch_size, _, hidden_size = hidden_states.shape
-            # rearrange b (h w) c -> b c h w
-            reshaped_hidden_state = hidden_states.view(batch_size, *input_dimensions, hidden_size)
-            reshaped_hidden_state = reshaped_hidden_state.permute(0, 3, 1, 2)
-            all_hidden_states += (hidden_states,)
-            all_reshaped_hidden_states += (reshaped_hidden_state,)
+    ) -> FocalNetEncoderOutput:
 
         for i, stage_module in enumerate(self.stages):
             stage_outputs = stage_module(hidden_states, input_dimensions)
 
-            hidden_states = stage_outputs[0]
-            hidden_states_before_downsampling = stage_outputs[1]
-            output_dimensions = stage_outputs[2]
-
-            input_dimensions = (output_dimensions[-2], output_dimensions[-1])
-
-            if output_hidden_states and output_hidden_states_before_downsampling:
-                batch_size, _, hidden_size = hidden_states_before_downsampling.shape
-                # rearrange b (h w) c -> b c h w
-                # here we use the original (not downsampled) height and width
-                reshaped_hidden_state = hidden_states_before_downsampling.view(
-                    batch_size, *(output_dimensions[0], output_dimensions[1]), hidden_size
-                )
-                reshaped_hidden_state = reshaped_hidden_state.permute(0, 3, 1, 2)
-                all_hidden_states += (hidden_states_before_downsampling,)
-                all_reshaped_hidden_states += (reshaped_hidden_state,)
-            elif output_hidden_states and not output_hidden_states_before_downsampling:
-                batch_size, _, hidden_size = hidden_states.shape
-                # rearrange b (h w) c -> b c h w
-                reshaped_hidden_state = hidden_states.view(batch_size, *input_dimensions, hidden_size)
-                reshaped_hidden_state = reshaped_hidden_state.permute(0, 3, 1, 2)
-                all_hidden_states += (hidden_states,)
-                all_reshaped_hidden_states += (reshaped_hidden_state,)
-
-        if not return_dict:
-            return tuple(v for v in [hidden_states, all_hidden_states] if v is not None)
-
         return FocalNetEncoderOutput(
-            last_hidden_state=hidden_states,
-            hidden_states=all_hidden_states,
-            reshaped_hidden_states=all_reshaped_hidden_states,
-        )
+            last_hidden_state=stage_outputs[0],
 
+        )
 
 @auto_docstring
 class FocalNetPreTrainedModel(PreTrainedModel):
@@ -579,6 +538,9 @@ class FocalNetPreTrainedModel(PreTrainedModel):
     main_input_name = "pixel_values"
     supports_gradient_checkpointing = True
     _no_split_modules = ["FocalNetStage"]
+    _can_record_outputs = {
+        "hidden_states": FocalNetStage
+    }
 
     @torch.no_grad()
     def _init_weights(self, module):
@@ -620,22 +582,19 @@ class FocalNetModel(FocalNetPreTrainedModel):
         return self.embeddings.patch_embeddings
 
     @auto_docstring
+    @capture_outputs
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
         bool_masked_pos: torch.BoolTensor | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | FocalNetModelOutput:
+    ) -> FocalNetModelOutput:
         r"""
         bool_masked_pos (`torch.BoolTensor` of shape `(batch_size, num_patches)`):
             Boolean masked positions. Indicates which patches are masked (1) and which aren't (0).
         """
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+
 
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
@@ -645,8 +604,6 @@ class FocalNetModel(FocalNetPreTrainedModel):
         encoder_outputs = self.encoder(
             embedding_output,
             input_dimensions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
         )
 
         sequence_output = encoder_outputs[0]
@@ -657,10 +614,6 @@ class FocalNetModel(FocalNetPreTrainedModel):
             pooled_output = self.pooler(sequence_output.transpose(1, 2))
             pooled_output = torch.flatten(pooled_output, 1)
 
-        if not return_dict:
-            output = (sequence_output, pooled_output) + encoder_outputs[1:]
-
-            return output
 
         return FocalNetModelOutput(
             last_hidden_state=sequence_output,
@@ -808,12 +761,12 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
         self.post_init()
 
     @auto_docstring
+    @can_return_tuple
     def forward(
         self,
         pixel_values: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> tuple | FocalNetImageClassifierOutput:
         r"""
@@ -822,12 +775,10 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
+        
         outputs = self.focalnet(
             pixel_values,
             output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
         )
 
         pooled_output = outputs[1]
@@ -837,10 +788,6 @@ class FocalNetForImageClassification(FocalNetPreTrainedModel):
         loss = None
         if labels is not None:
             loss = self.loss_function(labels, logits, self.config)
-
-        if not return_dict:
-            output = (logits,) + outputs[2:]
-            return ((loss,) + output) if loss is not None else output
 
         return FocalNetImageClassifierOutput(
             loss=loss,
@@ -868,11 +815,11 @@ class FocalNetBackbone(BackboneMixin, FocalNetPreTrainedModel):
         self.post_init()
 
     @auto_docstring
+    @can_return_tuple
     def forward(
         self,
         pixel_values: torch.Tensor,
         output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
     ) -> BackboneOutput:
         r"""
@@ -895,13 +842,9 @@ class FocalNetBackbone(BackboneMixin, FocalNetPreTrainedModel):
         >>> inputs = processor(image, return_tensors="pt")
         >>> outputs = model(**inputs)
         ```"""
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
 
         outputs = self.focalnet(pixel_values, output_hidden_states=True, return_dict=True)
-
+        print(outputs)
         hidden_states = outputs.reshaped_hidden_states
 
         feature_maps = ()
@@ -909,11 +852,6 @@ class FocalNetBackbone(BackboneMixin, FocalNetPreTrainedModel):
             if stage in self.out_features:
                 feature_maps += (hidden_states[idx],)
 
-        if not return_dict:
-            output = (feature_maps,)
-            if output_hidden_states:
-                output += (outputs.hidden_states,)
-            return output
 
         return BackboneOutput(
             feature_maps=feature_maps,


### PR DESCRIPTION
# What does this PR do?
This PR refactors the FocalNet implementation to adopt the new `@capture_outputs` and `@can_return_tuple` decorators for standardized output collection, as part of https://github.com/huggingface/transformers/issues/43979.

The goal is to align FocalNet with the new output capturing infrastructure and remove legacy `return_dict` / `output_hidden_states` handling where possible.

---

## Changes

1. **Integrated `FocalNetStage` with `_can_record_outputs`**
   - Registered stage-level outputs (e.g. `hidden_states`, `hidden_states_before_downsampling`, `output_dimensions`) using `OutputRecorder`.

2. **Added `@capture_outputs` to `FocalNetModel.forward`**
   - Enables standardized output collection via the new capturing system.

3. **Reduced reliance on legacy output flags**
   - Removed most dependencies on `return_dict` and `output_hidden_states` across forward functions.
   - The dependency is currently retained in `FocalNetEncoder` for compatibility and reshaping logic.

---

## Future Improvements

- Extend `OutputRecorder` to support post-processing callbacks.
  - This would allow reshaping (e.g., spatial reconstruction of hidden states) to be handled within the capture framework.
  - Doing so would eliminate the remaining `output_hidden_states` dependency inside `FocalNetEncoder` and further improve modularity.
  

## Tests

Passed 75 skipped 129
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@molbap 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @
@molbap 
 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
