### PR TITLE
feat: add eval_on_end to Trainer for final evaluation

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1860,6 +1860,10 @@ class Trainer:
             if self.control.should_training_stop:
                 break
 
+        if args.eval_on_end:
+            logger.info("Run final evaluation at the end of training")
+            self._evaluate(trial, ignore_keys_for_eval)
+
         logger.info("\n\nTraining completed. Do not forget to share your model on huggingface.co/models =)\n\n")
         if args.load_best_model_at_end and self.state.best_model_checkpoint is not None:
             self._load_best_model()

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -1090,6 +1090,12 @@ class TrainingArguments:
             "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
         },
     )
+
+    eval_on_end: bool = field(
+        default=False,
+        metadata={"help": "Whether to run through the entire `evaluation` step at the very end of training."},
+    )
+
     eval_do_concat_batches: bool = field(
         default=True,
         metadata={


### PR DESCRIPTION
Description:
Adds eval_on_end to TrainingArguments to force evaluation at the end of training, even if the last step doesn't align with eval_steps.

Changes:

training_args.py: Added eval_on_end field.

trainer.py: Added logic to call evaluate() at the end of train().

Status:

Formatted with Ruff.

Tested locally with pytest (14 passed).