### PR TITLE
fix(deepseek): pass config.rms_norm_eps to MLA q/kv layernorms

### DIFF
--- a/src/transformers/models/deepseek_v2/modeling_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/modeling_deepseek_v2.py
@@ -311,7 +311,7 @@ class DeepseekV2Attention(nn.Module):
             self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.qk_head_dim, bias=False)
         else:
             self.q_a_proj = nn.Linear(self.hidden_size, config.q_lora_rank, bias=config.attention_bias)
-            self.q_a_layernorm = DeepseekV2RMSNorm(config.q_lora_rank)
+            self.q_a_layernorm = DeepseekV2RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = nn.Linear(config.q_lora_rank, self.num_heads * self.qk_head_dim, bias=False)
 
         self.kv_a_proj_with_mqa = nn.Linear(
@@ -319,7 +319,7 @@ class DeepseekV2Attention(nn.Module):
             config.kv_lora_rank + config.qk_rope_head_dim,
             bias=config.attention_bias,
         )
-        self.kv_a_layernorm = DeepseekV2RMSNorm(config.kv_lora_rank)
+        self.kv_a_layernorm = DeepseekV2RMSNorm(config.kv_lora_rank, eps=config.rms_norm_eps)
         self.kv_b_proj = nn.Linear(
             config.kv_lora_rank,
             self.num_heads * (self.qk_head_dim - self.qk_rope_head_dim + self.v_head_dim),

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -384,7 +384,7 @@ class DeepseekV3Attention(nn.Module):
             self.q_proj = nn.Linear(config.hidden_size, self.num_heads * self.qk_head_dim, bias=False)
         else:
             self.q_a_proj = nn.Linear(config.hidden_size, config.q_lora_rank, bias=config.attention_bias)
-            self.q_a_layernorm = DeepseekV3RMSNorm(config.q_lora_rank)
+            self.q_a_layernorm = DeepseekV3RMSNorm(config.q_lora_rank, eps=config.rms_norm_eps)
             self.q_b_proj = nn.Linear(config.q_lora_rank, self.num_heads * self.qk_head_dim, bias=False)
 
         self.kv_a_proj_with_mqa = nn.Linear(
@@ -392,7 +392,7 @@ class DeepseekV3Attention(nn.Module):
             self.kv_lora_rank + self.qk_rope_head_dim,
             bias=config.attention_bias,
         )
-        self.kv_a_layernorm = DeepseekV3RMSNorm(self.kv_lora_rank)
+        self.kv_a_layernorm = DeepseekV3RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
         self.kv_b_proj = nn.Linear(
             self.kv_lora_rank,
             self.num_heads * (self.qk_nope_head_dim + self.v_head_dim),


### PR DESCRIPTION
# What does this PR do?

Fixes the `q_a_layernorm` and `kv_a_layernorm` in DeepSeek V2/V3 MLA attention to explicitly receive `config.rms_norm_eps` instead of falling back to the RMSNorm class default (`1e-6`).

**The problem:** All other RMSNorm instances in these models correctly use `config.rms_norm_eps`, but these two layernorms were constructed without passing `eps`. While current published DeepSeek configs happen to use `eps=1e-6`, this is a latent bug — any fine-tuned checkpoint or future variant with a different `rms_norm_eps` would silently use the wrong epsilon, causing precision drift.

**Changes:**
- `modeling_deepseek_v2.py` / `modular_deepseek_v2.py`: pass `config.rms_norm_eps` to `q_a_layernorm` and `kv_a_layernorm`
- `modeling_deepseek_v3.py` / `modular_deepseek_v3.py`: same fix

4 files, 8 lines changed. Aligns transformers with vLLM and SGLang, which both pass `config.rms_norm_eps` explicitly.

Fixes #44261

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. → #44261
- [ ] Did you make sure to update the documentation with your changes? *(N/A — no doc changes needed)*
- [ ] Did you write any new necessary tests? *(Existing tests pass; the fix is a correctness alignment that only manifests with non-default eps values)*

## Who can review?

@ArthurZucker @Cyrilvallez