### PR TITLE
Fix get_docstring_indentation_level to handle compiled functions

### DIFF
--- a/src/transformers/utils/doc.py
+++ b/src/transformers/utils/doc.py
@@ -29,7 +29,10 @@ def get_docstring_indentation_level(func):
     # We assume classes are always defined in the global scope
     if inspect.isclass(func):
         return 4
-    source = inspect.getsource(func)
+    try:
+        source = inspect.getsource(func)
+    except (TypeError, OSError):
+        return 4  # fallback for compiled/Cython functions
     first_line = source.splitlines()[0]
     function_def_level = len(first_line) - len(first_line.lstrip())
     return 4 + function_def_level


### PR DESCRIPTION
Fixes #44355. The inspect.getsource() call raises TypeError when running compiled Python files with Cython-compiled functions. Added try-except block to gracefully handle this case by returning a default indentation level of 4.