### PR TITLE
Update Nvidia CI docker file to use torch 2.10

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -9,12 +9,12 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='2.9.0'
+ARG PYTORCH='2.10.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu126'
 
 # This needs to be compatible with the above `PYTORCH`.
-ARG TORCHCODEC='0.8.0'
+ARG TORCHCODEC='0.10.0'
 
 ARG FLASH_ATTN='false'
 


### PR DESCRIPTION
# What does this PR do?

torch 2.11 is going to be released soon, but we still use 2.9.

Let's update it to 2.10 so at least a run with torch 2.10, before we update to torch 2.11 later.