### PR TITLE
Fix assistant_masks for multimodal inputs in apply_chat_template

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1847,27 +1847,77 @@ class ProcessorMixin(PushToHubMixin):
                     assistant_masks = []
                     offset_mapping = out.pop("offset_mapping")
                     input_ids = out["input_ids"]
-                    for i in range(len(input_ids)):
-                        current_mask = [0] * len(input_ids[i])
-                        offsets = offset_mapping[i]
-                        offset_starts = [start for start, end in offsets]
-                        for assistant_start_char, assistant_end_char in generation_indices[i]:
-                            start_pos = bisect.bisect_left(offset_starts, assistant_start_char)
-                            end_pos = bisect.bisect_left(offset_starts, assistant_end_char)
+                    has_multimodal = images_exist or videos_exist or bool(batch_audios)
 
-                            if not (
-                                start_pos >= 0
-                                and start_pos < len(offsets)
-                                and offsets[start_pos][0] <= assistant_start_char < offsets[start_pos][1]
-                            ):
-                                # start_token is out of bounds maybe due to truncation.
-                                continue
-                            # Ensure end_pos is also within bounds
-                            if end_pos > len(input_ids[i]):
-                                end_pos = len(input_ids[i])
-                            for token_id in range(start_pos, end_pos if end_pos else len(input_ids[i])):
-                                current_mask[token_id] = 1
-                        assistant_masks.append(current_mask)
+                    if has_multimodal:
+                        # Multimodal processors expand placeholder tokens (e.g. a single
+                        # <|image_pad|> becomes N copies), so offset_mapping from the
+                        # expanded text is misaligned with generation_indices which were
+                        # computed from the original (unexpanded) text.
+                        # Fix: tokenize the original text to get aligned offsets, build
+                        # the mask on that, then map it onto the expanded input_ids.
+                        original_prompts = prompt if is_batched else [prompt]
+                        orig_tokenized = self.tokenizer(
+                            original_prompts,
+                            return_offsets_mapping=True,
+                            add_special_tokens=kwargs.get("add_special_tokens", True),
+                        )
+                        for i in range(len(input_ids)):
+                            orig_offsets = orig_tokenized["offset_mapping"][i]
+                            orig_ids = orig_tokenized["input_ids"][i]
+                            orig_offset_starts = [s for s, e in orig_offsets]
+
+                            # Build mask on original (unexpanded) tokenization
+                            orig_mask = [0] * len(orig_ids)
+                            for assistant_start_char, assistant_end_char in generation_indices[i]:
+                                start_pos = bisect.bisect_left(orig_offset_starts, assistant_start_char)
+                                end_pos = bisect.bisect_left(orig_offset_starts, assistant_end_char)
+
+                                if not (
+                                    start_pos >= 0
+                                    and start_pos < len(orig_offsets)
+                                    and orig_offsets[start_pos][0] <= assistant_start_char < orig_offsets[start_pos][1]
+                                ):
+                                    continue
+                                if end_pos > len(orig_ids):
+                                    end_pos = len(orig_ids)
+                                for token_id in range(start_pos, end_pos if end_pos else len(orig_ids)):
+                                    orig_mask[token_id] = 1
+
+                            # Align orig_mask to expanded input_ids via two-pointer:
+                            # tokens shared between original and expanded are matched
+                            # sequentially; extra expansion tokens get mask value 0.
+                            expanded_ids = input_ids[i]
+                            current_mask = [0] * len(expanded_ids)
+                            orig_ptr = 0
+                            for exp_idx in range(len(expanded_ids)):
+                                if orig_ptr < len(orig_ids) and expanded_ids[exp_idx] == orig_ids[orig_ptr]:
+                                    current_mask[exp_idx] = orig_mask[orig_ptr]
+                                    orig_ptr += 1
+                            assistant_masks.append(current_mask)
+                    else:
+                        for i in range(len(input_ids)):
+                            current_mask = [0] * len(input_ids[i])
+                            offsets = offset_mapping[i]
+                            offset_starts = [start for start, end in offsets]
+                            for assistant_start_char, assistant_end_char in generation_indices[i]:
+                                start_pos = bisect.bisect_left(offset_starts, assistant_start_char)
+                                end_pos = bisect.bisect_left(offset_starts, assistant_end_char)
+
+                                if not (
+                                    start_pos >= 0
+                                    and start_pos < len(offsets)
+                                    and offsets[start_pos][0] <= assistant_start_char < offsets[start_pos][1]
+                                ):
+                                    # start_token is out of bounds maybe due to truncation.
+                                    continue
+                                # Ensure end_pos is also within bounds
+                                if end_pos > len(input_ids[i]):
+                                    end_pos = len(input_ids[i])
+                                for token_id in range(start_pos, end_pos if end_pos else len(input_ids[i])):
+                                    current_mask[token_id] = 1
+                            assistant_masks.append(current_mask)
+
                     out["assistant_masks"] = assistant_masks
                     out.convert_to_tensors(tensor_type=kwargs.get("return_tensors"))
                 return out

