### PR TITLE
Fix zamba2 rotary embedding call when use_mem_rope is False

### DIFF
--- a/src/transformers/models/zamba2/modeling_zamba2.py
+++ b/src/transformers/models/zamba2/modeling_zamba2.py
@@ -1337,7 +1337,12 @@ class Zamba2Model(Zamba2PreTrainedModel):
             past_key_values=past_key_values,
             position_ids=position_ids,
         )
-        position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+
+        # create position embeddings to be shared across the decoder layers
+        if self.config.use_mem_rope:
+            position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+        else:
+            position_embeddings = None
 
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None

--- a/src/transformers/models/zamba2/modular_zamba2.py
+++ b/src/transformers/models/zamba2/modular_zamba2.py
@@ -1058,7 +1058,12 @@ class Zamba2Model(ZambaModel, Zamba2PreTrainedModel):
             past_key_values=past_key_values,
             position_ids=position_ids,
         )
-        position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+
+        # create position embeddings to be shared across the decoder layers
+        if self.config.use_mem_rope:
+            position_embeddings = self.rotary_emb(hidden_states, position_ids=position_ids)
+        else:
+            position_embeddings = None
 
         all_hidden_states = () if output_hidden_states else None
         all_self_attns = () if output_attentions else None


### PR DESCRIPTION
`self.rotary_emb` is always called since https://github.com/huggingface/transformers/pull/39847 while only being initialized when `config.use_mem_rope` is True

inference failing since v5 for models `config.use_mem_rope=False` 
```
AttributeError: 'Zamba2Model' object has no attribute 'rotary_emb'
```

https://github.com/huggingface/transformers/blob/v4.57.6/src/transformers/models/zamba2/modeling_zamba2.py#L1312-L1316
