### PR TITLE
Add BnB 4-bit embedding quantization support

### DIFF
--- a/src/transformers/integrations/bitsandbytes.py
+++ b/src/transformers/integrations/bitsandbytes.py
@@ -47,6 +47,15 @@ class Bnb4bitQuantize(ConversionOps):
         # update param name to get the weights instead of the quantized stats
         module, _ = get_module_from_name(model, full_layer_name)
 
+        # Handle untying of embedding weights before quantization
+        input_embed = model.get_input_embeddings()
+        is_embedding_param = id(module) == id(input_embed)
+        untie = getattr(self.hf_quantizer.quantization_config, "untie_embedding_weights", False)
+
+        if untie and is_embedding_param:
+            setattr(model.config.get_text_config(decoder=True), "tie_word_embeddings", False)
+            lm_head = value.clone()
+
         # Support models using `Conv1D` in place of `nn.Linear` (e.g. openai-community/gpt2) by transposing the weight matrix prior to quantization.
         # Since weights are saved in the correct "orientation", we skip transposing when loading.
         if issubclass(module.source_cls, Conv1D):
@@ -55,7 +64,10 @@ class Bnb4bitQuantize(ConversionOps):
         old_value = model.get_parameter_or_buffer(full_layer_name)
         new_value = bnb.nn.Params4bit(value, requires_grad=False, **old_value.__dict__).to(value.device)
         module._is_hf_initialized = True
-        return {full_layer_name: new_value}
+        result = {full_layer_name: new_value}
+        if untie and is_embedding_param:
+            result["lm_head.weight"] = lm_head
+        return result
 
 
 class Bnb4bitDeserialize(ConversionOps):
