### PR TITLE
Fix glm_moe_dsa

### DIFF
--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -150,6 +150,7 @@ class GlmMoeDsaIndexer(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
         use_cache: bool = False,
+        cache_position: torch.LongTensor | None = None,
     ) -> torch.LongTensor:
         """
         Computes top-k token indices for sparse attention (DSA).
@@ -189,13 +190,20 @@ class GlmMoeDsaIndexer(nn.Module):
         k = torch.cat([k_pe, k_nope], dim=-1)  # [B, S, D]
 
         # === Key cache (managed by the indexer, not DynamicCache) ===
-        # Reset cache on prefill (new prompt) to avoid stale keys / batch-size mismatch
-        if seq_len > 1:
-            self._cached_keys = None
-
-        if use_cache:
+        if use_cache and cache_position is not None:
+            start_pos = cache_position[0]
+            if start_pos == 0:
+                k_cached = k
+            elif self._cached_keys is not None:
+                k_cached = torch.cat([self._cached_keys[:, :start_pos], k], dim=1)
+            else:
+                k_cached = k
+            self._cached_keys = k_cached
+        elif use_cache:
+            if seq_len > 1:
+                self._cached_keys = None
             if self._cached_keys is not None:
-                k_cached = torch.cat([self._cached_keys, k], dim=1)  # [B, T, D]
+                k_cached = torch.cat([self._cached_keys, k], dim=1)
             else:
                 k_cached = k
             self._cached_keys = k_cached
@@ -221,10 +229,9 @@ class GlmMoeDsaIndexer(nn.Module):
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 
-        if attention_mask is not None:
-            index_scores = index_scores + attention_mask
-
         total_len = index_scores.shape[-1]
+        if attention_mask is not None:
+            index_scores = index_scores + attention_mask[..., :total_len]
         topk = min(self.index_topk, total_len)
         topk_indices = index_scores.topk(topk, dim=-1).indices  # [B, S, topk]
         return topk_indices
@@ -387,20 +394,19 @@ class GlmMoeDsaAttention(nn.Module):
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # ===== Indexer (DSA sparse mask) =====
-        # attention_mask is [B, 1, S, T] (4D) for eager and (2D) otherwise but indexer works with [B, S, T] (3D)
-        indexer_mask = (
-            attention_mask[:, 0, :, :]
-            if attention_mask is not None and attention_mask.dim() == 4
-            else attention_mask.unsqueeze(1)
-            if attention_mask is not None
-            else None
-        )
+        # Normalize 2D mask to 4D so indexer and combined_mask logic is uniform
+        if attention_mask is not None and attention_mask.dim() == 2:
+            attention_mask = attention_mask[:, None, None, :]
+
+        indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+
         topk_indices = self.indexer(
             hidden_states,
             q_resid,
             position_embeddings,
             indexer_mask,
             use_cache=past_key_values is not None,
+            cache_position=cache_position,
         )  # [B, S, topk]
 
         # Build combined DSA + causal mask: -inf everywhere except selected top-k positions
@@ -413,15 +419,10 @@ class GlmMoeDsaAttention(nn.Module):
         )
         index_mask.scatter_(-1, topk_indices, 0.0)  # [B, S, T]
         index_mask = index_mask.unsqueeze(1)  # [B, 1, S, T]
-        if attention_mask is not None and attention_mask.dim() == 4:
-            causal_mask = attention_mask[..., :total_len]
-            combined_mask = index_mask + causal_mask
+        if attention_mask is not None:
+            combined_mask = index_mask + attention_mask[..., :total_len]
         else:
-            combined_mask = (
-                attention_mask.masked_fill(index_mask == float("-inf"), float("-inf"))
-                if attention_mask is not None
-                else index_mask
-            )
+            combined_mask = index_mask
 
         # Flash attention head_dim padding (qk_head_dim != v_head_dim)
         if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:

--- a/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
@@ -342,6 +342,7 @@ class GlmMoeDsaIndexer(nn.Module):
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
         use_cache: bool = False,
+        cache_position: torch.LongTensor | None = None,
     ) -> torch.LongTensor:
         """
         Computes top-k token indices for sparse attention (DSA).
@@ -381,13 +382,20 @@ class GlmMoeDsaIndexer(nn.Module):
         k = torch.cat([k_pe, k_nope], dim=-1)  # [B, S, D]
 
         # === Key cache (managed by the indexer, not DynamicCache) ===
-        # Reset cache on prefill (new prompt) to avoid stale keys / batch-size mismatch
-        if seq_len > 1:
-            self._cached_keys = None
-
-        if use_cache:
+        if use_cache and cache_position is not None:
+            start_pos = cache_position[0]
+            if start_pos == 0:
+                k_cached = k
+            elif self._cached_keys is not None:
+                k_cached = torch.cat([self._cached_keys[:, :start_pos], k], dim=1)
+            else:
+                k_cached = k
+            self._cached_keys = k_cached
+        elif use_cache:
+            if seq_len > 1:
+                self._cached_keys = None
             if self._cached_keys is not None:
