### PR TITLE
Add correct typing to custom images_kwargs in ProcessorsKwargs

### DIFF
--- a/src/transformers/models/align/processing_align.py
+++ b/src/transformers/models/align/processing_align.py
@@ -17,9 +17,11 @@ Image/Text processor class for ALIGN
 
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...utils import auto_docstring
+from ..efficientnet.image_processing_efficientnet import EfficientNetImageProcessorKwargs
 
 
 class AlignProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: EfficientNetImageProcessorKwargs
     # see processing_utils.ProcessingKwargs documentation for usage.
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/aya_vision/processing_aya_vision.py
+++ b/src/transformers/models/aya_vision/processing_aya_vision.py
@@ -20,9 +20,11 @@ from ...image_utils import ImageInput, make_flat_list_of_images
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
+from ..got_ocr2.image_processing_got_ocr2 import GotOcr2ImageProcessorKwargs
 
 
 class AyaVisionProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: GotOcr2ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding_side": "left",

--- a/src/transformers/models/bridgetower/processing_bridgetower.py
+++ b/src/transformers/models/bridgetower/processing_bridgetower.py
@@ -17,9 +17,11 @@ Processor class for BridgeTower.
 
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...utils import auto_docstring
+from .image_processing_bridgetower import BridgeTowerImageProcessorKwargs
 
 
 class BridgeTowerProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: BridgeTowerImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/cohere2_vision/processing_cohere2_vision.py
+++ b/src/transformers/models/cohere2_vision/processing_cohere2_vision.py
@@ -20,9 +20,11 @@ from ...image_utils import ImageInput
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
+from .image_processing_cohere2_vision_fast import Cohere2VisionFastImageProcessorKwargs
 
 
 class Cohere2VisionProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Cohere2VisionFastImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding_side": "left",

--- a/src/transformers/models/colqwen2/processing_colqwen2.py
+++ b/src/transformers/models/colqwen2/processing_colqwen2.py
@@ -29,9 +29,11 @@ from ...utils import auto_docstring, is_torch_available
 
 if is_torch_available():
     import torch
+from ..qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessorKwargs
 
 
 class ColQwen2ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Qwen2VLImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": "longest",

