### PR TITLE
fix(testing): Update stale device override test in GraniteSpeech

### DIFF
--- a/src/transformers/models/granite_speech/feature_extraction_granite_speech.py
+++ b/src/transformers/models/granite_speech/feature_extraction_granite_speech.py
@@ -115,7 +115,7 @@ class GraniteSpeechFeatureExtractor(FeatureExtractionMixin):
             # stacking and skipping by 2
             audio = logmel.reshape(bsz, -1, 2 * logmel.shape[-1])
 
-        return audio
+        return audio.cpu() if device is not None else audio
 
     def _get_num_audio_features(self, audio_lengths: Sequence[int]) -> Sequence[int]:
         """

--- a/src/transformers/models/granite_speech/feature_extraction_granite_speech.py
+++ b/src/transformers/models/granite_speech/feature_extraction_granite_speech.py
@@ -115,7 +115,7 @@ class GraniteSpeechFeatureExtractor(FeatureExtractionMixin):
             # stacking and skipping by 2
             audio = logmel.reshape(bsz, -1, 2 * logmel.shape[-1])
 
-        return audio.cpu() if device is not None else audio
+        return audio
 
     def _get_num_audio_features(self, audio_lengths: Sequence[int]) -> Sequence[int]:
         """

--- a/tests/models/granite_speech/test_processing_granite_speech.py
+++ b/tests/models/granite_speech/test_processing_granite_speech.py
@@ -196,8 +196,9 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
         assert num_calculated_features == [90, 171]
         assert sum(num_expected_features) == num_audio_tokens
 
+    @parameterized.expand(["cpu", "cuda"])
     @require_torch_accelerator
-    def test_device_placement(self):
+    def test_device_placement(self, device):
         """Ensure that the device parameter controls where speech inputs are placed."""
         tokenizer = self.get_tokenizer()
         audio_processor = self.get_audio_processor()
@@ -213,7 +214,7 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
             text=f"{processor.audio_token} Can you transcribe this audio?",
             audio=wav,
             return_tensors="pt",
-            device=torch_device,
+            device=device,
         )
 
-        assert inputs["input_features"].device.type == torch_device
+        assert inputs["input_features"].device.type == device

--- a/tests/models/granite_speech/test_processing_granite_speech.py
+++ b/tests/models/granite_speech/test_processing_granite_speech.py
@@ -197,10 +197,8 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
         assert sum(num_expected_features) == num_audio_tokens
 
     @require_torch_accelerator
-    def test_device_override(self):
-        """Ensure that we regardless of the processing device, the tensors
-        produced are on the CPU.
-        """
+    def test_device_placement(self):
+        """Ensure that the device parameter controls where speech inputs are placed."""
         tokenizer = self.get_tokenizer()
         audio_processor = self.get_audio_processor()
         processor = GraniteSpeechProcessor(
@@ -218,4 +216,4 @@ class GraniteSpeechProcessorTest(unittest.TestCase):
             device=torch_device,
         )
 
-        assert inputs["input_features"].device.type == "cpu"
+        assert inputs["input_features"].device.type == torch_device

--- a/tests/models/granite_speech/test_processing_granite_speech.py
+++ b/tests/models/granite_speech/test_processing_granite_speech.py
@@ -25,7 +25,6 @@ from transformers.testing_utils import (
     require_torch,
     require_torch_accelerator,
     require_torchaudio,
-    torch_device,
 )
 from transformers.utils import is_torchaudio_available
 


### PR DESCRIPTION
### What does this PR do?

The following issue was identified and fixed in this PR:

→ Updates the stale `test_device_override` in `test_processing_granite_speech.py` to verify that the device param controls where speech inputs are placed, rather than asserting outputs are unconditionally on CPU.
→ **Reasoning:** GraniteSpeech support was originally added (https://github.com/huggingface/transformers/commit/623d395aff) with [this condition in the feature extractor](https://github.com/huggingface/transformers/blob/623d395affc9099d0ad0223754097c1ad9b9f817/src/transformers/models/granite_speech/feature_extraction_granite_speech.py#L137-L138), and the test enforced that. Then [2d600a4363 ("Granite speech speedups")](https://github.com/huggingface/transformers/commit/2d600a4363) deliberately removed the `.cpu()` return as part of eliminating unnecessary device transfers, but the test was not updated. The updated test also aligns with the direction in `#43249`.

Fixes #44112.

**Before the fix (feel free to cross-check on CI; this error is reproducible):**

<img alt="Screenshot 2026-02-16 183613" src="https://github.com/user-attachments/assets/08afe321-2338-4e15-8b2a-f218b6ad6d2d" /><br>

**After the fix (feel free to cross-check):**

<img alt="image" src="https://github.com/user-attachments/assets/0b7c21bb-9db6-42fc-a104-83319bb5a8ad" />

### Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you fix any necessary existing tests?