### PR TITLE
fix: support linear_attention in continuous batching and fix serve ch…

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -826,7 +826,7 @@ class Serve:
             self.running_continuous_batching_manager.start()
 
         # TODO (Joao, Lysandre): this should also work with tool support
-        inputs = processor.apply_chat_template(
+        inputs = tokenizer.apply_chat_template(
             req["messages"], return_tensors="pt", add_generation_prompt=True, return_dict=True
         ).to(model.device)["input_ids"][0]
 

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -53,7 +53,15 @@ def group_layers_by_attn_type(config: PreTrainedConfig) -> tuple[list[list[int]]
             layer_groups.append(indices[i : i + group_size])
     # And note the layer types
     group_types = [layer_types[lg[0]] for lg in layer_groups]
-    return layer_groups, group_types
+
+    # Filter out linear_attention groups (they use recurrent state, not KV cache)
+    filtered_groups = []
+    filtered_types = []
+    for group, gtype in zip(layer_groups, group_types):
+        if gtype != "linear_attention":
+            filtered_groups.append(group)
+            filtered_types.append(gtype)
+    return filtered_groups, filtered_types
 
 
 @attach_tracer()

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -100,7 +100,10 @@ class ContinuousBatchingNonGenerationTest(unittest.TestCase):
         config = AutoConfig.from_pretrained("HuggingFaceTB/SmolLM-1.7B")
 
         if layer_types_str is not None:
-            layer_types = [{"f": "full_attention", "s": "sliding_window", "l": "linear_attention"}[char] for char in layer_types_str]
+            layer_types = [
+                {"f": "full_attention", "s": "sliding_window", "l": "linear_attention"}[char]
+                for char in layer_types_str
+            ]
         else:
             layer_types = None
             config.num_hidden_layers = len(expected_groups)

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -100,7 +100,7 @@ class ContinuousBatchingNonGenerationTest(unittest.TestCase):
         config = AutoConfig.from_pretrained("HuggingFaceTB/SmolLM-1.7B")
 
         if layer_types_str is not None:
-            layer_types = [{"f": "full_attention", "s": "sliding_window"}[char] for char in layer_types_str]
+            layer_types = [{"f": "full_attention", "s": "sliding_window", "l": "linear_attention"}[char] for char in layer_types_str]
         else:
             layer_types = None
             config.num_hidden_layers = len(expected_groups)
@@ -137,6 +137,41 @@ class ContinuousBatchingNonGenerationTest(unittest.TestCase):
                     expected_group_type,
                     f"Test failed for: {layer_types_str = }, {sliding_window = }, {group_types = }",
                 )
+
+    @parameterized.expand(
+        [
+            ("lf", None, [[1]]),
+            ("fl", None, [[0]]),
+            ("llf", None, [[2]]),
+            ("fllf", None, [[0, 3]]),
+            ("flsl", 4096, [[0], [2]]),
+            ("llfllf", None, [[2, 5]]),
+            ("lll", None, []),
+        ]
+    )
+    def test_group_layers_with_linear_attention(
+        self,
+        layer_types_str: str,
+        sliding_window: int | None,
+        expected_layer_groups: list[list[int]],
+    ) -> None:
+        """Test that linear_attention layers are filtered out of cache groups."""
+        config = AutoConfig.from_pretrained("HuggingFaceTB/SmolLM-1.7B")
+        layer_types = [
+            {"f": "full_attention", "s": "sliding_window", "l": "linear_attention"}[char] for char in layer_types_str
+        ]
+        config.layer_types = layer_types
+        config.sliding_window = sliding_window
+        config.num_hidden_layers = len(layer_types_str)
+
+        layer_groups, group_types = group_layers_by_attn_type(config)
+        self.assertEqual(
+            sorted(expected_layer_groups),
+            sorted(layer_groups),
+            f"Test failed for: {layer_types_str = }, {expected_layer_groups = }, {layer_groups = }",
+        )
+        # Verify no linear_attention groups remain
+        self.assertNotIn("linear_attention", group_types)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
# What does this PR do?
> Inspired by https://github.com/huggingface/transformers/pull/44347#issuecomment-3976028358

Fixes `transformers serve` failing with hybrid models like Qwen3.5 that use `linear_attention` layers.

Two issues are addressed:

1. **`ValueError` in `PagedAttentionCache`**: `group_layers_by_attn_type()` correctly groups `linear_attention` layers, but `PagedAttentionCache.__init__` only handles `full_attention` and `sliding_attention`, raising `ValueError("Invalid group type: linear_attention")`. Since linear attention layers (e.g. GatedDeltaNet) use recurrent state rather than KV cache, they should be filtered out of paged attention cache management entirely.

2. **`AttributeError` in chat completion**: `processor.apply_chat_template()` (`ProcessorMixin`) returns a `str`, but the code expects tensors. The `tokenizer` is already extracted at L807 but L829 mistakenly calls `processor` instead.

**Fix:** Filter `linear_attention` groups in `group_layers_by_attn_type()` and use `tokenizer.apply_chat_template()` instead of `processor.apply_chat_template()`.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @Cyrilvallez — continuous batching / cache owners
