### PR TITLE
Fix configs with `@strict`

### DIFF
--- a/src/transformers/models/edgetam_video/configuration_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/configuration_edgetam_video.py
@@ -297,7 +297,7 @@ class EdgeTamVideoConfig(PreTrainedConfig):
             self.vision_config["model_type"] = self.vision_config.get("model_type", "sam2_vision_model")
             self.vision_config = CONFIG_MAPPING[self.vision_config["model_type"]](**self.vision_config)
         elif self.vision_config is None:
-            self.vision_config = CONFIG_MAPPING["sam2_vision_model"](**self.vision_config)
+            self.vision_config = CONFIG_MAPPING["sam2_vision_model"]()
 
         if isinstance(self.prompt_encoder_config, dict):
             self.prompt_encoder_config = EdgeTamVideoPromptEncoderConfig(**self.prompt_encoder_config)

--- a/src/transformers/models/edgetam_video/modular_edgetam_video.py
+++ b/src/transformers/models/edgetam_video/modular_edgetam_video.py
@@ -279,7 +279,7 @@ class EdgeTamVideoConfig(PreTrainedConfig):
             self.vision_config["model_type"] = self.vision_config.get("model_type", "sam2_vision_model")
             self.vision_config = CONFIG_MAPPING[self.vision_config["model_type"]](**self.vision_config)
         elif self.vision_config is None:
-            self.vision_config = CONFIG_MAPPING["sam2_vision_model"](**self.vision_config)
+            self.vision_config = CONFIG_MAPPING["sam2_vision_model"]()
 
         if isinstance(self.prompt_encoder_config, dict):
             self.prompt_encoder_config = EdgeTamVideoPromptEncoderConfig(**self.prompt_encoder_config)

--- a/src/transformers/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/configuration_nemotron_h.py
@@ -104,24 +104,24 @@ class NemotronHConfig(PreTrainedConfig):
     use_mamba_kernels: bool = True
     ssm_state_size: int = 128
     mamba_num_heads: int = 128
-    mamba_n_groups: int = 8
     mamba_head_dim: int = 64
-    mamba_d_conv: int = 4
-    mamba_expand: int = 2
     mamba_hidden_act: str = "silu"
-    mamba_dt_min: float = 0.001
-    mamba_dt_max: float = 0.1
-    mamba_dt_limit: list[float] | tuple[float, ...] = (0.0, float("inf"))
-    mamba_dt_init_floor: float = 1e-4
-    mamba_conv_bias: bool = True
+    n_groups: int = 8
+    conv_kernel: int = 4
+    expand: int = 2
+    time_step_min: float = 0.001
+    time_step_max: float = 0.1
+    time_step_limit: list[float] | tuple[float, ...] = (0.0, float("inf"))
+    time_step_floor: float = 1e-4
+    use_conv_bias: bool = True
+    chunk_size: int = 128
     mamba_proj_bias: bool = False
-    mamba_chunk_size: int = 128
     mamba_ssm_cache_dtype: str = "float32"
     n_routed_experts: int = 8
     n_shared_experts: int = 1
     moe_intermediate_size: int = 7688
     moe_shared_expert_intermediate_size: int = 7688
-    moe_latent_size: int = None
+    moe_latent_size: int | None = None
     moe_shared_expert_overlap: bool = True
     num_experts_per_tok: int = 2
     routed_scaling_factor: float | int = 1.0
@@ -129,7 +129,7 @@ class NemotronHConfig(PreTrainedConfig):
     topk_group: int = 1
     norm_topk_prob: bool = True
     num_nextn_predict_layers: int = 0
-    mtp_layers_block_type: list[str] = ["attention", "moe"]
+    mtp_layers_block_type: list[str] | None = None
     use_bias: bool = False
     initializer_range: float = 0.02
     layer_norm_epsilon: float = 1e-5
@@ -138,6 +138,20 @@ class NemotronHConfig(PreTrainedConfig):
     rescale_prenorm_residual: bool = True
 
     def __post_init__(self, **kwargs):
