### PR TITLE
Fix failing `MarianIntegrationTests`

### DIFF
--- a/tests/models/marian/test_modeling_marian.py
+++ b/tests/models/marian/test_modeling_marian.py
@@ -404,8 +404,9 @@ class MarianIntegrationTest(unittest.TestCase):
     def model(self):
         model: MarianMTModel = MarianMTModel.from_pretrained(self.model_name).to(torch_device)
         c = model.config
-        self.assertListEqual(c.bad_words_ids, [[c.pad_token_id]])
-        self.assertEqual(c.max_length, 512)
+        generation_config = model.generation_config
+        self.assertListEqual(generation_config.bad_words_ids, [[c.pad_token_id]])
+        self.assertEqual(generation_config.max_length, 512)
         self.assertEqual(c.decoder_start_token_id, c.pad_token_id)
 
         if torch_device == "cuda":


### PR DESCRIPTION
# What does this PR do?
Fixes these failing [MarianIntegrationTests](https://github.com/huggingface/transformers/actions/runs/22606636929/job/65500458014#step:14:6186)

<img width="2378" height="657" alt="image" src="https://github.com/user-attachments/assets/6ed0bf99-8e1f-422d-a69f-29f2963c0804" />



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@Rocketknight1 @vasqu