### PR TITLE
Fix patchtsmixer call to post_init

### DIFF
--- a/src/transformers/models/patchtsmixer/configuration_patchtsmixer.py
+++ b/src/transformers/models/patchtsmixer/configuration_patchtsmixer.py
@@ -82,9 +82,6 @@ class PatchTSMixerConfig(PreTrainedConfig):
             error "mse".
         init_std (`float`, *optional*, defaults to 0.02):
             The standard deviation of the truncated normal weight initialization distribution.
-        post_init (`bool`, *optional*, defaults to `False`):
-            Whether to use custom weight initialization from `transformers` library, or the default initialization in
-            `PyTorch`. Setting it to `False` performs `PyTorch` weight initialization.
         norm_eps (`float`, *optional*, defaults to 1e-05):
             A value added to the denominator for numerical stability of normalization.
         mask_type (`str`, *optional*, defaults to `"random"`):
@@ -167,7 +164,6 @@ class PatchTSMixerConfig(PreTrainedConfig):
         scaling: str | bool | None = "std",
         loss: str = "mse",
         init_std: float = 0.02,
-        post_init: bool = False,
         norm_eps: float = 1e-5,
         # Pretrain model configuration
         mask_type: str = "random",
@@ -220,7 +216,6 @@ class PatchTSMixerConfig(PreTrainedConfig):
         self.self_attn = self_attn
         self.self_attn_heads = self_attn_heads
         self.init_std = init_std
-        self.post_init = post_init
         self.distribution_output = distribution_output
         self.loss = loss
         self.num_parallel_samples = num_parallel_samples

--- a/src/transformers/models/patchtsmixer/modeling_patchtsmixer.py
+++ b/src/transformers/models/patchtsmixer/modeling_patchtsmixer.py
@@ -1133,8 +1133,7 @@ class PatchTSMixerEncoder(PatchTSMixerPreTrainedModel):
         self.mlp_mixer_encoder = PatchTSMixerBlock(config=config)
 
         # Initialize weights and apply final processing
-        if config.post_init:
-            self.post_init()
+        self.post_init()
 
     @auto_docstring
     def forward(
@@ -1243,8 +1242,7 @@ class PatchTSMixerModel(PatchTSMixerPreTrainedModel):
             self.scaler = PatchTSMixerNOPScaler(config)
 
         # Initialize weights and apply final processing
-        if config.post_init:
-            self.post_init()
+        self.post_init()
 
     @auto_docstring
     def forward(
@@ -1354,8 +1352,7 @@ class PatchTSMixerForPretraining(PatchTSMixerPreTrainedModel):
         self.use_return_dict = config.use_return_dict
 
         # Initialize weights and apply final processing
-        if config.post_init:
-            self.post_init()
+        self.post_init()
 
     @auto_docstring
     def forward(
@@ -1566,8 +1563,7 @@ class PatchTSMixerForPrediction(PatchTSMixerPreTrainedModel):
         )
 
         # Initialize weights and apply final processing
-        if config.post_init:
-            self.post_init()
+        self.post_init()
 
     @auto_docstring
     def forward(
@@ -1791,8 +1787,7 @@ class PatchTSMixerForTimeSeriesClassification(PatchTSMixerPreTrainedModel):
             self.inject_scale = None
 
         # Initialize weights and apply final processing
-        if config.post_init:
-            self.post_init()
+        self.post_init()
 
     @auto_docstring
     def forward(
@@ -1982,8 +1977,7 @@ class PatchTSMixerForRegression(PatchTSMixerPreTrainedModel):
         )
 
         # Initialize weights and apply final processing
-        if config.post_init:
-            self.post_init()
+        self.post_init()
 
     @auto_docstring
     def forward(

--- a/tests/models/patchtsmixer/test_modeling_patchtsmixer.py
+++ b/tests/models/patchtsmixer/test_modeling_patchtsmixer.py
@@ -101,7 +101,6 @@ class PatchTSMixerModelTester:
         batch_size=13,
         is_training=True,
         seed_number=42,
-        post_init=True,
         num_parallel_samples=4,
     ):
         self.num_input_channels = num_input_channels
@@ -143,7 +142,6 @@ class PatchTSMixerModelTester:
         self.batch_size = batch_size
         self.is_training = is_training
         self.seed_number = seed_number
-        self.post_init = post_init
         self.num_parallel_samples = num_parallel_samples
 
     def get_config(self):
@@ -178,7 +176,6 @@ class PatchTSMixerModelTester:
             num_targets=self.num_targets,
             output_range=self.output_range,
             head_aggregation=self.head_aggregation,
-            post_init=self.post_init,
         )
         self.num_patches = config_.num_patches
         return config_


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/44077.
Indeed, the call is not optional. This is slightly breaking as the defaut used to be False, so fresh model instantiation will now use a different init (the one described in `_init_weights`)