### PR TITLE
Fix: propagate interpolate_pos_encoding through PixioEmbeddings and PixioModel

### DIFF
--- a/src/transformers/models/pixio/modular_pixio.py
+++ b/src/transformers/models/pixio/modular_pixio.py
@@ -172,10 +172,10 @@ class PixioEmbeddings(nn.Module):
 
         return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
 
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, _, height, width = pixel_values.shape
         target_dtype = self.patch_embeddings.projection.weight.dtype
-        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
+        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype), interpolate_pos_encoding=interpolate_pos_encoding)
 
         cls_tokens = self.cls_token.expand(batch_size, -1, -1)
         embeddings = torch.cat((cls_tokens, embeddings), dim=1)
@@ -274,12 +274,13 @@ class PixioModel(PixioPreTrainedModel):
     def forward(
         self,
         pixel_values: torch.Tensor | None = None,
+        interpolate_pos_encoding: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
 
         encoder_outputs: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         sequence_output = encoder_outputs.last_hidden_state


### PR DESCRIPTION
## Summary

Fixes #44716

`PixioPatchEmbeddings.forward` already accepted `interpolate_pos_encoding` but it was silently dropped — never passed from `PixioEmbeddings.forward` or `PixioModel.forward`, making the parameter effectively unusable from the model interface.

### Changes (in `modular_pixio.py`)

- `PixioEmbeddings.forward`: added `interpolate_pos_encoding: bool = False` parameter, passed to `PixioPatchEmbeddings`
- `PixioModel.forward`: added `interpolate_pos_encoding: bool = False` parameter, passed to `PixioEmbeddings`

The fix follows the same pattern already established in `SiglipVisionEmbeddings` / `SiglipModel`.

Since Pixio uses `modular_pixio.py`, the change is made there (not in the generated `modeling_pixio.py`).

## Coordination

- Issue discussion: https://github.com/huggingface/transformers/issues/44716#issuecomment-4061720108
- No existing open PRs address this fix (checked via `gh pr list --search "44716 in:body"` and `--search "pixio interpolate_pos_encoding"`)

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). The change was reviewed line-by-line by the submitter before opening.