### PR TITLE
Fix TypeError in RoPE validation when ignore_keys_at_rope_validation is a list

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -648,7 +648,7 @@ class RotaryEmbeddingConfigMixin:
             ignore_keys_at_rope_validation = (
                 set() if ignore_keys_at_rope_validation is None else set(ignore_keys_at_rope_validation)
             )
-            ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
+            ignore_keys_at_rope_validation = set(ignore_keys_at_rope_validation or []) | {"partial_rotary_factor"}
 
         self.standardize_rope_params()
         self.validate_rope(ignore_keys=ignore_keys_at_rope_validation)


### PR DESCRIPTION
This PR fixes a runtime `TypeError` encountered during model initialization when using Qwen3.5 configurations with recent `transformers` versions.

The error occurs in `modeling_rope_utils.py` during RoPE parameter validation:

```
TypeError: unsupported operand type(s) for |: 'list' and 'set'
```

The original implementation assumes that `ignore_keys_at_rope_validation` is always a `set` and merges it with another set using the `|` operator:

```python
ignore_keys_at_rope_validation = ignore_keys_at_rope_validation | {"partial_rotary_factor"}
```

However, depending on how the configuration is constructed, `ignore_keys_at_rope_validation` may be a `list` or `None`.
This leads to an invalid `list | set` operation and prevents the model from loading.

To ensure type safety, this PR normalizes the value before performing the union:

```python
ignore_keys_at_rope_validation = set(ignore_keys_at_rope_validation or []) | {"partial_rotary_factor"}
```

### Key improvements

* Ensures type safety by converting `ignore_keys_at_rope_validation` to a `set`
* Handles cases where the value may be `None`
* Preserves the intended semantics of extending the validation ignore list
* Prevents model initialization failures in environments using Qwen3.5 models (e.g., vLLM / Swift rollout pipelines)

This change improves robustness of RoPE configuration validation without altering the functional behavior.

---

# What does this PR do?

This PR fixes a compatibility issue in RoPE parameter validation that occurs when `ignore_keys_at_rope_validation` is provided as a `list` instead of a `set`.

By normalizing the value with `set(ignore_keys_at_rope_validation or [])`, the code becomes robust to different input types and avoids runtime failures when loading certain model configurations.

This issue was observed when initializing Qwen3.5 models in vLLM-based inference pipelines.

---

# Before submitting

* [x] This PR fixes a bug in the library
* [x] I have read the contributor guidelines
* [ ] This was discussed in an issue (optional but recommended)
* [ ] Documentation update not required
* [ ] No new tests added (small bugfix)