### PR TITLE
Fix crash in Qwen2_5_VLProcessor when using batched input with padding=False

### DIFF
--- a/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
@@ -909,11 +909,14 @@ class Qwen2_5_VLProcessor(Qwen2VLProcessor):
         self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video"])
 
         if return_mm_token_type_ids:
-            array_ids = np.array(text_inputs["input_ids"])
-            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            mm_token_type_ids[array_ids == self.image_token_id] = 1
-            mm_token_type_ids[array_ids == self.video_token_id] = 2
-            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+            mm_token_type_ids = []
+            for ids in text_inputs["input_ids"]:
+                ids_arr = np.array(ids)
+                mask = np.zeros_like(ids_arr)
+                mask[ids_arr == self.image_token_id] = 1
+                mask[ids_arr == self.video_token_id] = 2
+                mm_token_type_ids.append(mask.tolist())
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 

--- a/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
@@ -145,11 +145,14 @@ class Qwen2_5_VLProcessor(ProcessorMixin):
         self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video"])
 
         if return_mm_token_type_ids:
-            array_ids = np.array(text_inputs["input_ids"])
-            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            mm_token_type_ids[array_ids == self.image_token_id] = 1
-            mm_token_type_ids[array_ids == self.video_token_id] = 2
-            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+            mm_token_type_ids = []
+            for ids in text_inputs["input_ids"]:
+                ids_arr = np.array(ids)
+                mask = np.zeros_like(ids_arr)
+                mask[ids_arr == self.image_token_id] = 1
+                mask[ids_arr == self.video_token_id] = 2
+                mm_token_type_ids.append(mask.tolist())
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -319,9 +319,7 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             ],
         ]
         # Should not raise ValueError with the default padding=False
-        out = processor.apply_chat_template(
-            batch, tokenize=True, return_dict=True, padding=False
-        )
+        out = processor.apply_chat_template(batch, tokenize=True, return_dict=True, padding=False)
         self.assertIn("input_ids", out)
         self.assertEqual(len(out["input_ids"]), 2)
         self.assertIn("mm_token_type_ids", out)

--- a/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py
@@ -287,3 +287,42 @@ class Qwen2_5_VLProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         self.assertEqual(inputs[self.images_input_name].shape[0], 612)
         inputs = processor(text=input_str, images=image_input, return_tensors="pt")
         self.assertEqual(inputs[self.images_input_name].shape[0], 100)
+
+    def test_batched_apply_chat_template_no_padding(self):
+        """Regression test for #44521: batched call with padding=False must not crash."""
+        processor = self.get_processor()
+        if processor.chat_template is None:
+            self.skipTest("Processor has no chat template")
+
+        image_url = url_to_local_path(
+            "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/coco_sample.png"
+        )
+        # Two conversations with different text so token counts differ when padding=False
+        batch = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "url": image_url},
+                        {"type": "text", "text": "Describe this image."},
+                    ],
+                }
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "url": image_url},
+                        {"type": "text", "text": "What do you see?"},
+                    ],
+                }
+            ],
+        ]
+        # Should not raise ValueError with the default padding=False
+        out = processor.apply_chat_template(
+            batch, tokenize=True, return_dict=True, padding=False
+        )
+        self.assertIn("input_ids", out)
+        self.assertEqual(len(out["input_ids"]), 2)
+        self.assertIn("mm_token_type_ids", out)
+        self.assertEqual(len(out["mm_token_type_ids"]), 2)


### PR DESCRIPTION
## Problem

`Qwen2_5_VLProcessor.apply_chat_template` raises `ValueError: setting an array element with a sequence` when called with a batch of ≥2 conversations that include images under the default `padding=False` setting.

**Root cause:** `mm_token_type_ids` was built by calling `np.array(text_inputs["input_ids"])` on a ragged list (variable-length sequences when `padding=False`). NumPy ≥ 1.24 rejects inhomogeneous shapes for this operation.

## Fix

Iterate per-sequence instead of constructing a 2D array from a ragged list. Each `ids_arr = np.array(ids)` call receives a 1-D list, so the shape is always homogeneous.

Changed in both:
- `src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py`
- `src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py` (auto-generated copy, manually synced since `make` is unavailable on Windows)

## Test

Added `test_batched_apply_chat_template_no_padding` in `tests/models/qwen2_5_vl/test_processing_qwen2_5_vl.py` to guard against regression.

Closes #44545