### PR TITLE
fix(tokenization): preserve original tokenizer_class in save_pretrained

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1748,13 +1748,14 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         if tokenizer_config_file is not None:
             with open(tokenizer_config_file, encoding="utf-8") as tokenizer_config_handle:
                 init_kwargs = json.load(tokenizer_config_handle)
-            # used in the past to check if the tokenizer class matches the class in the repo
-            init_kwargs.pop("tokenizer_class", None)
+            # Preserve the original tokenizer_class from config for save_pretrained
+            original_tokenizer_class = init_kwargs.pop("tokenizer_class", None)
             saved_init_inputs = init_kwargs.pop("init_inputs", ())
             if not init_inputs:
                 init_inputs = saved_init_inputs
         else:
             init_kwargs = init_configuration
+            original_tokenizer_class = None
 
         if resolved_vocab_files.get("tokenizer_file", None) is not None:
             init_kwargs.pop("add_bos_token", None)
@@ -1921,6 +1922,10 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                 "Unable to load vocabulary from file. "
                 "Please check that the provided vocabulary is accessible and not corrupted."
             )
+
+        # Store original tokenizer_class from config for use in save_pretrained
+        tokenizer._original_tokenizer_class = original_tokenizer_class
+
         return tokenizer
 
     @classmethod
@@ -2049,16 +2054,19 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         tokenizer_config["added_tokens_decoder"] = added_tokens
 
         # Add tokenizer class to the tokenizer config to be able to reload it with from_pretrained
-        tokenizer_class = self.__class__.__name__
+        # Preserve the original tokenizer_class from loaded config if available (fixes #44297)
+        tokenizer_class = getattr(self, "_original_tokenizer_class", None)
+        if tokenizer_class is None:
+            tokenizer_class = self.__class__.__name__
+            # Remove the Fast at the end if we can save the slow tokenizer
+            if tokenizer_class.endswith("Fast") and getattr(self, "can_save_slow_tokenizer", False):
+                tokenizer_class = tokenizer_class[:-4]
 
         # tokenizers backend don't need to save added_tokens_decoder and additional_special_tokens
         if any(base.__name__ == "TokenizersBackend" for base in self.__class__.__mro__):
             tokenizer_config.pop("added_tokens_decoder", None)
             tokenizer_config.pop("additional_special_tokens", None)
 
-        # Remove the Fast at the end if we can save the slow tokenizer
-        if tokenizer_class.endswith("Fast") and getattr(self, "can_save_slow_tokenizer", False):
-            tokenizer_class = tokenizer_class[:-4]
         tokenizer_config["tokenizer_class"] = tokenizer_class
         if getattr(self, "_auto_map", None) is not None:
             tokenizer_config["auto_map"] = self._auto_map

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -352,3 +352,32 @@ class TokenizerUtilsTest(unittest.TestCase):
             new_tokenizer.decode(new_tokenizer.encode(text_with_nonspecial_tokens), skip_special_tokens=True)
             == text_with_nonspecial_tokens
         )
+
+    @require_tokenizers
+    def test_save_pretrained_preserves_tokenizer_class(self):
+        """Test that save_pretrained preserves the original tokenizer_class from config (fixes #44297)."""
+        import json
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            # Load a tokenizer with a known tokenizer_class
+            tokenizer = BertTokenizer.from_pretrained("google-bert/bert-base-cased")
+
+            # Save it
+            tokenizer.save_pretrained(tmpdirname)
+
+            # Check the saved config
+            with open(os.path.join(tmpdirname, "tokenizer_config.json")) as f:
+                saved_config = json.load(f)
+
+            # The tokenizer_class should be preserved as "BertTokenizer"
+            self.assertEqual(saved_config["tokenizer_class"], "BertTokenizer")
+
+            # Now load it again and save again - should still preserve the class
+            reloaded_tokenizer = AutoTokenizer.from_pretrained(tmpdirname)
+            reloaded_tokenizer.save_pretrained(tmpdirname)
+
+            with open(os.path.join(tmpdirname, "tokenizer_config.json")) as f:
+                resaved_config = json.load(f)
+
+            # Should still be "BertTokenizer", not "PreTrainedTokenizerFast" or similar
+            self.assertEqual(resaved_config["tokenizer_class"], "BertTokenizer")


### PR DESCRIPTION
Fixes #44297

## Problem
`tokenizer.save_pretrained()` overwrites `tokenizer_class` in `tokenizer_config.json` with the current wrapper class (e.g. `PreTrainedTokenizerFast`) instead of preserving the original class from the loaded config (e.g. `Qwen2Tokenizer`). This breaks round-trip loading for models like Qwen3.5.

## Fix
In `tokenization_utils_base.py`, when building the config dict to save, check if the original `tokenizer_class` is present and preserve it rather than overwriting with the current class name.

## Testing
Added test verifying `tokenizer_class` is preserved after save/reload cycle.