### PR TITLE
[generate] Always pass full input_ids in `prepare_inputs_for_generation`

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3744,7 +3744,7 @@ class GenerationMixin(ContinuousMixin):
             use_inputs_embeds = True
         if (cache := model_kwargs.get("past_key_values")) is not None:
             past_length = cache.get_seq_length()
-            # Always directly slice the inputs_embeds if present, as `prepare_inputs_for_generation` never need them full and _get_initial_cache_position
+            # Always directly slice the inputs_embeds if present, as `prepare_inputs_for_generation` never need them full and `_get_initial_cache_position`
             # rely on its size explicitly. For input_ids, we need to use `next_sequence_length` to slice later instead of explicit slicing,
             # as some model need them full for correct input preparation inside `prepare_inputs_for_generation` (i.e. audio models)
             if use_inputs_embeds:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -539,15 +539,12 @@ class GenerationMixin(ContinuousMixin):
             model_inputs["token_type_ids"] = token_type_ids
 
         # 3. Slice model inputs if it's an input that should have the same length as `input_ids`
-        # We check `use_cache` below because some stateful models (like `recurrent_gemma`) expect input slicing if
-        # their caching mechanism is used. To define `use_cache`, the user-defined argument takes precedence.
-        if past_key_values is not None or kwargs["use_cache"]:
-            for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
-                model_input = model_inputs.get(model_input_name)
-                if model_input is not None:
-                    # Input can be 2D or 3D, and we always slice on `seq-length` (last dim)
-                    model_input = model_input[..., -sequence_length:].clone(memory_format=torch.contiguous_format)
-                    model_inputs[model_input_name] = model_input
+        for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
+            model_input = model_inputs.get(model_input_name)
+            if model_input is not None and model_input.shape[-1] != sequence_length:
+                # Input can be 2D or 3D, and we always slice on `seq-length` (last dim)
+                model_input = model_input[..., -sequence_length:].clone(memory_format=torch.contiguous_format)
+                model_inputs[model_input_name] = model_input
 
         # 4. Create 4D attention mask is we are using a compilable cache (important for performant compiled forward
         # pass)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -539,7 +539,9 @@ class GenerationMixin(ContinuousMixin):
             model_inputs["token_type_ids"] = token_type_ids
 
         # 3. Slice model inputs if it's an input that should have the same length as `input_ids`
