### PR TITLE
[Misc][vlms] Use text_config when initializing the fine-grained FP8Expert

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -745,7 +745,9 @@ def replace_with_fp8_linear(
         with torch.device("meta"):
             if module_name.endswith(".experts"):
                 new_module = FP8Expert(
-                    config=model.config, block_size=quantization_config.weight_block_size, **module_kwargs
+                    config=model.config.get_text_config(),
+                    block_size=quantization_config.weight_block_size,
+                    **module_kwargs,
                 )
             elif isinstance(module, nn.Linear):
                 new_module = FP8Linear(


### PR DESCRIPTION
# What does this PR do?

Update FP8 expert replacement to use `model.config.text_config` when available (VLMs), falling back to model.config if it's text-only models.