### PR TITLE
fix(qwen2_5_vl): handle ragged batched input in apply_chat_template

### DIFF
--- a/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
@@ -909,11 +909,14 @@ class Qwen2_5_VLProcessor(Qwen2VLProcessor):
         self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video"])
 
         if return_mm_token_type_ids:
-            array_ids = np.array(text_inputs["input_ids"])
-            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            mm_token_type_ids[array_ids == self.image_token_id] = 1
-            mm_token_type_ids[array_ids == self.video_token_id] = 2
-            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+            mm_token_type_ids = []
+            for seq_ids in text_inputs["input_ids"]:
+                seq_array = np.array(seq_ids)
+                seq_mm_ids = np.zeros_like(seq_array)
+                seq_mm_ids[seq_array == self.image_token_id] = 1
+                seq_mm_ids[seq_array == self.video_token_id] = 2
+                mm_token_type_ids.append(seq_mm_ids.tolist())
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 

--- a/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
@@ -145,11 +145,14 @@ class Qwen2_5_VLProcessor(ProcessorMixin):
         self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video"])
 
         if return_mm_token_type_ids:
-            array_ids = np.array(text_inputs["input_ids"])
-            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            mm_token_type_ids[array_ids == self.image_token_id] = 1
-            mm_token_type_ids[array_ids == self.video_token_id] = 2
-            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+            mm_token_type_ids = []
+            for seq_ids in text_inputs["input_ids"]:
+                seq_array = np.array(seq_ids)
+                seq_mm_ids = np.zeros_like(seq_array)
+                seq_mm_ids[seq_array == self.image_token_id] = 1
+                seq_mm_ids[seq_array == self.video_token_id] = 2
+                mm_token_type_ids.append(seq_mm_ids.tolist())
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -57,6 +57,55 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertTrue("num_image_patches" in output)
         self.assertEqual(len(output["num_image_patches"]), 3)
 
+    def test_apply_chat_template_ragged_batched_mm_token_type_ids(self):
+        processor = self.get_processor()
+        if processor.chat_template is None:
+            self.skipTest("Processor has no chat template")
+
+        single_messages = [
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hi"}],
+                },
+            ]
+        ]
+        single_out = processor.apply_chat_template(
+            single_messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+        )
+        self.assertEqual(len(single_out["input_ids"]), 1)
+        self.assertEqual(len(single_out["mm_token_type_ids"]), 1)
+        self.assertEqual(len(single_out["mm_token_type_ids"][0]), len(single_out["input_ids"][0]))
+
+        ragged_batch_messages = [
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Hi"}],
+                },
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "Explain this image in detail. " * 30}],
+                },
+            ],
+        ]
+        ragged_out = processor.apply_chat_template(
+            ragged_batch_messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+        )
+        self.assertEqual(len(ragged_out["input_ids"]), 2)
+        self.assertEqual(len(ragged_out["mm_token_type_ids"]), 2)
+        self.assertNotEqual(len(ragged_out["input_ids"][0]), len(ragged_out["input_ids"][1]))
+        self.assertEqual(len(ragged_out["mm_token_type_ids"][0]), len(ragged_out["input_ids"][0]))
+        self.assertEqual(len(ragged_out["mm_token_type_ids"][1]), len(ragged_out["input_ids"][1]))
+
     @require_torch
     @require_av
     def _test_apply_chat_template(


### PR DESCRIPTION
## Summary

Fix `Qwen2_5_VLProcessor.apply_chat_template` crashing with `ValueError` when called with batched inputs of different sequence lengths (ragged lists) and `padding=False` (the default).

Fixes #44514

## Root Cause

The `mm_token_type_ids` construction calls `np.array(text_inputs["input_ids"])` which fails when the tokenized sequences have different lengths, because NumPy cannot create a homogeneous array from ragged lists:

```
ValueError: setting an array element with a sequence. The requested array
has an inhomogeneous shape after 1 dimensions.
```

Since `return_mm_token_type_ids` defaults to `True`, this code path always runs.

## Fix

Process each sequence individually instead of trying to create a single 2D array:

```python
mm_token_type_ids = []
for seq_ids in text_inputs["input_ids"]:
    seq_array = np.array(seq_ids)
    seq_mm_ids = np.zeros_like(seq_array)
    seq_mm_ids[seq_array == self.image_token_id] = 1
    seq_mm_ids[seq_array == self.video_token_id] = 2
    mm_token_type_ids.append(seq_mm_ids.tolist())
text_inputs["mm_token_type_ids"] = mm_token_type_ids
```

This produces the same output format (list of lists) and works for both equal-length and ragged batches.

## Changes

- **`modular_qwen2_5_vl.py`** — Updated source of truth with per-sequence processing
- **`processing_qwen2_5_vl.py`** — Updated generated file with same fix (couldn't run modular converter locally due to missing `libcst`)
- **`test_processing_qwen2_5_vl.py`** — Added `test_apply_chat_template_ragged_batched_mm_token_type_ids` covering single input and ragged batched input, verifying `mm_token_type_ids` length matches `input_ids` per sequence