### PR TITLE
Fix off-by-one in decode_spans boundary check

### DIFF
--- a/src/transformers/pipelines/document_question_answering.py
+++ b/src/transformers/pipelines/document_question_answering.py
@@ -94,7 +94,7 @@ def decode_spans(
     scores_flat = candidates.flatten()
     if topk == 1:
         idx_sort = [np.argmax(scores_flat)]
-    elif len(scores_flat) < topk:
+    elif len(scores_flat) <= topk:
         idx_sort = np.argsort(-scores_flat)
     else:
         idx = np.argpartition(-scores_flat, topk)[0:topk]

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -21,7 +21,7 @@ from transformers import (
     is_vision_available,
 )
 from transformers.pipelines import DocumentQuestionAnsweringPipeline, pipeline
-from transformers.pipelines.document_question_answering import apply_tesseract, decode_spans
+from transformers.pipelines.document_question_answering import apply_tesseract
 from transformers.testing_utils import (
     is_pipeline_test,
     nested_simplify,
@@ -59,27 +59,6 @@ else:
 INVOICE_URL = (
     "https://huggingface.co/spaces/impira/docquery/resolve/2f6c96314dc84dfda62d40de9da55f2f5165d403/invoice.png"
 )
-
-
-class DecodeSpansTest(unittest.TestCase):
-    def test_topk_equals_candidates_length(self):
-        """Test that decode_spans does not crash when len(scores_flat) == topk.
-
-        Regression test for https://github.com/huggingface/transformers/issues/44327
-        """
-        import numpy as np
-
-        # Create small inputs where candidates.flatten() has exactly topk elements
-        # start/end are 1D with 2 elements -> outer is (1, 2, 2) -> candidates flatten to 4
-        start = np.array([0.5, 0.5])
-        end = np.array([0.5, 0.5])
-        topk = 4
-        max_answer_len = 2
-        undesired_tokens = np.ones(2)
-
-        # This should not raise ValueError: kth out of bounds
-        starts, ends, scores = decode_spans(start, end, topk, max_answer_len, undesired_tokens)
-        self.assertIsInstance(starts, np.ndarray)
 
 
 @is_pipeline_test

--- a/tests/pipelines/test_pipelines_document_question_answering.py
+++ b/tests/pipelines/test_pipelines_document_question_answering.py
@@ -21,7 +21,7 @@ from transformers import (
     is_vision_available,
 )
 from transformers.pipelines import DocumentQuestionAnsweringPipeline, pipeline
-from transformers.pipelines.document_question_answering import apply_tesseract
+from transformers.pipelines.document_question_answering import apply_tesseract, decode_spans
 from transformers.testing_utils import (
     is_pipeline_test,
     nested_simplify,
@@ -59,6 +59,27 @@ else:
 INVOICE_URL = (
     "https://huggingface.co/spaces/impira/docquery/resolve/2f6c96314dc84dfda62d40de9da55f2f5165d403/invoice.png"
 )
+
+
+class DecodeSpansTest(unittest.TestCase):
+    def test_topk_equals_candidates_length(self):
+        """Test that decode_spans does not crash when len(scores_flat) == topk.
+
+        Regression test for https://github.com/huggingface/transformers/issues/44327
+        """
+        import numpy as np
+
+        # Create small inputs where candidates.flatten() has exactly topk elements
+        # start/end are 1D with 2 elements -> outer is (1, 2, 2) -> candidates flatten to 4
+        start = np.array([0.5, 0.5])
+        end = np.array([0.5, 0.5])
+        topk = 4
+        max_answer_len = 2
+        undesired_tokens = np.ones(2)
+
+        # This should not raise ValueError: kth out of bounds
+        starts, ends, scores = decode_spans(start, end, topk, max_answer_len, undesired_tokens)
+        self.assertIsInstance(starts, np.ndarray)
 
 
 @is_pipeline_test


### PR DESCRIPTION
# What does this PR do?

Fixes an off-by-one error in `decode_spans()` in the document question answering pipeline that causes a `ValueError: kth(=N) out of bounds` crash when `len(scores_flat) == topk`.

The boundary check on line 97 uses `<` but should use `<=`. When the flattened candidate array has exactly `topk` elements, `np.argpartition(-scores_flat, topk)` is called with `kth=topk`, which is out of bounds (0-indexed). Changing to `<=` ensures we fall through to `argsort` in this edge case.

Fixes #44327

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/huggingface/transformers/issues/44327
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@Rocketknight1 (pipelines)

This contribution was developed with AI assistance (Claude Code).