+        # Backward compatibility; configs expect different names for these fields when init
+        # but they have to be re-names when creating/saving the config.
+        self.n_groups = kwargs.pop("mamba_n_groups") if "mamba_n_groups" in kwargs else self.n_groups
+        self.conv_kernel = kwargs.pop("mamba_d_conv") if "mamba_d_conv" in kwargs else self.conv_kernel
+        self.expand = kwargs.pop("mamba_expand") if "mamba_expand" in kwargs else self.expand
+        self.time_step_min = kwargs.pop("mamba_dt_min") if "mamba_dt_min" in kwargs else self.time_step_min
+        self.time_step_max = kwargs.pop("mamba_dt_max") if "mamba_dt_max" in kwargs else self.time_step_max
+        self.time_step_limit = kwargs.pop("mamba_dt_limit") if "mamba_dt_limit" in kwargs else self.time_step_limit
+        self.time_step_floor = (
+            kwargs.pop("mamba_dt_init_floor") if "mamba_dt_init_floor" in kwargs else self.time_step_floor
+        )
+        self.use_conv_bias = kwargs.pop("mamba_conv_bias") if "mamba_conv_bias" in kwargs else self.use_conv_bias
+        self.chunk_size = kwargs.pop("mamba_chunk_size") if "mamba_chunk_size" in kwargs else self.chunk_size
+
         # Backward compatibility: convert hybrid_override_pattern to layers_block_type
         # Always pop hybrid_override_pattern from kwargs to prevent it from being set as an attribute
         if "hybrid_override_pattern" in kwargs:
@@ -160,9 +174,12 @@ class NemotronHConfig(PreTrainedConfig):
 
         # Backward compatibility: convert mtp_hybrid_override_pattern to mtp_layers_block_type
         # Always pop mtp_hybrid_override_pattern from kwargs to prevent it from being set as an attribute
+        if self.mtp_layers_block_type is None:
+            self.mtp_layers_block_type == ["attention", "moe"]
+
         if "mtp_hybrid_override_pattern" in kwargs:
             pattern = kwargs.pop("mtp_hybrid_override_pattern")
-            if self.mtp_layers_block_type is None or self.mtp_layers_block_type == ["attention", "moe"]:
+            if self.mtp_layers_block_type == ["attention", "moe"]:
                 self.mtp_layers_block_type = self._pattern_to_list(pattern)
 
         # for backward compatibility

--- a/src/transformers/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/configuration_nemotron_h.py
@@ -175,7 +175,7 @@ class NemotronHConfig(PreTrainedConfig):
         # Backward compatibility: convert mtp_hybrid_override_pattern to mtp_layers_block_type
         # Always pop mtp_hybrid_override_pattern from kwargs to prevent it from being set as an attribute
         if self.mtp_layers_block_type is None:
-            self.mtp_layers_block_type == ["attention", "moe"]
+            self.mtp_layers_block_type = ["attention", "moe"]
 
         if "mtp_hybrid_override_pattern" in kwargs:
             pattern = kwargs.pop("mtp_hybrid_override_pattern")

--- a/src/transformers/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/configuration_nemotron_h.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 """NemotronH model configuration"""
 
-from ...configuration_utils import PretrainedConfig
+from huggingface_hub.dataclasses import strict
+
+from ...configuration_utils import PreTrainedConfig
 from ...utils import auto_docstring, logging
 
 
@@ -21,7 +23,8 @@ logger = logging.get_logger(__name__)
 
 
 @auto_docstring(checkpoint="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16")
