### PR TITLE
[`Flash Attn`] Enable compatible implementations

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1787,8 +1787,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             base_implementation = attn_implementation.removeprefix("paged|")
 
             compatible_flash_implementations = getattr(self, "_compatible_flash_implementations", None)
-            if compatible_flash_implementations and is_flash_attention_requested(requested_attention_implementation=base_implementation) and base_implementation not in compatible_flash_implementations:
-                default_flash_implementation = f"paged|{compatible_flash_implementations[0]}" if is_paged else compatible_flash_implementations[0]
+            if (
+                compatible_flash_implementations
+                and is_flash_attention_requested(requested_attention_implementation=base_implementation)
+                and base_implementation not in compatible_flash_implementations
+            ):
+                default_flash_implementation = (
+                    f"paged|{compatible_flash_implementations[0]}" if is_paged else compatible_flash_implementations[0]
+                )
 
                 logger.warning_once(
                     f"This model is compatible with the following flash attention implementations: `{compatible_flash_implementations}`. "

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1144,9 +1144,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
     _supports_sdpa: bool = False
     _supports_flash_attn: bool = False
     _supports_flex_attn: bool = False
-    _default_flash_implementation: str | None = (
-        None  # Model's preferred flash kernel (e.g., "kernels-community/flash-mla")
-    )
+    # Model's compatible flash kernels (e.g., "kernels-community/flash-mla") defaulting to the first in the list
+    _compatible_flash_implementations: list[str] | None = None
 
     # Tensor-parallelism-related properties
     # A tensor parallel plan of the form `{"model.layer.mlp.param": "colwise"}` to be applied to the model when TP is enabled.
@@ -1782,19 +1781,20 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             `str`: The final attention implementation to use, including potential fallbacks from sdpa to eager, or from
             None to sdpa (to potentially eager).
         """
-        # Auto-correct flash_attention_2/3 to model's default flash implementation if specified
+        # Auto-correct model's default flash implementation if specified
         if attn_implementation is not None:
             is_paged = attn_implementation.startswith("paged|")
-            base_impl = attn_implementation.removeprefix("paged|")
+            base_implementation = attn_implementation.removeprefix("paged|")
 
-            if base_impl in ("flash_attention_2", "flash_attention_3"):
-                default_flash = getattr(self, "_default_flash_implementation", None)
-                if default_flash is not None:
-                    logger.warning_once(
-                        f"This model is optimized for '{default_flash}'. "
-                        f"Automatically using '{default_flash}' instead of '{attn_implementation}'."
-                    )
-                    attn_implementation = f"paged|{default_flash}" if is_paged else default_flash
+            compatible_flash_implementations = getattr(self, "_compatible_flash_implementations", None)
+            if compatible_flash_implementations and is_flash_attention_requested(requested_attention_implementation=base_implementation) and base_implementation not in compatible_flash_implementations:
+                default_flash_implementation = f"paged|{compatible_flash_implementations[0]}" if is_paged else compatible_flash_implementations[0]
+
+                logger.warning_once(
+                    f"This model is compatible with the following flash attention implementations: `{compatible_flash_implementations}`. "
+                    f"Automatically falling back to `{default_flash_implementation}` instead of `{attn_implementation}`."
+                )
+                attn_implementation = default_flash_implementation
 
         applicable_attn_implementation = attn_implementation
 

--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -653,7 +653,7 @@ class GlmMoeDsaPreTrainedModel(PreTrainedModel):
     # NOTE: FP8 quantization uses `_keep_in_fp32_modules` (not `_strict`) to decide which modules to NOT convert.
     # We must keep `indexer.weights_proj` as a plain Linear to match the checkpoint (no `weight_scale_inv`).
     _keep_in_fp32_modules = ["indexer.weights_proj"]
-    _default_flash_implementation = "kernels-community/flash-mla"
+    _compatible_flash_implementations = ["kernels-community/flash-mla"]
 
     @torch.no_grad()
     def _init_weights(self, module):

--- a/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
@@ -619,7 +619,7 @@ class GlmMoeDsaPreTrainedModel(Glm4MoePreTrainedModel):
     _supports_flash_attn = False  # flash-mla kernels need a bit more work in the way we enable them!
     _supports_sdpa = True
     _supports_flex_attn = False
-    _default_flash_implementation = "kernels-community/flash-mla"
+    _compatible_flash_implementations = ["kernels-community/flash-mla"]
 
 
 class GlmMoeDsaModel(Glm4MoeModel):

--- a/src/transformers/models/gpt_oss/configuration_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/configuration_gpt_oss.py
@@ -118,22 +118,5 @@ class GptOssConfig(PreTrainedConfig):
         self.eos_token_id = eos_token_id
         super().__init__(**kwargs)
 
-    def __setattr__(self, key, value):
-        """
-        Overwritten to allow checking for the proper attention implementation to be used.
-
-        Due to `set_attn_implementation` which internally assigns `_attn_implementation_internal = "..."`, simply overwriting
-        the specific attention setter is not enough. Using a property/setter for `_attn_implementation_internal` would result in
-        a recursive dependency (as `_attn_implementation` acts as a wrapper around `_attn_implementation_internal`) - hence, this
-        workaround.
-        """
-        if key in ("_attn_implementation", "_attn_implementation_internal"):
-            if value and "flash" in value and value.removeprefix("paged|") != "kernels-community/vllm-flash-attn3":
-                raise ValueError(
-                    f"GPT-OSS model does not support the specified flash attention implementation: {value}. "
-                    "Only `kernels-community/vllm-flash-attn3` is supported."
-                )
-        super().__setattr__(key, value)
-
 
 __all__ = ["GptOssConfig"]

--- a/src/transformers/models/gpt_oss/modeling_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modeling_gpt_oss.py
@@ -410,7 +410,7 @@ class GptOssPreTrainedModel(PreTrainedModel):
         "attentions": GptOssAttention,
     }
     _keep_in_fp32_modules = ["post_attention_layernorm", "input_layernorm", "norm"]
-    _default_flash_implementation = "kernels-community/vllm-flash-attn3"
+    _compatible_flash_implementations = ["kernels-community/vllm-flash-attn3"]
 
     @torch.no_grad()
     def _init_weights(self, module):

--- a/src/transformers/models/gpt_oss/modular_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/modular_gpt_oss.py
@@ -319,7 +319,7 @@ class GptOssDecoderLayer(LlamaDecoderLayer):
 class GptOssPreTrainedModel(LlamaPreTrainedModel):
     _keep_in_fp32_modules = ["post_attention_layernorm", "input_layernorm", "norm"]
     _supports_sdpa = False
-    _default_flash_implementation = "kernels-community/vllm-flash-attn3"
+    _compatible_flash_implementations = ["kernels-community/vllm-flash-attn3"]
     _can_record_outputs = {
         "router_logits": OutputRecorder(GptOssTopKRouter, index=0),
         "hidden_states": GptOssDecoderLayer,

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -94,7 +94,9 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
         # Option 2: Auto correction on load time
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             tmp_model.save_pretrained(tmp_dir_name)
-            model = GptOssModel.from_pretrained(tmp_dir_name, attn_implementation="flash_attention_2").to(device=torch_device)
+            model = GptOssModel.from_pretrained(tmp_dir_name, attn_implementation="flash_attention_2").to(
+                device=torch_device
+            )
             self.assertEqual(model.config._attn_implementation, expected_kernel)
 
         # Option 3: Auto correction on `set_attn_implementation`

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -33,7 +33,6 @@ from transformers import (
 from transformers.testing_utils import (
     cleanup,
     require_deterministic_for_xpu,
-    require_flash_attn,
     require_kernels,
     require_torch,
     require_torch_accelerator,
@@ -72,43 +71,12 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
     model_tester_class = GptOssModelTester
 
     @require_kernels
-    @require_flash_attn
-    @pytest.mark.flash_attn_test
-    @require_torch_gpu
-    def test_initialization_raises_error_for_flash_attn(self):
-        """
-        Tests that initializing the model with unsupported Flash Attention implementations raises a ValueError,
-        but allows the specific vllm kernel.
-        """
-
-        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
-        kernel_attn = "kernels-community/vllm-flash-attn3"
-
-        # Checking each via `set_attn_implementation` and manually setting within the config
-        model = GptOssModel(config).to(device=torch_device, dtype=torch.bfloat16)
-        model.set_attn_implementation("kernels-community/vllm-flash-attn3")
-        self.assertTrue(model.config._attn_implementation == kernel_attn)
-
-        config._attn_implementation = kernel_attn
-        self.assertTrue(model.config._attn_implementation == kernel_attn)
-
-        with torch.no_grad():
-            output = model(**inputs_dict)
-        self.assertIsNotNone(output)
-
-        with self.assertRaisesRegex(ValueError, "GPT-OSS model does not support"):
-            model.set_attn_implementation("flash_attention_2")
-
-        with self.assertRaisesRegex(ValueError, "GPT-OSS model does not support"):
-            config._attn_implementation = "flash_attention_2"
-
-    @require_kernels
     @pytest.mark.flash_attn_test
     @require_torch_gpu
     def test_default_flash_implementation_auto_correction(self):
         """
         Tests that setting attn_implementation="flash_attention_2" during model initialization
-        automatically corrects to the model's _default_flash_implementation.
+        automatically corrects to the model's `_compatible_flash_implementations`.
         """
         from kernels import get_kernel
 
@@ -117,11 +85,22 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
         flash = get_kernel(expected_kernel)
         if flash is None:
             self.skipTest(f"{expected_kernel} is not available, skipping auto-correction test.")
-        # Set flash_attention_2 in config before model init - should get auto-corrected
-        config._attn_implementation_internal = "flash_attention_2"
-        model = GptOssModel(config).to(device=torch_device, dtype=torch.bfloat16)
 
-        # Verify it was auto-corrected to the model's default flash implementation
+        # Option 1: Auto correction on setting config on init
+        config._attn_implementation = "flash_attention_2"
+        tmp_model = GptOssModel(config).to(device=torch_device, dtype=torch.bfloat16)
+        self.assertEqual(tmp_model.config._attn_implementation, expected_kernel)
+
+        # Option 2: Auto correction on load time
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            tmp_model.save_pretrained(tmp_dir_name)
+            model = GptOssModel.from_pretrained(tmp_dir_name, attn_implementation="flash_attention_2").to(device=torch_device)
+            self.assertEqual(model.config._attn_implementation, expected_kernel)
+
+        # Option 3: Auto correction on `set_attn_implementation`
+        model.set_attn_implementation("eager")
+        self.assertEqual(model.config._attn_implementation, "eager")
+        model.set_attn_implementation("flash_attention_2")
         self.assertEqual(model.config._attn_implementation, expected_kernel)
 
         # Verify model still works


### PR DESCRIPTION
As per title, spiritual successor to #44081

Why? Because as is
- Only defaults for fa2/fa3, not on other requested kernels
- Limits implementations to one kernel/implementation while I suspect that there will be multiple viable versions (in the future), e.g. FA4 integrates attention sinks natively