### PR TITLE
fix: off-by-one in decode_spans causes ValueError when topk == len(scores)

### DIFF
--- a/src/transformers/pipelines/document_question_answering.py
+++ b/src/transformers/pipelines/document_question_answering.py
@@ -94,7 +94,7 @@ def decode_spans(
     scores_flat = candidates.flatten()
     if topk == 1:
         idx_sort = [np.argmax(scores_flat)]
-    elif len(scores_flat) < topk:
+    elif len(scores_flat) <= topk:
         idx_sort = np.argsort(-scores_flat)
     else:
         idx = np.argpartition(-scores_flat, topk)[0:topk]

--- a/tests/pipelines/test_decode_spans.py
+++ b/tests/pipelines/test_decode_spans.py
@@ -1,0 +1,72 @@
+"""Regression tests for decode_spans in document_question_answering pipeline.
+
+See https://github.com/huggingface/transformers/issues/44327
+"""
+
+import unittest
+
+import numpy as np
+
+from transformers.pipelines.document_question_answering import decode_spans
+
+
+class DecodeSpansTests(unittest.TestCase):
+    def test_topk_equals_scores_length_no_crash(self):
+        """When len(scores_flat) == topk, argpartition must not be called with kth == len(arr).
+
+        Before fix: ValueError: kth(=100) out of bounds (100)
+        """
+        seq_len = 10  # 10^2 = 100 elements
+        topk = 100
+        max_answer_len = 15
+        np.random.seed(42)
+        start = np.random.rand(1, seq_len)
+        end = np.random.rand(1, seq_len)
+        undesired_tokens = np.ones(seq_len, dtype=bool)
+
+        # Should not raise ValueError
+        starts, ends, scores = decode_spans(start, end, topk, max_answer_len, undesired_tokens)
+        self.assertGreater(len(starts), 0)
+
+    def test_topk_greater_than_scores_length(self):
+        """topk > len(scores_flat) should use argsort path."""
+        seq_len = 3  # 9 elements, topk=100
+        topk = 100
+        max_answer_len = 15
+        np.random.seed(42)
+        start = np.random.rand(1, seq_len)
+        end = np.random.rand(1, seq_len)
+        undesired_tokens = np.ones(seq_len, dtype=bool)
+
+        starts, ends, scores = decode_spans(start, end, topk, max_answer_len, undesired_tokens)
+        self.assertGreater(len(starts), 0)
+
+    def test_topk_one(self):
+        """topk=1 uses argmax path."""
+        seq_len = 5
+        topk = 1
+        max_answer_len = 15
+        np.random.seed(42)
+        start = np.random.rand(1, seq_len)
+        end = np.random.rand(1, seq_len)
+        undesired_tokens = np.ones(seq_len, dtype=bool)
+
+        starts, ends, scores = decode_spans(start, end, topk, max_answer_len, undesired_tokens)
+        self.assertGreater(len(starts), 0)
+
+    def test_topk_less_than_scores_length(self):
+        """Normal case: topk < len(scores_flat), uses argpartition."""
+        seq_len = 20  # 400 elements
+        topk = 10
+        max_answer_len = 15
+        np.random.seed(42)
+        start = np.random.rand(1, seq_len)
+        end = np.random.rand(1, seq_len)
+        undesired_tokens = np.ones(seq_len, dtype=bool)
+
+        starts, ends, scores = decode_spans(start, end, topk, max_answer_len, undesired_tokens)
+        self.assertGreater(len(starts), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Fixes an off-by-one error in `decode_spans()` where `np.argpartition` is called with `kth == len(arr)` when `topk` equals the number of candidate scores. This raises `ValueError: kth(=N) out of bounds (N)`.

**Root cause:** The boundary check uses `<` instead of `<=`, so when `len(scores_flat) == topk`, it falls through to the `argpartition` path instead of the `argsort` path.

**Fix:** Change `<` to `<=` on line 97 of `document_question_answering.py`.

Fixes #44327

## Tests

Added `tests/pipelines/test_decode_spans.py` with 4 regression tests covering all branches:
- `topk == 1` (argmax path)
- `topk < len(scores)` (argpartition path)  
- `topk == len(scores)` (was crashing, now uses argsort)
- `topk > len(scores)` (argsort path)

Signed-off-by: sxu75374 <imshuaixu@gmail.com>