-class NemotronHConfig(PretrainedConfig):
+@strict(accept_kwargs=True)
+class NemotronHConfig(PreTrainedConfig):
     r"""
     layers_block_type (`list`, *optional*):
         Explicit list of layer types for each layer. Each element must be one of: "mamba", "attention", or "moe".
@@ -79,205 +82,129 @@ class NemotronHConfig(PretrainedConfig):
     model_type = "nemotron_h"
     keys_to_ignore_at_inference = ["past_key_values"]
 
-    @staticmethod
-    def _validate_layers_block_type(layers_block_type, expected_length=None, param_name="layers_block_type"):
-        """
-        Validate layers_block_type list.
+    vocab_size: int = 131072
+    hidden_size: int = 4096
+    layers_block_type: list[str] | None = None
+    tie_word_embeddings: bool = False
+    use_cache: bool = True
+    num_logits_to_keep: int = 1
+    pad_token_id: int | None = 0
+    bos_token_id: int | None = 1
+    eos_token_id: int | None = 2
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 8
+    head_dim: int = 128
+    max_position_embeddings: int = 4096
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    sliding_window: int | None = None
+    intermediate_size: int = 21504
+    mlp_hidden_act: str = "relu2"
+    mlp_bias: bool = False
+    use_mamba_kernels: bool = True
+    ssm_state_size: int = 128
+    mamba_num_heads: int = 128
+    mamba_n_groups: int = 8
+    mamba_head_dim: int = 64
+    mamba_d_conv: int = 4
+    mamba_expand: int = 2
+    mamba_hidden_act: str = "silu"
+    mamba_dt_min: float = 0.001
+    mamba_dt_max: float = 0.1
+    mamba_dt_limit: list[float] | tuple[float, ...] = (0.0, float("inf"))
+    mamba_dt_init_floor: float = 1e-4
+    mamba_conv_bias: bool = True
+    mamba_proj_bias: bool = False
+    mamba_chunk_size: int = 128
+    mamba_ssm_cache_dtype: str = "float32"
+    n_routed_experts: int = 8
+    n_shared_experts: int = 1
+    moe_intermediate_size: int = 7688
+    moe_shared_expert_intermediate_size: int = 7688
+    moe_latent_size: int = None
+    moe_shared_expert_overlap: bool = True
+    num_experts_per_tok: int = 2
+    routed_scaling_factor: float | int = 1.0
+    n_group: int = 1
+    topk_group: int = 1
+    norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 0
+    mtp_layers_block_type: list[str] = ["attention", "moe"]
+    use_bias: bool = False
+    initializer_range: float = 0.02
+    layer_norm_epsilon: float = 1e-5
+    residual_in_fp32: bool = False
+    hidden_dropout: float | int = 0.0
+    rescale_prenorm_residual: bool = True
 
