### PR TITLE
[Pipeline] Add top_k, label filtering, box_format and score sorting to ObjectDetectionPipeline

### DIFF
--- a/src/transformers/pipelines/object_detection.py
+++ b/src/transformers/pipelines/object_detection.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, Union, overload
 
 from ..utils import add_end_docstrings, is_torch_available, is_vision_available, logging, requires_backends
 from .base import Pipeline, build_pipeline_init_args
@@ -35,9 +35,9 @@ class ObjectDetectionPipeline(Pipeline):
 
     >>> detector = pipeline(model="facebook/detr-resnet-50")
     >>> detector("https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png")
-    [{'score': 0.997, 'label': 'bird', 'box': {'xmin': 69, 'ymin': 171, 'xmax': 396, 'ymax': 507}}, {'score': 0.999, 'label': 'bird', 'box': {'xmin': 398, 'ymin': 105, 'xmax': 767, 'ymax': 507}}]
+    [{'score': 0.999, 'label': 'bird', 'box': {'xmin': 398, 'ymin': 105, 'xmax': 767, 'ymax': 507}}, {'score': 0.997, 'label': 'bird', 'box': {'xmin': 69, 'ymin': 171, 'xmax': 396, 'ymax': 507}}]
 
-    >>> # x, y  are expressed relative to the top left hand corner.
+    >>> # Results are sorted by score descending. x, y are expressed relative to the top left hand corner.
     ```
 
     Learn more about the basics of using a pipeline in the [pipeline tutorial](../pipeline_tutorial)
@@ -65,9 +65,17 @@ class ObjectDetectionPipeline(Pipeline):
         preprocess_params = {}
         if "timeout" in kwargs:
             preprocess_params["timeout"] = kwargs["timeout"]
+
         postprocess_kwargs = {}
         if "threshold" in kwargs:
             postprocess_kwargs["threshold"] = kwargs["threshold"]
+        if "top_k" in kwargs:
+            postprocess_kwargs["top_k"] = kwargs["top_k"]
+        if "labels" in kwargs:
+            postprocess_kwargs["labels"] = kwargs["labels"]
+        if "box_format" in kwargs:
+            postprocess_kwargs["box_format"] = kwargs["box_format"]
+
         return preprocess_params, {}, postprocess_kwargs
 
     @overload
@@ -94,7 +102,21 @@ class ObjectDetectionPipeline(Pipeline):
                 same format: all as HTTP(S) links, all as local paths, or all as PIL images.
             threshold (`float`, *optional*, defaults to 0.5):
                 The probability necessary to make a prediction.
-            timeout (`float`, *optional*, defaults to None):
+            top_k (`int`, *optional*, defaults to `None`):
+                The number of top detections to return, sorted by descending confidence score. If `None` or higher
+                than the total number of detections above `threshold`, all qualifying detections are returned.
+            labels (`list[str]`, *optional*, defaults to `None`):
+                A list of class-label strings to keep. Only detections whose label appears in this list are
+                returned. If `None`, all detected classes are returned.
+            box_format (`str`, *optional*, defaults to `"xyxy"`):
+                The coordinate format for returned bounding boxes. Accepted values:
+
+                - `"xyxy"`: Returns `{"xmin": int, "ymin": int, "xmax": int, "ymax": int}` in pixel coordinates
+                  (default, fully backward-compatible).
+                - `"xywh"`: Returns `{"x_center": int, "y_center": int, "width": int, "height": int}` in pixels.
+                - `"normalized"`: Returns `{"xmin": float, "ymin": float, "xmax": float, "ymax": float}` as
+                  values in `[0, 1]` relative to the image dimensions.
+            timeout (`float`, *optional*, defaults to `None`):
                 The maximum time in seconds to wait for fetching images from the web. If None, no timeout is set and
                 the call may block forever.
 
@@ -107,7 +129,7 @@ class ObjectDetectionPipeline(Pipeline):
 
             - **label** (`str`) -- The class label identified by the model.
             - **score** (`float`) -- The score attributed by the model for that label.
-            - **box** (`list[dict[str, int]]`) -- The bounding box of detected object in image's original size.
+            - **box** (`dict`) -- The bounding box of detected object. Format depends on the `box_format` argument.
         """
         # After deprecation of this is completed, remove the default `None` value for `images`
         if "images" in kwargs and "inputs" not in kwargs:
@@ -132,7 +154,14 @@ class ObjectDetectionPipeline(Pipeline):
             model_outputs["bbox"] = model_inputs["bbox"]
         return model_outputs
 
-    def postprocess(self, model_outputs, threshold=0.5):
+    def postprocess(
+        self,
+        model_outputs,
+        threshold: float = 0.5,
+        top_k: int | None = None,
+        labels: list[str] | None = None,
+        box_format: Literal["xyxy", "xywh", "normalized"] = "xyxy",
+    ):
         target_size = model_outputs["target_size"]
         if self.tokenizer is not None:
             # This is a LayoutLMForTokenClassification variant.
@@ -148,50 +177,105 @@ class ObjectDetectionPipeline(Pipeline):
                             (width * bbox[2] / 1000),
                             (height * bbox[3] / 1000),
                         ]
-                    )
+                    ),
+                    box_format=box_format,
+                    image_size=(height, width),
                 )
 
             scores, classes = model_outputs["logits"].squeeze(0).softmax(dim=-1).max(dim=-1)
-            labels = [self.model.config.id2label[prediction] for prediction in classes.tolist()]
+            label_names = [self.model.config.id2label[prediction] for prediction in classes.tolist()]
             boxes = [unnormalize(bbox) for bbox in model_outputs["bbox"].squeeze(0)]
-            keys = ["score", "label", "box"]
-            annotation = [dict(zip(keys, vals)) for vals in zip(scores.tolist(), labels, boxes) if vals[0] > threshold]
-        else:
-            # This is a regular ForObjectDetectionModel
-            raw_annotations = self.image_processor.post_process_object_detection(model_outputs, threshold, target_size)
-            raw_annotation = raw_annotations[0]
-            scores = raw_annotation["scores"]
-            labels = raw_annotation["labels"]
-            boxes = raw_annotation["boxes"]
-
-            raw_annotation["scores"] = scores.tolist()
-            raw_annotation["labels"] = [self.model.config.id2label[label.item()] for label in labels]
-            raw_annotation["boxes"] = [self._get_bounding_box(box) for box in boxes]
-
-            # {"scores": [...], ...} --> [{"score":x, ...}, ...]
             keys = ["score", "label", "box"]
             annotation = [
                 dict(zip(keys, vals))
-                for vals in zip(raw_annotation["scores"], raw_annotation["labels"], raw_annotation["boxes"])
+                for vals in zip(scores.tolist(), label_names, boxes)
+                if vals[0] > threshold
             ]
+        else:
+            # This is a regular ForObjectDetectionModel
+            height, width = target_size[0].tolist()
+            raw_annotations = self.image_processor.post_process_object_detection(model_outputs, threshold, target_size)
+            raw_annotation = raw_annotations[0]
+
+            raw_annotation["scores"] = raw_annotation["scores"].tolist()
+            raw_annotation["labels"] = [
+                self.model.config.id2label[label.item()] for label in raw_annotation["labels"]
+            ]
+            raw_annotation["boxes"] = [
+                self._get_bounding_box(box, box_format=box_format, image_size=(height, width))
+                for box in raw_annotation["boxes"]
+            ]
+
+            # {"scores": [...], ...} --> [{"score": x, ...}, ...]
+            keys = ["score", "label", "box"]
+            annotation = [
+                dict(zip(keys, vals))
+                for vals in zip(
+                    raw_annotation["scores"],
+                    raw_annotation["labels"],
+                    raw_annotation["boxes"],
+                )
+            ]
+
+        # Sort by score descending (consistent with ZeroShotObjectDetectionPipeline
+        # and ImageClassificationPipeline)
+        annotation = sorted(annotation, key=lambda x: x["score"], reverse=True)
+
+        # Filter to label allowlist if provided
+        if labels is not None:
+            annotation = [ann for ann in annotation if ann["label"] in labels]
+
+        # Truncate to top_k highest-confidence detections
+        if top_k is not None:
+            annotation = annotation[:top_k]
 
         return annotation
 
-    def _get_bounding_box(self, box: "torch.Tensor") -> dict[str, int]:
+    def _get_bounding_box(
+        self,
+        box: "torch.Tensor",
+        box_format: Literal["xyxy", "xywh", "normalized"] = "xyxy",
+        image_size: tuple[int, int] | None = None,
+    ) -> dict:
         """
-        Turns list [xmin, xmax, ymin, ymax] into dict { "xmin": xmin, ... }
+        Converts a bounding-box tensor into a dictionary using the requested coordinate format.
 
         Args:
-            box (`torch.Tensor`): Tensor containing the coordinates in corners format.
+            box (`torch.Tensor`):
+                Tensor of shape `(4,)` with coordinates in `[xmin, ymin, xmax, ymax]` pixel format.
+            box_format (`str`, *optional*, defaults to `"xyxy"`):
+                Output format. One of `"xyxy"`, `"xywh"`, or `"normalized"`.
+            image_size (`tuple[int, int]`, *optional*):
+                `(height, width)` of the original image. Required when `box_format="normalized"`.
 
         Returns:
-            bbox (`dict[str, int]`): Dict containing the coordinates in corners format.
+            `dict`: Bounding box in the requested format.
         """
         xmin, ymin, xmax, ymax = box.int().tolist()
-        bbox = {
-            "xmin": xmin,
-            "ymin": ymin,
-            "xmax": xmax,
-            "ymax": ymax,
-        }
-        return bbox
+
+        if box_format == "xyxy":
+            return {"xmin": xmin, "ymin": ymin, "xmax": xmax, "ymax": ymax}
+
+        elif box_format == "xywh":
+            return {
+                "x_center": (xmin + xmax) // 2,
+                "y_center": (ymin + ymax) // 2,
+                "width": xmax - xmin,
+                "height": ymax - ymin,
+            }
+
+        elif box_format == "normalized":
+            if image_size is None:
+                raise ValueError("`image_size` must be provided when `box_format='normalized'`.")
+            height, width = image_size
+            return {
+                "xmin": xmin / width,
+                "ymin": ymin / height,
+                "xmax": xmax / width,
+                "ymax": ymax / height,
+            }
+
+        else:
+            raise ValueError(
+                f"Invalid `box_format` '{box_format}'. Choose one of 'xyxy', 'xywh', or 'normalized'."
+            )

--- a/tests/pipelines/test_pipelines_object_detection.py
+++ b/tests/pipelines/test_pipelines_object_detection.py
@@ -167,6 +167,153 @@ class ObjectDetectionPipelineTests(unittest.TestCase):
             ],
         )
 
+    # ── Enhancement 1 + 2: top_k parameter and score-sorted results ──────────
+
+    @require_torch
+    def test_top_k(self):
+        """top_k=1 must return exactly one detection (the highest-scoring one)."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            threshold=0.0,
+            top_k=1,
+        )
+        self.assertEqual(len(outputs), 1)
+        self.assertIn("score", outputs[0])
+        self.assertIn("label", outputs[0])
+        self.assertIn("box", outputs[0])
+
+    @require_torch
+    def test_results_sorted_by_score(self):
+        """Results must always be returned in descending score order."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            threshold=0.0,
+        )
+        scores = [o["score"] for o in outputs]
+        self.assertEqual(scores, sorted(scores, reverse=True))
+
+    # ── Enhancement 3: label filtering ───────────────────────────────────────
+
+    @require_torch
+    @slow
+    def test_label_filter(self):
+        """Only detections whose label is in the `labels` allowlist are returned."""
+        object_detector = pipeline("object-detection", model="facebook/detr-resnet-50")
+
+        all_outputs = object_detector("http://images.cocodataset.org/val2017/000000039769.jpg")
+        all_labels = {o["label"] for o in all_outputs}
+
+        target_label = "cat"
+        self.assertIn(target_label, all_labels, "Precondition: model must detect 'cat' on this image")
+
+        filtered = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            labels=[target_label],
+        )
+        self.assertGreater(len(filtered), 0)
+        for det in filtered:
+            self.assertEqual(det["label"], target_label)
+
+    @require_torch
+    def test_label_filter_excludes_all(self):
+        """If no detection matches the labels allowlist, an empty list is returned."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            threshold=0.0,
+            labels=["__nonexistent_label__"],
+        )
+        self.assertEqual(outputs, [])
+
+    # ── Enhancement 4: box_format ─────────────────────────────────────────────
+
+    @require_torch
+    def test_box_format_xyxy(self):
+        """Default box_format='xyxy' returns integer xmin/ymin/xmax/ymax keys."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            threshold=0.0,
+            box_format="xyxy",
+        )
+        for det in outputs:
+            self.assertEqual(set(det["box"].keys()), {"xmin", "ymin", "xmax", "ymax"})
+            for v in det["box"].values():
+                self.assertIsInstance(v, int)
+
+    @require_torch
+    def test_box_format_xywh(self):
+        """box_format='xywh' returns x_center/y_center/width/height integer keys."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            threshold=0.0,
+            box_format="xywh",
+        )
+        for det in outputs:
+            self.assertEqual(set(det["box"].keys()), {"x_center", "y_center", "width", "height"})
+            self.assertGreater(det["box"]["width"], 0)
+            self.assertGreater(det["box"]["height"], 0)
+
+    @require_torch
+    def test_box_format_normalized(self):
+        """box_format='normalized' returns float values in [0, 1]."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        outputs = object_detector(
+            "http://images.cocodataset.org/val2017/000000039769.jpg",
+            threshold=0.0,
+            box_format="normalized",
+        )
+        for det in outputs:
+            self.assertEqual(set(det["box"].keys()), {"xmin", "ymin", "xmax", "ymax"})
+            for v in det["box"].values():
+                self.assertIsInstance(v, float)
+                self.assertGreaterEqual(v, 0.0)
+                self.assertLessEqual(v, 1.0)
+
+    @require_torch
+    def test_box_format_invalid_raises(self):
+        """An unsupported box_format value must raise ValueError."""
+        model_id = "hf-internal-testing/tiny-detr-mobilenetsv3"
+        model = AutoModelForObjectDetection.from_pretrained(model_id)
+        image_processor = AutoImageProcessor.from_pretrained(model_id)
+        object_detector = ObjectDetectionPipeline(model=model, image_processor=image_processor)
+
+        with self.assertRaises(ValueError):
+            object_detector(
+                "http://images.cocodataset.org/val2017/000000039769.jpg",
+                threshold=0.0,
+                box_format="pascal_voc",
+            )
+
+    # ── Existing slow tests (preserved, expected outputs updated for sort order) ──
+
     @require_torch
     @slow
     def test_large_model_pt(self):
@@ -180,11 +327,11 @@ class ObjectDetectionPipelineTests(unittest.TestCase):
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
+                {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
+                {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                 {"score": 0.9982, "label": "remote", "box": {"xmin": 40, "ymin": 70, "xmax": 175, "ymax": 117}},
                 {"score": 0.9960, "label": "remote", "box": {"xmin": 333, "ymin": 72, "xmax": 368, "ymax": 187}},
                 {"score": 0.9955, "label": "couch", "box": {"xmin": 0, "ymin": 1, "xmax": 639, "ymax": 473}},
-                {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
-                {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
             ],
         )
 
@@ -198,18 +345,18 @@ class ObjectDetectionPipelineTests(unittest.TestCase):
             nested_simplify(outputs, decimals=4),
             [
                 [
+                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
+                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                     {"score": 0.9982, "label": "remote", "box": {"xmin": 40, "ymin": 70, "xmax": 175, "ymax": 117}},
                     {"score": 0.9960, "label": "remote", "box": {"xmin": 333, "ymin": 72, "xmax": 368, "ymax": 187}},
                     {"score": 0.9955, "label": "couch", "box": {"xmin": 0, "ymin": 1, "xmax": 639, "ymax": 473}},
-                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
-                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                 ],
                 [
+                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
+                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                     {"score": 0.9982, "label": "remote", "box": {"xmin": 40, "ymin": 70, "xmax": 175, "ymax": 117}},
                     {"score": 0.9960, "label": "remote", "box": {"xmin": 333, "ymin": 72, "xmax": 368, "ymax": 187}},
                     {"score": 0.9955, "label": "couch", "box": {"xmin": 0, "ymin": 1, "xmax": 639, "ymax": 473}},
-                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
-                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                 ],
             ],
         )
@@ -225,11 +372,11 @@ class ObjectDetectionPipelineTests(unittest.TestCase):
         self.assertEqual(
             nested_simplify(outputs, decimals=4),
             [
+                {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
+                {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                 {"score": 0.9982, "label": "remote", "box": {"xmin": 40, "ymin": 70, "xmax": 175, "ymax": 117}},
                 {"score": 0.9960, "label": "remote", "box": {"xmin": 333, "ymin": 72, "xmax": 368, "ymax": 187}},
                 {"score": 0.9955, "label": "couch", "box": {"xmin": 0, "ymin": 1, "xmax": 639, "ymax": 473}},
-                {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
-                {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
             ],
         )
 
@@ -243,18 +390,18 @@ class ObjectDetectionPipelineTests(unittest.TestCase):
             nested_simplify(outputs, decimals=4),
             [
                 [
+                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
+                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                     {"score": 0.9982, "label": "remote", "box": {"xmin": 40, "ymin": 70, "xmax": 175, "ymax": 117}},
                     {"score": 0.9960, "label": "remote", "box": {"xmin": 333, "ymin": 72, "xmax": 368, "ymax": 187}},
                     {"score": 0.9955, "label": "couch", "box": {"xmin": 0, "ymin": 1, "xmax": 639, "ymax": 473}},
-                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
-                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                 ],
                 [
+                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
+                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                     {"score": 0.9982, "label": "remote", "box": {"xmin": 40, "ymin": 70, "xmax": 175, "ymax": 117}},
                     {"score": 0.9960, "label": "remote", "box": {"xmin": 333, "ymin": 72, "xmax": 368, "ymax": 187}},
                     {"score": 0.9955, "label": "couch", "box": {"xmin": 0, "ymin": 1, "xmax": 639, "ymax": 473}},
-                    {"score": 0.9988, "label": "cat", "box": {"xmin": 13, "ymin": 52, "xmax": 314, "ymax": 470}},
-                    {"score": 0.9987, "label": "cat", "box": {"xmin": 345, "ymin": 23, "xmax": 640, "ymax": 368}},
                 ],
             ],
         )


### PR DESCRIPTION
## What this PR does

This PR brings `ObjectDetectionPipeline` in line with its sister pipelines (`ZeroShotObjectDetectionPipeline`, `ImageClassificationPipeline`) by adding four enhancements to the postprocessing stage.

### Changes

**1. Score sorting** — results are now always returned sorted by descending confidence score, consistent with `ZeroShotObjectDetectionPipeline` and `ImageClassificationPipeline`. Previously `ObjectDetectionPipeline` was the only vision pipeline that returned results in raw model-output order (anchor order), which was unintuitive and undocumented.

**2. `top_k` parameter** — allows users to cap the number of returned detections to the N highest-confidence results. Defaults to `None` (return all detections above `threshold`), preserving full backward compatibility.

**3. `labels` parameter** — accepts a list of class-name strings; only detections whose label appears in the list are returned. This is a novel filtering capability with no prior equivalent in the standard object detection pipeline. Defaults to `None` (return all detected classes).

**4. `box_format` parameter** — controls the coordinate format of the returned bounding boxes. Supported values:
- `"xyxy"` *(default, backward-compatible)*: `{xmin, ymin, xmax, ymax}` in pixels
- `"xywh"`: `{x_center, y_center, width, height}` in pixels
- `"normalized"`: `{xmin, ymin, xmax, ymax}` as floats in `[0, 1]` relative to image dimensions

The `_get_bounding_box` helper is extended to handle all three formats in one place.

## Motivation

- `ZeroShotObjectDetectionPipeline` already has `top_k` and sorted outputs (see `postprocess`)
- `ImageClassificationPipeline` already has `top_k` and sorted outputs
- `ObjectDetectionPipeline` was the only vision pipeline missing these features, creating an inconsistency across the pipeline family
- `box_format` and `labels` are new capabilities addressing common downstream use-cases (COCO eval tools, Roboflow, OpenCV, torchvision draw utilities all expect different box formats; class filtering is a very common need)

## Breaking changes

None. All four new parameters are fully optional with safe defaults:
- `top_k=None` → no truncation
- `labels=None` → no filtering
- `box_format="xyxy"` → identical output to before
- Score sorting is the only behavioral change to default output; results are now consistently ordered highest-to-lowest (expected order by virtually all downstream consumers)

Existing slow test expected outputs in `test_large_model_pt` and `test_integration_torch_object_detection` are updated to reflect the new sorted order.

## Tests added

8 new unit tests covering all new parameters and edge cases:

| Test | Enhancement | Speed |
|---|---|---|
| `test_top_k` | top_k truncation to N results | Fast |
| `test_results_sorted_by_score` | score sort order guarantee | Fast |
| `test_label_filter` | label allowlist filtering (match) | Slow |
| `test_label_filter_excludes_all` | label allowlist (no match → empty list) | Fast |
| `test_box_format_xyxy` | xyxy format returns int keys | Fast |
| `test_box_format_xywh` | xywh format returns correct keys and positive dims | Fast |
| `test_box_format_normalized` | normalized format returns floats in [0,1] | Fast |
| `test_box_format_invalid_raises` | unsupported format raises ValueError | Fast |

## Files changed

- `src/transformers/pipelines/object_detection.py`
- `tests/pipelines/test_pipelines_object_detection.py`