### PR TITLE
Fix unexpected `position_ids` keys when loading OwlViT models

### DIFF
--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -542,6 +542,10 @@ class Owlv2PreTrainedModel(PreTrainedModel):
         "hidden_states": Owlv2EncoderLayer,
         "attentions": Owlv2Attention,
     }
+    _keys_to_ignore_on_load_unexpected = [
+        r".*text_model.embeddings.position_ids",
+        r".*vision_model.embeddings.position_ids",
+    ]
 
     @torch.no_grad()
     def _init_weights(self, module: nn.Module):

--- a/src/transformers/models/owlv2/modeling_owlv2.py
+++ b/src/transformers/models/owlv2/modeling_owlv2.py
@@ -543,8 +543,8 @@ class Owlv2PreTrainedModel(PreTrainedModel):
         "attentions": Owlv2Attention,
     }
     _keys_to_ignore_on_load_unexpected = [
-        r".*text_model.embeddings.position_ids",
-        r".*vision_model.embeddings.position_ids",
+        r".*text_model\.embeddings\.position_ids",
+        r".*vision_model\.embeddings\.position_ids",
     ]
 
     @torch.no_grad()

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -530,8 +530,8 @@ class OwlViTPreTrainedModel(PreTrainedModel):
         "attentions": OwlViTAttention,
     }
     _keys_to_ignore_on_load_unexpected = [
-        r".*text_model.embeddings.position_ids",
-        r".*vision_model.embeddings.position_ids",
+        r".*text_model\.embeddings\.position_ids",
+        r".*vision_model\.embeddings\.position_ids",
     ]
 
     @torch.no_grad()

--- a/src/transformers/models/owlvit/modeling_owlvit.py
+++ b/src/transformers/models/owlvit/modeling_owlvit.py
@@ -529,6 +529,10 @@ class OwlViTPreTrainedModel(PreTrainedModel):
         "hidden_states": OwlViTEncoderLayer,
         "attentions": OwlViTAttention,
     }
+    _keys_to_ignore_on_load_unexpected = [
+        r".*text_model.embeddings.position_ids",
+        r".*vision_model.embeddings.position_ids",
+    ]
 
     @torch.no_grad()
     def _init_weights(self, module: nn.Module):


### PR DESCRIPTION
# What does this PR do?

Older OwlViT checkpoints stored `position_ids` as buffers in the text and vision embedding modules. These tensors are simple integer ranges (0 → max sequence length) and are now recomputed dynamically during initialization.

As a result, when loading models such as `google/owlvit-base-patch32`, the loader reports the following unexpected keys:

* `owlvit.text_model.embeddings.position_ids`
* `owlvit.vision_model.embeddings.position_ids`

These buffers are not required for correct model behavior and can be safely ignored.

This PR suppresses the warnings by adding the corresponding patterns to `_keys_to_ignore_on_load_unexpected` in `OwlViTPreTrainedModel`.

This change does **not affect model performance or weights** and only prevents unnecessary loading warnings when using older checkpoints.

Fixes #44493

## Before submitting

* [x] This PR fixes a bug (unexpected keys warning when loading OwlViT checkpoints).
* [x] Did you read the contributor guideline? Yes.
* [x] Was this discussed/approved via a Github issue or the forum? Yes, discussed in #44493.
* [ ] Did you make sure to update the documentation with your changes? Not required.
* [ ] Did you write any new necessary tests? Not required (warning suppression only).

## Who can review?

@Rocketknight1 
@yonigozlan 
