### PR TITLE
Fix skipped tests for glm_moe_dsa model

### DIFF
--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -150,6 +150,7 @@ class GlmMoeDsaIndexer(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
         use_cache: bool = False,
+        cache_position: torch.LongTensor | None = None,
     ) -> torch.LongTensor:
         """
         Computes top-k token indices for sparse attention (DSA).
@@ -189,13 +190,25 @@ class GlmMoeDsaIndexer(nn.Module):
         k = torch.cat([k_pe, k_nope], dim=-1)  # [B, S, D]
 
         # === Key cache (managed by the indexer, not DynamicCache) ===
-        # Reset cache on prefill (new prompt) to avoid stale keys / batch-size mismatch
-        if seq_len > 1:
-            self._cached_keys = None
-
-        if use_cache:
+        # Use cache_position for proper cache management across generation modes:
+        #   - Prefill (cache_position starts at 0): reset cache to just current keys
+        #   - Single-token decode: append one key to existing cache
+        #   - Multi-token decode (assisted generation): trim to correct position, then append
+        if use_cache and cache_position is not None:
+            start_pos = cache_position[0]
+            if start_pos == 0:
+                k_cached = k
+            elif self._cached_keys is not None:
+                k_cached = torch.cat([self._cached_keys[:, :start_pos], k], dim=1)
+            else:
+                k_cached = k
+            self._cached_keys = k_cached
+        elif use_cache:
+            # Fallback when cache_position is not available
+            if seq_len > 1:
+                self._cached_keys = None
             if self._cached_keys is not None:
-                k_cached = torch.cat([self._cached_keys, k], dim=1)  # [B, T, D]
+                k_cached = torch.cat([self._cached_keys, k], dim=1)
             else:
                 k_cached = k
             self._cached_keys = k_cached
@@ -221,10 +234,11 @@ class GlmMoeDsaIndexer(nn.Module):
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 
-        if attention_mask is not None:
-            index_scores = index_scores + attention_mask
-
         total_len = index_scores.shape[-1]
+        if attention_mask is not None:
+            # Trim mask to match indexer's cache length (may differ from main attention's cache,
+            # e.g. static cache pre-allocates for max_cache_len but indexer only has filled positions)
+            index_scores = index_scores + attention_mask[..., :total_len]
         topk = min(self.index_topk, total_len)
         topk_indices = index_scores.topk(topk, dim=-1).indices  # [B, S, topk]
         return topk_indices
@@ -387,20 +401,21 @@ class GlmMoeDsaAttention(nn.Module):
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # ===== Indexer (DSA sparse mask) =====
-        # attention_mask is [B, 1, S, T] (4D) for eager and (2D) otherwise but indexer works with [B, S, T] (3D)
-        indexer_mask = (
-            attention_mask[:, 0, :, :]
-            if attention_mask is not None and attention_mask.dim() == 4
-            else attention_mask.unsqueeze(1)
-            if attention_mask is not None
-            else None
-        )
+        # Normalize attention_mask to 4D for consistent handling downstream.
+        # _update_causal_mask returns 4D [B, 1, S, T] for eager/sdpa, or 2D [B, T] otherwise.
+        if attention_mask is not None and attention_mask.dim() == 2:
+            attention_mask = attention_mask[:, None, None, :]  # [B, T] → [B, 1, 1, T]
+
+        # Indexer works with [B, S, T] (3D) — extract from the (now always 4D) mask
+        indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+
         topk_indices = self.indexer(
             hidden_states,
             q_resid,
             position_embeddings,
             indexer_mask,
             use_cache=past_key_values is not None,
+            cache_position=cache_position,
         )  # [B, S, topk]
 
         # Build combined DSA + causal mask: -inf everywhere except selected top-k positions
@@ -413,15 +428,10 @@ class GlmMoeDsaAttention(nn.Module):
         )
         index_mask.scatter_(-1, topk_indices, 0.0)  # [B, S, T]
         index_mask = index_mask.unsqueeze(1)  # [B, 1, S, T]
-        if attention_mask is not None and attention_mask.dim() == 4:
-            causal_mask = attention_mask[..., :total_len]
-            combined_mask = index_mask + causal_mask
+        if attention_mask is not None:
+            combined_mask = index_mask + attention_mask[..., :total_len]
         else:
-            combined_mask = (
-                attention_mask.masked_fill(index_mask == float("-inf"), float("-inf"))
-                if attention_mask is not None
-                else index_mask
-            )
+            combined_mask = index_mask
 
         # Flash attention head_dim padding (qk_head_dim != v_head_dim)
         if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:

--- a/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
@@ -342,6 +342,7 @@ class GlmMoeDsaIndexer(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
         use_cache: bool = False,
+        cache_position: torch.LongTensor | None = None,
     ) -> torch.LongTensor:
         """
         Computes top-k token indices for sparse attention (DSA).
