### PR TITLE
fix(gpt2): Resolve NaN/Inf issue in lm_head on Python 3.13 with tied weights

### DIFF
--- a/src/transformers/models/gpt2/modeling_gpt2.py
+++ b/src/transformers/models/gpt2/modeling_gpt2.py
@@ -703,7 +703,11 @@ class GPT2LMHeadModel(GPT2PreTrainedModel, GenerationMixin):
         hidden_states = transformer_outputs.last_hidden_state
 
         slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
-        logits = self.lm_head(hidden_states[:, slice_indices, :])
+        # Fix for Python 3.13 numerical stability issue: clone weight to avoid NaN/Inf values
+        # caused by tied weights (lm_head.weight is tied to transformer.wte.weight)
+        # See: https://github.com/huggingface/transformers/issues/XXXXX
+        hidden_slice = hidden_states[:, slice_indices, :]
+        logits = nn.functional.linear(hidden_slice, self.lm_head.weight.clone())
 
         loss = None
         if labels is not None:
@@ -824,7 +828,10 @@ class GPT2DoubleHeadsModel(GPT2PreTrainedModel, GenerationMixin):
 
         hidden_states = transformer_outputs.last_hidden_state
 
-        lm_logits = self.lm_head(hidden_states)
+        # Fix for Python 3.13 numerical stability issue: clone weight to avoid NaN/Inf values
+        # caused by tied weights (lm_head.weight is tied to transformer.wte.weight)
+        # See: https://github.com/huggingface/transformers/issues/XXXXX
+        lm_logits = nn.functional.linear(hidden_states, self.lm_head.weight.clone())
         mc_logits = self.multiple_choice_head(hidden_states, mc_token_ids).squeeze(-1)
 
         mc_loss = None


### PR DESCRIPTION
Problem:
- On macOS ARM64 + Python 3.13 + transformers 5.x, GPT-2 model's lm_head forward pass produces NaN/Inf values during inference
- Root cause: lm_head.weight is tied to transformer.wte.weight, and the shared memory reference causes numerical instability in Python 3.13

Solution:
- Clone the lm_head weight before passing to F.linear in GPT2LMHeadModel and GPT2DoubleHeadsModel forward methods
- This breaks the memory sharing and resolves the NaN issue

Changes:
- src/transformers/models/gpt2/modeling_gpt2.py: Modified GPT2LMHeadModel.forward() and GPT2DoubleHeadsModel.forward() to use self.lm_head.weight.clone()

Testing:
- Verified fix with gpt2-medium model on Python 3.13.5 + PyTorch 2.6.0
- All existing GPT-2 model tests pass
## Reproduction Code

```python
from transformers import AutoModelForCausalLM, AutoTokenizer
import torch

model = AutoModelForCausalLM.from_pretrained("gpt2-medium")
model.eval()
tokenizer = AutoTokenizer.from_pretrained("gpt2-medium")
inputs = tokenizer("Hello world", return_tensors="pt")

with torch.no_grad():
    outputs = model(**inputs)
    logits = outputs.logits

print(f"Has NaN: {torch.isnan(logits).any().item()}")  # Should be False after fix
print(f"Has Inf: {torch.isinf(logits).any().item()}")  # Should be False after fix
```

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [x ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
