### PR TITLE
Clarify that causal LM labels are shifted internally

### DIFF
--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -1788,9 +1788,13 @@ class ConfigArgs:
 class ModelArgs:
     labels = {
         "description": """
-    Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+    Labels for computing the language modeling loss. Indices should either be in `[0, ...,
     config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
     (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+    For causal language models, the labels are **shifted internally** so that `labels[..., 1:]` are used to
+    predict `logits[..., :-1, :]`. This means you should pass unshifted labels matching `input_ids` (i.e.
+    `labels = input_ids`). Do **not** shift the labels yourself before passing them.
     """,
         "shape": "of shape `(batch_size, sequence_length)`",
     }


### PR DESCRIPTION
The generic `labels` docstring in `ModelArgs` says "masked language modeling loss" and doesn't mention that causal LM models shift labels internally. This has tripped up a lot of users who pre-shift their labels and end up training next-next-token prediction by accident.

Updates the shared docstring to say "language modeling loss" (since it's used by causal LM models too, not just masked LM) and adds a note explaining that causal LM models handle the shifting, so users should pass `labels = input_ids`.

Fixes #32944