### PR TITLE
Fix type of TrainingArguments.logging_steps

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -966,7 +966,7 @@ class TrainingArguments:
         default="steps",
         metadata={"help": "The logging strategy to adopt during training. Options: 'no', 'epoch', 'steps'."},
     )
-    logging_steps: float = field(
+    logging_steps: int | float = field(
         default=500,
         metadata={
             "help": (


### PR DESCRIPTION
Fix type of `TrainingArguments.logging_steps`.


This PR makes a minor update to the `TrainingArguments` class, so `logging_steps` parameter accepts both integers and floats, rather than only floats. Note these are the expected types in the implementation and the documentation.

- Configuration improvement:
  * Fixed the type of `logging_steps` from `float` to `int | float` in the `TrainingArguments` class to allow both input types.