### PR TITLE
Add backward compatibility for deprecated grouped_entities parameter

### DIFF
--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -147,12 +147,22 @@ class TokenClassificationPipeline(ChunkPipeline):
     def _sanitize_parameters(
         self,
         ignore_labels=None,
+        grouped_entities=None,
         aggregation_strategy: AggregationStrategy | None = None,
         offset_mapping: list[tuple[int, int]] | None = None,
         is_split_into_words: bool = False,
         stride: int | None = None,
         delimiter: str | None = None,
     ):
+        if grouped_entities is not None:
+            warnings.warn(
+                "`grouped_entities` is deprecated and will be removed in a future version. "
+                'Use `aggregation_strategy="simple"` instead.',
+                FutureWarning,
+            )
+            if aggregation_strategy is None:
+                aggregation_strategy = "simple" if grouped_entities else "none"
+
         preprocess_params = {}
         preprocess_params["is_split_into_words"] = is_split_into_words
 


### PR DESCRIPTION
## Fix for #44016

The `grouped_entities` parameter in `TokenClassificationPipeline._sanitize_parameters` was removed without a deprecation period, causing a `TypeError` when users pass `grouped_entities=True` to the `pipeline()` call (as shown in HF Course Section 3 examples).

### Changes
- Added `grouped_entities` back as an accepted parameter in `_sanitize_parameters`
- Issues a `FutureWarning` directing users to use `aggregation_strategy="simple"` instead
- Maps `grouped_entities=True` → `aggregation_strategy="simple"` and `grouped_entities=False` → `aggregation_strategy="none"`

### Before
```python
>>> pipeline("ner", grouped_entities=True)
TypeError: TokenClassificationPipeline._sanitize_parameters() got an unexpected keyword argument 'grouped_entities'
```

### After
```python
>>> pipeline("ner", grouped_entities=True)
FutureWarning: `grouped_entities` is deprecated... Use `aggregation_strategy="simple"` instead.
# Works correctly
```

Fixes #44016