### PR TITLE
add jamba tokenizer mapping to PreTrainedTokenizerFast (v4/v5 BC)

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -160,6 +160,7 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, str | None](
         ("instructblipvideo", "GPT2Tokenizer" if is_tokenizers_available() else None),
         ("internvl", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("jais2", "GPT2Tokenizer" if is_tokenizers_available() else None),
+        ("jamba", "PreTrainedTokenizerFast" if is_tokenizers_available() else None),
         ("kosmos-2", "XLMRobertaTokenizer" if is_tokenizers_available() else None),
         ("lasr_ctc", "ParakeetTokenizer" if is_tokenizers_available() else None),
         ("lasr_encoder", "ParakeetTokenizer" if is_tokenizers_available() else None),


### PR DESCRIPTION
add jamba tokenizer mapping to PreTrainedTokenizerFast (v4/v5 BC)

for vllm: https://buildkite.com/vllm/ci/builds/52260/steps/canvas?sid=019c76ad-c8f2-4e59-a2f4-5f3b5bbc204c&tab=output