### PR TITLE
Add `eval_on_end` argument to Trainer for final evaluation after training

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1906,6 +1906,13 @@ class Trainer:
         # for the embedding layer by removing the forward post hook.
         if self.neftune_noise_alpha is not None:
             deactivate_neftune(self.model, self.neftune_hook_handle, self.accelerator)
+        
+        if self.args.eval_on_end and self.eval_dataset is not None:
+            logger.info("Running evaluation at the end of training")
+            eval_metrics = self.evaluate(ignore_keys=ignore_keys_for_eval)
+            metrics.update(eval_metrics)
+
+
 
         return TrainOutput(self.state.global_step, train_loss, metrics)
 

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1090,6 +1090,13 @@ class TrainingArguments:
             "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
         },
     )
+    eval_on_end: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to run evaluation at the end of training."
+        },
+    )
+
     eval_do_concat_batches: bool = field(
         default=True,
         metadata={

--- a/tests/trainer/test_trainer.py
+++ b/tests/trainer/test_trainer.py
@@ -27,7 +27,10 @@ from functools import partial
 from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
-
+from transformers import Trainer, TrainingArguments
+import torch
+from torch import nn
+from datasets import Dataset
 import numpy as np
 import pytest
 from huggingface_hub import ModelCard, create_branch, list_repo_commits, list_repo_files
@@ -6093,3 +6096,48 @@ class OptimizerAndModelInspectionTest(unittest.TestCase):
                 self.assertIsInstance(module, torch.nn.Embedding)
                 self.assertEqual(name, "weight")
                 self.assertDictEqual(config, {"optim_bits": 32})
+    
+
+
+
+def test_eval_on_end(tmp_path):
+        
+    import torch
+    from torch import nn
+    from datasets import Dataset
+    from transformers import Trainer, TrainingArguments
+
+    class DummyModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.linear = nn.Linear(10, 2)
+
+        def forward(self, input_ids=None, labels=None):
+            logits = self.linear(input_ids.float())
+            loss = logits.mean()
+            return {"loss": loss, "logits": logits}
+
+
+    dataset = Dataset.from_dict({
+        "input_ids": [[1]*10]*8,
+        "labels": [1]*8,
+    })
+
+    args = TrainingArguments(
+        output_dir=str(tmp_path),
+        per_device_train_batch_size=2,
+        eval_on_end=True,
+        num_train_epochs=1,
+    )
+
+    trainer = Trainer(
+        model=DummyModel(),
+        args=args,
+        train_dataset=dataset,
+        eval_dataset=dataset,
+    )
+    output = trainer.train()
+
+    assert any(k.startswith("eval_") for k in output.metrics)
+
+


### PR DESCRIPTION
## What does this PR do?

This PR introduces a new argument `eval_on_end` to the `Trainer` class. When enabled, the Trainer automatically runs evaluation at the end of training.

This allows users to obtain final evaluation metrics without explicitly calling `trainer.evaluate()` after training.

## Why is this useful?

Currently, evaluation is controlled by the evaluation strategy (e.g., steps or epochs). There is no built-in mechanism to guarantee that evaluation is performed after training completes.

This change provides a simple and explicit way to ensure a final evaluation is always executed.

The change is fully backward compatible, as the default behavior remains unchanged unless `eval_on_end=True` is explicitly set.

## Implementation

- Added `eval_on_end` flag to `TrainingArguments`
- Updated `Trainer` to trigger evaluation after training completes
- Ensured evaluation metrics are included in the final metrics dictionary

## Tests

- Added a dedicated test for `eval_on_end` behavior
- Verified that all existing trainer tests pass successfully

## Checklist

- [x] Code follows project style
- [x] Tests added and passing
- [x] No breaking changes introduced

---

Happy to adjust naming or design if this should align better with existing evaluation strategies.