### PR TITLE
Fix Qwen3.5 num_labels propagation to text_config (fix #44625)

### DIFF
--- a/src/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -236,5 +236,27 @@ class Qwen3_5Config(PreTrainedConfig):
         self.tie_word_embeddings = tie_word_embeddings
         super().__init__(**kwargs)
 
+        # Keep the top-level `num_labels` in sync with the text sub-config so
+        # that sequence classification heads see a consistent label space when
+        # the config is constructed directly with `num_labels=...`.
+        if getattr(self, "text_config", None) is not None:
+            if getattr(self.text_config, "num_labels", None) != getattr(self, "num_labels", None):
+                self.text_config.num_labels = self.num_labels
+
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+        if key == "num_labels" and getattr(self, "text_config", None) is not None:
+            self.text_config.num_labels = value
+
+    def update(self, config_dict):
+        """
+        Extend the base update logic so that an updated top-level `num_labels`
+        is also reflected in the text sub-config used for classification when
+        the config is modified via `config.update(...)` (used by AutoConfig).
+        """
+        super().update(config_dict)
+        if "num_labels" in config_dict and getattr(self, "text_config", None) is not None:
+            self.text_config.num_labels = self.num_labels
+
 
 __all__ = ["Qwen3_5Config", "Qwen3_5TextConfig"]

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -211,6 +211,26 @@ class Qwen3_5Config(Qwen3VLConfig):
             **kwargs,
         )
 
+        # Ensure that the top-level `num_labels` stays in sync with the text
+        # sub-config used by sequence classification heads.
+        if getattr(self, "text_config", None) is not None:
+            if getattr(self.text_config, "num_labels", None) != getattr(self, "num_labels", None):
+                self.text_config.num_labels = self.num_labels
+
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+        if key == "num_labels" and getattr(self, "text_config", None) is not None:
+            self.text_config.num_labels = value
+
+    def update(self, config_dict):
+        """
+        Extend the base update logic so that an updated top-level `num_labels`
+        is also reflected in the text sub-config used for classification.
+        """
+        super().update(config_dict)
+        if "num_labels" in config_dict and getattr(self, "text_config", None) is not None:
+            self.text_config.num_labels = self.num_labels
+
 
 class Qwen3_5DynamicCache(Qwen3NextDynamicCache):
     pass


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where `num_labels` passed to `AutoConfig.from_pretrained` for Qwen3.5 did not propagate from the top‑level `Qwen3_5Config` into the `text_config`, so `AutoModelForSequenceClassification` still saw the default `text_config.num_labels=2`.

This made it impossible to correctly configure Qwen3.5 `ForSequenceClassification` by just passing `num_labels` on the main config; users had to manually pass a nested `text_config={"num_labels": ..., "id2label": ...}` instead (see [#44625](https://github.com/huggingface/transformers/issues/44625)).

**Changes:**

- In `Qwen3_5Config` (both modular and generated versions), ensure that the text sub-config stays in sync with the top‑level label space:
  - After construction, if `text_config.num_labels` differs from `num_labels`, set `text_config.num_labels = num_labels`.
  - Override `__setattr__` so that any later assignment to `config.num_labels` also updates `config.text_config.num_labels`.
  - Add an `update(...)` override in the modular config to keep behavior consistent when configs are updated via `config.update(...)`.

With this change, the reporter’s snippet now behaves as expected:

```python
config = AutoConfig.from_pretrained(model_name, num_labels=1)
assert config.num_labels == 1
assert config.text_config.num_labels == 1

model = AutoModelForSequenceClassification.from_pretrained(model_name, config=config)
assert model.config.num_labels == 1
```

Fixes #44625

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@zucchini-nlp (Qwen / multimodal + classification configs)
Optional: @CyrilVallez for config / model-loading context.