### PR TITLE
Fix tokenizer_class in tokenizer_config.json for Qwen3.5 save_pretrained (fixes #44297)

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -264,7 +264,6 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, str | None](
         ("qwen2_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen2_vl", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3", "Qwen2Tokenizer" if is_tokenizers_available() else None),
-        # Qwen3.5 Hub tokenizer_config uses "Qwen2Tokenizer"; use same so save_pretrained round-trips correctly (see #44297)
         ("qwen3_5", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3_5_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -264,8 +264,9 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, str | None](
         ("qwen2_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen2_vl", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3", "Qwen2Tokenizer" if is_tokenizers_available() else None),
-        ("qwen3_5", "Qwen3_5Tokenizer" if is_tokenizers_available() else None),
-        ("qwen3_5_moe", "Qwen3_5Tokenizer" if is_tokenizers_available() else None),
+        # Qwen3.5 Hub tokenizer_config uses "Qwen2Tokenizer"; use same so save_pretrained round-trips correctly (see #44297)
+        ("qwen3_5", "Qwen2Tokenizer" if is_tokenizers_available() else None),
+        ("qwen3_5_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3_next", "Qwen2Tokenizer" if is_tokenizers_available() else None),
         ("qwen3_omni_moe", "Qwen2Tokenizer" if is_tokenizers_available() else None),
@@ -385,6 +386,10 @@ def tokenizer_class_from_name(class_name: str) -> type[Any] | None:
     # Bloom tokenizer classes were removed but should map to the fast backend for BC
     if class_name in {"BloomTokenizer", "BloomTokenizerFast"}:
         return TokenizersBackend
+
+    # Qwen3.5 Hub uses Qwen2Tokenizer; alias so configs with "Qwen3_5Tokenizer" still load (see #44297)
+    if class_name == "Qwen3_5Tokenizer":
+        return tokenizer_class_from_name("Qwen2Tokenizer")
 
     if class_name in REGISTERED_FAST_ALIASES:
         return REGISTERED_FAST_ALIASES[class_name]


### PR DESCRIPTION
## Summary
Fixes #44297

Qwen3.5 models on the Hub (e.g. [Qwen/Qwen3.5-27B](https://huggingface.co/Qwen/Qwen3.5-27B)) use `"tokenizer_class": "Qwen2Tokenizer"` in `tokenizer_config.json`, but `TOKENIZER_MAPPING_NAMES` had `qwen3_5` → `"Qwen3_5Tokenizer"`. Loading and then `tokenizer.save_pretrained()` wrote `"Qwen3_5Tokenizer"`, so the saved config did not match the original.

## Changes
- **TOKENIZER_MAPPING_NAMES**: Map `qwen3_5` and `qwen3_5_moe` to `"Qwen2Tokenizer"` (same as the Hub) so that load/save round-trip preserves `tokenizer_class`.
- **tokenizer_class_from_name**: Add an alias so that `"Qwen3_5Tokenizer"` still resolves to the Qwen2Tokenizer class, preserving backward compatibility for any configs that already saved that class name.

As noted in the issue (comment by @cynricfu), the root cause was the mismatch between the Hub tokenizer_config and the mapping.

cc @itazap @arthurzucker