-        if kwargs["use_cache"]:
+        # We check `use_cache` below because some stateful models (like `recurrent_gemma`) expect input slicing if
+        # their caching mechanism is used. To define `use_cache`, the user-defined argument takes precedence.
+        if past_key_values is not None or kwargs["use_cache"]:
             for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
                 model_input = model_inputs.get(model_input_name)
                 if model_input is not None:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -493,6 +493,7 @@ class GenerationMixin(ContinuousMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
+        next_sequence_length: int | None = None,
         past_key_values: Cache | None = None,
         attention_mask: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
@@ -512,15 +513,18 @@ class GenerationMixin(ContinuousMixin):
         model_inputs = {}
 
         # 1. Prepare base model inputs
-        # input_ids/input_embeds are the source of truth for input shapes: they are always sliced correctly already
         input_ids_key = "decoder_input_ids" if self.config.is_encoder_decoder else "input_ids"
         # if `inputs_embeds` are passed, we only want to use them in the 1st generation step for every prompt.
         if not self.config.is_encoder_decoder and inputs_embeds is not None and is_first_iteration:
             model_inputs[input_ids_key] = None
+            inputs_embeds = (
+                inputs_embeds[:, -next_sequence_length:, :] if next_sequence_length is not None else inputs_embeds
+            )
             model_inputs["inputs_embeds"] = inputs_embeds.clone(memory_format=torch.contiguous_format)
             batch_size, sequence_length = inputs_embeds.shape[:2]
         else:
             # `clone` calls in this function ensure a consistent stride. See #32227
+            input_ids = input_ids[:, -next_sequence_length:] if next_sequence_length is not None else input_ids
             model_inputs[input_ids_key] = input_ids.clone(memory_format=torch.contiguous_format)
             batch_size, sequence_length = input_ids.shape[:2]  # we slice here as some models may have them 3D
 
@@ -535,17 +539,12 @@ class GenerationMixin(ContinuousMixin):
             model_inputs["token_type_ids"] = token_type_ids
 
         # 3. Slice model inputs if it's an input that should have the same length as `input_ids`
-        use_cache = kwargs.get("use_cache", getattr(self.config, "use_cache", False))
-        # We check `use_cache` below because some stateful models (like `recurrent_gemma`) expect input slicing if
-        # their caching mechanism is used. To define `use_cache`, the user-defined argument takes precedence.
-        if past_key_values is not None or use_cache:
-            for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
-                model_input = model_inputs.get(model_input_name)
-                if model_input is not None:
-                    # Input can be 2D or 3D, and we always slice on `seq-length` (last dim)
-                    model_input = model_input[..., -sequence_length:]
-                    model_input = model_input.clone(memory_format=torch.contiguous_format)
-                    model_inputs[model_input_name] = model_input
+        for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
+            model_input = model_inputs.get(model_input_name)
+            if model_input is not None and model_input.shape[-1] != sequence_length:
+                # Input can be 2D or 3D, and we always slice on `seq-length` (last dim)
+                model_input = model_input[..., -sequence_length:].clone(memory_format=torch.contiguous_format)
+                model_inputs[model_input_name] = model_input
 
         # 4. Create 4D attention mask is we are using a compilable cache (important for performant compiled forward
         # pass)
@@ -2729,9 +2728,10 @@ class GenerationMixin(ContinuousMixin):
 
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
-                use_cache = model_kwargs.get("use_cache", True)
-                new_inputs_ids = input_ids[:, -1:] if use_cache else input_ids
-                model_inputs = self.prepare_inputs_for_generation(new_inputs_ids, **model_kwargs)
+                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                model_inputs = self.prepare_inputs_for_generation(
+                    input_ids, next_sequence_length=next_sequence_length, **model_kwargs
+                )
                 with self._optimize_model_for_decode():
                     outputs = model_forward(**model_inputs, return_dict=True)
             prefill_consumed = True
@@ -3218,9 +3218,10 @@ class GenerationMixin(ContinuousMixin):
             if prefill_consumed:
                 # a. Forward current tokens, obtain the logits
                 flat_running_sequences = self._flatten_beam_dim(running_sequences[:, :, :cur_len])
-                use_cache = model_kwargs.get("use_cache", True)
-                new_flat_running_sequences = flat_running_sequences[:, -1:] if use_cache else flat_running_sequences
-                model_inputs = self.prepare_inputs_for_generation(new_flat_running_sequences, **model_kwargs)
+                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                model_inputs = self.prepare_inputs_for_generation(
+                    flat_running_sequences, next_sequence_length=next_sequence_length, **model_kwargs
+                )
                 model_outputs = self(**model_inputs, return_dict=True)
             prefill_consumed = True
 
@@ -3550,11 +3551,12 @@ class GenerationMixin(ContinuousMixin):
                     dim=0,
                 )
 
-            new_candidate_input_ids = (
-                candidate_input_ids if is_first_iteration else candidate_input_ids[:, -candidate_length - 1 :]
-            )
+            next_sequence_length = candidate_length + 1 if not is_first_iteration else None
             model_inputs = self.prepare_inputs_for_generation(
-                new_candidate_input_ids, is_first_iteration=is_first_iteration, **candidate_kwargs
+                candidate_input_ids,
+                next_sequence_length=next_sequence_length,
+                is_first_iteration=is_first_iteration,
+                **candidate_kwargs,
             )
 
             if "logits_to_keep" in model_inputs:

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -539,12 +539,13 @@ class GenerationMixin(ContinuousMixin):
             model_inputs["token_type_ids"] = token_type_ids
 
         # 3. Slice model inputs if it's an input that should have the same length as `input_ids`
-        for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
-            model_input = model_inputs.get(model_input_name)
-            if model_input is not None and model_input.shape[-1] != sequence_length:
-                # Input can be 2D or 3D, and we always slice on `seq-length` (last dim)
-                model_input = model_input[..., -sequence_length:].clone(memory_format=torch.contiguous_format)
-                model_inputs[model_input_name] = model_input
+        if kwargs["use_cache"]:
+            for model_input_name in [position_ids_key, "cache_position", "token_type_ids"]:
+                model_input = model_inputs.get(model_input_name)
+                if model_input is not None:
+                    # Input can be 2D or 3D, and we always slice on `seq-length` (last dim)
+                    model_input = model_input[..., -sequence_length:].clone(memory_format=torch.contiguous_format)
+                    model_inputs[model_input_name] = model_input
 
         # 4. Create 4D attention mask is we are using a compilable cache (important for performant compiled forward
         # pass)
