### PR TITLE
fix(auto): Map deepseek_v2 and deepseek_v3 to LlamaTokenizer

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -104,6 +104,8 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, str | None](
         ("data2vec-audio", "Wav2Vec2CTCTokenizer"),
         ("data2vec-text", "RobertaTokenizer"),
         ("dbrx", "GPT2Tokenizer" if is_tokenizers_available() else None),
+        ("deepseek_v2", "LlamaTokenizer" if is_tokenizers_available() else None),
+        ("deepseek_v3", "LlamaTokenizer" if is_tokenizers_available() else None),
         ("deberta", "DebertaTokenizer" if is_tokenizers_available() else None),
         ("deberta-v2", "DebertaV2Tokenizer" if is_tokenizers_available() else None),
         ("dia", "DiaTokenizer"),


### PR DESCRIPTION
This PR fixes the DeepSeek tokenizer issue where spaces were lost during decoding in Transformers v5.

## Problem

DeepSeek V2 and V3 models use SentencePiece tokenization (like Llama) but were falling back to the generic TokenizersBackend in v5. This caused incorrect decoding where spaces were lost. For example, encoding and decoding "How are you doing?" would produce "Howareyoudoing?".

## Root Cause

In Transformers v5, the tokenizer mapping system changed. Models not explicitly mapped in TOKENIZER_MAPPING_NAMES fall back to TokenizersBackend. DeepSeek models need the special SentencePiece handling provided by LlamaTokenizer (Metaspace pretokenizer with ▁ replacement and proper decoder chain).

## Fix

Explicitly map `deepseek_v2` and `deepseek_v3` model types to `LlamaTokenizer` in `TOKENIZER_MAPPING_NAMES`.

## Verification

- Verified that `deepseek_v2` and `deepseek_v3` now resolve to `LlamaTokenizer`
- Ran existing tokenizer auto tests - all pass
- The fix is minimal (2 lines) and follows the existing pattern for similar models

Fixes #44779

Tagging: @ArthurZucker @itazap (tokenizers),