### PR TITLE
fix: add device= to torch.arange in XLNet relative_positional_encoding

### DIFF
--- a/src/transformers/models/xlnet/modeling_xlnet.py
+++ b/src/transformers/models/xlnet/modeling_xlnet.py
@@ -939,7 +939,7 @@ class XLNetModel(XLNetPreTrainedModel):
 
     def relative_positional_encoding(self, qlen, klen, bsz=None):
         # create relative positional encoding.
-        freq_seq = torch.arange(0, self.d_model, 2.0, dtype=torch.int64).float()
+        freq_seq = torch.arange(0, self.d_model, 2.0, dtype=torch.int64, device=self.device).float()
         inv_freq = 1 / torch.pow(10000, (freq_seq / self.d_model))
 
         if self.attn_type == "bi":
@@ -952,8 +952,8 @@ class XLNetModel(XLNetPreTrainedModel):
             raise ValueError(f"Unknown `attn_type` {self.attn_type}.")
 
         if self.bi_data:
-            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64).float()
-            bwd_pos_seq = torch.arange(-beg, -end, 1.0, dtype=torch.int64).float()
+            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64, device=self.device).float()
+            bwd_pos_seq = torch.arange(-beg, -end, 1.0, dtype=torch.int64, device=self.device).float()
 
             if self.clamp_len > 0:
                 fwd_pos_seq = fwd_pos_seq.clamp(-self.clamp_len, self.clamp_len)
@@ -968,7 +968,7 @@ class XLNetModel(XLNetPreTrainedModel):
 
             pos_emb = torch.cat([fwd_pos_emb, bwd_pos_emb], dim=1)
         else:
-            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64).float()
+            fwd_pos_seq = torch.arange(beg, end, -1.0, dtype=torch.int64, device=self.device).float()
             if self.clamp_len > 0:
                 fwd_pos_seq = fwd_pos_seq.clamp(-self.clamp_len, self.clamp_len)
             pos_emb = self.positional_embedding(fwd_pos_seq, inv_freq, bsz)

--- a/tests/models/xlnet/test_modeling_xlnet.py
+++ b/tests/models/xlnet/test_modeling_xlnet.py
@@ -609,6 +609,22 @@ class XLNetModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixi
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_xlnet_qa(*config_and_inputs)
 
+    def test_relative_positional_encoding_device(self):
+        """Test that relative_positional_encoding creates tensors on the correct device."""
+        self.model_tester.set_seed()
+        config = self.model_tester.get_config()
+        model = XLNetModel(config)
+        model.to(torch_device)
+        model.eval()
+
+        qlen, klen, bsz = 4, 6, 2
+        pos_emb = model.relative_positional_encoding(qlen, klen, bsz=bsz)
+        self.assertEqual(
+            pos_emb.device.type,
+            torch.device(torch_device).type,
+            f"pos_emb should be on {torch_device}, but got {pos_emb.device}",
+        )
+
     @unittest.skip(reason="xlnet cannot keep gradients in attentions or hidden states")
     def test_retain_grad_hidden_states_attentions(self):
         return


### PR DESCRIPTION
## Summary

Fixes #44737

- Added `device=self.device` to all four `torch.arange()` calls in `XLNetModel.relative_positional_encoding()` so that intermediate tensors are created directly on the model's device instead of always on CPU.
- Without this fix, the entire sinusoidal positional encoding computation runs on CPU every forward pass, with only the final result moved to GPU via `.to(output_h.device)` at the call site (line 1143). This causes unnecessary CPU-GPU synchronization overhead.
- Added a test verifying `relative_positional_encoding()` produces output on the correct device.

## Details

The four fixed calls (all in `relative_positional_encoding`):
1. `freq_seq = torch.arange(0, self.d_model, 2.0, ...)` 
2. `fwd_pos_seq = torch.arange(beg, end, -1.0, ...)` (bi_data path)
3. `bwd_pos_seq = torch.arange(-beg, -end, 1.0, ...)` (bi_data path)
4. `fwd_pos_seq = torch.arange(beg, end, -1.0, ...)` (uni_data path)

## Test plan

- [x] Added `test_relative_positional_encoding_device` to `tests/models/xlnet/test_modeling_xlnet.py`
- [x] Test creates an `XLNetModel`, moves it to `torch_device`, and verifies the positional encoding output is on the same device