### PR TITLE
Fix resume_from_checkpoint key mismatch for models with _checkpoint_conversion_mapping

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -3270,6 +3270,36 @@ class Trainer:
 
     # ---- Checkpoint Resuming ----
 
+    @staticmethod
+    def _apply_conversion_mapping_to_state_dict(model: nn.Module, state_dict: dict) -> dict:
+        """Apply checkpoint conversion mapping to rename state dict keys.
+
+        Models with ``_checkpoint_conversion_mapping`` (e.g. VLMs like Qwen2.5VL) save
+        checkpoints in original format via ``revert_weight_conversion``, but
+        ``model.load_state_dict`` expects keys in the model's own format.  This helper
+        bridges the gap by applying the same renaming that ``from_pretrained`` uses.
+        """
+        if not isinstance(model, PreTrainedModel):
+            return state_dict
+
+        from .conversion_mapping import get_model_conversion_mapping
+        from .core_model_loading import WeightConverter, WeightRenaming, rename_source_key
+
+        weight_conversions = get_model_conversion_mapping(model, add_legacy=False)
+        if not weight_conversions:
+            return state_dict
+
+        renamings = [e for e in weight_conversions if isinstance(e, WeightRenaming)]
+        converters = [e for e in weight_conversions if isinstance(e, WeightConverter)]
+        meta_state_dict = dict.fromkeys(model.state_dict().keys())
+        prefix = model.base_model_prefix
+
+        renamed = {}
+        for key, value in state_dict.items():
+            new_key, _ = rename_source_key(key, renamings, converters, prefix, meta_state_dict)
+            renamed[new_key] = value
+        return renamed
+
     def _load_from_checkpoint(self, resume_from_checkpoint: str, model: nn.Module | None = None) -> None:
         """Load model weights from a checkpoint directory."""
         if model is None:
@@ -3361,6 +3391,8 @@ class Trainer:
                     check_torch_load_is_safe()
                     state_dict = torch.load(weights_file, map_location="cpu", weights_only=True)
 
+                # Apply checkpoint conversion mapping for models that save in original format
+                state_dict = self._apply_conversion_mapping_to_state_dict(model, state_dict)
                 # workaround for FSDP bug https://github.com/pytorch/pytorch/issues/82963
                 # which takes *args instead of **kwargs
                 load_result = model.load_state_dict(state_dict, False)
@@ -3485,6 +3517,8 @@ class Trainer:
                         check_torch_load_is_safe()
                         state_dict = torch.load(best_model_path, map_location="cpu", weights_only=True)
 
+                    # Apply checkpoint conversion mapping for models that save in original format
+                    state_dict = self._apply_conversion_mapping_to_state_dict(model, state_dict)
                     # If the model is on the GPU, it still works!
                     # workaround for FSDP bug https://github.com/pytorch/pytorch/issues/82963
                     # which takes *args instead of **kwargs

--- a/src/transformers/trainer_utils.py
+++ b/src/transformers/trainer_utils.py
@@ -1092,9 +1092,31 @@ def load_sharded_checkpoint(model, folder, strict=True, prefer_safe=True):
 
     shard_files = list(set(index["weight_map"].values()))
 
+    # Build the conversion mapping for models with _checkpoint_conversion_mapping (e.g. VLMs).
+    # Checkpoints are saved in original format via revert_weight_conversion, so we need to
+    # rename keys back to model format before loading.
+    _rename_fn = None
+    from .modeling_utils import PreTrainedModel
+
+    if isinstance(model, PreTrainedModel):
+        from .conversion_mapping import get_model_conversion_mapping
+        from .core_model_loading import WeightConverter, WeightRenaming, rename_source_key
+
+        weight_conversions = get_model_conversion_mapping(model, add_legacy=False)
+        if weight_conversions:
+            renamings = [e for e in weight_conversions if isinstance(e, WeightRenaming)]
+            converters = [e for e in weight_conversions if isinstance(e, WeightConverter)]
+            meta_state_dict = dict.fromkeys(model.state_dict().keys())
+            prefix = model.base_model_prefix
+
+            def _rename_fn(key):
+                new_key, _ = rename_source_key(key, renamings, converters, prefix, meta_state_dict)
+                return new_key
+
     # If strict=True, error before loading any of the state dicts.
-    # TODO: Here, update the weight map with the config.dynamic_weight_conversion
     loaded_keys = index["weight_map"].keys()
+    if _rename_fn is not None:
+        loaded_keys = {_rename_fn(k) for k in loaded_keys}
     model_keys = model.state_dict().keys()
     missing_keys = [key for key in model_keys if key not in loaded_keys]
     unexpected_keys = [key for key in loaded_keys if key not in model_keys]
@@ -1116,6 +1138,8 @@ def load_sharded_checkpoint(model, folder, strict=True, prefer_safe=True):
 
     for shard_file in shard_files:
         state_dict = loader(os.path.join(folder, shard_file))
+        if _rename_fn is not None:
+            state_dict = {_rename_fn(k): v for k, v in state_dict.items()}
         model.load_state_dict(state_dict, strict=False)
 
         # Make sure memory is freed before we load the next state dict.

--- a/tests/trainer/test_trainer_checkpointing.py
+++ b/tests/trainer/test_trainer_checkpointing.py
@@ -610,6 +610,118 @@ class TrainerResumeTrainingTest(TestCasePlus, TrainerIntegrationCommon):
         self.assertEqual(parameters, parameters1)
         self.check_trainer_state_are_the_same(state, state1)
 
