### PR TITLE
docs: Add document-question-answering example to pipeline tutorial

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ There are several ways you can contribute to 🤗 Transformers:
 
 If you don't know where to start, there is a special [Good First
 Issue](https://github.com/huggingface/transformers/contribute) listing. It will give you a list of
-open issues that are beginner-friendly and help you start contributing to open-source. The best way to do that is to open a Pull Request and link it to the issue that you'd like to work on. We try to give priority to opened PRs as we can easily track the progress of the fix, and if the contributor does not have time anymore, someone else can take the PR over.
+open issues that are beginner-friendly and help you start contributing to open-source.
+You can also browse issues labeled as [Good First Issue](https://github.com/huggingface/transformers/labels/Good%20First%20Issue). The best way to do that is to open a Pull Request and link it to the issue that you'd like to work on. We try to give priority to opened PRs as we can easily track the progress of the fix, and if the contributor does not have time anymore, someone else can take the PR over.
 
 For something slightly more challenging, you can also take a look at the [Good Second Issue](https://github.com/huggingface/transformers/labels/Good%20Second%20Issue) list. In general though, if you feel like you know what you're doing, go for it and we'll help you get there! 🚀
 

--- a/docs/source/en/pipeline_tutorial.md
+++ b/docs/source/en/pipeline_tutorial.md
@@ -112,6 +112,20 @@ pipeline(
 ```
 
 </hfoption>
+<hfoption id="document question answering">
+
+```py
+from transformers import pipeline
+
+pipeline = pipeline(task="document-question-answering", model="impira/layoutlm-document-qa")
+pipeline(
+    image="https://huggingface.co/spaces/impira/docquery/resolve/2359223c1837a7587402bda0f2643382a6eefeab/invoice.png",
+    question="What is the invoice number?",
+)
+[{'score': 0.425, 'answer': 'us-001', 'start': 16, 'end': 16}]
+```
+
+</hfoption>
 </hfoptions>
 
 ## Parameters


### PR DESCRIPTION
Add tutorial example for DocumentQuestionAnswering pipeline following the existing format of other task examples.

Fixes #18926