### PR TITLE
Fix position_ids docstring in modeling_flash_attention_utils.py

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -365,7 +365,8 @@ def prepare_fa_kwargs_from_position_ids(position_ids):
 
     Arguments:
         position_ids (`torch.Tensor`):
-            Boolean or int tensor of shape (batch_size, sequence_length), 1 means valid and 0 means not valid.
+            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range
+            `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).
 
     Return:
         (cu_seqlens_q, cu_seqlens_k) (`tuple[int]`):
@@ -418,7 +419,8 @@ def _prepare_from_posids(query, key, value, position_ids):
         value (`torch.Tensor`):
             Value state with padding. Shape: (batch_size, kv_seq_len, num_key_value_heads, head_dim).
         position_ids (`torch.Tensor`):
-            Boolean or int tensor of shape (batch_size, sequence_length), 1 means valid and 0 means not valid.
+            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range
+            `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).
 
     Return:
         query (`torch.Tensor`):

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -365,8 +365,7 @@ def prepare_fa_kwargs_from_position_ids(position_ids):
 
     Arguments:
         position_ids (`torch.Tensor`):
-            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range
-            `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).
+            Indices of positions of each input sequence tokens. Shape: (batch_size, sequence_length).
 
     Return:
         (cu_seqlens_q, cu_seqlens_k) (`tuple[int]`):
@@ -419,8 +418,7 @@ def _prepare_from_posids(query, key, value, position_ids):
         value (`torch.Tensor`):
             Value state with padding. Shape: (batch_size, kv_seq_len, num_key_value_heads, head_dim).
         position_ids (`torch.Tensor`):
-            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range
-            `[0, config.n_positions - 1]`. Shape: (batch_size, sequence_length).
+            Indices of positions of each input sequence tokens. Shape: (batch_size, sequence_length).
 
     Return:
         query (`torch.Tensor`):


### PR DESCRIPTION
Fixes #44373

## Summary
- Corrected the docstring for `position_ids` parameter in `prepare_fa_kwargs_from_position_ids` and `_prepare_from_posids` which incorrectly described attention mask semantics ("Boolean or int tensor... 1 means valid and 0 means not valid")
- The docstring now accurately describes position indices behavior

## Testing
- Docstring-only change, no code behavior affected

This contribution was developed with AI assistance (Claude Code).