### PR TITLE
Refactor fnet model to use @capture_outputs and @can_return_tuple decorators

### DIFF
--- a/src/transformers/models/fnet/modeling_fnet.py
+++ b/src/transformers/models/fnet/modeling_fnet.py
@@ -21,7 +21,8 @@ from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ... import initialization as init
-from ...utils import auto_docstring, is_scipy_available
+from ...utils import auto_docstring, can_return_tuple, is_scipy_available
+from ...utils.output_capturing import capture_outputs
 
 
 if is_scipy_available():
@@ -30,7 +31,6 @@ if is_scipy_available():
 from ...activations import ACT2FN
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import (
-    BaseModelOutput,
     BaseModelOutputWithPooling,
     MaskedLMOutput,
     ModelOutput,
@@ -265,24 +265,12 @@ class FNetEncoder(nn.Module):
         self.layer = nn.ModuleList([FNetLayer(config) for _ in range(config.num_hidden_layers)])
         self.gradient_checkpointing = False
 
-    def forward(self, hidden_states, output_hidden_states=False, return_dict=True):
-        all_hidden_states = () if output_hidden_states else None
-
-        for i, layer_module in enumerate(self.layer):
-            if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_states,)
-
+    def forward(self, hidden_states):
+        for layer_module in self.layer:
             layer_outputs = layer_module(hidden_states)
-
             hidden_states = layer_outputs[0]
 
-        if output_hidden_states:
-            all_hidden_states = all_hidden_states + (hidden_states,)
-
-        if not return_dict:
-            return tuple(v for v in [hidden_states, all_hidden_states] if v is not None)
-
-        return BaseModelOutput(last_hidden_state=hidden_states, hidden_states=all_hidden_states)
+        return hidden_states
 
 
 # Copied from transformers.models.bert.modeling_bert.BertPooler with Bert->FNet
@@ -372,6 +360,10 @@ class FNetPreTrainedModel(PreTrainedModel):
     base_model_prefix = "fnet"
     supports_gradient_checkpointing = True
 
+    _can_record_outputs = {
+        "hidden_states": FNetLayer,
+    }
+
     def _init_weights(self, module):
         super()._init_weights(module)
         if isinstance(module, FNetEmbeddings):
@@ -434,6 +426,7 @@ class FNetModel(FNetPreTrainedModel):
     def set_input_embeddings(self, value):
         self.embeddings.word_embeddings = value
 
+    @capture_outputs
     @auto_docstring
     def forward(
         self,
@@ -441,15 +434,8 @@ class FNetModel(FNetPreTrainedModel):
         token_type_ids: torch.LongTensor | None = None,
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | BaseModelOutput:
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
+    ) -> BaseModelOutputWithPooling:
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
@@ -487,23 +473,19 @@ class FNetModel(FNetPreTrainedModel):
             token_type_ids=token_type_ids,
             inputs_embeds=inputs_embeds,
         )
-        encoder_outputs = self.encoder(
-            embedding_output,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
-        )
-        sequence_output = encoder_outputs[0]
+        sequence_output = self.encoder(embedding_output)
 
         pooler_output = self.pooler(sequence_output) if self.pooler is not None else None
-
-        if not return_dict:
-            return (sequence_output, pooler_output) + encoder_outputs[1:]
 
         return BaseModelOutputWithPooling(
             last_hidden_state=sequence_output,
             pooler_output=pooler_output,
-            hidden_states=encoder_outputs.hidden_states,
         )
