### PR TITLE
bitsandbytes: Update links and docs

### DIFF
--- a/docs/source/en/quantization/bitsandbytes.md
+++ b/docs/source/en/quantization/bitsandbytes.md
@@ -198,7 +198,7 @@ This section explores some of the specific features of 8-bit quantization, such 
 
 ### Offloading
 
-8-bit models can offload weights between the CPU and GPU to fit very large models into memory. The weights dispatched to the CPU are stored in **float32** and aren't converted to 8-bit. For example, enable offloading for [bigscience/bloom-1b7](https://huggingface.co/bigscience/bloom-1b7) through [`BitsAndBytesConfig`].
+8-bit (and 4-bit) models can offload weights between the CPU and GPU to fit very large models into memory. The weights dispatched to the CPU are stored in **float32** and aren't converted to 8-bit. For example, enable offloading for [bigscience/bloom-1b7](https://huggingface.co/bigscience/bloom-1b7) through [`BitsAndBytesConfig`].
 
 ```py
 from transformers import AutoModelForCausalLM, BitsAndBytesConfig

--- a/src/transformers/quantizers/quantizer_bnb_4bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_4bit.py
@@ -76,7 +76,7 @@ class Bnb4BitHfQuantizer(HfQuantizer):
                     "quantized model. If you want to dispatch the model on the CPU or the disk while keeping these modules "
                     "in 32-bit, you need to set `llm_int8_enable_fp32_cpu_offload=True` and pass a custom `device_map` to "
                     "`from_pretrained`. Check "
-                    "https://huggingface.co/docs/transformers/main/en/main_classes/quantization#offload-between-cpu-and-gpu "
+                    "https://huggingface.co/docs/transformers/en/quantization/bitsandbytes#offloading "
                     "for more details. "
                 )
 

--- a/src/transformers/quantizers/quantizer_bnb_8bit.py
+++ b/src/transformers/quantizers/quantizer_bnb_8bit.py
@@ -76,7 +76,7 @@ class Bnb8BitHfQuantizer(HfQuantizer):
                     "quantized model. If you want to dispatch the model on the CPU or the disk while keeping these modules "
                     "in 32-bit, you need to set `llm_int8_enable_fp32_cpu_offload=True` and pass a custom `device_map` to "
                     "`from_pretrained`. Check "
-                    "https://huggingface.co/docs/transformers/main/en/main_classes/quantization#offload-between-cpu-and-gpu "
+                    "https://huggingface.co/docs/transformers/en/quantization/bitsandbytes#offloading "
                     "for more details. "
                 )
 


### PR DESCRIPTION
The links to the quantization offloading were outdated and 4-bit quantization also supports offloading which should be mentioned.

cc @SunMarc 