### PR TITLE
fix: add backward compatibility for grouped_entities parameter

### DIFF
--- a/src/transformers/pipelines/token_classification.py
+++ b/src/transformers/pipelines/token_classification.py
@@ -152,6 +152,7 @@ class TokenClassificationPipeline(ChunkPipeline):
         is_split_into_words: bool = False,
         stride: int | None = None,
         delimiter: str | None = None,
+        grouped_entities: bool | None = None,
     ):
         preprocess_params = {}
         preprocess_params["is_split_into_words"] = is_split_into_words
@@ -163,6 +164,14 @@ class TokenClassificationPipeline(ChunkPipeline):
             preprocess_params["offset_mapping"] = offset_mapping
 
         postprocess_params = {}
+        if grouped_entities is not None:
+            if aggregation_strategy is not None:
+                raise ValueError(
+                    "Cannot specify both `grouped_entities` and `aggregation_strategy`. "
+                    "Please use `aggregation_strategy` only, as `grouped_entities` is deprecated."
+                )
+            aggregation_strategy = AggregationStrategy.SIMPLE if grouped_entities else AggregationStrategy.NONE
+
         if aggregation_strategy is not None:
             if isinstance(aggregation_strategy, str):
                 aggregation_strategy = AggregationStrategy[aggregation_strategy.upper()]


### PR DESCRIPTION
## What does this PR fix?

This PR adds backward compatibility for the deprecated `grouped_entities` parameter in the `TokenClassificationPipeline`.

## Problem

The `grouped_entities` parameter was deprecated in favor of `aggregation_strategy`, but it was completely removed from `_sanitize_parameters()`, causing a `TypeError` when users try to use the old parameter:

```
TypeError: TokenClassificationPipeline._sanitize_parameters() got an unexpected keyword argument 'grouped_entities'
```

This breaks many existing notebooks and tutorials that still use `grouped_entities=True`.

## Solution

- Add `grouped_entities` as an optional parameter to `_sanitize_parameters()`
- Convert `grouped_entities=True` to `aggregation_strategy=AggregationStrategy.SIMPLE`
- Convert `grouped_entities=False` to `aggregation_strategy=AggregationStrategy.NONE`
- Raise a clear error if both `grouped_entities` and `aggregation_strategy` are specified

## Testing

The fix has been verified to work with the following test case:
```python
from transformers import pipeline
ner = pipeline("ner", grouped_entities=True)  # Now works!
```

Fixes #44016