### PR TITLE
Fix: propagate interpolate_pos_encoding through PixioEmbeddings and PixioModel

### DIFF
--- a/src/transformers/models/pixio/modeling_pixio.py
+++ b/src/transformers/models/pixio/modeling_pixio.py
@@ -132,10 +132,12 @@ class PixioEmbeddings(nn.Module):
 
         return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
 
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, _, height, width = pixel_values.shape
         target_dtype = self.patch_embeddings.projection.weight.dtype
-        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
+        embeddings = self.patch_embeddings(
+            pixel_values.to(dtype=target_dtype), interpolate_pos_encoding=interpolate_pos_encoding
+        )
 
         cls_tokens = self.cls_token.expand(batch_size, -1, -1)
         embeddings = torch.cat((cls_tokens, embeddings), dim=1)
@@ -407,12 +409,13 @@ class PixioModel(PixioPreTrainedModel):
     def forward(
         self,
         pixel_values: torch.Tensor | None = None,
+        interpolate_pos_encoding: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
 
         encoder_outputs: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         sequence_output = encoder_outputs.last_hidden_state

--- a/src/transformers/models/pixio/modular_pixio.py
+++ b/src/transformers/models/pixio/modular_pixio.py
@@ -172,10 +172,12 @@ class PixioEmbeddings(nn.Module):
 
         return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
 
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, _, height, width = pixel_values.shape
         target_dtype = self.patch_embeddings.projection.weight.dtype
-        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
+        embeddings = self.patch_embeddings(
+            pixel_values.to(dtype=target_dtype), interpolate_pos_encoding=interpolate_pos_encoding
+        )
 
         cls_tokens = self.cls_token.expand(batch_size, -1, -1)
         embeddings = torch.cat((cls_tokens, embeddings), dim=1)
@@ -274,12 +276,13 @@ class PixioModel(PixioPreTrainedModel):
     def forward(
         self,
         pixel_values: torch.Tensor | None = None,
+        interpolate_pos_encoding: bool = False,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
 
         encoder_outputs: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         sequence_output = encoder_outputs.last_hidden_state


### PR DESCRIPTION
## Summary
This PR fixes #44716 by exposing and forwarding `interpolate_pos_encoding` through the Pixio embedding/model call chain so the option is actually usable from `PixioModel.forward()`.

### Changes
- Added `interpolate_pos_encoding: bool = False` to `PixioEmbeddings.forward()` and forwarded it to `self.patch_embeddings(...)`.
- Added `interpolate_pos_encoding: bool = False` to `PixioModel.forward()` and forwarded it to `self.embeddings(...)`.
- Kept behavior and defaults aligned with similar vision models (e.g. SigLIP patterns) by defaulting to `False`.

### Why
`PixioPatchEmbeddings.forward()` already accepted `interpolate_pos_encoding`, but higher-level modules did not pass it through, making the parameter effectively inaccessible for end users.

Issue: https://github.com/huggingface/transformers/issues/44716
