### PR TITLE
Validate bounding box shape in LayoutLMv3Tokenizer

### DIFF
--- a/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
@@ -331,9 +331,19 @@ class LayoutLMv3Tokenizer(TokenizersBackend):
             for words_example, boxes_example in zip(words, boxes):
                 if len(words_example) != len(boxes_example):
                     raise ValueError("You must provide as many words as there are bounding boxes")
+                for box in boxes_example:
+                    if len(box) != 4:
+                        raise ValueError(
+                            f"Each bounding box should contain 4 values (x0, y0, x1, y1), but got {len(box)} values: {box}"
+                        )
         else:
             if len(words) != len(boxes):
                 raise ValueError("You must provide as many words as there are bounding boxes")
+            for box in boxes:
+                if len(box) != 4:
+                    raise ValueError(
+                        f"Each bounding box should contain 4 values (x0, y0, x1, y1), but got {len(box)} values: {box}"
+                    )
 
         if is_batched:
             if text_pair is not None and len(text) != len(text_pair):


### PR DESCRIPTION
## What does this PR do?

Adds input validation for bounding box shape in `LayoutLMv3Tokenizer`. When users pass boxes with fewer (or more) than 4 values per box, the tokenizer now raises a clear `ValueError` instead of a confusing generic tensor creation error.

**Before (confusing):**
```
ValueError: Unable to create tensor, you should probably activate truncation and/or padding...
Perhaps your features (`bbox` in this case) have excessive nesting
```

**After (clear):**
```
ValueError: Each bounding box should contain 4 values (x0, y0, x1, y1), but got 2 values: [123, 53]
```

Fixes #29127

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@ArthurZucker
