### PR TITLE
Add missing backtick in `AnyToAnyPipeline.__call__` docstring

### DIFF
--- a/src/transformers/pipelines/any_to_any.py
+++ b/src/transformers/pipelines/any_to_any.py
@@ -314,10 +314,10 @@ class AnyToAnyPipeline(Pipeline):
             A list or a list of list of `dict`: Each result comes as a dictionary with the following key (cannot
             return a combination of both `generated_text` and `generated_token_ids`):
 
-            - **generated_text** (`str`, present when `return_text=True` and `generation_mode="text") -- The generated text.
-            - **generated_audio** (`np.ndarray`, present when `generation_mode="audio") -- The generated audio.
-            - **generated_image** (`PIL.Image.Image`, present when `generation_mode="image") -- The generated image.
-            - **generated_token_ids** (`torch.Tensor`, present when `return_tensors=True` and `generation_mode="text") -- The token
+            - **generated_text** (`str`, present when `return_text=True` and `generation_mode="text"`) -- The generated text.
+            - **generated_audio** (`np.ndarray`, present when `generation_mode="audio"`) -- The generated audio.
+            - **generated_image** (`PIL.Image.Image`, present when `generation_mode="image"`) -- The generated image.
+            - **generated_token_ids** (`torch.Tensor`, present when `return_tensors=True` and `generation_mode="text"`) -- The token
                 ids of the generated text.
             - **input_text** (`str`) -- The input text.
         """


### PR DESCRIPTION
# What does this PR do?

This PR adds the missing backtick (`) on the `AnyToAnyPipeline.__call__` docstrings, as those were showing as in the screenshot below instead.

<img width="1023" height="400" alt="image" src="https://github.com/user-attachments/assets/4f1de504-c6cf-436f-bc61-0e08fd9960c7" />

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a GitHub issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

cc @zucchini-nlp as it's `any-to-any` related, but also @stevhliu as it's about the documentation

Thanks in advance 🤗 