@@ -221,6 +233,21 @@ def replace_with_bnb_linear(
                     new_module.requires_grad_(False)
                     model.set_submodule(module_name, new_module)
                     has_been_replaced = True
+            elif (
+                isinstance(module, nn.Embedding)
+                and quantization_config.quantization_method() != "llm_int8"
+                and getattr(quantization_config, "include_input_output_embeddings", False)
+            ):
+                new_module = bnb.nn.Embedding4bit(
+                    module.num_embeddings,
+                    module.embedding_dim,
+                    quant_type=quantization_config.bnb_4bit_quant_type,
+                    quant_storage=quantization_config.bnb_4bit_quant_storage,
+                )
+                new_module.source_cls = type(module)
+                new_module.requires_grad_(False)
+                model.set_submodule(module_name, new_module)
+                has_been_replaced = True
 
     if not has_been_replaced:
         logger.warning(
@@ -290,6 +317,7 @@ def dequantize_and_replace(model, quantization_config=None, dtype=None):
     quant_method = quantization_config.quantization_method()
 
     target_cls = bnb.nn.Linear8bitLt if quant_method == "llm_int8" else bnb.nn.Linear4bit
+    has_been_replaced = False
     for module_name, module in model.named_modules():
         if isinstance(module, target_cls):
             with torch.device("meta"):
@@ -308,6 +336,21 @@ def dequantize_and_replace(model, quantization_config=None, dtype=None):
             new_module.weight = torch.nn.Parameter(weight)
             if bias is not None:
                 new_module.bias = bias
+            if hasattr(module, "_hf_hook"):
+                old_hook = module._hf_hook
+                new_hook = _create_accelerate_new_hook(old_hook)
+                remove_hook_from_module(module)
+                add_hook_to_module(new_module, new_hook)
+            new_module.to(module.weight.device)
+            model.set_submodule(module_name, new_module)
+            has_been_replaced = True
+        elif isinstance(module, bnb.nn.Embedding4bit):
+            with torch.device("meta"):
+                new_module = torch.nn.Embedding(module.num_embeddings, module.embedding_dim)
+            weight = dequantize_bnb_weight(module.weight, None)
+            if dtype is not None:
+                weight = weight.to(dtype)
+            new_module.weight = torch.nn.Parameter(weight)
             if hasattr(module, "_hf_hook"):
                 old_hook = module._hf_hook
                 new_hook = _create_accelerate_new_hook(old_hook)

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -90,7 +90,9 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         import bitsandbytes as bnb
 
         module, name = get_module_from_name(model, param_name)
-        return isinstance(module, bnb.nn.Linear4bit) and name != "bias"
+        return (isinstance(module, bnb.nn.Linear4bit) and name != "bias") or (
+            isinstance(module, bnb.nn.Embedding4bit) and name == "weight"
+        )
 
     def adjust_max_memory(self, max_memory: dict[str, int | str]) -> dict[str, int | str]:
         # need more space for buffers that are created during quantization
@@ -127,6 +129,19 @@ class Bnb4BitHfQuantizer(HfQuantizer):
         self.modules_to_not_convert = self.get_modules_to_not_convert(
             model, self.quantization_config.llm_int8_skip_modules, model._keep_in_fp32_modules
         )
+
+        if self.quantization_config.include_input_output_embeddings:
+            input_emb = model.get_input_embeddings()
+            input_emb_names = [name for name, module in model.named_modules() if id(module) == id(input_emb)]
+            output_emb = model.get_output_embeddings()
+            output_emb_names = (
+                [name for name, module in model.named_modules() if id(module) == id(output_emb)]
+                if output_emb is not None
+                else []
+            )
+            self.modules_to_not_convert = [
+                x for x in self.modules_to_not_convert if x not in input_emb_names + output_emb_names
+            ]
 
         if self.quantization_config.llm_int8_enable_fp32_cpu_offload:
             if isinstance(device_map, dict):

--- a/src/transformers/utils/quantization_config.py
+++ b/src/transformers/utils/quantization_config.py
@@ -429,6 +429,12 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
             quantized again.
         bnb_4bit_quant_storage (`torch.dtype` or str, *optional*, defaults to `torch.uint8`):
             This sets the storage type to pack the quantized 4-bit params.
+        include_input_output_embeddings (`bool`, *optional*, defaults to `False`):
+            Whether to quantize input/output embedding layers. When enabled, embedding layers will be
+            replaced with `bnb.nn.Embedding4bit` (4-bit only, not supported for 8-bit quantization).
+        untie_embedding_weights (`bool`, *optional*, defaults to `False`):
+            Whether to untie weights when quantizing input embeddings that are tied to the output
+            (lm_head) layer. Requires `include_input_output_embeddings=True`.
         kwargs (`dict[str, Any]`, *optional*):
             Additional parameters from which to initialize the configuration object.
     """
@@ -445,6 +451,8 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
         bnb_4bit_quant_type="fp4",
         bnb_4bit_use_double_quant=False,
         bnb_4bit_quant_storage=None,
+        include_input_output_embeddings=False,
+        untie_embedding_weights=False,
         **kwargs,
     ):
         self.quant_method = QuantizationMethod.BITS_AND_BYTES
@@ -482,6 +490,9 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
             self.bnb_4bit_quant_storage = bnb_4bit_quant_storage
         else:
             raise ValueError("bnb_4bit_quant_storage must be a string or a torch.dtype")
+
+        self.include_input_output_embeddings = include_input_output_embeddings
+        self.untie_embedding_weights = untie_embedding_weights
 
         if kwargs:
             logger.info(f"Unused kwargs: {list(kwargs.keys())}. These kwargs are not used in {self.__class__}.")
@@ -543,6 +554,9 @@ class BitsAndBytesConfig(QuantizationConfigMixin):
 
         if not isinstance(self.bnb_4bit_use_double_quant, bool):
             raise TypeError("bnb_4bit_use_double_quant must be a boolean")
+
+        if self.untie_embedding_weights and not self.include_input_output_embeddings:
+            raise ValueError("`untie_embedding_weights` requires `include_input_output_embeddings=True`.")
 
     def is_quantizable(self):
         r"""

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -866,3 +866,87 @@ class Bnb4bitCompile(unittest.TestCase):
                 max_new_tokens=10,
                 cache_implementation="static",
             )
+
+
+@require_bitsandbytes
+@require_accelerate
+@require_torch
+@slow
+@apply_skip_if_not_implemented
+class Bnb4BitEmbeddingTest(unittest.TestCase):
+    model_name = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+
+    def setUp(self):
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name)
+
+    def tearDown(self):
+        gc.collect()
+        backend_empty_cache(torch_device)
+
+    def test_embedding_is_quantized(self):
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True, include_input_output_embeddings=True),
+            device_map="auto",
+        )
+        self.assertIsInstance(model.model.embed_tokens, bnb.nn.Embedding4bit)
+        self.assertIsInstance(model.lm_head, bnb.nn.Linear4bit)
+        del model
+
+    def test_embedding_memory_reduction(self):
+        model_no_emb = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True),
+            device_map="auto",
+        )
+        mem_no_emb = model_no_emb.get_memory_footprint()
+        del model_no_emb
+        gc.collect()
+        backend_empty_cache(torch_device)
+
+        model_with_emb = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True, include_input_output_embeddings=True),
+            device_map="auto",
+        )
+        mem_with_emb = model_with_emb.get_memory_footprint()
+        del model_with_emb
+
+        self.assertLess(mem_with_emb, mem_no_emb)
+
+    def test_embedding_generation(self):
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            quantization_config=BitsAndBytesConfig(load_in_4bit=True, include_input_output_embeddings=True),
+            device_map="auto",
+        )
+        encoded_input = self.tokenizer("Hello my name is", return_tensors="pt")
+        output = model.generate(input_ids=encoded_input["input_ids"].to(model.device), max_new_tokens=10)
+        decoded = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        self.assertGreater(len(decoded), len("Hello my name is"))
+        del model
+
+    def test_untie_embedding_weights(self):
+        model = AutoModelForCausalLM.from_pretrained(
+            self.model_name,
+            quantization_config=BitsAndBytesConfig(
+                load_in_4bit=True,
+                include_input_output_embeddings=True,
+                untie_embedding_weights=True,
+            ),
+            device_map="auto",
+        )
+        self.assertFalse(model.config.tie_word_embeddings)
+        self.assertIsNot(model.get_input_embeddings().weight, model.get_output_embeddings().weight)
+        encoded_input = self.tokenizer("Hello my name is", return_tensors="pt")
+        output = model.generate(input_ids=encoded_input["input_ids"].to(model.device), max_new_tokens=10)
+        self.assertGreater(len(self.tokenizer.decode(output[0], skip_special_tokens=True)), len("Hello my name is"))
+        del model
+
+    def test_config_validation(self):
+        with self.assertRaises(ValueError):
+            BitsAndBytesConfig(
+                load_in_4bit=True,
+                untie_embedding_weights=True,
+                include_input_output_embeddings=False,
+            )


