### PR TITLE
Fix processor.save_pretrained missing sub-processor config files

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -833,6 +833,14 @@ class ProcessorMixin(PushToHubMixin):
             elif attribute._auto_class is not None:
                 custom_object_save(attribute, save_directory, config=attribute)
 
+            # Also save primary non-tokenizer sub-processors (e.g. image_processor, feature_extractor)
+            # to their own standalone config files for backward compatibility.
+            # The unified processor_config.json already contains these as nested dicts,
+            # but saving them separately ensures tools and code that expect standalone
+            # config files (e.g. preprocessor_config.json) continue to work.
+            if modality != "tokenizer" and is_primary and hasattr(attribute, "save_pretrained"):
+                attribute.save_pretrained(save_directory)
+
         if self._auto_class is not None:
             # We added an attribute to the init_kwargs of the tokenizers, which needs to be cleaned up.
             for attribute_name in self.get_attributes():


### PR DESCRIPTION
## Summary

Fixes #44623

`processor.save_pretrained()` in v5 only saves the unified `processor_config.json` with nested sub-processor configs, but does not save standalone config files like `preprocessor_config.json` for the image processor. This breaks backward compatibility with tools and code that expect these standalone files.

**Root cause:** In `ProcessorMixin.save_pretrained()`, non-tokenizer primary sub-processors (e.g. `image_processor`, `feature_extractor`) were only serialized as nested dicts inside `processor_config.json`, without also calling their own `save_pretrained()` method to write standalone config files.

**Fix:** After the existing attribute-saving loop, also call `attribute.save_pretrained(save_directory)` for primary non-tokenizer sub-processors. This writes e.g. `preprocessor_config.json` alongside the unified config, maintaining backward compatibility while keeping the new unified format.

## Before (v5)
```
abc/
  chat_template.jinja
  processor_config.json      # has nested image_processor config
  tokenizer files...
  # preprocessor_config.json is MISSING
```

## After (with fix)
```
abc/
  chat_template.jinja
  preprocessor_config.json   # standalone image processor config (restored)
  processor_config.json      # still has nested config for new-style loading
  tokenizer files...
```

## Test plan
- [ ] Verify `processor.save_pretrained('abc')` now outputs `preprocessor_config.json`
- [ ] Verify `AutoProcessor.from_pretrained('abc')` still works (loads from unified config)
- [ ] Verify `AutoImageProcessor.from_pretrained('abc')` works (loads from standalone config)
- [ ] Run existing processor tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)