### PR TITLE
Refactor CTRL model output tracing with capture_outputs and can_return_tuple

### DIFF
--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -26,8 +26,10 @@ from ...modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast,
 from ...modeling_utils import PreTrainedModel
 from ...utils import (
     auto_docstring,
+    can_return_tuple,
     logging,
 )
+from ...utils.output_capturing import capture_outputs
 from .configuration_ctrl import CTRLConfig
 
 
@@ -104,7 +106,6 @@ class MultiHeadAttention(nn.Module):
         layer_past=None,
         attention_mask=None,
         use_cache=False,
-        output_attentions=False,
         cache_position=None,
     ):
         batch_size = q.shape[0]
@@ -152,11 +153,10 @@ class EncoderLayer(nn.Module):
         layer_past=None,
         attention_mask=None,
         use_cache=False,
-        output_attentions=False,
         cache_position=None,
     ):
         normed = self.layernorm1(x)
-        attn_outputs = self.multi_head_attention(
+        attn_output, attn_weights = self.multi_head_attention(
             normed,
             normed,
             normed,
@@ -164,10 +164,8 @@ class EncoderLayer(nn.Module):
             layer_past=layer_past,
             attention_mask=attention_mask,
             use_cache=use_cache,
-            output_attentions=output_attentions,
             cache_position=cache_position,
         )
-        attn_output = attn_outputs[0]
         attn_output = self.dropout1(attn_output)
         out1 = x + attn_output
 
@@ -176,14 +174,17 @@ class EncoderLayer(nn.Module):
         ffn_output = self.dropout2(ffn_output)
         out2 = out1 + ffn_output
 
-        outputs = (out2,) + attn_outputs[1:]
-        return outputs
+        return out2
 
 
 @auto_docstring
 class CTRLPreTrainedModel(PreTrainedModel):
     config: CTRLConfig
     base_model_prefix = "transformer"
+    _can_record_outputs = {
+        "hidden_states": EncoderLayer,
+        "attentions": MultiHeadAttention,
+    }
 
     def _init_weights(self, module):
         super()._init_weights(module)
@@ -225,6 +226,7 @@ class CTRLModel(CTRLPreTrainedModel):
     def set_input_embeddings(self, new_embeddings):
         self.w = new_embeddings
 
+    @capture_outputs
     @auto_docstring
     def forward(
         self,
@@ -235,12 +237,9 @@ class CTRLModel(CTRLPreTrainedModel):
         position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         cache_position: torch.Tensor | None = None,
-        **kwargs,  # NOOP kwargs, for now
-    ) -> tuple[torch.Tensor] | BaseModelOutputWithPast:
+        **kwargs,
+    ) -> BaseModelOutputWithPast:
         r"""
         Example:
 
@@ -261,13 +260,6 @@ class CTRLModel(CTRLPreTrainedModel):
         >>> list(last_hidden_states.shape)
         [1, 5, 1280]
         ```"""
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        use_cache = use_cache if use_cache is not None else self.config.use_cache
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:
@@ -296,18 +288,7 @@ class CTRLModel(CTRLPreTrainedModel):
             if batch_size <= 0:
                 raise ValueError("batch_size has to be defined and > 0")
             attention_mask = attention_mask.view(batch_size, -1)
-            # We create a 3D attention mask from a 2D tensor mask.
-            # Sizes are [batch_size, 1, 1, to_seq_length]
-            # So we can broadcast to [batch_size, num_heads, from_seq_length, to_seq_length]
-            # this attention mask is more simple than the triangular masking of causal attention
-            # used in OpenAI GPT, we just need to prepare the broadcast dimension here.
             attention_mask = attention_mask.unsqueeze(1).unsqueeze(2)
-
-            # Since attention_mask is 1.0 for positions we want to attend and 0.0 for
-            # masked positions, this operation will create a tensor which is 0.0 for
-            # positions we want to attend and the dtype's smallest value for masked positions.
-            # Since we are adding it to the raw scores before the softmax, this is
-            # effectively the same as removing these entirely.
             attention_mask = attention_mask.to(dtype=self.dtype)  # fp16 compatibility
             attention_mask = (1.0 - attention_mask) * torch.finfo(self.dtype).min
 
@@ -320,7 +301,6 @@ class CTRLModel(CTRLPreTrainedModel):
 
         if inputs_embeds is None:
             inputs_embeds = self.w(input_ids)
-        # inputs_embeds = embedded.unsqueeze(0) if len(input_ids.shape)<2 else embedded
         seq_len = input_shape[-1]
         mask = torch.triu(torch.ones(seq_len + past_length, seq_len + past_length), 1).to(device)
 
@@ -334,38 +314,21 @@ class CTRLModel(CTRLPreTrainedModel):
 
         hidden_states = self.dropout(hidden_states)
 
