### PR TITLE
Docs(it): fix typo in docstring wording

### DIFF
--- a/docs/source/it/add_new_model.md
+++ b/docs/source/it/add_new_model.md
@@ -708,7 +708,7 @@ Siete quasi alla fine! L'ultima cosa rimasta é avere una bella docstring e una 
 un template chiamato `docs/source/model_doc/brand_new_bert.rst`, che dovrete compilare. La prima cosa che un utente farà
 per usare il vostro modello sarà dare una bella lettura al doc. Quindi proponete una documentazione chiara e concisa. É molto
 utile per la community avere anche delle *Tips* per mostrare come il modello puo' essere usato. Non esitate a chiedere a Hugging Face
-riguardo alle docstirng.
+riguardo alle docstring.
 
 Quindi, assicuratevi che la docstring sia stata aggiunta a `src/transformers/models/brand_new_bert/modeling_brand_new_bert.py`.
 Assicuratevi che la docstring sia corretta e che includa tutti i necessari input e output. Abbiamo una guida dettagliata per


### PR DESCRIPTION
## Summary
- fix a typo in the Italian add-new-model guide: `docstirng` -> `docstring`.

## Why
Small docs quality fix that avoids confusion for readers following the contribution guide.
