### PR TITLE
Add Qwen3.5 support for sequence classification

### DIFF
--- a/docs/source/en/model_doc/qwen3_5.md
+++ b/docs/source/en/model_doc/qwen3_5.md
@@ -66,6 +66,11 @@ TODO
 [[autodoc]] Qwen3_5ForCausalLM
     - forward
 
+## Qwen3_5ForSequenceClassification
+
+[[autodoc]] Qwen3_5ForSequenceClassification
+    - forward
+
 ## Qwen3_5ForConditionalGeneration
 
 [[autodoc]] Qwen3_5ForConditionalGeneration

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -1253,6 +1253,8 @@ MODEL_FOR_SEQUENCE_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
         ("qwen2", "Qwen2ForSequenceClassification"),
         ("qwen2_moe", "Qwen2MoeForSequenceClassification"),
         ("qwen3", "Qwen3ForSequenceClassification"),
+        ("qwen3_5", "Qwen3_5ForSequenceClassification"),
+        ("qwen3_5_text", "Qwen3_5ForSequenceClassification"),
         ("qwen3_moe", "Qwen3MoeForSequenceClassification"),
         ("qwen3_next", "Qwen3NextForSequenceClassification"),
         ("reformer", "ReformerForSequenceClassification"),

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -34,7 +34,7 @@ from ...generation import GenerationMixin
 from ...integrations import use_kernelized_func
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
-from ...modeling_layers import GradientCheckpointingLayer
+from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import (
     BaseModelOutputWithPast,
     BaseModelOutputWithPooling,
@@ -1871,6 +1871,10 @@ class Qwen3_5ForCausalLM(Qwen3_5PreTrainedModel, GenerationMixin):
         )
 
 
+class Qwen3_5ForSequenceClassification(GenericForSequenceClassification, Qwen3_5PreTrainedModel):
+    config: Qwen3_5TextConfig
+
+
 @dataclass
 @auto_docstring(
     custom_intro="""
@@ -2283,6 +2287,7 @@ __all__ = [
     "Qwen3_5TextModel",
     "Qwen3_5Model",
     "Qwen3_5ForCausalLM",
+    "Qwen3_5ForSequenceClassification",
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5PreTrainedModel",
 ]

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -22,7 +22,7 @@ from torch import nn
 from ... import initialization as init
 from ...cache_utils import Cache
 from ...masking_utils import create_causal_mask
-from ...modeling_layers import GradientCheckpointingLayer
+from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
 from ...modeling_rope_utils import RopeParameters
 from ...modeling_utils import PreTrainedModel
@@ -807,6 +807,10 @@ class Qwen3_5ForCausalLM(Qwen3ForCausalLM):
         self.model = Qwen3_5TextModel(config)
 
 
+class Qwen3_5ForSequenceClassification(GenericForSequenceClassification, Qwen3_5PreTrainedModel):
+    config: Qwen3_5TextConfig
+
+
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
     def get_video_features(
         self,
@@ -828,6 +832,7 @@ __all__ = [
     "Qwen3_5TextModel",
     "Qwen3_5Model",
     "Qwen3_5ForCausalLM",
+    "Qwen3_5ForSequenceClassification",
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5PreTrainedModel",
 ]

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -38,6 +38,7 @@ if is_torch_available():
         Qwen3_5Config,
         Qwen3_5ForCausalLM,
         Qwen3_5ForConditionalGeneration,
+        Qwen3_5ForSequenceClassification,
         Qwen3_5Model,
         Qwen3_5TextConfig,
         Qwen3_5TextModel,
@@ -49,6 +50,7 @@ class Qwen3_5TextModelTester(CausalLMModelTester):
     if is_torch_available():
         base_model_class = Qwen3_5TextModel
         causal_lm_class = Qwen3_5ForCausalLM
+        sequence_classification_class = Qwen3_5ForSequenceClassification
 
     def __init__(self, parent):
         super().__init__(parent=parent)


### PR DESCRIPTION
Adds sequence-classification support for Qwen3.5 in AutoModelForSequenceClassification.

**What does this PR do?**
This PR enables loading Qwen3.5 checkpoints with `AutoModelForSequenceClassification`, which previously failed with:
`ValueError: Unrecognized configuration class Qwen3_5Config for AutoModelForSequenceClassification`.

**Changes**

- Adds Qwen3_5ForSequenceClassification in:
-- [src/transformers/models/qwen3_5/modular_qwen3_5.py](https://github.com/medhakimbedhief/transformers/commit/3bdc00b0c67025717c45b851b229c0f7af5a1702#:~:text=%2B-,class%20Qwen3_5ForSequenceClassification(GenericForSequenceClassification%2C%20Qwen3_5PreTrainedModel)%3A,-811)
-- generated [src/transformers/models/qwen3_5/modeling_qwen3_5.py](https://github.com/medhakimbedhief/transformers/commit/3bdc00b0c67025717c45b851b229c0f7af5a1702#:~:text=%2B-,from%20...modeling_layers%20import%20GenericForSequenceClassification%2C%20GradientCheckpointingLayer,-38)
- Exports the new class via the Qwen3.5 modeling `__all__`.
- Registers auto-mapping entries in:
-- [src/transformers/models/auto/modeling_auto.py](https://github.com/medhakimbedhief/transformers/commit/3bdc00b0c67025717c45b851b229c0f7af5a1702#:~:text=(%22qwen3_5%22%2C,%2C%20%22Qwen3_5ForSequenceClassification%22)%2C)
-- `("qwen3_5", "Qwen3_5ForSequenceClassification")`
-- `("qwen3_5_text", "Qwen3_5ForSequenceClassification")`

**Why both mappings?**
Qwen3.5 uses a composite VLM config (qwen3_5) with a text sub-config (`qwen3_5_text`).
Registering **both** ensures classification works for direct text config usage and composite config loading paths.

**Before :**
Loading from e.g. Qwen/Qwen3.5-0.8B raises `ValueError: Unrecognized configuration class Qwen3_5Config for AutoModelForSequenceClassification`.

**After this PR:**
Loading from `Qwen/Qwen3.5-0.8B` now resolves to `Qwen3_5ForSequenceClassification`.

@Cyrilvallez  @zucchini-nlp  @ArthurZucker 

Fixes #44405 
