### PR TITLE
Fix position_ids typo in Qwen3_5TextModel forward pass

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1373,7 +1373,7 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
                 hidden_states,
                 position_embeddings=position_embeddings,
                 attention_mask=layer_mask,
-                position_ids=position_ids,
+                position_ids=text_position_ids,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 cache_position=cache_position,

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -678,7 +678,7 @@ class Qwen3_5TextModel(Qwen3NextModel):
                 hidden_states,
                 position_embeddings=position_embeddings,
                 attention_mask=layer_mask,
-                position_ids=position_ids,
+                position_ids=text_position_ids,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 cache_position=cache_position,

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -1498,7 +1498,7 @@ class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
                 hidden_states,
                 position_embeddings=position_embeddings,
                 attention_mask=layer_mask,
-                position_ids=position_ids,
+                position_ids=text_position_ids,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 cache_position=cache_position,


### PR DESCRIPTION
## Summary

Fixes #44384

In `Qwen3_5TextModel.forward`, after splitting `position_ids` into `text_position_ids` (index 0, for text) and `position_ids` (indices 1:, for temporal/height/width), the decoder layer call incorrectly passed `position_ids` instead of `text_position_ids`.

This caused shape mismatches in FlashAttention2 when processing non-padded data, because the decoder layers received the 3D mrope position_ids (temporal/height/width) instead of the 2D text position_ids.

## Changes

- `modular_qwen3_5.py` line 681: `position_ids=position_ids` → `position_ids=text_position_ids`
- `modeling_qwen3_5.py` line 1376: same fix (auto-generated from modular)

This aligns with the corresponding code in [`Qwen3VLTextModel`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_vl/modular_qwen3_vl.py#L819) which correctly passes `text_position_ids` to decoder layers.

## Test plan

- [ ] Verify Qwen3.5 inference with non-padded batches no longer raises shape mismatch errors
- [ ] Verify FlashAttention2 backend works correctly with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)