### PR TITLE
Avoid device sync in training loss accumulation

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1741,18 +1741,15 @@ class Trainer:
                     with sync_context():
                         tr_loss_step = self.training_step(model, inputs, num_items_in_batch)
 
-                    if (
-                        args.logging_nan_inf_filter
-                        and not is_torch_xla_available()
-                        and not torch.isfinite(tr_loss_step)
-                    ):
+                    if tr_loss.device != tr_loss_step.device:
+                        raise ValueError(
+                            f"Calculated loss must be on the original device: {tr_loss.device} but device in use is {tr_loss_step.device}"
+                        )
+                    if args.logging_nan_inf_filter:
                         # if loss is nan or inf simply add the average of previous logged losses
-                        tr_loss = tr_loss + tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                        tr_loss_avg = tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                        tr_loss = tr_loss + torch.where(torch.isfinite(tr_loss_step), tr_loss_step, tr_loss_avg)
                     else:
-                        if tr_loss.device != tr_loss_step.device:
-                            raise ValueError(
-                                f"Calculated loss must be on the original device: {tr_loss.device} but device in use is {tr_loss_step.device}"
-                            )
                         tr_loss = tr_loss + tr_loss_step
 
                     self.current_flos += float(self.floating_point_ops(inputs))

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1760,8 +1760,13 @@ class Trainer:
 
                         # Gradient clipping
                         if args.max_grad_norm is not None and args.max_grad_norm > 0:
-                            if is_sagemaker_mp_enabled() and args.fp16:
-                                _grad_norm = self.optimizer.clip_master_grads(args.max_grad_norm)
+                            if self.accelerator.distributed_type == DistributedType.DEEPSPEED:
+                                # In some cases the grad norm may not return a float
+                                grad_norm = model.get_global_grad_norm()
+                                if isinstance(grad_norm, torch.Tensor):
+                                    grad_norm = grad_norm.clone()
+                            elif is_sagemaker_mp_enabled() and args.fp16:
+                                grad_norm = self.optimizer.clip_master_grads(args.max_grad_norm)
                             else:
                                 grad_norm_context = contextlib.nullcontext
                                 if self.is_tp_enabled:
@@ -1769,18 +1774,10 @@ class Trainer:
 
                                     grad_norm_context = implicit_replication
                                 with grad_norm_context():
-                                    _grad_norm = self.accelerator.clip_grad_norm_(
+                                    grad_norm = self.accelerator.clip_grad_norm_(
                                         model.parameters(),
                                         args.max_grad_norm,
                                     )
-
-                            if self.accelerator.distributed_type == DistributedType.DEEPSPEED:
-                                grad_norm = model.get_global_grad_norm()
-                                # In some cases the grad norm may not return a float
-                                if hasattr(grad_norm, "item"):
-                                    grad_norm = grad_norm.item()
-                            else:
-                                grad_norm = _grad_norm
 
                         self.control = self.callback_handler.on_pre_optimizer_step(args, self.state, self.control)
 

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1598,6 +1598,7 @@ class Trainer:
         self.state.epoch = 0
         start_time = time.time()
         self.initial_num_input_tokens_seen_for_session = self.state.num_input_tokens_seen
+        self._local_input_tokens_acc = None  # lazily initialized on-device accumulator
         epochs_trained = 0
         steps_trained_in_current_epoch = 0
 
@@ -1720,7 +1721,9 @@ class Trainer:
                                 input_tokens = inputs[main_input_name].numel()
 
                             input_tokens = torch.tensor(input_tokens, device=self.args.device, dtype=torch.int64)
-                            self.state.num_input_tokens_seen += self.accelerator.gather(input_tokens).sum().item()
+                            if self._local_input_tokens_acc is None:
+                                self._local_input_tokens_acc = torch.zeros(1, device=self.args.device, dtype=torch.int64)
+                            self._local_input_tokens_acc += input_tokens
 
                     if rng_to_sync:
                         self._load_rng_state(resume_from_checkpoint)
@@ -1858,6 +1861,8 @@ class Trainer:
         if args.load_best_model_at_end and self.state.best_model_checkpoint is not None:
             self._load_best_model()
 
+        # flush any remaining accumulated input token counts
+        self._flush_input_tokens_seen()
         # add remaining tr_loss
         self._total_loss_scalar += tr_loss.item()
         effective_global_step = max(self.state.global_step, 0.001)  # Avoid ZeroDivisionError
@@ -3026,6 +3031,7 @@ class Trainer:
 
         if self.hp_search_backend is None and trial is None:
             self.store_flos()
+            self._flush_input_tokens_seen()
 
         run_dir = self._get_output_dir(trial=trial)
         output_dir = os.path.join(run_dir, checkpoint_folder)
@@ -3839,6 +3845,7 @@ class Trainer:
         if self.state.epoch is not None:
             logs["epoch"] = self.state.epoch
         if self.args.include_num_input_tokens_seen != "no":
+            self._flush_input_tokens_seen()
             logs["num_input_tokens_seen"] = self.state.num_input_tokens_seen
             if start_time is not None:
                 current_session_num_tokens = (
@@ -3849,6 +3856,16 @@ class Trainer:
         output = {**logs, "step": self.state.global_step}
         self.state.log_history.append(output)
         self.control = self.callback_handler.on_log(self.args, self.state, self.control, logs)
+
+    def _flush_input_tokens_seen(self) -> None:
+        """Gather locally accumulated input token counts across ranks and update state."""
+        if self.args.include_num_input_tokens_seen == "no":
+            return
+        acc = getattr(self, "_local_input_tokens_acc", None)
+        if acc is None:
+            acc = torch.zeros(1, device=self.args.device, dtype=torch.int64)
+        self.state.num_input_tokens_seen += self.accelerator.gather(acc).sum().item()
+        self._local_input_tokens_acc = None  # lazily re-created on next accumulation
 
     def store_flos(self) -> None:
         """Store the number of floating-point operations that went into the model."""


### PR DESCRIPTION
# What does this PR do?
This PR avoids device sync in training loss accumulation by ```torch.where```. The `is_torch_xla_available` condition is also removed.