### PR TITLE
Docs(it): fix typo in sentencepiece install command

### DIFF
--- a/docs/source/it/migration.md
+++ b/docs/source/it/migration.md
@@ -79,7 +79,7 @@ pip install transformers[sentencepiece]
 ```
 o
 ```bash
-pip install transformers stentencepiece
+pip install transformers sentencepiece
 ```
 #### 3. L'architettura delle repo è stato aggiornata in modo che ogni modello abbia la propria cartella
 


### PR DESCRIPTION
## Summary
- fix a typo in the Italian migration guide install command:
  - `stentencepiece` -> `sentencepiece`

## Why
The current command fails if copied as-is. This makes the installation snippet runnable for users reading the Italian docs.
