### PR TITLE
Restore is_torch_fx_available for trust_remote_code backwards compatibility

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -25,6 +25,7 @@ import re
 import shutil
 import subprocess
 import sys
+import warnings
 from collections import OrderedDict
 from collections.abc import Callable
 from enum import Enum
@@ -186,6 +187,40 @@ def is_torch_less_or_equal(library_version: str, accept_dev: bool = False) -> bo
         return version.parse(version.parse(get_torch_version()).base_version) <= version.parse(library_version)
     else:
         return version.parse(get_torch_version()) <= version.parse(library_version)
+
+
+@lru_cache
+def is_torch_fx_available() -> bool:
+    """
+    Backwards-compatibility shim for remote code that still imports this symbol
+    from `transformers.utils.import_utils`.
+
+    In Transformers v5+, we require PyTorch >= 2.4 where `torch.fx` is always
+    available. This function therefore simply checks that PyTorch itself is
+    available and returns True in that case.
+
+    This API is deprecated and will be removed in a future major release.
+    Remote code should stop relying on it and instead assume `torch.fx` is
+    available under the supported PyTorch versions.
+    """
+    warnings.warn(
+        "`is_torch_fx_available` is deprecated and kept only for backwards "
+        "compatibility with older `trust_remote_code` models. It now simply "
+        "checks for the presence of PyTorch >= 2.4 and always returns True "
+        "in that case.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+
+    if not is_torch_available():
+        return False
+
+    try:
+        import torch.fx  # noqa: F401
+    except Exception:
+        return False
+
+    return True
 
 
 @lru_cache


### PR DESCRIPTION
# What does this PR do?

Restores `is_torch_fx_available` in `transformers.utils.import_utils` as a backwards-compatibility shim so that Hub models loaded with `trust_remote_code=True` that still import this symbol no longer raise `ImportError` on Transformers v5+.

**Context:** In v5, `is_torch_fx_available` was removed from `import_utils`. Many community models (e.g. `deepseek-ai/deepseek-moe-16b-base`) ship their own `modeling_*.py` and still do `from transformers.utils.import_utils import is_torch_fx_available`, which breaks at import time when using v5.

**Changes:**
- Re-add `is_torch_fx_available()` in `src/transformers/utils/import_utils.py`.
- The function emits a one-time `DeprecationWarning` (via `@lru_cache`), returns `False` if PyTorch is not available, and otherwise checks that `torch.fx` can be imported and returns `True`/`False`.
- Under the v5 requirement (PyTorch >= 2.4), `torch.fx` is always available, so behavior for existing callers is unchanged.

Fixes #44561

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @Rocketknight1 — this restores a symbol removed in v5 that breaks `trust_remote_code` models (see #44561). Optional: @CyrilVallez for model-loading/import-utils context.