### PR TITLE
Fix TypeError when loading float8 models by falling back to bfloat16 in local_torch_dtype

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -235,6 +235,11 @@ def local_torch_dtype(dtype: torch.dtype, model_class_name: str | None = None):
             error_message = f"Cannot set `{dtype}` as torch's default as it's not a floating-point dtype"
         raise ValueError(error_message)
 
+    # float8 types (e.g. float8_e4m3fn, float8_e5m2) are not supported by torch.set_default_dtype.
+    # Fall back to bfloat16 for model initialization; actual float8 weights are loaded separately.
+    if "float8" in str(dtype):
+        dtype = torch.bfloat16
+
     original_dtype = torch.get_default_dtype()
     try:
         torch.set_default_dtype(dtype)

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1960,6 +1960,27 @@ class ModelUtilsTest(TestCasePlus):
         self.assertTrue(torch.get_default_dtype() == torch.float32)
         torch.set_default_dtype(old_dtype)
 
+    def test_local_torch_dtype_float8_fallback(self):
+        """
+        Tests that `local_torch_dtype` gracefully handles float8 dtypes by falling back to bfloat16,
+        since `torch.set_default_dtype` does not support float8 types.
+        See https://github.com/huggingface/transformers/issues/44589
+        """
+        from transformers.modeling_utils import local_torch_dtype
+
+        old_dtype = torch.get_default_dtype()
+
+        # float8_e4m3fn should fall back to bfloat16 without raising
+        with local_torch_dtype(torch.float8_e4m3fn):
+            self.assertEqual(torch.get_default_dtype(), torch.bfloat16)
+
+        # float8_e5m2 should also fall back to bfloat16 without raising
+        with local_torch_dtype(torch.float8_e5m2):
+            self.assertEqual(torch.get_default_dtype(), torch.bfloat16)
+
+        # default dtype should be restored after exiting
+        self.assertEqual(torch.get_default_dtype(), old_dtype)
+
     def test_unknown_quantization_config(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             config = BertConfig(


### PR DESCRIPTION
Fix TypeError when loading float8 models by falling back to bfloat16 in local_torch_dtype

# What does this PR do?

When loading FP8 models (e.g. `Qwen/Qwen3.5-35B-A3B-FP8`) with `dtype="auto"`, the auto-detected dtype from checkpoint weights can be `torch.float8_e4m3fn`. This dtype flows to `local_torch_dtype()` which calls `torch.set_default_dtype()`, but PyTorch does not support float8 types as default dtype, causing:
TypeError: couldn't find storage object Float8_e4m3fnStorage

This happens when:
- The top-level config has no `dtype` set (common with composite models where `dtype` is only in a sub-config)
- `_get_dtype()` auto-detects `torch.float8_e4m3fn` from the checkpoint weights
- `FineGrainedFP8HfQuantizer` doesn't override `update_dtype()`, so it can't intercept this

This PR adds a check in `local_torch_dtype()` to fall back to `torch.bfloat16` when a float8 dtype is encountered. This only affects model skeleton initialization (`set_default_dtype`); actual float8 weights are still loaded correctly downstream via `_load_pretrained_model`.

Also adds a unit test to verify the fallback behavior for both `float8_e4m3fn` and `float8_e5m2`.

Fixes #44589

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. https://github.com/huggingface/transformers/issues/44589
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@CyrilVallez (model loading / from_pretrained)
@SunMarc (quantization)
