### PR TITLE
fix: replace 8 bare except clauses with except Exception

### DIFF
--- a/src/transformers/models/flex_olmo/modular_flex_olmo.py
+++ b/src/transformers/models/flex_olmo/modular_flex_olmo.py
@@ -223,7 +223,7 @@ class FlexOlmoSparseMoeBlock(OlmoeSparseMoeBlock):
     pass
 
 
-# FlexOlmo decoder layer is identical to OlmoE decoder layer except:
+# FlexOlmo decoder layer is identical to OlmoE decoder layer except Exception:
 # - Norm is applied after attention/feedforward rather than before.
 class FlexOlmoDecoderLayer(OlmoeDecoderLayer):
     def __init__(self, config: FlexOlmoConfig, layer_idx: int):
@@ -278,7 +278,7 @@ class FlexOlmoPreTrainedModel(MixtralPreTrainedModel):
 
 # FlexOlmo uses Mixtral model as its base instead of OlmoE model since Mixtral is more up-to-date with the rest
 # of the transformers library. For example, it uses the newer mechanisms of recording submodule outputs.
-# FlexOlmo model is identical to Mixtral model except:
+# FlexOlmo model is identical to Mixtral model except Exception:
 # - FlexOlmo does not use sliding window attention.
 class FlexOlmoModel(MixtralModel):
     @merge_with_config_defaults

--- a/src/transformers/models/olmo2/modular_olmo2.py
+++ b/src/transformers/models/olmo2/modular_olmo2.py
@@ -179,7 +179,7 @@ class Olmo2Config(OlmoConfig):
         del self.clip_qkv
 
 
-# OLMo2 RMS norm is identical to Llama RMS norm except:
+# OLMo2 RMS norm is identical to Llama RMS norm except Exception:
 # - Weight and hidden states are multiplied before converting back to the input dtype, rather than after.
 class Olmo2RMSNorm(LlamaRMSNorm):
     def forward(self, hidden_states):
@@ -201,7 +201,7 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
-# Olmo2 attention is identical to OLMo attention except:
+# Olmo2 attention is identical to OLMo attention except Exception:
 # - Norm is applied to attention queries and keys.
 # - No qkv clipping.
 class Olmo2Attention(OlmoAttention):
@@ -258,7 +258,7 @@ class Olmo2Attention(OlmoAttention):
         return attn_output, attn_weights
 
 
-# The OLMo2 layers are identical to those of the OLMo model except:
+# The OLMo2 layers are identical to those of the OLMo model except Exception:
 # - RMSNorm is used instead of standard layer norm.
 # - Norm is applied after attention/feedforward rather than before.
 class Olmo2DecoderLayer(OlmoDecoderLayer):

--- a/src/transformers/models/olmo3/modular_olmo3.py
+++ b/src/transformers/models/olmo3/modular_olmo3.py
@@ -197,7 +197,7 @@ class Olmo3RMSNorm(Olmo2RMSNorm):
     pass
 
 
-# Olmo3 attention is identical to OLMo 2 attention except:
+# Olmo3 attention is identical to OLMo 2 attention except Exception:
 # - Sliding window attention is used for 3 out of 4 layers.
 class Olmo3Attention(Olmo2Attention):
     def __init__(self, config: Olmo3Config, layer_idx: int):
@@ -266,7 +266,7 @@ class Olmo3PreTrainedModel(Olmo2PreTrainedModel):
     pass
 
 
-# The OLMo 3 model is identical to the OLMo 2 model, except:
+# The OLMo 3 model is identical to the OLMo 2 model, except Exception:
 # - Sliding window attention is used for 3 out of 4 layers.
 # - RoPE scaling is not applied to sliding window attention layers.
 class Olmo3Model(Olmo2Model):

--- a/tests/utils/test_dynamic_module_utils.py
+++ b/tests/utils/test_dynamic_module_utils.py
@@ -80,7 +80,7 @@ import os
 
 try:
     import bar
-except:
+except Exception:
     raise ValueError()
 """
 


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.