### PR TITLE
fix: handle None value from TOKENIZER_MAPPING_NAMES.get() in AutoTokenizer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -649,7 +649,7 @@ class AutoTokenizer:
             and tokenizer_config_class is not None
             and config_model_type is not None
             and config_model_type != ""
-            and TOKENIZER_MAPPING_NAMES.get(config_model_type, "").replace("Fast", "")
+            and (TOKENIZER_MAPPING_NAMES.get(config_model_type) or "").replace("Fast", "")
             != tokenizer_config_class.replace("Fast", "")
         ):
             # new model, but we ignore it unless the model type is the same


### PR DESCRIPTION
Fixes #44117

`TOKENIZER_MAPPING_NAMES.get(config_model_type, "")` returns `None` when the key exists with value `None`, causing `AttributeError: 'NoneType' object has no attribute 'replace'` when loading models like `google/siglip2-so400m-patch14-384`.

Changed `.get(key, "")` to `(.get(key) or "")` to handle both missing keys and `None` values.