### PR TITLE
fix: add device parameter to torch.arange calls in XLNet

### DIFF
--- a/src/transformers/integrations/flex_attention.py
+++ b/src/transformers/integrations/flex_attention.py
@@ -282,24 +282,38 @@ def flex_attention_forward(
     # On CPU we must skip returning LSE due to a runtime issue; elsewhere, follow PyTorch API and return it
     return_lse = query.device.type != "cpu"
 
+    # PyTorch >= 2.9 renamed return_lse to return_aux
+    torch_version = get_torch_version()
+    use_return_aux = version.parse(torch_version).base_version >= "2.9"
+
     if not return_lse and s_aux is not None:
         raise ValueError(
             "Attention sinks cannot be run on CPU with flex attention. Please switch to a different device, e.g. CUDA"
         )
 
+    # Build the kwargs for flex attention
+    flex_attn_kwargs = {
+        "score_mod": score_mod,
+        "block_mask": block_mask,
+        "enable_gqa": enable_gqa,
+        "scale": scaling,
+        "kernel_options": kernel_options,
+        "training": module.training,
+    }
+
+    # Last time checked on PyTorch == 2.5.1: Flex Attention always computes the lse regardless.
+    # For simplification, we thus always return it as no additional computations are introduced.
+    # In PyTorch >= 2.9, return_lse was renamed to return_aux
+    if use_return_aux:
+        flex_attn_kwargs["return_aux"] = return_lse
+    else:
+        flex_attn_kwargs["return_lse"] = return_lse
+
     flex_attention_output = compile_friendly_flex_attention(
         query,
         key,
         value,
-        score_mod=score_mod,
-        block_mask=block_mask,
-        enable_gqa=enable_gqa,
-        scale=scaling,
-        kernel_options=kernel_options,
-        # Last time checked on PyTorch == 2.5.1: Flex Attention always computes the lse regardless.
-        # For simplification, we thus always return it as no additional computations are introduced.
-        return_lse=return_lse,
-        training=module.training,
+        **flex_attn_kwargs,
     )
     # lse is returned in float32
     if return_lse:

--- a/src/transformers/models/auto/processing_auto.py
+++ b/src/transformers/models/auto/processing_auto.py
@@ -14,7 +14,6 @@
 """AutoProcessor class."""
 
 import importlib
-import inspect
 import json
 from collections import OrderedDict
 from typing import TYPE_CHECKING
@@ -297,7 +296,22 @@ class AutoProcessor:
 
         # First, let's see if we have a processor or preprocessor config.
         # Filter the kwargs for `cached_file`.
-        cached_file_kwargs = {key: kwargs[key] for key in inspect.signature(cached_file).parameters if key in kwargs}
+        # Note: cached_file uses **kwargs, so we explicitly list the supported parameters
+        # to ensure they are passed through correctly (e.g., force_download, proxies, etc.)
+        cached_file_kwargs = {
+            key: kwargs[key]
+            for key in (
+                "cache_dir",
+                "force_download",
+                "proxies",
+                "token",
+                "revision",
+                "local_files_only",
+                "subfolder",
+                "repo_type",
+            )
+            if key in kwargs
+        }
         # We don't want to raise
         cached_file_kwargs.update(
             {

--- a/src/transformers/models/doge/modeling_doge.py
+++ b/src/transformers/models/doge/modeling_doge.py
@@ -34,6 +34,8 @@ from ...cache_utils import Cache, DynamicCache
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_forward_from_hub, use_kernel_func_from_hub
 from ...integrations.flex_attention import compile_friendly_flex_attention
+from ...utils.import_utils import get_torch_version
+from packaging import version
 from ...masking_utils import create_causal_mask, create_sliding_window_causal_mask
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPast
@@ -233,17 +235,31 @@ def flex_attention_forward(
             score = score + causal_mask[batch_idx][head_idx][q_idx][kv_idx]
         return score
 
+    # PyTorch >= 2.9 renamed return_lse to return_aux
+    torch_version = get_torch_version()
+    use_return_aux = version.parse(torch_version).base_version >= "2.9"
+
+    # Build kwargs for flex attention
+    flex_attn_kwargs = {
+        "score_mod": score_mod,
+        "block_mask": block_mask,
+        "enable_gqa": True,
+        "scale": scaling,
+    }
+
+    # Last time checked on PyTorch == 2.5.1: Flex Attention always computes the lse regardless.
+    # For simplification, we thus always return it as no additional computations are introduced.
+    # In PyTorch >= 2.9, return_lse was renamed to return_aux
+    if use_return_aux:
+        flex_attn_kwargs["return_aux"] = True
+    else:
+        flex_attn_kwargs["return_lse"] = True
+
     attn_output, attention_weights = compile_friendly_flex_attention(
         query,
         key,
         value,
-        score_mod=score_mod,
-        block_mask=block_mask,
-        enable_gqa=True,
-        scale=scaling,
-        # Last time checked on PyTorch == 2.5.1: Flex Attention always computes the lse regardless.
-        # For simplification, we thus always return it as no additional computations are introduced.
-        return_lse=True,
+        **flex_attn_kwargs,
     )
     # lse is returned in float32
     attention_weights = attention_weights.to(value.dtype)

--- a/src/transformers/models/doge/modular_doge.py
+++ b/src/transformers/models/doge/modular_doge.py
@@ -28,6 +28,8 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache
 from ...configuration_utils import PreTrainedConfig
 from ...integrations.flex_attention import compile_friendly_flex_attention
+from ...utils.import_utils import get_torch_version
+from packaging import version
 from ...modeling_layers import GradientCheckpointingLayer
 from ...modeling_outputs import MoeCausalLMOutputWithPast, MoeModelOutputWithPast
 from ...modeling_rope_utils import RopeParameters
@@ -202,17 +204,31 @@ def flex_attention_forward(
             score = score + causal_mask[batch_idx][head_idx][q_idx][kv_idx]
         return score
 
+    # PyTorch >= 2.9 renamed return_lse to return_aux
+    torch_version = get_torch_version()
+    use_return_aux = version.parse(torch_version).base_version >= "2.9"
+
+    # Build kwargs for flex attention
+    flex_attn_kwargs = {
+        "score_mod": score_mod,
+        "block_mask": block_mask,
+        "enable_gqa": True,
+        "scale": scaling,
+    }
+
+    # Last time checked on PyTorch == 2.5.1: Flex Attention always computes the lse regardless.
+    # For simplification, we thus always return it as no additional computations are introduced.
+    # In PyTorch >= 2.9, return_lse was renamed to return_aux
+    if use_return_aux:
+        flex_attn_kwargs["return_aux"] = True
+    else:
+        flex_attn_kwargs["return_lse"] = True
+
     attn_output, attention_weights = compile_friendly_flex_attention(
         query,
         key,
         value,
-        score_mod=score_mod,
-        block_mask=block_mask,
-        enable_gqa=True,
-        scale=scaling,
-        # Last time checked on PyTorch == 2.5.1: Flex Attention always computes the lse regardless.
-        # For simplification, we thus always return it as no additional computations are introduced.
-        return_lse=True,
+        **flex_attn_kwargs,
     )
     # lse is returned in float32
     attention_weights = attention_weights.to(value.dtype)

--- a/src/transformers/models/fuyu/image_processing_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_fuyu.py
@@ -114,7 +114,7 @@ class FuyuBatchFeature(BatchFeature):
         def _safe_convert_tensor(elem):
             try:
                 return _convert_tensor(elem)
-            except:  # noqa E722
+            except Exception:
                 if key == "overflowing_values":
                     raise ValueError("Unable to create tensor returning overflowing values of different lengths. ")
                 raise ValueError(

--- a/src/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/configuration_qwen2_5_vl.py
@@ -232,12 +232,24 @@ class Qwen2_5_VLConfig(PreTrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Extract label-related arguments to propagate to text_config
+        num_labels = kwargs.get("num_labels")
+        id2label = kwargs.get("id2label")
+        label2id = kwargs.get("label2id")
+
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(text_config, dict):
+            # Add label-related args to text_config dict if not already present
+            if num_labels is not None and "num_labels" not in text_config:
+                text_config["num_labels"] = num_labels
+            if id2label is not None and "id2label" not in text_config:
+                text_config["id2label"] = id2label
+            if label2id is not None and "label2id" not in text_config:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
             # Hub configs are saved as flat dicts so we pop some of kwargs to init `TextConfig`
@@ -245,7 +257,16 @@ class Qwen2_5_VLConfig(PreTrainedConfig):
             text_params = list(text_params) + ["rope_scaling", "rope_theta"]
             text_config = {key: kwargs.pop(key) for key in text_params if key in kwargs}
             text_config["dtype"] = kwargs.get("torch_dtype", kwargs.get("dtype"))  # don't pop the dtype
+            # Pass label-related args to text_config when creating default
+            if num_labels is not None:
+                text_config["num_labels"] = num_labels
+            if id2label is not None:
+                text_config["id2label"] = id2label
+            if label2id is not None:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/configuration_qwen2_vl.py
@@ -209,12 +209,24 @@ class Qwen2VLConfig(PreTrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Extract label-related arguments to propagate to text_config
+        num_labels = kwargs.get("num_labels")
+        id2label = kwargs.get("id2label")
+        label2id = kwargs.get("label2id")
+
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(text_config, dict):
+            # Add label-related args to text_config dict if not already present
+            if num_labels is not None and "num_labels" not in text_config:
+                text_config["num_labels"] = num_labels
+            if id2label is not None and "id2label" not in text_config:
+                text_config["id2label"] = id2label
+            if label2id is not None and "label2id" not in text_config:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
             # Hub configs are saved as flat dicts so we pop some of kwargs to init `TextConfig`
@@ -222,7 +234,16 @@ class Qwen2VLConfig(PreTrainedConfig):
             text_params = list(text_params) + ["rope_scaling", "rope_theta"]
             text_config = {key: kwargs.pop(key) for key in text_params if key in kwargs}
             text_config["dtype"] = kwargs.get("torch_dtype", kwargs.get("dtype"))  # don't pop the dtype
+            # Pass label-related args to text_config when creating default
+            if num_labels is not None:
+                text_config["num_labels"] = num_labels
+            if id2label is not None:
+                text_config["id2label"] = id2label
+            if label2id is not None:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/src/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -219,15 +219,37 @@ class Qwen3_5Config(PreTrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Extract label-related arguments to propagate to text_config
+        num_labels = kwargs.get("num_labels")
+        id2label = kwargs.get("id2label")
+        label2id = kwargs.get("label2id")
+
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(text_config, dict):
+            # Add label-related args to text_config dict if not already present
+            if num_labels is not None and "num_labels" not in text_config:
+                text_config["num_labels"] = num_labels
+            if id2label is not None and "id2label" not in text_config:
+                text_config["id2label"] = id2label
+            if label2id is not None and "label2id" not in text_config:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
-            self.text_config = self.sub_configs["text_config"]()
+            # Pass label-related args to text_config when creating default
+            text_config_kwargs = {}
+            if num_labels is not None:
+                text_config_kwargs["num_labels"] = num_labels
+            if id2label is not None:
+                text_config_kwargs["id2label"] = id2label
+            if label2id is not None:
+                text_config_kwargs["label2id"] = label2id
+            self.text_config = self.sub_configs["text_config"](**text_config_kwargs)
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/configuration_qwen3_vl.py
@@ -173,15 +173,37 @@ class Qwen3VLConfig(PreTrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Extract label-related arguments to propagate to text_config
+        num_labels = kwargs.get("num_labels")
+        id2label = kwargs.get("id2label")
+        label2id = kwargs.get("label2id")
+
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(text_config, dict):
+            # Add label-related args to text_config dict if not already present
+            if num_labels is not None and "num_labels" not in text_config:
+                text_config["num_labels"] = num_labels
+            if id2label is not None and "id2label" not in text_config:
+                text_config["id2label"] = id2label
+            if label2id is not None and "label2id" not in text_config:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
-            self.text_config = self.sub_configs["text_config"]()
+            # Pass label-related args to text_config when creating default
+            text_config_kwargs = {}
+            if num_labels is not None:
+                text_config_kwargs["num_labels"] = num_labels
+            if id2label is not None:
+                text_config_kwargs["id2label"] = id2label
+            if label2id is not None:
+                text_config_kwargs["label2id"] = label2id
+            self.text_config = self.sub_configs["text_config"](**text_config_kwargs)
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -229,15 +229,38 @@ class Qwen3VLConfig(PreTrainedConfig):
         tie_word_embeddings=False,
         **kwargs,
     ):
+        # Extract label-related arguments to propagate to text_config
+        # but also keep them for the outer config
+        num_labels = kwargs.get("num_labels")
+        id2label = kwargs.get("id2label")
+        label2id = kwargs.get("label2id")
+
         if isinstance(vision_config, dict):
             self.vision_config = self.sub_configs["vision_config"](**vision_config)
         elif vision_config is None:
             self.vision_config = self.sub_configs["vision_config"]()
 
         if isinstance(text_config, dict):
+            # Add label-related args to text_config dict if not already present
+            if num_labels is not None and "num_labels" not in text_config:
+                text_config["num_labels"] = num_labels
+            if id2label is not None and "id2label" not in text_config:
+                text_config["id2label"] = id2label
+            if label2id is not None and "label2id" not in text_config:
+                text_config["label2id"] = label2id
             self.text_config = self.sub_configs["text_config"](**text_config)
         elif text_config is None:
-            self.text_config = self.sub_configs["text_config"]()
+            # Pass label-related args to text_config when creating default
+            text_config_kwargs = {}
+            if num_labels is not None:
+                text_config_kwargs["num_labels"] = num_labels
+            if id2label is not None:
+                text_config_kwargs["id2label"] = id2label
+            if label2id is not None:
+                text_config_kwargs["label2id"] = label2id
+            self.text_config = self.sub_configs["text_config"](**text_config_kwargs)
+        else:
+            self.text_config = text_config
 
         self.image_token_id = image_token_id
         self.video_token_id = video_token_id

--- a/src/transformers/models/xlnet/modeling_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_xlnet.py
@@ -939,7 +939,7 @@ class XLNetModel(XLNetPreTrainedModel):
 
     def relative_positional_encoding(self, qlen, klen, bsz=None):
         # create relative positional encoding.
-        freq_seq = torch.arange(0, self.d_model, 2.0, dtype=torch.int64).float()
+        freq_seq = torch.arange(0, self.d_model, 2.0, dtype=torch.int64, device=self.device).float()
         inv_freq = 1 / torch.pow(10000, (freq_seq / self.d_model))
 
         if self.attn_type == "bi":
@@ -952,8 +952,8 @@ class XLNetModel(XLNetPreTrainedModel):
             raise ValueError(f"Unknown `attn_type` {self.attn_type}.")
 
         if self.bi_data:
-            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64).float()
-            bwd_pos_seq = torch.arange(-beg, -end, 1.0, dtype=torch.int64).float()
+            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64, device=self.device).float()
+            bwd_pos_seq = torch.arange(-beg, -end, 1.0, dtype=torch.int64, device=self.device).float()
 
             if self.clamp_len > 0:
                 fwd_pos_seq = fwd_pos_seq.clamp(-self.clamp_len, self.clamp_len)
@@ -968,7 +968,7 @@ class XLNetModel(XLNetPreTrainedModel):
 
             pos_emb = torch.cat([fwd_pos_emb, bwd_pos_emb], dim=1)
         else:
-            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64).float()
+            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64, device=self.device).float()
             if self.clamp_len > 0:
                 fwd_pos_seq = fwd_pos_seq.clamp(-self.clamp_len, self.clamp_len)
             pos_emb = self.positional_embedding(fwd_pos_seq, inv_freq, bsz)


### PR DESCRIPTION
Fixed Issue #44737: XLNet relative_positional_encoding function missing device parameter in torch.arange calls.