@@ -2729,7 +2730,7 @@ class GenerationMixin(ContinuousMixin):
 
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
-                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                next_sequence_length = 1 if model_kwargs["use_cache"] else None
                 model_inputs = self.prepare_inputs_for_generation(
                     input_ids, next_sequence_length=next_sequence_length, **model_kwargs
                 )
@@ -3219,7 +3220,7 @@ class GenerationMixin(ContinuousMixin):
             if prefill_consumed:
                 # a. Forward current tokens, obtain the logits
                 flat_running_sequences = self._flatten_beam_dim(running_sequences[:, :, :cur_len])
-                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                next_sequence_length = 1 if model_kwargs["use_cache"] else None
                 model_inputs = self.prepare_inputs_for_generation(
                     flat_running_sequences, next_sequence_length=next_sequence_length, **model_kwargs
                 )

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3736,6 +3736,7 @@ class GenerationMixin(ContinuousMixin):
         # including previous inputs, or only the new tokens but in this case the attention_mask still contains the
         # FULL sequence (because otherwise we may lose some early padding tokens information). So slice inputs
         # according to that if needed
+        next_sequence_length = None
         if (cache := model_kwargs.get("past_key_values")) is not None:
             attention_mask_key = "decoder_attention_mask" if self.config.is_encoder_decoder else "attention_mask"
             attention_mask = model_kwargs.get(attention_mask_key)
@@ -3744,18 +3745,17 @@ class GenerationMixin(ContinuousMixin):
             # In this case we need to slice - if it's smaller than the mask, only the new inputs were passed -> no need to do anything
             if attention_mask is not None and current_input_length == attention_mask.shape[1]:
                 past_length = cache.get_seq_length()
-                input_ids = input_ids[:, past_length:]
-                if inputs_embeds is not None:
-                    model_kwargs["inputs_embeds"] = inputs_embeds[:, past_length:, :]
-                # When inputs_embeds are present, input_ids may be in the model_kwargs as well
-                if "input_ids" in model_kwargs:
-                    model_kwargs["input_ids"] = model_kwargs["input_ids"][:, past_length:]
+                # inputs will be sliced as `input_ids[:, -next_sequence_length :]` in `prepare_inputs_for_generation`
+                next_sequence_length = current_input_length - past_length
 
         # Usual prefill
         if generation_config.prefill_chunk_size is None:
             model_kwargs = self._get_initial_cache_position(input_ids.shape[1], input_ids.device, model_kwargs)
             model_inputs = self.prepare_inputs_for_generation(
-                input_ids, is_first_iteration=is_first_iteration, **model_kwargs
+                input_ids,
+                next_sequence_length=next_sequence_length,
+                is_first_iteration=is_first_iteration,
+                **model_kwargs,
             )
             return self(**model_inputs, return_dict=True)
 

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -586,6 +586,7 @@ class GenerationMixin(ContinuousMixin):
 
         # 6. Remove unexpected `generate` inputs (TODO @joao: fix trainer and examples)
         model_inputs.pop("labels", None)
+        model_inputs.pop("next_sequence_length", None)  # if the method is overriden, usually it becomes a kwarg
 
         return model_inputs
 
@@ -3737,11 +3738,11 @@ class GenerationMixin(ContinuousMixin):
         # FULL sequence (because otherwise we may lose some early padding tokens information). So slice inputs
         # according to that if needed
         next_sequence_length = None
+        inputs_embeds = model_kwargs.get("inputs_embeds")
+        current_input_length = input_ids.shape[1] if inputs_embeds is None else inputs_embeds.shape[1]
         if (cache := model_kwargs.get("past_key_values")) is not None:
             attention_mask_key = "decoder_attention_mask" if self.config.is_encoder_decoder else "attention_mask"
             attention_mask = model_kwargs.get(attention_mask_key)
