### PR TITLE
[docs] Fix typos in GenerationConfig docstring

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -100,11 +100,11 @@ class GenerationConfig(PushToHubMixin):
 
     </Tip>
 
-    Note: the configuration field that are still `None` will be overriden by `GenerationConfig._get_default_generation_params()`
+    Note: the configuration fields that are still `None` will be overridden by `GenerationConfig._get_default_generation_params()`
     during the generation loop. If you want to use different values for these fields, make sure to explicitly set them in the
     generation config.
 
-    Arg:
+    Args:
         > Parameters that control the length of the output
 
         max_length (`int`, *optional*):


### PR DESCRIPTION
## What does this PR do?

Fixes minor typos in the `GenerationConfig` class docstring:

- "overriden" → "overridden"
- "field that are" → "fields that are"  
- "Arg:" → "Args:" (consistent with the rest of the docstring)

No code changes, documentation only.