### PR TITLE
Fix: bidirectional mask skip when attention dropout is active (#44188)

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -305,6 +305,7 @@ def _ignore_bidirectional_mask_sdpa(
     padding_mask: torch.Tensor | None,
     kv_length: int,
     local_attention_size: int | None = None,
+    dropout: float = 0.0,
 ) -> bool:
     """
     Detects whether the bidirectional mask can be ignored in case PyTorch's SDPA is used.
@@ -314,6 +315,12 @@ def _ignore_bidirectional_mask_sdpa(
     allowing to dispatch to the flash attention kernel (that can otherwise not be used if a custom `attn_mask` is
     passed).
     """
+    # when dropout is used, different sdpa backends handle dropout rng differently;
+    # to ensure consistent numerics between eager and compiled modes, we should not,
+    # skip mask creation when dropout is active. [see: https://github.com/huggingface/transformers/issues/44188]
+    if dropout > 0.0:
+        return False
+
     if _is_torch_xpu_available:
         # XPU devices have special handling for mask skipping:
         # - Skip if no padding and no local attention constraint
@@ -376,6 +383,7 @@ def sdpa_mask(
     allow_is_bidirectional_skip: bool = False,
     allow_torch_fix: bool = True,
     use_vmap: bool = False,
+    dropout: float = 0.0,
     **kwargs,
 ) -> torch.Tensor | None:
     """
@@ -487,7 +495,7 @@ def sdpa_mask(
     #   2. Bidirectional do not need any further processing (no bias)
     if allow_is_causal_skip and _ignore_causal_mask_sdpa(padding_mask, q_length, kv_length, kv_offset, local_size):
         return None
-    if allow_is_bidirectional_skip and _ignore_bidirectional_mask_sdpa(padding_mask, kv_length, local_size):
+    if allow_is_bidirectional_skip and _ignore_bidirectional_mask_sdpa(padding_mask, kv_length, local_size, dropout):
         return None
 
     # Potentially add the padding 2D mask
@@ -541,6 +549,7 @@ def eager_mask(
     dtype: torch.dtype = torch.float32,
     allow_is_bidirectional_skip: bool = False,
     use_vmap: bool = False,
+    dropout: float = 0.0,
     **kwargs,
 ) -> torch.Tensor:
     """
@@ -584,6 +593,7 @@ def eager_mask(
         allow_is_bidirectional_skip=allow_is_bidirectional_skip,
         allow_torch_fix=False,
         use_vmap=use_vmap,
+        dropout=dropout,
         **kwargs,
     )
     # only bidirectional masks can be skipped, otherwise we convert bool -> float
@@ -995,6 +1005,12 @@ def create_bidirectional_mask(
 
     # Allow skipping the mask creation except we have additional masking operators (and/or masks)
     allow_is_bidirectional_skip = True
+    # extract attention dropout for sdpa, where different backends handle dropout rng differently
+    attention_dropout = 0.0
+    if config._attn_implementation == "sdpa":
+        attention_dropout = (
+            getattr(config, "attention_probs_dropout_prob", None) or getattr(config, "attention_dropout", 0.0) or 0.0
+        )
     # Defaulting to using non-vmap based mask creations except when detecting
     # users passing custom mask functions (as we cannot guarantee that they
     # are properly index-based as required by our implementation).
@@ -1027,6 +1043,7 @@ def create_bidirectional_mask(
         # Additional kwargs for sdpa
         allow_is_causal_skip=False,
         allow_is_bidirectional_skip=allow_is_bidirectional_skip,
+        dropout=attention_dropout,  # additional kwarg for sdpa/eager to prevent skip when dropout is active
         dtype=dtype,  # Additional kwarg for eager
         config=config,  # Pass the config as well, in case someone wants to easily have their own mask_interface
         use_vmap=use_vmap,  # Short-circuit to non-vmap expansions for the mask
@@ -1199,6 +1216,13 @@ def create_bidirectional_sliding_window_mask(
 
     use_vmap = False
     allow_is_bidirectional_skip = True
+    # extracts attention dropout from the config (as different models use different attribute names)
+    # only relevant for sdpa, where different backends handle dropout rng differently
+    attention_dropout = 0.0
+    if config._attn_implementation == "sdpa":
+        attention_dropout = (
+            getattr(config, "attention_probs_dropout_prob", None) or getattr(config, "attention_dropout", 0.0) or 0.0
+        )
 
     if or_mask_function is not None:
         if not _is_torch_greater_or_equal_than_2_6:
@@ -1222,6 +1246,7 @@ def create_bidirectional_sliding_window_mask(
         attention_mask=attention_mask,
         allow_is_causal_skip=False,
         allow_is_bidirectional_skip=allow_is_bidirectional_skip,
+        dropout=attention_dropout,  # additional kwarg for sdpa/eager to prevent skip when dropout is active
         local_size=sliding_window,  # Additional kwarg for sdpa
         dtype=dtype,  # Additional kwarg for eager
         config=config,  # Pass the config as well, in case someone wants to easily have their own mask_interface

--- a/tests/utils/test_masking_utils.py
+++ b/tests/utils/test_masking_utils.py
@@ -385,3 +385,40 @@ class MaskTest(unittest.TestCase):
 
         self.assertTrue(padded_mask[0] is not None)
         self.assertTrue(padded_mask[1] is not None)
+
+    def test_bidirectional_mask_no_skip_with_dropout(self):
+        """
+        checks that when attention dropout is active, bidirectional mask creation does not skip mask creation.
+        this prevents numerical divergence between eager and compiled modes due to different sdpa backends
+        handling dropout rng differently. [see: https://github.com/huggingface/transformers/issues/44188]
+        """
+        batch_size = 2
+        q_length = 10
+
+        inputs_embeds = torch.ones((batch_size, q_length, 1), dtype=torch.float16)
+
+        # case 1 - with dropout > 0, mask should not be skipped(even with full mask/no padding)
+        config_with_dropout = LlamaConfig()
+        config_with_dropout._attn_implementation = "sdpa"
+        config_with_dropout.attention_dropout = 0.1
+
+        mask_with_dropout = create_bidirectional_mask(
+            config=config_with_dropout,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+        )
+        # mask should be materialized(not None) as dropout is active
+        self.assertTrue(mask_with_dropout is not None)
+
+        # case 2 - with dropout = 0, mask should be skipped(returns None)
+        config_no_dropout = LlamaConfig()
+        config_no_dropout._attn_implementation = "sdpa"
+        config_no_dropout.attention_dropout = 0.0
+
+        mask_no_dropout = create_bidirectional_mask(
+            config=config_no_dropout,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+        )
+        # mask should be skipped(None) as no dropout
+        self.assertTrue(mask_no_dropout is None)


### PR DESCRIPTION
# What does this PR do?

When `torch.compile` is used, [_ignore_bidirectional_mask_sdpa](cci:1://file:///c:/Users/BIT/Desktop/proj/gitrepo_clones/transformers/src/transformers/masking_utils.py:303:0-338:16) behaves differently than in eager mode due to the [is_tracing()](cci:1://file:///c:/Users/BIT/Desktop/proj/gitrepo_clones/transformers/src/transformers/utils/import_utils.py:1390:0-1402:22) check. In eager mode (no tracing), the bidirectional mask is skipped (returns `None`), allowing SDPA to dispatch to flash attention. Under `torch.compile` ([is_tracing()](cci:1://file:///c:/Users/BIT/Desktop/proj/gitrepo_clones/transformers/src/transformers/utils/import_utils.py:1390:0-1402:22) returns `True`), the mask is materialized, causing SDPA to use the memory-efficient backend instead.

When attention dropout is active (like, BERT's default `attention_probs_dropout_prob=0.1`), these two backends handle dropout RNG differently, leading to large numerical divergences.

**Fix:** adding a [dropout](cci:1://file:///c:/Users/BIT/Desktop/proj/gitrepo_clones/transformers/tests/utils/test_masking_utils.py:388:4-423:48) condition to [_ignore_bidirectional_mask_sdpa](cci:1://file:///c:/Users/BIT/Desktop/proj/gitrepo_clones/transformers/src/transformers/masking_utils.py:303:0-338:16) - when `dropout > 0`, mask creation is never skipped, ensuring the same SDPA backend is used in both eager and compiled modes. The dropout value is extracted from the model-config (supporting both `attention_probs_dropout_prob` and `attention_dropout` attribute names).

Fixes #44188

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
      - https://github.com/huggingface/transformers/issues/44188
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@vasqu @ArthurZucker @CyrilVallez