### PR TITLE
fix: don't move model to device under other dist train backends

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1353,7 +1353,9 @@ class Trainer:
 
         # When fp16/bf16 full eval is enabled, __init__ skips device placement so that
         # evaluation_loop can cast dtype and move in one step. Move the model now for training.
-        if (args.fp16_full_eval or args.bf16_full_eval) and not self.is_model_parallel and self.model_init is None:
+        if (args.fp16_full_eval or args.bf16_full_eval) and not self.is_model_parallel and not self.is_deepspeed_enabled \
+            and not self.is_fsdp_xla_enabled and not self.is_fsdp_enabled and not is_sagemaker_mp_enabled() \
+            and self.model_init is None:
             self._move_model_to_device(self.model, args.device)
 
         # This might change the seed so needs to run first.


### PR DESCRIPTION
# What does this PR do?

Under fp16_full_eval or bf16_full_eval, still don't move model to device if using another dist train backend.

This is causing bugs with FSDP2 + bf16_full_eval. The dist train backend would still be in charge of moving model to device.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@SunMarc