### PR TITLE
fix: ModelOutput keys not updated when setting previously-None dataclass fields

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -407,6 +407,8 @@ class ModelOutput(OrderedDict):
                 if v is not None:
                     self[field.name] = v
 
+        self.__dict__["_post_init_complete"] = True
+
     def __delitem__(self, *args, **kwargs):
         raise Exception(f"You cannot use ``__delitem__`` on a {self.__class__.__name__} instance.")
 
@@ -429,6 +431,15 @@ class ModelOutput(OrderedDict):
     def __setattr__(self, name, value):
         if name in self.keys() and value is not None:
             # Don't call self.__setitem__ to avoid recursion errors
+            super().__setitem__(name, value)
+        elif (
+            value is not None
+            and self.__dict__.get("_post_init_complete", False)
+            and is_dataclass(self)
+            and any(f.name == name for f in fields(self))
+        ):
+            # If the field was previously None (not in dict keys), but is a valid dataclass field
+            # being set to a non-None value after initialization, add it to the dict as well.
             super().__setitem__(name, value)
         super().__setattr__(name, value)
 

--- a/tests/utils/test_model_output.py
+++ b/tests/utils/test_model_output.py
@@ -103,6 +103,27 @@ class ModelOutputTester(unittest.TestCase):
         self.assertEqual(x.a, 10)
         self.assertEqual(x["a"], 10)
 
+    def test_set_attributes_previously_none(self):
+        # Setting a dataclass field that was initially None should add it to keys
+        x = ModelOutputTest(a=30)
+        self.assertEqual(list(x.keys()), ["a"])
+        self.assertIsNone(x.b)
+
+        x.b = 10
+        self.assertEqual(x.b, 10)
+        self.assertEqual(x["b"], 10)
+        self.assertEqual(list(x.keys()), ["a", "b"])
+
+        # Setting multiple previously-None fields
+        x.c = 20
+        self.assertEqual(list(x.keys()), ["a", "b", "c"])
+        self.assertEqual(list(x.values()), [30, 10, 20])
+
+        # Overwriting a field that was set from None should still work
+        x.b = 99
+        self.assertEqual(x.b, 99)
+        self.assertEqual(x["b"], 99)
+
     def test_set_keys(self):
         x = ModelOutputTest(a=30)
         x["a"] = 10


### PR DESCRIPTION
## Fix

Fixes #44079

When a `ModelOutput` dataclass field is initialized as `None`, it is correctly excluded from the OrderedDict keys. However, **subsequently setting that field to a non-None value** via attribute assignment (e.g. `outputs.pooler_output = tensor`) does not add it to the dict keys — causing `keys()`, `values()`, `items()`, and `to_tuple()` to silently omit the value.

### Root cause

`__setattr__` only calls `super().__setitem__()` when `name in self.keys()`, but fields initialized as `None` are never added to the keys in `__post_init__`.

### Changes

**`src/transformers/utils/generic.py`:**
- Added an `elif` branch in `__setattr__` that also adds the key to the dict when the value is not `None`, `__post_init__` has completed, and the name is a valid dataclass field
- Set `_post_init_complete` flag at end of `__post_init__` to avoid interfering with dict-like initialization

**`tests/utils/test_model_output.py`:**
- Added `test_set_attributes_previously_none` covering: None→value, multiple fields, and overwrite scenarios

### Reproduction (from #44079)

```python
from transformers.modeling_outputs import BaseModelOutputWithPooling
import torch

outputs = BaseModelOutputWithPooling(
    last_hidden_state=torch.randn(1, 2, 4),
    pooler_output=None,
)
outputs.pooler_output = torch.arange(4)
print(outputs.keys())
# Before fix: dict_keys(['last_hidden_state']) — pooler_output missing
# After fix:  dict_keys(['last_hidden_state', 'pooler_output'])
```

### Tests

All existing tests pass (`test_model_output.py` + `test_generic.py`), including the dict-like init path that was sensitive to this change.