### PR TITLE
docs(pipelines): remove outdated question-answering example

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -601,11 +601,6 @@ def pipeline(
     >>> # Sentiment analysis pipeline
     >>> analyzer = pipeline("sentiment-analysis")
 
-    >>> # Question answering pipeline, specifying the checkpoint identifier
-    >>> oracle = pipeline(
-    ...     "question-answering", model="distilbert/distilbert-base-cased-distilled-squad", tokenizer="google-bert/bert-base-cased"
-    ... )
-
     >>> # Named entity recognition pipeline, passing in a specific model and tokenizer
     >>> model = AutoModelForTokenClassification.from_pretrained("dbmdz/bert-large-cased-finetuned-conll03-english")
     >>> tokenizer = AutoTokenizer.from_pretrained("google-bert/bert-base-cased")


### PR DESCRIPTION
The pipeline() docstring included an example using the 'question-answering' task, but this task is not in SUPPORTED_TASKS and will raise an error when used. Remove this outdated example to avoid confusing users following the documentation.

Fixes huggingface/course#1211