### PR TITLE
fix: add load balancing loss when output_router_logits=False

### DIFF
--- a/src/transformers/models/mixtral/modeling_mixtral.py
+++ b/src/transformers/models/mixtral/modeling_mixtral.py
@@ -649,6 +649,10 @@ class MixtralForCausalLM(MixtralPreTrainedModel, GenerationMixin):
             output_router_logits if output_router_logits is not None else self.config.output_router_logits
         )
 
+        # If labels are provided, we need to compute load balancing loss, so we need to collect router_logits
+        # regardless of output_router_logits setting
+        forward_router_logits = output_router_logits or (labels is not None)
+
         # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
         outputs: MoeModelOutputWithPast = self.model(
             input_ids=input_ids,
@@ -657,7 +661,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel, GenerationMixin):
             past_key_values=past_key_values,
             inputs_embeds=inputs_embeds,
             use_cache=use_cache,
-            output_router_logits=output_router_logits,
+            output_router_logits=forward_router_logits,
             cache_position=cache_position,
             **kwargs,
         )
@@ -672,15 +676,14 @@ class MixtralForCausalLM(MixtralPreTrainedModel, GenerationMixin):
             loss = self.loss_function(logits, labels, self.vocab_size, **kwargs)
 
         aux_loss = None
-        if output_router_logits:
+        if labels is not None and forward_router_logits:
             aux_loss = load_balancing_loss_func(
                 outputs.router_logits,
                 self.num_experts,
                 self.num_experts_per_tok,
                 attention_mask,
             )
-            if labels is not None:
-                loss += self.router_aux_loss_coef * aux_loss.to(loss.device)  # make sure to reside in the same device
+            loss += self.router_aux_loss_coef * aux_loss.to(loss.device)  # make sure to reside in the same device
 
         return MoeCausalLMOutputWithPast(
             loss=loss,
@@ -689,7 +692,7 @@ class MixtralForCausalLM(MixtralPreTrainedModel, GenerationMixin):
             past_key_values=outputs.past_key_values,
             hidden_states=outputs.hidden_states,
             attentions=outputs.attentions,
-            router_logits=outputs.router_logits,
+            router_logits=outputs.router_logits if output_router_logits else None,
         )
 
 

--- a/tests/models/mixtral/test_modeling_mixtral.py
+++ b/tests/models/mixtral/test_modeling_mixtral.py
@@ -107,6 +107,61 @@ class MixtralModelTest(CausalLMModelTest, unittest.TestCase):
         # This is to mimic torch.testing.assert_not_close
         self.assertNotAlmostEqual(include_padding_result.aux_loss.item(), result.aux_loss.item())
 
+    @is_flaky(max_attempts=2)
+    def test_load_balancing_loss_with_output_router_logits_false(self):
+        r"""
+        Test that load balancing loss is still computed and added to total loss even when output_router_logits=False.
+        This is a regression test for https://github.com/huggingface/transformers/issues/44242
+        """
+        # Set seed for deterministic test
+        set_seed(42)
+        config, input_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config.num_labels = 3
+        config.num_local_experts = 3
+        config.output_router_logits = False  # Explicitly set to False
+        input_ids = input_dict["input_ids"]
+        attention_mask = input_ids.ne(1).to(torch_device)
+
+        # Test 1: With labels (training mode), aux_loss should be computed even with output_router_logits=False
+        model = MixtralForCausalLM(config)
+        model.to(torch_device)
+        model.eval()
+
+        # When labels are provided, load balancing loss should be computed
+        result_with_labels = model(
+            input_ids,
+            attention_mask=attention_mask,
+            labels=input_ids,  # Provide labels to trigger loss computation
+            output_router_logits=False,
+        )
+        # The loss should include the aux_loss contribution
+        self.assertIsNotNone(result_with_labels.loss)
+        # aux_loss should be computed
+        self.assertIsNotNone(result_with_labels.aux_loss)
+        # router_logits should NOT be in output since output_router_logits=False
+        self.assertIsNone(result_with_labels.router_logits)
+
+        # Test 2: Without labels (inference mode), aux_loss should not be computed
+        result_without_labels = model(
+            input_ids,
+            attention_mask=attention_mask,
+            output_router_logits=False,
+        )
+        # aux_loss should be None when no labels
+        self.assertIsNone(result_without_labels.aux_loss)
+        # router_logits should NOT be in output
+        self.assertIsNone(result_without_labels.router_logits)
+
+        # Test 3: Verify that with output_router_logits=True, we get router_logits in output
+        result_with_router = model(
+            input_ids,
+            attention_mask=attention_mask,
+            labels=input_ids,
+            output_router_logits=True,
+        )
+        self.assertIsNotNone(result_with_router.router_logits)
+        self.assertEqual(result_with_router.router_logits[0].shape, (91, config.num_local_experts))
+
 
 @require_torch
 class MixtralIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Fixes #44242

Load balancing loss was not being added when `output_router_logits=False` in Mixtral models.

## Changes

- Fixed loss calculation to include load balancing even when router logits are not output
- Added test case

## Testing

Added test in `test_modeling_mixtral.py`