### PR TITLE
docs: fix typo 'AuoQuant' → 'AutoQuant' and clarify FINEGRAINED_FP8 library column

### DIFF
--- a/docs/source/en/quantization/overview.md
+++ b/docs/source/en/quantization/overview.md
@@ -40,7 +40,7 @@ Use the Space below to help you pick a quantization method depending on your har
 | [FBGEMM_FP8](./fbgemm_fp8)                | 🟢                   | 🔴              | 🟢        | 🔴        | 🔴                                 | 🔴              | 🔴              | 8            | 🔴               | 🟢                          | 🟢                      | https://github.com/pytorch/FBGEMM       |
 | [torchao](./torchao)                      | 🟢                   | 🟢               | 🟢        | 🔴        | 🟡 | 🟢              |                 | 4/8          |                  | 🟢🔴                        | 🟢                      | https://github.com/pytorch/ao       |
 | [VPTQ](./vptq)                            | 🔴                   | 🔴              |     🟢     | 🟡        | 🔴                                 | 🔴              | 🟢              | 1/8          | 🔴               | 🟢                          | 🟢                      | https://github.com/microsoft/VPTQ            |
-| [FINEGRAINED_FP8](./finegrained_fp8)      | 🟢                   | 🔴              | 🟢        | 🔴        | 🔴                                 | 🟢              | 🔴              | 8            | 🔴               | 🟢                          | 🟢                      |        |
+| [FINEGRAINED_FP8](./finegrained_fp8)      | 🟢                   | 🔴              | 🟢        | 🔴        | 🔴                                 | 🟢              | 🔴              | 8            | 🔴               | 🟢                          | 🟢                      | Built-in |
 | [SpQR](./spqr)                            | 🔴                     |  🔴   | 🟢        | 🔴              |    🔴    | 🔴         |         🟢              | 3            |              🔴                     | 🟢           | 🟢                      | https://github.com/Vahe1994/SpQR/       |
 | [Quark](./quark)                          | 🔴                     | 🟢 | 🟢      | 🟢      | 🟢                   | 🟢       | ?               | 2/4/6/8/9/16 | 🔴                | 🔴                               | 🟢                       | https://quark.docs.amd.com/latest/                      |
 
@@ -58,4 +58,4 @@ If you are looking for a user-friendly quantization experience, you can use the 
 * [Bitsandbytes Space](https://huggingface.co/spaces/bnb-community/bnb-my-repo)
 * [GGUF Space](https://huggingface.co/spaces/ggml-org/gguf-my-repo)
 * [MLX Space](https://huggingface.co/spaces/mlx-community/mlx-my-repo)
-* [AuoQuant Notebook](https://colab.research.google.com/drive/1b6nqC7UZVt8bx4MksX7s656GXPM-eWw4?usp=sharing#scrollTo=ZC9Nsr9u5WhN)
+* [AutoQuant Notebook](https://colab.research.google.com/drive/1b6nqC7UZVt8bx4MksX7s656GXPM-eWw4?usp=sharing#scrollTo=ZC9Nsr9u5WhN)


### PR DESCRIPTION
## What

Two small corrections in `docs/source/en/quantization/overview.md`:

1. **Typo fix**: `AuoQuant Notebook` → `AutoQuant Notebook` in the *User-Friendly Quantization Tools* section. The letter `t` was missing from the link text.

2. **Empty table cell**: The `FINEGRAINED_FP8` row had an empty *Link to library* cell. Since Fine-grained FP8 quantization is implemented natively within Transformers (no external library required), the cell now reads `Built-in` to make it clear this is not a missing link.

## Why

- The `AuoQuant` typo is confusing and makes the link text harder to find when scanning the page.
- The empty cell in the `FINEGRAINED_FP8` row looks like a mistake or missing information; clarifying it as `Built-in` is consistent with how Transformers-native features are typically presented in documentation.

## Testing

- Verified the Colab URL in the corrected link is still valid
- Confirmed `FineGrainedFP8` is implemented in `src/transformers/quantizers/quantizer_finegrained_fp8.py` and `src/transformers/integrations/finegrained_fp8.py` with no external package dependency

## Checklist

- [x] Documentation-only change
- [x] Fixes the `AuoQuant` typo
- [x] Adds `Built-in` note for `FINEGRAINED_FP8` to clarify the empty library column