### PR TITLE
Fix #43937: [GLM-5] ValueError: GenerationConfig is invalid

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -757,6 +757,7 @@ class GenerationConfig(PushToHubMixin):
         save_directory: str | os.PathLike,
         config_file_name: str | os.PathLike | None = None,
         push_to_hub: bool = False,
+        strict: bool = True,
         **kwargs,
     ):
         r"""
@@ -772,6 +773,10 @@ class GenerationConfig(PushToHubMixin):
                 Whether or not to push your model to the Hugging Face model hub after saving it. You can specify the
                 repository you want to push to with `repo_id` (will default to the name of `save_directory` in your
                 namespace).
+            strict (`bool`, *optional*, defaults to `True`):
+                Whether to strictly enforce that the configuration is valid before saving. If `True`, a `ValueError`
+                is raised when the configuration is invalid, and the configuration is not saved. If `False`, invalid
+                configurations are saved with a warning, so they can be fixed at a later time.
             kwargs (`dict[str, Any]`, *optional*):
                 Additional key word arguments passed along to the [`~utils.PushToHubMixin.push_to_hub`] method.
         """
@@ -782,7 +787,13 @@ class GenerationConfig(PushToHubMixin):
         try:
             self.validate(strict=True)
         except ValueError as exc:
-            raise ValueError(str(exc) + "\n\nFix these issues to save the configuration.")
+            if strict:
+                raise ValueError(str(exc) + "\n\nFix these issues to save the configuration.")
+            else:
+                logger.warning(
+                    "The generation configuration is invalid -- you should fix it prior to using it with "
+                    f"`model.generate()`. The following issues were found:\n{exc}"
+                )
 
         config_file_name = config_file_name if config_file_name is not None else GENERATION_CONFIG_NAME
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3260,7 +3260,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             if not _hf_peft_config_loaded:
                 model_to_save.config.save_pretrained(save_directory)
             if self.can_generate():
-                model_to_save.generation_config.save_pretrained(save_directory)
+                model_to_save.generation_config.save_pretrained(save_directory, strict=False)
 
             if _hf_peft_config_loaded:
                 logger.info(

--- a/tests/generation/test_configuration_utils.py
+++ b/tests/generation/test_configuration_utils.py
@@ -272,6 +272,30 @@ class GenerationConfigTest(unittest.TestCase):
             self.assertEqual(len(captured_logs.out), 0)
             self.assertEqual(len(os.listdir(tmp_dir)), 1)
 
+    def test_save_with_invalid_config_non_strict(self):
+        """Tests that we can save an invalid generation config when strict=False (used by model.save_pretrained)."""
+        logger = transformers_logging.get_logger("transformers.generation.configuration_utils")
+
+        # An invalid config (top_p set without do_sample=True, as seen in some hub models like GLM-5) should
+        # warn but still save when strict=False.
+        config = GenerationConfig()
+        config.top_p = 0.95  # invalid without do_sample=True
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            logger.warning_once.cache_clear()
+            with CaptureLogger(logger) as captured_logs:
+                config.save_pretrained(tmp_dir, strict=False)
+            # A warning should be issued about the invalid config
+            self.assertIn("invalid", captured_logs.out)
+            # The file should still be saved
+            self.assertEqual(len(os.listdir(tmp_dir)), 1)
+
+        # strict=True (the default) should still raise and not save
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            with self.assertRaises(ValueError):
+                config.save_pretrained(tmp_dir, strict=True)
+            self.assertEqual(len(os.listdir(tmp_dir)), 0)
+
     def test_generation_mode(self):
         """Tests that the `get_generation_mode` method is working as expected."""
         config = GenerationConfig()


### PR DESCRIPTION
Fixes #43937

## Summary
This PR fixes: [GLM-5] ValueError: GenerationConfig is invalid

## Changes
```
src/transformers/generation/configuration_utils.py | 13 +++++++++++-
 src/transformers/modeling_utils.py                 |  2 +-
 tests/generation/test_configuration_utils.py       | 24 ++++++++++++++++++++++
 3 files changed, 37 insertions(+), 2 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: high. Happy to make any adjustments!*