### PR TITLE
[`Modular`] Fix file type regression

### DIFF
--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -522,7 +522,7 @@ ALL_FILE_TYPES = (
     "image_processing.*_fast",
     "image_processing",
     "video_processing",
-    "feature-extraction",
+    "feature_extraction",
 )
 
 


### PR DESCRIPTION
Accidentally caused by #43325, wrong naming --> modular doesn't properly convert some files (e.g. kyutai)

Also fixes red CI on main