### PR TITLE
[docs] callbacks and collators

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -152,6 +152,13 @@
       title: Subclassing Trainer methods
     - local: trainer_callbacks
       title: Callbacks
+    title: Trainer API
+  - isExpanded: false
+    sections:
+    - local: trainer_callbacks
+      title: Callbacks
+    - local: data_collators
+      title: Data collators
     - local: optimizers
       title: Optimizers
     - local: hpo_train

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -152,11 +152,6 @@
       title: Subclassing Trainer methods
     - local: trainer_callbacks
       title: Callbacks
-    title: Trainer API
-  - isExpanded: false
-    sections:
-    - local: trainer_callbacks
-      title: Callbacks
     - local: data_collators
       title: Data collators
     - local: optimizers
@@ -164,11 +159,6 @@
     - local: hpo_train
       title: Hyperparameter search
     title: Customization
-  - isExpanded: false
-    sections:
-    - local: model_memory_anatomy
-      title: Model training anatomy
-    title: Performance
   - isExpanded: false
     sections:
     - local: accelerator_selection
@@ -198,6 +188,8 @@
       title: Intel Gaudi
     - local: perf_hardware
       title: Build your own machine
+    - local: model_memory_anatomy
+      title: Model training anatomy
     title: Hardware
   - local: peft
     title: PEFT

