### PR TITLE
Remove refs to grouped_entities

### DIFF
--- a/docs/source/it/migration.md
+++ b/docs/source/it/migration.md
@@ -35,7 +35,7 @@ Ciò introduce due modifiche sostanziali:
 
 ##### Come ottenere lo stesso comportamento di v3.x in v4.x
 
-- Le pipeline ora contengono funzionalità aggiuntive pronte all'uso. Vedi la [pipeline di classificazione dei token con il flag `grouped_entities`](main_classes/pipelines#transformers.TokenClassificationPipeline).
+- Le pipeline ora contengono funzionalità aggiuntive pronte all'uso. Vedi la [pipeline di classificazione dei token con il parametro `aggregation_strategy`](main_classes/pipelines#transformers.TokenClassificationPipeline).
 - Gli auto-tokenizer ora restituiscono tokenizer rust. Per ottenere invece i tokenizer python, l'utente deve usare il flag `use_fast` impostandolo `False`:
 
 Nella versione `v3.x`:

--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -63,9 +63,6 @@ class AggregationStrategy(ExplicitEnum):
     r"""
         ignore_labels (`list[str]`, defaults to `["O"]`):
             A list of labels to ignore.
-        grouped_entities (`bool`, *optional*, defaults to `False`):
-            DEPRECATED, use `aggregation_strategy` instead. Whether or not to group the tokens corresponding to the
-            same entity together in the predictions or not.
         stride (`int`, *optional*):
             If stride is provided, the pipeline is applied on all the text. The text is split into chunks of size
             model_max_length. Works only with fast tokenizers and `aggregation_strategy` different from `NONE`. The


### PR DESCRIPTION
Our code has some references to the `grouped_entities` arg to the token classification pipeline, but this is no longer usable. This PR cleans them up entirely!

Fixes #44016