### PR TITLE
[fix] mistral 4 docs

### DIFF
--- a/docs/source/en/model_doc/mistral4.md
+++ b/docs/source/en/model_doc/mistral4.md
@@ -110,7 +110,3 @@ print(decoded_output)
 ## Mistral4ForTokenClassification
 
 [[autodoc]] Mistral4ForTokenClassification
-
-## Mistral4ForQuestionAnswering
-
-[[autodoc]] Mistral4ForQuestionAnswering


### PR DESCRIPTION
the doc-builder is breaking because it can't find `Mistral4ForQuestionAnswering`, which looks like it doesn't exist