### PR TITLE
Fix KeyError in convert_to_native_format for dict vocab

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -155,7 +155,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 if isinstance(vocab, list):
                     vocab = list(map(tuple, vocab))  # TODO just for now
             elif cls.model.__name__ == "Unigram":
-                if vocab and isinstance(vocab[0], (list, tuple)):
+                if isinstance(vocab, list) and vocab and isinstance(vocab[0], (list, tuple)):
                     vocab = [tuple(item) for item in vocab]
             elif cls.model.__name__ == "WordLevel":
                 vocab = {token: i for i, token in enumerate(vocab)}


### PR DESCRIPTION
## Fix KeyError in `convert_to_native_format` for dict vocab

Fixes #44451

### Problem

`AutoTokenizer.from_pretrained("vesteinn/ScandiBERT")` raises `KeyError: 0` in `convert_to_native_format`.

ScandiBERT's `tokenizer_config.json` specifies `tokenizer_class: "XLMRobertaTokenizer"`, which has `model = Unigram`. When `convert_to_native_format` reads the `tokenizer.json`, it enters the Unigram branch and executes:

```python
if vocab and isinstance(vocab[0], (list, tuple)):
```

However, the `vocab` from `tokenizer.json` is a **dict** (`{"token": score, ...}`), not a list. Indexing a dict with `[0]` raises `KeyError` because there is no key `0`.

### Fix

Add an `isinstance(vocab, list)` check before attempting to index `vocab[0]`:

```python
if isinstance(vocab, list) and vocab and isinstance(vocab[0], (list, tuple)):
```

This is consistent with the guards used in the other branches (e.g., BPE/WordPiece branch on line 163). When `vocab` is already a dict, no conversion is needed and it is passed through as-is.

### Regression

Introduced in v5 by #42894 (`use TokenizersBackend`).