### PR TITLE
Add /v1/completions endpoint (OpenAI legacy completions API) to `transformers serve`

### DIFF
--- a/docs/source/en/serve-cli/serving.md
+++ b/docs/source/en/serve-cli/serving.md
@@ -24,6 +24,7 @@ The `transformers serve` CLI is a lightweight option for local or self-hosted se
 The `transformers serve` command spawns a local server compatible with the [OpenAI SDK](https://platform.openai.com/docs/overview). The server works with many third-party applications and supports the REST APIs below.
 
 - `/v1/chat/completions` for text, image, audio, and video requests
+- `/v1/completions` for legacy text completions from a freeform prompt
 - `/v1/responses` supports the [Responses API](https://platform.openai.com/docs/api-reference/responses)
 - `/v1/audio/transcriptions` for audio transcriptions
 - `/v1/models` lists available models for third-party integrations
@@ -958,6 +959,86 @@ The follow-up question "How many people live there?" relies on the prior context
 ```
 As of 2021, the population of Paris is approximately 2.2 million people.
 ```
+
+## v1/completions
+
+The `v1/completions` API is based on the [legacy Completions API](https://platform.openai.com/docs/api-reference/completions). Unlike `/v1/chat/completions`, it takes a freeform text `prompt` instead of chat messages and returns generated text in `choices[].text`. This is useful for base (non-instruct) models and text completion tasks where a chat template is not needed. It also supports `suffix` for fill-in-the-middle text insertion.
+
+<hfoptions id="legacy-completion">
+<hfoption id="curl">
+
+```shell
+curl -X POST http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-0.5B",
+    "prompt": "The capital of France is",
+    "max_tokens": 20
+  }'
+```
+
+The command returns the following response.
+
+```json
+{
+  "id": "chatcmpl-abc123",
+  "object": "text_completion",
+  "created": 1234567890,
+  "model": "Qwen/Qwen2.5-0.5B@main",
+  "choices": [
+    {
+      "text": " Paris, and the capital of the United States is Washington, D.C.",
+      "index": 0,
+      "logprobs": null,
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 5,
+    "completion_tokens": 16,
+    "total_tokens": 21
+  }
+}
+```
+
+</hfoption>
+<hfoption id="openai">
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="<random_string>")
+
+# Non-streaming
+completion = client.completions.create(
+    model="Qwen/Qwen2.5-0.5B",
+    prompt="The capital of France is",
+    max_tokens=20,
+)
+print(completion.choices[0].text)
+```
+
+The [OpenAI](https://platform.openai.com/docs/quickstart) client returns the following.
+
+```shell
+ Paris, and the capital of the United States is Washington, D.C.
+```
+
+Streaming is also supported.
+
+```python
+stream = client.completions.create(
+    model="Qwen/Qwen2.5-0.5B",
+    prompt="The capital of France is",
+    max_tokens=20,
+    stream=True,
+)
+for chunk in stream:
+    print(chunk.choices[0].text, end="")
+```
+
+</hfoption>
+</hfoptions>
 
 ## v1/responses
 

--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -83,6 +83,7 @@ class Serve:
         import uvicorn
 
         from .serving.chat_completion import ChatCompletionHandler
+        from .serving.completion import CompletionHandler
         from .serving.model_manager import ModelManager
         from .serving.response import ResponseHandler
         from .serving.server import build_server
@@ -131,6 +132,11 @@ class Serve:
             generation_state=self._generation_state,
         )
 
+        self._completion_handler = CompletionHandler(
+            model_manager=self._model_manager,
+            generation_state=self._generation_state,
+        )
+
         self._response_handler = ResponseHandler(
             model_manager=self._model_manager,
             generation_state=self._generation_state,
@@ -141,6 +147,7 @@ class Serve:
         app = build_server(
             self._model_manager,
             self._chat_handler,
+            completion_handler=self._completion_handler,
             response_handler=self._response_handler,
             transcription_handler=self._transcription_handler,
             enable_cors=enable_cors,
@@ -183,6 +190,7 @@ Models will be loaded and unloaded automatically based on usage and a timeout.
 \b
 Endpoints:
     POST /v1/chat/completions — Chat completions (streaming + non-streaming).
+    POST /v1/completions      — Legacy text completions from a prompt.
     GET  /v1/models           — Lists available models.
     GET  /health              — Health check.
 

--- a/src/transformers/cli/serving/completion.py
+++ b/src/transformers/cli/serving/completion.py
@@ -1,0 +1,275 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Handler for the /v1/completions endpoint (OpenAI legacy Completions API).
+
+Accepts a freeform text prompt (no chat template) and returns generated text
+in choices[].text. Supports streaming and non-streaming modes, and suffix for
+fill-in-the-middle text insertion.
+"""
+
+import asyncio
+import time
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+from ...utils import logging
+from ...utils.import_utils import is_serve_available
+
+
+if is_serve_available():
+    from fastapi import HTTPException
+    from fastapi.responses import JSONResponse, StreamingResponse
+    from openai.types import Completion, CompletionChoice, CompletionUsage
+    from openai.types.completion_create_params import CompletionCreateParamsBase
+
+
+from .utils import BaseGenerateManager, BaseHandler, _StreamError
+
+
+if TYPE_CHECKING:
+    from transformers import GenerationConfig, PreTrainedModel, PreTrainedTokenizerFast, ProcessorMixin
+
+
+class TransformersTextCompletionCreateParams(CompletionCreateParamsBase, total=False):
+    generation_config: str
+    seed: int
+    stream: bool
+
+
+# Fields accepted by the OpenAI schema but not yet supported.
+UNUSED_LEGACY_COMPLETION_FIELDS = {
+    "best_of",
+    "echo",
+    "logprobs",
+    "n",
+    "presence_penalty",
+    "stream_options",
+    "user",
+}
+
+
+logger = logging.get_logger(__name__)
+
+
+class CompletionHandler(BaseHandler):
+    """Handler for the `/v1/completions` endpoint.
+
+    Takes a raw text ``prompt`` (no chat template) and generates text returned in
+    ``choices[].text``. Supports streaming (SSE) and non-streaming (JSON) responses,
+    and ``suffix`` for fill-in-the-middle insertion.
+    """
+
+    _valid_params_class = TransformersTextCompletionCreateParams
+    _unused_fields = UNUSED_LEGACY_COMPLETION_FIELDS
+
+    async def handle_request(self, body: dict, request_id: str) -> "StreamingResponse | JSONResponse":
+        """Validate the request, load the model, and dispatch to streaming or non-streaming.
+
+        Args:
+            body (`dict`): The raw JSON request body (OpenAI legacy completions format).
+            request_id (`str`): Unique request identifier (from header or auto-generated).
+
+        Returns:
+            `StreamingResponse | JSONResponse`: SSE stream or JSON depending on ``body["stream"]``.
+        """
+        self._validate_request(body)
+
+        prompt = body.get("prompt", "")
+        if not isinstance(prompt, str):
+            raise HTTPException(status_code=400, detail="prompt must be a string.")
+
+        model_id, model, processor = self._resolve_model(body)
+        modality = self.model_manager.get_model_modality(model, processor=processor)
+        use_cb = self.generation_state.use_continuous_batching(model, modality)
+        logger.warning(f"[Request received] Model: {model_id}, CB: {use_cb}")
+        gen_manager = self.generation_state.get_manager(model_id, use_cb=use_cb)
+
+        tokenizer = getattr(processor, "tokenizer", processor)
+        inputs = tokenizer(prompt, return_tensors=None if use_cb else "pt")
+        if not use_cb:
+            inputs = inputs.to(model.device)
+
+        gen_config = self._build_generation_config(body, model.generation_config, use_cb=use_cb)
+        if use_cb:
+            gen_manager.init_cb(model, gen_config)
+
+        suffix = body.get("suffix")
+        streaming = body.get("stream")
+
+        if streaming:
+            return self._streaming(request_id, model, processor, model_id, inputs, gen_config, gen_manager, suffix)
+        else:
+            return await self._non_streaming(
+                request_id, model, processor, model_id, inputs, gen_config, gen_manager, suffix
+            )
+
+    # ----- streaming -----
+
+    def _streaming(
+        self,
+        request_id: str,
+        model: "PreTrainedModel",
+        processor: "ProcessorMixin | PreTrainedTokenizerFast",
+        model_id: str,
+        inputs: dict,
+        gen_config: "GenerationConfig",
+        gen_manager: BaseGenerateManager,
+        suffix: str | None = None,
+    ) -> "StreamingResponse":
+        """Stream tokens as SSE."""
+        queue, streamer = gen_manager.generate_streaming(model, processor, inputs, gen_config, request_id=request_id)
+        input_ids = inputs["input_ids"]
+        input_len = len(input_ids) if isinstance(input_ids, list) else input_ids.shape[-1]
+
+        async def sse_gen() -> AsyncGenerator[str, None]:
+            try:
+                done = False
+                while not done:
+                    text = await queue.get()
+                    batch = [text]
+                    try:
+                        while True:
+                            batch.append(queue.get_nowait())
+                    except asyncio.QueueEmpty:
+                        pass
+
+                    sse_parts: list[str] = []
+                    for text in batch:
+                        if text is None:
+                            done = True
+                            break
+                        if isinstance(text, _StreamError):
+                            sse_parts.append(f'data: {{"error": "{text.msg}"}}\n\n')
+                            yield "".join(sse_parts)
+                            return
+
+                        sse_parts.append(self._build_chunk_sse(request_id, model_id, text=text))
+
+                    if sse_parts:
+                        yield "".join(sse_parts)
+
+                hit_max = gen_config.max_new_tokens is not None and streamer.total_tokens >= gen_config.max_new_tokens
+                finish_reason = "length" if hit_max else "stop"
+
+                if suffix is not None:
+                    yield self._build_chunk_sse(request_id, model_id, text=suffix)
+                usage = CompletionUsage(
+                    prompt_tokens=input_len,
+                    completion_tokens=streamer.total_tokens,
+                    total_tokens=input_len + streamer.total_tokens,
+                )
+                yield self._build_chunk_sse(request_id, model_id, finish_reason=finish_reason, usage=usage)
+            except (GeneratorExit, asyncio.CancelledError):
+                streamer.cancel()
+                raise
+
+        return StreamingResponse(sse_gen(), media_type="text/event-stream")
+
+    # ----- non-streaming -----
+
+    async def _non_streaming(
+        self,
+        request_id: str,
+        model: "PreTrainedModel",
+        processor: "ProcessorMixin | PreTrainedTokenizerFast",
+        model_id: str,
+        inputs: dict,
+        gen_config: "GenerationConfig",
+        gen_manager: BaseGenerateManager,
+        suffix: str | None = None,
+    ) -> "JSONResponse":
+        """Run generation and return a JSONResponse."""
+        text, input_len, generated_ids = await gen_manager.generate_non_streaming(
+            model, processor, inputs, gen_config, request_id=request_id
+        )
+
+        if suffix is not None:
+            text = text + suffix
+
+        completion_tokens = len(generated_ids)
+        hit_max = gen_config.max_new_tokens is not None and completion_tokens >= gen_config.max_new_tokens
+        finish_reason = "length" if hit_max else "stop"
+
+        usage = CompletionUsage(
+            prompt_tokens=input_len,
+            completion_tokens=completion_tokens,
+            total_tokens=input_len + completion_tokens,
+        )
+
+        result = Completion(
+            id=request_id,
+            created=int(time.time()),
+            model=model_id,
+            choices=[
+                CompletionChoice(
+                    text=text,
+                    index=0,
+                    logprobs=None,
+                    finish_reason=finish_reason,
+                )
+            ],
+            object="text_completion",
+            usage=usage,
+        )
+
+        return JSONResponse(result.model_dump(exclude_none=True), media_type="application/json")
+
+    # ----- helpers -----
+
+    def _build_chunk_sse(
+        self,
+        request_id: str,
+        model_id: str,
+        text: str = "",
+        finish_reason: str | None = None,
+        usage: "CompletionUsage | None" = None,
+    ) -> str:
+        """Build a streaming ``Completion`` chunk and format it as an SSE ``data:`` line.
+
+        Uses ``model_construct`` to bypass pydantic validation so that ``finish_reason``
+        can be ``None`` for mid-stream chunks (the OpenAI SDK's ``CompletionChoice`` only
+        accepts literal values).
+        """
+        chunk = Completion.model_construct(
+            id=request_id,
+            object="text_completion",
+            created=int(time.time()),
+            model=model_id,
+            choices=[
+                CompletionChoice.model_construct(
+                    text=text,
+                    index=0,
+                    logprobs=None,
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=usage,
+        )
+        return self.chunk_to_sse(chunk)
+
+    # ----- generation config -----
+
+    def _build_generation_config(self, body: dict, model_generation_config: "GenerationConfig", use_cb: bool = False):
+        """Apply legacy completion params (``max_tokens``, ``frequency_penalty``, ``stop``) on top of base config."""
+        generation_config = super()._build_generation_config(body, model_generation_config, use_cb=use_cb)
+
+        if body.get("max_tokens") is not None:
+            generation_config.max_new_tokens = int(body["max_tokens"])
+        if body.get("frequency_penalty") is not None:
+            generation_config.repetition_penalty = 1.0 + float(body["frequency_penalty"])
+        if body.get("stop") is not None:
+            generation_config.stop_strings = body["stop"]
+
+        return generation_config

--- a/src/transformers/cli/serving/server.py
+++ b/src/transformers/cli/serving/server.py
@@ -28,6 +28,7 @@ if is_serve_available():
     from fastapi.responses import JSONResponse, StreamingResponse
 
 from .chat_completion import ChatCompletionHandler
+from .completion import CompletionHandler
 from .model_manager import ModelManager
 from .response import ResponseHandler
 from .transcription import TranscriptionHandler
@@ -40,6 +41,7 @@ logger = logging.get_logger(__name__)
 def build_server(
     model_manager: ModelManager,
     chat_handler: ChatCompletionHandler,
+    completion_handler: CompletionHandler,
     response_handler: ResponseHandler,
     transcription_handler: TranscriptionHandler,
     enable_cors: bool = False,
@@ -89,6 +91,10 @@ def build_server(
     @app.post("/v1/chat/completions")
     async def chat_completions(request: Request, body: dict):
         return await chat_handler.handle_request(body, request.state.request_id)
+
+    @app.post("/v1/completions")
+    async def completions(request: Request, body: dict):
+        return await completion_handler.handle_request(body, request.state.request_id)
 
     @app.post("/v1/responses")
     async def responses(request: Request, body: dict):

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -27,6 +27,7 @@ import httpx
 
 from transformers.cli.serve import Serve
 from transformers.cli.serving.chat_completion import ChatCompletionHandler
+from transformers.cli.serving.completion import CompletionHandler
 from transformers.cli.serving.model_manager import ModelManager, TimedModel
 from transformers.cli.serving.response import ResponseHandler, compute_usage
 from transformers.cli.serving.server import build_server
@@ -546,9 +547,16 @@ class TestAppRoutes(unittest.TestCase):
             {"id": "test/model", "owned_by": "test", "object": "model", "created": 0}
         ]
         cls.chat_handler = MagicMock(spec=ChatCompletionHandler)
+        cls.completion_handler = MagicMock(spec=CompletionHandler)
         cls.response_handler = MagicMock(spec=ResponseHandler)
         cls.transcription_handler = MagicMock(spec=TranscriptionHandler)
-        cls.app = build_server(cls.model_manager, cls.chat_handler, cls.response_handler, cls.transcription_handler)
+        cls.app = build_server(
+            cls.model_manager,
+            cls.chat_handler,
+            cls.completion_handler,
+            cls.response_handler,
+            cls.transcription_handler,
+        )
         cls.transport = httpx.ASGITransport(app=cls.app)
 
     async def _request(self, method: str, path: str, **kwargs) -> httpx.Response:
@@ -774,6 +782,194 @@ class TestChatCompletion(unittest.TestCase):
             max_tokens=10,
         )
         self.assertIsNotNone(resp.choices[0].message.content)
+
+
+@slow
+@require_serve
+class TestCompletion(unittest.TestCase):
+    """Integration tests for /v1/completions with a real model.
+
+    Covers sequential and continuous-batching generation, both streaming and
+    non-streaming, plus finish_reason, usage, stop strings, suffix, and
+    cancellation behaviour.
+    """
+
+    MODEL = "Qwen/Qwen2.5-0.5B"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.serve, port = _start_serve()
+        cls.base_url = f"http://localhost:{port}"
+        cls.client = OpenAI(base_url=f"{cls.base_url}/v1", api_key="unused")
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.serve.kill_server()
+
+    # ----- non-streaming -----
+
+    def test_non_streaming(self):
+        from openai.types import Completion as OpenAICompletion
+
+        result = self.client.completions.create(
+            model=self.MODEL,
+            prompt="The capital of France is",
+            max_tokens=5,
+        )
+
+        self.assertIsInstance(result, OpenAICompletion)
+        self.assertEqual(result.object, "text_completion")
+        self.assertIsInstance(result.choices[0].text, str)
+        self.assertTrue(len(result.choices[0].text) > 0)
+        self.assertIn(result.choices[0].finish_reason, ("stop", "length"))
+
+    def test_non_streaming_usage(self):
+        result = self.client.completions.create(
+            model=self.MODEL,
+            prompt="The capital of France is",
+            max_tokens=5,
+        )
+        self.assertIsNotNone(result.usage)
+        self.assertGreater(result.usage.prompt_tokens, 0)
+        self.assertGreater(result.usage.completion_tokens, 0)
+        self.assertEqual(result.usage.total_tokens, result.usage.prompt_tokens + result.usage.completion_tokens)
+
+    def test_finish_reason_length(self):
+        result = self.client.completions.create(model=self.MODEL, prompt="Hello", max_tokens=1)
+        self.assertEqual(result.choices[0].finish_reason, "length")
+
+    def test_finish_reason_stop(self):
+        result = self.client.completions.create(model=self.MODEL, prompt="Hello", max_tokens=1024)
+        self.assertEqual(result.choices[0].finish_reason, "stop")
+
+    def test_stop_strings(self):
+        result = self.client.completions.create(
+            model=self.MODEL,
+            prompt="one two three four",
+            max_tokens=20,
+            stop=["six"],
+        )
+        self.assertNotIn("seven", result.choices[0].text)
+
+    def test_suffix(self):
+        """suffix should be appended to generated text."""
+        suffix = " [END]"
+        result = self.client.completions.create(
+            model=self.MODEL,
+            prompt="The capital of France is",
+            max_tokens=5,
+            suffix=suffix,
+        )
+        self.assertTrue(result.choices[0].text.endswith(suffix))
+
+    # ----- streaming -----
+
+    def test_streaming(self):
+        chunks = list(
+            self.client.completions.create(
+                model=self.MODEL,
+                prompt="The capital of France is",
+                max_tokens=5,
+                stream=True,
+            )
+        )
+        texts = [c.choices[0].text for c in chunks]
+        self.assertTrue(any(t != "" for t in texts))
+        self.assertIn(chunks[-1].choices[0].finish_reason, ("stop", "length"))
+
+    def test_streaming_usage(self):
+        chunks = list(
+            self.client.completions.create(
+                model=self.MODEL,
+                prompt="The capital of France is",
+                max_tokens=5,
+                stream=True,
+            )
+        )
+        last = chunks[-1]
+        self.assertIsNotNone(last.usage)
+        self.assertGreater(last.usage.prompt_tokens, 0)
+        self.assertGreater(last.usage.completion_tokens, 0)
+        self.assertEqual(last.usage.total_tokens, last.usage.prompt_tokens + last.usage.completion_tokens)
+
+    def test_streaming_finish_reason_length(self):
+        chunks = list(self.client.completions.create(model=self.MODEL, prompt="Hello", max_tokens=1, stream=True))
+        self.assertEqual(chunks[-1].choices[0].finish_reason, "length")
+
+    def test_streaming_suffix(self):
+        """suffix should be emitted as a final text chunk before finish_reason."""
+        suffix = " [END]"
+        chunks = list(
+            self.client.completions.create(
+                model=self.MODEL,
+                prompt="The capital of France is",
+                max_tokens=5,
+                suffix=suffix,
+                stream=True,
+            )
+        )
+        all_text = "".join(c.choices[0].text for c in chunks)
+        self.assertTrue(all_text.endswith(suffix))
+
+    def test_request_cancellation(self):
+        """Closing a stream early doesn't crash and the server stays healthy."""
+        with httpx.stream(
+            "POST",
+            f"{self.base_url}/v1/completions",
+            json={"model": self.MODEL, "prompt": "Count slowly:", "max_tokens": 500, "stream": True},
+            timeout=30,
+        ) as resp:
+            self.assertEqual(resp.status_code, 200)
+            chunks_read = 0
+            for _ in resp.iter_lines():
+                chunks_read += 1
+                if chunks_read >= 3:
+                    break
+
+        result = self.client.completions.create(model=self.MODEL, prompt="Hello", max_tokens=5)
+        self.assertIsNotNone(result.choices[0].text)
+
+    # ----- continuous batching -----
+
+    @require_torch_accelerator
+    def test_cb_streaming(self):
+        """Streaming completion with CB produces text."""
+        serve, port = _start_serve(
+            force_model=self.MODEL,
+            device="cuda:0",
+            continuous_batching=True,
+            attn_implementation="sdpa",
+        )
+        try:
+            client = OpenAI(base_url=f"http://localhost:{port}/v1", api_key="unused")
+            chunks = list(
+                client.completions.create(
+                    model=self.MODEL, prompt="The capital of France is", max_tokens=10, stream=True
+                )
+            )
+            texts = [c.choices[0].text for c in chunks]
+            self.assertTrue(any(t != "" for t in texts))
+            self.assertIn(chunks[-1].choices[0].finish_reason, ("stop", "length"))
+        finally:
+            serve.kill_server()
+
+    @require_torch_accelerator
+    def test_cb_non_streaming(self):
+        """Non-streaming completion with CB returns a full response."""
+        serve, port = _start_serve(
+            force_model=self.MODEL,
+            device="cuda:0",
+            continuous_batching=True,
+            attn_implementation="sdpa",
+        )
+        try:
+            client = OpenAI(base_url=f"http://localhost:{port}/v1", api_key="unused")
+            result = client.completions.create(model=self.MODEL, prompt="The capital of France is", max_tokens=10)
+            self.assertIsInstance(result.choices[0].text, str)
+            self.assertTrue(len(result.choices[0].text) > 0)
+            self.assertIn(result.choices[0].finish_reason, ("stop", "length"))
+        finally:
+            serve.kill_server()
 
 
 @require_serve


### PR DESCRIPTION
> Adds support for the legacy text completions endpoint, which accepts a freeform text prompt (no chat template) and returns generated text in choices[].text. Supports both streaming and non-streaming modes, suffix for fill-in-the-middle insertion, and proper finish_reason detection.

# What does this PR do?

Hello, my motivation for this:

I work with base models. I often need to continue text documents. So I need the OpenAI /v1/completions that uses an LLM to continune text. This is applicable for base models/pretrained foundational models, which have not been post-trained as instruct models to follow a chat template.

The 'transformers' tool is amazingly useful for bringing up a quick API endpoint, and I would love this to support the ability to continue a prompt! That's why I worked with Claude Code/Opus 4.6 to produce this PR.

Note: While this is a legacy feature of the OpenAI API (they have moved away from providing base model support) vllm still supports. It's very useful for research or any work with pretrained models.

* https://developers.openai.com/api/docs/guides/completions/
* https://docs.vllm.ai/en/latest/serving/openai_compatible_server/#completions-api

Here's an example script that tests the functionality

```python
from openai import OpenAI
client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")

# Non-streaming
resp = client.completions.create(
    model="Qwen/Qwen3.5-0.8B-Base",
    prompt="The capital of France is",
    max_tokens=20
)
for i, choice in enumerate(resp.choices):
    print(i)
    print("-")
    print(choice.text)
    print("\n\n")

# Streaming
for chunk in client.completions.create(
    model="Qwen/Qwen3.5-0.8B-Base",
    prompt="Once upon a time",
    max_tokens=50,
    stream=True,
):
    print(chunk.choices[0].text, end="", flush=True)

```

So I run `transformers serve` then run that script and I get the result:

```
0
-
 Paris, and the capital of the United States is Washington, D.C. The capital of the United



, in a magical land of science, there was a very special kind of animal called a jellyfish. This jellyfish had a really interesting way of living.
```

So this implementation is working well for my purposes.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case). **No this provides a new feature to the transformers command line tool**
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section? **yes**
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. **no, this PR is the first contact**
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation). **Yes, API endpoint documented**
- [x] Did you write any new necessary tests? **Yes, we added a test for this feature. and also tested the functionality with an independent pythoon script*


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

 -->

based on git blame I tag @LysandreJik
