### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -242,7 +242,7 @@ def _build_peft_weight_mapping(
                         peft_weight_operations.append(op)
 
                 # TODO: this assumption may not hold for models != mixtral
-                # For source, we capture the orignal weights + the lora weights
+                # For source, we capture the original weights + the lora weights
                 new_source_patterns = []
                 for pat in list(orig_conversion.source_patterns):
                     # we replace the weight pattern to colllect loras
@@ -281,7 +281,7 @@ def _build_peft_weight_mapping(
                             peft_weight_operations.append(Transpose(dim0=0, dim1=1))
 
                 # TODO: this assumption may not hold for models != mixtral
-                # For source, we capture the orignal weights + the lora weights
+                # For source, we capture the original weights + the lora weights
                 new_source_patterns = []
                 for pat in list(orig_conversion.source_patterns):
                     # we replace the weight pattern to colllect loras

--- a/src/transformers/models/dia/processing_dia.py
+++ b/src/transformers/models/dia/processing_dia.py
@@ -86,7 +86,7 @@ class DiaProcessor(ProcessorMixin):
     def __init__(self, feature_extractor, tokenizer, audio_tokenizer):
         r"""
         audio_tokenizer (`DacModel`):
-            An instance of [`DacModel`] used to encode/decode audio into/from codebooks. It is is a required input.
+            An instance of [`DacModel`] used to encode/decode audio into/from codebooks. It is a required input.
         """
         super().__init__(feature_extractor, tokenizer, audio_tokenizer=audio_tokenizer)
 


### PR DESCRIPTION
Fix minor typos found in comments and docstrings:

- `orignal` → `original` in `src/transformers/integrations/peft.py` (lines 245, 284)
- Duplicate word `is is` → `is` in `src/transformers/models/dia/processing_dia.py` (line 89)

Small cleanup, no functional changes.