### PR TITLE
Fix more model tester missing `parent` issue

### DIFF
--- a/tests/models/pp_lcnet/test_modeling_pp_lcnet.py
+++ b/tests/models/pp_lcnet/test_modeling_pp_lcnet.py
@@ -52,6 +52,7 @@ if is_vision_available():
 class PPLCNetModelTester:
     def __init__(
         self,
+        parent,
         batch_size=3,
         image_size=128,
         num_channels=3,
@@ -68,6 +69,7 @@ class PPLCNetModelTester:
         out_indices=[2, 3, 4],
         stem_channels=16,
     ):
+        self.parent = parent
         self.batch_size = batch_size
         self.num_channels = num_channels
         self.image_size = image_size
@@ -134,7 +136,7 @@ class PPLCNetBackboneTest(BackboneTesterMixin, unittest.TestCase):
     config_class = PPLCNetConfig
 
     def setUp(self):
-        self.model_tester = PPLCNetModelTester()
+        self.model_tester = PPLCNetModelTester(self)
         self.config_tester = ConfigTester(
             self,
             config_class=PPLCNetConfig,
@@ -153,7 +155,7 @@ class PPLCNetModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase)
     test_resize_embeddings = False
 
     def setUp(self):
-        self.model_tester = PPLCNetModelTester()
+        self.model_tester = PPLCNetModelTester(self)
         self.config_tester = ConfigTester(
             self,
             config_class=PPLCNetConfig,

--- a/tests/models/pp_lcnet_v3/test_modeling_pp_lcnet_v3.py
+++ b/tests/models/pp_lcnet_v3/test_modeling_pp_lcnet_v3.py
@@ -33,6 +33,7 @@ from ...test_modeling_common import floats_tensor
 class PPLCNetV3ModelTester:
     def __init__(
         self,
+        parent,
         batch_size=3,
         image_size=128,
         num_channels=3,
@@ -49,6 +50,7 @@ class PPLCNetV3ModelTester:
         out_indices=[2, 3, 4],
         stem_channels=16,
     ):
+        self.parent = parent
         self.batch_size = batch_size
         self.num_channels = num_channels
         self.image_size = image_size
@@ -112,7 +114,7 @@ class PPLCNetBackboneTest(BackboneTesterMixin, unittest.TestCase):
     config_class = PPLCNetV3Config
 
     def setUp(self):
-        self.model_tester = PPLCNetV3ModelTester()
+        self.model_tester = PPLCNetV3ModelTester(self)
         self.config_tester = ConfigTester(
             self,
             config_class=PPLCNetV3Config,

--- a/tests/models/pp_ocrv5_mobile_det/test_modeling_pp_ocrv5_mobile_det.py
+++ b/tests/models/pp_ocrv5_mobile_det/test_modeling_pp_ocrv5_mobile_det.py
@@ -50,6 +50,7 @@ if is_vision_available():
 class PPOCRV5MobileDetModelTester:
     def __init__(
         self,
+        parent,
         batch_size=3,
         image_size=128,
         num_channels=3,
@@ -62,6 +63,7 @@ class PPOCRV5MobileDetModelTester:
         kernel_list=[3, 2, 2],
         interpolate_mode="nearest",
     ):
+        self.parent = parent
         self.batch_size = batch_size
         self.image_size = image_size
         self.num_channels = num_channels
@@ -138,6 +140,7 @@ class PPOCRV5MobileDetModelTest(ModelTesterMixin, unittest.TestCase):
 
     def setUp(self):
         self.model_tester = PPOCRV5MobileDetModelTester(
+            self,
             batch_size=3,
             is_training=False,
             image_size=128,


### PR DESCRIPTION
# What does this PR do?

For tiny model creation script - new added model test files still miss this argument ...