### PR TITLE
Fix #44079: `ModelOutput` keys aren't correctly assigned if key was prev

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -427,7 +427,9 @@ class ModelOutput(OrderedDict):
             return self.to_tuple()[k]
 
     def __setattr__(self, name, value):
-        if name in self.keys() and value is not None:
+        if value is not None and (
+            name in self.keys() or (is_dataclass(self) and name in {f.name for f in fields(self)})
+        ):
             # Don't call self.__setitem__ to avoid recursion errors
             super().__setitem__(name, value)
         super().__setattr__(name, value)


### PR DESCRIPTION
Fixes #44079

## Summary
This PR fixes: `ModelOutput` keys aren't correctly assigned if key was previously None

## Changes
```
src/transformers/utils/generic.py | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*