--- a/src/transformers/models/deepseek_vl/processing_deepseek_vl.py
+++ b/src/transformers/models/deepseek_vl/processing_deepseek_vl.py
@@ -24,9 +24,11 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
+from .image_processing_deepseek_vl import DeepseekVLImageProcessorKwargs
 
 
 class DeepseekVLProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: DeepseekVLImageProcessorKwargs
     _defaults = {
         "text_kwargs": {"padding": False},
         "common_kwargs": {"return_tensors": "pt"},

--- a/src/transformers/models/deepseek_vl_hybrid/processing_deepseek_vl_hybrid.py
+++ b/src/transformers/models/deepseek_vl_hybrid/processing_deepseek_vl_hybrid.py
@@ -23,9 +23,11 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
+from .image_processing_deepseek_vl_hybrid import DeepseekVLHybridImageProcessorKwargs
 
 
 class DeepseekVLHybridProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: DeepseekVLHybridImageProcessorKwargs
     _defaults = {
         "text_kwargs": {"padding": False},
         "common_kwargs": {"return_tensors": "pt"},

--- a/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/processing_ernie4_5_vl_moe.py
@@ -22,9 +22,11 @@ from ...image_utils import ImageInput
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...video_utils import VideoInput
+from .image_processing_ernie4_5_vl_moe import Ernie4_5_VL_MoeImageProcessorKwargs
 
 
 class Ernie4_5_VL_MoeProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Ernie4_5_VL_MoeImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -41,6 +41,7 @@ logger = logging.get_logger(__name__)
 
 if is_torch_available():
     import torch
+from .image_processing_fuyu import FuyuImagesKwargs
 
 
 TEXT_REPR_BBOX_OPEN = "<box>"
@@ -56,6 +57,7 @@ BEGINNING_OF_ANSWER_STRING = "<0x04>"  # <boa>
 
 
 class FuyuProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: FuyuImagesKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/gemma3/processing_gemma3.py
+++ b/src/transformers/models/gemma3/processing_gemma3.py
@@ -21,9 +21,11 @@ from ...image_utils import ImageInput, make_nested_list_of_images
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, to_py_obj
+from .image_processing_gemma3 import Gemma3ImageProcessorKwargs
 
 
 class Gemma3ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Gemma3ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/glm46v/processing_glm46v.py
+++ b/src/transformers/models/glm46v/processing_glm46v.py
@@ -27,12 +27,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from .image_processing_glm46v import Glm46VImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class Glm46VProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Glm46VImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/glm4v/processing_glm4v.py
+++ b/src/transformers/models/glm4v/processing_glm4v.py
@@ -26,12 +26,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from .image_processing_glm4v import Glm4vImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class Glm4vProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Glm4vImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/grounding_dino/processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/processing_grounding_dino.py
@@ -30,6 +30,7 @@ if is_torch_available():
 
 if TYPE_CHECKING:
     from .modeling_grounding_dino import GroundingDinoObjectDetectionOutput
+from .image_processing_grounding_dino import GroundingDinoImageProcessorKwargs
 
 
 AnnotationType = dict[str, int | str | list[dict]]
@@ -98,6 +99,7 @@ class DictWithDeprecationWarning(dict):
 
 
 class GroundingDinoProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: GroundingDinoImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/idefics/processing_idefics.py
+++ b/src/transformers/models/idefics/processing_idefics.py
@@ -31,6 +31,7 @@ from ...utils import auto_docstring, is_torch_available
 
 if is_torch_available():
     import torch
+from .image_processing_idefics import IdeficsImageProcessorKwargs
 
 
 IMAGE_TOKEN = "<image>"
@@ -52,6 +53,7 @@ class IdeficsTextKwargs(TextKwargs, total=False):
 
 
 class IdeficsProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: IdeficsImageProcessorKwargs
     text_kwargs: IdeficsTextKwargs
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/idefics2/processing_idefics2.py
+++ b/src/transformers/models/idefics2/processing_idefics2.py
@@ -32,6 +32,7 @@ from ...utils import auto_docstring, logging
 
 if TYPE_CHECKING:
     from ...tokenization_utils_base import PreTokenizedInput
+from .image_processing_idefics2 import Idefics2ImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
@@ -46,6 +47,7 @@ def is_image_or_image_url(elem):
 
 
 class Idefics2ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Idefics2ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/idefics3/processing_idefics3.py
+++ b/src/transformers/models/idefics3/processing_idefics3.py
@@ -30,6 +30,7 @@ from ...utils import auto_docstring, logging
 
 if TYPE_CHECKING:
     from ...tokenization_utils_base import PreTokenizedInput
+from .image_processing_idefics3 import Idefics3ImageProcessorKwargs
 
 logger = logging.get_logger(__name__)
 
@@ -87,6 +88,7 @@ def get_image_prompt_string(
 
 
 class Idefics3ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Idefics3ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/internvl/processing_internvl.py
+++ b/src/transformers/models/internvl/processing_internvl.py
@@ -21,9 +21,11 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
 from ...video_utils import VideoInput
+from ..got_ocr2.image_processing_got_ocr2 import GotOcr2ImageProcessorKwargs
 
 
 class InternVLProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: GotOcr2ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding_side": "left",

--- a/src/transformers/models/janus/processing_janus.py
+++ b/src/transformers/models/janus/processing_janus.py
@@ -20,6 +20,7 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, TextKwargs, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
+from .image_processing_janus import JanusImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
@@ -43,6 +44,7 @@ class JanusTextKwargs(TextKwargs, total=False):
 
 
 class JanusProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: JanusImageProcessorKwargs
     text_kwargs: JanusTextKwargs
     _defaults = {
         "text_kwargs": {"padding": False, "generation_mode": "text"},

--- a/src/transformers/models/lfm2_vl/processing_lfm2_vl.py
+++ b/src/transformers/models/lfm2_vl/processing_lfm2_vl.py
@@ -23,6 +23,7 @@ from ...processing_utils import (
 )
 from ...tokenization_utils_base import BatchEncoding, TextInput
 from ...utils import auto_docstring, logging
+from .image_processing_lfm2_vl_fast import Lfm2VlImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
@@ -40,6 +41,7 @@ class Lfm2VlTextKwargs(TextKwargs, total=False):
 
 
 class Lfm2VlProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Lfm2VlImageProcessorKwargs
     text_kwargs: Lfm2VlTextKwargs
     _defaults = {
         "images_kwargs": {

--- a/src/transformers/models/lighton_ocr/processing_lighton_ocr.py
+++ b/src/transformers/models/lighton_ocr/processing_lighton_ocr.py
@@ -26,9 +26,11 @@ from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ChannelDimension, ImageInput, get_image_size
 from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
+from ..pixtral.image_processing_pixtral import PixtralImageProcessorKwargs
 
 
 class LightOnOcrProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: PixtralImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/llama4/processing_llama4.py
+++ b/src/transformers/models/llama4/processing_llama4.py
@@ -19,9 +19,11 @@ from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 from ...image_processing_utils import BatchFeature
 from ...image_utils import ImageInput, make_flat_list_of_images
 from ...utils import auto_docstring
+from .image_processing_llama4_fast import Llama4ImageProcessorKwargs
 
 
 class Llama4ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Llama4ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding_side": "left",

--- a/src/transformers/models/llava_next/processing_llava_next.py
+++ b/src/transformers/models/llava_next/processing_llava_next.py
@@ -28,12 +28,14 @@ from ...processing_utils import (
 )
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
+from .image_processing_llava_next import LlavaNextImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class LlavaNextProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: LlavaNextImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/llava_next_video/processing_llava_next_video.py
+++ b/src/transformers/models/llava_next_video/processing_llava_next_video.py
@@ -24,12 +24,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from ..llava_next.image_processing_llava_next import LlavaNextImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class LlavaNextVideoProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: LlavaNextImageProcessorKwargs
     # see processing_utils.ProcessingKwargs documentation for usage.
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/llava_onevision/processing_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/processing_llava_onevision.py
@@ -27,12 +27,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from .image_processing_llava_onevision import LlavaOnevisionImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class LlavaOnevisionProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: LlavaOnevisionImageProcessorKwargs
     # see processing_utils.ProcessingKwargs documentation for usage.
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/mllama/processing_mllama.py
+++ b/src/transformers/models/mllama/processing_mllama.py
@@ -21,9 +21,11 @@ from ...image_utils import ImageInput, make_nested_list_of_images
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
+from .image_processing_mllama import MllamaImageProcessorKwargs
 
 
 class MllamaProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: MllamaImageProcessorKwargs
     _defaults = {
         "image_kwargs": {
             "max_image_tiles": 4,

--- a/src/transformers/models/omdet_turbo/processing_omdet_turbo.py
+++ b/src/transformers/models/omdet_turbo/processing_omdet_turbo.py
@@ -33,6 +33,7 @@ from ...utils.import_utils import requires
 
 if TYPE_CHECKING:
     from .modeling_omdet_turbo import OmDetTurboObjectDetectionOutput
+from ..detr.image_processing_detr import DetrImageProcessorKwargs
 
 
 class OmDetTurboTextKwargs(TextKwargs, total=False):
@@ -55,6 +56,7 @@ if is_torchvision_available():
 
 
 class OmDetTurboProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: DetrImageProcessorKwargs
     text_kwargs: OmDetTurboTextKwargs
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/ovis2/processing_ovis2.py
+++ b/src/transformers/models/ovis2/processing_ovis2.py
@@ -18,12 +18,14 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
+from .image_processing_ovis2 import Ovis2ImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class Ovis2ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Ovis2ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/paddleocr_vl/processing_paddleocr_vl.py
+++ b/src/transformers/models/paddleocr_vl/processing_paddleocr_vl.py
@@ -30,9 +30,11 @@ from ...image_processing_utils import BatchFeature
 from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
+from .image_processing_paddleocr_vl import PaddleOCRVLImageProcessorKwargs
 
 
 class PaddleOCRVLProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: PaddleOCRVLImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/perception_lm/processing_perception_lm.py
+++ b/src/transformers/models/perception_lm/processing_perception_lm.py
@@ -24,12 +24,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from .image_processing_perception_lm_fast import PerceptionLMImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class PerceptionLMProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: PerceptionLMImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/phi4_multimodal/processing_phi4_multimodal.py
+++ b/src/transformers/models/phi4_multimodal/processing_phi4_multimodal.py
@@ -24,12 +24,14 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import TextInput
 from ...utils import auto_docstring, logging
+from .image_processing_phi4_multimodal_fast import Phi4MultimodalImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class Phi4MultimodalProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Phi4MultimodalImageProcessorKwargs
     _defaults = {
         "audio_kwargs": {
             "device": "cpu",

--- a/src/transformers/models/pix2struct/processing_pix2struct.py
+++ b/src/transformers/models/pix2struct/processing_pix2struct.py
@@ -19,9 +19,11 @@ from ...feature_extraction_utils import BatchFeature
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack
 from ...tokenization_utils_base import BatchEncoding, PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
+from .image_processing_pix2struct import Pix2StructImageProcessorKwargs
 
 
 class Pix2StructProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Pix2StructImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/pixtral/processing_pixtral.py
+++ b/src/transformers/models/pixtral/processing_pixtral.py
@@ -31,12 +31,14 @@ from ...utils import auto_docstring, is_vision_available, logging
 
 if is_vision_available():
     from .image_processing_pixtral import get_resize_output_image_size
+from .image_processing_pixtral import PixtralImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class PixtralProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: PixtralImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -27,6 +27,7 @@ from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack, Videos
 from ...tokenization_utils_base import AudioInput, PreTokenizedInput, TextInput
 from ...utils import auto_docstring
 from ...video_utils import VideoInput
+from ..qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessorKwargs
 
 
 # Redefine kwargs for videos because Qwen-Omni uses some kwargs for processing omni
@@ -78,6 +79,7 @@ class Qwen2_5_OmniVideosKwargs(VideosKwargs, total=False):
 
 
 class Qwen2_5OmniProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Qwen2VLImageProcessorKwargs
     videos_kwargs: Qwen2_5_OmniVideosKwargs
 
     _defaults = {

--- a/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
@@ -31,9 +31,11 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
 from ...video_utils import VideoInput
+from ..qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessorKwargs
 
 
 class Qwen2_5_VLProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Qwen2VLImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/qwen2_vl/processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/processing_qwen2_vl.py
@@ -28,12 +28,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from .image_processing_qwen2_vl import Qwen2VLImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class Qwen2VLProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Qwen2VLImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -29,6 +29,7 @@ from ...processing_utils import ProcessingKwargs, ProcessorMixin, VideosKwargs
 from ...tokenization_utils_base import TextInput
 from ...utils import auto_docstring
 from ...video_utils import VideoInput, make_batched_videos
+from ..qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessorKwargs
 
 
 # Redefine kwargs for videos because Qwen-Omni uses some kwargs for processing omni
@@ -80,6 +81,7 @@ class Qwen3OmniMoeVideosKwargs(VideosKwargs, total=False):
 
 
 class Qwen3OmniMoeProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Qwen2VLImageProcessorKwargs
     videos_kwargs: Qwen3OmniMoeVideosKwargs
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/processing_qwen3_vl.py
@@ -26,12 +26,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from ..qwen2_vl.image_processing_qwen2_vl import Qwen2VLImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class Qwen3VLProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Qwen2VLImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/shieldgemma2/processing_shieldgemma2.py
+++ b/src/transformers/models/shieldgemma2/processing_shieldgemma2.py
@@ -19,6 +19,7 @@ from ...image_utils import ImageInput
 from ...processing_utils import Unpack
 from ...utils import logging
 from ..gemma3.processing_gemma3 import Gemma3Processor, Gemma3ProcessorKwargs
+from ..gemma3.image_processing_gemma3 import Gemma3ImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
@@ -45,6 +46,7 @@ DEFAULT_SHIELDGEMMA2_POLICIES: Mapping[str, str] = {
 
 
 class ShieldGemma2ProcessorKwargs(Gemma3ProcessorKwargs, total=False):
+    images_kwargs: Gemma3ImageProcessorKwargs
     policies: Sequence[str] | None
     custom_policies: Mapping[str, str] | None
     _defaults = {

--- a/src/transformers/models/siglip2/processing_siglip2.py
+++ b/src/transformers/models/siglip2/processing_siglip2.py
@@ -17,9 +17,11 @@ Image/Text processor class for SigLIP2.
 
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...utils import auto_docstring
+from .image_processing_siglip2 import Siglip2ImageProcessorKwargs
 
 
 class Siglip2ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: Siglip2ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": "max_length",

--- a/src/transformers/models/smolvlm/processing_smolvlm.py
+++ b/src/transformers/models/smolvlm/processing_smolvlm.py
@@ -24,6 +24,7 @@ from ...processing_utils import AllKwargsForChatTemplate, ProcessingKwargs, Proc
 from ...tokenization_utils_base import BatchEncoding, TextInput
 from ...utils import auto_docstring, is_num2words_available, is_vision_available, logging
 from ...video_utils import VideoInput
+from .image_processing_smolvlm import SmolVLMImageProcessorKwargs
 
 
 if is_vision_available():
@@ -96,6 +97,7 @@ def get_image_prompt_string(
 
 
 class SmolVLMProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: SmolVLMImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,

--- a/src/transformers/models/tvp/processing_tvp.py
+++ b/src/transformers/models/tvp/processing_tvp.py
@@ -17,9 +17,11 @@ Processor class for TVP.
 
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...utils import auto_docstring
+from .image_processing_tvp import TvpImageProcessorKwargs
 
 
 class TvpProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: TvpImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "truncation": True,

--- a/src/transformers/models/udop/processing_udop.py
+++ b/src/transformers/models/udop/processing_udop.py
@@ -22,6 +22,7 @@ from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, TextKwargs, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring
+from ..layoutlmv3.image_processing_layoutlmv3 import LayoutLMv3ImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
@@ -33,6 +34,7 @@ class UdopTextKwargs(TextKwargs, total=False):
 
 
 class UdopProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: LayoutLMv3ImageProcessorKwargs
     text_kwargs: UdopTextKwargs
     _defaults = {
         "text_kwargs": {

--- a/src/transformers/models/video_llama_3/processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/processing_video_llama_3.py
@@ -26,12 +26,14 @@ from ...processing_utils import MultiModalData, ProcessingKwargs, ProcessorMixin
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+from .image_processing_video_llama_3 import VideoLlama3ImageProcessorKwargs
 
 
 logger = logging.get_logger(__name__)
 
 
 class VideoLlama3ProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: VideoLlama3ImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "padding": False,

--- a/src/transformers/models/vilt/processing_vilt.py
+++ b/src/transformers/models/vilt/processing_vilt.py
@@ -17,9 +17,11 @@ Processor class for ViLT.
 
 from ...processing_utils import ProcessingKwargs, ProcessorMixin
 from ...utils import auto_docstring
+from .image_processing_vilt import ViltImageProcessorKwargs
 
 
 class ViltProcessorKwargs(ProcessingKwargs, total=False):
+    images_kwargs: ViltImageProcessorKwargs
     _defaults = {
         "text_kwargs": {
             "add_special_tokens": True,


### PR DESCRIPTION
# What does this PR do?

A lot of ProcessorsKwargs have incorrect/unspecified type hints in their ProcessorsKwargs TypedDict for their images_kwargs attribute.
Functionnaly, this did not cause issues as "_merge_kwargs" automatically picks up the correct CustomImagesKwargs to define the valid_processor_kwargs for image processors. However it is incoherent and confusing for users looking at the code and at the docs.