### PR TITLE
[vLLM] Fix backward compatibility with hardcoded subprocessors classes in processors

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1519,8 +1519,13 @@ class ProcessorMixin(PushToHubMixin):
                     )
                 args.append(tokenizer)
             elif is_primary:
-                # Primary non-tokenizer sub-processor: load via Auto class
-                auto_processor_class = MODALITY_TO_AUTOPROCESSOR_MAPPING[sub_processor_type]
+                # For backward compatibility, check if sub-processor class name is hardcoded as an attribute of the processor class.
+                if hasattr(cls, sub_processor_type + "_class"):
+                    auto_processor_class_name = getattr(cls, sub_processor_type + "_class")
+                    auto_processor_class = cls.get_possibly_dynamic_module(auto_processor_class_name)
+                else:
+                    # Primary non-tokenizer sub-processor: load via Auto class
+                    auto_processor_class = MODALITY_TO_AUTOPROCESSOR_MAPPING[sub_processor_type]
                 sub_processor = auto_processor_class.from_pretrained(
                     pretrained_model_name_or_path, subfolder=subfolder, **kwargs
                 )

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1519,13 +1519,16 @@ class ProcessorMixin(PushToHubMixin):
                     )
                 args.append(tokenizer)
             elif is_primary:
+                # Primary non-tokenizer sub-processor: load via Auto class
+                auto_processor_class = MODALITY_TO_AUTOPROCESSOR_MAPPING[sub_processor_type]
                 # For backward compatibility, check if sub-processor class name is hardcoded as an attribute of the processor class.
                 if hasattr(cls, sub_processor_type + "_class"):
-                    auto_processor_class_name = getattr(cls, sub_processor_type + "_class")
-                    auto_processor_class = cls.get_possibly_dynamic_module(auto_processor_class_name)
-                else:
-                    # Primary non-tokenizer sub-processor: load via Auto class
-                    auto_processor_class = MODALITY_TO_AUTOPROCESSOR_MAPPING[sub_processor_type]
+                    sub_processor_class_name = getattr(cls, sub_processor_type + "_class")
+                    logger.warning_once(
+                        f"`{cls.__name__}` defines `{sub_processor_type}_class = '{sub_processor_class_name}'`, "
+                        f"which is deprecated. Register the correct mapping in `{auto_processor_class.__name__}` instead.",
+                    )
+                    auto_processor_class = cls.get_possibly_dynamic_module(sub_processor_class_name)
                 sub_processor = auto_processor_class.from_pretrained(
                     pretrained_model_name_or_path, subfolder=subfolder, **kwargs
                 )


### PR DESCRIPTION
# What does this PR do?

Fixes MiniCPM-o-2_6 related tests failures in vLLM, and improve backward compatibility with remote code in general.

Cc @hmellor @zucchini-nlp 