### PR TITLE
fix(layoutlmv2): store only_label_first_subword attribute in tokenizer

### DIFF
--- a/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
+++ b/src/transformers/models/layoutlmv2/tokenization_layoutlmv2.py
@@ -221,6 +221,7 @@ class LayoutLMv2Tokenizer(TokenizersBackend):
         self.sep_token_box = sep_token_box
         self.pad_token_box = pad_token_box
         self.pad_token_label = pad_token_label
+        self.only_label_first_subword = only_label_first_subword
 
         # Now set post_processor with actual token IDs
         cls = str(self.cls_token)


### PR DESCRIPTION
## What does this PR do?

Fixes #44186

`LayoutLMv2Tokenizer.__init__` passes `only_label_first_subword` to `super().__init__()` but never stores it as `self.only_label_first_subword`. This causes an `AttributeError` when `word_labels` is passed for NER token classification tasks, since `_batch_encode_plus` references `self.only_label_first_subword` at line 661.

The fix adds `self.only_label_first_subword = only_label_first_subword` to `__init__`, matching the pattern used by both `LayoutXLMTokenizer` and `UdopTokenizer`.

## One-line change

```python
self.only_label_first_subword = only_label_first_subword
```

## Before this PR

```python
tokenizer = LayoutLMv2Tokenizer.from_pretrained("microsoft/layoutlmv2-base-uncased")
tokenizer(words, boxes=boxes, word_labels=word_labels)
# AttributeError: 'LayoutLMv2Tokenizer' object has no attribute 'only_label_first_subword'
```

## After this PR

NER tokenization with `word_labels` works as expected, producing correct label alignment with subword masking.