### PR TITLE
Remove `is_causal` from `EuroBertConfig`

### DIFF
--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -34,8 +34,6 @@ class EuroBertConfig(LlamaConfig):
         Mask token id.
     classifier_pooling (`str`, *optional*, defaults to `"late"`):
         The pooling strategy to use for the classifier. Can be one of ['bos', 'mean', 'late'].
-    is_causal (`bool`, *optional*, defaults to `False`):
-        Whether to use causal attention masking. Set to `False` for bidirectional attention.
 
     ```python
     >>> from transformers import EuroBertModel, EuroBertConfig
@@ -74,7 +72,6 @@ class EuroBertConfig(LlamaConfig):
     mlp_bias: bool = False
     head_dim: int | None = None
     classifier_pooling: str = "late"
-    is_causal: bool = False
 
     def __post_init__(self, **kwargs):
         if self.num_key_value_heads is None:

--- a/src/transformers/models/eurobert/modular_eurobert.py
+++ b/src/transformers/models/eurobert/modular_eurobert.py
@@ -36,8 +36,6 @@ class EuroBertConfig(LlamaConfig):
         Mask token id.
     classifier_pooling (`str`, *optional*, defaults to `"late"`):
         The pooling strategy to use for the classifier. Can be one of ['bos', 'mean', 'late'].
-    is_causal (`bool`, *optional*, defaults to `False`):
-        Whether to use causal attention masking. Set to `False` for bidirectional attention.
 
     ```python
     >>> from transformers import EuroBertModel, EuroBertConfig
@@ -76,7 +74,6 @@ class EuroBertConfig(LlamaConfig):
     mlp_bias: bool = False
     head_dim: int | None = None
     classifier_pooling: str = "late"
-    is_causal: bool = False
 
     def __post_init__(self, **kwargs):
         if self.num_key_value_heads is None:


### PR DESCRIPTION
# What does this PR do?

Remove `is_causal` from `EuroBertConfig`