### PR TITLE
docs(tasks): remove references to removed question-answering pipeline

### DIFF
--- a/docs/source/ar/tasks/question_answering.md
+++ b/docs/source/ar/tasks/question_answering.md
@@ -252,23 +252,7 @@ pip install transformers datasets evaluate
 >>> context = "BLOOM has 176 billion parameters and can generate text in 46 languages natural languages and 13 programming languages."
 ```
 
-أبسط طريقة لتجربة نموذجك المُدرَّب للاستدلال هي استخدامه في [`pipeline`]. قم بإنشاء كائن لـ `pipeline` للإجابة على الأسئلة باستخدام نموذجك، ومرِّر النص إليه:
-
-```py
->>> from transformers import pipeline
-
->>> question_answerer = pipeline("question-answering", model="my_awesome_qa_model")
->>> question_answerer(question=question, context=context)
-{'score': 0.2058267742395401,
- 'start': 10,
- 'end': 95,
- 'answer': '176 مليار معامل ويمكنه إنشاء نصوص بـ 46 لغة طبيعية و 13'}
-```
-
-يمكنك أيضًا تكرار نتائج `pipeline` يدويًا إذا أردت:
-
- 
- قسّم النص وأرجع تنسورات PyTorch:
+أبسط طريقة لتجربة نموذجك المُدرَّب للاستدلال هي استخدامه مباشرة مع tokenizer والنموذج. قسّم النص وأرجع تنسورات PyTorch:
 
 ```py
 >>> from transformers import AutoTokenizer

--- a/docs/source/ja/tasks/question_answering.md
+++ b/docs/source/ja/tasks/question_answering.md
@@ -69,23 +69,7 @@
 >>> context = "BLOOM has 176 billion parameters and can generate text in 46 languages natural languages and 13 programming languages."
 ```
 
-推論用に微調整されたモデルを試す最も簡単な方法は、それを [`pipeline`] で使用することです。モデルを使用して質問応答用の`pipeline`をインスタンス化し、それにテキストを渡します。
-
-```py
->>> from transformers import pipeline
-
->>> question_answerer = pipeline("question-answering", model="my_awesome_qa_model")
->>> question_answerer(question=question, context=context)
-{'score': 0.2058267742395401,
- 'start': 10,
- 'end': 95,
- 'answer': '176 billion parameters and can generate text in 46 languages natural languages and 13'}
-```
-
-必要に応じて、`pipeline`の結果を手動で複製することもできます。
-
-
-テキストをトークン化して PyTorch テンソルを返します。
+推論用に微調整されたモデルを試す最も簡単な方法は、tokenizerとmodelを直接使用することです。テキストをトークン化して PyTorch テンソルを返します:
 
 ```py
 >>> from transformers import AutoTokenizer

--- a/docs/source/ko/tasks/question_answering.md
+++ b/docs/source/ko/tasks/question_answering.md
@@ -246,22 +246,7 @@ pip install transformers datasets evaluate
 >>> context = "BLOOM has 176 billion parameters and can generate text in 46 languages natural languages and 13 programming languages."
 ```
 
-추론을 위해 미세 조정한 모델을 테스트하는 가장 쉬운 방법은 [`pipeline`]을 사용하는 것 입니다. 모델을 사용해 질의 응답을 하기 위해서 `pipeline`을 인스턴스화하고 텍스트를 입력합니다:
-
-```py
->>> from transformers import pipeline
-
->>> question_answerer = pipeline("question-answering", model="my_awesome_qa_model")
->>> question_answerer(question=question, context=context)
-{'score': 0.2058267742395401,
- 'start': 10,
- 'end': 95,
- 'answer': '176 billion parameters and can generate text in 46 languages natural languages and 13'}
-```
-
-원한다면 `pipeline`의 결과를 직접 복제할 수도 있습니다:
-
-텍스트를 토큰화해서 PyTorch 텐서를 반환합니다:
+추론을 위해 미세 조정된 모델을 테스트하는 가장 쉬운 방법은 tokenizer와 model을 직접 사용하는 것 입니다. 텍스트를 토큰화해서 PyTorch 텐서를 반환합니다:
 
 ```py
 >>> from transformers import AutoTokenizer

--- a/docs/source/zh/tasks/question_answering.md
+++ b/docs/source/zh/tasks/question_answering.md
@@ -247,22 +247,7 @@ pip install transformers datasets evaluate
 >>> context = "BLOOM has 176 billion parameters and can generate text in 46 languages natural languages and 13 programming languages."
 ```
 
-使用微调后的模型进行推断最简单的方式是在 [`pipeline`] 中使用它。用您的模型实例化一个问答 `pipeline`，并将文本传递给它：
-
-```py
->>> from transformers import pipeline
-
->>> question_answerer = pipeline("question-answering", model="my_awesome_qa_model")
->>> question_answerer(question=question, context=context)
-{'score': 0.2058267742395401,
- 'start': 10,
- 'end': 95,
- 'answer': '176 billion parameters and can generate text in 46 languages natural languages and 13'}
-```
-
-如果您愿意，也可以手动复现 `pipeline` 的结果：
-
-对文本进行分词并返回 PyTorch 张量：
+使用微调后的模型进行推断最简单的方式是直接使用 tokenizer 和 model。对文本进行分词并返回 PyTorch 张量：
 
 ```py
 >>> from transformers import AutoTokenizer


### PR DESCRIPTION
The question-answering pipeline was removed in v5.0.0 per MIGRATION_GUIDE_V5.md, but the non-English task guides still referenced it.

This updates the Arabic, Chinese, Japanese, and Korean question answering task guides to remove usage of `pipeline('question-answering')` which no longer exists and would raise:
```
Unknown task question-answering, available tasks are [...]
```

The docs now show the direct tokenizer/model approach instead (using `AutoTokenizer` and `AutoModelForQuestionAnswering`), consistent with the English version of the guide.

Fixes huggingface/course#1211