### PR TITLE
Remove `other_workflow_run_ids` for `issue_comment` in `utils/notification_service.py`

### DIFF
--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -1511,18 +1511,6 @@ if __name__ == "__main__":
                 token=os.environ["ACCESS_REPO_INFO_TOKEN"], workflow_id=other_workflow_id, commit_sha=ci_sha
             )
             other_workflow_run_ids.append(other_workflow_run_id)
-    # triggered via `issue_comment` for CI on pull requests (e.g. using the comment `run-slow:`)
-    # TODO (ydshieh): We introduced `include_all` in `Message.payload` in PR # XXXXX, we no longer need this
-    #                 block. But let's keep this for a while and remove it when the CI runs become more stable.
-    elif os.environ.get("GITHUB_EVENT_NAME") in ["issue_comment", "pull_request"]:
-        # TODO (ydshieh): Make this flexible once we implement `run-slow` for AMD CI and others.
-        # The id of the workflow `.github/workflows/self-scheduled-caller.yml` (not of a workflow run of it).
-        prev_workflow_id = "90575235"
-        # TODO (ydshieh): It's better to make sure using the last completed scheduled workflow run with the commit being a parent
-        #  of the PR's `merge_commit`.
-        prev_workflow_run_id = get_last_daily_ci_workflow_run_id(
-            token=os.environ["ACCESS_REPO_INFO_TOKEN"], workflow_id=prev_workflow_id
-        )
     else:
         prev_workflow_run_id = os.environ["PREV_WORKFLOW_RUN_ID"]
         other_workflow_run_id = os.environ["OTHER_WORKFLOW_RUN_ID"]


### PR DESCRIPTION
# What does this PR do?

So the following logic added in a previous PR #44033 could take effect

```python
            # `include_all` is `True` when the CI is running on a pull request, so it treats all failing tests
            # in the current CI run as "new failing tests". The `utils/check_bad_commit.py`, run in a later job,
            # will analyze the scenario in depth, in particular if a failing test in the current run is a new
            # failing test, or already failed before but with the same/different failing reason.
            include_all = os.environ.get("GITHUB_EVENT_NAME") in ["issue_comment", "pull_request"]
            if include_all and prev_ci_artifacts is None:
                prev_ci_artifacts = {}
```