### PR TITLE
Fix Qwen3.5 num_labels not propagated to text_config

### DIFF
--- a/src/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -219,6 +219,18 @@ class Qwen3_5Config(PreTrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Propagate label-related kwargs to text_config so that e.g.
+        # AutoConfig.from_pretrained(model, num_labels=1) also updates the
+        # inner text_config used by ForSequenceClassification heads.
+        _label_keys = ("num_labels", "id2label", "label2id")
+        _label_kwargs = {k: kwargs[k] for k in _label_keys if k in kwargs}
+        if _label_kwargs:
+            if text_config is None:
+                text_config = {}
+            if isinstance(text_config, dict):
+                for k, v in _label_kwargs.items():
+                    text_config.setdefault(k, v)
+
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:

--- a/src/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -230,7 +230,6 @@ class Qwen3_5Config(PreTrainedConfig):
             if isinstance(text_config, dict):
                 for k, v in _label_kwargs.items():
                     text_config.setdefault(k, v)
-
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -200,6 +200,18 @@ class Qwen3_5Config(Qwen3VLConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Propagate label-related kwargs to text_config so that e.g.
+        # AutoConfig.from_pretrained(model, num_labels=1) also updates the
+        # inner text_config used by ForSequenceClassification heads.
+        _label_keys = ("num_labels", "id2label", "label2id")
+        _label_kwargs = {k: kwargs[k] for k in _label_keys if k in kwargs}
+        if _label_kwargs:
+            if text_config is None:
+                text_config = {}
+            if isinstance(text_config, dict):
+                for k, v in _label_kwargs.items():
+                    text_config.setdefault(k, v)
+
         super().__init__(
             text_config=text_config,
             vision_config=vision_config,


### PR DESCRIPTION
## Summary
- Fixes `num_labels` (and `id2label`/`label2id`) not being propagated from the outer `Qwen3_5Config` to its inner `text_config` when passed via `AutoConfig.from_pretrained(..., num_labels=1)`.
- When `text_config` is `None` or a dict, label-related kwargs are now forwarded using `setdefault` (so explicitly provided `text_config` values take precedence).
- Both the modular source (`modular_qwen3_5.py`) and the auto-generated config (`configuration_qwen3_5.py`) are updated.

## Reproduction (from issue)
```python
from transformers import AutoConfig

config = AutoConfig.from_pretrained(
    "onnx-internal-testing/tiny-random-Qwen3_5ForConditionalGeneration",
    num_labels=1,
)
print(config.num_labels)             # 1
print(config.text_config.num_labels) # 2  <-- should be 1
```

## Fix
Before `text_config` is instantiated, propagate `num_labels`, `id2label`, and `label2id` from `kwargs` into `text_config` (as a dict) using `setdefault`, so that user-supplied values reach the inner config without overriding explicit `text_config` entries.

Fixes #44625

## Test plan
- [ ] Verify `AutoConfig.from_pretrained(model, num_labels=1)` sets `config.text_config.num_labels == 1`
- [ ] Verify explicitly passing `text_config={"num_labels": 3}` still takes precedence
- [ ] Verify default behavior (no `num_labels` kwarg) is unchanged (`text_config.num_labels == 2`)