### PR TITLE
Fix Pegasus sinusoidal position embedding init regression in v5

### DIFF
--- a/src/transformers/models/marian/modeling_marian.py
+++ b/src/transformers/models/marian/modeling_marian.py
@@ -443,10 +443,15 @@ class MarianPreTrainedModel(PreTrainedModel):
 
     @torch.no_grad()
     def _init_weights(self, module):
-        super()._init_weights(module)
         if isinstance(module, MarianSinusoidalPositionalEmbedding):
-            init.copy_(module.weight, module.create_weight())
-        elif isinstance(module, MarianMTModel):
+            # Sinusoidal embeddings are deterministic and should not go through generic
+            # nn.Embedding init (which would call init.normal_). We skip super() entirely
+            # and directly copy the sinusoidal weights.
+            weight = module.create_weight()
+            init.copy_(module.weight, weight.to(dtype=module.weight.dtype, device=module.weight.device))
+            return
+        super()._init_weights(module)
+        if isinstance(module, MarianMTModel):
             init.zeros_(module.final_logits_bias)
 
     @property

--- a/src/transformers/models/pegasus/modeling_pegasus.py
+++ b/src/transformers/models/pegasus/modeling_pegasus.py
@@ -437,10 +437,15 @@ class PegasusPreTrainedModel(PreTrainedModel):
 
     @torch.no_grad()
     def _init_weights(self, module):
-        super()._init_weights(module)
         if isinstance(module, PegasusSinusoidalPositionalEmbedding):
-            init.copy_(module.weight, module.create_weight())
-        elif isinstance(module, PegasusForConditionalGeneration):
+            # Sinusoidal embeddings are deterministic and should not go through generic
+            # nn.Embedding init (which would call init.normal_). We skip super() entirely
+            # and directly copy the sinusoidal weights.
+            weight = module.create_weight()
+            init.copy_(module.weight, weight.to(dtype=module.weight.dtype, device=module.weight.device))
+            return
+        super()._init_weights(module)
+        if isinstance(module, PegasusForConditionalGeneration):
             init.zeros_(module.final_logits_bias)
 
 

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -155,7 +155,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 if isinstance(vocab, list):
                     vocab = list(map(tuple, vocab))  # TODO just for now
             elif cls.model.__name__ == "Unigram":
-                if vocab and isinstance(vocab[0], (list, tuple)):
+                if isinstance(vocab, list) and vocab and isinstance(vocab[0], (list, tuple)):
                     vocab = [tuple(item) for item in vocab]
             elif cls.model.__name__ == "WordLevel":
                 vocab = {token: i for i, token in enumerate(vocab)}


### PR DESCRIPTION
## Summary

- Fixes the `_init_weights` method in `PegasusPreTrainedModel` and `MarianPreTrainedModel` to handle sinusoidal position embeddings before calling `super()._init_weights(module)`, preventing the generic `nn.Embedding` branch from running `init.normal_()` on deterministic sinusoidal weights
- Ensures `create_weight()` output matches the target tensor's dtype and device before `init.copy_()`, improving robustness with `dtype=torch.float16` and `device_map="auto"`

## Background

In v5, `_init_weights` was refactored to call `super()._init_weights(module)` first, which treats `PegasusSinusoidalPositionalEmbedding` as a generic `nn.Embedding` and applies `init.normal_()`. While `init.copy_()` is called afterwards to restore the sinusoidal values, this flow is fragile during `from_pretrained` with meta-device initialization (see #43632).

The v4 code checked for `PegasusSinusoidalPositionalEmbedding` *before* the `nn.Embedding` branch, avoiding unnecessary random initialization. Other models with the same pattern (e.g., FSMT, Autoformer) already follow this safer approach.

This fix restructures the check order with an early return to skip the generic init entirely, matching the v4 behavior and the pattern used by FSMT.

Fixes #44448

## Test plan

- [ ] Verify `test_device_map` passes (checks embed_positions.weight equality with/without device_map)
- [ ] Verify `test_pegasus_xsum_summary` passes (integration test with expected output)
- [ ] Reproduce issue with `google/pegasus-cnn_dailymail`, `dtype=torch.float16`, `device_map="auto"`, `attn_implementation="sdpa"`, `cache_implementation="static"` and confirm coherent output

🤖 Generated with [Claude Code](https://claude.com/claude-code)