### PR TITLE
fix zero3 init config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,7 @@ _deps = [
     "rjieba",
     "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff==0.14.10",
+    "ty==0.0.12",
     # `sacrebleu` not used in `transformers`. However, it is needed in several tests, when a test calls
     # `evaluate.load("sacrebleu")`. This metric is used in the examples that we use to test the `Trainer` with, in the
     # `Trainer` tests (see references to `run_translation.py`).
@@ -180,7 +181,7 @@ if PYTHON_MINOR_VERSION < 13:
     extras["audio"] += deps_list("kenlm")
 extras["video"] = deps_list("av")
 extras["timm"] = deps_list("timm")
-extras["quality"] = deps_list("datasets", "ruff", "GitPython", "urllib3", "libcst", "rich")
+extras["quality"] = deps_list("datasets", "ruff", "GitPython", "urllib3", "libcst", "rich", "ty")
 extras["kernels"] = deps_list("kernels")
 extras["sentencepiece"] = deps_list("sentencepiece", "protobuf")
 extras["tiktoken"] = deps_list("tiktoken", "blobfile")

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -56,6 +56,7 @@ deps = {
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff==0.14.10",
+    "ty": "ty==0.0.12",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",
     "safetensors": "safetensors>=0.4.3",

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1462,17 +1462,29 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         if dtype is not None:
             init_contexts.append(local_torch_dtype(dtype, cls.__name__))
 
-        if is_deepspeed_zero3_enabled() and not _is_quantized and not _is_ds_init_called:
+        needs_zero3_init = is_deepspeed_zero3_enabled() and not _is_quantized and not _is_ds_init_called
+        if needs_zero3_init:
             logger.info("Detected DeepSpeed ZeRO-3: activating zero.init() for this model")
             # this immediately partitions the model across all gpus, to avoid the overhead in time
             # and memory copying it on CPU or each GPU first
             import deepspeed
 
-            init_contexts.extend([deepspeed.zero.Init(config_dict_or_path=deepspeed_config()), set_zero3_state()])
+            init_contexts.extend(
+                [init.no_init_weights(), deepspeed.zero.Init(config_dict_or_path=deepspeed_config()), set_zero3_state()]
+            )
 
         # Instantiate the model
         with ContextManagers(init_contexts):
             model = cls(config, **kwargs)
+
+        # Under ZeRO-3, parameters were partitioned into empty tensors during construction,
+        # so weight init was suppressed. Re-initialize using the ZeRO-3 variant which gathers
+        # each module's parameters before init to avoid OOM on large models.
+        if needs_zero3_init:
+            from .integrations.deepspeed import initialize_weights_zero3
+
+            initialize_weights_zero3(model)
+            model.tie_weights()
 
         return model
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1470,7 +1470,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             import deepspeed
 
             init_contexts.extend(
-                [init.no_init_weights(), deepspeed.zero.Init(config_dict_or_path=deepspeed_config()), set_zero3_state()]
+                [
+                    init.no_init_weights(),
+                    deepspeed.zero.Init(config_dict_or_path=deepspeed_config()),
+                    set_zero3_state(),
+                ]
             )
 
         # Instantiate the model

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -274,6 +274,54 @@ class CoreIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
                     AutoModel.from_pretrained(T5_TINY)
         self.assertNotIn("Detected DeepSpeed ZeRO-3", cl.out)
 
+    @require_torch_accelerator
+    def test_from_config_zero3_weight_init(self):
+        # test that from_config() correctly initializes weights under zero3
+        # (regression test: without the fix, _init_weights runs on partitioned empty tensors
+        # and custom initialization is silently skipped)
+        import deepspeed
+        import torch
+
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        ds_config = {
+            "train_batch_size": 1,
+            "zero_optimization": {
+                "stage": 3,
+            },
+            "bf16": {
+                "enabled": True,
+            },
+        }
+
+        config = AutoConfig.from_pretrained(GPT2_TINY)
+
+        # 1. Baseline: from_config without DeepSpeed, in bf16 to match ZeRO-3 dtype
+        torch.manual_seed(42)
+        baseline_model = AutoModelForCausalLM.from_config(config, dtype=torch.bfloat16)
+        baseline_std = baseline_model.transformer.h[0].attn.c_attn.weight.data.float().std().item()
+        del baseline_model
+
+        # 2. ZeRO-3: from_config with DeepSpeed
+        torch.manual_seed(42)
+        dschf = HfDeepSpeedConfig(ds_config)
+
+        with mockenv_context(**self.dist_env_1_gpu):
+            model = AutoModelForCausalLM.from_config(config)
+
+        param = model.transformer.h[0].attn.c_attn.weight
+        with deepspeed.zero.GatheredParameters([param]):
+            zero3_std = param.data.float().std().item()
+
+        # Weight std should be in the same ballpark between baseline and ZeRO-3.
+        # The seeds produce slightly different values due to different init ordering,
+        # but delta=0.3 catches the buggy case (ratio ~0.58, i.e. 42% off).
+        ratio = zero3_std / baseline_std
+        self.assertAlmostEqual(ratio, 1.0, delta=0.3, msg=(
+            f"ZeRO-3 from_config() weight init diverges from baseline: "
+            f"baseline_std={baseline_std:.6f}, zero3_std={zero3_std:.6f}, ratio={ratio:.4f}"
+        ))
+
     def test_init_zero3_missing_params(self):
         # test that zero.Init() for missing parameters works correctly under zero3
         import deepspeed

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -274,6 +274,54 @@ class CoreIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
                     AutoModel.from_pretrained(T5_TINY)
         self.assertNotIn("Detected DeepSpeed ZeRO-3", cl.out)
 
+    @require_torch_accelerator
+    def test_from_config_zero3_weight_init(self):
+        # test that from_config() correctly initializes weights under zero3
+        # (regression test: without the fix, _init_weights runs on partitioned empty tensors
+        # and custom initialization is silently skipped)
+        import deepspeed
+        import torch
+
+        from transformers import AutoConfig, AutoModelForCausalLM
+
+        ds_config = {
+            "train_batch_size": 1,
+            "zero_optimization": {
+                "stage": 3,
+            },
+            "bf16": {
+                "enabled": True,
+            },
+        }
+
+        config = AutoConfig.from_pretrained(GPT2_TINY)
+
+        # 1. Baseline: from_config without DeepSpeed, in bf16 to match ZeRO-3 dtype
+        torch.manual_seed(42)
+        baseline_model = AutoModelForCausalLM.from_config(config, dtype=torch.bfloat16)
+        baseline_std = baseline_model.transformer.h[0].attn.c_attn.weight.data.float().std().item()
+        del baseline_model
+
+        # 2. ZeRO-3: from_config with DeepSpeed
+        torch.manual_seed(42)
+        HfDeepSpeedConfig(ds_config)
+
+        with mockenv_context(**self.dist_env_1_gpu):
+            model = AutoModelForCausalLM.from_config(config)
+
+        param = model.transformer.h[0].attn.c_attn.weight
+        with deepspeed.zero.GatheredParameters([param]):
+            zero3_std = param.data.float().std().item()
+
+        # Weight std should be in the same ballpark between baseline and ZeRO-3.
+        # The seeds produce slightly different values due to different init ordering,
+        # but delta=0.3 catches the buggy case (ratio ~0.58, i.e. 42% off).
+        ratio = zero3_std / baseline_std
+        self.assertAlmostEqual(ratio, 1.0, delta=0.3, msg=(
+            f"ZeRO-3 from_config() weight init diverges from baseline: "
+            f"baseline_std={baseline_std:.6f}, zero3_std={zero3_std:.6f}, ratio={ratio:.4f}"
+        ))
+
     def test_init_zero3_missing_params(self):
         # test that zero.Init() for missing parameters works correctly under zero3
         import deepspeed

--- a/tests/deepspeed/test_deepspeed.py
+++ b/tests/deepspeed/test_deepspeed.py
@@ -317,10 +317,15 @@ class CoreIntegrationDeepSpeed(TestCasePlus, TrainerIntegrationCommon):
         # The seeds produce slightly different values due to different init ordering,
         # but delta=0.3 catches the buggy case (ratio ~0.58, i.e. 42% off).
         ratio = zero3_std / baseline_std
-        self.assertAlmostEqual(ratio, 1.0, delta=0.3, msg=(
-            f"ZeRO-3 from_config() weight init diverges from baseline: "
-            f"baseline_std={baseline_std:.6f}, zero3_std={zero3_std:.6f}, ratio={ratio:.4f}"
-        ))
+        self.assertAlmostEqual(
+            ratio,
+            1.0,
+            delta=0.3,
+            msg=(
+                f"ZeRO-3 from_config() weight init diverges from baseline: "
+                f"baseline_std={baseline_std:.6f}, zero3_std={zero3_std:.6f}, ratio={ratio:.4f}"
+            ),
+        )
 
     def test_init_zero3_missing_params(self):
         # test that zero.Init() for missing parameters works correctly under zero3


### PR DESCRIPTION
# What does this PR do?

Supersedes https://github.com/huggingface/transformers/pull/43847

When using zero3 + from_config, the model was incorrectly initialized as we were not gathering the params. Added a test also. 

cc @tohtana 