### PR TITLE
Fix mutable default in TPU optimizer and unclosed file handles

### DIFF
--- a/src/transformers/integrations/tpu.py
+++ b/src/transformers/integrations/tpu.py
@@ -151,7 +151,9 @@ def wrap_model_xla_fsdp(model, args, is_fsdp_xla_v2_enabled):
 
     # Patch `xm.optimizer_step` should not reduce gradients in this case,
     # as FSDP does not need gradient reduction over sharded parameters.
-    def patched_optimizer_step(optimizer, barrier=False, optimizer_args={}):
+    def patched_optimizer_step(optimizer, barrier=False, optimizer_args=None):
+        if optimizer_args is None:
+            optimizer_args = {}
         loss = optimizer.step(**optimizer_args)
         if barrier:
             xm.mark_step()

--- a/src/transformers/models/pixtral/convert_pixtral_weights_to_hf.py
+++ b/src/transformers/models/pixtral/convert_pixtral_weights_to_hf.py
@@ -236,7 +236,8 @@ def main():
     image_processor = PixtralImageProcessor()
     processor = PixtralProcessor(tokenizer=tokenizer, image_processor=image_processor, image_token="[IMG]")
     if args.chat_template_file:
-        processor.chat_template = open(args.chat_template_file).read()
+        with open(args.chat_template_file) as f:
+            processor.chat_template = f.read()
     processor.save_pretrained(args.output_dir)
 
 

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1109,9 +1109,8 @@ class ProcessorMixin(PushToHubMixin):
         # json file contains only references to the model path and repo id
         if resolved_audio_tokenizer_file is not None or "audio_tokenizer" in processor_dict:
             if resolved_audio_tokenizer_file is not None:
-                reader = open(resolved_audio_tokenizer_file, "r", encoding="utf-8")
-                audio_tokenizer_dict = reader.read()
-                audio_tokenizer_dict = json.loads(audio_tokenizer_dict)
+                with open(resolved_audio_tokenizer_file, "r", encoding="utf-8") as reader:
+                    audio_tokenizer_dict = json.loads(reader.read())
             else:
                 audio_tokenizer_dict = processor_dict["audio_tokenizer"]
 


### PR DESCRIPTION
# What does this PR do?

Fixes a mutable default argument and two resource leaks:

1. **`integrations/tpu.py`** - `patched_optimizer_step` used `optimizer_args={}` as a default parameter. Mutable defaults are shared across calls, so any mutation of `optimizer_args` inside one call would persist into subsequent calls.

2. **`processing_utils.py`** - The audio tokenizer file was opened with `open()` and assigned to a local variable, but never closed. If `json.loads` raises an exception, the file handle leaks.

3. **`models/pixtral/convert_pixtral_weights_to_hf.py`** - `open(args.chat_template_file).read()` creates a file handle that is never explicitly closed.

All three are fixed with standard Python patterns (None default + guard, context managers).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?