### PR TITLE
Fix Seq2SeqTrainer generation path for decoder-only models

### DIFF
--- a/src/transformers/trainer_seq2seq.py
+++ b/src/transformers/trainer_seq2seq.py
@@ -319,6 +319,35 @@ class Seq2SeqTrainer(Trainer):
                 k: v for k, v in inputs.items() if k not in ("decoder_input_ids", "decoder_attention_mask")
             }
 
+        is_encoder_decoder = getattr(model.config, "is_encoder_decoder", False)
+        if not is_encoder_decoder and "generation_input_ids" in generation_inputs:
+            generation_input_ids = generation_inputs.pop("generation_input_ids")
+            generation_attention_mask = generation_inputs.pop("generation_attention_mask", None)
+            generation_inputs["input_ids"] = generation_input_ids
+
+            if generation_attention_mask is not None:
+                generation_inputs["attention_mask"] = generation_attention_mask
+            elif (
+                "attention_mask" not in generation_inputs
+                or generation_inputs["attention_mask"].shape != generation_input_ids.shape
+            ):
+                generation_inputs["attention_mask"] = torch.ones_like(generation_input_ids)
+        elif not is_encoder_decoder and "labels" in generation_inputs and "input_ids" in generation_inputs:
+            generation_input_ids, generation_attention_mask = self._prepare_decoder_only_generation_inputs(
+                generation_inputs["input_ids"],
+                generation_inputs.get("attention_mask"),
+                generation_inputs["labels"],
+            )
+            if generation_input_ids is not None:
+                generation_inputs["input_ids"] = generation_input_ids
+                generation_inputs["attention_mask"] = generation_attention_mask
+
+        prompt_input_length = (
+            generation_inputs["input_ids"].shape[-1]
+            if (not is_encoder_decoder and "input_ids" in generation_inputs)
+            else None
+        )
+
         summon_full_params_context = (
             FullyShardedDataParallel.summon_full_params(self.model)
             if torch.distributed.is_available() and isinstance(self.model, FullyShardedDataParallel)
@@ -327,6 +356,8 @@ class Seq2SeqTrainer(Trainer):
 
         with summon_full_params_context:
             generated_tokens = self.model.generate(**generation_inputs, **gen_kwargs)
+            if prompt_input_length is not None:
+                generated_tokens = generated_tokens[:, prompt_input_length:]
 
         # Temporary hack to ensure the generation config is not initialized for each iteration of the evaluation loop
         # TODO: remove this hack when the legacy code that initializes generation_config from a model config is
@@ -371,19 +402,58 @@ class Seq2SeqTrainer(Trainer):
 
         return loss, generated_tokens, labels
 
-    def _pad_tensors_to_max_len(self, tensor, max_length):
+    @staticmethod
+    def _get_prompt_lengths_from_labels(labels: torch.Tensor) -> torch.Tensor:
+        # Labels use -100 to mask prompt tokens; we only keep the contiguous prefix.
+        prompt_prefix_mask = labels.eq(-100).long().cumprod(dim=-1).bool()
+        return prompt_prefix_mask.long().sum(dim=-1)
+
+    def _prepare_decoder_only_generation_inputs(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor | None,
+        labels: torch.Tensor,
+    ) -> tuple[torch.Tensor | None, torch.Tensor | None]:
+        prompt_lengths = self._get_prompt_lengths_from_labels(labels)
+        if prompt_lengths.max().item() == 0:
+            return None, None
+
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
+
+        valid_lengths = attention_mask.long().sum(dim=-1)
+        prompt_lengths = torch.where(prompt_lengths > 0, prompt_lengths, valid_lengths)
+        max_prompt_length = int(prompt_lengths.max().item())
+        pad_token_id = self._get_pad_token_id()
+
+        generation_input_ids = input_ids.new_full((input_ids.shape[0], max_prompt_length), pad_token_id)
+        generation_attention_mask = attention_mask.new_zeros((input_ids.shape[0], max_prompt_length))
+
+        for row_idx, prompt_length in enumerate(prompt_lengths.tolist()):
+            if prompt_length == 0:
+                continue
+
+            generation_input_ids[row_idx, -prompt_length:] = input_ids[row_idx, :prompt_length]
+            generation_attention_mask[row_idx, -prompt_length:] = 1
+
+        return generation_input_ids, generation_attention_mask
+
+    def _get_pad_token_id(self) -> int:
         if self.processing_class is not None and hasattr(self.processing_class, "pad_token_id"):
-            # If PAD token is not defined at least EOS token has to be defined
             pad_token_id = (
                 self.processing_class.pad_token_id
                 if self.processing_class.pad_token_id is not None
                 else self.processing_class.eos_token_id
             )
+        elif getattr(self.model.config, "pad_token_id", None) is not None:
+            pad_token_id = self.model.config.pad_token_id
         else:
-            if getattr(self.model.config, "pad_token_id", None) is not None:
-                pad_token_id = self.model.config.pad_token_id
-            else:
-                raise ValueError("Pad_token_id must be set in the configuration of the model, in order to pad tensors")
+            raise ValueError("Pad_token_id must be set in the configuration of the model, in order to pad tensors")
+
+        return pad_token_id
+
+    def _pad_tensors_to_max_len(self, tensor, max_length):
+        pad_token_id = self._get_pad_token_id()
 
         padded_tensor = pad_token_id * torch.ones(
             (tensor.shape[0], max_length), dtype=tensor.dtype, device=tensor.device

--- a/tests/trainer/test_trainer_seq2seq.py
+++ b/tests/trainer/test_trainer_seq2seq.py
@@ -15,6 +15,7 @@
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from transformers import (
@@ -52,11 +53,122 @@ if is_datasets_available():
 
 if is_torch_available():
     import torch
+    from torch import nn
+
+
+if is_torch_available():
+
+    class DummyGenerationModel(nn.Module):
+        def __init__(self, is_encoder_decoder: bool = False):
+            super().__init__()
+            self.config = SimpleNamespace(is_encoder_decoder=is_encoder_decoder, pad_token_id=0)
+            self.generation_config = GenerationConfig(
+                max_length=6, max_new_tokens=None, pad_token_id=0, eos_token_id=1
+            )
+            self.last_generate_kwargs = None
+
+        def forward(self, input_ids, labels=None, **kwargs):
+            logits = torch.zeros(*input_ids.shape, 8, device=input_ids.device)
+            loss = torch.tensor(0.0, device=input_ids.device)
+            return {"loss": loss, "logits": logits}
+
+        def generate(self, input_ids, attention_mask=None, **kwargs):
+            captured_kwargs = {"input_ids": input_ids, "attention_mask": attention_mask, **kwargs}
+            self.last_generate_kwargs = {
+                key: value.detach().clone() if torch.is_tensor(value) else value
+                for key, value in captured_kwargs.items()
+            }
+            generated_token = torch.full((input_ids.shape[0], 1), 9, dtype=input_ids.dtype, device=input_ids.device)
+            return torch.cat([input_ids, generated_token], dim=-1)
 
 
 set_seed(42)
 MARIAN_MODEL = "sshleifer/student_marian_en_ro_6_1"
 MBART_TINY = "sshleifer/tiny-mbart"
+
+
+@require_torch
+class Seq2SeqTrainerPredictionStepTester(TestCasePlus):
+    def _get_trainer_and_model(self, is_encoder_decoder: bool = False):
+        model = DummyGenerationModel(is_encoder_decoder=is_encoder_decoder)
+        training_args = Seq2SeqTrainingArguments(
+            self.get_auto_remove_tmp_dir(),
+            predict_with_generate=True,
+            report_to="none",
+            per_device_eval_batch_size=2,
+        )
+        trainer = Seq2SeqTrainer(model=model, args=training_args)
+        return trainer, model
+
+    def test_decoder_only_prediction_step_uses_generate(self):
+        trainer, model = self._get_trainer_and_model(is_encoder_decoder=False)
+        inputs = {
+            "input_ids": torch.tensor([[4, 5, 6], [7, 8, 9]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long),
+            "labels": torch.tensor([[4, 5, 6], [7, 8, 9]], dtype=torch.long),
+        }
+
+        loss, generated_tokens, _ = trainer.prediction_step(model, inputs, prediction_loss_only=False)
+
+        self.assertIsNotNone(loss)
+        self.assertIsNotNone(model.last_generate_kwargs)
+        self.assertEqual(generated_tokens[0, 0].item(), 9)
+
+    def test_decoder_only_uses_generation_inputs_when_provided(self):
+        trainer, model = self._get_trainer_and_model(is_encoder_decoder=False)
+        inputs = {
+            "input_ids": torch.tensor([[50, 51, 52], [60, 61, 62]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long),
+            "generation_input_ids": torch.tensor([[11, 12], [21, 22]], dtype=torch.long),
+            "generation_attention_mask": torch.tensor([[1, 1], [1, 1]], dtype=torch.long),
+            "labels": torch.tensor([[-100, 12, 13], [-100, 22, 23]], dtype=torch.long),
+        }
+
+        _, generated_tokens, _ = trainer.prediction_step(model, inputs, prediction_loss_only=False)
+
+        self.assertTrue(torch.equal(model.last_generate_kwargs["input_ids"].cpu(), inputs["generation_input_ids"]))
+        self.assertTrue(
+            torch.equal(model.last_generate_kwargs["attention_mask"].cpu(), inputs["generation_attention_mask"])
+        )
+        self.assertNotIn("generation_input_ids", model.last_generate_kwargs)
+        self.assertNotIn("generation_attention_mask", model.last_generate_kwargs)
+        self.assertEqual(generated_tokens[0, 0].item(), 9)
+        self.assertEqual(generated_tokens.shape[-1], model.generation_config.max_length)
+
+    def test_decoder_only_builds_left_padded_prompt_from_labels(self):
+        trainer, model = self._get_trainer_and_model(is_encoder_decoder=False)
+        inputs = {
+            "input_ids": torch.tensor([[11, 12, 21, 22, 0], [31, 32, 33, 41, 42]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1, 1, 0], [1, 1, 1, 1, 1]], dtype=torch.long),
+            "labels": torch.tensor([[-100, -100, 21, 22, -100], [-100, -100, -100, 41, 42]], dtype=torch.long),
+        }
+
+        _, generated_tokens, labels = trainer.prediction_step(model, inputs, prediction_loss_only=False)
+
+        expected_input_ids = torch.tensor([[0, 11, 12], [31, 32, 33]], dtype=torch.long)
+        expected_attention_mask = torch.tensor([[0, 1, 1], [1, 1, 1]], dtype=torch.long)
+
+        self.assertTrue(torch.equal(model.last_generate_kwargs["input_ids"].cpu(), expected_input_ids))
+        self.assertTrue(torch.equal(model.last_generate_kwargs["attention_mask"].cpu(), expected_attention_mask))
+        self.assertEqual(generated_tokens[0, 0].item(), 9)
+        self.assertEqual(generated_tokens.shape[-1], model.generation_config.max_length)
+        self.assertEqual(labels.shape[-1], model.generation_config.max_length)
+
+    def test_encoder_decoder_path_remains_unchanged(self):
+        trainer, model = self._get_trainer_and_model(is_encoder_decoder=True)
+        inputs = {
+            "input_ids": torch.tensor([[2, 3, 4], [5, 6, 7]], dtype=torch.long),
+            "attention_mask": torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long),
+            "decoder_input_ids": torch.tensor([[9, 9, 9], [8, 8, 8]], dtype=torch.long),
+            "decoder_attention_mask": torch.tensor([[1, 1, 1], [1, 1, 1]], dtype=torch.long),
+            "labels": torch.tensor([[9, 9, 9], [8, 8, 8]], dtype=torch.long),
+        }
+
+        trainer.prediction_step(model, inputs, prediction_loss_only=False)
+
+        self.assertNotIn("decoder_input_ids", model.last_generate_kwargs)
+        self.assertNotIn("decoder_attention_mask", model.last_generate_kwargs)
+        self.assertTrue(torch.equal(model.last_generate_kwargs["input_ids"].cpu(), inputs["input_ids"]))
 
 
 @require_sentencepiece


### PR DESCRIPTION
Closes #44593

## Summary
- use generation_input_ids/generation_attention_mask when provided for decoder-only models
- otherwise infer prompt from leading -100 labels and build left-padded prompt batch
- return completion tokens for decoder-only generation (strip prompt)
- keep encoder-decoder behavior unchanged

## Tests
- PYTHONPATH=src python -m pytest tests/trainer/test_trainer_seq2seq.py -k Seq2SeqTrainerPredictionStepTester -q -rs

Related #26474, #33396
Follow-up to #32346