### PR DESCRIPTION
# What does this PR do?

  Adds 4-bit embedding quantization for BitsAndBytes, mirroring TorchAO's existing
  `include_input_output_embeddings` and `untie_embedding_weights` pattern (PRs #37802, #37905, #37935).

  Large-vocabulary models (Llama 3 128K, Qwen 2 150K, Gemma 256K) have embeddings that can be 50%+ of a
   quantized model's footprint. BnB quantizes `nn.Linear` layers but skips `nn.Embedding` entirely.
  `bnb.nn.Embedding4bit` exists upstream but transformers doesn't use it. Builds on @galqiwi's upstream work adding bnb.nn.Embedding4bit to bitsandbytes(bitsandbytes-foundation/bitsandbytes#1292).

  This PR adds two flags to `BitsAndBytesConfig`:
  - `include_input_output_embeddings` — replaces `nn.Embedding` with `bnb.nn.Embedding4bit`
  - `untie_embedding_weights` — unties embed_tokens ↔ lm_head before quantization (needed for models
  with tied weights like Llama)

  4-bit only — not supported for 8-bit quantization. Serialization is not included (aligned with
  @SunMarc's guidance on the issue).

  Also fixes a pre-existing `NameError` in `dequantize_and_replace` where `has_been_replaced` was used
  without initialization.

  Fixes #31474

  ## Before submitting
  - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the
  case).
  - [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/
  CONTRIBUTING.md#create-a-pull-request), Pull Request section?
  - [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
   Please add a link to it if that's the case. https://github.com/huggingface/transformers/issues/31474
  - [ ] Did you make sure to update the documentation with your changes?
  - [x] Did you write any new necessary tests?

  ## Who can review?

  @SunMarc @MekkCyber — quantization
