### PR TITLE
Add GIT model support in VQA pipeline

### DIFF
--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -1337,6 +1337,7 @@ MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES = OrderedDict(
     [
         ("blip", "BlipForQuestionAnswering"),
         ("blip-2", "Blip2ForConditionalGeneration"),
+        ("git", "GitForCausalLM"),
         ("vilt", "ViltForQuestionAnswering"),
     ]
 )

--- a/src/transformers/pipelines/visual_question_answering.py
+++ b/src/transformers/pipelines/visual_question_answering.py
@@ -1,3 +1,4 @@
+import inspect
 from typing import Union
 
 from ..generation import GenerationConfig
@@ -178,6 +179,10 @@ class VisualQuestionAnsweringPipeline(Pipeline):
             padding=padding,
             truncation=truncation,
         )
+        # Filter out tokenizer outputs that the model does not accept (e.g., token_type_ids
+        # produced by BERT-based tokenizers but not accepted by models like GIT)
+        model_forward_params = set(inspect.signature(self.model.forward).parameters.keys())
+        model_inputs = {k: v for k, v in model_inputs.items() if k in model_forward_params}
         image_features = self.image_processor(images=image, return_tensors="pt")
         image_features = image_features.to(self.dtype)
         model_inputs.update(image_features)

--- a/tests/models/git/test_modeling_git.py
+++ b/tests/models/git/test_modeling_git.py
@@ -373,6 +373,7 @@ class GitModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin,
             "image-to-text": GitForCausalLM,
             "text-generation": GitForCausalLM,
             "image-text-to-text": GitForCausalLM,
+            "visual-question-answering": GitForCausalLM,
             "any-to-any": GitForCausalLM,
         }
         if is_torch_available()

--- a/tests/pipelines/test_pipelines_visual_question_answering.py
+++ b/tests/pipelines/test_pipelines_visual_question_answering.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import tempfile
 import unittest
 
 from datasets import load_dataset
@@ -35,6 +36,7 @@ from .test_pipelines_common import ANY
 if is_torch_available():
     import torch
 
+    from transformers import AutoTokenizer, CLIPImageProcessor, GitConfig, GitForCausalLM
     from transformers.pipelines.pt_utils import KeyDataset
 
 
@@ -137,6 +139,55 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
         outputs = vqa_pipeline(image=image, question=question)
         self.assertEqual(outputs, [{"answer": ANY(str)}])
 
+    @require_torch
+    def test_small_model_pt_git(self):
+        # GIT uses GitForCausalLM for VQA (generative approach).
+        # Create a tiny GIT model from config since there is no public tiny-random model on the hub.
+        config = GitConfig(
+            vision_config={
+                "num_channels": 3,
+                "image_size": 30,
+                "patch_size": 15,
+                "hidden_size": 32,
+                "projection_dim": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+            },
+            vocab_size=30522,
+            hidden_size=32,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            intermediate_size=37,
+            max_position_embeddings=512,
+        )
+        model = GitForCausalLM(config)
+        model.eval()
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model.save_pretrained(tmp_dir)
+            # GIT uses a BertTokenizer and CLIPImageProcessor
+            tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-bert")
+            tokenizer.save_pretrained(tmp_dir)
+            image_processor = CLIPImageProcessor(size={"height": 30, "width": 30}, crop_size={"height": 30, "width": 30})
+            image_processor.save_pretrained(tmp_dir)
+
+            vqa_pipeline = pipeline(
+                "visual-question-answering",
+                model=tmp_dir,
+            )
+
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "How many cats are there?"
+
+        outputs = vqa_pipeline(image=image, question=question)
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(outputs, [[{"answer": ANY(str)}]] * 2)
+
     @slow
     @require_torch
     def test_large_model_pt(self):
@@ -186,6 +237,22 @@ class VisualQuestionAnsweringPipelineTests(unittest.TestCase):
 
         outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
         self.assertEqual(outputs, [[{"answer": "two"}]] * 2)
+
+    @slow
+    @require_torch
+    def test_large_model_pt_git(self):
+        vqa_pipeline = pipeline("visual-question-answering", model="microsoft/git-base-textvqa")
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        question = "How many cats are there?"
+
+        outputs = vqa_pipeline(image=image, question=question)
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
+
+        outputs = vqa_pipeline({"image": image, "question": question})
+        self.assertEqual(outputs, [{"answer": ANY(str)}])
+
+        outputs = vqa_pipeline([{"image": image, "question": question}, {"image": image, "question": question}])
+        self.assertEqual(outputs, [[{"answer": ANY(str)}]] * 2)
 
     @require_torch
     def test_small_model_pt_image_list(self):


### PR DESCRIPTION
## Summary
- Adds `GitForCausalLM` to `MODEL_FOR_VISUAL_QUESTION_ANSWERING_MAPPING_NAMES` so GIT can be used with the `visual-question-answering` pipeline
- Filters tokenizer outputs in VQA pipeline `preprocess` to only pass keys accepted by the model's `forward` method (fixes `token_type_ids` error with BERT-based tokenizers used by GIT)
- Adds `visual-question-answering` to GIT's `pipeline_model_mapping` in tests
- Adds both a fast unit test (tiny model from config) and a slow integration test for GIT VQA

Fixes part of #21110

## Motivation

GIT (Generative Image-to-text Transformer) supports VQA as a generative task where the question is used as a text prefix and the answer is generated auto-regressively. The VQA pipeline already handles generative models via `can_generate()`, so the main change is registering GIT in the model mapping and ensuring tokenizer compatibility.

## Test plan
- [x] Existing VQA pipeline tests pass (ViLT, BLIP2)
- [x] New `test_small_model_pt_git` test passes with tiny model created from config
- [x] New `test_large_model_pt_git` slow test added for `microsoft/git-base-textvqa`
- [x] All 6 non-slow VQA pipeline tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)