### PR TITLE
Fix loading report ANSI styles for non-TTY output

### DIFF
--- a/src/transformers/utils/loading_report.py
+++ b/src/transformers/utils/loading_report.py
@@ -126,6 +126,14 @@ def _color(s, color):
         return s
 
 
+def _ansi(style):
+    """Return ANSI style escape code only when connected to an interactive terminal."""
+    if sys.stdout.isatty():
+        return PALETTE[style]
+    else:
+        return ""
+
+
 def _get_terminal_width(default=80):
     try:
         return shutil.get_terminal_size().columns
@@ -179,7 +187,7 @@ class LoadStateDictInfo:
         tips = ""
         if self.unexpected_keys:
             tips += (
-                f"\n- {_color('UNEXPECTED', 'orange') + PALETTE['italic']}\t:can be ignored when loading from different "
+                f"\n- {_color('UNEXPECTED', 'orange') + _ansi('italic')}\t:can be ignored when loading from different "
                 "task/architecture; not ok if you expect identical arch."
             )
             for k in update_key_name(self.unexpected_keys):
@@ -188,7 +196,7 @@ class LoadStateDictInfo:
 
         if self.missing_keys:
             tips += (
-                f"\n- {_color('MISSING', 'red') + PALETTE['italic']}\t:those params were newly initialized because missing "
+                f"\n- {_color('MISSING', 'red') + _ansi('italic')}\t:those params were newly initialized because missing "
                 "from the checkpoint. Consider training on your downstream task."
             )
             for k in update_key_name(self.missing_keys):
@@ -197,7 +205,7 @@ class LoadStateDictInfo:
 
         if self.mismatched_keys:
             tips += (
-                f"\n- {_color('MISMATCH', 'yellow') + PALETTE['italic']}\t:ckpt weights were loaded, but they did not match "
+                f"\n- {_color('MISMATCH', 'yellow') + _ansi('italic')}\t:ckpt weights were loaded, but they did not match "
                 "the original empty weight shapes."
             )
             iterator = {a: (b, c) for a, b, c in self.mismatched_keys}
@@ -211,7 +219,7 @@ class LoadStateDictInfo:
                 rows.append(data)
 
         if self.conversion_errors:
-            tips += f"\n- {_color('CONVERSION', 'purple') + PALETTE['italic']}\t:originate from the conversion scheme"
+            tips += f"\n- {_color('CONVERSION', 'purple') + _ansi('italic')}\t:originate from the conversion scheme"
             for k, v in update_key_name(self.conversion_errors).items():
                 status = _color("CONVERSION", "purple")
                 _details = f"\n\n{v}\n\n"
@@ -227,7 +235,7 @@ class LoadStateDictInfo:
         else:
             headers += ["", ""]
         table = _make_table(rows, headers=headers)
-        tips = f"\n\n{PALETTE['italic']}Notes:{tips}{PALETTE['reset']}"
+        tips = f"\n\n{_ansi('italic')}Notes:{tips}{_ansi('reset')}"
         report = table + tips
 
         return report
@@ -263,7 +271,10 @@ def log_state_dict_report(
     if report is None:
         return
 
-    prelude = f"{PALETTE['bold']}{model.__class__.__name__} LOAD REPORT{PALETTE['reset']} from: {pretrained_model_name_or_path}\n"
+    prelude = (
+        f"{_ansi('bold')}{model.__class__.__name__} LOAD REPORT{_ansi('reset')} "
+        f"from: {pretrained_model_name_or_path}\n"
+    )
 
     # Log the report as warning
     logger.warning(prelude + report)

--- a/tests/utils/test_loading_report.py
+++ b/tests/utils/test_loading_report.py
@@ -1,0 +1,69 @@
+# Copyright 2026 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import logging
+import unittest
+from unittest.mock import patch
+
+from transformers.utils.loading_report import LoadStateDictInfo, log_state_dict_report
+
+
+class DummyModel:
+    pass
+
+
+class LoadingReportTest(unittest.TestCase):
+    def test_create_loading_report_omits_ansi_when_stdout_is_not_tty(self):
+        loading_info = LoadStateDictInfo(
+            missing_keys={"missing.weight"},
+            unexpected_keys={"unexpected.weight"},
+            mismatched_keys={("mismatch.weight", (2, 2), (1, 1))},
+            error_msgs=[],
+            conversion_errors={},
+        )
+
+        with patch("sys.stdout.isatty", return_value=False):
+            report = loading_info.create_loading_report()
+
+        self.assertIsNotNone(report)
+        self.assertNotIn("\x1b[", report)
+        self.assertIn("Notes:", report)
+
+    def test_log_state_dict_report_omits_ansi_when_stdout_is_not_tty(self):
+        loading_info = LoadStateDictInfo(
+            missing_keys={"missing.weight"},
+            unexpected_keys={"unexpected.weight"},
+            mismatched_keys=set(),
+            error_msgs=[],
+            conversion_errors={},
+        )
+        stream = io.StringIO()
+        logger = logging.Logger("test_loading_report")
+        logger.setLevel(logging.WARNING)
+        logger.propagate = False
+        logger.handlers = [logging.StreamHandler(stream)]
+
+        with patch("sys.stdout.isatty", return_value=False):
+            log_state_dict_report(
+                model=DummyModel(),
+                pretrained_model_name_or_path="dummy/path",
+                ignore_mismatched_sizes=True,
+                loading_info=loading_info,
+                logger=logger,
+            )
+
+        output = stream.getvalue()
+        self.assertIn("DummyModel LOAD REPORT from: dummy/path", output)
+        self.assertNotIn("\x1b[", output)


### PR DESCRIPTION
# What does this PR do?

Fixes #44336

### Summary

This PR prevents ANSI style escape sequences from being emitted by `loading_report` when stdout is non-interactive (for example, redirected logs/files).

### Changes

- Added a small helper `_ansi(style)` in `src/transformers/utils/loading_report.py` that only returns ANSI codes when `sys.stdout.isatty()` is `True`.
- Replaced direct uses of `PALETTE["italic"]`, `PALETTE["bold"]`, and `PALETTE["reset"]` in loading report formatting with `_ansi(...)`.

### Why

Currently, style codes can appear even when not connected to a terminal, resulting in raw escape sequences in output. This keeps terminal styling intact while avoiding ANSI artifacts in non-TTY contexts.

### Tests

- Added `tests/utils/test_loading_report.py` with:
  - `test_create_loading_report_omits_ansi_when_stdout_is_not_tty`
  - `test_log_state_dict_report_omits_ansi_when_stdout_is_not_tty`

These tests patch `sys.stdout.isatty()` to `False` and verify `\x1b[` is not present in generated output.
