### PR TITLE
Remove useless identity assignment

### DIFF
--- a/src/transformers/models/paligemma/modeling_paligemma.py
+++ b/src/transformers/models/paligemma/modeling_paligemma.py
@@ -268,7 +268,6 @@ class PaliGemmaModel(PaliGemmaPreTrainedModel):
         image_outputs = self.vision_tower(pixel_values, return_dict=True, **kwargs)
         selected_image_feature = image_outputs.last_hidden_state
         image_features = self.multi_modal_projector(selected_image_feature)
-        image_features = image_features
         image_outputs.pooler_output = image_features
 
         return image_outputs


### PR DESCRIPTION
# What does this PR do?

Small mistake in https://github.com/huggingface/transformers/pull/44432. cc @zucchini-nlp, was it intended to remove the scaling? (I assume so since the embedding now has the saling baked in, and I guess paligemma always uses gemma?)