### PR TITLE
fix: propagate `weights_only` param to `load_state_dict` in .bin loading path (#43782)

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4208,7 +4208,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             elif checkpoint_files is not None:
                 merged_state_dict = {}
                 for ckpt_file in checkpoint_files:
-                    merged_state_dict.update(load_state_dict(ckpt_file))
+                    merged_state_dict.update(
+                        load_state_dict(ckpt_file, map_location="cpu", weights_only=load_config.weights_only)
+                    )
             else:
                 raise ValueError("Neither a state dict nor checkpoint files were found.")
 


### PR DESCRIPTION
Fixes #43782 

The `weights_only` parameter passed to `from_pretrained()` was not being forwarded to `load_state_dict()` when loading `.bin` checkpoint files in the non-DeepSpeed code path. This caused `weights_only` to always default to `True`, ignoring the user's explicit `weights_only=False` setting and resulting in `_pickle.UnpicklingError` for checkpoints containing non-tensor Python objects.

So i fixed `weights_only` parameter not being forwarded to `load_state_dict()` when loading `.bin` checkpoints in the non-DeepSpeed code path, causing `_pickle.UnpicklingError` even when users explicitly pass `weights_only=False` to `from_pretrained()`

The `weights_only` parameter passed to `from_pretrained()` is correctly stored in `LoadStateDictConfig` (line 4091) and correctly used in the DeepSpeed Zero-3 path (line 4184), but was missing from the regular `.bin` loading path (line 4211). This caused `load_state_dict()` to always use its default `weights_only=True`, ignoring the user's setting.

The fix adds `map_location="cpu"` and `weights_only=load_config.weights_only` to match the DeepSpeed path exactly.

## Tests ran
- [x] Verified all three `load_state_dict()` call sites in `modeling_utils.py` now explicitly pass `weights_only`
- [x] Tested `.bin` checkpoint loading with `weights_only=False` succeeds for checkpoints containing non-tensor Python objects
- [x] Tested `.bin` checkpoint loading with `weights_only=True` (default) still works for standard tensor-only checkpoints

