### PR TITLE
fix: catch HfHubHTTPError in safetensors auto_conversion thread

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -669,7 +669,7 @@ def _get_resolved_checkpoint_files(
                         Thread(
                             target=auto_conversion,
                             args=(pretrained_model_name_or_path,),
-                            kwargs={"ignore_errors_during_conversion": False, **cached_file_kwargs},
+                            kwargs={"ignore_errors_during_conversion": True, **cached_file_kwargs},
                             name="Thread-auto_conversion",
                         ).start()
 

--- a/src/transformers/safetensors_conversion.py
+++ b/src/transformers/safetensors_conversion.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import httpx
 from huggingface_hub import Discussion, HfApi, get_repo_discussions
+from huggingface_hub.errors import HfHubHTTPError
 
 from .utils import cached_file, http_user_agent, logging
 
@@ -11,12 +12,15 @@ logger = logging.get_logger(__name__)
 
 def previous_pr(api: HfApi, model_id: str, pr_title: str, token: str) -> Optional["Discussion"]:
     main_commit = api.list_repo_commits(model_id, token=token)[0].commit_id
-    for discussion in get_repo_discussions(repo_id=model_id, token=token):
-        if discussion.title == pr_title and discussion.status == "open" and discussion.is_pull_request:
-            commits = api.list_repo_commits(model_id, revision=discussion.git_reference, token=token)
+    try:
+        for discussion in get_repo_discussions(repo_id=model_id, token=token):
+            if discussion.title == pr_title and discussion.status == "open" and discussion.is_pull_request:
+                commits = api.list_repo_commits(model_id, revision=discussion.git_reference, token=token)
 
-            if main_commit == commits[1].commit_id:
-                return discussion
+                if main_commit == commits[1].commit_id:
+                    return discussion
+    except HfHubHTTPError:
+        logger.debug(f"Could not list discussions for {model_id}. Discussions may be disabled for this repo.")
     return None
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the noisy `HfHubHTTPError` exception output that appears when loading a transformer model from a repository that has discussions disabled.

### Root cause

The `previous_pr()` function in `safetensors_conversion.py` calls `get_repo_discussions()` which raises `HfHubHTTPError` (403 Forbidden) when a repo has discussions disabled. This exception propagated up through the background `Thread-auto_conversion` thread, producing a scary traceback during normal model loading.

### Changes

1. **`src/transformers/safetensors_conversion.py`**: Wrap the `get_repo_discussions()` iteration in `previous_pr()` with a `try/except HfHubHTTPError` block, logging a debug-level message instead of propagating the exception.

2. **`src/transformers/modeling_utils.py`**: Change `ignore_errors_during_conversion` from `False` to `True` for the background auto-conversion thread, since this thread is a best-effort optimization for future loads and should never produce user-visible error output.

Fixes #44403

## Before

```
>>> from transformers import AutoModel
>>> bert_model = AutoModel.from_pretrained('hfl/chinese-electra-180g-large-discriminator')
...
Exception in Thread-auto_conversion:
Traceback (most recent call last):
  ...
huggingface_hub.errors.HfHubHTTPError: 403 Forbidden: Discussions are disabled for this repo.
```

## After

```
>>> from transformers import AutoModel
>>> bert_model = AutoModel.from_pretrained('hfl/chinese-electra-180g-large-discriminator')
>>> # No exception output
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)