### PR TITLE
Add missing ReLU in GlmMoeDsaIndexer scoring

### DIFF
--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -217,6 +217,8 @@ class GlmMoeDsaIndexer(nn.Module):
 
         # q·k^T per head: [B, S, H, D] @ [B, T, D]^T → [B, S, H, T]
         scores = torch.einsum("bshd,btd->bsht", q.float(), k_cached.float()) * self.softmax_scale
+        # Apply ReLU before weighted sum across heads (reference: T.max(logits, 0))
+        scores = torch.relu(scores)
 
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)

--- a/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
@@ -409,6 +409,8 @@ class GlmMoeDsaIndexer(nn.Module):
 
         # q·k^T per head: [B, S, H, D] @ [B, T, D]^T → [B, S, H, T]
         scores = torch.einsum("bshd,btd->bsht", q.float(), k_cached.float()) * self.softmax_scale
+        # Apply ReLU before weighted sum across heads (reference: T.max(logits, 0))
+        scores = torch.relu(scores)
 
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)


### PR DESCRIPTION
## What does this PR do?

Adds the missing ReLU activation in `GlmMoeDsaIndexer.forward()` on per-head q·k scores before the weighted sum across heads.

The reference DeepSeek-V3.2 `fp8_index` kernel applies `T.max(logits, 0)` (i.e., ReLU) at [this line](https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp/blob/main/inference/kernel.py#L241), which clamps negative per-head scores to zero so they do not incorrectly influence top-k token selection for sparse attention.

The change is applied to both `modular_glm_moe_dsa.py` (source of truth) and `modeling_glm_moe_dsa.py` (generated).

Fixes #44360

## Test plan

- [ ] CI passes (`check_repository_consistency`, `check_code_quality`)
- [ ] `run-slow: glm_moe_dsa` (maintainer-triggered)