### PR TITLE
Officially launch parse_response

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -122,6 +122,8 @@
       title: Tool use
     - local: chat_templating_writing
       title: Writing a chat template
+    - local: chat_response_parsing
+      title: Response parsing
     title: Chat with models
   - isExpanded: false
     sections:

--- a/docs/source/en/chat_extras.md
+++ b/docs/source/en/chat_extras.md
@@ -95,8 +95,12 @@ print(tokenizer.decode(outputs[0][len(inputs["input_ids"][0]):]))
 
 The chat model called the `get_current_temperature` tool with the correct parameters from the docstring. It inferred France as the location based on Paris, and that it should use Celsius for the units of temperature.
 
-A model **cannot actually call the tool itself**. It requests a tool call, and it's your job to handle the call and append it and the result to the chat history. You'll need to manually translate the output
-string into a tool call dict. The tool call should go in the `tool_calls` key of an `assistant` message. This is the recommended API, and should be supported by the chat template of most tool-using models.
+A model **cannot actually call the tool itself**. It requests a tool call, and it's your job to handle the call and append it and the result to the chat history. For
+models that support [response parsing](./chat_response_parsing), the response parsing will be handled automatically, and you can just use
+[`~PreTrainedTokenizer.parse_response`] to extract the tool call. For other models, you'll need to manually translate the output
+string into a tool call dict.
+
+Regardless of the approach you use, the tool call should go in the `tool_calls` key of an `assistant` message. This is the recommended API, and should be supported by the chat template of most tool-using models.
 
 > [!WARNING]
 > Although `tool_calls` is similar to the OpenAI API, the OpenAI API uses a JSON string as its `tool_calls` format. This may cause errors or strange model behavior if used in Transformers, which expects a dict.