@@ -381,13 +382,25 @@ class GlmMoeDsaIndexer(nn.Module):
         k = torch.cat([k_pe, k_nope], dim=-1)  # [B, S, D]
 
         # === Key cache (managed by the indexer, not DynamicCache) ===
-        # Reset cache on prefill (new prompt) to avoid stale keys / batch-size mismatch
-        if seq_len > 1:
-            self._cached_keys = None
-
-        if use_cache:
+        # Use cache_position for proper cache management across generation modes:
+        #   - Prefill (cache_position starts at 0): reset cache to just current keys
+        #   - Single-token decode: append one key to existing cache
+        #   - Multi-token decode (assisted generation): trim to correct position, then append
+        if use_cache and cache_position is not None:
+            start_pos = cache_position[0]
+            if start_pos == 0:
+                k_cached = k
+            elif self._cached_keys is not None:
+                k_cached = torch.cat([self._cached_keys[:, :start_pos], k], dim=1)
+            else:
+                k_cached = k
+            self._cached_keys = k_cached
+        elif use_cache:
+            # Fallback when cache_position is not available
+            if seq_len > 1:
+                self._cached_keys = None
             if self._cached_keys is not None:
-                k_cached = torch.cat([self._cached_keys, k], dim=1)  # [B, T, D]
+                k_cached = torch.cat([self._cached_keys, k], dim=1)
             else:
                 k_cached = k
             self._cached_keys = k_cached
@@ -413,10 +426,11 @@ class GlmMoeDsaIndexer(nn.Module):
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 
-        if attention_mask is not None:
-            index_scores = index_scores + attention_mask
-
         total_len = index_scores.shape[-1]
+        if attention_mask is not None:
+            # Trim mask to match indexer's cache length (may differ from main attention's cache,
+            # e.g. static cache pre-allocates for max_cache_len but indexer only has filled positions)
+            index_scores = index_scores + attention_mask[..., :total_len]
         topk = min(self.index_topk, total_len)
         topk_indices = index_scores.topk(topk, dim=-1).indices  # [B, S, topk]
         return topk_indices
@@ -542,20 +556,21 @@ class GlmMoeDsaAttention(nn.Module):
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # ===== Indexer (DSA sparse mask) =====
-        # attention_mask is [B, 1, S, T] (4D) for eager and (2D) otherwise but indexer works with [B, S, T] (3D)
-        indexer_mask = (
-            attention_mask[:, 0, :, :]
-            if attention_mask is not None and attention_mask.dim() == 4
-            else attention_mask.unsqueeze(1)
-            if attention_mask is not None
-            else None
-        )
+        # Normalize attention_mask to 4D for consistent handling downstream.
+        # _update_causal_mask returns 4D [B, 1, S, T] for eager/sdpa, or 2D [B, T] otherwise.
+        if attention_mask is not None and attention_mask.dim() == 2:
+            attention_mask = attention_mask[:, None, None, :]  # [B, T] → [B, 1, 1, T]
+
+        # Indexer works with [B, S, T] (3D) — extract from the (now always 4D) mask
+        indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+
         topk_indices = self.indexer(
             hidden_states,
             q_resid,
             position_embeddings,
             indexer_mask,
             use_cache=past_key_values is not None,
+            cache_position=cache_position,
         )  # [B, S, topk]
 
         # Build combined DSA + causal mask: -inf everywhere except selected top-k positions
