### PR TITLE
Another (small) set of fixes required for tiny model creation

### DIFF
--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -109,6 +109,9 @@ class Gemma3nAudioModelTester:
             conf_attention_context_left=5,
         )
 
+    def get_config(self):
+        return self.get_audio_encoder_config()
+
     def prepare_config_and_inputs_for_common(self):
         # Prepare inputs for the audio encoder
         feature_extractor_config = self.get_feature_extractor_config()

--- a/tests/models/patchtsmixer/test_modeling_patchtsmixer.py
+++ b/tests/models/patchtsmixer/test_modeling_patchtsmixer.py
@@ -63,6 +63,7 @@ if is_torch_available():
 class PatchTSMixerModelTester:
     def __init__(
         self,
+        parent,
         context_length: int = 32,
         patch_length: int = 8,
         num_input_channels: int = 3,
@@ -103,6 +104,7 @@ class PatchTSMixerModelTester:
         seed_number=42,
         num_parallel_samples=4,
     ):
+        self.parent = parent
         self.num_input_channels = num_input_channels
         self.context_length = context_length
         self.patch_length = patch_length
@@ -227,7 +229,7 @@ class PatchTSMixerModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.Test
     has_attentions = False
 
     def setUp(self):
-        self.model_tester = PatchTSMixerModelTester()
+        self.model_tester = PatchTSMixerModelTester(self)
         self.config_tester = ConfigTester(
             self,
             config_class=PatchTSMixerConfig,

--- a/tests/models/pp_ocrv5_server_det/test_modeling_pp_ocrv5_server_det.py
+++ b/tests/models/pp_ocrv5_server_det/test_modeling_pp_ocrv5_server_det.py
@@ -51,7 +51,15 @@ if is_vision_available():
 
 class PPOCRV5ServerDetModelTester:
     def __init__(
-        self, parent, batch_size=3, image_size=128, num_channels=3, num_stages=5, is_training=False, scale=1.0, divisor=16
+        self,
+        parent,
+        batch_size=3,
+        image_size=128,
+        num_channels=3,
+        num_stages=5,
+        is_training=False,
+        scale=1.0,
+        divisor=16,
     ):
         self.parent = parent
         self.batch_size = batch_size

--- a/tests/models/pp_ocrv5_server_det/test_modeling_pp_ocrv5_server_det.py
+++ b/tests/models/pp_ocrv5_server_det/test_modeling_pp_ocrv5_server_det.py
@@ -51,8 +51,9 @@ if is_vision_available():
 
 class PPOCRV5ServerDetModelTester:
     def __init__(
-        self, batch_size=3, image_size=128, num_channels=3, num_stages=5, is_training=False, scale=1.0, divisor=16
+        self, parent, batch_size=3, image_size=128, num_channels=3, num_stages=5, is_training=False, scale=1.0, divisor=16
     ):
+        self.parent = parent
         self.batch_size = batch_size
         self.num_channels = num_channels
         self.image_size = image_size
@@ -142,6 +143,7 @@ class PPOCRV5ServerDetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.
 
     def setUp(self):
         self.model_tester = PPOCRV5ServerDetModelTester(
+            self,
             batch_size=3,
             is_training=False,
             image_size=128,


### PR DESCRIPTION
# What does this PR do?

- 2 model tester classes didn't follow the usual way we do things, which cause the tiny model creation script to fail with those model classes.
  - (the script initializes instances of model testers, in order to call methods like `get_config`) 

- Add a `get_config` for `Gemma3nAudioModelTester`: the script tries to get the config via the model tester classes: it checks some usual tester methods, but not `get_audio_encoder_config`.