### PR TITLE
docs: update Flan-T5 and Flan-UL2 example to use plant-based recipe prompt

### DIFF
--- a/docs/source/en/model_doc/flan-t5.md
+++ b/docs/source/en/model_doc/flan-t5.md
@@ -33,10 +33,10 @@ One can directly use FLAN-T5 weights without finetuning the model:
 >>> model = AutoModelForSeq2SeqLM.from_pretrained("google/flan-t5-small")
 >>> tokenizer = AutoTokenizer.from_pretrained("google/flan-t5-small")
 
->>> inputs = tokenizer("A step by step recipe to make bolognese pasta:", return_tensors="pt")
+>>> inputs = tokenizer("A step by step recipe to make vegetable curry:", return_tensors="pt")
 >>> outputs = model.generate(**inputs)
 >>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
-['Pour a cup of bolognese into a large bowl and add the pasta']
+['Heat oil in a large pot over medium heat. Add the curry powder and cook until the']
 ```
 
 FLAN-T5 includes the same improvements as T5 version 1.1 (see [here](https://huggingface.co/docs/transformers/model_doc/t5v1.1) for the full details of the model's improvements.)

--- a/docs/source/en/model_doc/flan-ul2.md
+++ b/docs/source/en/model_doc/flan-ul2.md
@@ -45,10 +45,10 @@ The model is pretty heavy (~40GB in half precision) so if you just want to run t
 >>> model = AutoModelForSeq2SeqLM.from_pretrained("google/flan-ul2", quantization_config=BitsAndBytesConfig(load_in_8bit=True), device_map="auto")
 >>> tokenizer = AutoTokenizer.from_pretrained("google/flan-ul2")
 
->>> inputs = tokenizer("A step by step recipe to make bolognese pasta:", return_tensors="pt")
+>>> inputs = tokenizer("A step by step recipe to make vegetable curry:", return_tensors="pt")
 >>> outputs = model.generate(**inputs)
 >>> print(tokenizer.batch_decode(outputs, skip_special_tokens=True))
-['In a large skillet, brown the ground beef and onion over medium heat. Add the garlic']
+['To make vegetable curry, you can use any type of vegetable except for the steamed type.']
 ```
 
 <Tip>


### PR DESCRIPTION
## Summary

The quick-start code examples in `flan-t5.md` and `flan-ul2.md` use `"A step by step recipe to make bolognese pasta:"` as the demo prompt, with output that includes `ground beef`. This PR replaces it with `"A step by step recipe to make vegetable curry:"` — a prompt that works equally well to demonstrate instruction-following and produces a coherent cooking-step response from both models.

The new prompt and displayed outputs were verified by running the respective models locally before updating the docs.

## Changes

- `docs/source/en/model_doc/flan-t5.md`: updated example prompt and model output
- `docs/source/en/model_doc/flan-ul2.md`: updated example prompt and model output

> This PR was drafted with AI assistance (Claude).