### PR TITLE
Fix AutoProcessor.from_pretrained silently dropping hub kwargs

### DIFF
--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -14,7 +14,6 @@
 """AutoProcessor class."""
 
 import importlib
-import inspect
 import json
 from collections import OrderedDict
 from typing import TYPE_CHECKING
@@ -297,7 +296,21 @@ class AutoProcessor:
 
         # First, let's see if we have a processor or preprocessor config.
         # Filter the kwargs for `cached_file`.
-        cached_file_kwargs = {key: kwargs[key] for key in inspect.signature(cached_file).parameters if key in kwargs}
+        # Note: can't use inspect.signature here because cached_file uses **kwargs,
+        # so we explicitly list the hub-related params it actually forwards.
+        _hub_kwargs = (
+            "cache_dir",
+            "force_download",
+            "proxies",
+            "token",
+            "revision",
+            "local_files_only",
+            "subfolder",
+            "repo_type",
+            "user_agent",
+            "_commit_hash",
+        )
+        cached_file_kwargs = {key: kwargs[key] for key in _hub_kwargs if key in kwargs}
         # We don't want to raise
         cached_file_kwargs.update(
             {

--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -296,9 +296,7 @@ class AutoProcessor:
 
         # First, let's see if we have a processor or preprocessor config.
         # Filter the kwargs for `cached_file`.
-        # Note: can't use inspect.signature here because cached_file uses **kwargs,
-        # so we explicitly list the hub-related params it actually forwards.
-        _hub_kwargs = (
+        _hub_valid_kwargs = (
             "cache_dir",
             "force_download",
             "proxies",
@@ -308,9 +306,8 @@ class AutoProcessor:
             "subfolder",
             "repo_type",
             "user_agent",
-            "_commit_hash",
         )
-        cached_file_kwargs = {key: kwargs[key] for key in _hub_kwargs if key in kwargs}
+        cached_file_kwargs = {key: kwargs[key] for key in _hub_valid_kwargs if key in kwargs}
         # We don't want to raise
         cached_file_kwargs.update(
             {


### PR DESCRIPTION
## What does this PR do?

Fixes `AutoProcessor.from_pretrained` silently dropping hub kwargs like `force_download`, `cache_dir`, `token`, `revision`, etc.

### The bug

The existing code on line ~300 filters kwargs using `inspect.signature(cached_file).parameters`:

```python
cached_file_kwargs = {key: kwargs[key] for key in inspect.signature(cached_file).parameters if key in kwargs}
```

But `cached_file()` is defined as:

```python
def cached_file(path_or_repo_id, filename, **kwargs):
```

So `inspect.signature` only sees three parameter names: `path_or_repo_id`, `filename`, and `kwargs`. Hub parameters like `force_download`, `cache_dir`, `token`, etc. are never matched, and get silently dropped before reaching the `cached_file` calls.

### The fix

Replace the `inspect.signature` filtering with an explicit tuple of the hub parameter names that `cached_file` actually accepts (via `cached_files`). This is consistent with how other auto classes like `AutoTokenizer` handle the same situation -- they pass hub kwargs explicitly by name rather than trying to introspect the signature.

Also removes the now-unused `import inspect`.

Fixes #44704

## Who can review?

@ArthurZucker @Rocketknight1