-        Args:
-            layers_block_type: List of layer types to validate
-            expected_length: If provided, validate the list has this length
-            param_name: Parameter name for error messages
-
-        Raises:
-            ValueError: If validation fails
-        """
-        if not isinstance(layers_block_type, list):
-            raise ValueError(f"{param_name} must be a list of strings. Got type: {type(layers_block_type)}")
-
-        if expected_length is not None and len(layers_block_type) != expected_length:
-            raise ValueError(f"{param_name} must have length {expected_length}. Got length {len(layers_block_type)}.")
-
-        valid_types = {"mamba", "attention", "moe"}
-        if not all(block_type in valid_types for block_type in layers_block_type):
-            invalid = set(layers_block_type) - valid_types
-            raise ValueError(f"{param_name} contains invalid types: {invalid}. Must be one of: {valid_types}")
-
-    def __init__(
-        self,
-        # General model config
-        vocab_size=131072,
-        hidden_size=4096,
-        layers_block_type=None,
-        num_hidden_layers=None,  # Deprecated, only for backward compatibility
-        tie_word_embeddings=False,
-        use_cache=True,
-        num_logits_to_keep=1,
-        # Token IDs
-        pad_token_id=0,
-        bos_token_id=1,
-        eos_token_id=2,
-        # Attention layer config
-        num_attention_heads=32,
-        num_key_value_heads=8,
-        head_dim=128,
-        max_position_embeddings=4096,
-        attention_bias=False,
-        attention_dropout=0.0,
-        sliding_window=None,
-        # MLP layer config
-        intermediate_size=21504,
-        mlp_hidden_act="relu2",
-        mlp_bias=False,
-        # Mamba layer config
-        use_mamba_kernels=True,
-        ssm_state_size=128,
-        mamba_num_heads=128,
-        mamba_n_groups=8,
-        mamba_head_dim=64,
-        mamba_d_conv=4,
-        mamba_expand=2,
-        mamba_hidden_act="silu",
-        mamba_dt_min=0.001,
-        mamba_dt_max=0.1,
-        mamba_dt_limit=(0.0, float("inf")),
-        mamba_dt_init_floor=1e-4,
-        mamba_conv_bias=True,
-        mamba_proj_bias=False,
-        mamba_chunk_size=128,
-        mamba_ssm_cache_dtype="float32",
-        # MoE config
-        n_routed_experts=8,
-        n_shared_experts=1,
-        moe_intermediate_size=7688,
-        moe_shared_expert_intermediate_size=7688,
-        moe_latent_size=None,
-        moe_shared_expert_overlap=True,
-        num_experts_per_tok=2,
-        routed_scaling_factor=1.0,
-        n_group=1,
-        topk_group=1,
-        norm_topk_prob=True,
-        # Multi-token prediction config
-        num_nextn_predict_layers=0,
-        mtp_layers_block_type=["attention", "moe"],
-        # General training config
-        use_bias=False,
-        initializer_range=0.02,
-        layer_norm_epsilon=1e-5,
-        residual_in_fp32=False,
-        hidden_dropout=0.0,
-        rescale_prenorm_residual=True,
-        **kwargs,
-    ):
+    def __post_init__(self, **kwargs):
         # Backward compatibility: convert hybrid_override_pattern to layers_block_type
         # Always pop hybrid_override_pattern from kwargs to prevent it from being set as an attribute
         if "hybrid_override_pattern" in kwargs:
             pattern = kwargs.pop("hybrid_override_pattern")
-            if layers_block_type is None:
-                layers_block_type = self._pattern_to_list(pattern)
-        elif layers_block_type is None:
+            if self.layers_block_type is None:
+                self.layers_block_type = self._pattern_to_list(pattern)
+        elif self.layers_block_type is None:
             # Default layers_block_type if not provided
-            layers_block_type = ["mamba", "moe", "attention", "moe"]
+            self.layers_block_type = ["mamba", "moe", "attention", "moe"]
 
         # Note: num_hidden_layers is deprecated and ignored if layers_block_type is explicitly provided
         # It's only kept for backward compatibility when loading old configs
-        if num_hidden_layers is not None:
+        if self.num_hidden_layers is not None:
             # Warn if num_hidden_layers is provided but doesn't match layers_block_type
-            if len(layers_block_type) != num_hidden_layers:
+            if len(self.layers_block_type) != self.num_hidden_layers:
                 logger.warning(
-                    f"num_hidden_layers ({num_hidden_layers}) is deprecated and doesn't match "
-                    f"layers_block_type length ({len(layers_block_type)}). Using layers_block_type length."
+                    f"num_hidden_layers ({self.num_hidden_layers}) is deprecated and doesn't match "
+                    f"layers_block_type length ({len(self.layers_block_type)}). Using layers_block_type length."
                 )
 
         # Backward compatibility: convert mtp_hybrid_override_pattern to mtp_layers_block_type
         # Always pop mtp_hybrid_override_pattern from kwargs to prevent it from being set as an attribute
         if "mtp_hybrid_override_pattern" in kwargs:
             pattern = kwargs.pop("mtp_hybrid_override_pattern")
-            if mtp_layers_block_type is None or mtp_layers_block_type == ["attention", "moe"]:
-                mtp_layers_block_type = self._pattern_to_list(pattern)
-
-        self.vocab_size = vocab_size
-        self.tie_word_embeddings = tie_word_embeddings
-        self.hidden_size = hidden_size
-        self.intermediate_size = intermediate_size
-        self.num_attention_heads = num_attention_heads
-        self.head_dim = head_dim
-        self.sliding_window = sliding_window
-        self.max_position_embeddings = max_position_embeddings
-        self.attention_dropout = attention_dropout
-        self.hidden_dropout = hidden_dropout
-
-        # Validate layers_block_type (no longer checking length against num_hidden_layers)
-        self._validate_layers_block_type(layers_block_type, expected_length=None, param_name="layers_block_type")
-        self.layers_block_type = layers_block_type
+            if self.mtp_layers_block_type is None or self.mtp_layers_block_type == ["attention", "moe"]:
+                self.mtp_layers_block_type = self._pattern_to_list(pattern)
 
         # for backward compatibility
-        if num_key_value_heads is None:
-            num_key_value_heads = num_attention_heads
+        if self.num_key_value_heads is None:
+            self.num_key_value_heads = self.num_attention_heads
 
-        self.num_key_value_heads = num_key_value_heads
-        self.mlp_hidden_act = mlp_hidden_act
-        self.attention_bias = attention_bias
-        self.mlp_bias = mlp_bias
-        self.use_bias = use_bias
-        self.initializer_range = initializer_range
-        self.layer_norm_epsilon = layer_norm_epsilon
-        self.residual_in_fp32 = residual_in_fp32
+        super().__post_init__(**kwargs)
 
-        self.use_cache = use_cache
-        self.num_logits_to_keep = num_logits_to_keep
+    @staticmethod
+    def validate_layers_block_type(self):
+        """
+        Validate layers_block_type list.
+        """
+        if not isinstance(self.layers_block_type, list):
+            raise ValueError(
+                f"`layers_block_type` must be a list of strings. Got type: {type(self.layers_block_type)}"
+            )
 
-        self.use_mamba_kernels = use_mamba_kernels
-        self.n_groups = mamba_n_groups
-        self.mamba_head_dim = mamba_head_dim
-        self.ssm_state_size = ssm_state_size
-        self.mamba_num_heads = mamba_num_heads
-        self.conv_kernel = mamba_d_conv
-        self.expand = mamba_expand
-        self.mamba_hidden_act = mamba_hidden_act
-        self.time_step_min = mamba_dt_min
-        self.time_step_max = mamba_dt_max
-        self.time_step_limit = mamba_dt_limit
-        self.time_step_floor = mamba_dt_init_floor
-        self.use_conv_bias = mamba_conv_bias
-        self.mamba_proj_bias = mamba_proj_bias
-        self.chunk_size = mamba_chunk_size
-        self.rescale_prenorm_residual = rescale_prenorm_residual
-        self.n_routed_experts = n_routed_experts
-        self.n_shared_experts = n_shared_experts
-        self.moe_intermediate_size = moe_intermediate_size
-        self.moe_shared_expert_intermediate_size = moe_shared_expert_intermediate_size
-        self.moe_latent_size = moe_latent_size
-        self.moe_shared_expert_overlap = moe_shared_expert_overlap
-        self.num_experts_per_tok = num_experts_per_tok
-        self.routed_scaling_factor = routed_scaling_factor
-        self.n_group = n_group
-        self.topk_group = topk_group
-        self.norm_topk_prob = norm_topk_prob
-        self.mamba_ssm_cache_dtype = mamba_ssm_cache_dtype
+        valid_types = {"mamba", "attention", "moe"}
+        if not all(block_type in valid_types for block_type in self.layers_block_type):
+            invalid = set(self.layers_block_type) - valid_types
+            raise ValueError(f"`layers_block_type` contains invalid types: {invalid}. Must be one of: {valid_types}")
 
-        # MTP config
-        self.num_nextn_predict_layers = num_nextn_predict_layers
-
-        # Validate mtp_layers_block_type is provided when MTP is enabled
         if self.num_nextn_predict_layers > 0:
-            if mtp_layers_block_type is None:
+            if self.mtp_layers_block_type is None:
                 raise ValueError(
                     "mtp_layers_block_type is required when num_nextn_predict_layers > 0. "
                     "Please provide an explicit list of layer types for MTP layers. "
                     "Example: mtp_layers_block_type=['attention', 'moe']"
                 )
-            self._validate_layers_block_type(mtp_layers_block_type, None, "mtp_layers_block_type")
-        self.mtp_layers_block_type = mtp_layers_block_type
 
-        super().__init__(
-            pad_token_id=pad_token_id,
-            bos_token_id=bos_token_id,
-            eos_token_id=eos_token_id,
-            tie_word_embeddings=tie_word_embeddings,
-            **kwargs,
-        )
+            if not isinstance(self.mtp_layers_block_type, list):
+                raise ValueError(
+                    f"`mtp_layers_block_type` must be a list of strings. Got type: {type(self.mtp_layers_block_type)}"
+                )
+
+            valid_types = {"mamba", "attention", "moe"}
+            if not all(block_type in valid_types for block_type in self.mtp_layers_block_type):
+                invalid = set(self.mtp_layers_block_type) - valid_types
+                raise ValueError(
+                    f"`mtp_layers_block_type` contains invalid types: {invalid}. Must be one of: {valid_types}"
+                )
 
     @property
     def num_hidden_layers(self) -> int:

--- a/src/transformers/models/sam3_tracker_video/configuration_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/configuration_sam3_tracker_video.py
@@ -211,7 +211,7 @@ class Sam3TrackerVideoConfig(PreTrainedConfig):
     vision_config: dict | PreTrainedConfig | None = None
     prompt_encoder_config: dict | PreTrainedConfig | None = None
     mask_decoder_config: dict | PreTrainedConfig | None = None
-    initializer_range: int = 0.02
+    initializer_range: float = 0.02
     num_maskmem: int = 7
     sigmoid_scale_for_mem_enc: float = 20.0
     sigmoid_bias_for_mem_enc: float = -10.0

--- a/src/transformers/models/sam3_tracker_video/modular_sam3_tracker_video.py
+++ b/src/transformers/models/sam3_tracker_video/modular_sam3_tracker_video.py
@@ -202,7 +202,7 @@ class Sam3TrackerVideoConfig(PreTrainedConfig):
     vision_config: dict | PreTrainedConfig | None = None
     prompt_encoder_config: dict | PreTrainedConfig | None = None
     mask_decoder_config: dict | PreTrainedConfig | None = None
-    initializer_range: int = 0.02
+    initializer_range: float = 0.02
     num_maskmem: int = 7
     sigmoid_scale_for_mem_enc: float = 20.0
     sigmoid_bias_for_mem_enc: float = -10.0

--- a/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/configuration_vibevoice_asr.py
@@ -17,7 +17,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from huggingface_hub.dataclasses import strict
 
 from ...configuration_utils import PretrainedConfig
 from ...utils import auto_docstring
@@ -25,6 +25,7 @@ from ..auto import CONFIG_MAPPING, AutoConfig
 
 
 @auto_docstring(checkpoint="microsoft/VibeVoice-ASR-HF")
+@strict(accept_kwargs=True)
 class VibeVoiceAsrConfig(PretrainedConfig):
     r"""
     acoustic_tokenizer_encoder_config (`Union[VibeVoiceAcousticTokenizerConfig, dict]`, *optional*):