@@ -568,15 +583,10 @@ class GlmMoeDsaAttention(nn.Module):
         )
         index_mask.scatter_(-1, topk_indices, 0.0)  # [B, S, T]
         index_mask = index_mask.unsqueeze(1)  # [B, 1, S, T]
-        if attention_mask is not None and attention_mask.dim() == 4:
-            causal_mask = attention_mask[..., :total_len]
-            combined_mask = index_mask + causal_mask
+        if attention_mask is not None:
+            combined_mask = index_mask + attention_mask[..., :total_len]
         else:
-            combined_mask = (
-                attention_mask.masked_fill(index_mask == float("-inf"), float("-inf"))
-                if attention_mask is not None
-                else index_mask
-            )
+            combined_mask = index_mask
 
         # Flash attention head_dim padding (qk_head_dim != v_head_dim)
         if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:

--- a/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
+++ b/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 """Testing suite for the PyTorch GlmMoeDsa model."""
 
+import copy
+import re
+import tempfile
 import unittest
 
 import torch
@@ -122,47 +125,62 @@ class GlmMoeDsaModelTest(CausalLMModelTest, unittest.TestCase):
     ):
         pass
 
-    @unittest.skip("I am in a rush, will check it out later on")
-    def test_keep_in_fp32_modules_strict(self):
-        pass
-
-    @unittest.skip("I am in a rush, will check it out later on")
     def test_keep_in_fp32_modules(self):
