### PR TITLE
Fix and optimize ANSI color handling in loading report for interactive terminals

### DIFF
--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -120,10 +120,12 @@ PALETTE = {
 
 def _color(s, color):
     """Return color-formatted input `s` if `sys.stdout` is interactive, e.g. connected to a terminal."""
-    if sys.stdout.isatty():
-        return f"{PALETTE[color]}{s}{PALETTE['reset']}"
-    else:
-        return s
+    return f"{PALETTE[color]}{s}{PALETTE['reset']}" if sys.stdout.isatty() else s
+
+
+def _palette(style: str):
+    """Return the ANSI code for the given color or format if `sys.stdout` is interactive, else return an empty string."""
+    return PALETTE[style] if sys.stdout.isatty() else style
 
 
 def _get_terminal_width(default=80):
@@ -179,7 +181,7 @@ class LoadStateDictInfo:
         tips = ""
         if self.unexpected_keys:
             tips += (
-                f"\n- {_color('UNEXPECTED', 'orange') + PALETTE['italic']}\t:can be ignored when loading from different "
+                f"\n- {_color('UNEXPECTED', 'orange') + _palette('italic')}\t:can be ignored when loading from different "
                 "task/architecture; not ok if you expect identical arch."
             )
             for k in update_key_name(self.unexpected_keys):
@@ -188,7 +190,7 @@ class LoadStateDictInfo:
 
         if self.missing_keys:
             tips += (
-                f"\n- {_color('MISSING', 'red') + PALETTE['italic']}\t:those params were newly initialized because missing "
+                f"\n- {_color('MISSING', 'red') + _palette('italic')}\t:those params were newly initialized because missing "
                 "from the checkpoint. Consider training on your downstream task."
             )
             for k in update_key_name(self.missing_keys):
@@ -197,7 +199,7 @@ class LoadStateDictInfo:
 
         if self.mismatched_keys:
             tips += (
-                f"\n- {_color('MISMATCH', 'yellow') + PALETTE['italic']}\t:ckpt weights were loaded, but they did not match "
+                f"\n- {_color('MISMATCH', 'yellow') + _palette('italic')}\t:ckpt weights were loaded, but they did not match "
                 "the original empty weight shapes."
             )
             iterator = {a: (b, c) for a, b, c in self.mismatched_keys}
@@ -211,7 +213,7 @@ class LoadStateDictInfo:
                 rows.append(data)
 
         if self.conversion_errors:
-            tips += f"\n- {_color('CONVERSION', 'purple') + PALETTE['italic']}\t:originate from the conversion scheme"
+            tips += f"\n- {_color('CONVERSION', 'purple') + _palette('italic')}\t:originate from the conversion scheme"
             for k, v in update_key_name(self.conversion_errors).items():
                 status = _color("CONVERSION", "purple")
                 _details = f"\n\n{v}\n\n"
@@ -227,7 +229,7 @@ class LoadStateDictInfo:
         else:
             headers += ["", ""]
         table = _make_table(rows, headers=headers)
-        tips = f"\n\n{PALETTE['italic']}Notes:{tips}{PALETTE['reset']}"
+        tips = f"\n\n{_palette('italic')}Notes:{tips}{_palette('reset')}"
         report = table + tips
 
         return report
@@ -263,7 +265,7 @@ def log_state_dict_report(
     if report is None:
         return
 
-    prelude = f"{PALETTE['bold']}{model.__class__.__name__} LOAD REPORT{PALETTE['reset']} from: {pretrained_model_name_or_path}\n"
+    prelude = f"{_palette('bold')}{model.__class__.__name__} LOAD REPORT{_palette('reset')} from: {pretrained_model_name_or_path}\n"
 
     # Log the report as warning
     logger.warning(prelude + report)


### PR DESCRIPTION
Fixes #44336 

## Changes
* Added a new `_palette` function to return the ANSI code for a given color or format only if `sys.stdout` is interactive. (`src/transformers/utils/loading_report.py`)
* Updated all usages of `PALETTE[<format>]` in the loading report to use `_palette(<format>)`, ensuring formatting is only applied in interactive terminals. (`src/transformers/utils/loading_report.py`)
* Shortened the `_color` function to a singular line.

## Who can help
@CyrilVallez