### PR TITLE
Update assignee for generate in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,7 +44,7 @@ body:
 
         Library:
 
-          - generate: @zucchini-nlp (visual-language models) or @gante (all others)
+          - generate: @zucchini-nlp (visual-language models) or @cyrilvallez (all others)
           - continuous batching: @remi-or @ArthurZucker @McPatate
           - pipelines: @Rocketknight1
           - tokenizers: @ArthurZucker and @itazap


### PR DESCRIPTION
Joao is regrettably no longer with us :saluting_face:  so we should really stop getting users to ping him! This PR makes @cyrilvallez responsible for `generate` issues outside of VLMs.