### PR TITLE
Conditinally passing and_mask_function arg to create_causal_mask 

### DIFF
--- a/src/transformers/models/falcon/modeling_falcon.py
+++ b/src/transformers/models/falcon/modeling_falcon.py
@@ -784,7 +784,7 @@ class FalconModel(FalconPreTrainedModel):
             cache_position=cache_position,
             past_key_values=past_key_values,
             # Force mask creation for alibi
-            and_mask_function=lambda *args: torch.tensor(True, dtype=torch.bool),
+            and_mask_function=(lambda *args: torch.tensor(True, dtype=torch.bool)) if self.use_alibi else None,
         )
         if alibi is not None and causal_mask is not None and causal_mask.ndim == 4:
             min_dtype = torch.finfo(inputs_embeds.dtype).min


### PR DESCRIPTION
# What does this PR do?

Issue: A full 4D attention mask of shape `[1, 1, seq_len, seq_len]` is being created during attention, even when not using alibi for positional embeddings. 
- This occupied extra memory during training. 

Root Cause:
The `create_causal_mask` call in the Falcon model was passing an `and_mask_function` argument:
```
causal_mask = create_causal_mask(
    ...
    and_mask_function=lambda *args: torch.tensor(True, dtype=torch.bool),  # Forces mask creation
)
```

This was added with the comment "Force mask creation for alibi" - as ALiBi positional encoding requires the materialized mask to apply linear biases to attention scores.

However, in Falcon model even when alibi is not used, the `and_mask_function` argument unconditionally sets `allow_is_causal_skip = False`, which materializes a full `seq_len x seq_len` shaped mask. 

Fix:
Only pass `and_mask_function`  to `create_causal_mask`  function when alibi is used.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
