### PR TITLE
[`fix`] Prevent crash with Apertus without xielu installed

### DIFF
--- a/src/transformers/activations.py
+++ b/src/transformers/activations.py
@@ -267,9 +267,8 @@ class XIELUActivation(nn.Module):
             logger.warning_once(msg)
         except Exception as err:
             logger.warning_once(
-                "CUDA-fused xIELU not available (%s) – falling back to a Python version.\n"
-                "For CUDA xIELU (experimental), `pip install git+https://github.com/nickjbrowning/XIELU`",
-                str(err),
+                f"CUDA-fused xIELU not available ({err}) – falling back to a Python version.\n"
+                "For CUDA xIELU (experimental), `pip install git+https://github.com/nickjbrowning/XIELU`"
             )
 
     def _xielu_python(self, x: Tensor) -> Tensor:


### PR DESCRIPTION
# What does this PR do?

Currently, when using Apertus (or rather, it's `XIELUActivation`), and you don't have `xielu` installed, then you'll fall to this `except:`
https://github.com/huggingface/transformers/blob/5a098a1e01034095f037c8a37f7fe87c31118e26/src/transformers/activations.py#L268-L273

However, `logger.warning_once` doesn't accept multiple parameters like this, and so it'll crash:
```
            except Exception as err:
                msg += f" Could not enable torch._dynamo for xIELU ({err}) - this may result in slower performance."
                self._xielu_cuda_fn = self._xielu_cuda
            logger.warning_once(msg)
        except Exception as err:
>           logger.warning_once(
                "CUDA-fused xIELU not available (%s) – falling back to a Python version.\n"
                "For CUDA xIELU (experimental), `pip install git+https://github.com/nickjbrowning/XIELU`",
                str(err),
            )
E           TypeError: NNCFLogger.warning_once() takes 2 positional arguments but 3 were given
```

Instead, this PR uses f-string formatting to place the stringified error into the first line, resulting in this logger warning instead:
```
CUDA-fused xIELU not available (No module named 'xielu') – falling back to a Python version.
For CUDA xIELU (experimental), `pip install git+https://github.com/nickjbrowning/XIELU`
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@Cyrilvallez @vasqu

- Tom Aarsen