@@ -67,52 +68,44 @@ class VibeVoiceAsrConfig(PretrainedConfig):
         "text_config": AutoConfig,
     }
 
-    def __init__(
-        self,
-        acoustic_tokenizer_encoder_config=None,
-        semantic_tokenizer_encoder_config=None,
-        text_config=None,
-        audio_token_id=151648,
-        audio_bos_token_id=151646,
-        audio_eos_token_id=151647,
-        acoustic_tokenizer_chunk_size=1440000,
-        **kwargs,
-    ):
-        if isinstance(acoustic_tokenizer_encoder_config, dict):
-            acoustic_tokenizer_encoder_config["model_type"] = acoustic_tokenizer_encoder_config.get(
+    acoustic_tokenizer_encoder_config: dict | PretrainedConfig | None = None
+    semantic_tokenizer_encoder_config: dict | PretrainedConfig | None = None
+    text_config: dict | PretrainedConfig | None = None
+    audio_token_id: int = 151648
+    audio_bos_token_id: int = 151646
+    audio_eos_token_id: int = 151647
+    acoustic_tokenizer_chunk_size: int = 1440000
+
+    def __post_init__(self, **kwargs):
+        if isinstance(self.acoustic_tokenizer_encoder_config, dict):
+            self.acoustic_tokenizer_encoder_config["model_type"] = self.acoustic_tokenizer_encoder_config.get(
                 "model_type", "vibevoice_acoustic_tokenizer_encoder"
             )
-            acoustic_tokenizer_encoder_config = CONFIG_MAPPING[acoustic_tokenizer_encoder_config["model_type"]](
-                **acoustic_tokenizer_encoder_config
-            )
-        elif acoustic_tokenizer_encoder_config is None:
-            acoustic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"]()
-        self.acoustic_tokenizer_encoder_config = acoustic_tokenizer_encoder_config
+            self.acoustic_tokenizer_encoder_config = CONFIG_MAPPING[
+                self.acoustic_tokenizer_encoder_config["model_type"]
+            ](**self.acoustic_tokenizer_encoder_config)
+        elif self.acoustic_tokenizer_encoder_config is None:
+            self.acoustic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"]()
 
-        if isinstance(semantic_tokenizer_encoder_config, dict):
-            semantic_tokenizer_encoder_config["model_type"] = semantic_tokenizer_encoder_config.get(
+        if isinstance(self.semantic_tokenizer_encoder_config, dict):
+            self.semantic_tokenizer_encoder_config["model_type"] = self.semantic_tokenizer_encoder_config.get(
                 "model_type", "vibevoice_acoustic_tokenizer_encoder"
             )
-            semantic_tokenizer_encoder_config = CONFIG_MAPPING[semantic_tokenizer_encoder_config["model_type"]](
-                **semantic_tokenizer_encoder_config
+            self.semantic_tokenizer_encoder_config = CONFIG_MAPPING[
+                self.semantic_tokenizer_encoder_config["model_type"]
+            ](**self.semantic_tokenizer_encoder_config)
+        elif self.semantic_tokenizer_encoder_config is None:
+            self.semantic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"](
+                hidden_size=128
             )
-        elif semantic_tokenizer_encoder_config is None:
-            semantic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"](hidden_size=128)
-        self.semantic_tokenizer_encoder_config = semantic_tokenizer_encoder_config
 
-        if isinstance(text_config, dict):
-            text_config["model_type"] = text_config.get("model_type", "qwen2")
-            text_config = CONFIG_MAPPING[text_config["model_type"]](**text_config)
-        elif text_config is None:
-            text_config = CONFIG_MAPPING["qwen2"]()
-        self.text_config = text_config
+        if isinstance(self.text_config, dict):
+            self.text_config["model_type"] = self.text_config.get("model_type", "qwen2")
+            self.text_config = CONFIG_MAPPING[self.text_config["model_type"]](**self.text_config)
+        elif self.text_config is None:
+            self.text_config = CONFIG_MAPPING["qwen2"]()
 
-        self.audio_token_id = audio_token_id
-        self.audio_bos_token_id = audio_bos_token_id
-        self.audio_eos_token_id = audio_eos_token_id
-        self.acoustic_tokenizer_chunk_size = acoustic_tokenizer_chunk_size
-
-        super().__init__(**kwargs)
+        super().__post_init__(**kwargs)
 
 
 __all__ = ["VibeVoiceAsrConfig"]

--- a/src/transformers/models/vibevoice_asr/modeling_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modeling_vibevoice_asr.py
@@ -17,8 +17,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import torch
 from torch import nn
 

--- a/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
+++ b/src/transformers/models/vibevoice_asr/modular_vibevoice_asr.py
@@ -11,9 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
 import torch
+from huggingface_hub.dataclasses import strict
 from torch import nn
 
 from ...cache_utils import Cache
@@ -33,6 +32,7 @@ logger = logging.get_logger(__name__)
 
 
 @auto_docstring(checkpoint="microsoft/VibeVoice-ASR-HF")
+@strict(accept_kwargs=True)
 class VibeVoiceAsrConfig(PretrainedConfig):
     r"""
     acoustic_tokenizer_encoder_config (`Union[VibeVoiceAcousticTokenizerConfig, dict]`, *optional*):
@@ -75,52 +75,44 @@ class VibeVoiceAsrConfig(PretrainedConfig):
         "text_config": AutoConfig,
     }
 
-    def __init__(
-        self,
-        acoustic_tokenizer_encoder_config=None,
-        semantic_tokenizer_encoder_config=None,
-        text_config=None,
-        audio_token_id=151648,
-        audio_bos_token_id=151646,
-        audio_eos_token_id=151647,
-        acoustic_tokenizer_chunk_size=1440000,
-        **kwargs,
-    ):
-        if isinstance(acoustic_tokenizer_encoder_config, dict):
-            acoustic_tokenizer_encoder_config["model_type"] = acoustic_tokenizer_encoder_config.get(
+    acoustic_tokenizer_encoder_config: dict | PretrainedConfig | None = None
+    semantic_tokenizer_encoder_config: dict | PretrainedConfig | None = None
+    text_config: dict | PretrainedConfig | None = None
+    audio_token_id: int = 151648
+    audio_bos_token_id: int = 151646
+    audio_eos_token_id: int = 151647
+    acoustic_tokenizer_chunk_size: int = 1440000
+
+    def __post_init__(self, **kwargs):
+        if isinstance(self.acoustic_tokenizer_encoder_config, dict):
+            self.acoustic_tokenizer_encoder_config["model_type"] = self.acoustic_tokenizer_encoder_config.get(
                 "model_type", "vibevoice_acoustic_tokenizer_encoder"
             )
-            acoustic_tokenizer_encoder_config = CONFIG_MAPPING[acoustic_tokenizer_encoder_config["model_type"]](
-                **acoustic_tokenizer_encoder_config
-            )
-        elif acoustic_tokenizer_encoder_config is None:
-            acoustic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"]()
-        self.acoustic_tokenizer_encoder_config = acoustic_tokenizer_encoder_config
+            self.acoustic_tokenizer_encoder_config = CONFIG_MAPPING[
+                self.acoustic_tokenizer_encoder_config["model_type"]
+            ](**self.acoustic_tokenizer_encoder_config)
+        elif self.acoustic_tokenizer_encoder_config is None:
+            self.acoustic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"]()
 
-        if isinstance(semantic_tokenizer_encoder_config, dict):
-            semantic_tokenizer_encoder_config["model_type"] = semantic_tokenizer_encoder_config.get(
+        if isinstance(self.semantic_tokenizer_encoder_config, dict):
+            self.semantic_tokenizer_encoder_config["model_type"] = self.semantic_tokenizer_encoder_config.get(
                 "model_type", "vibevoice_acoustic_tokenizer_encoder"
             )
-            semantic_tokenizer_encoder_config = CONFIG_MAPPING[semantic_tokenizer_encoder_config["model_type"]](
-                **semantic_tokenizer_encoder_config
+            self.semantic_tokenizer_encoder_config = CONFIG_MAPPING[
+                self.semantic_tokenizer_encoder_config["model_type"]
+            ](**self.semantic_tokenizer_encoder_config)
+        elif self.semantic_tokenizer_encoder_config is None:
+            self.semantic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"](
+                hidden_size=128
             )
-        elif semantic_tokenizer_encoder_config is None:
-            semantic_tokenizer_encoder_config = CONFIG_MAPPING["vibevoice_acoustic_tokenizer_encoder"](hidden_size=128)
-        self.semantic_tokenizer_encoder_config = semantic_tokenizer_encoder_config
 
-        if isinstance(text_config, dict):
-            text_config["model_type"] = text_config.get("model_type", "qwen2")
-            text_config = CONFIG_MAPPING[text_config["model_type"]](**text_config)
-        elif text_config is None:
-            text_config = CONFIG_MAPPING["qwen2"]()
-        self.text_config = text_config
+        if isinstance(self.text_config, dict):
+            self.text_config["model_type"] = self.text_config.get("model_type", "qwen2")
+            self.text_config = CONFIG_MAPPING[self.text_config["model_type"]](**self.text_config)
+        elif self.text_config is None:
+            self.text_config = CONFIG_MAPPING["qwen2"]()
 
-        self.audio_token_id = audio_token_id
-        self.audio_bos_token_id = audio_bos_token_id
-        self.audio_eos_token_id = audio_eos_token_id
-        self.acoustic_tokenizer_chunk_size = acoustic_tokenizer_chunk_size
-
-        super().__init__(**kwargs)
+        super().__post_init__(**kwargs)
 
 
 class VibeVoiceAsrRMSNorm(Qwen2RMSNorm):

--- a/src/transformers/models/voxtral_realtime/configuration_voxtral_realtime.py
+++ b/src/transformers/models/voxtral_realtime/configuration_voxtral_realtime.py
@@ -23,6 +23,7 @@ from ..mistral.configuration_mistral import MistralConfig
 
 
 @auto_docstring(checkpoint="mistralai/Voxtral-Mini-4B-Realtime-2602")
+@strict(accept_kwargs=True)
 class VoxtralRealtimeTextConfig(MistralConfig):
     model_type = "voxtral_realtime_text"
 

--- a/tests/models/auto/test_configuration_auto.py
+++ b/tests/models/auto/test_configuration_auto.py
@@ -121,6 +121,9 @@ class AutoConfigTest(unittest.TestCase):
         class NewModelConfigLocal(BertConfig):
             model_type = "new-model"
 
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+
         try:
             AutoConfig.register("new-model", NewModelConfigLocal)
             # If remote code is not set, the default is to use local

--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -442,6 +442,9 @@ class AutoModelTest(unittest.TestCase):
         class NewModelConfigLocal(BertConfig):
             model_type = "new-model"
 
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+
         class NewModel(BertModel):
             config_class = NewModelConfigLocal
 

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 
 import pytest
+from huggingface_hub.errors import StrictDataclassClassValidationError
 from parameterized import parameterized
 
 from transformers import AutoTokenizer, NemotronHConfig, NemotronHForCausalLM, is_torch_available
@@ -626,7 +627,7 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         self.assertEqual(config.num_hidden_layers, 4)
 
         # Invalid layer type - should raise error
-        with self.assertRaises(ValueError):
+        with self.assertRaises(StrictDataclassClassValidationError):
             NemotronHConfig(
                 vocab_size=100,
                 hidden_size=32,


### PR DESCRIPTION
# What does this PR do?


Fix tests failing because of `strict` type validation and decorate two missing configs, Nemotron and VibeVoice