### PR TITLE
fix(deepseek): pass rms_norm_eps to MLA q/kv layernorms

### DIFF
--- a/src/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -311,7 +311,7 @@ class DeepseekV2Attention(nn.Module):
             self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.qk_head_dim, bias=False)
         else:
             self.q_a_proj = nn.Linear(self.hidden_size, config.q_lora_rank, bias=config.attention_bias)
-            self.q_a_layernorm = DeepseekV2RMSNorm(config.q_lora_rank)
+            self.q_a_layernorm = DeepseekV2RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = nn.Linear(config.q_lora_rank, self.num_heads * self.qk_head_dim, bias=False)
 
         self.kv_a_proj_with_mqa = nn.Linear(
@@ -319,7 +319,7 @@ class DeepseekV2Attention(nn.Module):
             config.kv_lora_rank + config.qk_rope_head_dim,
             bias=config.attention_bias,
         )
-        self.kv_a_layernorm = DeepseekV2RMSNorm(config.kv_lora_rank)
+        self.kv_a_layernorm = DeepseekV2RMSNorm(config.kv_lora_rank, eps=config.rms_norm_eps)
         self.kv_b_proj = nn.Linear(
             config.kv_lora_rank,
             self.num_heads * (self.qk_head_dim - self.qk_rope_head_dim + self.v_head_dim),

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -384,7 +384,7 @@ class DeepseekV3Attention(nn.Module):
             self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.qk_head_dim, bias=False)
         else:
             self.q_a_proj = nn.Linear(config.hidden_size, config.q_lora_rank, bias=config.attention_bias)
-            self.q_a_layernorm = DeepseekV3RMSNorm(config.q_lora_rank)
+            self.q_a_layernorm = DeepseekV3RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = nn.Linear(config.q_lora_rank, self.num_heads * self.qk_head_dim, bias=False)
 
         self.kv_a_proj_with_mqa = nn.Linear(
@@ -392,7 +392,7 @@ class DeepseekV3Attention(nn.Module):
             self.kv_lora_rank + self.qk_rope_head_dim,
             bias=config.attention_bias,
         )
-        self.kv_a_layernorm = DeepseekV3RMSNorm(self.kv_lora_rank)
+        self.kv_a_layernorm = DeepseekV3RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
         self.kv_b_proj = nn.Linear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),


### PR DESCRIPTION
# What does this PR do?

Passes `config.rms_norm_eps` explicitly to `q_a_layernorm` and `kv_a_layernorm` in both DeepSeek V2 and V3 MLA attention.

Currently these two norms are constructed without `eps`, falling back to the `RMSNorm` class default (1e-6). Every other `RMSNorm` in these models correctly uses `config.rms_norm_eps`.

**Why it matters:** While DeepSeek's published configs happen to set `rms_norm_eps=1e-6`, omitting the explicit parameter is a latent bug — any fine-tuned checkpoint or future variant with a different epsilon would silently use the wrong value for these two norms, causing precision drift that's extremely hard to track down.

This aligns transformers with vLLM and SGLang, which both pass `config.rms_norm_eps` explicitly.

Fixes #44261

## Changes

- `modeling_deepseek_v2.py`: pass `eps=config.rms_norm_eps` to `q_a_layernorm` and `kv_a_layernorm`
- `modeling_deepseek_v3.py`: same fix

4 lines changed across 2 files — minimal, zero-risk.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a Github issue? #44261
- [ ] Did you write any new necessary tests?

No new tests — this is a parameter-passing fix. Existing model tests cover the affected code paths.

## Who can review?

@ArthurZucker @Cyrilvallez