### PR TITLE
Add eval_on_end flag to Trainer

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1519,7 +1519,7 @@ class Trainer:
             if self.control.should_training_stop:
                 break
 
-        return self._finalize_training(trial, num_train_samples, start_time)
+        return self._finalize_training(trial, num_train_samples, start_time, ignore_keys_for_eval)
 
     def _init_training_state(
         self, max_steps, num_update_steps_per_epoch, num_train_epochs, resume_from_checkpoint, trial
@@ -1815,9 +1815,12 @@ class Trainer:
             learning_rate=learning_rate,
         )
 
-    def _finalize_training(self, trial, num_train_samples, start_time):
+    def _finalize_training(self, trial, num_train_samples, start_time, ignore_keys_for_eval=None):
         """Finalize training: metrics, best-model loading, cleanup. Returns TrainOutput."""
         logger.info("\n\nTraining completed. Do not forget to share your model on huggingface.co/models =)\n\n")
+
+        if self.args.eval_on_end:
+            self._evaluate(trial, ignore_keys_for_eval, skip_scheduler=True)
 
         # add remaining tr_loss
         self._total_loss_scalar += self._tr_loss.item()

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -418,6 +418,9 @@ class TrainingArguments:
             When performing evaluation and generating predictions, only returns the loss.
         eval_on_start (`bool`, *optional*, defaults to `False`):
             Whether to perform a evaluation step (sanity check) before the training to ensure the validation steps works correctly.
+        eval_on_end (`bool`, *optional*, defaults to `False`):
+            Whether to perform an evaluation step at the very end of training, regardless of `eval_strategy`. This is
+            the symmetric counterpart to `eval_on_start` and ensures a final evaluation is always run.
         eval_do_concat_batches (`bool`, *optional*, defaults to `True`):
             Whether to recursively concat inputs/losses/labels/predictions across batches. If `False`,
             will instead store them as lists, with each batch kept separate.
@@ -1090,6 +1093,10 @@ class TrainingArguments:
         metadata={
             "help": "Whether to run through the entire `evaluation` step at the very beginning of training as a sanity check."
         },
+    )
+    eval_on_end: bool = field(
+        default=False,
+        metadata={"help": "Whether to run through the entire `evaluation` step at the very end of training."},
     )
     eval_do_concat_batches: bool = field(
         default=True,


### PR DESCRIPTION
Fixes #43935

## Summary
- Added `eval_on_end` argument to `TrainingArguments` (default: `False`)
- Added conditional evaluation at the end of training in `Trainer.train()`, symmetric to `eval_on_start`
- Implementation mirrors the existing `eval_on_start` pattern exactly

This feature has been requested multiple times (see #28539, #30160) and provides a symmetric counterpart to `eval_on_start`.

## Testing
- Verified `TrainingArguments` accepts the new parameter
- The implementation uses the same `_evaluate()` helper as `eval_on_start`, with `skip_scheduler=True`
- The final evaluation runs before `load_best_model_at_end` so it can participate in best-model selection

This contribution was developed with AI assistance (Claude Code).