### PR TITLE
Fix #44062: TypeError: tokenizers.AddedToken() got multiple values for k

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1836,12 +1836,12 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                     if key in kwargs and kwargs[key]:
                         continue  # User-provided kwargs take precedence
                     if isinstance(value, dict) and key != "extra_special_tokens":
-                        value = AddedToken(**value, special=True)
+                        value = AddedToken(**{**value, "special": value.get("special", True)})
                     elif key == "extra_special_tokens" and isinstance(value, list):
                         # Merge list tokens, converting dicts to AddedToken
                         existing = list(init_kwargs.get("extra_special_tokens") or [])
                         for tok in value:
-                            tok = AddedToken(**tok, special=True) if isinstance(tok, dict) else tok
+                            tok = AddedToken(**{**tok, "special": tok.get("special", True)}) if isinstance(tok, dict) else tok
                             if tok not in existing:
                                 existing.append(tok)
                         value = existing


### PR DESCRIPTION
Fixes #44062

## Summary
This PR fixes: TypeError: tokenizers.AddedToken() got multiple values for keyword argument 'special'

## Changes
```
src/transformers/tokenization_utils_base.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*