### PR TITLE
Fix `transformers serve --continuous-batching` for multimodal models

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -826,9 +826,13 @@ class Serve:
             self.running_continuous_batching_manager.start()
 
         # TODO (Joao, Lysandre): this should also work with tool support
-        inputs = processor.apply_chat_template(
+        chat_output = processor.apply_chat_template(
             req["messages"], return_tensors="pt", add_generation_prompt=True, return_dict=True
-        ).to(model.device)["input_ids"][0]
+        )
+        if isinstance(chat_output, str):
+            inputs = tokenizer(chat_output, return_tensors="pt").to(model.device)["input_ids"][0]
+        else:
+            inputs = chat_output.to(model.device)["input_ids"][0]
 
         def stream_chat_completion(request_id, decode_stream):
             from ..generation.continuous_batching import RequestStatus


### PR DESCRIPTION
## What does this PR do?

Fixes `AttributeError: 'str' object has no attribute 'to'` when using `transformers serve --continuous-batching` with multimodal models like Qwen3.5-9B.

`processor.apply_chat_template()` returns a plain string (not `BatchEncoding`) for some multimodal processors. The current code calls `.to(model.device)` directly on the return value, which fails.

Added a type check: if the output is a string, tokenize it first using `tokenizer` before moving to device.

Fixes #44423

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. (#44423)
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@remi-or @ArthurZucker @McPatate
