### PR TITLE
Docs(it): update deprecated grouped_entities reference

### DIFF
--- a/docs/source/it/migration.md
+++ b/docs/source/it/migration.md
@@ -35,7 +35,7 @@ Ciò introduce due modifiche sostanziali:
 
 ##### Come ottenere lo stesso comportamento di v3.x in v4.x
 
-- Le pipeline ora contengono funzionalità aggiuntive pronte all'uso. Vedi la [pipeline di classificazione dei token con il flag `grouped_entities`](main_classes/pipelines#transformers.TokenClassificationPipeline).
+- Le pipeline ora contengono funzionalità aggiuntive pronte all'uso. Vedi la [pipeline di classificazione dei token con `aggregation_strategy` (in precedenza `grouped_entities`)](main_classes/pipelines#transformers.TokenClassificationPipeline).
 - Gli auto-tokenizer ora restituiscono tokenizer rust. Per ottenere invece i tokenizer python, l'utente deve usare il flag `use_fast` impostandolo `False`:
 
 Nella versione `v3.x`:


### PR DESCRIPTION
## Summary
- Update the Italian migration guide to avoid pointing users to the deprecated `grouped_entities` flag.
- Clarify that `aggregation_strategy` is the current option (with a note that it was previously `grouped_entities`).

## Why
Recent reports (e.g. around NER examples) show confusion from users hitting `TypeError` when using `grouped_entities`. This keeps the migration docs aligned with current pipeline parameters.
