### PR TITLE
[ Dynamic weight loader] fix remote code when format matches

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1129,9 +1129,7 @@ def convert_and_load_state_dict_in_model(
         )
         if renamed_key not in meta_model_state_dict and original_key in meta_model_state_dict:
             # Key should probably not have been renamed :)
-            renamed_key, source_pattern = rename_source_key(
-                original_key, [], [], prefix, meta_model_state_dict
-            )
+            renamed_key, source_pattern = rename_source_key(original_key, [], [], prefix, meta_model_state_dict)
 
         # 2. finally, collect the tensor into the proper converter
         if renamed_key in meta_model_state_dict:

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1128,7 +1128,7 @@ def convert_and_load_state_dict_in_model(
             original_key, renamings, converters, prefix, meta_model_state_dict
         )
         if renamed_key not in meta_model_state_dict and original_key in meta_model_state_dict:
-            # Key should probably not have been renamed :)
+            # Key should probably not have been renamed but we might need the `prefix` to be added.`
             renamed_key, source_pattern = rename_source_key(original_key, [], [], prefix, meta_model_state_dict)
 
         # 2. finally, collect the tensor into the proper converter

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1127,6 +1127,11 @@ def convert_and_load_state_dict_in_model(
         renamed_key, source_pattern = rename_source_key(
             original_key, renamings, converters, prefix, meta_model_state_dict
         )
+        if renamed_key not in meta_model_state_dict and original_key in meta_model_state_dict:
+            # Key should probably not have been renamed :)
+            renamed_key, source_pattern = rename_source_key(
+                original_key, [], [], prefix, meta_model_state_dict
+            )
 
         # 2. finally, collect the tensor into the proper converter
         if renamed_key in meta_model_state_dict:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1765,7 +1765,6 @@ class ModelUtilsTest(TestCasePlus):
             outputs_from_saved = new_model(input_ids)
             torch.testing.assert_close(outputs_from_saved["logits"], outputs["logits"])
 
-
     def test_can_generate(self):
         """Tests the behavior of `PreTrainedModel.can_generate` method."""
         logger = logging.get_logger("transformers.modeling_utils")

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1765,21 +1765,6 @@ class ModelUtilsTest(TestCasePlus):
             outputs_from_saved = new_model(input_ids)
             torch.testing.assert_close(outputs_from_saved["logits"], outputs["logits"])
 
-    def test_warning_for_beta_gamma_parameters(self):
-        config = PreTrainedConfig()
-        model = TestModelGammaBeta(config)
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            model.save_pretrained(tmp_dir)
-            with LoggingLevel(logging.INFO):
-                _, loading_info = TestModelGammaBeta.from_pretrained(tmp_dir, config=config, output_loading_info=True)
-
-        missing_keys = loading_info["missing_keys"]
-        unexpected_keys = loading_info["unexpected_keys"]
-        self.assertIn("LayerNorm.gamma", missing_keys)
-        self.assertIn("LayerNorm.weight", unexpected_keys)
-        self.assertIn("LayerNorm.beta", missing_keys)
-        self.assertIn("LayerNorm.bias", unexpected_keys)
 
     def test_can_generate(self):
         """Tests the behavior of `PreTrainedModel.can_generate` method."""


### PR DESCRIPTION
# What does this PR do?
Some renaming should just never be applied when the weight format already matches. (this is actually regardless of remote code). 

This allows us to remove 1 test added in https://github.com/huggingface/transformers/commit/8c1b5d37827a6691fef4b2d926f2d04fb6f5a9e3 ! 

FYI @vasqu we discussed offline with @Cyrilvallez and this makes sense mostly for "errors" or special cases were a model type has 2 checkpoint formats. 