-            inputs_embeds = model_kwargs.get("inputs_embeds")
-            current_input_length = input_ids.shape[1] if inputs_embeds is None else inputs_embeds.shape[1]
             # In this case we need to slice - if it's smaller than the mask, only the new inputs were passed -> no need to do anything
             if attention_mask is not None and current_input_length == attention_mask.shape[1]:
                 past_length = cache.get_seq_length()
@@ -3750,7 +3751,9 @@ class GenerationMixin(ContinuousMixin):
 
         # Usual prefill
         if generation_config.prefill_chunk_size is None:
-            model_kwargs = self._get_initial_cache_position(input_ids.shape[1], input_ids.device, model_kwargs)
+            # The cache is already taken into account in `_get_initial_cache_position`, so the length is only the new tokens if we slice
+            effective_input_length = next_sequence_length if next_sequence_length is not None else current_input_length
+            model_kwargs = self._get_initial_cache_position(effective_input_length, input_ids.device, model_kwargs)
             model_inputs = self.prepare_inputs_for_generation(
                 input_ids,
                 next_sequence_length=next_sequence_length,
@@ -3778,11 +3781,14 @@ class GenerationMixin(ContinuousMixin):
             )
 
             attention_mask = model_kwargs.pop("attention_mask", None)
+            position_ids = model_kwargs.pop("position_ids", None)
             past_length = 0
             for input_chunk in input_chunks:
                 current_length = past_length + input_chunk.shape[-1]
                 if attention_mask is not None:
                     model_kwargs["attention_mask"] = attention_mask[:, :current_length]
+                if position_ids is not None:
+                    model_kwargs["position_ids"] = position_ids[:, past_length:current_length]
                 model_kwargs["cache_position"] = torch.arange(
                     past_length, current_length, dtype=torch.long, device=input_chunk.device
                 )
@@ -3798,7 +3804,7 @@ class GenerationMixin(ContinuousMixin):
             model_kwargs["cache_position"] = torch.arange(
                 input_ids.shape[1], dtype=torch.long, device=input_ids.device
             )
-            model_kwargs["position_ids"] = self._prepare_position_ids_for_generation(input_ids, model_kwargs)
+            model_kwargs["position_ids"] = position_ids
 
             # Latest outputs contain next token logits
             return outputs

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3739,7 +3739,11 @@ class GenerationMixin(ContinuousMixin):
         # according to that if needed
         next_sequence_length = None
         inputs_embeds = model_kwargs.get("inputs_embeds")
