### PR TITLE
[docs] fix broken chat_templating links in tasks docs

### DIFF
--- a/docs/source/en/tasks/any_to_any.md
+++ b/docs/source/en/tasks/any_to_any.md
@@ -44,7 +44,7 @@ model = AutoModelForMultimodalLM.from_pretrained(
 processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-Omni-3B")
 ```
 
-These models typically include a [chat template](./chat_templating) to structure conversations across modalities. Inputs can mix images, text, audio, or other supported formats in a single turn. Outputs may also vary (e.g., text generation or audio generation), depending on the configuration.
+These models typically include a [chat template](../chat_templating) to structure conversations across modalities. Inputs can mix images, text, audio, or other supported formats in a single turn. Outputs may also vary (e.g., text generation or audio generation), depending on the configuration.
 
 Below is an example providing a "text + audio" input and requesting a text response.
 

--- a/docs/source/en/tasks/image_text_to_text.md
+++ b/docs/source/en/tasks/image_text_to_text.md
@@ -54,7 +54,7 @@ model = AutoModelForImageTextToText.from_pretrained(
 processor = AutoProcessor.from_pretrained("Qwen/Qwen3-VL-4B-Instruct")
 ```
 
-This model has a [chat template](./chat_templating) that helps user parse chat outputs. Moreover, the model can also accept multiple images as input in a single conversation or message. We will now prepare the inputs.
+This model has a [chat template](../chat_templating) that helps user parse chat outputs. Moreover, the model can also accept multiple images as input in a single conversation or message. We will now prepare the inputs.
 
 The image inputs look like the following.
 


### PR DESCRIPTION
## Summary                                                        
                                                      
- Fix broken `[chat template](./chat_templating)` links in
`docs/source/en/tasks/`
- `./chat_templating` resolves within `tasks/` (doesn't exist);
corrected to `../chat_templating`
- Affected files: `tasks/image_text_to_text.md` and`tasks/any_to_any.md`
