### PR TITLE
Fix TypeError in modeling_rope_utils.py when ignore_keys_at_rope_vali…

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -648,7 +648,7 @@ class RotaryEmbeddingConfigMixin:
             ignore_keys_at_rope_validation = (
                 set() if ignore_keys_at_rope_validation is None else set(ignore_keys_at_rope_validation)
             )
-            ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
+            ignore_keys_at_rope_validation = set(ignore_keys_at_rope_validation or []) | {"partial_rotary_factor"}
 
         self.standardize_rope_params()
         self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)


### PR DESCRIPTION

# What does this PR do?

When loading the new Qwen 3.5 models (e.g., 'Qwen/Qwen3.5-35B-A3B') using the 'transformers' (5.3.0.dev0), the initialization crashes with a 'TypeError' .
 **Error Traceback Context:**
(APIServer pid=98544)   File ".../.venv/lib/python3.12/site-packages/transformers/configuration_utils.py", line 219, in __init__
(APIServer pid=98544)     kwargs = self.convert_rope_params_to_dict(
(APIServer pid=98544)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=98544)   File ".../.venv/lib/python3.12/site-packages/transformers/modeling_rope_utils.py", line 651, in convert_rope_params_to_dict
(APIServer pid=98544)     ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
(APIServer pid=98544)                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
(APIServer pid=98544) TypeError: unsupported operand type(s) for |: 'list' and 'set'

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Models:

- text models: @ArthurZucker @Cyrilvallez


