### PR TITLE
docs: remove outdated use_diff docstring from DistributedConfig.to_js…

### DIFF
--- a/src/transformers/distributed/configuration_utils.py
+++ b/src/transformers/distributed/configuration_utils.py
@@ -55,9 +55,6 @@ class DistributedConfig:
         Args:
             json_file_path (`str` or `os.PathLike`):
                 Path to the JSON file in which this configuration instance's parameters will be saved.
-            use_diff (`bool`, *optional*, defaults to `True`):
-                If set to `True`, only the difference between the config instance and the default
-                `QuantizationConfig()` is serialized to JSON file.
         """
         with open(json_file_path, "w", encoding="utf-8") as writer:
             config_dict = self.to_dict()

--- a/src/transformers/distributed/configuration_utils.py
+++ b/src/transformers/distributed/configuration_utils.py
@@ -48,7 +48,6 @@ class DistributedConfig:
             kwargs.pop(key, None)
         return config
 
-    # Copied from transformers.utils.quantization_config.QuantizationConfigMixin.to_json_file
     def to_json_file(self, json_file_path: str | os.PathLike):
         """
         Save this instance to a JSON file.


### PR DESCRIPTION
Removes outdated use_diff entry from the docstring. The parameter is not present in the method signature or implementation.