### PR TITLE
Fix missing / incorrect `config` class in some model class definitions

### DIFF
--- a/src/transformers/models/blip_2/modeling_blip_2.py
+++ b/src/transformers/models/blip_2/modeling_blip_2.py
@@ -877,6 +877,8 @@ class Blip2TextEmbeddings(nn.Module):
     """
 )
 class Blip2QFormerModel(Blip2PreTrainedModel):
+    config: Blip2QFormerConfig
+
     _supports_attention_backend = False  # adds position on attn weights before last matmul
     _supports_flash_attn = False
     _supports_sdpa = False

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -1201,7 +1201,8 @@ class Emu3RotaryEmbedding(nn.Module):
 
 @auto_docstring
 class Emu3TextModel(Emu3PreTrainedModel):
-    def __init__(self, config: Emu3Config):
+    config: Emu3TextConfig
+    def __init__(self, config: Emu3TextConfig):
         super().__init__(config)
         self.padding_idx = config.pad_token_id
         self.vocab_size = config.vocab_size

--- a/src/transformers/models/emu3/modeling_emu3.py
+++ b/src/transformers/models/emu3/modeling_emu3.py
@@ -1202,6 +1202,7 @@ class Emu3RotaryEmbedding(nn.Module):
 @auto_docstring
 class Emu3TextModel(Emu3PreTrainedModel):
     config: Emu3TextConfig
+
     def __init__(self, config: Emu3TextConfig):
         super().__init__(config)
         self.padding_idx = config.pad_token_id

--- a/src/transformers/models/emu3/modular_emu3.py
+++ b/src/transformers/models/emu3/modular_emu3.py
@@ -879,7 +879,9 @@ class Emu3PreTrainedModel(ChameleonPreTrainedModel):
 
 
 class Emu3TextModel(LlamaModel, Emu3PreTrainedModel):
-    def __init__(self, config: Emu3Config):
+    config: Emu3TextConfig
+
+    def __init__(self, config: Emu3TextConfig):
         super().__init__(config)
         self.layers = nn.ModuleList(
             [Emu3DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1295,6 +1295,7 @@ class Qwen3_5ModelOutputWithPast(ModelOutput):
 
 class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
     config: Qwen3_5TextConfig
+
     def __init__(self, config: Qwen3_5TextConfig):
         super().__init__(config)
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -1294,6 +1294,7 @@ class Qwen3_5ModelOutputWithPast(ModelOutput):
 
 
 class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
+    config: Qwen3_5TextConfig
     def __init__(self, config: Qwen3_5TextConfig):
         super().__init__(config)
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -530,6 +530,8 @@ class Qwen3_5ModelOutputWithPast(Qwen3VLModelOutputWithPast):
 
 
 class Qwen3_5TextModel(Qwen3NextModel):
+    config: Qwen3_5TextConfig
+
     def __init__(self, config: Qwen3_5TextConfig):
         super().__init__(config)
         self.rotary_emb = Qwen3_5TextRotaryEmbedding(config=config)

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -1419,6 +1419,7 @@ class Qwen3_5MoeCausalLMOutputWithPast(ModelOutput):
 
 
 class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
+    config: Qwen3_5MoeTextConfig
     def __init__(self, config: Qwen3_5MoeTextConfig):
         super().__init__(config)
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -1420,6 +1420,7 @@ class Qwen3_5MoeCausalLMOutputWithPast(ModelOutput):
 
 class Qwen3_5MoeTextModel(Qwen3_5MoePreTrainedModel):
     config: Qwen3_5MoeTextConfig
+
     def __init__(self, config: Qwen3_5MoeTextConfig):
         super().__init__(config)
         self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, config.pad_token_id)

--- a/src/transformers/models/sam3/modeling_sam3.py
+++ b/src/transformers/models/sam3/modeling_sam3.py
@@ -792,6 +792,7 @@ class Sam3PreTrainedModel(PreTrainedModel):
 
 @auto_docstring
 class Sam3ViTModel(Sam3PreTrainedModel):
+    config: Sam3ViTConfig
     _can_record_outputs = {
         "hidden_states": Sam3ViTLayer,
         "attentions": Sam3ViTRoPEAttention,


### PR DESCRIPTION
# What does this PR do?

As discussed internally, some component model classes didn't specify the correct config classes.

This PR fixes them (those I could found - because the tiny model creation script fails due to those mistakes).