### PR TITLE
[AMD CI] Add missing timm dependency to ROCm Docker image

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -43,3 +43,6 @@ RUN git clone https://github.com/ROCm/flash-attention/ -b tridao && \
 # GPU_ARCHS builds for MI300, MI325 but not MI355: we would need to add `;gfx950` but it takes too long to build.
 
 RUN python3 -m pip install --no-cache-dir einops
+
+# timm is required for many vision models tests
+RUN python3 -m pip install --no-cache-dir timm

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -36,8 +36,8 @@ from transformers.testing_utils import (
     Expectations,
     cleanup,
     require_deterministic_for_xpu,
-    require_torch,
     require_timm,
+    require_torch,
     require_torch_accelerator,
     set_config_for_less_flaky_test,
     set_model_for_less_flaky_test,
@@ -638,6 +638,7 @@ class Gemma3nTextModelTest(CausalLMModelTest, unittest.TestCase):
             torch.testing.assert_close(yarn_cos_long, original_cos_long)
         with self.assertRaises(AssertionError):
             torch.testing.assert_close(yarn_sin_long, original_sin_long)
+
 
 class Gemma3nVision2TextModelTester:
     text_config = {"activation_sparsity_pattern": None}

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -37,6 +37,7 @@ from transformers.testing_utils import (
     cleanup,
     require_deterministic_for_xpu,
     require_torch,
+    require_timm,
     require_torch_accelerator,
     set_config_for_less_flaky_test,
     set_model_for_less_flaky_test,
@@ -638,7 +639,6 @@ class Gemma3nTextModelTest(CausalLMModelTest, unittest.TestCase):
         with self.assertRaises(AssertionError):
             torch.testing.assert_close(yarn_sin_long, original_sin_long)
 
-
 class Gemma3nVision2TextModelTester:
     text_config = {"activation_sparsity_pattern": None}
     forced_config_args = ["text_config"]
@@ -769,6 +769,7 @@ class Gemma3nVision2TextModelTester:
 
 
 @require_torch
+@require_timm
 class Gemma3nVision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCase):
     all_model_classes = (Gemma3nModel, Gemma3nForConditionalGeneration) if is_torch_available() else ()
     all_generative_model_classes = (Gemma3nForConditionalGeneration,) if is_torch_available() else ()


### PR DESCRIPTION
Adds explicit `timm` installation to the AMD ROCm Docker image.
This causes ~200 test failures in AMD CI (e.g., [gemma3n vision tests](https://github.com/huggingface/transformers/actions/runs/22474359922/job/65104428291)).
This mirrors what's done in the NVIDIA `transformers-all-latest-gpu` Dockerfile which has an explicit `timm` install.