-        all_hidden_states = () if output_hidden_states else None
-        all_attentions = () if output_attentions else None
-        for i, h in enumerate(self.h):
-            if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_states,)
-            outputs = h(
+        for h in self.h:
+            hidden_states = h(
                 hidden_states,
                 mask,
                 layer_past=past_key_values,
                 attention_mask=attention_mask,
                 use_cache=use_cache,
-                output_attentions=output_attentions,
                 cache_position=cache_position,
             )
-            hidden_states = outputs[0]
-            if output_attentions:
-                all_attentions += (outputs[1],)
 
         hidden_states = self.layernorm(hidden_states)
-        if output_hidden_states:
-            all_hidden_states = all_hidden_states + (hidden_states,)
-
-        if not return_dict:
-            return tuple(
-                v for v in [hidden_states, past_key_values, all_hidden_states, all_attentions] if v is not None
-            )
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
-            hidden_states=all_hidden_states,
-            attentions=all_attentions,
         )
 
 
@@ -386,6 +349,7 @@ class CTRLLMHeadModel(CTRLPreTrainedModel, GenerationMixin):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -397,13 +361,10 @@ class CTRLLMHeadModel(CTRLPreTrainedModel, GenerationMixin):
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         cache_position: torch.Tensor | None = None,
         logits_to_keep: int | torch.Tensor = 0,
         **kwargs,
-    ) -> tuple[torch.Tensor] | CausalLMOutputWithPast:
+    ) -> CausalLMOutputWithPast:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
             Labels for language modeling. Note that the labels **are shifted** inside the model, i.e. you can set
@@ -435,8 +396,6 @@ class CTRLLMHeadModel(CTRLPreTrainedModel, GenerationMixin):
         >>> list(outputs.logits.shape)
         [1, 5, 246534]
         ```"""
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
         transformer_outputs = self.transformer(
             input_ids,
             past_key_values=past_key_values,
@@ -445,13 +404,11 @@ class CTRLLMHeadModel(CTRLPreTrainedModel, GenerationMixin):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
             cache_position=cache_position,
+            **kwargs,
         )
 
-        hidden_states = transformer_outputs[0]
+        hidden_states = transformer_outputs.last_hidden_state
         # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
         logits = self.lm_head(hidden_states[:, slice_indices, :])
@@ -464,10 +421,6 @@ class CTRLLMHeadModel(CTRLPreTrainedModel, GenerationMixin):
                 vocab_size=self.config.vocab_size,
                 **kwargs,
             )
-
-        if not return_dict:
-            output = (logits,) + transformer_outputs[1:]
-            return ((loss,) + output) if loss is not None else output
 
         return CausalLMOutputWithPast(
             loss=loss,
@@ -517,6 +470,7 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
         # Initialize weights and apply final processing
         self.post_init()
 
+    @can_return_tuple
     @auto_docstring
     def forward(
         self,
@@ -528,11 +482,8 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
         **kwargs,
-    ) -> tuple[torch.Tensor] | SequenceClassifierOutput:
+    ) -> SequenceClassifierOutput:
         r"""
         labels (`torch.LongTensor` of shape `(batch_size,)`, *optional*):
             Labels for computing the sequence classification/regression loss. Indices should be in `[0, ...,
@@ -609,9 +560,6 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
         >>> loss = model(**inputs, labels=labels).loss
         >>> loss.backward()  # doctest: +IGNORE_RESULT
         ```"""
-
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
-
         transformer_outputs = self.transformer(
             input_ids,
             past_key_values=past_key_values,
@@ -620,12 +568,10 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
             position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            **kwargs,
         )
 
-        hidden_states = transformer_outputs[0]
+        hidden_states = transformer_outputs.last_hidden_state
         logits = self.classifier(hidden_states)
 
         if input_ids is not None:
@@ -673,9 +619,6 @@ class CTRLForSequenceClassification(CTRLPreTrainedModel):
             elif self.config.problem_type == "multi_label_classification":
                 loss_fct = BCEWithLogitsLoss()
                 loss = loss_fct(pooled_logits, labels)
-        if not return_dict:
-            output = (pooled_logits,) + transformer_outputs[2:]
-            return ((loss,) + output) if loss is not None else output
 
         return SequenceClassifierOutput(
             loss=loss,

--- a/src/transformers/models/ctrl/modeling_ctrl.py
+++ b/src/transformers/models/ctrl/modeling_ctrl.py
@@ -260,6 +260,8 @@ class CTRLModel(CTRLPreTrainedModel):
         >>> list(last_hidden_states.shape)
         [1, 5, 1280]
         ```"""
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
         if input_ids is not None and inputs_embeds is not None:
             raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
         elif input_ids is not None:


### PR DESCRIPTION
## Summary

Refactors the CTRL model to use the standardized output collection interface as part of #43979.

## Changes

- Added `_can_record_outputs` to `CTRLPreTrainedModel` mapping `hidden_states` → `EncoderLayer` and `attentions` → `MultiHeadAttention`
- Added `@capture_outputs` decorator to `CTRLModel.forward` (base model with layer loop)
- Added `@can_return_tuple` decorator to `CTRLLMHeadModel.forward` and `CTRLForSequenceClassification.forward`
- Removed manual `output_attentions`, `output_hidden_states`, and `return_dict` parameter resolution and collection loops
- Simplified `EncoderLayer.forward` to return `hidden_states` directly (instead of a tuple)
- Removed `output_attentions` parameter from `EncoderLayer` and `MultiHeadAttention` (attention weights are always returned as `(attn_output, attn_weights)`)

## Reference

Used `llama` as the reference implementation, following the migration guide in #43979.

Fixes part of #43979