+    @require_torch_non_multi_accelerator
+    def test_resume_training_with_conversion_mapping(self):
+        """Test that resume_from_checkpoint works for models with _checkpoint_conversion_mapping.
+
+        Models with _checkpoint_conversion_mapping (e.g. VLMs like Qwen2.5VL) save
+        checkpoints in original format via revert_weight_conversion, but load_state_dict
+        expects keys in the model's own format. This test verifies that the Trainer
+        correctly applies the conversion mapping when resuming from checkpoint.
+
+        Regression test for https://github.com/huggingface/transformers/issues/43701
+        """
+        from transformers.conversion_mapping import register_checkpoint_conversion_mapping
+        from transformers.core_model_loading import WeightRenaming
+
+        # Create a model whose checkpoint conversion mapping renames "lm.*" -> "model.*"
+        # In the model, parameters are named "model.param_a" and "model.param_b" (via the inner Module).
+        # In saved checkpoints, they'll be renamed to "lm.param_a" and "lm.param_b".
+        class InnerModule(nn.Module):
+            def __init__(self, a, b):
+                super().__init__()
+                self.param_a = nn.Parameter(torch.tensor(a).float())
+                self.param_b = nn.Parameter(torch.tensor(b).float())
+
+        class ConversionMappingConfig(RegressionModelConfig):
+            model_type = "conversion_mapping_test"
+
+        class ConversionMappingModel(RegressionPreTrainedModel):
+            config_class = ConversionMappingConfig
+            base_model_prefix = "model"
+
+            def __init__(self, config):
+                # Skip RegressionPreTrainedModel.__init__ to avoid its param setup
+                super(RegressionPreTrainedModel, self).__init__(config)
+                self.model = InnerModule(config.a, config.b)
+                self.double_output = config.double_output
+                self.post_init()
+
+            def forward(self, input_x, labels=None, **kwargs):
+                y = input_x * self.model.param_a + self.model.param_b
+                if labels is None:
+                    return (y,)
+                loss = nn.functional.mse_loss(y, labels)
+                return (loss, y)
+
+        # Register the conversion mapping: checkpoint "lm." -> model "model."
+        register_checkpoint_conversion_mapping(
+            "conversion_mapping_test",
+            [WeightRenaming("lm.", "model.")],
+            overwrite=True,
+        )
+
+        tmp_dir = self.get_auto_remove_tmp_dir()
+        config = ConversionMappingConfig(a=0, b=0)
+        model = ConversionMappingModel(config)
+
+        train_dataset = RegressionDataset(length=128)
+        eval_dataset = RegressionDataset(length=64)
+
+        kwargs = {
+            "output_dir": tmp_dir,
+            "save_steps": 5,
+            "learning_rate": 0.1,
+            "logging_steps": 5,
+            "max_steps": 10,
+        }
+        args = TrainingArguments(**kwargs)
+
+        trainer = Trainer(
+            model=model,
+            args=args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+        trainer.model_accepts_loss_kwargs = False
+        trainer.train()
+
+        # Verify checkpoint was saved with converted (original-format) keys
+        checkpoint_dir = os.path.join(tmp_dir, "checkpoint-5")
+        saved_state = safetensors.torch.load_file(os.path.join(checkpoint_dir, SAFE_WEIGHTS_NAME))
+        saved_keys = set(saved_state.keys())
+        # Keys should be in checkpoint format: "lm.param_a", "lm.param_b"
+        self.assertIn("lm.param_a", saved_keys, f"Expected 'lm.param_a' in saved keys, got {saved_keys}")
+        self.assertIn("lm.param_b", saved_keys, f"Expected 'lm.param_b' in saved keys, got {saved_keys}")
+        self.assertNotIn("model.param_a", saved_keys, "model-format keys should NOT be in checkpoint")
+
+        # Now resume from checkpoint — this is where the bug manifested (key mismatch)
+        model2 = ConversionMappingModel(config)
+        trainer2 = Trainer(
+            model=model2,
+            args=args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+        )
+        trainer2.model_accepts_loss_kwargs = False
+
+        # This should not raise a key mismatch error
+        trainer2.train(resume_from_checkpoint=checkpoint_dir)
+
+        # Verify model parameters are loaded correctly
+        self.assertAlmostEqual(
+            model2.model.param_a.item(),
+            model.model.param_a.item(),
+            places=4,
+            msg="param_a should match after resume",
+        )
+        self.assertAlmostEqual(
+            model2.model.param_b.item(),
+            model.model.param_b.item(),
+            places=4,
+            msg="param_b should match after resume",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Auto batch size finder tests


### PR DESCRIPTION
## Summary

Fixes #43701

Models with `_checkpoint_conversion_mapping` (e.g. VLMs like Qwen2.5VL, LLaVA, ColPali, etc.) use a key renaming system:
- **Loading** (`from_pretrained`): Checkpoint keys are renamed from original format → model format via `convert_and_load_state_dict_in_model()`
- **Saving** (`save_pretrained`): Model keys are **reverted** back to original format via `revert_weight_conversion()` (default `save_original_format=True`)
- **Resume** (`Trainer._load_from_checkpoint`): Was loading checkpoint directly with `model.load_state_dict()` — **no conversion applied** → key mismatch crash

This PR adds `_apply_conversion_mapping_to_state_dict()` to `Trainer`, which applies the same `rename_source_key` logic that `from_pretrained` uses, and patches all three checkpoint loading paths:

- `Trainer._load_from_checkpoint()` — single-file resume
- `Trainer._load_best_model()` — best model loading
- `load_sharded_checkpoint()` in `trainer_utils.py` — sharded checkpoint resume (also fixes key validation that was marked as a TODO)

## Test plan

- [x] Added `test_resume_training_with_conversion_mapping` test that creates a model with registered conversion mapping, trains, saves checkpoint, and verifies resume works without key mismatch
- [x] All 11 existing resume tests pass with no regressions
- [x] `make style` passes