### PR TITLE
Fix KeyError in _parse_type_hint when Union contains Any

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -114,7 +114,7 @@ def _parse_type_hint(hint: str) -> dict:
         if len(subtypes) == 1:
             # A single non-null type can be expressed directly
             return_dict = subtypes[0]
-        elif all(isinstance(subtype["type"], str) for subtype in subtypes):
+        elif all("type" in subtype and isinstance(subtype["type"], str) for subtype in subtypes):
             # A union of basic types can be expressed as a list in the schema
             return_dict = {"type": sorted([subtype["type"] for subtype in subtypes])}
         else:


### PR DESCRIPTION
## Summary

Fixes a `KeyError` crash in `_parse_type_hint` in `chat_template_utils.py` (line 117).

When processing Union types, the code accesses `subtype["type"]` without checking the key exists. `_get_json_schema_type(Any)` returns `{}` (empty dict with no "type" key), so Union types containing `Any` (e.g., `Union[str, Any]`) crash with a `KeyError`.

```python
# Before:
elif all(isinstance(subtype["type"], str) for subtype in subtypes):

# After:
elif all("type" in subtype and isinstance(subtype["type"], str) for subtype in subtypes):
```

This guard ensures the code falls through to the `anyOf` branch for types that don't have a simple "type" key.

## Test plan
- [x] Verified `_get_json_schema_type(Any)` returns `{}` with no "type" key
- [x] Verified the fix correctly falls through to the `anyOf` branch
- [ ] Existing tests should continue to pass
