### PR TITLE
fix: handle Cython-compiled functions in get_docstring_indentation_level

### DIFF
--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -29,7 +29,11 @@ def get_docstring_indentation_level(func):
     # We assume classes are always defined in the global scope
     if inspect.isclass(func):
         return 4
-    source = inspect.getsource(func)
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):
+        # Cython-compiled functions and built-ins don't have source code
+        return 4
     first_line = source.splitlines()[0]
     function_def_level = len(first_line) - len(first_line.lstrip())
     return 4 + function_def_level


### PR DESCRIPTION
## Summary

Fixes #44355

`inspect.getsource()` fails with `TypeError` when called on Cython-compiled functions or built-in functions that don't have Python source code. This adds a try/except block to gracefully handle this case by returning the default indentation level of 4.

## Changes

- `src/transformers/utils/doc.py`: Added try/except around `inspect.getsource()` to catch `OSError` and `TypeError`

## Root Cause

The `get_docstring_indentation_level` function called `inspect.getsource(func)` without handling the case where the function is a Cython-compiled function or a built-in function.

## Reproduction (before fix)

```python
from transformers.utils.doc import get_docstring_indentation_level

# This would raise TypeError with Cython-compiled functions
get_docstring_indentation_level(len)  # TypeError: module, class, method, function... expected, got builtin_function_or_method
```

## Verification (after fix)

```python
from transformers.utils.doc import get_docstring_indentation_level

# Now returns default indentation of 4 instead of raising
assert get_docstring_indentation_level(len) == 4
```

## Testing

Tested with:
- Regular Python functions (works correctly)
- Classes (works correctly)  
- Built-in functions like `len` (now works correctly)