### PR TITLE
Neuron kernels integration

### DIFF
--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -57,8 +57,8 @@ def infer_device(model):
 def add_to_mapping(layer_name, device, repo_name, mode, compatible_mapping):
     from kernels import LayerRepository
 
-    if device not in ["cuda", "rocm", "xpu", "npu"]:
-        raise ValueError(f"Only cuda, rocm, xpu and npu devices supported, got: {device}")
+    if device not in ["cuda", "rocm", "xpu", "npu", "neuron"]:
+        raise ValueError(f"Only cuda, rocm, xpu, npu and neuron devices supported, got: {device}")
     repo_layer_name = repo_name.split(":")[1]
     repo_id = repo_name.split(":")[0]
     compatible_mapping[layer_name] = {
@@ -76,8 +76,8 @@ def add_to_mapping_local(layer_name, device, repo_name, mode, compatible_mapping
 
     from kernels import LocalLayerRepository
 
-    if device not in ["cuda", "rocm", "xpu", "npu"]:
-        raise ValueError(f"Only cuda, rocm, xpu and npu devices supported, got: {device}")
+    if device not in ["cuda", "rocm", "xpu", "npu", "neuron"]:
+        raise ValueError(f"Only cuda, rocm, xpu, npu and neuron devices supported, got: {device}")
     repo_layer_name = repo_name.split(":")[1]
     repo_path = repo_name.split(":")[0]
     repo_package_name = repo_path.split("/")[-1]
@@ -193,8 +193,8 @@ class KernelConfig(PushToHubMixin):
 
             elif isinstance(kernel, dict):
                 for device, repo_name in kernel.items():
-                    if device not in ["cuda", "rocm", "xpu", "npu"]:
-                        raise ValueError(f"Only cuda, rocm, xpu and npu devices supported, got: {device}")
+                    if device not in ["cuda", "rocm", "xpu", "npu", "neuron"]:
+                        raise ValueError(f"Only cuda, rocm, xpu, npu and neuron devices supported, got: {device}")
 
                     if not isinstance(repo_name, str) or "/" not in repo_name or ":" not in repo_name:
                         raise ValueError(


### PR DESCRIPTION
# What does this PR do?

To be merged after #44302 and https://github.com/huggingface/kernels/pull/285. It adds the `neuron` device in checks for custom kernels, enabling to load kernels for Neuron devices.