### PR TITLE
Fix missing BPE token conversion step in Chameleon

### DIFF
--- a/src/transformers/models/chameleon/modeling_chameleon.py
+++ b/src/transformers/models/chameleon/modeling_chameleon.py
@@ -899,8 +899,10 @@ class ChameleonModel(ChameleonPreTrainedModel):
         pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, image_size, image_size)`):
             The tensors corresponding to the input images.
         """
+        batch_size = pixel_values.shape[0]
         vqmodel_outputs: ChameleonVQVAEModelOutput = self.vqmodel.encode(pixel_values, return_dict=True, **kwargs)
-        vqmodel_outputs.pooler_output = self.get_input_embeddings()(vqmodel_outputs.image_tokens)
+        bpe_tokens = self.vocabulary_mapping.convert_img2bpe(vqmodel_outputs.image_tokens).view(batch_size, -1)
+        vqmodel_outputs.pooler_output = self.get_input_embeddings()(bpe_tokens)
         return vqmodel_outputs
 
     def get_placeholder_mask(


### PR DESCRIPTION
# What does this PR do?

Fix an issue introduced in #42564 . The refactor embedded raw image tokens instead of BPE tokens, causing the model to output gibberish. This fix adds back the image tokens to BPE tokens conversion before embedding.

Cc @hmellor @zucchini-nlp 
