### PR TITLE
[`simple`] Fix up `__repr__` whitespace/brackets

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1595,7 +1595,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
             f"{self.__class__.__name__}(name_or_path='{self.name_or_path}',"
             f" vocab_size={self.vocab_size}, model_max_length={self.model_max_length},"
             f" padding_side='{self.padding_side}', truncation_side='{self.truncation_side}',"
-            f" special_tokens={self.special_tokens_map}"
+            f" special_tokens={self.special_tokens_map})"
         )
 
     def added_tokens_decoder(self):

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1404,12 +1404,14 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
     def __repr__(self) -> str:
         added_tokens_decoder_rep = "\n\t".join([f"{k}: {v.__repr__()}," for k, v in self.added_tokens_decoder.items()])
+        if added_tokens_decoder_rep:
+            added_tokens_decoder_rep = f"\n\t{added_tokens_decoder_rep}\n"
         return (
             f"{self.__class__.__name__}(name_or_path='{self.name_or_path}',"
             f" vocab_size={self.vocab_size}, model_max_length={self.model_max_length},"
             f" padding_side='{self.padding_side}', truncation_side='{self.truncation_side}',"
             f" special_tokens={self.special_tokens_map},"
-            " added_tokens_decoder={\n\t" + added_tokens_decoder_rep + "\n}\n)"
+            f" added_tokens_decoder={{{added_tokens_decoder_rep}}})"
         )
 
     def __len__(self) -> int:


### PR DESCRIPTION
# What does this PR do?

* Fix up `__repr__` whitespace/brackets

## Reproducer
```python
from transformers import AutoTokenizer, PreTrainedTokenizerBase

# __repr__ via PreTrainedTokenizerBase
tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
print(tokenizer)

print("=====")

# __repr__ via PreTrainedTokenizerBase with empty added_tokens_decoder
class DummyTokenizer(PreTrainedTokenizerBase):
    def __init__(self, vocab_size=100, **kwargs):
        super().__init__(**kwargs)
        self._vocab = {str(i): i for i in range(vocab_size)}

    @property
    def vocab_size(self):
        return len(self._vocab)

    @property
    def added_tokens_decoder(self):
        return {}

# processor.added_tokens_decoder = {}
tokenizer = DummyTokenizer()
print(tokenizer)

print("=====")

# __repr__ via MistralCommonBackend
tokenizer = AutoTokenizer.from_pretrained("tiny-random/voxtral")
print(tokenizer)
```

## Before (i.e. `main`)

### `__repr__`  via PreTrainedTokenizerBase
```python
BertTokenizer(name_or_path='bert-base-uncased', vocab_size=30522, model_max_length=512, padding_side='right', truncation_side='right', special_tokens={'unk_token': '[UNK]', 'sep_token': '[SEP]', 'pad_token': '[PAD]', 'cls_token': '[CLS]', 'mask_token': '[MASK]'}, added_tokens_decoder={
        0: AddedToken("[PAD]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        100: AddedToken("[UNK]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        101: AddedToken("[CLS]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        102: AddedToken("[SEP]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        103: AddedToken("[MASK]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
}
)
```

### `__repr__` via PreTrainedTokenizerBase with empty added_tokens_decoder
```python
DummyTokenizer(name_or_path='', vocab_size=100, model_max_length=1000000000000000019884624838656, padding_side='right', truncation_side='right', special_tokens={}, added_tokens_decoder={

}
)
```

### `__repr__` via MistralCommonBackend
```python
MistralCommonBackend(name_or_path='', vocab_size=131072, model_max_length=1000000000000000019884624838656, padding_side='left', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '<pad>'}
```

## After

### `__repr__`  via PreTrainedTokenizerBase
```python
BertTokenizer(name_or_path='bert-base-uncased', vocab_size=30522, model_max_length=512, padding_side='right', truncation_side='right', special_tokens={'unk_token': '[UNK]', 'sep_token': '[SEP]', 'pad_token': '[PAD]', 'cls_token': '[CLS]', 'mask_token': '[MASK]'}, added_tokens_decoder={
        0: AddedToken("[PAD]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        100: AddedToken("[UNK]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        101: AddedToken("[CLS]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        102: AddedToken("[SEP]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
        103: AddedToken("[MASK]", rstrip=False, lstrip=False, single_word=False, normalized=False, special=True),
})
```
* Note: no newline between `}` and `)`.

### `__repr__` via PreTrainedTokenizerBase with empty added_tokens_decoder
```python
DummyTokenizer(name_or_path='', vocab_size=100, model_max_length=1000000000000000019884624838656, padding_side='right', truncation_side='right', special_tokens={}, added_tokens_decoder={})
```
* Note: no newlines between `{` and `}` or newline between `}` and `)`.

### `__repr__` via MistralCommonBackend
```python
MistralCommonBackend(name_or_path='', vocab_size=131072, model_max_length=1000000000000000019884624838656, padding_side='left', truncation_side='right', special_tokens={'bos_token': '<s>', 'eos_token': '</s>', 'unk_token': '<unk>', 'pad_token': '<pad>'})
```
* Note: has the previously missing `)`

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@vasqu 

- Tom Aarsen