### PR TITLE
Fix AMD Docker image build timeout by pinning Flash Attention commit

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -36,10 +36,12 @@ RUN python3 -m pip uninstall -y kernels
 # On ROCm, torchcodec is required to decode audio files and 0.4 or 0.6 fails
 RUN python3 -m pip install --no-cache-dir "torchcodec==0.7"
 
-# Install flash attention from source. Tested with commit 6387433156558135a998d5568a9d74c1778666d8
+# Install flash attention from source. Pinned to commit 6387433156558135a998d5568a9d74c1778666d8
+# to avoid compilation time exceeding the 6h GitHub Actions job limit.
 RUN git clone https://github.com/ROCm/flash-attention/ -b tridao && \
     cd flash-attention && \
-    GPU_ARCHS="gfx942" python setup.py install  
+    git checkout 6387433156558135a998d5568a9d74c1778666d8 && \
+    GPU_ARCHS="gfx942" python setup.py install
 # GPU_ARCHS builds for MI300, MI325 but not MI355: we would need to add `;gfx950` but it takes too long to build.
 
 RUN python3 -m pip install --no-cache-dir einops


### PR DESCRIPTION
The AMD Docker image build (`latest-pytorch-amd`) has been failing since early February due to the 6h GitHub Actions job time limit being exceeded. The root cause is that Flash Attention is cloned and compiled from the latest commit on the tridao branch, which has grown slower to build over time.                                                                                                                                                                           

This PR pins the Flash Attention checkout to commit 6387433156558135a998d5568a9d74c1778666d8 (which was already referenced in a comment but never actually used), bringing build time back to ~4h.                                       
                                                                                                                                                                                                                                           Tested successfully on branch `build_ci_docker_image_amd_fix` 