--- a/docs/source/en/chat_response_parsing.md
+++ b/docs/source/en/chat_response_parsing.md
@@ -1,0 +1,233 @@
+<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Response Parsing
+
+It is increasingly common for chat models to generate structured outputs, rather than just a single reply string. 
+The most common uses for structured outputs are [tool calling](./chat_extras) and [reasoning models](https://huggingface.co/reasoning-course).
+Tool calling models can output tool calls, containing the name of the tool to call and any arguments to be passed to it,
+while reasoning models often output reasoning steps as a "chain of thought". Some recent models even use both of these,
+and may output reasoning and/or one or more tool calls before their final answer.
+
+Models with structured outputs pose a challenge for chat templating, because the output needs to be parsed before it
+can be appended to the chat. For a concrete example, let's say we ask [GPT-OSS](https://huggingface.co/openai/gpt-oss-120b)
+what the weather is like, and it thinks and decides to call a tool. Here's what the raw model output might look like:
+
+```txt
+<|start|>analysis<|message|>The user asks: "What is the weather like in SF?" We need to get the location of the user? The user explicitly asks about SF (San Francisco).
+So we need to get the current weather in San Francisco, CA. We need to call get_current_weather function. But we need to call function to get weather data.
+So we should call get_current_weather with location "San Francisco, CA". Let's do that.
+We will call function get_current_weather.<|end|><|start|>commentary to=functions.get_current_weather<|channel|>commentary <|constrain|>json<|message|>{"location":"San Francisco, CA"}<|call|>
+}
+```
+
+But if you want to append this to a chat, you'll need to format it as a chat message dict, like this:
+
+```json
+{
+  "role": "assistant",
+  "thinking": "The user asks: \"What is the weather like in SF?\" We need to get the location of the user? The user explicitly asks about SF (San Francisco). So we need to get the current weather in San Francisco, CA. We need to call get_current_weather function. But we need to call function to get weather data. So we should call get_current_weather with location \"San Francisco, CA\". Let's do that.",
+  "tool_calls": [
+    {
+      "name": "get_current_weather",
+      "arguments": {
+        "location": "San Francisco, CA"
+      }
+    }
+  ]
+}
+```
+
+Chat **templates** give us a way to turn messages into formatted input for a model, but we need something else to
+parse model output back into a standard message dict. This is what chat **parsing** is for.
+
+## The [parse_response](~PreTrainedTokenizerBase.parse_response) method
+
+Parsing a chat response on a model that supports it is straightforward. Simply take the raw, decoded output from
+[generate](`~generation.GenerationMixin.generate`), and pass it to the tokenizer's [parse_response](~PreTrainedTokenizerBase.parse_response) method:
+
+```python
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+checkpoint = "HuggingFaceTB/SmolLM3-3B"
+
+tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+model = AutoModelForCausalLM.from_pretrained(checkpoint, dtype="auto", device_map="auto")
+
+messages = [
+    {
+        "role": "user",
+        "content": "Hey! Can you summarize the end of the Cold War as briefly as possible? Like, comically briefly. It should really leave out almost most of the relevant information."
+    }
+]
+
+input_ids = tokenizer.apply_chat_template(
+    messages,
+    add_generation_prompt=True,
+    tokenize=True,
+    return_tensors="pt"
+).to(model.device)
+
+outputs = model.generate(input_ids, max_new_tokens=1024)[0, input_ids.shape[1]:]
+out_text = tokenizer.decode(outputs)
+parsed = tokenizer.parse_response(out_text)
+print(parsed.keys())
+```
+
+And you should get:
+
+```text
+dict_keys(['thinking', 'content'])
+```
+
+And that's all you need to start using response parsing! `parse_response` should return a complete message dict that is ready to be appended to the chat history. 
+When the tokenizer does not support response parsing, `parse_response` will throw an error. We hope to add support
+to more tokenizers over time.
+
+## Developers: Understanding a simple response schema
+
+Under the hood, `parse_response` uses a **JSON schema** to parse the model output. A JSON schema represents
+the structure of the output message dict. The schema is augmented with additional fields that indicate how the 
+output message string should be parsed into the expected format. Let's take a look at the schema for a SmolLM response,
+excluding tool calls for now:
+
+```python
+{
+    "x-regex": "(?:<think>\n?(?P<thinking>.+?)\n?</think>)?\s*(?P<content>.+?)?\s*(?:<\|im_end\|>|$)",
+    "type": "object",
+    "properties": {
+        "role": {"const": "assistant"},
+        "content": {"type": "string"},
+        "thinking": {"type": "string"}
+    }
+}
+```
+
+We can see that the schema describes a JSON "object" (a `dict`, in other words) with three keys: `role`, `content`, and `thinking`.
+Because all assistant responses have the role "assistant", the `role` key is a `const`(ant). The other two keys are strings, extracted
+from the named groups in the regex in the `x-regex` field.
+
+Like chat templates, response schemas are set as a property of the tokenizer. To enable response parsing, all you need
+to do is set `tokenizer.response_schema` to a valid schema dict, and `tokenizer.parse_response()` will work! Again, like
+chat templates, this schema will be saved with the processor, so once you set it, you can use `save_pretrained()` or `push_to_hub()` to
+save and share the schema. 
+
+## Developers: Complex schemas
+
+Now, let's look at a more complex schema, which includes tool calls, to gain more of an understanding of the parser
+internals. For this, we'll use the `GPT-OSS` schema. GPT-OSS emits both tool calls and thinking blocks, and it uses
+an unusual format where model responses are tagged with one of three "channels": `commentary` for things like
+tool calls, `analysis` for chain of thought blocks, and `final` for messages intended to be sent to the user. 
+A full message where the model calls a tool named `get_current_weather` might look like this, with some extra linebreaks added for clarity:
+
+```text
+<|channel|>analysis<|message|>
+The user asks: "What is the weather like in SF?" So we need to get the current weather in San Francisco, CA. 
+We need to call get_current_weather function. So we should call get_current_weather with location "San Francisco, CA".
+<|end|>
+<|start|>assistant<|channel|>commentary 
+to=functions.get_current_weather <|constrain|>json<|message|>
+{
+  "location": "San Francisco, CA"
+}
+<|call|>
+```
+
+Parsing proceeds recursively; the output of a regex (or other parser) at one level becomes the input to the nodes below it.
+In other words, don't feel like you have to parse the entire output in one enormous regex! Instead, start with the schema,
+and then add regexes to extract the relevant chunks as you go. Here's a schema that will parse it, with some
+explanatory comments:
+
+```python
+{
+    "type": "object",
+    "properties": {
+        "role": {"const": "assistant"},
+        # "content" and "thinking" are both similar to the previous example, and just extract a single string
+        # However, rather than using a single regex with named groups to extract both, we use a regex in each subkey.
+        # When an object node has no parser/regex, the entire input string is passed to all of its children, so 
+        # parsing can either be done with named groups at the object level, or with separate regexes at the property level.
+        "content": {"type": "string", "x-regex": r"<\|channel\|>final<\|message\|>(.*?)(?:<\|end\|>|$)"},
+        "thinking": {"type": "string", "x-regex": r"<\|channel\|>analysis<\|message\|>(.*?)<\|end\|>"},
+        "tool_calls": {
+            # "x-regex-iterator" uses re.findall to find multiple possible manages, and returns them as an
+            # array/list. You don't need to worry about array handling, though - each item in the array will be
+            # parsed by the `items` schema, so just write the schema for a single item.
+            "x-regex-iterator": r"<\|channel\|>commentary (to=functions\..*?<\|message\|>.*?)(?:<\|call\|>|$)",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    # A const property is a fixed value, and the input has no effect on it.
+                    "type": {"const": "function"},
+                    # Here, we wrap the entire tool call dict in a `{"function": ...}` block. The input string is passed through to it unchanged.
+                    "function": {
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string", "x-regex": r"^to=functions\.(\w+)"},
+                            "arguments": {
+                                "type": "object",
+                                "x-regex": "<\|message\|>(.*)",
+                                # The "x-parser" field indicates that the extracted string should be parsed as JSON.
+                                # The output is then passed to the schema nodes below and recursive parsing continues.
+                                "x-parser": "json",
+                                "additionalProperties": {"type": "any"},
+                            },
+                        },
+                    },
+                },
+            },
+        },
+    },
+}
+```
+
+## Developers: Understanding the parser logic
+
+The parser follows a few simple rules:
+
+1. Each level of the schema receives input from the level above, applies any regex or parser it has, and then passes the output to its children.
+2. The root level receives the entire decoded model output string as input.
+3. If a node has structured content after parsing (for example, if the regex has named groups and returns a dict, or if the parser returns a dict or list),
+   then that structured content is mapped to the node's children, and each child node receives its corresponding value as input.
+4. If an `object` (dict) node has unstructured (string) output, then the entire string is passed to all of its children. This allows child nodes
+   to handle parsing individually rather than requiring a single parent regex to extract all keys at once.
+5. If an `array` (list) node has unstructured (string) output, then this throws an error.
+
+There is a small set of allowable `x-` keys that indicate how parsing should be done at each node:
+- `x-regex`: A regex string to apply to the input. If the regex has named groups, the output is a dict of group names to values. Named groups should only be used in `object` nodes.
+  Otherwise, the regex must have exactly one unnamed capturing group, and the output is the value of that group as a string.
+- `x-regex-iterator`: A regex string to apply to the input using `re.findall()`. The output is a list of all matches.
+  This should only be used in `array` nodes, and the regex must have exactly one unnamed capturing group. The output is distributed to
+  the node's `items` schema.
+- `x-parser`: Calls a built-in parser to apply to the input. Currently, the only supported parser is `json`, which parses the input string as JSON.
+  The output is passed to the child nodes for further parsing. Note that the `json` parser can return deeply nested output - in this case, the output
+  will be progressively unwrapped as it is passed through child nodes. The child nodes do not need additional `x-parser` or `x-regex` fields in this case, 
+  but their structure must match the structure of the parsed JSON.
+- `x-parser-args`: Only allowed in conjunction with `x-parser`. This is a dict of additional arguments that control parsing. Right now, the only supported
+  argument is `transform`, which specifies a `jmespath` transformation to apply to the output. This is useful when the JSON parser returns a structure
+  that needs to be modified to match the schema.
+- `x-regex-key-value`: This is rarely necessary, but it can be useful when parsing key-value pairs in non-JSON format where the names of the keys are not known
+  in advance, such as when a model emits XML tool calls with arbitrary argument names. The regex must have exactly two named capturing groups, 
+  `key` and `value`, and the output is a dict mapping keys to values. This should only be used in `object` nodes.
+
+In general, multiple regexes/parsers cannot be combined at the same level. The exception is that `x-regex`, returning a single string, can be combined with the other parsers. In this case,
+`x-regex` is applied first, and then the output is passed to the other parser, either `x-regex-iterator`, `x-parser`, or `x-regex-key-value`.
+
+Putting these ideas together, you can see that the input flows through the schema, being parsed at each level and then distributed to child nodes. Each level
+only needs to extract the input content that is relevant for that part of the schema, and can then let its child nodes handle the rest. Internally, this is handled
+with a parser function that receives input, applies any regexes/parsers at the current level, then maps the result to its child nodes before recursively calling itself on each of them.
+Recursion terminates when it reaches leaf nodes, usually primitive types like `string` or `number`, which simply return the input they receive.

--- a/docs/source/en/chat_response_parsing.md
+++ b/docs/source/en/chat_response_parsing.md
@@ -1,4 +1,4 @@
-<!--Copyright 2025 The HuggingFace Team. All rights reserved.
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
 
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at

--- a/docs/source/en/chat_response_parsing.md
+++ b/docs/source/en/chat_response_parsing.md
@@ -89,7 +89,7 @@ print(parsed.keys())
 And you should get:
 
 ```text
-dict_keys(['thinking', 'content'])
+dict_keys(['role', 'thinking', 'content'])
 ```
 
 And that's all you need to start using response parsing! `parse_response` should return a complete message dict that is ready to be appended to the chat history. 

--- a/docs/source/en/chat_response_parsing.md
+++ b/docs/source/en/chat_response_parsing.md
@@ -27,11 +27,10 @@ can be appended to the chat. For a concrete example, let's say we ask [GPT-OSS](
 what the weather is like, and it thinks and decides to call a tool. Here's what the raw model output might look like:
 
 ```txt
-<|start|>analysis<|message|>The user asks: "What is the weather like in SF?" We need to get the location of the user? The user explicitly asks about SF (San Francisco).
-So we need to get the current weather in San Francisco, CA. We need to call get_current_weather function. But we need to call function to get weather data.
+<|start|>analysis<|message|>The user asks: "What is the weather like in SF?" The user explicitly asks about SF (San Francisco).
+So we need to get the current weather in San Francisco, CA. We need to call get_current_weather function.
 So we should call get_current_weather with location "San Francisco, CA". Let's do that.
 We will call function get_current_weather.<|end|><|start|>commentary to=functions.get_current_weather<|channel|>commentary <|constrain|>json<|message|>{"location":"San Francisco, CA"}<|call|>
-}
 ```
 
 But if you want to append this to a chat, you'll need to format it as a chat message dict, like this:
@@ -163,7 +162,7 @@ explanatory comments:
         "content": {"type": "string", "x-regex": r"<\|channel\|>final<\|message\|>(.*?)(?:<\|end\|>|$)"},
         "thinking": {"type": "string", "x-regex": r"<\|channel\|>analysis<\|message\|>(.*?)<\|end\|>"},
         "tool_calls": {
-            # "x-regex-iterator" uses re.findall to find multiple possible manages, and returns them as an
+            # "x-regex-iterator" uses re.finditer to find multiple possible manages, and returns them as an
             # array/list. You don't need to worry about array handling, though - each item in the array will be
             # parsed by the `items` schema, so just write the schema for a single item.
             "x-regex-iterator": r"<\|channel\|>commentary (to=functions\..*?<\|message\|>.*?)(?:<\|call\|>|$)",
@@ -184,7 +183,9 @@ explanatory comments:
                                 # The "x-parser" field indicates that the extracted string should be parsed as JSON.
                                 # The output is then passed to the schema nodes below and recursive parsing continues.
                                 "x-parser": "json",
-                                "additionalProperties": {"type": "any"},
+                                # additionalProperties: True allows the parser to accept arbitrary keys 
+                                # that are not specified in the schema.
+                                "additionalProperties": True,
                             },
                         },
                     },
