### PR TITLE
Fix TypeError in convert_rope_params_to_dict when ignore_keys is a list

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -646,7 +646,7 @@ class RotaryEmbeddingConfigMixin:
         if partial_rotary_factor is not None:
             self.rope_parameters.setdefault("partial_rotary_factor", partial_rotary_factor)
             ignore_keys_at_rope_validation = (
-                set() if ignore_keys_at_rope_validation is None else ignore_keys_at_rope_validation
+                set() if ignore_keys_at_rope_validation is None else set(ignore_keys_at_rope_validation)
             )
             ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
 


### PR DESCRIPTION
## What does this PR do?

Fixes a `TypeError: unsupported operand type(s) for |: 'list' and 'set'` in `RotaryEmbeddingConfigMixin.convert_rope_params_to_dict` when `ignore_keys_at_rope_validation` is a `list` instead of a `set`.

### Root cause

In `modeling_rope_utils.py` line 649, the `else` branch passes through `ignore_keys_at_rope_validation` without type coercion. Line 651 then performs `ignore_keys_at_rope_validation | {"partial_rotary_factor"}`, which fails if the value is a `list` (since `list | set` is not supported in Python).

### When does this happen?

Model configs define `ignore_keys_at_rope_validation` as a `set` literal in `__init__`, so the normal `from_pretrained` flow works. However, when third-party serving frameworks (e.g. vLLM) define their own config classes that pass this field through JSON deserialization, the value arrives as a `list`, triggering the crash.

Encountered in practice when serving **Qwen3.5-27B** via vLLM (which bundles its own `Qwen3_5TextConfig` that inherits from `PretrainedConfig`).

### Fix

Wrap in `set()` to normalize any iterable. `set(already_a_set)` returns a copy, so existing behavior is preserved.

```diff
- set() if ignore_keys_at_rope_validation is None else ignore_keys_at_rope_validation
+ set() if ignore_keys_at_rope_validation is None else set(ignore_keys_at_rope_validation)
```

## Traceback

```
File "transformers/modeling_rope_utils.py", line 651, in convert_rope_params_to_dict
    ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
TypeError: unsupported operand type(s) for |: 'list' and 'set'
```

Full call chain: `Qwen3_5TextConfig.__init__` → `PretrainedConfig.__init__` → `convert_rope_params_to_dict`