### PR TITLE
[Quantisation] account for nested tensors from quantisers

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4649,9 +4649,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         def __recursive_getattr(object, attribute, *args):
             """Recurse through a parameter name that is '.' seperated to get the attribute"""
+
             def __getattr(object, attribute):
                 return getattr(object, attribute, *args)
-            return functools.reduce(__getattr, [object] + attribute.split('.'))
+
+            return functools.reduce(__getattr, [object] + attribute.split("."))
 
         try:
             # get the actual tensor parameter from a possible nested list

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4647,7 +4647,17 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         ):
             return module.get_extra_state()
 
-        raise AttributeError(f"`{target}` is neither a parameter, buffer, nor extra state.")
+        def __recursive_getattr(object, attribute, *args):
+            """Recurse through a parameter name that is '.' seperated to get the attribute"""
+            def __getattr(object, attribute):
+                return getattr(object, attribute, *args)
+            return functools.reduce(__getattr, [object] + attribute.split('.'))
+
+        try:
+            # get the actual tensor parameter from a possible nested list
+            return __recursive_getattr(module, param_name)
+        except AttributeError:
+            raise AttributeError(f"`{target}` is neither a parameter, buffer, nor extra state.")
 
     def named_non_persistent_buffers(
         self, recurse: bool = True, remove_duplicate: bool = True

--- a/src/transformers/quantizers/quantizers_utils.py
+++ b/src/transformers/quantizers/quantizers_utils.py
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-from typing import Any
+from torch.nn import Module
 
-
-def get_module_from_name(module, tensor_name: str) -> tuple[Any, str]:
-    if "." in tensor_name:
-        module_name, tensor_name = tensor_name.rsplit(".", 1)
-        module = module.get_submodule(module_name)
-    return module, tensor_name
+def get_module_from_name(module: Module, tensor_name: str) -> tuple[Module, str]:
+    """Split the tensor name into the module its from and the name itself."""
+    possible_modules = tensor_name.split(".")
+    current_module = module
+    
+    # Iterate through the list of possible modules,
+    # checking that the next possible sub-module is an attribute of the current module
+    for i, part in enumerate(possible_modules):
+        # Check if the next segment exists and is a Module
+        next_attribute = getattr(current_module, part, None)
+        
+        if isinstance(next_attribute, Module):
+            current_module = next_attribute
+        else:
+            # We hit a non-module (Parameter, Buffer, or nested attribute)
+            # Everything from this point forward is the parameter name
+            param_name = ".".join(possible_modules[i:])
+            return current_module, param_name
+    
+    return current_module, ""
 
 
 def should_convert_module(full_name, patterns: list[str] | None = None):

--- a/src/transformers/quantizers/quantizers_utils.py
+++ b/src/transformers/quantizers/quantizers_utils.py
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+
 from torch.nn import Module
+
 
 def get_module_from_name(module: Module, tensor_name: str) -> tuple[Module, str]:
     """Split the tensor name into the module its from and the name itself."""
     possible_modules = tensor_name.split(".")
     current_module = module
-    
+
     # Iterate through the list of possible modules,
     # checking that the next possible sub-module is an attribute of the current module
     for i, part in enumerate(possible_modules):
         # Check if the next segment exists and is a Module
         next_attribute = getattr(current_module, part, None)
-        
+
         if isinstance(next_attribute, Module):
             current_module = next_attribute
         else:
@@ -32,7 +34,7 @@ def get_module_from_name(module: Module, tensor_name: str) -> tuple[Module, str]
             # Everything from this point forward is the parameter name
             param_name = ".".join(possible_modules[i:])
             return current_module, param_name
-    
+
     return current_module, ""
 
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->
When using a quantisation config with a colpali-engine model like so:
```python
from colpali_engine.models import BiQwen2_5, BiQwen2_5_Processor
import torch

model_name = f"nomic-ai/nomic-embed-multimodal-3b"

attention = None
if is_flash_attn_2_available():
    attention = "flash_attention_2"

assert is_accelerate_available(), (
    "Accelerate library needed for auto device mapping"
)

quantisation_config = QuantoConfig(
        weights="int4"
        )

model = BiQwen2_5.from_pretrained(
    model_name,
    dtype=torch.bfloat16,
    device_map="auto",
    attn_implementation=attention,
    quantization_config=quantisation_config,
).eval()

processor = BiQwen2_5_Processor.from_pretrained(model_name)
```
Using 5.3.0.dev0, the following error would occur:
```bash
    model = BiQwen2_5.from_pretrained(
            ~~~~~~~~~~~~~~~~~~~~~~~~~^
        model_name,                                                
        ^^^^^^^^^^^                    
    ...<3 lines>...                        
        quantization_config=quantisation_config,         
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).eval()                                                                                                                                                
    ^                              
  File ".../.venv/lib/python3.13/site-packages/colpali_engine/models/qwen2_5/biqwen2_5/modeling_biqwen2_5.py", line 27, in from_pretrained                                                                                                                                                     
    return super().from_pretrained(*args, **kwargs, key_mapping=key_mapping)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                
  File ".../.venv/lib/python3.13/site-packages/transformers/modeling_utils.py", line 4127, in from_pretrained                      
    loading_info = model.load_adapter(                              
        _adapter_model_path,                                                                                                                                
    ...<2 lines>...         
        adapter_kwargs=adapter_kwargs,
    )                                                                                                                                                       
  File ".../.venv/lib/python3.13/site-packages/transformers/integrations/peft.py", line 575, in load_adapter                       
    loading_info, _ = self._load_pretrained_model(                                                                                                          
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~^                                                                                                          
        model=self,                   
        ^^^^^^^^^^^             
    ...<2 lines>...                                                                                                                                         
        load_config=load_config,                                                                                                                            
        ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                            
    )                                                                                                                                                       
    ^                        
  File ".../.venv/lib/python3.13/site-packages/transformers/modeling_utils.py", line 4175, in _load_pretrained_model               
    caching_allocator_warmup(model, expanded_device_map, load_config.hf_quantizer)                                                                          
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                          
  File ".../.venv/lib/python3.13/site-packages/transformers/modeling_utils.py", line 4731, in caching_allocator_warmup             
    total_byte_count = get_total_byte_count(model, accelerator_device_map, hf_quantizer)                                                                                                                                                                                                                                
  File ".../.venv/lib/python3.13/site-packages/transformers/modeling_utils.py", line 4688, in get_total_byte_count                                                                                                                                                                             
    param = model.get_parameter_or_buffer(param_name)
  File ".../.venv/lib/python3.13/site-packages/transformers/modeling_utils.py", line 4592, in get_parameter_or_buffer
    module, param_name = get_module_from_name(self, target)
                         ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File ".../.venv/lib/python3.13/site-packages/transformers/quantizers/quantizers_utils.py", line 21, in get_module_from_name
    module = module.get_submodule(module_name)
  File ".../.venv/lib/python3.13/site-packages/torch/nn/modules/module.py", line 732, in get_submodule
    raise AttributeError("`" + item + "` is not an nn.Module")
AttributeError: `weight` is not an nn.Module
```
Upon inspection, `get_module_from_name`, was assuming that the parameter name was only the string after the last '.' in the `tensor_name`, and when it got a tensor name like so: 
```bash
tensor_name='visual.blocks.0.attn.qkv.weight._data._data'
```
the check for a module would fail, as it would assume that `_data` is the param name, and everything else is the module.

What this fix does, is correctly identify that the parameter is `weight._data._data` by checking if each possible module name is an instance of a torch module.

Since we know get a potentially listed param name, in `get_parameter_or_buffer` we then recurse through the param name to get the leaf param to be returned.

`pytest tests/utils/test_modeling_utils.py` passed, I'm not entirely sure what else to test.

I'm assuming that this was introduced by either the quantisation process, or is a facet of the colpali model, but again, I'm not entirely sure.
<!-- Remove if not applicable -->


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@SunMarc @MekkCyber

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc @MekkCyber
- kernels: @MekkCyber @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
