### PR TITLE
Fix speculative tests that are flaky with SDPA

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -3384,7 +3384,9 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertTrue(out.shape[-1] <= (input_length + 7))
 
     def test_model_kwarg_assisted_decoding_decoder_only(self):
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+        model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-gpt2", attn_implementation="eager"
+        ).to(torch_device)
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         model.generation_config.pad_token_id = tokenizer.eos_token_id
 
@@ -3405,7 +3407,9 @@ class GenerationIntegrationTests(unittest.TestCase):
             self.assertListEqual(outputs_tti.tolist(), outputs_normal.tolist())
 
         # Assistant model
-        assistant = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+        assistant = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-gpt2", attn_implementation="eager"
+        ).to(torch_device)
         assistant.config.pad_token_id = tokenizer.eos_token_id
 
         # If assisted generation passes model_kwargs correctly, should be same as previous
@@ -3668,8 +3672,9 @@ class GenerationIntegrationTests(unittest.TestCase):
         draft_name = "double7/vicuna-68m"
         target_name = "Qwen/Qwen2-0.5B-Instruct"
 
-        draft_model = AutoModelForCausalLM.from_pretrained(draft_name)
-        target_model = AutoModelForCausalLM.from_pretrained(target_name)
+        set_seed(42)
+        draft_model = AutoModelForCausalLM.from_pretrained(draft_name, attn_implementation="eager")
+        target_model = AutoModelForCausalLM.from_pretrained(target_name, attn_implementation="eager")
 
         assistant_tokenizer = AutoTokenizer.from_pretrained(draft_name)
         target_tokenizer = AutoTokenizer.from_pretrained(target_name)
@@ -3932,7 +3937,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(checkpoint)
         inputs = tokenizer(prompt, return_tensors="pt").to(torch_device)
 
-        model = AutoModelForCausalLM.from_pretrained(checkpoint).to(torch_device)
+        model = AutoModelForCausalLM.from_pretrained(checkpoint, attn_implementation="eager").to(torch_device)
         original_outputs = model.generate(**inputs, do_sample=False, max_new_tokens=20)
         original_decoded = tokenizer.batch_decode(original_outputs, skip_special_tokens=True)
         self.assertEqual(original_decoded, [expected_output])

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -61,6 +61,7 @@ from transformers.utils.generic import is_flash_attention_requested
 if is_torch_available():
     import torch
     import torch.nn.functional as F
+    from torch.nn.attention import SDPBackend, sdpa_kernel
 
     from transformers import (
         AutoModelForCausalLM,
@@ -3384,9 +3385,7 @@ class GenerationIntegrationTests(unittest.TestCase):
         self.assertTrue(out.shape[-1] <= (input_length + 7))
 
     def test_model_kwarg_assisted_decoding_decoder_only(self):
-        model = AutoModelForCausalLM.from_pretrained(
-            "hf-internal-testing/tiny-random-gpt2", attn_implementation="eager"
-        ).to(torch_device)
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         model.generation_config.pad_token_id = tokenizer.eos_token_id
 
@@ -3394,31 +3393,30 @@ class GenerationIntegrationTests(unittest.TestCase):
         tokenized_inputs = tokenizer([text], return_tensors="pt")
         input_ids = tokenized_inputs.input_ids.to(torch_device)
 
-        # Traditional way of generating text
-        outputs_normal = model.generate(input_ids)
-        self.assertEqual(outputs_normal.shape, (1, 20 + input_ids.shape[1]))
+        with sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]):
+            # Traditional way of generating text
+            outputs_normal = model.generate(input_ids)
+            self.assertEqual(outputs_normal.shape, (1, 20 + input_ids.shape[1]))
 
-        # Should be different with token_type_ids
-        outputs_tti = model.generate(
-            input_ids,
-            token_type_ids=torch.zeros(input_ids.shape, dtype=torch.long).to(torch_device),
-        )
-        with self.assertRaises(AssertionError):
-            self.assertListEqual(outputs_tti.tolist(), outputs_normal.tolist())
+            # Should be different with token_type_ids
+            outputs_tti = model.generate(
+                input_ids,
+                token_type_ids=torch.zeros(input_ids.shape, dtype=torch.long).to(torch_device),
+            )
+            with self.assertRaises(AssertionError):
+                self.assertListEqual(outputs_tti.tolist(), outputs_normal.tolist())
 
