### PR TITLE
Fix fast tokenizers overwriting custom `pre_tokenizer` from `tokenizer.json`

### DIFF
--- a/src/transformers/models/gpt2/tokenization_gpt2.py
+++ b/src/transformers/models/gpt2/tokenization_gpt2.py
@@ -106,18 +106,19 @@ class GPT2Tokenizer(TokenizersBackend):
         self.add_prefix_space = add_prefix_space
         self._vocab = vocab if vocab is not None else {}
         self._merges = merges or []
-        self._tokenizer = Tokenizer(
-            BPE(
-                vocab=self._vocab,
-                merges=self._merges,
-                dropout=None,
-                continuing_subword_prefix="",
-                end_of_word_suffix="",
-                fuse_unk=False,
+        if "tokenizer_object" not in kwargs:
+            self._tokenizer = Tokenizer(
+                BPE(
+                    vocab=self._vocab,
+                    merges=self._merges,
+                    dropout=None,
+                    continuing_subword_prefix="",
+                    end_of_word_suffix="",
+                    fuse_unk=False,
+                )
             )
-        )
-        self._tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=add_prefix_space)
-        self._tokenizer.decoder = decoders.ByteLevel()
+            self._tokenizer.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=add_prefix_space)
+            self._tokenizer.decoder = decoders.ByteLevel()
         super().__init__(
             errors=errors,
             unk_token=unk_token,

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -116,7 +116,9 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             return local_kwargs
         elif fast_tokenizer_file is not None and os.path.isfile(fast_tokenizer_file):
             # we extract vocab / merges from the tokenizer file to pass them to __init__
-            processor = TokenizerFast.from_file(fast_tokenizer_file).post_processor
+            fast_tokenizer = TokenizerFast.from_file(fast_tokenizer_file)
+            processor = fast_tokenizer.post_processor
+            local_kwargs["tokenizer_object"] = fast_tokenizer
             with open(fast_tokenizer_file, encoding="utf-8") as tokenizer_handle:
                 tokenizer_json = json.load(tokenizer_handle)
             vocab = tokenizer_json.get("model", {}).get("vocab", None)
@@ -245,7 +247,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         merges = kwargs.get("merges")
 
         fast_tokenizer = None
-        if tokenizer_object is not None:
+        if tokenizer_object is not None and self._tokenizer is None:
             fast_tokenizer = copy.deepcopy(tokenizer_object)
         elif fast_tokenizer_file is not None and os.path.isfile(fast_tokenizer_file):
             # We have a serialization from tokenizers which let us directly build the backend


### PR DESCRIPTION
## What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Fixes a bug where fast tokenizer classes that define their own `__init__` (e.g. `GPT2Tokenizer`, used by `allenai/Olmo-3-7B-Instruct`, `microsoft/phi-4`) silently discard the `pre_tokenizer` from the model's `tokenizer.json` and replace it with a generic `ByteLevel`.

**Root cause:** In `TokenizersBackend.convert_to_native_format`, when a tokenizer class has a custom `__init__`, the method only extracted `vocab`/`merges` from `tokenizer.json` but did not pass the full `tokenizer_object`. The child's `__init__` would then construct a fresh tokenizer and forcefully set `pre_tokenizer = ByteLevel(...)`, discarding the `Sequence` (containing `Split` regex + `ByteLevel`) defined in the file.

**Fix:** Also pass `tokenizer_object` in the `elif` branch so the parent `__init__` overrides the child's manually-constructed tokenizer with the complete one from `tokenizer.json`, preserving all settings (`pre_tokenizer`, `decoder`, `normalizer`, etc.).

The bug caused incorrect tokenization of inputs with newlines, as shown in the example below:
- **Before (broken):** `\n\nhello` → `['Ċ', 'Ċ', 'hello']` (3 pre-tokens)
- **After (correct):** `\n\nhello` → `['ĊĊ', 'hello']` (2 pre-tokens)

This subtle tokenization difference can have a significant impact on downstream tasks, especially for instruction-tuned models that rely on a chat template. For example, if the chat template appends `\n\n` after the assistant message tag to trigger the model's response, the correct tokenization is a single `ĊĊ` token -- which is what the model saw during pre-training. With the broken `pre_tokenizer`, inference produces two separate `Ċ` tokens instead. Since the sequence `[Ċ, Ċ]` was never seen in that position during pre-training, the model may produce degraded or unexpected outputs at generation time.

Regression introduced in v5.0.0rc1.

### Reproduction

```python
from transformers import AutoTokenizer
import json

model_id = "allenai/Olmo-3-7B-Instruct"
tokenizer = AutoTokenizer.from_pretrained(model_id)

# Check the pre_tokenizer type
backend_json = json.loads(tokenizer.backend_tokenizer.to_str())
print(json.dumps(backend_json["pre_tokenizer"], indent=2))
# Before fix: {"type": "ByteLevel", ...}
# After fix:  {"type": "Sequence", "pretokenizers": [{"type": "Split", ...}, {"type": "ByteLevel", ...}]}

# Tokenization of "\n\nhello"
pre_tokens = tokenizer._tokenizer.pre_tokenizer.pre_tokenize_str("\n\nhello")
split_words = [word for word, _ in pre_tokens]
print(f"Pre-tokens: {split_words}")
# Before fix (wrong): ['Ċ', 'Ċ', 'hello']  — newlines split individually
# After fix (correct): ['ĊĊ', 'hello']      — newlines grouped per the Split regex

tokens = tokenizer.tokenize("\n\nhello")
print(f"Tokens: {tokens}")
# Before fix (wrong): ['Ċ', 'Ċ', 'hello']
# After fix (correct): ['ĊĊ', 'hello']
```

@ArthurZucker @itazap 