### PR TITLE
Add missing ReLU in GlmMoeDsaIndexer

### DIFF
--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -218,6 +218,10 @@ class GlmMoeDsaIndexer(nn.Module):
         # q·k^T per head: [B, S, H, D] @ [B, T, D]^T → [B, S, H, T]
         scores = torch.einsum("bshd,btd->bsht", q.float(), k_cached.float()) * self.softmax_scale
 
+        # ReLU: clamp negative per-head scores to zero before the weighted sum,
+        # matching the reference fp8_index kernel's `T.max(logits, 0)`.
+        scores = torch.relu(scores)
+
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 

--- a/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
@@ -417,6 +417,10 @@ class GlmMoeDsaIndexer(nn.Module):
         # q·k^T per head: [B, S, H, D] @ [B, T, D]^T → [B, S, H, T]
         scores = torch.einsum("bshd,btd->bsht", q.float(), k_cached.float()) * self.softmax_scale
 
+        # ReLU: clamp negative per-head scores to zero before the weighted sum,
+        # matching the reference fp8_index kernel's `T.max(logits, 0)`.
+        scores = torch.relu(scores)
+
         # Weight per head and sum across heads → [B, S, T]
         index_scores = torch.einsum("bsht,bsh->bst", scores, weights)
 


### PR DESCRIPTION
Fixes #44360

The reference `fp8_index` kernel clamps per-head q·k scores with `T.max(logits, 0)` before the weighted sum across heads ([kernel.py#L241](https://huggingface.co/deepseek-ai/DeepSeek-V3.2-Exp/blob/main/inference/kernel.py#L241)). The current indexer skips this step, letting negative scores leak into the top-k selection.

One-liner fix: `scores = torch.relu(scores)` right after the scaled einsum, applied in both modular and generated modeling files.