### PR TITLE
Fix: AQLM quantizer to match updated replace_with_aqlm_linear signature

### DIFF
--- a/src/transformers/quantizers/quantizer_aqlm.py
+++ b/src/transformers/quantizers/quantizer_aqlm.py
@@ -55,7 +55,7 @@ class AqlmHfQuantizer(HfQuantizer):
         replace_with_aqlm_linear(
             model,
             quantization_config=self.quantization_config,
-            linear_weights_not_to_quantize=self.quantization_config.linear_weights_not_to_quantize,
+            modules_to_not_convert=self.quantization_config.linear_weights_not_to_quantize,
         )
 
     @property

--- a/tests/quantization/aqlm_integration/test_aqlm.py
+++ b/tests/quantization/aqlm_integration/test_aqlm.py
@@ -117,7 +117,7 @@ class AqlmTest(unittest.TestCase):
             if isinstance(module, torch.nn.Linear):
                 nb_linears += 1
 
-        model, _ = replace_with_aqlm_linear(model, quantization_config=quantization_config)
+        model = replace_with_aqlm_linear(model, quantization_config=quantization_config)
         nb_aqlm_linear = 0
         for module in model.modules():
             if isinstance(module, QuantizedLinear):
@@ -125,12 +125,12 @@ class AqlmTest(unittest.TestCase):
 
         self.assertEqual(nb_linears, nb_aqlm_linear)
 
-        # Try with `linear_weights_not_to_quantize`
+        # Try with `modules_to_not_convert`
         with torch.device("meta"):
             model = OPTForCausalLM(config)
 
-        model, _ = replace_with_aqlm_linear(
-            model, quantization_config=quantization_config, linear_weights_not_to_quantize=["lm_head.weight"]
+        model = replace_with_aqlm_linear(
+            model, quantization_config=quantization_config, modules_to_not_convert=["lm_head"]
         )
         nb_aqlm_linear = 0
         for module in model.modules():


### PR DESCRIPTION
  - Fix quantizer_aqlm.py to use renamed modules_to_not_convert parameter instead of removed linear_weights_not_to_quantize
  - Update test to match new function signature: no tuple return, module names instead of weight names