### PR TITLE
Reduce tqdm verbosity during weight loading

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1204,7 +1204,7 @@ def convert_and_load_state_dict_in_model(
 
     try:
         total_entries = len(param_name_to_load)
-        with logging.tqdm(total=total_entries, desc="Loading weights") as pbar:
+        with logging.tqdm(total=total_entries, desc="Loading weights", mininterval=2.0) as pbar:
             for first_param_name, mapping in param_name_to_load.items():
                 pbar.set_postfix({"param": first_param_name}, refresh=False)
                 pbar.update(1)

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1206,9 +1206,8 @@ def convert_and_load_state_dict_in_model(
         total_entries = len(param_name_to_load)
         with logging.tqdm(total=total_entries, desc="Loading weights") as pbar:
             for first_param_name, mapping in param_name_to_load.items():
+                pbar.set_postfix({"param": first_param_name}, refresh=False)
                 pbar.update(1)
-                pbar.set_postfix({"Materializing param": first_param_name})
-                pbar.refresh()
                 try:
                     realized_value = mapping.convert(
                         first_param_name,


### PR DESCRIPTION
Fixes #44303

The weight loading progress bar called `pbar.refresh()` on every single parameter, bypassing tqdm's built-in rate-limiting. When output is redirected to a log file (e.g. in CI), this produced one line per parameter -- hundreds or thousands of lines like:

```
Loading weights:  38%|███▊      | 74/197 [..., Materializing param=model.decoder.layers.4.final_layer_norm.bias]
Loading weights:  38%|███▊      | 74/197 [..., Materializing param=model.decoder.layers.4.final_layer_norm.bias]
Loading weights:  38%|███▊      | 75/197 [..., Materializing param=model.decoder.layers.4.final_layer_norm.weight]
```

Fix: remove the explicit `refresh()` and pass `refresh=False` to `set_postfix`, letting tqdm use its default `mininterval=0.1s` rate-limiting. The progress bar still updates in interactive terminals but no longer floods log files.