### PR TITLE
Refactored vits to match standardized output collection interface

### DIFF
--- a/src/transformers/models/vits/modeling_vits.py
+++ b/src/transformers/models/vits/modeling_vits.py
@@ -31,6 +31,7 @@ from ...modeling_outputs import BaseModelOutput, ModelOutput
 from ...modeling_utils import PreTrainedModel
 from ...utils import auto_docstring, logging, torch_compilable_check
 from .configuration_vits import VitsConfig
+from ..utils.capture_outputs import capture_outputs
 
 
 logger = logging.get_logger(__name__)
@@ -1091,12 +1092,10 @@ class VitsEncoder(nn.Module):
         hidden_states: torch.FloatTensor,
         padding_mask: torch.FloatTensor,
         attention_mask: torch.Tensor | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
-    ) -> tuple | BaseModelOutput:
-        all_hidden_states = () if output_hidden_states else None
-        all_self_attentions = () if output_attentions else None
+    
+    ) ->  BaseModelOutput:
+        # all_hidden_states = () if output_hidden_states else None
+        # all_self_attentions = () if output_attentions else None
 
         attention_mask = create_bidirectional_mask(
             config=self.config,
@@ -1109,8 +1108,8 @@ class VitsEncoder(nn.Module):
         synced_gpus = is_deepspeed_zero3_enabled() or is_fsdp_managed_module(self)
 
         for encoder_layer in self.layers:
-            if output_hidden_states:
-                all_hidden_states = all_hidden_states + (hidden_states,)
+            # if output_hidden_states:
+            #     all_hidden_states = all_hidden_states + (hidden_states,)
 
             # add LayerDrop (see https://huggingface.co/papers/1909.11556 for description)
             dropout_probability = np.random.uniform(0, 1)
@@ -1122,28 +1121,23 @@ class VitsEncoder(nn.Module):
                     hidden_states,
                     attention_mask=attention_mask,
                     padding_mask=padding_mask,
-                    output_attentions=output_attentions,
+                    # output_attentions=output_attentions,
                 )
                 hidden_states = layer_outputs[0]
 
             if skip_the_layer:
                 layer_outputs = (None, None)
 
-            if output_attentions:
-                all_self_attentions = all_self_attentions + (layer_outputs[1],)
+            # if output_attentions:
+            #     all_self_attentions = all_self_attentions + (layer_outputs[1],)
 
         hidden_states = hidden_states * padding_mask
 
-        if output_hidden_states:
-            all_hidden_states = all_hidden_states + (hidden_states,)
-
-        if not return_dict:
-            return tuple(v for v in [hidden_states, all_hidden_states, all_self_attentions] if v is not None)
+        # if not return_dict:
+        #     return tuple(v for v in [hidden_states, all_hidden_states, all_self_attentions] if v is not None)
 
         return BaseModelOutput(
             last_hidden_state=hidden_states,
-            hidden_states=all_hidden_states,
-            attentions=all_self_attentions,
         )
 
 
@@ -1164,9 +1158,9 @@ class VitsTextEncoder(nn.Module):
         input_ids: torch.Tensor,
         padding_mask: torch.FloatTensor,
         attention_mask: torch.Tensor | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = True,
+        # output_attentions: bool | None = None,
+        # output_hidden_states: bool | None = None,
+        # return_dict: bool | None = True,
     ) -> tuple[torch.Tensor] | VitsTextEncoderOutput:
         hidden_states = self.embed_tokens(input_ids) * math.sqrt(self.config.hidden_size)
 
@@ -1174,26 +1168,25 @@ class VitsTextEncoder(nn.Module):
             hidden_states=hidden_states,
             padding_mask=padding_mask,
             attention_mask=attention_mask,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+            # output_attentions=output_attentions,
+            # output_hidden_states=output_hidden_states,
+            # return_dict=return_dict,
         )
 
-        last_hidden_state = encoder_outputs[0] if not return_dict else encoder_outputs.last_hidden_state
-
+        last_hidden_state = encoder_outputs[0] #if not return_dict else encoder_outputs.last_hidden_state
         stats = self.project(last_hidden_state.transpose(1, 2)).transpose(1, 2) * padding_mask
         prior_means, prior_log_variances = torch.split(stats, self.config.flow_size, dim=2)
 
