### PR TITLE
fix: restore missing `tokenizer_class` attribute in `ModelInfos.__init__`

### DIFF
--- a/src/transformers/cli/add_new_model_like.py
+++ b/src/transformers/cli/add_new_model_like.py
@@ -142,6 +142,7 @@ class ModelInfos:
 
         # Get tokenizer class
         if self.lowercase_name in TOKENIZER_MAPPING_NAMES:
+            self.tokenizer_class = None
             self.fast_tokenizer_class = TOKENIZER_MAPPING_NAMES[self.lowercase_name]
             self.fast_tokenizer_class = (
                 None if self.fast_tokenizer_class == "PreTrainedTokenizerFast" else self.fast_tokenizer_class


### PR DESCRIPTION
## Summary

Fixes #44661 — `transformers add-new-model-like` crashes with `AttributeError: 'ModelInfos' object has no attribute 'tokenizer_class'` when selecting a model that is in `TOKENIZER_MAPPING_NAMES`.

## Root Cause

PR #40936 refactored `TOKENIZER_MAPPING_NAMES` from `(slow_class, fast_class)` tuples to single fast tokenizer class names. During this change, `self.tokenizer_class` was removed from the `if` branch in `ModelInfos.__init__` (line 144), but `get_user_input()` still accesses it at line 719:

```python
if old_model_infos.tokenizer_class is not None:
```

The `else` branch (when the model is NOT in `TOKENIZER_MAPPING_NAMES`) correctly sets `self.tokenizer_class = None`, but the `if` branch (when it IS in the mapping) never assigns it at all.

## Fix

Add `self.tokenizer_class = None` in the `if` branch of `ModelInfos.__init__`, matching the behavior of the `else` branch:

```diff
  if self.lowercase_name in TOKENIZER_MAPPING_NAMES:
+     self.tokenizer_class = None
      self.fast_tokenizer_class = TOKENIZER_MAPPING_NAMES[self.lowercase_name]
```

## Reproduction

```bash
transformers add-new-model-like
# Select qwen2_5_vl (or any model in TOKENIZER_MAPPING_NAMES)
# → AttributeError: 'ModelInfos' object has no attribute 'tokenizer_class'
```