-        current_input_length = input_ids.shape[1] if inputs_embeds is None else inputs_embeds.shape[1]
+        # We use inputs_embeds only in this case
+        if not self.config.is_encoder_decoder and inputs_embeds is not None and is_first_iteration:
+            current_input_length = inputs_embeds.shape[1]
+        else:
+            current_input_length = input_ids.shape[1]
         if (cache := model_kwargs.get("past_key_values")) is not None:
             attention_mask_key = "decoder_attention_mask" if self.config.is_encoder_decoder else "attention_mask"
             attention_mask = model_kwargs.get(attention_mask_key)

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -3733,30 +3733,34 @@ class GenerationMixin(ContinuousMixin):
         should be treated as if it's the first iteration. However, for assisted decoding, assistants call `generate`
         several time in a row for a same batch of inputs, so we need to pass `is_first_iteration` here for such cases.
         """
-        # When restarting from previous cache, the `input_ids` or `inputs_embeds` are either the FULL sequence,
-        # including previous inputs, or only the new tokens but in this case the attention_mask still contains the
-        # FULL sequence (because otherwise we may lose some early padding tokens information). So slice inputs
-        # according to that if needed
+        # When restarting from previous cache, the `input_ids` are either the FULL sequence, including previous inputs,
+        # or only the new tokens but in this case the attention_mask still contains the FULL sequence (because otherwise we may
+        # lose some early padding tokens information). So slice inputs according to that if needed
+        # When restarting from `inputs_embeds`, it's always the FULL sequence, and we always need to slice
         next_sequence_length = None
         inputs_embeds = model_kwargs.get("inputs_embeds")
-        # We use inputs_embeds only in this case
+        use_inputs_embeds = False
         if not self.config.is_encoder_decoder and inputs_embeds is not None and is_first_iteration:
-            current_input_length = inputs_embeds.shape[1]
-        else:
-            current_input_length = input_ids.shape[1]
+            use_inputs_embeds = True
         if (cache := model_kwargs.get("past_key_values")) is not None:
-            attention_mask_key = "decoder_attention_mask" if self.config.is_encoder_decoder else "attention_mask"
-            attention_mask = model_kwargs.get(attention_mask_key)
-            # In this case we need to slice - if it's smaller than the mask, only the new inputs were passed -> no need to do anything
-            if attention_mask is not None and current_input_length == attention_mask.shape[1]:
-                past_length = cache.get_seq_length()
-                # inputs will be sliced as `input_ids[:, -next_sequence_length :]` in `prepare_inputs_for_generation`
-                next_sequence_length = current_input_length - past_length
+            past_length = cache.get_seq_length()
+            # Always directly slice the inputs_embeds if present, as `prepare_inputs_for_generation` never need them full and _get_initial_cache_position
+            # rely on its size explicitly. For input_ids, we need to use `next_sequence_length` to slice later instead of explicit slicing,
+            # as some model need them full for correct input preparation inside `prepare_inputs_for_generation` (i.e. audio models)
+            if use_inputs_embeds:
+                model_kwargs["inputs_embeds"] = inputs_embeds[:, past_length:, :]
+            else:
+                attention_mask_key = "decoder_attention_mask" if self.config.is_encoder_decoder else "attention_mask"
+                attention_mask = model_kwargs.get(attention_mask_key)
+                # In this case we need to slice - if it's smaller than the mask, only the new inputs were passed -> no need to do anything
+                if attention_mask is not None and input_ids.shape[1] == attention_mask.shape[1]:
+                    # inputs will be sliced as `input_ids[:, -next_sequence_length :]` in `prepare_inputs_for_generation`
+                    next_sequence_length = input_ids.shape[1] - past_length
 
         # Usual prefill
         if generation_config.prefill_chunk_size is None:
             # The cache is already taken into account in `_get_initial_cache_position`, so the length is only the new tokens if we slice
-            effective_input_length = next_sequence_length if next_sequence_length is not None else current_input_length
+            effective_input_length = next_sequence_length if next_sequence_length is not None else input_ids.shape[1]
             model_kwargs = self._get_initial_cache_position(effective_input_length, input_ids.device, model_kwargs)
             model_inputs = self.prepare_inputs_for_generation(
                 input_ids,

--- a/src/transformers/models/csm/generation_csm.py
+++ b/src/transformers/models/csm/generation_csm.py
@@ -219,7 +219,7 @@ class CsmGenerationMixin(GenerationMixin):
 
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
-                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                next_sequence_length = 1 if model_kwargs["use_cache"] else None
                 model_inputs = self.prepare_inputs_for_generation(
                     input_ids, next_sequence_length=next_sequence_length, **model_kwargs
                 )

--- a/src/transformers/models/csm/generation_csm.py
+++ b/src/transformers/models/csm/generation_csm.py
@@ -219,9 +219,10 @@ class CsmGenerationMixin(GenerationMixin):
 
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
-                use_cache = model_kwargs.get("use_cache", True)
-                new_inputs_ids = input_ids[:, -1:] if use_cache else input_ids
-                model_inputs = self.prepare_inputs_for_generation(new_inputs_ids, **model_kwargs)
+                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                model_inputs = self.prepare_inputs_for_generation(
+                    input_ids, next_sequence_length=next_sequence_length, **model_kwargs
+                )
                 # prepare variable output controls (note: some models won't accept all output controls)
                 model_inputs.update({"output_attentions": output_attentions} if output_attentions else {})
                 outputs = model_forward(**model_inputs, return_dict=True)

--- a/src/transformers/models/csm/modeling_csm.py
+++ b/src/transformers/models/csm/modeling_csm.py
@@ -643,6 +643,7 @@ class CsmDepthDecoderForCausalLM(CsmPreTrainedModel, GenerationMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
+        next_sequence_length: int | None = None,
         past_key_values: Cache | None = None,
         attention_mask: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
@@ -650,7 +651,7 @@ class CsmDepthDecoderForCausalLM(CsmPreTrainedModel, GenerationMixin):
         **kwargs,
     ):
         model_inputs = super().prepare_inputs_for_generation(
-            input_ids, past_key_values, attention_mask, inputs_embeds, cache_position, **kwargs
+            input_ids, next_sequence_length, past_key_values, attention_mask, inputs_embeds, cache_position, **kwargs
         )
 
         is_first_generation_step = model_inputs["cache_position"][0] == 0
@@ -917,6 +918,7 @@ class CsmForConditionalGeneration(CsmPreTrainedModel, CsmGenerationMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
+        next_sequence_length: int | None = None,
         past_key_values: Cache | None = None,
         attention_mask: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
@@ -925,6 +927,7 @@ class CsmForConditionalGeneration(CsmPreTrainedModel, CsmGenerationMixin):
     ):
         model_inputs = super().prepare_inputs_for_generation(
             input_ids=input_ids,
+            next_sequence_length=next_sequence_length,
             past_key_values=past_key_values,
             attention_mask=attention_mask,
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/csm/modular_csm.py
+++ b/src/transformers/models/csm/modular_csm.py
@@ -292,6 +292,7 @@ class CsmDepthDecoderForCausalLM(LlamaForCausalLM, GenerationMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
+        next_sequence_length: int | None = None,
         past_key_values: Cache | None = None,
         attention_mask: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
@@ -299,7 +300,7 @@ class CsmDepthDecoderForCausalLM(LlamaForCausalLM, GenerationMixin):
         **kwargs,
     ):
         model_inputs = super().prepare_inputs_for_generation(
-            input_ids, past_key_values, attention_mask, inputs_embeds, cache_position, **kwargs
+            input_ids, next_sequence_length, past_key_values, attention_mask, inputs_embeds, cache_position, **kwargs
         )
 
         is_first_generation_step = model_inputs["cache_position"][0] == 0
@@ -567,6 +568,7 @@ class CsmForConditionalGeneration(CsmPreTrainedModel, CsmGenerationMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids: torch.LongTensor,
+        next_sequence_length: int | None = None,
         past_key_values: Cache | None = None,
         attention_mask: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
@@ -575,6 +577,7 @@ class CsmForConditionalGeneration(CsmPreTrainedModel, CsmGenerationMixin):
     ):
         model_inputs = super().prepare_inputs_for_generation(
             input_ids=input_ids,
+            next_sequence_length=next_sequence_length,
             past_key_values=past_key_values,
             attention_mask=attention_mask,
             inputs_embeds=inputs_embeds,

--- a/src/transformers/models/higgs_audio_v2/generation_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/generation_higgs_audio_v2.py
@@ -275,10 +275,9 @@ class HiggsAudioV2GenerationMixin(GenerationMixin):
 
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
-                use_cache = model_kwargs.get("use_cache", True)
-                new_input_ids = input_ids[:, -1:] if use_cache else input_ids
+                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
                 model_inputs = self.prepare_inputs_for_generation(
-                    new_input_ids, full_input_ids=input_ids, **model_kwargs
+                    input_ids, next_sequence_length=next_sequence_length, **model_kwargs
                 )
                 with self._optimize_model_for_decode():
                     outputs = model_forward(**model_inputs, return_dict=True)

--- a/src/transformers/models/higgs_audio_v2/generation_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/generation_higgs_audio_v2.py
@@ -275,7 +275,7 @@ class HiggsAudioV2GenerationMixin(GenerationMixin):
 
         while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
             if prefill_consumed:
-                next_sequence_length = 1 if model_kwargs.get("use_cache", True) else None
+                next_sequence_length = 1 if model_kwargs["use_cache"] else None
                 model_inputs = self.prepare_inputs_for_generation(
                     input_ids, next_sequence_length=next_sequence_length, **model_kwargs
                 )

--- a/src/transformers/models/higgs_audio_v2/modeling_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/modeling_higgs_audio_v2.py
@@ -633,13 +633,12 @@ class HiggsAudioV2ForConditionalGeneration(HiggsAudioV2PreTrainedModel, HiggsAud
         audio_input_ids_mask: torch.LongTensor | None = None,
         **kwargs,
     ):
-        full_input_ids = kwargs.pop("full_input_ids", input_ids)
         model_inputs = super().prepare_inputs_for_generation(input_ids, **kwargs)
 
         if audio_input_ids is not None and model_inputs.get("past_key_values") is not None:
             current_cache_length = model_inputs["cache_position"][0]
-            audio_token_mask = (full_input_ids == self.config.audio_token_id) | (
-                full_input_ids == self.config.audio_delay_token_id
+            audio_token_mask = (input_ids == self.config.audio_token_id) | (
+                input_ids == self.config.audio_delay_token_id
             )
             in_cache_num_audio_input_ids = audio_token_mask[:, :current_cache_length].sum(dim=-1)
 

--- a/src/transformers/models/higgs_audio_v2/modular_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/modular_higgs_audio_v2.py
@@ -515,13 +515,12 @@ class HiggsAudioV2ForConditionalGeneration(HiggsAudioV2PreTrainedModel, HiggsAud
         audio_input_ids_mask: torch.LongTensor | None = None,
         **kwargs,
     ):
-        full_input_ids = kwargs.pop("full_input_ids", input_ids)
         model_inputs = super().prepare_inputs_for_generation(input_ids, **kwargs)
 
         if audio_input_ids is not None and model_inputs.get("past_key_values") is not None:
             current_cache_length = model_inputs["cache_position"][0]
-            audio_token_mask = (full_input_ids == self.config.audio_token_id) | (
-                full_input_ids == self.config.audio_delay_token_id
+            audio_token_mask = (input_ids == self.config.audio_token_id) | (
+                input_ids == self.config.audio_delay_token_id
             )
             in_cache_num_audio_input_ids = audio_token_mask[:, :current_cache_length].sum(dim=-1)
 

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -1498,6 +1498,7 @@ class Kosmos2_5TextForCausalLM(Kosmos2_5PreTrainedModel, GenerationMixin):
 
             # Kosmos2.5 starts position_ids at `pad_token_id`...
             if model_inputs.get("position_ids") is not None:
+                # NOTE: we need this op out-of-place, otherwise it modifies the `model_kwargs` dict used in `generate` in-place!
                 model_inputs["position_ids"] = model_inputs["position_ids"] + 1 + self.config.pad_token_id
 
         # appending `False` to `image_embeds_position_mask` (because `input_ids` grows during generation)

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -1495,12 +1495,13 @@ class Kosmos2_5TextForCausalLM(Kosmos2_5PreTrainedModel, GenerationMixin):
         if past_key_values is not None and past_key_values.get_seq_length() > 0:
             model_inputs["image_embeds"] = None
             model_inputs["image_embeds_position_mask"] = None
+            current_length = model_inputs["cache_position"].shape[0]
             model_inputs["position_ids"] = (
                 Kosmos2_5TextSinusoidalPositionalEmbedding.create_position_ids_from_input_ids(
                     input_ids,
                     padding_idx=self.config.pad_token_id,
                     past_key_values_length=0,
-                )[:, -cache_position.shape[0] :]
+                )[:, -current_length:]
             )
 
         # appending `False` to `image_embeds_position_mask` (because `input_ids` grows during generation)

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -1498,7 +1498,7 @@ class Kosmos2_5TextForCausalLM(Kosmos2_5PreTrainedModel, GenerationMixin):
 
             # Kosmos2.5 starts position_ids at `pad_token_id`...
             if model_inputs.get("position_ids") is not None:
-                model_inputs["position_ids"] += 1 + self.config.pad_token_id
+                model_inputs["position_ids"] = model_inputs["position_ids"] + 1 + self.config.pad_token_id
 
         # appending `False` to `image_embeds_position_mask` (because `input_ids` grows during generation)
         elif image_embeds_position_mask is not None:

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -1495,14 +1495,10 @@ class Kosmos2_5TextForCausalLM(Kosmos2_5PreTrainedModel, GenerationMixin):
         if past_key_values is not None and past_key_values.get_seq_length() > 0:
             model_inputs["image_embeds"] = None
             model_inputs["image_embeds_position_mask"] = None
-            current_length = model_inputs["cache_position"].shape[0]
-            model_inputs["position_ids"] = (
-                Kosmos2_5TextSinusoidalPositionalEmbedding.create_position_ids_from_input_ids(
-                    input_ids,
-                    padding_idx=self.config.pad_token_id,
-                    past_key_values_length=0,
-                )[:, -current_length:]
-            )
+
+            # Kosmos2.5 starts position_ids at `pad_token_id`...
+            if model_inputs.get("position_ids") is not None:
+                model_inputs["position_ids"] += 1 + self.config.pad_token_id
 
         # appending `False` to `image_embeds_position_mask` (because `input_ids` grows during generation)
         elif image_embeds_position_mask is not None:

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -577,7 +577,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixi
 
         # position_ids in Paligemma are 1-indexed
         if model_inputs.get("position_ids") is not None:
-            model_inputs["position_ids"] += 1
+            model_inputs["position_ids"] = model_inputs["position_ids"] + 1
 
         # Pixel values are used only in the first iteration if available
         # In subsequent iterations, they are already merged with text and cached

--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -577,6 +577,7 @@ class PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixi
 
         # position_ids in Paligemma are 1-indexed
         if model_inputs.get("position_ids") is not None:
+            # NOTE: we need this op out-of-place, otherwise it modifies the `model_kwargs` dict used in `generate` in-place!
             model_inputs["position_ids"] = model_inputs["position_ids"] + 1
 
         # Pixel values are used only in the first iteration if available

--- a/src/transformers/models/rag/modeling_rag.py
+++ b/src/transformers/models/rag/modeling_rag.py
@@ -1566,6 +1566,7 @@ class RagTokenForGeneration(RagPreTrainedModel, GenerationMixin):
         model_kwargs["encoder_outputs"] = encoder_outputs
         model_kwargs["attention_mask"] = context_attention_mask
         model_kwargs["n_docs"] = n_docs
+        model_kwargs["use_cache"] = generation_config.use_cache
 
         prepared_logits_processor = self._get_logits_processor(
             generation_config=generation_config,

--- a/src/transformers/models/xglm/modeling_xglm.py
+++ b/src/transformers/models/xglm/modeling_xglm.py
@@ -90,7 +90,7 @@ class XGLMSinusoidalPositionalEmbedding(nn.Module):
     @torch.no_grad()
     def forward(self, position_ids: torch.Tensor | None = None, past_key_values_length: int = 0):
         bsz, seq_len = position_ids.size()
-        position_ids += self.offset
+        position_ids = position_ids + self.offset
 
         max_pos = 2 + seq_len + past_key_values_length
         if max_pos > self.weights.size(0):

--- a/tests/models/xlm/test_modeling_xlm.py
+++ b/tests/models/xlm/test_modeling_xlm.py
@@ -550,5 +550,5 @@ class XLMModelLanguageGenerationTest(unittest.TestCase):
         ]  # the president the president the president the president the president the president the president the president the president the president
         # TODO(PVP): this and other input_ids I tried for generation give pretty bad results. Not sure why. Model might just not be made for auto-regressive inference
         # We limit the generation output to (max_length - input_length) while by default 20 new tokens will be generated.
-        output_ids = model.generate(input_ids, do_sample=False, max_length=20)
+        output_ids = model.generate(input_ids, do_sample=False, max_length=20, use_cache=False)
         self.assertListEqual(output_ids[0].tolist(), expected_output_ids)


### PR DESCRIPTION
# What does this PR do?

As per the title. It looks like some models (xlnet and kosmos2_5) and most audio models sometimes rely on the full previous input_ids to prepare inputs. Note that this cannot be compatible with restarting generation from a previously filled cache and new inputs, so those models are not well-behaved in general (if they use a cache, they should be able to restart from it with any input). However, it's a simple fix to forward the full inputs and slice inside `prepare_inputs_for_generation` for those models.

This should fix all audio models cc @eustlb. Please note my comment about how that means audio models cannot restart from old cache, not sure if it's known/intended/fixable.
As for the other only 2 non-audio models requiring past input_ids (xlnet and kosmos2_5), it's in general the same issue. Kosmos could be fixed, the other not sure.

See https://huggingface.co/datasets/hf-internal-testing/transformers_daily_ci/raw/8785954cca2fdca181de0b9567059471bcadb959/2026-02-21/ci_results_run_models_gpu/new_failures_with_bad_commit_grouped_by_authors.json for details on the failing tests.

cc @zucchini-nlp @vasqu 
