### PR TITLE
Fix AutoTokenizer ignoring tokenizer.json for unregistered model types

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -674,16 +674,28 @@ class AutoTokenizer:
 
         # if there is a config, we can check that the tokenizer class != than model class and can thus assume we need to use TokenizersBackend
         # Skip this early exit if auto_map is present (custom tokenizer with trust_remote_code)
+        registered_tokenizer = TOKENIZER_MAPPING_NAMES.get(config_model_type) if config_model_type else None
         if (
             tokenizer_auto_map is None
             and tokenizer_config_class is not None
             and config_model_type is not None
             and config_model_type != ""
-            and TOKENIZER_MAPPING_NAMES.get(config_model_type) is not None
-            and TOKENIZER_MAPPING_NAMES.get(config_model_type).replace("Fast", "")
-            != tokenizer_config_class.replace("Fast", "")
+            and (
+                # Case 1: model_type is registered but hub tokenizer_class differs — the
+                # model ships a custom tokenizer.json that should be loaded directly.
+                (
+                    registered_tokenizer is not None
+                    and registered_tokenizer.replace("Fast", "") != tokenizer_config_class.replace("Fast", "")
+                )
+                # Case 2: model_type has no registered tokenizer mapping.  The hub
+                # tokenizer_class may point to another model's tokenizer (e.g.
+                # deepseek-coder with model_type "llama" and tokenizer_class
+                # "LlamaTokenizerFast").  That tokenizer's __init__ may override the
+                # normalizer/pre_tokenizer from tokenizer.json, so prefer loading via
+                # TokenizersBackend which faithfully preserves tokenizer.json.
+                or registered_tokenizer is None
+            )
         ):
-            # new model, but we ignore it unless the model type is the same
             if TokenizersBackend is not None:
                 try:
                     return TokenizersBackend.from_pretrained(pretrained_model_name_or_path, *inputs, **kwargs)


### PR DESCRIPTION
## What does this PR do?

Fixes #44462

When a model's `model_type` (e.g. `"llama"`) has no entry in `TOKENIZER_MAPPING_NAMES`, `AutoTokenizer.from_pretrained` falls through to loading the tokenizer class declared in `tokenizer_config.json` (e.g. `LlamaTokenizerFast`). That class's `__init__` rebuilds the backend tokenizer from scratch and unconditionally overwrites the normalizer, pre_tokenizer and decoder with its own defaults, discarding the custom settings from the repository's `tokenizer.json`.

This affects models like `deepseek-ai/deepseek-coder-6.7b-instruct` whose `tokenizer.json` contains a custom `Sequence` pre_tokenizer with `Split` + `ByteLevel` rules, but whose `model_type` is `"llama"`.

### Root cause

The early `TokenizersBackend` fallback at [line 677](https://github.com/huggingface/transformers/blob/main/src/transformers/models/auto/tokenization_auto.py#L677) only triggers when `config_model_type` **is** registered in `TOKENIZER_MAPPING_NAMES` **and** the registered class differs from the hub's `tokenizer_class`. When `config_model_type` is **not** registered at all (as with `"llama"`), the check is skipped entirely, and code falls through to instantiating the hub-declared class (`LlamaTokenizer`), which overrides `tokenizer.json` settings.

### Fix

Extend the condition to also trigger `TokenizersBackend` when `config_model_type` has no registered tokenizer mapping. This ensures `tokenizer.json` is loaded faithfully for models that borrow another architecture's tokenizer class but ship their own tokenizer configuration.

### Before (broken)

```python
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("deepseek-ai/deepseek-coder-6.7b-instruct")
# normalizer: null
# pre_tokenizer: {"type": "Metaspace", ...}   ← LlamaTokenizer defaults
```

### After (fixed)

```python
from transformers import AutoTokenizer
tok = AutoTokenizer.from_pretrained("deepseek-ai/deepseek-coder-6.7b-instruct")
# normalizer: {"type": "Sequence", "normalizers": []}
# pre_tokenizer: {"type": "Sequence", "pretokenizers": [Split, Split, ..., ByteLevel]}
#   ← faithful to tokenizer.json
```

## Who can review?

@ArthurZucker @itazap