### PR TITLE
[voxtral-realtime] get more perfs!

### DIFF
--- a/docs/source/en/model_doc/voxtral_realtime.md
+++ b/docs/source/en/model_doc/voxtral_realtime.md
@@ -77,6 +77,12 @@ for decoded_output in decoded_outputs:
     print(decoded_output)
 ```
 
+### Audio encoder precomputation
+
+By default, when the full audio is available (i.e. not streaming), the audio encoder and projector are run once before generation begins. The resulting embeddings are then simply sliced at each decoding step, which is much faster than running the encoder repeatedly.
+
+This is the default behavior (`precompute_audio_embeds=True`). You can disable it if needed. Note that the default vLLM implementation runs the encoder at every step since it relies on a different optimization paradigm.
+
 ### Streaming Transcription
 > [!NOTE]
 > This is an experimental feature and the API is subject to change.

--- a/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modeling_voxtral_realtime.py
@@ -1052,6 +1052,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
         cache_position: torch.LongTensor | None = None,
         logits_to_keep: int | torch.Tensor = 0,
         num_delay_tokens: int | torch.Tensor = None,
+        audio_embeds: torch.FloatTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> VoxtralRealtimeCausalLMOutputWithPast:
         r"""
@@ -1063,6 +1064,11 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
             Optionally, instead of passing `input_features` you can choose to directly pass an embedded representation for the encoder.
         num_delay_tokens (`int` or `torch.Tensor`, *optional*):
             Number of delay tokens used when preparing inputs, see [`~VoxtralRealtimeProcessor`] for more details.
+        audio_embeds (`torch.FloatTensor`, *optional*):
+            Pre-computed audio embeddings (after encoder and projector). When provided, the audio encoder is
+            skipped and these embeddings are added directly to the text input embeddings. This is used internally
+            by `generate` when `precompute_audio_embeds=True` (the default) to avoid running the encoder
+            iteratively.
 
         Example:
 
@@ -1088,13 +1094,16 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if (input_features is None) ^ (encoder_inputs_embeds is not None):
+        if audio_embeds is None and (input_features is None) ^ (encoder_inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_features or encoder_inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
-        if input_features is not None or encoder_inputs_embeds is not None:
+        audio_outputs = None
+        if audio_embeds is not None:
+            inputs_embeds += audio_embeds.to(inputs_embeds.device)
+        elif input_features is not None or encoder_inputs_embeds is not None:
             audio_outputs = self.get_audio_features(
                 input_features=input_features,
                 encoder_inputs_embeds=encoder_inputs_embeds,
@@ -1140,19 +1149,25 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
-            encoder_past_key_values=audio_outputs.past_key_values if use_cache else None,
-            padding_cache=audio_outputs.padding_cache if use_cache else None,
+            encoder_past_key_values=audio_outputs.past_key_values if use_cache and audio_outputs is not None else None,
+            padding_cache=audio_outputs.padding_cache if use_cache and audio_outputs is not None else None,
         )
 
     def prepare_inputs_for_generation(
         self,
         *args,
         encoder_inputs_embeds: torch.Tensor | None = None,
+        audio_embeds: torch.Tensor | None = None,
+        precompute_audio_embeds: bool = True,
         **kwargs,
     ):
         model_inputs = super().prepare_inputs_for_generation(*args, **kwargs)
 
-        if encoder_inputs_embeds is not None:
+        if audio_embeds is not None:
+            start_idx = model_inputs["cache_position"][0]
+            end_idx = model_inputs["cache_position"][-1] + 1
+            model_inputs["audio_embeds"] = audio_embeds[:, start_idx:end_idx, :]
+        elif encoder_inputs_embeds is not None:
             start_idx = model_inputs["cache_position"][0] * self.config.downsample_factor
             end_idx = (model_inputs["cache_position"][-1] + 1) * self.config.downsample_factor
             model_inputs["encoder_inputs_embeds"] = encoder_inputs_embeds[:, start_idx:end_idx, :]
@@ -1167,9 +1182,18 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
     ) -> tuple[torch.Tensor, str | None, dict[str, torch.Tensor]]:
         inputs, input_name, model_kwargs = super()._prepare_model_inputs(inputs, bos_token_id, model_kwargs)
 
+        precompute_audio_embeds = model_kwargs.pop("precompute_audio_embeds", True)
+
         input_features = model_kwargs.get("input_features")
         if input_features is not None and not isinstance(input_features, GeneratorType):
-            model_kwargs["encoder_inputs_embeds"] = self.audio_tower.embedder(model_kwargs.pop("input_features"))
+            if precompute_audio_embeds:
+                audio_outputs = self.get_audio_features(
+                    input_features=model_kwargs.pop("input_features"),
+                    return_dict=True,
+                )
+                model_kwargs["audio_embeds"] = audio_outputs.pooler_output
+            else:
+                model_kwargs["encoder_inputs_embeds"] = self.audio_tower.embedder(model_kwargs.pop("input_features"))
 
         elif isinstance(input_features, GeneratorType):
             input_features_generator = model_kwargs.pop("input_features")
@@ -1266,6 +1290,8 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
         generation_config,
         **kwargs,
     ):
+        precompute_audio_embeds = kwargs.pop("precompute_audio_embeds", True)
+
         # Check if user explicitly provided max_length or max_new_tokens BEFORE
         # the base class applies defaults
         user_set_max_length = kwargs.get("max_length") is not None or (
@@ -1276,6 +1302,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralRealtimePreTrainedModel, Ge
         )
 
         generation_config, model_kwargs = super()._prepare_generation_config(generation_config, **kwargs)
+        model_kwargs["precompute_audio_embeds"] = precompute_audio_embeds
 
         input_features = model_kwargs.get("input_features")
         if input_features is not None and not isinstance(input_features, GeneratorType):

--- a/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/modular_voxtral_realtime.py
@@ -662,6 +662,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
         cache_position: torch.LongTensor | None = None,
         logits_to_keep: int | torch.Tensor = 0,
         num_delay_tokens: int | torch.Tensor = None,
+        audio_embeds: torch.FloatTensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> VoxtralRealtimeCausalLMOutputWithPast:
         r"""
@@ -673,6 +674,11 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
             Optionally, instead of passing `input_features` you can choose to directly pass an embedded representation for the encoder.
         num_delay_tokens (`int` or `torch.Tensor`, *optional*):
             Number of delay tokens used when preparing inputs, see [`~VoxtralRealtimeProcessor`] for more details.
+        audio_embeds (`torch.FloatTensor`, *optional*):
+            Pre-computed audio embeddings (after encoder and projector). When provided, the audio encoder is
+            skipped and these embeddings are added directly to the text input embeddings. This is used internally
+            by `generate` when `precompute_audio_embeds=True` (the default) to avoid running the encoder
+            iteratively.
 
         Example:
 
@@ -698,13 +704,16 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if (input_features is None) ^ (encoder_inputs_embeds is not None):
+        if audio_embeds is None and (input_features is None) ^ (encoder_inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_features or encoder_inputs_embeds")
 
         if inputs_embeds is None:
             inputs_embeds = self.get_input_embeddings()(input_ids)
 
-        if input_features is not None or encoder_inputs_embeds is not None:
+        audio_outputs = None
+        if audio_embeds is not None:
+            inputs_embeds += audio_embeds.to(inputs_embeds.device)
+        elif input_features is not None or encoder_inputs_embeds is not None:
             audio_outputs = self.get_audio_features(
                 input_features=input_features,
                 encoder_inputs_embeds=encoder_inputs_embeds,
@@ -750,19 +759,25 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
-            encoder_past_key_values=audio_outputs.past_key_values if use_cache else None,
-            padding_cache=audio_outputs.padding_cache if use_cache else None,
+            encoder_past_key_values=audio_outputs.past_key_values if use_cache and audio_outputs is not None else None,
+            padding_cache=audio_outputs.padding_cache if use_cache and audio_outputs is not None else None,
         )
 
     def prepare_inputs_for_generation(
         self,
         *args,
         encoder_inputs_embeds: torch.Tensor | None = None,
+        audio_embeds: torch.Tensor | None = None,
+        precompute_audio_embeds: bool = True,
         **kwargs,
     ):
         model_inputs = GenerationMixin.prepare_inputs_for_generation(*args, **kwargs)
 
-        if encoder_inputs_embeds is not None:
+        if audio_embeds is not None:
+            start_idx = model_inputs["cache_position"][0]
+            end_idx = model_inputs["cache_position"][-1] + 1
+            model_inputs["audio_embeds"] = audio_embeds[:, start_idx:end_idx, :]
+        elif encoder_inputs_embeds is not None:
             start_idx = model_inputs["cache_position"][0] * self.config.downsample_factor
             end_idx = (model_inputs["cache_position"][-1] + 1) * self.config.downsample_factor
             model_inputs["encoder_inputs_embeds"] = encoder_inputs_embeds[:, start_idx:end_idx, :]
@@ -777,9 +792,18 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
     ) -> tuple[torch.Tensor, str | None, dict[str, torch.Tensor]]:
         inputs, input_name, model_kwargs = GenerationMixin._prepare_model_inputs(inputs, bos_token_id, model_kwargs)
 
+        precompute_audio_embeds = model_kwargs.pop("precompute_audio_embeds", True)
+
         input_features = model_kwargs.get("input_features")
         if input_features is not None and not isinstance(input_features, GeneratorType):
-            model_kwargs["encoder_inputs_embeds"] = self.audio_tower.embedder(model_kwargs.pop("input_features"))
+            if precompute_audio_embeds:
+                audio_outputs = self.get_audio_features(
+                    input_features=model_kwargs.pop("input_features"),
+                    return_dict=True,
+                )
+                model_kwargs["audio_embeds"] = audio_outputs.pooler_output
+            else:
+                model_kwargs["encoder_inputs_embeds"] = self.audio_tower.embedder(model_kwargs.pop("input_features"))
 
         elif isinstance(input_features, GeneratorType):
             input_features_generator = model_kwargs.pop("input_features")
@@ -876,6 +900,8 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
         generation_config,
         **kwargs,
     ):
+        precompute_audio_embeds = kwargs.pop("precompute_audio_embeds", True)
+
         # Check if user explicitly provided max_length or max_new_tokens BEFORE
         # the base class applies defaults
         user_set_max_length = kwargs.get("max_length") is not None or (
@@ -886,6 +912,7 @@ class VoxtralRealtimeForConditionalGeneration(VoxtralForConditionalGeneration, G
         )
 
         generation_config, model_kwargs = GenerationMixin._prepare_generation_config(generation_config, **kwargs)
+        model_kwargs["precompute_audio_embeds"] = precompute_audio_embeds
 
         input_features = model_kwargs.get("input_features")
         if input_features is not None and not isinstance(input_features, GeneratorType):


### PR DESCRIPTION
# What does this PR do?

so @Deep-unlearning noticed, benchmarking for the Open ASR leaderbaord, that the current implem is particularly slow. That would make sense since we go through every layer of the encoder forward, and that the streaming paradigm mean the genrate way more tokens (since they are time-aligned).

Profiling shows indeed:
**voxtral**
<img width="1005" height="50" alt="Screenshot 2026-02-18 at 21 48 53" src="https://github.com/user-attachments/assets/b4778b2f-7cc7-4fc1-a7ec-ad0977b3bdee" />

**voxtral-realtime**
<img width="1020" height="47" alt="Screenshot 2026-02-18 at 21 48 35" src="https://github.com/user-attachments/assets/f8ca0a38-123e-4157-9c06-db4ef4bf1205" />

But we don't necessarily have to do it! Let's just run the encoder fully once at the beginning when we can.