### PR TITLE
Fix for `VibeVoiceAcousticTokenizer`

### DIFF
--- a/src/transformers/models/vibevoice_acoustic_tokenizer/configuration_vibevoice_acoustic_tokenizer.py
+++ b/src/transformers/models/vibevoice_acoustic_tokenizer/configuration_vibevoice_acoustic_tokenizer.py
@@ -19,7 +19,7 @@ from ...configuration_utils import PretrainedConfig
 from ...utils import auto_docstring
 
 
-@auto_docstring(checkpoint="microsoft/VibeVoice-1.5B")
+@auto_docstring(checkpoint="microsoft/VibeVoice-AcousticTokenizer")
 class VibeVoiceAcousticTokenizerConfig(PretrainedConfig):
     r"""
     channels (`int`, *optional*, defaults to 1):
@@ -101,7 +101,7 @@ class VibeVoiceAcousticTokenizerConfig(PretrainedConfig):
         return VibeVoiceAcousticTokenizerDecoderConfig(**config_dict)
 
 
-@auto_docstring(checkpoint="microsoft/VibeVoice-1.5B")
+@auto_docstring(checkpoint="microsoft/VibeVoice-AcousticTokenizer")
 class VibeVoiceAcousticTokenizerEncoderConfig(VibeVoiceAcousticTokenizerConfig):
     model_type = "vibevoice_acoustic_tokenizer_encoder"
     base_config_key = "encoder_config"
@@ -115,7 +115,7 @@ class VibeVoiceAcousticTokenizerEncoderConfig(VibeVoiceAcousticTokenizerConfig):
         return None
 
 
-@auto_docstring(checkpoint="microsoft/VibeVoice-1.5B")
+@auto_docstring(checkpoint="microsoft/VibeVoice-AcousticTokenizer")
 class VibeVoiceAcousticTokenizerDecoderConfig(VibeVoiceAcousticTokenizerConfig):
     model_type = "vibevoice_acoustic_tokenizer_decoder"
     base_config_key = "decoder_config"

--- a/src/transformers/models/vibevoice_acoustic_tokenizer/configuration_vibevoice_acoustic_tokenizer.py
+++ b/src/transformers/models/vibevoice_acoustic_tokenizer/configuration_vibevoice_acoustic_tokenizer.py
@@ -106,11 +106,27 @@ class VibeVoiceAcousticTokenizerEncoderConfig(VibeVoiceAcousticTokenizerConfig):
     model_type = "vibevoice_acoustic_tokenizer_encoder"
     base_config_key = "encoder_config"
 
+    @property
+    def encoder_config(self):
+        return None
+
+    @property
+    def decoder_config(self):
+        return None
+
 
 @auto_docstring(checkpoint="microsoft/VibeVoice-1.5B")
 class VibeVoiceAcousticTokenizerDecoderConfig(VibeVoiceAcousticTokenizerConfig):
     model_type = "vibevoice_acoustic_tokenizer_decoder"
     base_config_key = "decoder_config"
+
+    @property
+    def encoder_config(self):
+        return None
+
+    @property
+    def decoder_config(self):
+        return None
 
     @property
     def upsampling_ratios(self):

--- a/src/transformers/models/vibevoice_acoustic_tokenizer/modeling_vibevoice_acoustic_tokenizer.py
+++ b/src/transformers/models/vibevoice_acoustic_tokenizer/modeling_vibevoice_acoustic_tokenizer.py
@@ -30,7 +30,11 @@ from ...integrations import use_kernel_forward_from_hub
 from ...modeling_utils import PreTrainedModel
 from ...utils import ModelOutput, auto_docstring, can_return_tuple, is_torchdynamo_compiling
 from ..auto.modeling_auto import AutoModel
-from .configuration_vibevoice_acoustic_tokenizer import VibeVoiceAcousticTokenizerConfig
+from .configuration_vibevoice_acoustic_tokenizer import (
+    VibeVoiceAcousticTokenizerConfig,
+    VibeVoiceAcousticTokenizerDecoderConfig,
+    VibeVoiceAcousticTokenizerEncoderConfig,
+)
 
 
 @dataclass
@@ -367,6 +371,8 @@ class VibeVoiceAcousticTokenizerPreTrainedModel(PreTrainedModel):
 
 
 class VibeVoiceAcousticTokenizerEncoderModel(VibeVoiceAcousticTokenizerPreTrainedModel):
+    config: VibeVoiceAcousticTokenizerEncoderConfig
+
     def __init__(self, config):
         super().__init__(config)
 
@@ -458,6 +464,8 @@ class VibeVoiceAcousticTokenizerDecoderLayer(nn.Module):
 
 
 class VibeVoiceAcousticTokenizerDecoderModel(VibeVoiceAcousticTokenizerPreTrainedModel):
+    config: VibeVoiceAcousticTokenizerDecoderConfig
+
     def __init__(self, config):
         super().__init__(config)
 

--- a/src/transformers/models/vibevoice_acoustic_tokenizer/modular_vibevoice_acoustic_tokenizer.py
+++ b/src/transformers/models/vibevoice_acoustic_tokenizer/modular_vibevoice_acoustic_tokenizer.py
@@ -25,7 +25,11 @@ from ...utils import ModelOutput, auto_docstring, can_return_tuple
 from ..auto.modeling_auto import AutoModel
 from ..llama.modeling_llama import LlamaRMSNorm
 from ..voxtral_realtime.modeling_voxtral_realtime import VoxtralRealtimeConv1dPaddingCache
-from .configuration_vibevoice_acoustic_tokenizer import VibeVoiceAcousticTokenizerConfig
+from .configuration_vibevoice_acoustic_tokenizer import (
+    VibeVoiceAcousticTokenizerConfig,
+    VibeVoiceAcousticTokenizerDecoderConfig,
+    VibeVoiceAcousticTokenizerEncoderConfig,
+)
 
 
 @dataclass
@@ -289,6 +293,8 @@ class VibeVoiceAcousticTokenizerPreTrainedModel(PreTrainedModel):
 
 
 class VibeVoiceAcousticTokenizerEncoderModel(VibeVoiceAcousticTokenizerPreTrainedModel):
+    config: VibeVoiceAcousticTokenizerEncoderConfig
+
     def __init__(self, config):
         super().__init__(config)
 
@@ -380,6 +386,8 @@ class VibeVoiceAcousticTokenizerDecoderLayer(nn.Module):
 
 
 class VibeVoiceAcousticTokenizerDecoderModel(VibeVoiceAcousticTokenizerPreTrainedModel):
+    config: VibeVoiceAcousticTokenizerDecoderConfig
+
     def __init__(self, config):
         super().__init__(config)
 


### PR DESCRIPTION
# What does this PR do?

- `encoder_config` and `decoder_config` should return `None` for encoder / decoder config classes themselves.
- The encoder / decoder model classes should have the correct config classes associated to them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized configuration/typing fixes that mainly affect model instantiation and doc metadata, with minimal runtime behavior changes.
> 
> **Overview**
> Fixes `VibeVoiceAcousticTokenizer` config/model wiring by updating the documented checkpoint to `microsoft/VibeVoice-AcousticTokenizer` and preventing `VibeVoiceAcousticTokenizerEncoderConfig`/`...DecoderConfig` from recursively producing nested `encoder_config`/`decoder_config` (they now return `None`).
> 
> Also tightens typing by associating `VibeVoiceAcousticTokenizerEncoderModel` and `VibeVoiceAcousticTokenizerDecoderModel` with their respective config classes in both the modular and generated modeling files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3fdac1a6b64efc9612d468a50196a5565f956068. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->