+        """Override: base test doesn't account for _keep_in_fp32_modules_strict also being fp32."""
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+                model = model_class(copy.deepcopy(config))
+                if len(model._keep_in_fp32_modules) == 0:
+                    self.skipTest(reason=f"{model_class.__name__} has no _keep_in_fp32_modules")
+                all_fp32 = list(set(model._keep_in_fp32_modules) | set(model._keep_in_fp32_modules_strict))
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    model.save_pretrained(tmpdirname)
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in all_fp32):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
+                        else:
+                            self.assertTrue(param.dtype == torch.float16, f"{name} was upcasted but it should NOT")
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules_strict):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not kept strict fp32")
+                        else:
+                            self.assertTrue(param.dtype == torch.bfloat16, f"{name} was upcasted but it should NOT")
+
+    def test_keep_in_fp32_modules_strict(self):
+        """Override: base test doesn't account for _keep_in_fp32_modules also being fp32 in fp16 loading."""
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        for model_class in self.all_model_classes:
+            with self.subTest(model_class.__name__):
+                model = model_class(copy.deepcopy(config))
+                if len(model._keep_in_fp32_modules_strict) == 0:
+                    self.skipTest(reason=f"{model_class.__name__} has no _keep_in_fp32_modules_strict")
+                all_fp32 = list(set(model._keep_in_fp32_modules) | set(model._keep_in_fp32_modules_strict))
+                with tempfile.TemporaryDirectory() as tmpdirname:
+                    model.save_pretrained(tmpdirname)
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.float16)
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in all_fp32):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not upcasted to fp32")
+                        else:
+                            self.assertTrue(param.dtype == torch.float16, f"{name} was upcasted but it should NOT")
+                    model = model_class.from_pretrained(tmpdirname, dtype=torch.bfloat16)
+                    for name, param in model.state_dict().items():
+                        if any(re.search(rf"(?:^|\.){k}(?:\.|$)", name) for k in model._keep_in_fp32_modules_strict):
+                            self.assertTrue(param.dtype == torch.float32, f"{name} not kept strict fp32")
+                        else:
+                            self.assertTrue(param.dtype == torch.bfloat16, f"{name} was upcasted but it should NOT")
+
+    @unittest.skip("Indexer mutable cache (dynamic shape) is incompatible with fullgraph compilation")
+    def test_generate_compile_model_forward_fullgraph(self):
         pass
 
     @require_torch_accelerator
     @slow
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         self.skipTest(reason="Qwen2Moe flash attention does not support right padding")
-
-    @unittest.skip("DSA indexer mask shape mismatch with assisted decoding")
-    @parameterized.expand([("random",), ("same",)])
-    def test_assisted_decoding_matches_greedy_search(self, assistant_type):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with assisted decoding")
-    def test_assisted_decoding_sample(self):
-        pass
-
-    @unittest.skip("Requires torch>=2.9.0 for grouped MM")
-    def test_eager_matches_batched_and_grouped_inference(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with static cache")
-    def test_generate_from_inputs_embeds_with_static_cache(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with compiled forward")
-    def test_generate_compile_model_forward_fullgraph(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with compilation")
-    def test_generate_compilation_all_outputs(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with static cache")
-    def test_generate_with_static_cache(self):
-        pass
 
 
 @require_torch_accelerator


### PR DESCRIPTION
## Summary

Fixes #44052 — resolves 10 of 11 skipped tests for the `glm_moe_dsa` model.

**Root causes fixed:**

- **DSA indexer mask shape mismatch**: The attention mask was not properly normalized to 4D before being passed to the indexer and combined with the DSA index mask. When `attention_mask` was 2D `[B, T]`, the `combined_mask` broadcasting failed. Fixed by normalizing to 4D early in the attention forward.

- **Indexer cache broken for assisted decoding**: The previous `if seq_len > 1: self._cached_keys = None` heuristic incorrectly reset the indexer's key cache during multi-token decode steps in assisted generation, losing all previous context keys. Fixed by using `cache_position` to properly manage prefill vs decode cache transitions.

- **Indexer mask size mismatch with static cache**: Static cache pre-allocates for `max_cache_len` but the indexer only caches filled positions. The indexer mask was not trimmed to match, causing size mismatches. Fixed by trimming the mask to the indexer's actual cache length.

- **FP32 module tests**: The base tests don't handle models with both `_keep_in_fp32_modules` and `_keep_in_fp32_modules_strict` non-empty — each test only accounts for its own list. Overridden both tests to properly handle the cross-list interaction.

- **Compile test (`test_generate_compilation_all_outputs`)**: The indexer cache logic uses `cache_position[0]` which causes a graph break, but this test allows graph breaks (unlike fullgraph). Removed the unnecessary skip.

**Tests fixed (10/11):**
- `test_assisted_decoding_matches_greedy_search` (random + same)
- `test_assisted_decoding_sample`
- `test_generate_from_inputs_embeds_with_static_cache`
- `test_generate_with_static_cache`
- `test_keep_in_fp32_modules`
- `test_keep_in_fp32_modules_strict`
- `test_eager_matches_batched_and_grouped_inference` (all dtype variants)
- `test_generate_compilation_all_outputs`

**Test still skipped (1/11):**
- `test_generate_compile_model_forward_fullgraph` — requires `fullgraph=True` torch.compile with zero graph breaks. The indexer's mutable `_cached_keys` changes shape between forward calls (grows as tokens are generated), which is fundamentally incompatible with fullgraph tracing. Fixing this would require rewriting the indexer to use a pre-allocated static cache, which is a larger architectural change.

## Test plan

- [x] All 120 model tests pass locally (`pytest tests/models/glm_moe_dsa/ -v`)
- [x] Previously skipped tests now pass: assisted decoding, static cache, fp32 modules, grouped MM, compilation
- [x] Existing tests (not previously skipped) continue to pass
- [x] `modular_model_converter.py` generates correct modeling file from modular changes