-        # Assistant model
-        assistant = AutoModelForCausalLM.from_pretrained(
-            "hf-internal-testing/tiny-random-gpt2", attn_implementation="eager"
-        ).to(torch_device)
-        assistant.config.pad_token_id = tokenizer.eos_token_id
+            # Assistant model
+            assistant = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device)
+            assistant.config.pad_token_id = tokenizer.eos_token_id
 
-        # If assisted generation passes model_kwargs correctly, should be same as previous
-        outputs_assisted = model.generate(
-            input_ids,
-            token_type_ids=torch.zeros(input_ids.shape, dtype=torch.long).to(torch_device),
-            assistant_model=assistant,
-        )
-        self.assertListEqual(outputs_assisted.tolist(), outputs_tti.tolist())
+            # If assisted generation passes model_kwargs correctly, should be same as previous
+            outputs_assisted = model.generate(
+                input_ids,
+                token_type_ids=torch.zeros(input_ids.shape, dtype=torch.long).to(torch_device),
+                assistant_model=assistant,
+            )
+            self.assertListEqual(outputs_assisted.tolist(), outputs_tti.tolist())
 
     def test_assisted_decoding_num_assistant_tokens_heuristic_schedule(self):
         # This test ensures that the assisted generation num_assistant_tokens 'heuristic' schedule works properly.
@@ -3672,9 +3670,11 @@ class GenerationIntegrationTests(unittest.TestCase):
         draft_name = "double7/vicuna-68m"
         target_name = "Qwen/Qwen2-0.5B-Instruct"
 
+        # TODO Matt: Slightly flaky (~1%) without set_seed - if anyone wants to do
+        #            a deep dive on why, feel free!
         set_seed(42)
-        draft_model = AutoModelForCausalLM.from_pretrained(draft_name, attn_implementation="eager")
-        target_model = AutoModelForCausalLM.from_pretrained(target_name, attn_implementation="eager")
+        draft_model = AutoModelForCausalLM.from_pretrained(draft_name)
+        target_model = AutoModelForCausalLM.from_pretrained(target_name)
 
         assistant_tokenizer = AutoTokenizer.from_pretrained(draft_name)
         target_tokenizer = AutoTokenizer.from_pretrained(target_name)
@@ -3937,14 +3937,15 @@ class GenerationIntegrationTests(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(checkpoint)
         inputs = tokenizer(prompt, return_tensors="pt").to(torch_device)
 
-        model = AutoModelForCausalLM.from_pretrained(checkpoint, attn_implementation="eager").to(torch_device)
-        original_outputs = model.generate(**inputs, do_sample=False, max_new_tokens=20)
-        original_decoded = tokenizer.batch_decode(original_outputs, skip_special_tokens=True)
-        self.assertEqual(original_decoded, [expected_output])
+        model = AutoModelForCausalLM.from_pretrained(checkpoint).to(torch_device)
+        with sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION, SDPBackend.MATH]):
+            original_outputs = model.generate(**inputs, do_sample=False, max_new_tokens=20)
+            original_decoded = tokenizer.batch_decode(original_outputs, skip_special_tokens=True)
+            self.assertEqual(original_decoded, [expected_output])
 
-        outputs_assisted = model.generate(**inputs, assistant_early_exit=4, do_sample=False, max_new_tokens=20)
-        decoded_assisted = tokenizer.batch_decode(outputs_assisted, skip_special_tokens=True)
-        self.assertEqual(decoded_assisted, [expected_output])
+            outputs_assisted = model.generate(**inputs, assistant_early_exit=4, do_sample=False, max_new_tokens=20)
+            decoded_assisted = tokenizer.batch_decode(outputs_assisted, skip_special_tokens=True)
+            self.assertEqual(decoded_assisted, [expected_output])
 
     @slow
     def test_beam_search_advanced_stopping_criteria(self):


### PR DESCRIPTION
Some speculative tests seem flaky with SDPA but reliable with `eager` attention. In local testing, `test_speculative_decoding_equals_regular_decoding` fails 5-10% of the time without this change. and I also saw CI failures. Failures are resolved with this change.