### PR TITLE
Fix AddedToken duplicate 'special' kwarg for extra_special_tokens

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1846,7 +1846,10 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                         # Merge list tokens, converting dicts to AddedToken
                         existing = list(init_kwargs.get("extra_special_tokens") or [])
                         for tok in value:
-                            tok = AddedToken(**tok, special=True) if isinstance(tok, dict) else tok
+                            if isinstance(tok, dict):
+                                tok.pop("special", None)
+                                tok = AddedToken(**tok, special=True)
+
                             if tok not in existing:
                                 existing.append(tok)
                         value = existing


### PR DESCRIPTION
Fixes the same `TypeError: AddedToken() got multiple values for keyword argument 'special'` that #44281 addressed, but for the `extra_special_tokens` code path which was missed.

#44281 (commit 8e663c7) correctly added `value.pop("special", None)` before `AddedToken(**value, special=True)` for regular special tokens loaded from `special_tokens_map.json`. However, the same pattern in the `extra_special_tokens` loop on the next line was not updated, so tokenizers whose `extra_special_tokens` dicts contain a `"special"` key still crash.

Related: #44062