### PR TITLE
Fix incorrect position_ids docstring in modeling_flash_attention_utils.py

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -357,7 +357,8 @@ def prepare_fa_kwargs_from_position_ids(position_ids):
 
     Arguments:
         position_ids (`torch.Tensor`):
-            Boolean or int tensor of shape (batch_size, sequence_length), 1 means valid and 0 means not valid.
+            Indices of positions of each input sequence token in the position embeddings. Selected in the range
+            `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).
 
     Return:
         (cu_seqlens_q, cu_seqlens_k) (`tuple[int]`):
@@ -410,7 +411,8 @@ def _prepare_from_posids(query, key, value, position_ids):
         value (`torch.Tensor`):
             Value state with padding. Shape: (batch_size, kv_seq_len, num_key_value_heads, head_dim).
         position_ids (`torch.Tensor`):
-            Boolean or int tensor of shape (batch_size, sequence_length), 1 means valid and 0 means not valid.
+            Indices of positions of each input sequence token in the position embeddings. Selected in the range
+            `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).
 
     Return:
         query (`torch.Tensor`):


### PR DESCRIPTION
## What does this PR do?

Fixes #44373

The `position_ids` parameter docstrings in `_get_unpad_data()` (line 360) and `_upad_input()` (line 413) in `src/transformers/modeling_flash_attention_utils.py` were incorrectly describing `attention_mask` behavior:

> Boolean or int tensor of shape (batch_size, sequence_length), 1 means valid and 0 means not valid.

This has been corrected to properly describe position indices:

> Indices of positions of each input sequence token in the position embeddings. Selected in the range `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).