### PR TITLE
fix: avoid redundant fp16/bf16 model casts in evaluation_loop

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -2652,9 +2652,13 @@ class Trainer:
         # while ``train`` is running, cast it to the right dtype first and then put on device
         if not self.is_in_train:
             if args.fp16_full_eval:
-                model = model.to(dtype=torch.float16, device=args.device)
+                # Only cast if not already in fp16 to avoid redundant copies
+                if next(model.parameters()).dtype != torch.float16:
+                    model = model.to(dtype=torch.float16, device=args.device)
             elif args.bf16_full_eval:
-                model = model.to(dtype=torch.bfloat16, device=args.device)
+                # Only cast if not already in bf16 to avoid redundant copies
+                if next(model.parameters()).dtype != torch.bfloat16:
+                    model = model.to(dtype=torch.bfloat16, device=args.device)
 
         batch_size = self.args.eval_batch_size
 


### PR DESCRIPTION
## Summary

Checks if model is already in target dtype before casting to avoid redundant copies that cause 25% performance degradation with `--fp16_full_eval`.

## Changes

- Added dtype check before casting model to fp16/bf16 in `evaluation_loop`
- Only casts if model dtype differs from target dtype

## Testing

This fix addresses the performance issue reported in the issue where eval with `--fp16_full_eval` is 25% slower due to redundant model casting on every evaluation call.

Fixes #10816