### PR TITLE
[docs] kernelconfig fix

### DIFF
--- a/docs/source/en/kernel_doc/loading_kernels.md
+++ b/docs/source/en/kernel_doc/loading_kernels.md
@@ -129,11 +129,11 @@ from transformers import AutoModelForCausalLM, KernelConfig
 kernel_config = KernelConfig(
     kernel_mapping={
         "RMSNorm": "kernels-community/liger_kernels:LigerRMSNorm",
-        "LlamaAttention": "kernels-community/flash-attn2:FlashAttention2",
     }
 )
 model = AutoModelForCausalLM.from_pretrained(
     "Qwen/Qwen3-0.6B",
+    attn_implementation="kernels-community/flash-attn2:FlashAttention2",
     use_kernels=True,
     kernel_config=kernel_config,
     device_map="cuda"

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -182,7 +182,7 @@ class KernelConfig(PushToHubMixin):
         for layer_name, kernel in self.kernel_mapping.items():
             if layer_name not in self.registered_layer_names.values():
                 raise ValueError(
-                    f"Layer {layer_name} is not registered in the model, please register it first using register_kernel_forward_from_hub"
+                    f"Layer {layer_name} is not registered in the model, please register it first using use_kernel_forward_from_hub"
                 )
 
             if isinstance(kernel, str):


### PR DESCRIPTION
- moves `kernels-community/flash-attn2:FlashAttention2` to `from_pretrained(attn_implementation...)`
- fix error message for registering a kernel