-                k_cached = torch.cat([self._cached_keys, k], dim=1)  # [B, T, D]
+                k_cached = torch.cat([self._cached_keys, k], dim=1)
             else:
                 k_cached = k
             self._cached_keys = k_cached
@@ -413,10 +421,9 @@ class GlmMoeDsaIndexer(nn.Module):
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 
-        if attention_mask is not None:
-            index_scores = index_scores + attention_mask
-
         total_len = index_scores.shape[-1]
+        if attention_mask is not None:
+            index_scores = index_scores + attention_mask[..., :total_len]
         topk = min(self.index_topk, total_len)
         topk_indices = index_scores.topk(topk, dim=-1).indices  # [B, S, topk]
         return topk_indices
@@ -542,20 +549,19 @@ class GlmMoeDsaAttention(nn.Module):
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
 
         # ===== Indexer (DSA sparse mask) =====
-        # attention_mask is [B, 1, S, T] (4D) for eager and (2D) otherwise but indexer works with [B, S, T] (3D)
-        indexer_mask = (
-            attention_mask[:, 0, :, :]
-            if attention_mask is not None and attention_mask.dim() == 4
-            else attention_mask.unsqueeze(1)
-            if attention_mask is not None
-            else None
-        )
+        # Normalize 2D mask to 4D so indexer and combined_mask logic is uniform
+        if attention_mask is not None and attention_mask.dim() == 2:
+            attention_mask = attention_mask[:, None, None, :]
+
+        indexer_mask = attention_mask[:, 0, :, :] if attention_mask is not None else None
+
         topk_indices = self.indexer(
             hidden_states,
             q_resid,
             position_embeddings,
             indexer_mask,
             use_cache=past_key_values is not None,
+            cache_position=cache_position,
         )  # [B, S, topk]
 
         # Build combined DSA + causal mask: -inf everywhere except selected top-k positions
@@ -568,15 +574,10 @@ class GlmMoeDsaAttention(nn.Module):
         )
         index_mask.scatter_(-1, topk_indices, 0.0)  # [B, S, T]
         index_mask = index_mask.unsqueeze(1)  # [B, 1, S, T]
-        if attention_mask is not None and attention_mask.dim() == 4:
-            causal_mask = attention_mask[..., :total_len]
-            combined_mask = index_mask + causal_mask
+        if attention_mask is not None:
+            combined_mask = index_mask + attention_mask[..., :total_len]
         else:
-            combined_mask = (
-                attention_mask.masked_fill(index_mask == float("-inf"), float("-inf"))
-                if attention_mask is not None
-                else index_mask
-            )
+            combined_mask = index_mask
 
         # Flash attention head_dim padding (qk_head_dim != v_head_dim)
         if is_flash_attention_requested(self.config) and self.qk_head_dim != self.v_head_dim:

--- a/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
+++ b/tests/models/glm_moe_dsa/test_modeling_glm_moe_dsa.py
@@ -127,33 +127,8 @@ class GlmMoeDsaModelTest(CausalLMModelTest, unittest.TestCase):
     def test_flash_attn_2_inference_equivalence_right_padding(self):
         self.skipTest(reason="Qwen2Moe flash attention does not support right padding")
 
-    @unittest.skip("DSA indexer mask shape mismatch with assisted decoding")
-    @parameterized.expand([("random",), ("same",)])
-    def test_assisted_decoding_matches_greedy_search(self, assistant_type):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with assisted decoding")
-    def test_assisted_decoding_sample(self):
-        pass
-
-    @unittest.skip("Requires torch>=2.9.0 for grouped MM")
-    def test_eager_matches_batched_and_grouped_inference(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with static cache")
-    def test_generate_from_inputs_embeds_with_static_cache(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with compiled forward")
+    @unittest.skip("Indexer mutable cache (dynamic shape) is incompatible with fullgraph compilation")
     def test_generate_compile_model_forward_fullgraph(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with compilation")
-    def test_generate_compilation_all_outputs(self):
-        pass
-
-    @unittest.skip("DSA indexer mask shape mismatch with static cache")
-    def test_generate_with_static_cache(self):
         pass
 
 


### PR DESCRIPTION
Fixes #44052


Now and then, the indexer ran into trouble switching between masks and cache. Most of the test failures came from these hiccups:

- Indexer cache: the old if seq_len > 1: reset cache heuristic broke assisted decoding (multi-token decode steps). Switched to using cache_position to know when we're in prefill vs decode.

- Mask shape: _update_causal_mask returns 2D for some backends and 4D for others. The indexer and combined mask logic assumed one or the other. Now normalizes to 4D upfront.

- Trimming masks: even though static cache sets aside space up to max_cache_len, the indexer fills slots one by one, meaning excess bits get cut off to fit.

That last skip - called test_generate_compile_model_forward_fullgraph - isn’t working because the indexer cache keeps reshaping itself step by step. Since that happens while trying to use fullgraph=True, it just can’t fit. Shape mismatch kills it.