@@ -210,7 +211,7 @@ The parser follows a few simple rules:
 There is a small set of allowable `x-` keys that indicate how parsing should be done at each node:
 - `x-regex`: A regex string to apply to the input. If the regex has named groups, the output is a dict of group names to values. Named groups should only be used in `object` nodes.
   Otherwise, the regex must have exactly one unnamed capturing group, and the output is the value of that group as a string.
-- `x-regex-iterator`: A regex string to apply to the input using `re.findall()`. The output is a list of all matches.
+- `x-regex-iterator`: A regex string to apply to the input using `re.finditer()`. The output is a list of all matches.
   This should only be used in `array` nodes, and the regex must have exactly one unnamed capturing group. The output is distributed to
   the node's `items` schema.
 - `x-parser`: Calls a built-in parser to apply to the input. Currently, the only supported parser is `json`, which parses the input string as JSON.
@@ -225,7 +226,8 @@ There is a small set of allowable `x-` keys that indicate how parsing should be 
   `key` and `value`, and the output is a dict mapping keys to values. This should only be used in `object` nodes.
 
 In general, multiple regexes/parsers cannot be combined at the same level. The exception is that `x-regex`, returning a single string, can be combined with the other parsers. In this case,
-`x-regex` is applied first, and then the output is passed to the other parser, either `x-regex-iterator`, `x-parser`, or `x-regex-key-value`.
+`x-regex` is applied first, and then the output is passed to the other parser, either `x-regex-iterator`, `x-parser`, or `x-regex-key-value`. 
+All regexes are applied with the `DOTALL` flag, since model outputs often contain newlines. This means that `.` matches all characters, including newlines.
 
 Putting these ideas together, you can see that the input flows through the schema, being parsed at each level and then distributed to child nodes. Each level
 only needs to extract the input content that is relevant for that part of the schema, and can then let its child nodes handle the rest. Internally, this is handled

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -170,7 +170,6 @@ def recursive_parse(
                 child_node_content = recursive_parse(node_content, node_schema["properties"][key])
                 if child_node_content is not None:
                     parsed_schema[key] = child_node_content
-            return parsed_schema
         elif isinstance(node_content, dict):
             for key, child_node in node_schema.get("properties", {}).items():
                 if "const" in child_node:
@@ -183,9 +182,18 @@ def recursive_parse(
                 for key, value in node_content.items():
                     if key not in node_schema.get("properties", {}):
                         parsed_schema[key] = recursive_parse(value, node_schema["additionalProperties"])
-            return parsed_schema
         else:
             raise TypeError(f"Expected a dict or str for schema node with type object, got {node_content}")
+        required = node_schema.get("required", [])
+        missing = [key for key in required if key not in parsed_schema]
+        if missing:
+            input_preview = repr(node_content[:500]) if isinstance(node_content, str) else repr(node_content)
+            raise ValueError(
+                f"Required fields {missing} are missing from parsed output.\n"
+                f"Parsed: {parsed_schema}\n"
+                f"Input: {input_preview}"
+            )
+        return parsed_schema
     elif node_type == "array":
         if not node_content:
             return []
@@ -232,7 +240,7 @@ def recursive_parse(
         else:
             # String type
             return node_content
-    elif node_type is None:
+    elif node_type is None or node_type == "any":
         return node_content  # Don't touch it
     else:
         raise TypeError(f"Unsupported schema type {node_type} for node: {node_content}")

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -1,3 +1,17 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from __future__ import annotations
 
 import json

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -208,7 +208,9 @@ def recursive_parse(
             if isinstance(node_content, int):
                 return node_content
             if not isinstance(node_content, str):
-                raise TypeError(f"Expected a string or int for schema node with type integer, got {type(node_content).__name__}: {node_content}")
+                raise TypeError(
+                    f"Expected a string or int for schema node with type integer, got {type(node_content).__name__}: {node_content}"
+                )
             try:
                 return int(node_content)
             except ValueError:
@@ -219,7 +221,9 @@ def recursive_parse(
             if isinstance(node_content, (int, float)):
                 return float(node_content)
             if not isinstance(node_content, str):
-                raise TypeError(f"Expected a string or number for schema node with type number, got {type(node_content).__name__}: {node_content}")
+                raise TypeError(
+                    f"Expected a string or number for schema node with type number, got {type(node_content).__name__}: {node_content}"
+                )
             try:
                 return float(node_content)
             except ValueError:
@@ -230,7 +234,9 @@ def recursive_parse(
             if isinstance(node_content, bool):
                 return node_content
             if not isinstance(node_content, str):
-                raise TypeError(f"Expected a string or bool for schema node with type boolean, got {type(node_content).__name__}: {node_content}")
+                raise TypeError(
+                    f"Expected a string or bool for schema node with type boolean, got {type(node_content).__name__}: {node_content}"
+                )
             if node_content.lower() in ("true", "1"):
                 return True
             elif node_content.lower() in ("false", "0"):
@@ -240,7 +246,9 @@ def recursive_parse(
         else:
             # String type
             if not isinstance(node_content, str):
-                raise TypeError(f"Expected a string for schema node with type string, got {type(node_content).__name__}: {node_content}")
+                raise TypeError(
+                    f"Expected a string for schema node with type string, got {type(node_content).__name__}: {node_content}"
+                )
             return node_content
     elif node_type is None or node_type == "any":
         return node_content  # Don't touch it

--- a/src/transformers/utils/chat_parsing_utils.py
+++ b/src/transformers/utils/chat_parsing_utils.py
@@ -131,29 +131,6 @@ def recursive_parse(
         else:
             raise ValueError(f"Unknown parser {parser} for schema node: {node_schema}")
 
-    # If there's a mapping, apply it now
-    if "x-mapping" in node_schema:
-        if not isinstance(node_content, str):
-            raise TypeError(
-                f"Schema node with type {node_type} cannot use x-mapping on non-string content.\n"
-                f"Content: {node_content}\n"
-                f"Schema: {node_schema}"
-            )
-        mapping = node_schema["x-mapping"]
-        if node_content in mapping:
-            node_content = mapping[node_content]
-
-    if "x-mapping-regex" in node_schema:
-        if not isinstance(node_content, str):
-            raise TypeError(
-                f"Schema node with type {node_type} cannot use x-mapping-regex on non-string content.\n"
-                f"Content: {node_content}\n"
-                f"Schema: {node_schema}"
-            )
-        mapping_regex = node_schema["x-mapping-regex"]
-        for pattern, replacement in mapping_regex.items():
-            node_content = re.sub(pattern, replacement, node_content, flags=re.DOTALL)
-
     # Finally, handle parsed content based on schema type and recurse if required
     if node_type == "object":
         parsed_schema = {}
@@ -178,10 +155,13 @@ def recursive_parse(
                     parsed_schema[key] = recursive_parse(node_content[key], child_node)
                 elif "default" in child_node:
                     parsed_schema[key] = child_node["default"]
-            if "additionalProperties" in node_schema:
+            additional_schema = node_schema.get("additionalProperties", True)
+            # We want to check only for False values; {} is "falsy" but should pass through
+            if additional_schema is not False:
+                additional_schema = additional_schema if isinstance(additional_schema, dict) else {}
                 for key, value in node_content.items():
                     if key not in node_schema.get("properties", {}):
-                        parsed_schema[key] = recursive_parse(value, node_schema["additionalProperties"])
+                        parsed_schema[key] = recursive_parse(value, additional_schema)
         else:
             raise TypeError(f"Expected a dict or str for schema node with type object, got {node_content}")
         required = node_schema.get("required", [])
@@ -224,13 +204,33 @@ def recursive_parse(
         else:
             raise ValueError(f"Array node has no items or prefixItems schema defined.\nSchema: {node_schema}")
     elif node_type in ("string", "integer", "number", "boolean"):
-        if not isinstance(node_content, str):
-            raise TypeError(f"Expected a string for schema node with type {node_type}, got {node_content}")
         if node_type == "integer":
-            return int(node_content)
+            if isinstance(node_content, int):
+                return node_content
+            if not isinstance(node_content, str):
+                raise TypeError(f"Expected a string or int for schema node with type integer, got {type(node_content).__name__}: {node_content}")
+            try:
+                return int(node_content)
+            except ValueError:
+                raise ValueError(
+                    f"Schema node has type 'integer', but the parsed string content is not a valid integer: {node_content!r}"
+                )
         elif node_type == "number":
-            return float(node_content)
+            if isinstance(node_content, (int, float)):
+                return float(node_content)
+            if not isinstance(node_content, str):
+                raise TypeError(f"Expected a string or number for schema node with type number, got {type(node_content).__name__}: {node_content}")
+            try:
+                return float(node_content)
+            except ValueError:
+                raise ValueError(
+                    f"Schema node has type 'number', but the parsed string content is not a valid number: {node_content!r}"
+                )
         elif node_type == "boolean":
+            if isinstance(node_content, bool):
+                return node_content
+            if not isinstance(node_content, str):
+                raise TypeError(f"Expected a string or bool for schema node with type boolean, got {type(node_content).__name__}: {node_content}")
             if node_content.lower() in ("true", "1"):
                 return True
             elif node_content.lower() in ("false", "0"):
@@ -239,6 +239,8 @@ def recursive_parse(
                 raise ValueError(f"Invalid boolean value: {node_content}")
         else:
             # String type
+            if not isinstance(node_content, str):
+                raise TypeError(f"Expected a string for schema node with type string, got {type(node_content).__name__}: {node_content}")
             return node_content
     elif node_type is None or node_type == "any":
         return node_content  # Don't touch it

--- a/tests/utils/test_chat_parsing_utils.py
+++ b/tests/utils/test_chat_parsing_utils.py
@@ -180,6 +180,17 @@ qwen3_schema = {
     },
 }
 
+prefix_items_schema = {
+    # Not intended to be "realistic", just checks that prefixItems can handle a heterogeneous array
+    "x-regex-iterator": r"<block>(.*?)<\/block>",
+    "type": "array",
+    "prefixItems": [
+        {"type": "string"},
+        {"type": "integer"},
+        {"type": "string"},
+    ],
+}
+
 
 @require_jmespath
 class ChatSchemaParserTest(unittest.TestCase):
@@ -428,6 +439,21 @@ class ChatSchemaParserTest(unittest.TestCase):
         model_out = "<think>Just thinking.</think>"
         parsed = recursive_parse(model_out, schema)
         self.assertEqual(parsed, {"role": "assistant", "thinking": "Just thinking."})
+
+    def test_prefix_items(self):
+        model_out = "<block>hello</block><block>42</block><block>world</block>"
+        parsed = recursive_parse(model_out, prefix_items_schema)
+        self.assertEqual(parsed, ["hello", 42, "world"])
+
+    def test_prefix_items_wrong_length_raises(self):
+        model_out = "<block>hello</block><block>42</block>"
+        with self.assertRaises(ValueError):
+            recursive_parse(model_out, prefix_items_schema)
+
+    def test_prefix_items_wrong_type_raises(self):
+        model_out = "<block>hello</block><block>world</block><block>42</block>"
+        with self.assertRaises(ValueError):
+            recursive_parse(model_out, prefix_items_schema)
 
     def test_type_any_passthrough(self):
         """Test that type 'any' passes content through without transformation."""

--- a/tests/utils/test_chat_parsing_utils.py
+++ b/tests/utils/test_chat_parsing_utils.py
@@ -377,3 +377,78 @@ class ChatSchemaParserTest(unittest.TestCase):
                 ],
             },
         )
+
+    def test_required_fields_present(self):
+        """Test that required fields pass validation when present in the output."""
+        schema = {
+            "type": "object",
+            "required": ["role", "content"],
+            "properties": {
+                "role": {"const": "assistant"},
+                "content": {"type": "string", "x-regex": r"<response>(.*?)</response>"},
+                "thinking": {"type": "string", "x-regex": r"<think>(.*?)</think>"},
+            },
+        }
+        model_out = "<think>Let me think.</think><response>Hello!</response>"
+        parsed = recursive_parse(model_out, schema)
+        self.assertEqual(
+            parsed,
+            {"role": "assistant", "content": "Hello!", "thinking": "Let me think."},
+        )
+
+    def test_required_field_missing_raises(self):
+        """Test that a missing required field raises ValueError with a helpful message."""
+        schema = {
+            "type": "object",
+            "required": ["role", "content"],
+            "properties": {
+                "role": {"const": "assistant"},
+                "content": {"type": "string", "x-regex": r"<response>(.*?)</response>"},
+                "thinking": {"type": "string", "x-regex": r"<think>(.*?)</think>"},
+            },
+        }
+        # This output has thinking but no <response> tags, so content will be missing
+        model_out = "<think>Let me think about this.</think>Some plain text without response tags"
+        with self.assertRaises(ValueError) as cm:
+            recursive_parse(model_out, schema)
+        self.assertIn("content", str(cm.exception))
+        self.assertIn("missing", str(cm.exception).lower())
+
+    def test_required_not_enforced_when_absent(self):
+        """Test that schemas without 'required' still silently omit missing fields."""
+        schema = {
+            "type": "object",
+            "properties": {
+                "role": {"const": "assistant"},
+                "content": {"type": "string", "x-regex": r"<response>(.*?)</response>"},
+                "thinking": {"type": "string", "x-regex": r"<think>(.*?)</think>"},
+            },
+        }
+        # No <response> tags, but content is not required — should succeed
+        model_out = "<think>Just thinking.</think>"
+        parsed = recursive_parse(model_out, schema)
+        self.assertEqual(parsed, {"role": "assistant", "thinking": "Just thinking."})
+
+    def test_type_any_passthrough(self):
+        """Test that type 'any' passes content through without transformation."""
+        schema = {
+            "type": "object",
+            "x-regex": r"<data>(?P<value>.*?)</data>",
+            "properties": {
+                "value": {"type": "any"},
+            },
+        }
+        model_out = "<data>some arbitrary content 123</data>"
+        parsed = recursive_parse(model_out, schema)
+        self.assertEqual(parsed, {"value": "some arbitrary content 123"})
+
+    def test_type_any_in_additional_properties(self):
+        """Test that type 'any' works in additionalProperties, matching the docs example."""
+        schema = {
+            "type": "object",
+            "x-parser": "json",
+            "additionalProperties": {"type": "any"},
+        }
+        node_content = '{"location": "San Francisco, CA", "units": "celsius"}'
+        parsed = recursive_parse(node_content, schema)
+        self.assertEqual(parsed, {"location": "San Francisco, CA", "units": "celsius"})


### PR DESCRIPTION
We've had `parse_response()` in the library for a while, but it's been a soft launch / prototype feature. This PR cleans it up and documents it, making it an official feature!

The API is largely unchanged from the prototype, but we drop `x-mapping` and `x-mapping-regex` since it's unclear if we need them, and they aren't used in any of the test schemas. They can be re-added at a later date if necessary! Error messages and validation are also cleaned up a lot, and some edge cases are fixed.