### PR TITLE
Fix AssistantTracker.is_active() returning False after activation with empty lists

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -439,7 +439,7 @@ def _cached_compile_jinja_template(chat_template):
             return rv
 
         def is_active(self) -> bool:
-            return self._rendered_blocks or self._generation_indices
+            return self._rendered_blocks is not None or self._generation_indices is not None
 
         @contextmanager
         def activate_tracker(self, rendered_blocks: list[int], generation_indices: list[int]):


### PR DESCRIPTION
## Summary

Fixes a bug in `AssistantTracker.is_active()` in `chat_template_utils.py`.

After activation via `activate_tracker()`, `_rendered_blocks` and `_generation_indices` are set to list arguments which may be empty `[]`. The `is_active()` method checks truthiness (`return self._rendered_blocks or self._generation_indices`), which returns `False` for empty lists, incorrectly indicating the tracker is inactive.

This means calling `activate_tracker` with empty lists, then checking `is_active()`, returns `False` even though the tracker was activated. This breaks the re-entrance guard in `activate_tracker` which relies on `is_active()` to detect double activation.

```python
# Before:
def is_active(self) -> bool:
    return self._rendered_blocks or self._generation_indices

# After:
def is_active(self) -> bool:
    return self._rendered_blocks is not None or self._generation_indices is not None
```

## Test plan
- [x] Verified `_rendered_blocks` is initialized as `None` and set to list on activation
- [x] Verified `is_active()` is used as re-entrance guard in `activate_tracker`
- [ ] Existing tests should continue to pass