--- a/docs/source/en/data_collators.md
+++ b/docs/source/en/data_collators.md
@@ -1,0 +1,117 @@
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Data collators
+
+A data collator assembles individual dataset samples into a batch for the model. It can also dynamically pad samples to the longest sequence in *each batch*, which is more efficient than padding to a global maximum length.
+
+```md
+Dataset[0] → {"input_ids": [101, 2003, ...], "labels": 1}
+Dataset[1] → {"input_ids": [101, 2003, 1996, ...], "labels": 0}
+Dataset[2] → {"input_ids": [101, 7592, ...], "labels": 1}
+         ↓  collator
+{
+  "input_ids": tensor([[101, 2003,    0],   # padded to longest
+                        [101, 2003, 1996],
+                        [101, 7592,    0]]),
+  "labels":    tensor([1, 0, 1])
+}
+```
+
+Transformers provides data collators for various tasks (see all available [data collators](./main_classes/data_collator)). Create a custom data collator with:
+
+- [DataCollatorWithPadding](#datacollatorwithpadding) when you need standard tokenizer-based padding plus extra fields.
+- [DataCollatorMixin](#datacollatormixin) when you need custom padding logic, multiple paired inputs per sample, or a batch structure the tokenizer can't produce on its own.
+
+## DataCollatorWithPadding
+
+For simple use cases like adding an extra field, subclass [`DataCollatorWithPadding`] and extend its `__call__` method. The example below adds a `"score"` field.
+
+1. Remove the custom field first because [`~PreTrainedTokenizerBase.pad`] doesn't recognize it.
+2. Call the parent class to handle `input_ids` and `attention_mask`.
+3. Add the `"score"` field back to the batch.
+
+```py
+import torch
+from dataclasses import dataclass
+from transformers import DataCollatorWithPadding, PreTrainedTokenizerBase
+
+@dataclass
+class DataCollatorWithScore(DataCollatorWithPadding):
+    tokenizer: PreTrainedTokenizerBase
+
+    def __call__(self, features):
+        scores = [f.pop("score") for f in features]
+
+        batch = super().__call__(features)
+        batch["score"] = torch.tensor(scores, dtype=torch.float)
+
+        return batch
+```
+
+Pass the custom data collator to [`Trainer`] like any other data collator.
+
+```py
+trainer = Trainer(
+    ...,
+    data_collator=DataCollatorWithScore(tokenizer=tokenizer),
+)
+```
+
+## DataCollatorMixin
+
+Subclass [`DataCollatorMixin`] for full control over batch assembly and implement your own `__call__` method. Build custom padding logic, handle multiple input types, or create entirely new batch structures. The [`~trl.trainer.dpo_trainer.DataCollatorForPreference`] example below uses [`DataCollatorMixin`] because each training sample has a chosen and rejected response, and the model needs to see both.
+
+1. Separate `chosen_input_ids` and `rejected_input_ids` because [`~trl.trainer.utils.pad`] expects flat lists.
+2. Concatenate the input pair into a single list.
+3. Generate `attention_mask` with [torch.ones_like](https://docs.pytorch.org/docs/stable/generated/torch.ones_like.html) instead of the tokenizer because the collator works with raw token ID lists.
+4. Pad `input_ids` and `attention_mask`.
+
+```py
+import torch
+from transformers import DataCollatorMixin
+from trl.trainer.utils import pad
+
+class DataCollatorForPreference(DataCollatorMixin):
+    pad_token_id: int
+    pad_to_multiple_of: int | None = None
+
+    def __call__(self, examples: list[dict]) -> dict:
+        chosen_input_ids   = [torch.tensor(ex["chosen_input_ids"])   for ex in examples]
+        rejected_input_ids = [torch.tensor(ex["rejected_input_ids"]) for ex in examples]
+
+        input_ids      = chosen_input_ids + rejected_input_ids
+        attention_mask = [torch.ones_like(ids) for ids in input_ids]
+
+        output = {
+            "input_ids": pad(
+                input_ids,
+                padding_value=self.pad_token_id,
+                padding_side="right",
+                pad_to_multiple_of=self.pad_to_multiple_of,
+            ),
+            "attention_mask": pad(
+                attention_mask,
+                padding_value=0,
+                padding_side="right",
+                pad_to_multiple_of=self.pad_to_multiple_of,
+            ),
+        }
+
+        ...
+
+        return output
+```

--- a/docs/source/en/data_collators.md
+++ b/docs/source/en/data_collators.md
@@ -19,9 +19,9 @@ rendered properly in your Markdown viewer.
 A data collator assembles individual dataset samples into a batch for the model. It can also dynamically pad samples to the longest sequence in *each batch*, which is more efficient than padding to a global maximum length.
 
 ```md
-Dataset[0] → {"input_ids": [101, 2003, ...], "labels": 1}
-Dataset[1] → {"input_ids": [101, 2003, 1996, ...], "labels": 0}
-Dataset[2] → {"input_ids": [101, 7592, ...], "labels": 1}
+Dataset[0] → {"input_ids": [101, 2003], "labels": 1}
+Dataset[1] → {"input_ids": [101, 2003, 1996], "labels": 0}
+Dataset[2] → {"input_ids": [101, 7592], "labels": 1}
          ↓  collator
 {
   "input_ids": tensor([[101, 2003,    0],   # padded to longest
@@ -73,9 +73,9 @@ trainer = Trainer(
 
 ## DataCollatorMixin
 
-Subclass [`DataCollatorMixin`] for full control over batch assembly and implement your own `__call__` method. Build custom padding logic, handle multiple input types, or create entirely new batch structures. The [`~trl.trainer.dpo_trainer.DataCollatorForPreference`] example below uses [`DataCollatorMixin`] because each training sample has a chosen and rejected response, and the model needs to see both.
+Subclass [`DataCollatorMixin`] for full control over batch assembly and implement your own `__call__` method. Build custom padding logic, handle multiple input types, or create entirely new batch structures. The [DataCollatorForPreference](https://github.com/huggingface/trl/blob/cfbdd3bea4448cde878c0da0de49551f553c61fe/trl/trainer/reward_trainer.py#L126) example below uses [`DataCollatorMixin`] because each training sample has a chosen and rejected response, and the model needs to see both.
 
-1. Separate `chosen_input_ids` and `rejected_input_ids` because [`~trl.trainer.utils.pad`] expects flat lists.
+1. Separate `chosen_ids` and `rejected_ids` because [`~trl.trainer.utils.pad`] expects flat lists.
 2. Concatenate the input pair into a single list.
 3. Generate `attention_mask` with [torch.ones_like](https://docs.pytorch.org/docs/stable/generated/torch.ones_like.html) instead of the tokenizer because the collator works with raw token ID lists.
 4. Pad `input_ids` and `attention_mask`.
@@ -90,8 +90,8 @@ class DataCollatorForPreference(DataCollatorMixin):
     pad_to_multiple_of: int | None = None
 
     def __call__(self, examples: list[dict]) -> dict:
-        chosen_input_ids   = [torch.tensor(ex["chosen_input_ids"])   for ex in examples]
-        rejected_input_ids = [torch.tensor(ex["rejected_input_ids"]) for ex in examples]
+        chosen_input_ids   = [torch.tensor(ex["chosen_ids"])   for ex in examples]
+        rejected_input_ids = [torch.tensor(ex["rejected_ids"]) for ex in examples]
 
         input_ids      = chosen_input_ids + rejected_input_ids
         attention_mask = [torch.ones_like(ids) for ids in input_ids]
@@ -115,3 +115,7 @@ class DataCollatorForPreference(DataCollatorMixin):
 
         return output
 ```
+
+## Next steps
+
+- See all available [data collators](./main_classes/data_collator) for common tasks like token classification.

--- a/docs/source/en/main_classes/callback.md
+++ b/docs/source/en/main_classes/callback.md
@@ -24,29 +24,7 @@ Callbacks are "read only" pieces of code, apart from the [`TrainerControl`] obje
 cannot change anything in the training loop. For customizations that require changes in the training loop, you should
 subclass [`Trainer`] and override the methods you need (see [trainer](trainer) for examples).
 
-By default, `TrainingArguments.report_to` is set to `"all"`, so a [`Trainer`] will use the following callbacks.
-
-- [`DefaultFlowCallback`] which handles the default behavior for logging, saving and evaluation.
-- [`PrinterCallback`] or [`ProgressCallback`] to display progress and print the
-  logs (the first one is used if you deactivate tqdm through the [`TrainingArguments`], otherwise
-  it's the second one).
-- [`~integrations.TensorBoardCallback`] if tensorboard is accessible (either through PyTorch >= 1.4
-  or tensorboardX).
-- [`~integrations.TrackioCallback`] if [trackio](https://github.com/gradio-app/trackio) is installed.
-- [`~integrations.WandbCallback`] if [wandb](https://www.wandb.com/) is installed.
-- [`~integrations.CometCallback`] if [comet_ml](https://www.comet.com/site/) is installed.
-- [`~integrations.MLflowCallback`] if [mlflow](https://www.mlflow.org/) is installed.
-- [`~integrations.AzureMLCallback`] if [azureml-sdk](https://pypi.org/project/azureml-sdk/) is
-  installed.
-- [`~integrations.CodeCarbonCallback`] if [codecarbon](https://pypi.org/project/codecarbon/) is
-  installed.
-- [`~integrations.ClearMLCallback`] if [clearml](https://github.com/allegroai/clearml) is installed.
-- [`~integrations.DagsHubCallback`] if [dagshub](https://dagshub.com/) is installed.
-- [`~integrations.FlyteCallback`] if [flyte](https://flyte.org/) is installed.
-- [`~integrations.DVCLiveCallback`] if [dvclive](https://dvc.org/doc/dvclive) is installed.
-- [`~integrations.SwanLabCallback`] if [swanlab](http://swanlab.cn/) is installed.
-
-If a package is installed but you don't wish to use the accompanying integration, you can change `TrainingArguments.report_to` to a list of just those integrations you want to use (e.g. `["azure_ml", "wandb"]`).
+By default, `TrainingArguments.report_to` is set to `"none"`.
 
 The main class that implements callbacks is [`TrainerCallback`]. It gets the
 [`TrainingArguments`] used to instantiate the [`Trainer`], can access that

--- a/docs/source/en/trainer.md
+++ b/docs/source/en/trainer.md
@@ -26,3 +26,5 @@ Underneath, [`Trainer`] handles batching, shuffling, and padding your dataset in
 
 - Start with the [fine-tuning](./training) tutorial for an introduction to training a large language model with [`Trainer`].
 - Check the [Subclassing Trainer methods](./trainer_customize) guide for examples of how to subclass [`Trainer`] methods.
+- See the [Data collators](./data_collators) guide to learn how to create a data collator for custom batch assembly.
+- See the [Callbacks](./trainer_callbacks) guide to learn how to hook into training events.

--- a/docs/source/en/trainer_callbacks.md
+++ b/docs/source/en/trainer_callbacks.md
@@ -84,7 +84,7 @@ trainer = Trainer(
 
 ## Built-in callbacks
 
-Transformers includes several built-in callbacks that are active by default. Additional [integrated callbacks](./main_classes/callback#available-callbacks) log to platforms like [Trackio](https://huggingface.co/docs/trackio/en/index) and [CodeCarbon](https://mlco2.github.io/codecarbon/).
+Transformers includes several built-in callbacks that are active by default. Additional [integrated callbacks](./main_classes/callback#available-callbacks) log to platforms like [Trackio](https://huggingface.co/docs/trackio/en/index).
 
 ### DefaultFlowCallback
 
@@ -92,17 +92,14 @@ Transformers includes several built-in callbacks that are active by default. Add
 
 Overriding this callback is the main way to customize *when* logging, evaluation, or saving happens.
 
-### ProgressCallback
+### ProgressCallback and PrinterCallback
 
-[`ProgressCallback`] displays a progress bar during training and a separate bar during evaluation or prediction. On each `on_log` event, it prints the latest metrics alongside the bar. During distributed training, it only runs on the main process to avoid duplicate output.
+[`Trainer`] automatically picks between these two callbacks based on the [disable_tqdm](https://huggingface.co/docs/transformers/en/main_classes/trainer#transformers.TrainingArguments.disable_tqdm) field in [`TrainingArguments`].
 
-Replace with [`PrinterCallback`] if you want printed logs instead of a progress bar.
+- [`ProgressCallback`] is used by default. It displays a tqdm progress bar during training and a separate bar during evaluation or prediction, and prints the latest metrics on each `on_log` event. During distributed training, it only runs on the main process to avoid duplicate output.
+- [`PrinterCallback`] is used when `disable_tqdm=True`. It prints the log dictionary to stdout on every `on_log` event with no progress bar.
 
-### PrinterCallback
-
-[`PrinterCallback`] prints the log dictionary to stdout on every `on_log` event with no progress bar.
-
-Use [`~Trainer.remove_callback`] and [`~Trainer.add_callback`] to replace a callback.
+You can also swap them manually with [`~Trainer.remove_callback`] and [`~Trainer.add_callback`].
 
 ```py
 from transformers import PrinterCallback
@@ -132,5 +129,5 @@ trainer = Trainer(
 
 ## Next steps
 
-- The [Customizing the Trainer](./trainer_customize) guide covers subclassing [`Trainer`] methods for deeper control.
->>>>>>> e7737441a1 (callbacks and collators)
+- See all available [integrated callbacks](./main_classes/callback#available-callbacks) for logging to experiment trackers.
+- The [Subclassing Trainer methods](./trainer_customize) guide covers overriding [`Trainer`] methods when you need to change what the training loop computes.

--- a/docs/source/en/trainer_callbacks.md
+++ b/docs/source/en/trainer_callbacks.md
@@ -1,30 +1,136 @@
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
 # Callbacks
 
-[Callbacks](./main_classes/callback) are another way to customize [`Trainer`], but they don't change anything *inside the training loop*. Instead, a callback inspects the training loop state and executes some action (early stopping, logging, etc.) depending on the state. For example, you can't implement a custom loss function with a callback because that requires overriding [`~Trainer.compute_loss`].
+[`TrainerCallback`] hooks into specific training events (epoch start, evaluation, training end) to modify training state or control flow. Use callbacks to log metrics to experiment trackers like Trackio, customize when saving and evaluation happen, or add other custom behavior. Stack multiple callbacks to combine features.
 
-To use a callback, create a class that inherits from [`TrainerCallback`] and implements the functionality you want. Then pass the callback to the `callback` parameter in [`Trainer`]. The example below implements an early stopping callback that stops training after 10 steps.
+Callbacks can't modify the training loop itself, like the forward pass. To change what [`Trainer`] computes, [subclass](./trainer_customize) its methods instead.
 
-```py
-from transformers import TrainerCallback, Trainer
+The diagram below shows every event a callback can hook into.
 
-class EarlyStoppingCallback(TrainerCallback):
-    def __init__(self, num_steps=10):
-        self.num_steps = num_steps
+```md
+on_train_begin
+  └─ for each epoch:
+      on_epoch_begin
+      └─ for each step:
+          on_step_begin
+          ├─ for each gradient accumulation substep:
+          │   on_substep_end
+          on_pre_optimizer_step   ← after gradient clipping, before optimizer.step()
+          on_optimizer_step       ← after optimizer.step()
+          on_step_end
+          └─ (conditionally):
+              on_log
+              on_evaluate
+              on_save
+      on_epoch_end
+on_train_end
+on_predict / on_prediction_step
+on_push_begin
+```
+
+## Creating a callback
+
+Subclass [`TrainerCallback`] and override one or more event methods from the diagram above. The example below demonstrates three hooks:
+
+- `on_epoch_begin` prints the current epoch from [`TrainerState`] (a live value) and the learning rate from [`TrainingArguments`] (a static value).
+- `on_step_end` reads the current learning rate from the lr_scheduler (passed via `**kwargs`) and sets `should_evaluate` on [`TrainerControl`] (see [`TrainerControl`] for a complete list of control objects) to trigger an evaluation when it drops below the threshold.
+- `on_train_end` prints the best metric and the step where it occurred.
+
+```python
+from transformers import TrainerCallback
+
+class EpochLoggerCallback(TrainerCallback):
+    def __init__(self, lr_eval_threshold=1e-5):
+        self.lr_eval_threshold = lr_eval_threshold
+
+    def on_epoch_begin(self, args, state, control, **kwargs):
+        print(f"Starting epoch {int(state.epoch) + 1}/{state.num_train_epochs} "
+              f"(lr={args.learning_rate})")
 
     def on_step_end(self, args, state, control, **kwargs):
-        if state.global_step >= self.num_steps:
-            return {"should_training_stop": True}
-        else:
-            return {}
+        lr_scheduler = kwargs.get("lr_scheduler")
+        if lr_scheduler is not None:
+            current_lr = lr_scheduler.get_last_lr()[0]
+            if current_lr < self.lr_eval_threshold:
+                control.should_evaluate = True
 
+    def on_train_end(self, args, state, control, **kwargs):
+        print(f"Training complete! Best metric: {state.best_metric} at step {state.best_global_step}")
+```
+
+Register the callback with [`Trainer`] in the `callbacks` argument. You can also pass multiple callbacks as a list.
+
+```python
 trainer = Trainer(
-    model=model,
-    args=training_args,
-    train_dataset=dataset["train"],
-    eval_dataset=dataset["test"],
-    processing_class=tokenizer,
-    data_collator=data_collator,
-    compute_metrics=compute_metrics,
-    callbacks=[EarlyStoppingCallback()],
+    callbacks=[EpochLoggerCallback(lr_eval_threshold=1e-5)],
+    ...,
 )
 ```
+
+## Built-in callbacks
+
+Transformers includes several built-in callbacks that are active by default. Additional [integrated callbacks](./main_classes/callback#available-callbacks) log to platforms like [Trackio](https://huggingface.co/docs/trackio/en/index) and [CodeCarbon](https://mlco2.github.io/codecarbon/).
+
+### DefaultFlowCallback
+
+[`DefaultFlowCallback`] manages the default logging, evaluation, and checkpoint schedule based on the `logging_strategy`, `eval_strategy`, and `save_strategy` values in [`TrainingArguments`]. At the right step or epoch, it sets the corresponding `control` flags (`should_log`, `should_evaluate`, `should_save`). It also sets `should_training_stop` when `global_step` reaches `max_steps`.
+
+Overriding this callback is the main way to customize *when* logging, evaluation, or saving happens.
+
+### ProgressCallback
+
+[`ProgressCallback`] displays a progress bar during training and a separate bar during evaluation or prediction. On each `on_log` event, it prints the latest metrics alongside the bar. During distributed training, it only runs on the main process to avoid duplicate output.
+
+Replace with [`PrinterCallback`] if you want printed logs instead of a progress bar.
+
+### PrinterCallback
+
+[`PrinterCallback`] prints the log dictionary to stdout on every `on_log` event with no progress bar.
+
+Use [`~Trainer.remove_callback`] and [`~Trainer.add_callback`] to replace a callback.
+
+```py
+from transformers import PrinterCallback
+
+trainer = Trainer(...)
+trainer.remove_callback(ProgressCallback)
+trainer.add_callback(PrinterCallback)
+```
+
+### EarlyStoppingCallback
+
+[`EarlyStoppingCallback`] stops training when an evaluation metric stops improving. After each evaluation, it checks whether the metric improved by more than `early_stopping_threshold`. If the metric hasn't improved for `early_stopping_patience` consecutive evaluations, training stops.
+
+[`EarlyStoppingCallback`] requires two [`TrainingArguments`]:
+
+- `metric_for_best_model`, the evaluation metric to monitor
+- `eval_strategy`, whether to evaluate on `"steps"` or `"epoch"`
+
+```py
+from transformers import EarlyStoppingCallback
+
+trainer = Trainer(
+    ...,
+    callbacks=[EarlyStoppingCallback(early_stopping_patience=3, early_stopping_threshold=0.001)],
+)
+```
+
+## Next steps
+
+- The [Customizing the Trainer](./trainer_customize) guide covers subclassing [`Trainer`] methods for deeper control.
+>>>>>>> e7737441a1 (callbacks and collators)

--- a/docs/source/en/trainer_customize.md
+++ b/docs/source/en/trainer_customize.md
@@ -96,3 +96,4 @@ def compute_loss(
 ## Next steps
 
 - For more real-world examples, see how [`~trl.GRPOTrainer`] and [`~trl.DPOTrainer`] extend [`Trainer`] in TRL, or how [Axolotl](https://github.com/axolotl-ai-cloud/axolotl/tree/main/src/axolotl/core/trainers) builds custom trainers on top of it.
+- Check the [Callbacks](./trainer_callbacks) guide if you only need to customize what happens during a training event such as logging metrics at the end of a training step. 

--- a/docs/source/en/training.md
+++ b/docs/source/en/training.md
@@ -153,4 +153,6 @@ trainer.push_to_hub()
 ## Next steps
 
 - Read the [Subclassing Trainer methods](./trainer_customize) guide to learn how to subclass [`Trainer`] methods to support new and custom functionalities.
+- Read the [Callbacks](./trainer_callbacks) guide to learn how to hook into training events for logging, early stopping, and other custom behavior.
+- Read the [Data collators](./data_collators) guide to learn how to customize how samples are assembled into batches.
 - Browse [transformers/examples/pytorch](https://github.com/huggingface/transformers/tree/main/examples/pytorch), [notebooks](./notebooks), or the **Resources > Task Recipes** section for additional training examples on different text, audio, vision, and multimodal tasks.


### PR DESCRIPTION
part 2 of refactoring the training docs adds new dedicated guide to callbacks and data collators

todo:

- [x] backlink to `## Next steps` in `trainer.md` once https://github.com/huggingface/transformers/pull/44185 is merged