### PR TITLE
Fix failing `DepthProModelIntegrationTest`

### DIFF
--- a/tests/models/depth_pro/test_modeling_depth_pro.py
+++ b/tests/models/depth_pro/test_modeling_depth_pro.py
@@ -311,7 +311,7 @@ class DepthProModelIntegrationTest(unittest.TestCase):
     def test_inference_depth_estimation(self):
         model_path = "apple/DepthPro-hf"
         image_processor = DepthProImageProcessor.from_pretrained(model_path)
-        model = DepthProForDepthEstimation.from_pretrained(model_path).to(torch_device)
+        model = DepthProForDepthEstimation.from_pretrained(model_path, dtype=torch.float32).to(torch_device)
         config = model.config
 
         image = prepare_img()


### PR DESCRIPTION
# What does this PR do?
Fixes this failing [DepthProModelIntegrationTest](https://github.com/huggingface/transformers/actions/runs/22606636929/job/65500453624#step:14:4893).

<img width="2231" height="99" alt="image" src="https://github.com/user-attachments/assets/455f0a76-c40d-43d8-b8f0-1817632afa64" />


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@Rocketknight1 @vasqu