### PR TITLE
fix: handle ragged input_ids in Qwen2_5_VLProcessor.apply_chat_template

### DIFF
--- a/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
@@ -891,11 +891,15 @@ class Qwen2_5_VLProcessor(Qwen2VLProcessor):
         self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video"])
 
         if return_mm_token_type_ids:
-            array_ids = np.array(text_inputs["input_ids"])
-            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            mm_token_type_ids[array_ids == self.image_token_id] = 1
-            mm_token_type_ids[array_ids == self.video_token_id] = 2
-            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+            # Process each sequence individually to handle ragged (unpadded) input_ids
+            mm_token_type_ids = []
+            for ids in text_inputs["input_ids"]:
+                arr = np.array(ids)
+                token_types = np.zeros_like(arr)
+                token_types[arr == self.image_token_id] = 1
+                token_types[arr == self.video_token_id] = 2
+                mm_token_type_ids.append(token_types.tolist())
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 

--- a/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py
@@ -145,11 +145,15 @@ class Qwen2_5_VLProcessor(ProcessorMixin):
         self._check_special_mm_tokens(text, text_inputs, modalities=["image", "video"])
 
         if return_mm_token_type_ids:
-            array_ids = np.array(text_inputs["input_ids"])
-            mm_token_type_ids = np.zeros_like(text_inputs["input_ids"])
-            mm_token_type_ids[array_ids == self.image_token_id] = 1
-            mm_token_type_ids[array_ids == self.video_token_id] = 2
-            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+            # Process each sequence individually to handle ragged (unpadded) input_ids
+            mm_token_type_ids = []
+            for ids in text_inputs["input_ids"]:
+                arr = np.array(ids)
+                token_types = np.zeros_like(arr)
+                token_types[arr == self.image_token_id] = 1
+                token_types[arr == self.video_token_id] = 2
+                mm_token_type_ids.append(token_types.tolist())
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids
 
         return BatchFeature(data={**text_inputs, **image_inputs, **videos_inputs}, tensor_type=return_tensors)
 


### PR DESCRIPTION
## Summary

Fixes #44514.

`Qwen2_5_VLProcessor.apply_chat_template` crashes with `ValueError` when called with batched input and `padding=False` (the default). The root cause is `np.array(text_inputs["input_ids"])` which fails when sequences have different lengths (ragged lists).

## Changes

Process each sequence individually in a loop instead of trying to create a single NumPy array from the whole batch. Each row's `input_ids` is converted to a NumPy array separately, so variable-length sequences are handled correctly.

Files changed:
- `src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py`
- `src/transformers/models/qwen2_5_vl/processing_qwen2_5_vl.py`

## Test plan

- [x] Batched input with different prompt lengths and `padding=False` no longer crashes
- [x] Single input still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)