--- a/tests/test_processing_common.py
+++ b/tests/test_processing_common.py
@@ -1981,6 +1981,89 @@ class ProcessorTesterMixin:
         ids_is_same = processor.tokenizer.encode(assistant_text, add_special_tokens=False), assistant_ids.tolist()
         self.assertTrue(text_is_same or ids_is_same)
 
+    @require_torch
+    def test_apply_chat_template_assistant_mask_with_image(self):
+        """Tests that assistant_masks are correct when multimodal (image) inputs cause placeholder expansion."""
+        processor = self.get_processor()
+
+        if processor.chat_template is None:
+            self.skipTest("Processor has no chat template")
+
+        if "image_processor" not in self.processor_class.get_attributes():
+            self.skipTest(f"image_processor attribute not present in {self.processor_class}")
+
+        if not hasattr(processor, "image_token"):
+            self.skipTest("Processor has no image_token attribute")
+
+        image_input = self.prepare_image_inputs()
+        image_token = processor.image_token
+
+        messages = [
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image", "image": image_input},
+                        {"type": "text", "text": "Describe the image."},
+                    ],
+                },
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "The image shows a scenic view."},
+                    ],
+                },
+            ]
+        ]
+
+        # Use a dummy template with {% generation %} that emits the processor's
+        # real image_token so the processor expands it (e.g. 1 -> N copies),
+        # triggering the offset misalignment this test guards against.
+        dummy_template = (
+            "{% for message in messages %}"
+            "{% if message['role'] == 'user' %}"
+            "{{'<|special_start|>user\n'}}"
+            "{% for content in message['content'] %}"
+            "{% if content['type'] == 'image' %}"
+            "{{ '" + image_token + "' }}"
+            "{% elif content['type'] == 'text' %}"
+            "{{ content['text'] }}"
+            "{% endif %}"
+            "{% endfor %}"
+            "{{'<|special_end|>\n'}}"
+            "{% elif message['role'] == 'assistant' %}"
+            "{{'<|special_start|>assistant\n'}}"
+            "{% generation %}"
+            "{{ message['content'][0]['text'] + '<|special_end|>\n' }}"
+            "{% endgeneration %}"
+            "{% endif %}"
+            "{% endfor %}"
+        )
+
+        inputs = processor.apply_chat_template(
+            messages,
+            add_generation_prompt=False,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+            return_assistant_tokens_mask=True,
+            chat_template=dummy_template,
+        )
+
+        self.assertIn("assistant_masks", inputs)
+        mask = inputs["assistant_masks"]
+        self.assertEqual(len(mask), len(inputs["input_ids"]))
+
+        # The mask must not be all zeros — the assistant response should be marked
+        self.assertGreater(mask.sum().item(), 0, "assistant_masks is all zeros with multimodal input")
+
+        # Verify the masked tokens decode to the expected assistant text
+        assistant_ids = inputs["input_ids"][mask.bool()]
+        assistant_text = "The image shows a scenic view.<|special_end|>\n"
+        text_is_same = assistant_text == processor.decode(assistant_ids, clean_up_tokenization_spaces=True)
+        ids_is_same = processor.tokenizer.encode(assistant_text, add_special_tokens=False), assistant_ids.tolist()
+        self.assertTrue(text_is_same or ids_is_same)
+
     def test_get_num_multimodal_tokens_matches_processor_call(self):
         "Tests that the helper used internally in vLLM works correctly"
 


### PR DESCRIPTION
# What does this PR do?

Fixes #44521

`apply_chat_template` with `return_assistant_tokens_mask=True` returns all-zero masks when multimodal inputs (images/videos) are present.

## Root cause

`generation_indices` (character-level positions of assistant responses) are computed from the **original** prompt text rendered by Jinja, which contains a single placeholder token per image (e.g. one `<|image_pad|>`). However, the processor's `__call__` expands each placeholder into N copies (based on image resolution), so `offset_mapping` returned by the tokenizer corresponds to the **expanded** text. The `bisect_left` lookup then fails to find the assistant span, and the mask stays all zeros.

## Fix

When multimodal inputs are present:
1. Tokenize the **original** (unexpanded) prompt separately to get `offset_mapping` aligned with `generation_indices`
2. Build the assistant mask on the original tokenization (where `bisect_left` works correctly)
3. Map the mask onto the expanded `input_ids` via two-pointer alignment — matching tokens get their mask value, extra expansion tokens get 0

This approach is generic and works for any multimodal processor that expands placeholder tokens, without requiring model-specific logic.

When no multimodal inputs are present, the original code path is used unchanged.

## Tests

Added `test_apply_chat_template_assistant_mask_with_image` in `test_processing_common.py`. Verified on Qwen2.5-VL and Qwen3-VL:
- Without fix: **FAIL** (mask is all zeros)
- With fix: **PASS** (mask correctly marks assistant tokens)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@zucchini-nlp (author of the original `return_assistant_tokens_mask` support in PR #38545, multimodal models)