### PR TITLE
[`Chmv2`] Fix conversion after capture refactor

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -68,6 +68,7 @@ _MODEL_TO_CONVERSION_PATTERN = {
 
 def _build_checkpoint_conversion_mapping():
     mapping = {
+        "chmv2": [WeightRenaming(r"backbone.layer.", r"backbone.model.layer.")],
         "dinov3_convnext": [WeightRenaming(r"(?<!model\.)stages", r"model.stages")],
         "dinov3_vit": [WeightRenaming(r"(?<!model\.)layer.", r"model.layer.")],
         "timesfm2_5": [


### PR DESCRIPTION
Dinov3 vit was refactored to introduce a module between top level and layers to have the capture decorators work as intended. Otherwise, it would force the backbone to do manual collection.

This introduced a small conversion which is now also needed for any model that uses it as backbone - unideal tbh but which makes it obvious that initial implementations need to be solid :cry: 