### PR TITLE
Fix missing post_processor in DebertaV2Tokenizer causing no special t…

### DIFF
--- a/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/tokenization_deberta_v2.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """Tokenization class for model DeBERTa-v2."""
 
-from tokenizers import Regex, Tokenizer, decoders, normalizers, pre_tokenizers
+from tokenizers import Regex, Tokenizer, decoders, normalizers, pre_tokenizers, processors
 from tokenizers.models import Unigram
 
 from ...tokenization_utils_tokenizers import TokenizersBackend
@@ -151,6 +151,18 @@ class DebertaV2Tokenizer(TokenizersBackend):
             split_by_punct=split_by_punct,
             add_prefix_space=add_prefix_space,
             **kwargs,
+        )
+
+        cls_token_id = self.cls_token_id if self.cls_token_id is not None else 0
+        sep_token_id = self.sep_token_id if self.sep_token_id is not None else 0
+
+        self._tokenizer.post_processor = processors.TemplateProcessing(
+            single=f"{str(self.cls_token)}:0 $A:0 {str(self.sep_token)}:0",
+            pair=f"{str(self.cls_token)}:0 $A:0 {str(self.sep_token)}:0 $B:1 {str(self.sep_token)}:1",
+            special_tokens=[
+                (str(self.cls_token), cls_token_id),
+                (str(self.sep_token), sep_token_id),
+            ],
         )
 
 

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -117,24 +117,3 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
-
-    def test_add_special_tokens(self):
-        extractor = SentencePieceExtractor(SAMPLE_VOCAB)
-        vocab, vocab_scores, merges = extractor.extract()
-        tokenizer = DebertaV2Tokenizer(vocab=vocab_scores, unk_token="<unk>")
-
-        cls_id = tokenizer.cls_token_id
-        sep_id = tokenizer.sep_token_id
-
-        # Single sequence: [CLS] tokens [SEP]
-        ids_with_special = tokenizer.encode("hello", add_special_tokens=True)
-        ids_without_special = tokenizer.encode("hello", add_special_tokens=False)
-        self.assertEqual(ids_with_special[0], cls_id)
-        self.assertEqual(ids_with_special[-1], sep_id)
-        self.assertEqual(ids_with_special[1:-1], ids_without_special)
-
-        # Pair of sequences: [CLS] A [SEP] B [SEP]
-        ids_pair = tokenizer.encode("hello", "world", add_special_tokens=True)
-        self.assertEqual(ids_pair[0], cls_id)
-        self.assertEqual(ids_pair[-1], sep_id)
-        self.assertGreater(ids_pair.count(sep_id), 1)

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -117,3 +117,24 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
+
+    def test_add_special_tokens(self):
+        extractor = SentencePieceExtractor(SAMPLE_VOCAB)
+        vocab, vocab_scores, merges = extractor.extract()
+        tokenizer = DebertaV2Tokenizer(vocab=vocab_scores, unk_token="<unk>")
+
+        cls_id = tokenizer.cls_token_id
+        sep_id = tokenizer.sep_token_id
+
+        # Single sequence: [CLS] tokens [SEP]
+        ids_with_special = tokenizer.encode("hello", add_special_tokens=True)
+        ids_without_special = tokenizer.encode("hello", add_special_tokens=False)
+        self.assertEqual(ids_with_special[0], cls_id)
+        self.assertEqual(ids_with_special[-1], sep_id)
+        self.assertEqual(ids_with_special[1:-1], ids_without_special)
+
+        # Pair of sequences: [CLS] A [SEP] B [SEP]
+        ids_pair = tokenizer.encode("hello", "world", add_special_tokens=True)
+        self.assertEqual(ids_pair[0], cls_id)
+        self.assertEqual(ids_pair[-1], sep_id)
+        self.assertGreater(ids_pair.count(sep_id), 1)

--- a/tests/models/deberta_v2/test_tokenization_deberta_v2.py
+++ b/tests/models/deberta_v2/test_tokenization_deberta_v2.py
@@ -117,3 +117,20 @@ class DebertaV2TokenizationTest(TokenizerTesterMixin, unittest.TestCase):
         tokens = tokenizer.convert_ids_to_tokens(tokenizer.encode(sequence, add_special_tokens=False))
 
         self.assertListEqual(tokens, tokens_target)
+
+    def test_post_processor_adds_special_tokens(self):
+        extractor = SentencePieceExtractor(SAMPLE_VOCAB)
+        vocab, vocab_scores, merges = extractor.extract()
+        tokenizer = DebertaV2Tokenizer(vocab=vocab_scores, unk_token="<unk>")
+
+        encoding = tokenizer("Hello world")
+        tokens = tokenizer.convert_ids_to_tokens(encoding["input_ids"])
+        self.assertEqual(tokens[0], "[CLS]")
+        self.assertEqual(tokens[-1], "[SEP]")
+
+        encoding_pair = tokenizer("Hello", "World")
+        tokens_pair = tokenizer.convert_ids_to_tokens(encoding_pair["input_ids"])
+        self.assertEqual(tokens_pair[0], "[CLS]")
+        sep_indices = [i for i, t in enumerate(tokens_pair) if t == "[SEP]"]
+        self.assertEqual(len(sep_indices), 2)
+        self.assertEqual(sep_indices[-1], len(tokens_pair) - 1)


### PR DESCRIPTION
  # What does this PR do?                                                                                                                                                                
                                                                                                                                                                                           
  In transformers v5, `DebertaV2Tokenizer` was rewritten to use `TokenizersBackend`, but the `post_processor` responsible for adding `[CLS]`/`[SEP]` tokens was never set. This causes     
  `add_special_tokens=True` to silently produce output without special tokens for models like `microsoft/mdeberta-v3-base`.                                                                
                                                                                                                                                                                           
  The root cause: in v4, special tokens were added via `build_inputs_with_special_tokens()` (Python-level). In v5, this method was removed in favor of the Rust-level `post_processor` on  
  the `tokenizers` backend — but for `DebertaV2Tokenizer` this processor was never configured. Other tokenizers like `BertTokenizer` set it correctly.                                     
                                                                                                                                                                                           
  The fix adds a `TemplateProcessing` post-processor after `super().__init__()`, matching the pattern used by `BertTokenizer` and the template previously defined in                       
  `DebertaV2Converter.post_processor()`.                                                                                                                                                   

  Fixes #44568

  ## Before submitting
  - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
        Pull Request section?
  - [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
        to it if that's the case. #44568
  - [ ] Did you make sure to update the documentation with your changes? Here are the
        [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
        [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
  - [x] Did you write any new necessary tests?

  ## Who can review?

  @ArthurZucker @itazap — tokenizers