### PR TITLE
Add position_ids to RoFormerForCausalLM forward pass

### DIFF
--- a/src/transformers/models/roformer/modeling_roformer.py
+++ b/src/transformers/models/roformer/modeling_roformer.py
@@ -421,6 +421,7 @@ class RoFormerEncoder(nn.Module):
         output_hidden_states=False,
         return_dict=True,
         cache_position=None,
+        position_ids=None,
     ):
         if self.gradient_checkpointing and self.training:
             if use_cache:
@@ -436,7 +437,15 @@ class RoFormerEncoder(nn.Module):
         past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0
 
         # [sequence_length, embed_size_per_head] -> [batch_size, num_heads, sequence_length, embed_size_per_head]
-        sinusoidal_pos = self.embed_positions(hidden_states.shape[:-1], past_key_values_length)[None, None, :, :]
+        sinusoidal_pos = self.embed_positions(
+            hidden_states.shape[:-1], past_key_values_length, position_ids=position_ids
+        )
+        if sinusoidal_pos.dim() == 2:
+            # position_ids was None or 1D: output is [seq_len, embed_dim]
+            sinusoidal_pos = sinusoidal_pos[None, None, :, :]
+        else:
+            # position_ids was 2D: output is [batch, seq_len, embed_dim]
+            sinusoidal_pos = sinusoidal_pos[:, None, :, :]
 
         for i, layer_module in enumerate(self.layer):
             if output_hidden_states:
@@ -682,6 +691,7 @@ class RoFormerModel(RoFormerPreTrainedModel):
         input_ids: torch.LongTensor | None = None,
         attention_mask: torch.FloatTensor | None = None,
         token_type_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         encoder_hidden_states: torch.FloatTensor | None = None,
         encoder_attention_mask: torch.FloatTensor | None = None,
@@ -763,6 +773,7 @@ class RoFormerModel(RoFormerPreTrainedModel):
             output_hidden_states=output_hidden_states,
             return_dict=return_dict,
             cache_position=cache_position,
+            position_ids=position_ids,
         )
         sequence_output = encoder_outputs[0]
 
@@ -898,6 +909,7 @@ class RoFormerForCausalLM(RoFormerPreTrainedModel, GenerationMixin):
         input_ids: torch.LongTensor | None = None,
         attention_mask: torch.FloatTensor | None = None,
         token_type_ids: torch.LongTensor | None = None,
+        position_ids: torch.LongTensor | None = None,
         inputs_embeds: torch.FloatTensor | None = None,
         encoder_hidden_states: torch.FloatTensor | None = None,
         encoder_attention_mask: torch.FloatTensor | None = None,
@@ -939,6 +951,7 @@ class RoFormerForCausalLM(RoFormerPreTrainedModel, GenerationMixin):
             input_ids,
             attention_mask=attention_mask,
             token_type_ids=token_type_ids,
+            position_ids=position_ids,
             inputs_embeds=inputs_embeds,
             encoder_hidden_states=encoder_hidden_states,
             encoder_attention_mask=encoder_attention_mask,


### PR DESCRIPTION
Fixes part of #32937

## What does this PR do?

RoFormer introduced rotary position embeddings, but its `ForCausalLM` forward method doesn't accept `position_ids` — which means callers can't specify custom positions for packed sequences or flash attention without padding.

The interesting bit is that `RoFormerSinusoidalPositionalEmbedding.forward()` already accepts a `position_ids` argument. It just was never wired up from the model's public API.

This PR threads `position_ids` through the full call chain:

`RoFormerForCausalLM` → `RoFormerModel` → `RoFormerEncoder` → `RoFormerSinusoidalPositionalEmbedding`

When `position_ids` is `None`, behaviour is identical to before (sequential positions are generated internally). When provided, the embedding layer uses them directly.

### Shape handling during generation

`GenerationMixin` passes 2D `position_ids` of shape `[batch_size, seq_len]`, which makes the embedding output 3D instead of the usual 2D. The encoder now checks the output dimensionality and reshapes accordingly — `[1, 1, seq_len, dim]` for the broadcast case, `[batch, 1, seq_len, dim]` when batch-specific positions are provided.

## How was it tested?

- Full RoFormer test suite: **77 passed**, 123 skipped, 3 xfailed, 0 failures
- `test_for_generate_causal_lm` passes (this exercises the `GenerationMixin` → `position_ids` path)
- `make style` and `make fix-repo` both clean

```
python -m pytest tests/models/roformer/test_modeling_roformer.py -v
```

## Coordination

Commented on #32937 [here](https://github.com/huggingface/transformers/issues/32937#issuecomment-4060864159). This covers RoFormer specifically — other models missing `position_ids` can be addressed in separate PRs.