### PR TITLE
fix(lasr): remove spurious center arg from _torch_extract_fbank_features call

### DIFF
--- a/src/transformers/models/lasr/feature_extraction_lasr.py
+++ b/src/transformers/models/lasr/feature_extraction_lasr.py
@@ -149,7 +149,6 @@ class LasrFeatureExtractor(SequenceFeatureExtractor):
         do_normalize: bool | None = None,
         device: str | None = "cpu",
         return_token_timestamps: bool | None = None,
-        center: bool = True,
         **kwargs,
     ) -> BatchFeature:
         """
@@ -204,8 +203,6 @@ class LasrFeatureExtractor(SequenceFeatureExtractor):
 
                 Whether or not to return the number of frames of the input raw_speech.
                 These num_frames can be used by the model to compute word level timestamps.
-            center (`bool`, *optional*, defaults to `True`):
-                Whether to use centering for the STFT computation.
         """
         if sampling_rate is not None:
             if sampling_rate != self.sampling_rate:
@@ -263,7 +260,7 @@ class LasrFeatureExtractor(SequenceFeatureExtractor):
             return_tensors="pt",
         )
         input_features = padded_inputs.input_features.squeeze(-1)
-        input_features = self._torch_extract_fbank_features(input_features, device, center)
+        input_features = self._torch_extract_fbank_features(input_features, device)
         data = {
             "input_features": input_features.to(torch.float32),
         }


### PR DESCRIPTION
Fixes #44206

## Problem

PR #43769 ("Add Voxtral Realtime") added a `center` parameter to `LasrFeatureExtractor.__call__()` and passed it to `_torch_extract_fbank_features()`, but that method does not accept it. This causes a `TypeError` on **all** LASR model inference (e.g. `google/medasr`) in transformers v5.2.0.

## Fix

Remove the `center` parameter from `__call__()` signature, docstring, and the call to `_torch_extract_fbank_features()`. LASR uses `waveform.unfold()` + `torch.fft.rfft()` (not `torch.stft()`), so `center` would be a no-op even if accepted.

## Changes

- `src/transformers/models/lasr/feature_extraction_lasr.py`: Remove `center` parameter (4 lines removed)

cc @eustlb