-        if not return_dict:
-            outputs = (last_hidden_state, prior_means, prior_log_variances) + encoder_outputs[1:]
-            return outputs
+        # if not return_dict:
+        #     outputs = (last_hidden_state, prior_means, prior_log_variances) + encoder_outputs[1:]
+        #     return outputs
 
         return VitsTextEncoderOutput(
             last_hidden_state=last_hidden_state,
             prior_means=prior_means,
             prior_log_variances=prior_log_variances,
-            hidden_states=encoder_outputs.hidden_states,
-            attentions=encoder_outputs.attentions,
+            # hidden_states=encoder_outputs.hidden_states,
+            # attentions=encoder_outputs.attentions,
         )
 
 
@@ -1203,6 +1196,7 @@ class VitsPreTrainedModel(PreTrainedModel):
     base_model_prefix = "vits"
     main_input_name = "input_ids"
     supports_gradient_checkpointing = True
+    _can_capture_outputs = {"attentions" : VitsAttention  , "hidden_states" :  VitsEncoderLayer}
 
     @torch.no_grad()
     def _init_weights(self, module: nn.Module):
@@ -1266,19 +1260,19 @@ class VitsModel(VitsPreTrainedModel):
 
         # Initialize weights and apply final processing
         self.post_init()
-
+    @capture_outputs
     @auto_docstring
     def forward(
         self,
         input_ids: torch.Tensor | None = None,
         attention_mask: torch.Tensor | None = None,
         speaker_id: int | None = None,
-        output_attentions: bool | None = None,
-        output_hidden_states: bool | None = None,
-        return_dict: bool | None = None,
+        # output_attentions: bool | None = None,
+        # output_hidden_states: bool | None = None,
+        # return_dict: bool | None = None,
         labels: torch.FloatTensor | None = None,
         **kwargs,
-    ) -> tuple[Any] | VitsModelOutput:
+    ) -> VitsModelOutput:
         r"""
         speaker_id (`int`, *optional*):
             Which speaker embedding to use. Only used for multispeaker models.
@@ -1305,11 +1299,11 @@ class VitsModel(VitsPreTrainedModel):
         torch.Size([1, 45824])
         ```
         """
-        output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
-        output_hidden_states = (
-            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
-        )
-        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+        # output_attentions = output_attentions if output_attentions is not None else self.config.output_attentions
+        # output_hidden_states = (
+        #     output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        # )
+        # return_dict = return_dict if return_dict is not None else self.config.use_return_dict
 
         if labels is not None:
             raise NotImplementedError("Training of VITS is not supported yet.")
@@ -1333,15 +1327,13 @@ class VitsModel(VitsPreTrainedModel):
             input_ids=input_ids,
             padding_mask=input_padding_mask,
             attention_mask=attention_mask,
-            output_attentions=output_attentions,
-            output_hidden_states=output_hidden_states,
-            return_dict=return_dict,
+        
         )
-        hidden_states = text_encoder_output[0] if not return_dict else text_encoder_output.last_hidden_state
+        hidden_states = text_encoder_output.last_hidden_state
         hidden_states = hidden_states.transpose(1, 2)
         input_padding_mask = input_padding_mask.transpose(1, 2)
-        prior_means = text_encoder_output[1] if not return_dict else text_encoder_output.prior_means
-        prior_log_variances = text_encoder_output[2] if not return_dict else text_encoder_output.prior_log_variances
+        prior_means = text_encoder_output.prior_means
+        prior_log_variances = text_encoder_output.prior_log_variances
 
         if self.config.use_stochastic_duration_prediction:
             log_duration = self.duration_predictor(
@@ -1385,16 +1377,16 @@ class VitsModel(VitsPreTrainedModel):
         waveform = waveform.squeeze(1)
         sequence_lengths = predicted_lengths * np.prod(self.config.upsample_rates)
 
-        if not return_dict:
-            outputs = (waveform, sequence_lengths, spectrogram) + text_encoder_output[3:]
-            return outputs
+        # if not return_dict:
+        #     outputs = (waveform, sequence_lengths, spectrogram) + text_encoder_output[3:]
+        #     return outputs
 
         return VitsModelOutput(
             waveform=waveform,
             sequence_lengths=sequence_lengths,
             spectrogram=spectrogram,
-            hidden_states=text_encoder_output.hidden_states,
-            attentions=text_encoder_output.attentions,
+            # hidden_states=text_encoder_output.hidden_states,
+            # attentions=text_encoder_output.attentions,
         )
 
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #43979 

This pr refactors the vits code to match the standardized outputs using the` @capture_outputs `decorator . Changes are only applied to `VitsModel` , `VitsTextEncoder` , `VitsEncoder` class


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [X] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
