### PR TITLE
Fix #43986: Confusing crash when loading a video model through AutoProce

### DIFF
--- a/src/transformers/models/auto/video_processing_auto.py
+++ b/src/transformers/models/auto/video_processing_auto.py
@@ -95,6 +95,8 @@ VIDEO_PROCESSOR_MAPPING = _LazyAutoMapping(CONFIG_MAPPING_NAMES, VIDEO_PROCESSOR
 
 def video_processor_class_from_name(class_name: str):
     for module_name, extractors in VIDEO_PROCESSOR_MAPPING_NAMES.items():
+        if extractors is None:
+            continue
         if class_name in extractors:
             module_name = model_type_to_module_name(module_name)
 


### PR DESCRIPTION
Fixes #43986

## Summary
This PR fixes: Confusing crash when loading a video model through AutoProcessor without torchvision installed

## Changes
```
src/transformers/models/auto/video_processing_auto.py | 2 ++
 1 file changed, 2 insertions(+)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*