### PR TITLE
Add THD support in ESM

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -452,6 +452,9 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming(source_patterns="norm2", target_patterns="post_mlp_layernorm"),
         ],
     }
+    # The legacy mapping is added to the esm model here since the extra weight renaming do not apply to the esm model.
+    mapping["esm"] += mapping["legacy"].copy()
+
     mapping["legacy"] += [
         WeightRenaming(
             source_patterns=".weight_g$",

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -142,6 +142,12 @@ def _build_checkpoint_conversion_mapping():
                 target_patterns="model.vlm.language_model.embed_tokens",
             ),
         ],
+        "esm": [
+            WeightRenaming(
+                "encoder.layer.*.attention.self.rotary_embeddings.inv_freq",
+                "rotary_embeddings.inv_freq",
+            ),
+        ],
         "dinov3_convnext": [WeightRenaming(r"(?<!model\.)stages", r"model.stages")],
         "dinov3_vit": [WeightRenaming(r"(?<!model\.)layer.", r"model.layer.")],
         "timesfm2_5": [

--- a/src/transformers/models/esm/configuration_esm.py
+++ b/src/transformers/models/esm/configuration_esm.py
@@ -218,7 +218,6 @@ class EsmConfig(PreTrainedConfig):
 
     def __post_init__(self, **kwargs):
         if self.is_folding_model:
-            self.model_type = "esmfold"
             if self.esmfold_config is None:
                 logger.info("No esmfold_config supplied for folding model, using default values.")
                 self.esmfold_config = EsmFoldConfig()

--- a/src/transformers/models/esm/configuration_esm.py
+++ b/src/transformers/models/esm/configuration_esm.py
@@ -218,6 +218,7 @@ class EsmConfig(PreTrainedConfig):
 
     def __post_init__(self, **kwargs):
         if self.is_folding_model:
+            self.model_type = "esmfold"
             if self.esmfold_config is None:
                 logger.info("No esmfold_config supplied for folding model, using default values.")
                 self.esmfold_config = EsmFoldConfig()

--- a/src/transformers/models/esm/configuration_esm.py
+++ b/src/transformers/models/esm/configuration_esm.py
@@ -215,6 +215,8 @@ class EsmConfig(PreTrainedConfig):
     is_decoder: bool | None = False
     add_cross_attention: bool | None = False
     tie_word_embeddings: bool = True
+    bos_token_id: int | None = None
+    eos_token_id: int | list[int] | None = 2
 
     def __post_init__(self, **kwargs):
         if self.is_folding_model:

--- a/src/transformers/models/esm/configuration_esm.py
+++ b/src/transformers/models/esm/configuration_esm.py
@@ -163,6 +163,8 @@ class EsmConfig(PreTrainedConfig):
         Type of position embedding. Choose either `"absolute"` or "rotary"`.
     emb_layer_norm_before (`bool`, *optional*):
         Whether to apply layer normalization after embeddings but before the main stem of the network.
+    rope_theta (`float`, defaults to 10000.0):
+        The base period of the RoPE embeddings. Only used when `position_embedding_type` is set to `"rotary"`.
     token_dropout (`bool`, defaults to `False`):
         When this is enabled, masked tokens are treated as if they had been dropped out by input dropout.
     is_folding_model (`bool`, defaults to `False`):
@@ -200,6 +202,7 @@ class EsmConfig(PreTrainedConfig):
     hidden_dropout_prob: float | None = 0.1
     attention_probs_dropout_prob: float | None = 0.1
     max_position_embeddings: int = 1026
+    rope_theta: float = 10000.0
     initializer_range: float = 0.02
     layer_norm_eps: float | None = 1e-12
     position_embedding_type: str | None = "absolute"

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -726,12 +726,6 @@ class EsmModel(EsmPreTrainedModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        seq_len = inputs_embeds.shape[1] if inputs_embeds is not None else input_ids.shape[1]
-        device = input_ids.device if input_ids is not None else inputs_embeds.device
-
-        if position_ids is None:
-            position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
-
         if inputs_embeds is None:
             # Important, attention_mask must be passed to the embedding class
             # This effects how the token_dropout is calculated
@@ -749,9 +743,13 @@ class EsmModel(EsmPreTrainedModel):
             past_key_values=None,
         )
 
-        position_embeddings = (
-            self.rotary_embeddings(inputs_embeds, position_ids) if self.position_embedding_type == "rotary" else None
-        )
+        if self.position_embedding_type == "rotary":
+            if position_ids is None:
+                seq_len = inputs_embeds.shape[1]
+                position_ids = torch.arange(seq_len, device=inputs_embeds.device).unsqueeze(0)
+            position_embeddings = self.rotary_embeddings(inputs_embeds, position_ids)
+        else:
+            position_embeddings = None
 
         encoder_outputs = self.encoder(
             inputs_embeds,

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -103,54 +103,6 @@ def average_product_correct(x):
     return normalized
 
 
-# class RotaryEmbedding(torch.nn.Module):
-#     """
-#     Rotary position embeddings based on those in
-#     [RoFormer](https://huggingface.co/docs/transformers/model_doc/roformer). Query and keys are transformed by rotation
-#     matrices which depend on their relative positions.
-#     """
-
-#     inv_freq: torch.Tensor  # fix linting for `register_buffer`
-
-#     def __init__(self, dim: int):
-#         super().__init__()
-#         self.dim = dim
-#         # Generate and save the inverse frequency buffer (non trainable)
-#         inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
-#         self.register_buffer("inv_freq", inv_freq)
-
-#     def _update_cos_sin_tables(self, x, seq_dimension=2, seq_len=None, position_ids=None):
-#         if seq_len is None:
-#             seq_len = x.shape[seq_dimension]
-
-#         if position_ids is None:
-#             t = torch.arange(x.shape[seq_dimension], device=x.device).type_as(self.inv_freq)
-#         else:
-#             t = position_ids.squeeze()
-#             if t.dim() != 1:
-#                 raise ValueError(
-#                     f"position_ids must be 1-D after squeezing, got shape {position_ids.shape}. "
-#                     "Custom position_ids are intended for use with DataCollatorWithFlattening (batch_size=1)."
-#                 )
-#         freqs = torch.outer(t, self.inv_freq)
-#         emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
-
-#         cos = emb.cos()[None, None, :, :]
-#         sin = emb.sin()[None, None, :, :]
-
-#         return cos, sin
-
-#     def forward(
-#         self, q: torch.Tensor, k: torch.Tensor, seq_len: int | None = None, position_ids: torch.Tensor | None = None
-#     ) -> tuple[torch.Tensor, torch.Tensor]:
-#         cos, sin = self._update_cos_sin_tables(k, seq_dimension=-2, seq_len=seq_len, position_ids=position_ids)
-
-#         return (
-#             apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
-#             apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
-#         )
-
-
 class EsmRotaryEmbedding(nn.Module):
     """
     Rotary position embeddings.
@@ -159,95 +111,15 @@ class EsmRotaryEmbedding(nn.Module):
 
     inv_freq: torch.Tensor  # fix linting for `register_buffer`
 
-    # def __init__(self, config: EsmConfig, device=None):
-    #     super().__init__()
-    #     self.max_seq_len_cached = config.max_position_embeddings
-    #     self.original_max_seq_len = config.max_position_embeddings
-
-    #     self.config = config
-
-    #     self.layer_types = list(set(config.layer_types))
-    #     self.rope_type = {}
-    #     for layer_type in self.layer_types:
-    #         rope_params = self.config.rope_parameters[layer_type]
-    #         if rope_params is None:
-    #             continue
-
-    #         self.rope_type[layer_type] = rope_params["rope_type"]
-    #         rope_init_fn: Callable = self.compute_default_rope_parameters
-    #         if self.rope_type[layer_type] != "default":
-    #             rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
-    #         curr_inv_freq, curr_attention_scaling = rope_init_fn(self.config, device, layer_type=layer_type)
-    #         self.register_buffer(f"{layer_type}_inv_freq", curr_inv_freq, persistent=False)
-    #         self.register_buffer(f"{layer_type}_original_inv_freq", curr_inv_freq.clone(), persistent=False)
-    #         setattr(self, f"{layer_type}_attention_scaling", curr_attention_scaling)
-
     def __init__(self, config: EsmConfig, device=None):
         super().__init__()
-        # self.max_seq_len_cached = config.max_position_embeddings
-        # self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
-
-        # self.layer_types = list(set(config.layer_types))
         self.rope_type = {}
-        # for layer_type in self.layer_types:
-        #     rope_params = self.config.rope_parameters[layer_type]
-        #     if rope_params is None:
-        #         continue
 
-        #     self.rope_type[layer_type] = rope_params["rope_type"]
-        #     rope_init_fn: Callable = self.compute_default_rope_parameters
-        #     if self.rope_type[layer_type] != "default":
-        #         rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
-        #     curr_inv_freq, curr_attention_scaling = rope_init_fn(self.config, device, layer_type=layer_type)
-        #     self.register_buffer(f"{layer_type}_inv_freq", curr_inv_freq, persistent=False)
-        #     self.register_buffer(f"{layer_type}_original_inv_freq", curr_inv_freq.clone(), persistent=False)
-        #     setattr(self, f"{layer_type}_attention_scaling", curr_attention_scaling)
-
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        # if self.rope_type[layer_type] != "default":
-        #     rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
-        curr_inv_freq, curr_attention_scaling = rope_init_fn(self.config, device)
+        curr_inv_freq, curr_attention_scaling = self.compute_default_rope_parameters(self.config, device)
         self.register_buffer("inv_freq", curr_inv_freq)
-        # self.register_buffer(f"original_inv_freq", curr_inv_freq.clone(), persistent=False)
         setattr(self, "attention_scaling", curr_attention_scaling)
-
-    # @staticmethod
-    # def compute_default_rope_parameters(
-    #     config: EsmConfig | None = None,
-    #     device: Optional["torch.device"] = None,
-    #     seq_len: int | None = None,
-    #     layer_type: str | None = None,
-    # ) -> tuple["torch.Tensor", float]:
-    #     """
-    #     Computes the inverse frequencies according to the original RoPE implementation
-    #     Args:
-    #         config ([`~transformers.PreTrainedConfig`]):
-    #             The model configuration.
-    #         device (`torch.device`):
-    #             The device to use for initialization of the inverse frequencies.
-    #         seq_len (`int`, *optional*):
-    #             The current sequence length. Unused for this type of RoPE.
-    #         layer_type (`str`, *optional*):
-    #             The current layer type if the model has different RoPE parameters per type.
-    #             Should not be used unless `config.layer_types is not None`
-
-    #     Returns:
-    #         Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
-    #         post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
-    #     """
-    #     # For backward compatibility standardize the `rope_parameters_dict` if it uses old format
-    #     base = config.rope_parameters[layer_type]["rope_theta"]
-    #     dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
-
-    #     attention_factor = 1.0  # Unused in this type of RoPE
-
-    #     # Compute the inverse frequencies
-    #     inv_freq = 1.0 / (
-    #         base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
-    #     )
-    #     return inv_freq, attention_factor
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -269,7 +141,6 @@ class EsmRotaryEmbedding(nn.Module):
             Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
             post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
         """
-        # For backward compatibility standardize the `rope_parameters_dict` if it uses old format
         base = config.rope_theta
         dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
 
@@ -485,7 +356,6 @@ class EsmSelfAttention(nn.Module):
             config, "position_embedding_type", "absolute"
         )
         self.scaling = 1.0  # For BC we apply scaling before RoPE
-
         self.is_decoder = config.is_decoder
         self.layer_idx = layer_idx
         self.is_causal = self.is_decoder and not is_cross_attention
@@ -515,11 +385,6 @@ class EsmSelfAttention(nn.Module):
         # but not when rotary embeddings get involved. Therefore, we scale the query here to match the original
         # ESM code and fix rotary embeddings.
         query_layer = query_layer * self.attention_head_size**-0.5
-
-        # if self.position_embedding_type == "rotary":
-        #     query_layer, key_layer = self.rotary_embeddings(
-        #         query_layer, key_layer, seq_len, kwargs.get("position_ids")
-        #     )
 
         if self.position_embedding_type == "rotary":
             cos, sin = position_embeddings
@@ -751,7 +616,6 @@ class EsmPreTrainedModel(PreTrainedModel):
         elif isinstance(module, EsmRotaryEmbedding):
             curr_inv_freq, _ = module.compute_default_rope_parameters(module.config)
             init.copy_(getattr(module, "inv_freq"), curr_inv_freq)
-            # init.copy_(getattr(module, "original_inv_freq"), curr_inv_freq)
 
     def get_output_embeddings(self):
         # NOTE: get_output_embeddings() must return None to prevent accidental weight tying.

--- a/src/transformers/models/esm/modeling_esm.py
+++ b/src/transformers/models/esm/modeling_esm.py
@@ -16,12 +16,14 @@
 
 import math
 from collections.abc import Callable
+from typing import Optional
 
 import torch
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
 from ... import initialization as init
+from ...integrations import use_kernel_func_from_hub, use_kernelized_func
 from ...masking_utils import create_bidirectional_mask, create_causal_mask
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import (
@@ -31,10 +33,11 @@ from ...modeling_outputs import (
     SequenceClassifierOutput,
     TokenClassifierOutput,
 )
+from ...modeling_rope_utils import dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import Unpack
 from ...utils import TransformersKwargs, auto_docstring, can_return_tuple, logging
-from ...utils.generic import merge_with_config_defaults
+from ...utils.generic import maybe_autocast, merge_with_config_defaults
 from ...utils.output_capturing import OutputRecorder, capture_outputs
 from .configuration_esm import EsmConfig
 
@@ -43,15 +46,37 @@ logger = logging.get_logger(__name__)
 
 
 def rotate_half(x):
-    x1, x2 = x.chunk(2, dim=-1)
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
     return torch.cat((-x2, x1), dim=-1)
 
 
-def apply_rotary_pos_emb(x, cos, sin):
-    cos = cos[:, :, : x.shape[-2], :]
-    sin = sin[:, :, : x.shape[-2], :]
+@use_kernel_func_from_hub("rotary_pos_emb")
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
 
-    return (x * cos) + (rotate_half(x) * sin)
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    original_dtype = q.dtype
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q.float() * cos) + (rotate_half(q.float()) * sin)
+    k_embed = (k.float() * cos) + (rotate_half(k.float()) * sin)
+    return q_embed.to(original_dtype), k_embed.to(original_dtype)
 
 
 def gelu(x):
@@ -78,49 +103,201 @@ def average_product_correct(x):
     return normalized
 
 
-class RotaryEmbedding(torch.nn.Module):
+# class RotaryEmbedding(torch.nn.Module):
+#     """
+#     Rotary position embeddings based on those in
+#     [RoFormer](https://huggingface.co/docs/transformers/model_doc/roformer). Query and keys are transformed by rotation
+#     matrices which depend on their relative positions.
+#     """
+
+#     inv_freq: torch.Tensor  # fix linting for `register_buffer`
+
+#     def __init__(self, dim: int):
+#         super().__init__()
+#         self.dim = dim
+#         # Generate and save the inverse frequency buffer (non trainable)
+#         inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
+#         self.register_buffer("inv_freq", inv_freq)
+
+#     def _update_cos_sin_tables(self, x, seq_dimension=2, seq_len=None, position_ids=None):
+#         if seq_len is None:
+#             seq_len = x.shape[seq_dimension]
+
+#         if position_ids is None:
+#             t = torch.arange(x.shape[seq_dimension], device=x.device).type_as(self.inv_freq)
+#         else:
+#             t = position_ids.squeeze()
+#             if t.dim() != 1:
+#                 raise ValueError(
+#                     f"position_ids must be 1-D after squeezing, got shape {position_ids.shape}. "
+#                     "Custom position_ids are intended for use with DataCollatorWithFlattening (batch_size=1)."
+#                 )
+#         freqs = torch.outer(t, self.inv_freq)
+#         emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+
+#         cos = emb.cos()[None, None, :, :]
+#         sin = emb.sin()[None, None, :, :]
+
+#         return cos, sin
+
+#     def forward(
+#         self, q: torch.Tensor, k: torch.Tensor, seq_len: int | None = None, position_ids: torch.Tensor | None = None
+#     ) -> tuple[torch.Tensor, torch.Tensor]:
+#         cos, sin = self._update_cos_sin_tables(k, seq_dimension=-2, seq_len=seq_len, position_ids=position_ids)
+
+#         return (
+#             apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
+#             apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
+#         )
+
+
+class EsmRotaryEmbedding(nn.Module):
     """
-    Rotary position embeddings based on those in
-    [RoFormer](https://huggingface.co/docs/transformers/model_doc/roformer). Query and keys are transformed by rotation
-    matrices which depend on their relative positions.
+    Rotary position embeddings.
+    Implementation based on [ModernBERT's RotaryEmbedding](https://github.com/huggingface/transformers/blob/aad13b87ed59f2afcfaebc985f403301887a35fc/src/transformers/models/modernbert/modeling_modernbert.py#L94).
     """
 
     inv_freq: torch.Tensor  # fix linting for `register_buffer`
 
-    def __init__(self, dim: int):
+    # def __init__(self, config: EsmConfig, device=None):
+    #     super().__init__()
+    #     self.max_seq_len_cached = config.max_position_embeddings
+    #     self.original_max_seq_len = config.max_position_embeddings
+
+    #     self.config = config
+
+    #     self.layer_types = list(set(config.layer_types))
+    #     self.rope_type = {}
+    #     for layer_type in self.layer_types:
+    #         rope_params = self.config.rope_parameters[layer_type]
+    #         if rope_params is None:
+    #             continue
+
+    #         self.rope_type[layer_type] = rope_params["rope_type"]
+    #         rope_init_fn: Callable = self.compute_default_rope_parameters
+    #         if self.rope_type[layer_type] != "default":
+    #             rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
+    #         curr_inv_freq, curr_attention_scaling = rope_init_fn(self.config, device, layer_type=layer_type)
+    #         self.register_buffer(f"{layer_type}_inv_freq", curr_inv_freq, persistent=False)
+    #         self.register_buffer(f"{layer_type}_original_inv_freq", curr_inv_freq.clone(), persistent=False)
+    #         setattr(self, f"{layer_type}_attention_scaling", curr_attention_scaling)
+
+    def __init__(self, config: EsmConfig, device=None):
         super().__init__()
-        self.dim = dim
-        # Generate and save the inverse frequency buffer (non trainable)
-        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
-        self.register_buffer("inv_freq", inv_freq)
+        # self.max_seq_len_cached = config.max_position_embeddings
+        # self.original_max_seq_len = config.max_position_embeddings
 
-        self._seq_len_cached = None
-        self._cos_cached = None
-        self._sin_cached = None
+        self.config = config
 
-    def _update_cos_sin_tables(self, x, seq_dimension=2):
-        seq_len = x.shape[seq_dimension]
+        # self.layer_types = list(set(config.layer_types))
+        self.rope_type = {}
+        # for layer_type in self.layer_types:
+        #     rope_params = self.config.rope_parameters[layer_type]
+        #     if rope_params is None:
+        #         continue
 
-        # Reset the tables if the sequence length has changed,
-        # or if we're on a new device (possibly due to tracing for instance)
-        if seq_len != self._seq_len_cached or self._cos_cached.device != x.device:
-            self._seq_len_cached = seq_len
-            t = torch.arange(x.shape[seq_dimension], device=x.device).type_as(self.inv_freq)
-            freqs = torch.outer(t, self.inv_freq)
-            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+        #     self.rope_type[layer_type] = rope_params["rope_type"]
+        #     rope_init_fn: Callable = self.compute_default_rope_parameters
+        #     if self.rope_type[layer_type] != "default":
+        #         rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
+        #     curr_inv_freq, curr_attention_scaling = rope_init_fn(self.config, device, layer_type=layer_type)
+        #     self.register_buffer(f"{layer_type}_inv_freq", curr_inv_freq, persistent=False)
+        #     self.register_buffer(f"{layer_type}_original_inv_freq", curr_inv_freq.clone(), persistent=False)
+        #     setattr(self, f"{layer_type}_attention_scaling", curr_attention_scaling)
 
-            self._cos_cached = emb.cos()[None, None, :, :]
-            self._sin_cached = emb.sin()[None, None, :, :]
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        # if self.rope_type[layer_type] != "default":
+        #     rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type[layer_type]]
+        curr_inv_freq, curr_attention_scaling = rope_init_fn(self.config, device)
+        self.register_buffer("inv_freq", curr_inv_freq)
+        # self.register_buffer(f"original_inv_freq", curr_inv_freq.clone(), persistent=False)
+        setattr(self, "attention_scaling", curr_attention_scaling)
 
-        return self._cos_cached, self._sin_cached
+    # @staticmethod
+    # def compute_default_rope_parameters(
+    #     config: EsmConfig | None = None,
+    #     device: Optional["torch.device"] = None,
+    #     seq_len: int | None = None,
+    #     layer_type: str | None = None,
+    # ) -> tuple["torch.Tensor", float]:
+    #     """
+    #     Computes the inverse frequencies according to the original RoPE implementation
+    #     Args:
+    #         config ([`~transformers.PreTrainedConfig`]):
+    #             The model configuration.
+    #         device (`torch.device`):
+    #             The device to use for initialization of the inverse frequencies.
+    #         seq_len (`int`, *optional*):
+    #             The current sequence length. Unused for this type of RoPE.
+    #         layer_type (`str`, *optional*):
+    #             The current layer type if the model has different RoPE parameters per type.
+    #             Should not be used unless `config.layer_types is not None`
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        self._cos_cached, self._sin_cached = self._update_cos_sin_tables(k, seq_dimension=-2)
+    #     Returns:
+    #         Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
+    #         post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
+    #     """
+    #     # For backward compatibility standardize the `rope_parameters_dict` if it uses old format
+    #     base = config.rope_parameters[layer_type]["rope_theta"]
+    #     dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
 
-        return (
-            apply_rotary_pos_emb(q, self._cos_cached, self._sin_cached).to(dtype=q.dtype),
-            apply_rotary_pos_emb(k, self._cos_cached, self._sin_cached).to(dtype=k.dtype),
+    #     attention_factor = 1.0  # Unused in this type of RoPE
+
+    #     # Compute the inverse frequencies
+    #     inv_freq = 1.0 / (
+    #         base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
+    #     )
+    #     return inv_freq, attention_factor
+
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: EsmConfig | None = None,
+        device: Optional["torch.device"] = None,
+        seq_len: int | None = None,
+    ) -> tuple["torch.Tensor", float]:
+        """
+        Computes the inverse frequencies according to the original RoPE implementation
+        Args:
+            config ([`~transformers.PreTrainedConfig`]):
+                The model configuration.
+            device (`torch.device`):
+                The device to use for initialization of the inverse frequencies.
+            seq_len (`int`, *optional*):
+                The current sequence length. Unused for this type of RoPE.
+
+        Returns:
+            Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
+            post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
+        """
+        # For backward compatibility standardize the `rope_parameters_dict` if it uses old format
+        base = config.rope_theta
+        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
+
+        attention_factor = 1.0  # Unused in this type of RoPE
+
+        # Compute the inverse frequencies
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
         )
+        return inv_freq, attention_factor
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids, layer_type=None):
+        inv_freq = getattr(self, "inv_freq")
+        attention_scaling = getattr(self, "attention_scaling")
+
+        inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * attention_scaling
+            sin = emb.sin() * attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
 class EsmContactPredictionHead(nn.Module):
@@ -282,6 +459,7 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
+@use_kernelized_func(apply_rotary_pos_emb)
 class EsmSelfAttention(nn.Module):
     def __init__(self, config, position_embedding_type=None, layer_idx=None, is_cross_attention=False):
         super().__init__()
@@ -303,14 +481,11 @@ class EsmSelfAttention(nn.Module):
 
         self.dropout = config.attention_probs_dropout_prob
 
-        self.rotary_embeddings = None
         self.position_embedding_type = position_embedding_type or getattr(
             config, "position_embedding_type", "absolute"
         )
-        if self.position_embedding_type == "rotary":
-            self.rotary_embeddings = RotaryEmbedding(dim=self.attention_head_size)
-
         self.scaling = 1.0  # For BC we apply scaling before RoPE
+
         self.is_decoder = config.is_decoder
         self.layer_idx = layer_idx
         self.is_causal = self.is_decoder and not is_cross_attention
@@ -321,6 +496,7 @@ class EsmSelfAttention(nn.Module):
         attention_mask: torch.FloatTensor | None = None,
         encoder_hidden_states: torch.FloatTensor | None = None,
         encoder_attention_mask: torch.FloatTensor | None = None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor]:
         batch_size, seq_length = hidden_states.shape[:-1]
@@ -340,8 +516,14 @@ class EsmSelfAttention(nn.Module):
         # ESM code and fix rotary embeddings.
         query_layer = query_layer * self.attention_head_size**-0.5
 
+        # if self.position_embedding_type == "rotary":
+        #     query_layer, key_layer = self.rotary_embeddings(
+        #         query_layer, key_layer, seq_len, kwargs.get("position_ids")
+        #     )
+
         if self.position_embedding_type == "rotary":
-            query_layer, key_layer = self.rotary_embeddings(query_layer, key_layer)
+            cos, sin = position_embeddings
+            query_layer, key_layer = apply_rotary_pos_emb(query_layer, key_layer, cos, sin, unsqueeze_dim=1)
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -389,6 +571,7 @@ class EsmAttention(nn.Module):
         attention_mask=None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ):
         hidden_states_ln = self.LayerNorm(hidden_states)
@@ -397,6 +580,7 @@ class EsmAttention(nn.Module):
             attention_mask=attention_mask,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         attn_output = self.output(attn_output, hidden_states)
@@ -449,11 +633,13 @@ class EsmLayer(GradientCheckpointingLayer):
         attention_mask=None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ):
         attention_output = self.attention(
             hidden_states,
             attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
 
@@ -469,6 +655,7 @@ class EsmLayer(GradientCheckpointingLayer):
                 attention_mask=attention_mask,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
 
@@ -497,6 +684,7 @@ class EsmEncoder(nn.Module):
         attention_mask=None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ):
         for i, layer_module in enumerate(self.layer):
@@ -505,6 +693,7 @@ class EsmEncoder(nn.Module):
                 attention_mask=attention_mask,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
 
@@ -559,9 +748,10 @@ class EsmPreTrainedModel(PreTrainedModel):
             init.zeros_(module.bias)
         elif isinstance(module, EsmEmbeddings):
             init.copy_(module.position_ids, torch.arange(module.position_ids.shape[-1]).expand((1, -1)))
-        elif isinstance(module, RotaryEmbedding):
-            inv_freq = 1.0 / (10000 ** (torch.arange(0, module.dim, 2, dtype=torch.int64).float() / module.dim))
-            init.copy_(module.inv_freq, inv_freq)
+        elif isinstance(module, EsmRotaryEmbedding):
+            curr_inv_freq, _ = module.compute_default_rope_parameters(module.config)
+            init.copy_(getattr(module, "inv_freq"), curr_inv_freq)
+            # init.copy_(getattr(module, "original_inv_freq"), curr_inv_freq)
 
     def get_output_embeddings(self):
         # NOTE: get_output_embeddings() must return None to prevent accidental weight tying.
@@ -592,6 +782,12 @@ class EsmModel(EsmPreTrainedModel):
         self.config = config
 
         self.embeddings = EsmEmbeddings(config)
+
+        self.rotary_embeddings = None
+        self.position_embedding_type = getattr(config, "position_embedding_type", "absolute")
+        if self.position_embedding_type == "rotary":
+            self.rotary_embeddings = EsmRotaryEmbedding(config=config)
+
         self.encoder = EsmEncoder(config)
 
         self.pooler = EsmPooler(config) if add_pooling_layer else None
@@ -600,8 +796,31 @@ class EsmModel(EsmPreTrainedModel):
             in_features=config.num_hidden_layers * config.num_attention_heads, bias=True
         )
 
+        self._register_load_state_dict_pre_hook(self.load_hook)
         # Initialize weights and apply final processing
         self.post_init()
+
+    def load_hook(self, state_dict, prefix, *args):
+        """Remap per-layer rotary inv_freq keys from old checkpoints to the new model-level location.
+
+        Old checkpoints stored inv_freq per attention layer at:
+            {prefix}encoder.layer.{i}.attention.self.rotary_embeddings.inv_freq
+        New code stores a single shared inv_freq at:
+            {prefix}rotary_embeddings.inv_freq
+        The old checkpoint values must be preserved (not recomputed) because they may
+        have been saved in float16, matching the precision used during training.
+        """
+        new_key = f"{prefix}rotary_embeddings.inv_freq"
+        if new_key not in state_dict:
+            old_keys = sorted(
+                k
+                for k in list(state_dict.keys())
+                if k.startswith(prefix) and k.endswith(".attention.self.rotary_embeddings.inv_freq")
+            )
+            if old_keys:
+                state_dict[new_key] = state_dict[old_keys[0]]
+            for k in old_keys:
+                del state_dict[k]
 
     def get_input_embeddings(self):
         return self.embeddings.word_embeddings
@@ -643,6 +862,12 @@ class EsmModel(EsmPreTrainedModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
+        seq_len = inputs_embeds.shape[1] if inputs_embeds is not None else input_ids.shape[1]
+        device = input_ids.device if input_ids is not None else inputs_embeds.device
+
+        if position_ids is None:
+            position_ids = torch.arange(seq_len, device=device).unsqueeze(0)
+
         if inputs_embeds is None:
             # Important, attention_mask must be passed to the embedding class
             # This effects how the token_dropout is calculated
@@ -660,11 +885,16 @@ class EsmModel(EsmPreTrainedModel):
             past_key_values=None,
         )
 
+        position_embeddings = (
+            self.rotary_embeddings(inputs_embeds, position_ids) if self.position_embedding_type == "rotary" else None
+        )
+
         encoder_outputs = self.encoder(
             inputs_embeds,
             attention_mask=attention_mask,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         sequence_output = encoder_outputs[0]

--- a/src/transformers/models/evolla/configuration_evolla.py
+++ b/src/transformers/models/evolla/configuration_evolla.py
@@ -31,6 +31,8 @@ class SaProtConfig(PreTrainedConfig):
         The id of the *mask* token in the protein sequence model.
     position_embedding_type (`str`, *optional*, defaults to `"rotary"`):
         The type of position embedding to use in the protein sequence model. Currently only `"rotary"` is supported.
+    rope_theta (`float`, *optional*, defaults to 10000.0):
+        The base period of the RoPE embeddings.
     emb_layer_norm_before (`bool`, *optional*, defaults to `False`):
         Whether to apply layer normalization before the position embedding in the protein sequence model.
     token_dropout (`bool`, *optional*, defaults to `True`):
@@ -50,6 +52,7 @@ class SaProtConfig(PreTrainedConfig):
     initializer_range: float = 0.02
     layer_norm_eps: float = 1e-05
     position_embedding_type: str = "rotary"
+    rope_theta: float = 10000.0
     emb_layer_norm_before: bool = False
     token_dropout: bool = True
     is_decoder: bool = False

--- a/src/transformers/models/evolla/modeling_evolla.py
+++ b/src/transformers/models/evolla/modeling_evolla.py
@@ -162,61 +162,72 @@ class EvollaSaProtEmbeddings(nn.Module):
         return position_ids.unsqueeze(0).expand(input_shape)
 
 
-def rotate_half_esm(x):
-    x1, x2 = x.chunk(2, dim=-1)
-    return torch.cat((-x2, x1), dim=-1)
-
-
-def apply_rotary_pos_emb_esm(x, cos, sin):
-    cos = cos[:, :, : x.shape[-2], :]
-    sin = sin[:, :, : x.shape[-2], :]
-
-    return (x * cos) + (rotate_half_esm(x) * sin)
-
-
 class EvollaSaProtRotaryEmbedding(nn.Module):
     """
-    Rotary position embeddings based on those in
-    [RoFormer](https://huggingface.co/docs/transformers/model_doc/roformer). Query and keys are transformed by rotation
-    matrices which depend on their relative positions.
+    Rotary position embeddings.
+    Implementation based on [ModernBERT's RotaryEmbedding](https://github.com/huggingface/transformers/blob/aad13b87ed59f2afcfaebc985f403301887a35fc/src/transformers/models/modernbert/modeling_modernbert.py#L94).
     """
 
     inv_freq: torch.Tensor  # fix linting for `register_buffer`
 
-    def __init__(self, dim: int):
+    def __init__(self, config: SaProtConfig, device=None):
         super().__init__()
-        self.dim = dim
-        # Generate and save the inverse frequency buffer (non trainable)
-        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
-        self.register_buffer("inv_freq", inv_freq)
 
-        self._seq_len_cached = None
-        self._cos_cached = None
-        self._sin_cached = None
+        self.config = config
+        self.rope_type = {}
 
-    def _update_cos_sin_tables(self, x, seq_dimension=2):
-        seq_len = x.shape[seq_dimension]
+        curr_inv_freq, curr_attention_scaling = self.compute_default_rope_parameters(self.config, device)
+        self.register_buffer("inv_freq", curr_inv_freq)
+        setattr(self, "attention_scaling", curr_attention_scaling)
 
-        # Reset the tables if the sequence length has changed,
-        # or if we're on a new device (possibly due to tracing for instance)
-        if seq_len != self._seq_len_cached or self._cos_cached.device != x.device:
-            self._seq_len_cached = seq_len
-            t = torch.arange(x.shape[seq_dimension], device=x.device).type_as(self.inv_freq)
-            freqs = torch.outer(t, self.inv_freq)
-            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: SaProtConfig | None = None,
+        device: "torch.device | None" = None,
+        seq_len: int | None = None,
+    ) -> tuple["torch.Tensor", float]:
+        """
+        Computes the inverse frequencies according to the original RoPE implementation
+        Args:
+            config ([`~transformers.PreTrainedConfig`]):
+                The model configuration.
+            device (`torch.device`):
+                The device to use for initialization of the inverse frequencies.
+            seq_len (`int`, *optional*):
+                The current sequence length. Unused for this type of RoPE.
 
-            self._cos_cached = emb.cos()[None, None, :, :]
-            self._sin_cached = emb.sin()[None, None, :, :]
+        Returns:
+            Tuple of (`torch.Tensor`, `float`), containing the inverse frequencies for the RoPE embeddings and the
+            post-processing scaling factor applied to the computed cos/sin (unused in this type of RoPE).
+        """
+        base = config.rope_theta
+        dim = getattr(config, "head_dim", None) or config.hidden_size // config.num_attention_heads
 
-        return self._cos_cached, self._sin_cached
+        attention_factor = 1.0  # Unused in this type of RoPE
 
-    def forward(self, q: torch.Tensor, k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        self._cos_cached, self._sin_cached = self._update_cos_sin_tables(k, seq_dimension=-2)
-
-        return (
-            apply_rotary_pos_emb_esm(q, self._cos_cached, self._sin_cached).to(dtype=q.dtype),
-            apply_rotary_pos_emb_esm(k, self._cos_cached, self._sin_cached).to(dtype=k.dtype),
+        # Compute the inverse frequencies
+        inv_freq = 1.0 / (
+            base ** (torch.arange(0, dim, 2, dtype=torch.int64).to(device=device, dtype=torch.float) / dim)
         )
+        return inv_freq, attention_factor
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids, layer_type=None):
+        inv_freq = getattr(self, "inv_freq")
+        attention_scaling = getattr(self, "attention_scaling")
+
+        inv_freq_expanded = inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with maybe_autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * attention_scaling
+            sin = emb.sin() * attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
 def rotate_half(x):
@@ -303,16 +314,12 @@ class EvollaSaProtSelfAttention(nn.Module):
 
         self.dropout = config.attention_probs_dropout_prob
 
-        self.rotary_embeddings = None
         self.position_embedding_type = position_embedding_type or getattr(
             config, "position_embedding_type", "absolute"
         )
-        if self.position_embedding_type == "rotary":
-            self.rotary_embeddings = EvollaSaProtRotaryEmbedding(dim=self.attention_head_size)
-
+        self.scaling = 1.0  # For BC we apply scaling before RoPE
         self.is_decoder = config.is_decoder
         self.layer_idx = layer_idx
-        self.scaling = 1.0
         self.is_causal = self.is_decoder and not is_cross_attention
 
     def forward(
@@ -562,17 +569,19 @@ class EvollaSaProtPreTrainedModel(PreTrainedModel):
         ],
     }
 
+    @torch.no_grad()
     def _init_weights(self, module):
         super()._init_weights(module)
         if isinstance(module, EvollaSaProtRotaryEmbedding):
-            inv_freq = 1.0 / (10000 ** (torch.arange(0, module.dim, 2, dtype=torch.int64).float() / module.dim))
-            init.copy_(module.inv_freq, inv_freq)
+            curr_inv_freq, _ = module.compute_default_rope_parameters(module.config)
+            init.copy_(getattr(module, "inv_freq"), curr_inv_freq)
 
 
 class EvollaSaProtProteinEncoder(EvollaSaProtPreTrainedModel):
     def __init__(self, config: SaProtConfig):
         super().__init__(config)
         self.embeddings = EvollaSaProtEmbeddings(config)
+        self.rotary_embeddings = EvollaSaProtRotaryEmbedding(config=config)
         self.encoder = EvollaSaProtEncoder(config)
         self.post_init()
 
@@ -604,7 +613,12 @@ class EvollaSaProtProteinEncoder(EvollaSaProtPreTrainedModel):
             attention_mask=attention_mask,
         )
 
-        encoder_outputs = self.encoder(inputs_embeds, attention_mask=attention_mask, **kwargs)
+        position_ids = torch.arange(seq_length, device=device).unsqueeze(0)
+        position_embeddings = self.rotary_embeddings(inputs_embeds, position_ids)
+
+        encoder_outputs = self.encoder(
+            inputs_embeds, attention_mask=attention_mask, position_embeddings=position_embeddings, **kwargs
+        )
         sequence_output = encoder_outputs[0]
 
         return BaseModelOutputWithPoolingAndCrossAttentions(
@@ -1253,6 +1267,7 @@ class EvollaPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = True
     _no_split_modules = [
         "EvollaDecoderLayer",
+        "EvollaSaProtLayer",
         "EvollaSequenceCompressorResampler",
         "EvollaSequenceAlignerCrossAttention",
     ]

--- a/src/transformers/models/evolla/modeling_evolla.py
+++ b/src/transformers/models/evolla/modeling_evolla.py
@@ -219,6 +219,40 @@ class EvollaSaProtRotaryEmbedding(nn.Module):
         )
 
 
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+@use_kernel_func_from_hub("rotary_pos_emb")
+def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    original_dtype = q.dtype
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q.float() * cos) + (rotate_half(q.float()) * sin)
+    k_embed = (k.float() * cos) + (rotate_half(k.float()) * sin)
+    return q_embed.to(original_dtype), k_embed.to(original_dtype)
+
+
 def eager_attention_forward(
     module: nn.Module,
     query: torch.Tensor,
@@ -247,6 +281,7 @@ def eager_attention_forward(
     return attn_output, attn_weights
 
 
+@use_kernelized_func(apply_rotary_pos_emb)
 class EvollaSaProtSelfAttention(nn.Module):
     def __init__(self, config, position_embedding_type=None, layer_idx=None, is_cross_attention=False):
         super().__init__()
@@ -286,6 +321,7 @@ class EvollaSaProtSelfAttention(nn.Module):
         attention_mask: torch.FloatTensor | None = None,
         encoder_hidden_states: torch.FloatTensor | None = None,
         encoder_attention_mask: torch.FloatTensor | None = None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> tuple[torch.Tensor]:
         batch_size, seq_length = hidden_states.shape[:-1]
@@ -306,7 +342,8 @@ class EvollaSaProtSelfAttention(nn.Module):
         query_layer = query_layer * self.attention_head_size**-0.5
 
         if self.position_embedding_type == "rotary":
-            query_layer, key_layer = self.rotary_embeddings(query_layer, key_layer)
+            cos, sin = position_embeddings
+            query_layer, key_layer = apply_rotary_pos_emb(query_layer, key_layer, cos, sin, unsqueeze_dim=1)
 
         attention_interface: Callable = ALL_ATTENTION_FUNCTIONS.get_interface(
             self.config._attn_implementation, eager_attention_forward
@@ -354,6 +391,7 @@ class EvollaSaProtAttention(nn.Module):
         attention_mask=None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ):
         hidden_states_ln = self.LayerNorm(hidden_states)
@@ -362,6 +400,7 @@ class EvollaSaProtAttention(nn.Module):
             attention_mask=attention_mask,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
         attn_output = self.output(attn_output, hidden_states)
@@ -421,11 +460,13 @@ class EvollaSaProtLayer(GradientCheckpointingLayer):
         attention_mask=None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ):
         attention_output = self.attention(
             hidden_states,
             attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
             **kwargs,
         )
 
@@ -441,6 +482,7 @@ class EvollaSaProtLayer(GradientCheckpointingLayer):
                 attention_mask=attention_mask,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
 
@@ -469,6 +511,7 @@ class EvollaSaProtEncoder(nn.Module):
         attention_mask=None,
         encoder_hidden_states=None,
         encoder_attention_mask=None,
+        position_embeddings: torch.Tensor | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ):
         for i, layer_module in enumerate(self.layer):
@@ -477,6 +520,7 @@ class EvollaSaProtEncoder(nn.Module):
                 attention_mask=attention_mask,
                 encoder_hidden_states=encoder_hidden_states,
                 encoder_attention_mask=encoder_attention_mask,
+                position_embeddings=position_embeddings,
                 **kwargs,
             )
 
@@ -1050,39 +1094,6 @@ class EvollaMLP(nn.Module):
     def forward(self, x):
         down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         return down_proj
-
-
-def rotate_half(x):
-    """Rotates half the hidden dims of the input."""
-    x1 = x[..., : x.shape[-1] // 2]
-    x2 = x[..., x.shape[-1] // 2 :]
-    return torch.cat((-x2, x1), dim=-1)
-
-
-@use_kernel_func_from_hub("rotary_pos_emb")
-def apply_rotary_pos_emb(q, k, cos, sin, unsqueeze_dim=1):
-    """Applies Rotary Position Embedding to the query and key tensors.
-
-    Args:
-        q (`torch.Tensor`): The query tensor.
-        k (`torch.Tensor`): The key tensor.
-        cos (`torch.Tensor`): The cosine part of the rotary embedding.
-        sin (`torch.Tensor`): The sine part of the rotary embedding.
-        unsqueeze_dim (`int`, *optional*, defaults to 1):
-            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
-            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
-            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
-            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
-            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
-            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
-    Returns:
-        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
-    """
-    cos = cos.unsqueeze(unsqueeze_dim)
-    sin = sin.unsqueeze(unsqueeze_dim)
-    q_embed = (q * cos) + (rotate_half(q) * sin)
-    k_embed = (k * cos) + (rotate_half(k) * sin)
-    return q_embed, k_embed
 
 
 def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:

--- a/src/transformers/models/evolla/modular_evolla.py
+++ b/src/transformers/models/evolla/modular_evolla.py
@@ -43,6 +43,7 @@ from ..esm.modeling_esm import (
     EsmLayer,
     EsmOutput,
     EsmPooler,
+    EsmRotaryEmbedding,
     EsmSelfAttention,
     EsmSelfOutput,
 )
@@ -67,95 +68,21 @@ class EvollaSaProtEmbeddings(EsmEmbeddings):
         self.position_ids = None
 
 
-def rotate_half_esm(x):
-    x1, x2 = x.chunk(2, dim=-1)
-    return torch.cat((-x2, x1), dim=-1)
+class EvollaSaProtRotaryEmbedding(EsmRotaryEmbedding):
+    def __init__(self, config: SaProtConfig, device=None):
+        super().__init__(config, device)
 
-
-def apply_rotary_pos_emb_esm(x, cos, sin):
-    cos = cos[:, :, : x.shape[-2], :]
-    sin = sin[:, :, : x.shape[-2], :]
-
-    return (x * cos) + (rotate_half_esm(x) * sin)
-
-
-class EvollaSaProtRotaryEmbedding(nn.Module):
-    """
-    Rotary position embeddings based on those in
-    [RoFormer](https://huggingface.co/docs/transformers/model_doc/roformer). Query and keys are transformed by rotation
-    matrices which depend on their relative positions.
-    """
-
-    inv_freq: torch.Tensor  # fix linting for `register_buffer`
-
-    def __init__(self, dim: int):
-        super().__init__()
-        self.dim = dim
-        # Generate and save the inverse frequency buffer (non trainable)
-        inv_freq = 1.0 / (10000 ** (torch.arange(0, dim, 2, dtype=torch.int64).float() / dim))
-        self.register_buffer("inv_freq", inv_freq)
-
-        self._seq_len_cached = None
-        self._cos_cached = None
-        self._sin_cached = None
-
-    def _update_cos_sin_tables(self, x, seq_dimension=2):
-        seq_len = x.shape[seq_dimension]
-
-        # Reset the tables if the sequence length has changed,
-        # or if we're on a new device (possibly due to tracing for instance)
-        if seq_len != self._seq_len_cached or self._cos_cached.device != x.device:
-            self._seq_len_cached = seq_len
-            t = torch.arange(x.shape[seq_dimension], device=x.device).type_as(self.inv_freq)
-            freqs = torch.outer(t, self.inv_freq)
-            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
-
-            self._cos_cached = emb.cos()[None, None, :, :]
-            self._sin_cached = emb.sin()[None, None, :, :]
-
-        return self._cos_cached, self._sin_cached
-
-    def forward(self, q: torch.Tensor, k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        self._cos_cached, self._sin_cached = self._update_cos_sin_tables(k, seq_dimension=-2)
-
-        return (
-            apply_rotary_pos_emb_esm(q, self._cos_cached, self._sin_cached).to(dtype=q.dtype),
-            apply_rotary_pos_emb_esm(k, self._cos_cached, self._sin_cached).to(dtype=k.dtype),
-        )
+    @staticmethod
+    def compute_default_rope_parameters(
+        config: SaProtConfig | None = None,
+        device: "torch.device | None" = None,
+        seq_len: int | None = None,
+    ) -> tuple["torch.Tensor", float]:
+        return super().compute_default_rope_parameters(config, device, seq_len)
 
 
 class EvollaSaProtSelfAttention(EsmSelfAttention):
-    def __init__(self, config, position_embedding_type=None, layer_idx=None, is_cross_attention=False):
-        nn.Module.__init__(self)
-        self.config = config
-
-        if config.hidden_size % config.num_attention_heads != 0 and not hasattr(config, "embedding_size"):
-            raise ValueError(
-                f"The hidden size ({config.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({config.num_attention_heads})"
-            )
-
-        self.num_attention_heads = config.num_attention_heads
-        self.attention_head_size = int(config.hidden_size / config.num_attention_heads)
-        self.all_head_size = self.num_attention_heads * self.attention_head_size
-
-        self.query = nn.Linear(config.hidden_size, self.all_head_size)
-        self.key = nn.Linear(config.hidden_size, self.all_head_size)
-        self.value = nn.Linear(config.hidden_size, self.all_head_size)
-
-        self.dropout = config.attention_probs_dropout_prob
-
-        self.rotary_embeddings = None
-        self.position_embedding_type = position_embedding_type or getattr(
-            config, "position_embedding_type", "absolute"
-        )
-        if self.position_embedding_type == "rotary":
-            self.rotary_embeddings = EvollaSaProtRotaryEmbedding(dim=self.attention_head_size)
-
-        self.is_decoder = config.is_decoder
-        self.layer_idx = layer_idx
-        self.scaling = 1.0
-        self.is_causal = self.is_decoder and not is_cross_attention
+    pass
 
 
 class EvollaSaProtSelfOutput(EsmSelfOutput):
@@ -203,17 +130,19 @@ class EvollaSaProtPreTrainedModel(PreTrainedModel):
         ],
     }
 
+    @torch.no_grad()
     def _init_weights(self, module):
         super()._init_weights(module)
         if isinstance(module, EvollaSaProtRotaryEmbedding):
-            inv_freq = 1.0 / (10000 ** (torch.arange(0, module.dim, 2, dtype=torch.int64).float() / module.dim))
-            init.copy_(module.inv_freq, inv_freq)
+            curr_inv_freq, _ = module.compute_default_rope_parameters(module.config)
+            init.copy_(getattr(module, "inv_freq"), curr_inv_freq)
 
 
 class EvollaSaProtProteinEncoder(EvollaSaProtPreTrainedModel):
     def __init__(self, config: SaProtConfig):
         super().__init__(config)
         self.embeddings = EvollaSaProtEmbeddings(config)
+        self.rotary_embeddings = EvollaSaProtRotaryEmbedding(config=config)
         self.encoder = EvollaSaProtEncoder(config)
         self.post_init()
 
@@ -245,7 +174,12 @@ class EvollaSaProtProteinEncoder(EvollaSaProtPreTrainedModel):
             attention_mask=attention_mask,
         )
 
-        encoder_outputs = self.encoder(inputs_embeds, attention_mask=attention_mask, **kwargs)
+        position_ids = torch.arange(seq_length, device=device).unsqueeze(0)
+        position_embeddings = self.rotary_embeddings(inputs_embeds, position_ids)
+
+        encoder_outputs = self.encoder(
+            inputs_embeds, attention_mask=attention_mask, position_embeddings=position_embeddings, **kwargs
+        )
         sequence_output = encoder_outputs[0]
 
         return BaseModelOutputWithPoolingAndCrossAttentions(
@@ -720,6 +654,7 @@ class EvollaPreTrainedModel(LlamaPreTrainedModel):
     _supports_attention_backend = False
     _no_split_modules = [
         "EvollaDecoderLayer",
+        "EvollaSaProtLayer",
         "EvollaSequenceCompressorResampler",
         "EvollaSequenceAlignerCrossAttention",
     ]

--- a/tests/models/esm/test_modeling_esm.py
+++ b/tests/models/esm/test_modeling_esm.py
@@ -18,7 +18,7 @@ import unittest
 
 import pytest
 
-from transformers import BitsAndBytesConfig, EsmConfig, is_torch_available, set_seed
+from transformers import BitsAndBytesConfig, DataCollatorWithFlattening, EsmConfig, is_torch_available, set_seed
 from transformers.testing_utils import (
     TestCasePlus,
     is_flaky,
@@ -246,6 +246,90 @@ class EsmModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_forward_and_backwards(*config_and_inputs, gradient_checkpointing=True)
 
+    @require_flash_attn
+    @require_torch_accelerator
+    @pytest.mark.flash_attn_test
+    def test_model_generation_flash_attn_with_packing(self):
+        """Test that packing two sequences produces the same per-sample outputs as running
+        them in a batched run.
+        """
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        config = config_and_inputs[0]
+        config.position_embedding_type = "rotary"
+        config.attn_implementation = "flash_attention_2"
+
+        model = EsmModel(config=config).to(dtype=torch.bfloat16, device=torch_device).eval()
+
+        seq_len_a = 3
+        seq_len_b = 4
+
+        input_ids_a = ids_tensor([1, seq_len_a], config.vocab_size)
+        input_ids_b = ids_tensor([1, seq_len_b], config.vocab_size)
+
+        # --- Batched run ----
+        max_len = max(seq_len_a, seq_len_b)
+        pad_a = max_len - seq_len_a
+        pad_b = max_len - seq_len_b
+
+        batched_input_ids = torch.cat(
+            [
+                torch.nn.functional.pad(input_ids_a, (0, pad_a), value=config.pad_token_id),
+                torch.nn.functional.pad(input_ids_b, (0, pad_b), value=config.pad_token_id),
+            ],
+            dim=0,
+        ).to(torch_device)
+
+        batched_attention_mask = torch.cat(
+            [
+                torch.nn.functional.pad(torch.ones(1, seq_len_a, dtype=torch.long), (0, pad_a)),
+                torch.nn.functional.pad(torch.ones(1, seq_len_b, dtype=torch.long), (0, pad_b)),
+            ],
+            dim=0,
+        ).to(torch_device)
+
+        with torch.no_grad():
+            result_batched = model(batched_input_ids, attention_mask=batched_attention_mask)
+
+        # --- Packed run ----
+        collator = DataCollatorWithFlattening(
+            return_position_ids=True,
+            return_flash_attn_kwargs=True,
+        )
+
+        features = [
+            {"input_ids": input_ids_a.squeeze(0)},
+            {"input_ids": input_ids_b.squeeze(0)},
+        ]
+
+        packed = collator(features)
+
+        packed_kwargs = {
+            "input_ids": packed["input_ids"].to(torch_device),
+            "attention_mask": None,
+            "position_ids": packed["position_ids"].to(torch_device),
+            "cu_seq_lens_q": packed["cu_seq_lens_q"].to(torch_device),
+            "cu_seq_lens_k": packed["cu_seq_lens_k"].to(torch_device),
+            "max_length_q": packed["max_length_q"],
+            "max_length_k": packed["max_length_k"],
+        }
+
+        with torch.no_grad():
+            result_packed = model(**packed_kwargs)
+
+        # Compare per-sample outputs
+        torch.testing.assert_close(
+            result_batched.last_hidden_state[0, :seq_len_a],
+            result_packed.last_hidden_state[0, :seq_len_a],
+            atol=1e-5,
+            rtol=1e-5,
+        )
+        torch.testing.assert_close(
+            result_batched.last_hidden_state[1, :seq_len_b],
+            result_packed.last_hidden_state[0, seq_len_a:],
+            atol=1e-5,
+            rtol=1e-5,
+        )
+
     @slow
     def test_model_from_pretrained(self):
         model_name = "facebook/esm2_t6_8M_UR50D"
@@ -377,6 +461,19 @@ class EsmModelIntegrationTest(TestCasePlus):
                 [[[0.1444, 0.5413, 0.3248], [0.3034, 0.0053, 0.3108], [0.3228, -0.2499, 0.3415]]]
             )
             torch.testing.assert_close(output[:, :3, :3], expected_slice, rtol=1e-4, atol=1e-4)
+
+    def test_inv_freq_preserves_checkpoint_precision(self):
+        """The checkpoint's inv_freq was saved after an fp16 cast, so it differs from a fresh
+        float32 computation but matches exactly when the fresh values are round-tripped through fp16."""
+        model_from_ckpt = EsmModel.from_pretrained("facebook/esm2_t6_8M_UR50D")
+        config = EsmConfig.from_pretrained("facebook/esm2_t6_8M_UR50D")
+        model_fresh = EsmModel(config)
+
+        inv_freq_ckpt = model_from_ckpt.rotary_embeddings.inv_freq
+        inv_freq_fresh = model_fresh.rotary_embeddings.inv_freq
+
+        self.assertFalse(torch.equal(inv_freq_ckpt, inv_freq_fresh))
+        self.assertTrue(torch.equal(inv_freq_ckpt, inv_freq_fresh.to(torch.float16).float()))
 
     @require_bitsandbytes
     def test_inference_bitsandbytes(self):

--- a/tests/models/esm/test_modeling_esmfold.py
+++ b/tests/models/esm/test_modeling_esmfold.py
@@ -225,6 +225,23 @@ class EsmFoldModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     def test_feed_forward_chunking(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        # EsmFold defaults to absolute position embeddings, which means it has no
+        # rotary_embeddings.inv_freq keys. Temporarily switch to rotary so the
+        # inv_freq conversion pattern registered for "esm" has keys to match.
+        original = self.model_tester.get_config
+
+        def _get_config_with_rotary():
+            config = original()
+            config.position_embedding_type = "rotary"
+            return config
+
+        self.model_tester.get_config = _get_config_with_rotary
+        try:
+            super().test_reverse_loading_mapping()
+        finally:
+            self.model_tester.get_config = original
+
     @unittest.skip(reason="ESMFold doesn't support data parallel.")
     def test_multi_gpu_data_parallel_forward(self):
         pass


### PR DESCRIPTION
# What does this PR do?

This PR adds support for sequence packing in the ESM2 model. Currently, the RotaryEmbedding class of the ESM2 model supports BSHD format. This PR makes the RotayEmbedding class aware of the`position_ids` and builds the cos and sin tables accordingly.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
