### PR TITLE
Fix #43975: `deepseek-ai/deepseek-coder-6.7b-instruct` incorrectly detok

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -116,7 +116,8 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             return local_kwargs
         elif fast_tokenizer_file is not None and os.path.isfile(fast_tokenizer_file):
             # we extract vocab / merges from the tokenizer file to pass them to __init__
-            processor = TokenizerFast.from_file(fast_tokenizer_file).post_processor
+            _loaded_fast_tokenizer = TokenizerFast.from_file(fast_tokenizer_file)
+            processor = _loaded_fast_tokenizer.post_processor
             with open(fast_tokenizer_file, encoding="utf-8") as tokenizer_handle:
                 tokenizer_json = json.load(tokenizer_handle)
             vocab = tokenizer_json.get("model", {}).get("vocab", None)
@@ -141,6 +142,15 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
             if processor is not None:
                 local_kwargs["post_processor"] = processor
+
+            # If the tokenizer uses a ByteLevel decoder (e.g., GPT-2-style tokenizers like deepseek-coder
+            # that are tagged as LlamaTokenizerFast), pass the original tokenizer object so its decoder
+            # and pre-tokenizer are preserved. Without this, the class's custom __init__ would replace
+            # them with an incompatible Metaspace-based setup, causing spaces to be dropped on decode.
+            decoder_config = tokenizer_json.get("decoder", {})
+            if isinstance(decoder_config, dict) and decoder_config.get("type") == "ByteLevel":
+                local_kwargs["tokenizer_object"] = _loaded_fast_tokenizer
+
             return local_kwargs
 
         vocab_file = local_kwargs.get("vocab_file")

--- a/tests/models/llama/test_tokenization_llama.py
+++ b/tests/models/llama/test_tokenization_llama.py
@@ -1,3 +1,6 @@
+import json
+import os
+import tempfile
 import unittest
 
 from tests.test_tokenization_common import TokenizerTesterMixin
@@ -35,3 +38,60 @@ class LlamaTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     def get_tokenizers(self, **kwargs):
         kwargs.setdefault("pad_token", "<PAD>")
         return super().get_tokenizers(**kwargs)
+
+    def test_bytelevel_decoder_preserved_on_load(self):
+        """
+        Regression test for https://github.com/huggingface/transformers/issues/43975
+
+        Some models (e.g. deepseek-ai/deepseek-coder-6.7b-instruct) declare
+        ``tokenizer_class: LlamaTokenizerFast`` in their tokenizer_config.json but use
+        a GPT-2-style ByteLevel decoder rather than the SentencePiece Metaspace decoder
+        that ``LlamaTokenizer.__init__`` normally configures.  When loaded with v5, the
+        custom ``__init__`` was replacing the correct ByteLevel decoder with a Metaspace
+        one, causing all spaces to be silently dropped on decode.
+        """
+        from tokenizers import Tokenizer, decoders, models, pre_tokenizers, trainers
+        from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+
+        # Build a minimal ByteLevel BPE tokenizer (same style as deepseek-coder).
+        tokenizer_backend = Tokenizer(models.BPE(unk_token="<unk>"))
+        tokenizer_backend.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+        tokenizer_backend.decoder = decoders.ByteLevel()
+
+        trainer = trainers.BpeTrainer(
+            vocab_size=500,
+            special_tokens=["<unk>", "<s>", "</s>"],
+        )
+        tokenizer_backend.train_from_iterator(
+            [
+                "simple test sentence",
+                "hello world foo bar baz",
+                "a b c d e f g h i j k l m n o p q r s t u v w x y z",
+            ],
+            trainer=trainer,
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            tokenizer_backend.save(os.path.join(tmp_dir, "tokenizer.json"))
+
+            # Mimic the tokenizer_config.json that deepseek-coder ships with.
+            tokenizer_config = {
+                "tokenizer_class": "LlamaTokenizerFast",
+                "bos_token": "<s>",
+                "eos_token": "</s>",
+                "unk_token": "<unk>",
+                "legacy": True,
+            }
+            with open(os.path.join(tmp_dir, "tokenizer_config.json"), "w") as f:
+                json.dump(tokenizer_config, f)
+
+            loaded = LlamaTokenizer.from_pretrained(tmp_dir)
+
+            # The decoder must still be ByteLevel, not replaced by the Metaspace decoder.
+            self.assertIsInstance(loaded._tokenizer.decoder, ByteLevelDecoder)
+
+            # Spaces must be preserved in an encode → decode round-trip.
+            test_input = "simple test sentence"
+            ids = loaded.encode(test_input, add_special_tokens=False)
+            decoded = loaded.decode(ids, skip_special_tokens=True)
+            self.assertEqual(decoded, test_input)


### PR DESCRIPTION
Fixes #43975

## Summary
This PR fixes: `deepseek-ai/deepseek-coder-6.7b-instruct` incorrectly detokenizes in v5

## Changes
```
src/transformers/tokenization_utils_tokenizers.py | 12 ++++-
 tests/models/llama/test_tokenization_llama.py     | 60 +++++++++++++++++++++++
 2 files changed, 71 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*