+
+
+def _fnet_filter_kwargs(**kwargs):
+    """Filter out None values from kwargs to let capture_outputs use config defaults."""
+    return {k: v for k, v in kwargs.items() if v is not None}
 
 
 @auto_docstring(
@@ -534,6 +516,7 @@ class FNetForPreTraining(FNetPreTrainedModel):
         self.cls.predictions.decoder = new_embeddings
         self.cls.predictions.bias = new_embeddings.bias
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -546,7 +529,7 @@ class FNetForPreTraining(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | FNetForPreTrainingOutput:
+    ) -> FNetForPreTrainingOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should be in `[-100, 0, ...,
@@ -572,18 +555,16 @@ class FNetForPreTraining(FNetPreTrainedModel):
         >>> prediction_logits = outputs.prediction_logits
         >>> seq_relationship_logits = outputs.seq_relationship_logits
         ```"""
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        outputs = self.fnet(
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        sequence_output, pooled_output = outputs[:2]
+        sequence_output, pooled_output = outputs.last_hidden_state, outputs.pooler_output
         prediction_scores, seq_relationship_score = self.cls(sequence_output, pooled_output)
 
         total_loss = None
@@ -592,10 +573,6 @@ class FNetForPreTraining(FNetPreTrainedModel):
             masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), labels.view(-1))
             next_sentence_loss = loss_fct(seq_relationship_score.view(-1, 2), next_sentence_label.view(-1))
             total_loss = masked_lm_loss + next_sentence_loss
-
-        if not return_dict:
-            output = (prediction_scores, seq_relationship_score) + outputs[2:]
-            return ((total_loss,) + output) if total_loss is not None else output
 
         return FNetForPreTrainingOutput(
             loss=total_loss,
@@ -628,6 +605,7 @@ class FNetForMaskedLM(FNetPreTrainedModel):
         self.cls.predictions.decoder = new_embeddings
         self.cls.predictions.bias = new_embeddings.bias
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -639,35 +617,29 @@ class FNetForMaskedLM(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | MaskedLMOutput:
+    ) -> MaskedLMOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the masked language modeling loss. Indices should be in `[-100, 0, ...,
             config.vocab_size]` (see `input_ids` docstring) Tokens with indices set to `-100` are ignored (masked), the
             loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        outputs = self.fnet(
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        sequence_output = outputs[0]
+        sequence_output = outputs.last_hidden_state
         prediction_scores = self.cls(sequence_output)
 
         masked_lm_loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss()  # -100 index = padding token
             masked_lm_loss = loss_fct(prediction_scores.view(-1, self.config.vocab_size), labels.view(-1))
-
-        if not return_dict:
-            output = (prediction_scores,) + outputs[2:]
-            return ((masked_lm_loss,) + output) if masked_lm_loss is not None else output
 
         return MaskedLMOutput(loss=masked_lm_loss, logits=prediction_scores, hidden_states=outputs.hidden_states)
 
@@ -687,6 +659,7 @@ class FNetForNextSentencePrediction(FNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -698,7 +671,7 @@ class FNetForNextSentencePrediction(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | NextSentencePredictorOutput:
+    ) -> NextSentencePredictorOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the next sequence prediction (classification) loss. Input should be a sequence pair
@@ -722,19 +695,16 @@ class FNetForNextSentencePrediction(FNetPreTrainedModel):
         >>> logits = outputs.logits
         >>> assert logits[0, 0] < logits[0, 1]  # next sentence was random
         ```"""
-
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        outputs = self.fnet(
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        pooled_output = outputs[1]
+        pooled_output = outputs.pooler_output
 
         seq_relationship_scores = self.cls(pooled_output)
 
@@ -742,10 +712,6 @@ class FNetForNextSentencePrediction(FNetPreTrainedModel):
         if labels is not None:
             loss_fct = CrossEntropyLoss()
             next_sentence_loss = loss_fct(seq_relationship_scores.view(-1, 2), labels.view(-1))
-
-        if not return_dict:
-            output = (seq_relationship_scores,) + outputs[2:]
-            return ((next_sentence_loss,) + output) if next_sentence_loss is not None else output
 
         return NextSentencePredictorOutput(
             loss=next_sentence_loss,
@@ -772,6 +738,7 @@ class FNetForSequenceClassification(FNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -783,25 +750,23 @@ class FNetForSequenceClassification(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | SequenceClassifierOutput:
+    ) -> SequenceClassifierOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
             config.num_labels - 1]`. If `config.num_labels == 1` a regression loss is computed (Mean-Square loss), If
             `config.num_labels > 1` a classification loss is computed (Cross-Entropy).
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        outputs = self.fnet(
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        pooled_output = outputs[1]
+        pooled_output = outputs.pooler_output
         pooled_output = self.dropout(pooled_output)
         logits = self.classifier(pooled_output)
 
@@ -827,9 +792,6 @@ class FNetForSequenceClassification(FNetPreTrainedModel):
             elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()
                 loss = loss_fct(logits, labels)
-        if not return_dict:
-            output = (logits,) + outputs[2:]
-            return ((loss,) + output) if loss is not None else output
 
         return SequenceClassifierOutput(loss=loss, logits=logits, hidden_states=outputs.hidden_states)
 
@@ -846,6 +808,7 @@ class FNetForMultipleChoice(FNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -857,7 +820,7 @@ class FNetForMultipleChoice(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | MultipleChoiceModelOutput:
+    ) -> MultipleChoiceModelOutput:
         r"""
         input_ids (`torch.LongTensor` of shape `(batch_size, num_choices, sequence_length)`):
             Indices of input sequence tokens in the vocabulary.
@@ -888,7 +851,6 @@ class FNetForMultipleChoice(FNetPreTrainedModel):
             num_choices-1]` where `num_choices` is the size of the second dimension of the input tensors. (See
             `input_ids` above)
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
         num_choices = input_ids.shape[1] if input_ids is not None else inputs_embeds.shape[1]
 
         input_ids = input_ids.view(-1, input_ids.size(-1)) if input_ids is not None else None
@@ -900,16 +862,16 @@ class FNetForMultipleChoice(FNetPreTrainedModel):
             else None
         )
 
-        outputs = self.fnet(
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        pooled_output = outputs[1]
+        pooled_output = outputs.pooler_output
 
         pooled_output = self.dropout(pooled_output)
         logits = self.classifier(pooled_output)
@@ -919,10 +881,6 @@ class FNetForMultipleChoice(FNetPreTrainedModel):
         if labels is not None:
             loss_fct = CrossEntropyLoss()
             loss = loss_fct(reshaped_logits, labels)
-
-        if not return_dict:
-            output = (reshaped_logits,) + outputs[2:]
-            return ((loss,) + output) if loss is not None else output
 
         return MultipleChoiceModelOutput(loss=loss, logits=reshaped_logits, hidden_states=outputs.hidden_states)
 
@@ -941,6 +899,7 @@ class FNetForTokenClassification(FNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -952,23 +911,21 @@ class FNetForTokenClassification(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | TokenClassifierOutput:
+    ) -> TokenClassifierOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for computing the token classification loss. Indices should be in `[0, ..., config.num_labels - 1]`.
         """
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        outputs = self.fnet(
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        sequence_output = outputs[0]
+        sequence_output = outputs.last_hidden_state
 
         sequence_output = self.dropout(sequence_output)
         logits = self.classifier(sequence_output)
@@ -976,12 +933,7 @@ class FNetForTokenClassification(FNetPreTrainedModel):
         loss = None
         if labels is not None:
             loss_fct = CrossEntropyLoss()
-            # Only keep active parts of the loss
             loss = loss_fct(logits.view(-1, self.num_labels), labels.view(-1))
-
-        if not return_dict:
-            output = (logits,) + outputs[2:]
-            return ((loss,) + output) if loss is not None else output
 
         return TokenClassifierOutput(loss=loss, logits=logits, hidden_states=outputs.hidden_states)
 
@@ -999,6 +951,7 @@ class FNetForQuestionAnswering(FNetPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -1011,19 +964,17 @@ class FNetForQuestionAnswering(FNetPreTrainedModel):
         output_hidden_states: bool | None = None,
         return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple | QuestionAnsweringModelOutput:
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
-        outputs = self.fnet(
+    ) -> QuestionAnsweringModelOutput:
+        outputs: BaseModelOutputWithPooling = self.fnet(
             input_ids,
             token_type_ids=token_type_ids,
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **_fnet_filter_kwargs(output_hidden_states=output_hidden_states),
+            **kwargs,
         )
 
-        sequence_output = outputs[0]
+        sequence_output = outputs.last_hidden_state
 
         logits = self.qa_outputs(sequence_output)
         start_logits, end_logits = logits.split(1, dim=-1)
@@ -1046,10 +997,6 @@ class FNetForQuestionAnswering(FNetPreTrainedModel):
             start_loss = loss_fct(start_logits, start_positions)
             end_loss = loss_fct(end_logits, end_positions)
             total_loss = (start_loss + end_loss) / 2
-
-        if not return_dict:
-            output = (start_logits, end_logits) + outputs[2:]
-            return ((total_loss,) + output) if total_loss is not None else output
 
         return QuestionAnsweringModelOutput(
             loss=total_loss, start_logits=start_logits, end_logits=end_logits, hidden_states=outputs.hidden_states


### PR DESCRIPTION
## What does this PR do?

Refactors the `fnet` model to use the new `@capture_outputs` and `@can_return_tuple` decorators, as part of #43979.

### Changes:
- Added `_can_record_outputs = {"hidden_states": FNetLayer}` to `FNetPreTrainedModel`
- Added `@capture_outputs` to `FNetModel.forward` — output hidden states are now captured automatically via hooks on `FNetLayer`
- Added `@can_return_tuple` to all wrapper model forwards (`FNetForPreTraining`, `FNetForMaskedLM`, `FNetForNextSentencePrediction`, `FNetForSequenceClassification`, `FNetForMultipleChoice`, `FNetForTokenClassification`, `FNetForQuestionAnswering`)
- Removed manual `output_hidden_states`/`return_dict` handling from all forward methods
- Simplified `FNetEncoder.forward` to just return hidden states (output collection now handled by hooks)
- Removed `BaseModelOutput` import (no longer needed)
- Replaced index-based output access (`outputs[0]`, `outputs[1]`) with named attribute access (`outputs.last_hidden_state`, `outputs.pooler_output`)

### Testing:
All 71 fnet tests pass (127 skipped, 3 xfailed).

Fixes part of #43979