### PR TITLE
Fix: Eurobert model was missing @strict decorator and invalid test kwargs

### DIFF
--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -19,12 +19,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+from ...configuration_utils import strict
 from ...modeling_rope_utils import RopeParameters
 from ...utils import auto_docstring
 from ..llama import LlamaConfig
 
 
 @auto_docstring(checkpoint="EuroBERT/EuroBERT-210m")
+@strict(accept_kwargs=True)
 class EuroBertConfig(LlamaConfig):
     r"""
     mask_token_id (`int`, *optional*, defaults to 128002):

--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -31,6 +31,8 @@ class EuroBertConfig(LlamaConfig):
         Mask token id.
     classifier_pooling (`str`, *optional*, defaults to `"late"`):
         The pooling strategy to use for the classifier. Can be one of ['bos', 'mean', 'late'].
+    is_causal (`bool`, *optional*, defaults to `False`):
+        Whether to use causal attention masking. Set to `False` for bidirectional attention.
 
     ```python
     >>> from transformers import EuroBertModel, EuroBertConfig

--- a/src/transformers/models/eurobert/modular_eurobert.py
+++ b/src/transformers/models/eurobert/modular_eurobert.py
@@ -34,6 +34,8 @@ class EuroBertConfig(LlamaConfig):
         Mask token id.
     classifier_pooling (`str`, *optional*, defaults to `"late"`):
         The pooling strategy to use for the classifier. Can be one of ['bos', 'mean', 'late'].
+    is_causal (`bool`, *optional*, defaults to `False`):
+        Whether to use causal attention masking. Set to `False` for bidirectional attention.
 
     ```python
     >>> from transformers import EuroBertModel, EuroBertConfig

--- a/src/transformers/models/eurobert/modular_eurobert.py
+++ b/src/transformers/models/eurobert/modular_eurobert.py
@@ -17,6 +17,7 @@ import torch
 from torch import nn
 from torch.nn import BCEWithLogitsLoss, CrossEntropyLoss, MSELoss
 
+from ...configuration_utils import strict
 from ...masking_utils import create_bidirectional_mask
 from ...modeling_outputs import BaseModelOutput, MaskedLMOutput, SequenceClassifierOutput, TokenClassifierOutput
 from ...modeling_rope_utils import RopeParameters
@@ -28,6 +29,7 @@ from ..llama.modeling_llama import LlamaAttention, LlamaModel, LlamaPreTrainedMo
 
 
 @auto_docstring(checkpoint="EuroBERT/EuroBERT-210m")
+@strict(accept_kwargs=True)
 class EuroBertConfig(LlamaConfig):
     r"""
     mask_token_id (`int`, *optional*, defaults to 128002):

--- a/tests/models/eurobert/test_modeling_eurobert.py
+++ b/tests/models/eurobert/test_modeling_eurobert.py
@@ -222,7 +222,7 @@ class EuroBertModelTest(ModelTesterMixin, PipelineTesterMixin, unittest.TestCase
 
     def setUp(self):
         self.model_tester = EuroBertModelTester(self)
-        self.config_tester = ConfigTester(self, config_class=EuroBertConfig, hidden_size=32)
+        self.config_tester = ConfigTester(self, config_class=EuroBertConfig, hidden_size=32, num_attention_heads=2)
 
     def test_config(self):
         self.config_tester.run_common_tests()

--- a/tests/models/eurobert/test_modeling_eurobert.py
+++ b/tests/models/eurobert/test_modeling_eurobert.py
@@ -124,11 +124,8 @@ class EuroBertModelTester:
             num_attention_heads=self.num_attention_heads,
             intermediate_size=self.intermediate_size,
             hidden_act=self.hidden_act,
-            hidden_dropout_prob=self.hidden_dropout_prob,
-            attention_probs_dropout_prob=self.attention_probs_dropout_prob,
+            attention_dropout=self.attention_probs_dropout_prob,
             max_position_embeddings=self.max_position_embeddings,
-            type_vocab_size=self.type_vocab_size,
-            is_decoder=False,
             initializer_range=self.initializer_range,
             pad_token_id=self.pad_token_id,
         )


### PR DESCRIPTION
# What does this PR do?

EuroBertConfig was missing `@strict(accept_kwargs=True)` unlike its parent LlamaConfig, causing failures when reloading saved configs that include  extra keys like `architectures`. 

Also fixed the test helper passing BERT-style kwargs (`hidden_dropout_prob`, `type_vocab_size`, `is_decoder`) that don't exist on the Llama-based config.