### PR TITLE
Use `index_select` instead of advanced indexing in `batched_mm_experts_forward`

### DIFF
--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -127,11 +127,11 @@ def batched_mm_experts_forward(
 
     # Select gate_up or just up projection weights and biases
     if self.has_gate:
-        selected_weights = self.gate_up_proj[expert_ids]
-        selected_biases = self.gate_up_proj_bias[expert_ids] if self.has_bias else None
+        selected_weights = torch.index_select(self.gate_up_proj, 0, expert_ids)
+        selected_biases = torch.index_select(self.gate_up_proj_bias, 0, expert_ids) if self.has_bias else None
     else:
-        selected_weights = self.up_proj[expert_ids]
-        selected_biases = self.up_proj_bias[expert_ids] if self.has_bias else None
+        selected_weights = torch.index_select(self.up_proj, 0, expert_ids)
+        selected_biases = torch.index_select(self.up_proj_bias, 0, expert_ids) if self.has_bias else None
 
     # --- Up projection per expert (batched) ---
     proj_out = _batched_linear(
@@ -147,8 +147,8 @@ def batched_mm_experts_forward(
         proj_out = self.act_fn(proj_out)  # (S, intermediate_dim)
 
     # Select down projection weights and biases for selected samples
-    selected_weights = self.down_proj[expert_ids]
-    selected_biases = self.down_proj_bias[expert_ids] if self.has_bias else None
+    selected_weights = torch.index_select(self.down_proj, 0, expert_ids)
+    selected_biases = torch.index_select(self.down_proj_bias, 0, expert_ids) if self.has_bias else None
 
     # --- Down projection per expert (batched) ---
     proj_out = _batched_linear(


### PR DESCRIPTION
Fixes #44678

## Summary
- Replace advanced indexing (`self.gate_up_proj[expert_ids]`) with explicit `torch.index_select(self.gate_up_proj, 0, expert_ids)` in `batched_mm_experts_forward`
- 6 replacements total (3 weight tensors + 3 bias tensors)
- Semantically identical — `index_select` is the explicit, unambiguous API for selecting along a dimension
- Improves compatibility with non-CUDA compiler backends (XLA, Neuron) that may not correctly lower fancy indexing

## Test plan
- Existing MoE tests pass with no behavioral change
- `torch.index_select(t, 0, idx)` and `t[idx]` produce identical results when `idx` is a 1D integer tensor

## AI disclosure
This PR was developed with AI assistance (Claude). All changes reviewed and validated by a human contributor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)