### PR TITLE
Fix Qwen3.5 num_labels not propagated to text_config

### DIFF
--- a/src/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -236,5 +236,10 @@ class Qwen3_5Config(PreTrainedConfig):
         self.tie_word_embeddings = tie_word_embeddings
         super().__init__(**kwargs)
 
+        # Propagate num_labels to text_config so that sequence classification
+        # models that rely on text_config.num_labels get the correct value.
+        if self.text_config.num_labels != self.num_labels:
+            self.text_config.num_labels = self.num_labels
+
 
 __all__ = ["Qwen3_5Config", "Qwen3_5TextConfig"]

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -211,6 +211,11 @@ class Qwen3_5Config(Qwen3VLConfig):
             **kwargs,
         )
 
+        # Propagate num_labels to text_config so that sequence classification
+        # models that rely on text_config.num_labels get the correct value.
+        if self.text_config.num_labels != self.num_labels:
+            self.text_config.num_labels = self.num_labels
+
 
 class Qwen3_5DynamicCache(Qwen3NextDynamicCache):
     pass


### PR DESCRIPTION
## Summary

Fixes #44625

When passing `num_labels` to `AutoConfig.from_pretrained` for Qwen3.5, the value is set on the outer `Qwen3_5Config` but not propagated to `text_config`. This causes `AutoModelForSequenceClassification` to use the default `num_labels=2` from `text_config` instead of the user-specified value.

## Fix

After the parent `__init__` completes (which sets `num_labels` on the outer config and creates `text_config` with defaults), propagate `num_labels` to `text_config` when they differ. This is done in both:
- `modular_qwen3_5.py` (source of truth)
- `configuration_qwen3_5.py` (auto-generated)

## Reproduction

```python
from transformers import AutoConfig

config = AutoConfig.from_pretrained(
    "onnx-internal-testing/tiny-random-Qwen3_5ForConditionalGeneration",
    num_labels=1,
)
print(config.num_labels)              # 1
print(config.text_config.num_labels)  # Before fix: 2, After fix: 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)