### PR TITLE
fix: disable mmap on Strix Halo APUs to avoid OOM

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import functools
 import math
 import os
 import re
@@ -805,9 +806,28 @@ class WeightConverter(WeightTransform):
 GLOBAL_WORKERS = min(4, os.cpu_count() or 4)
 
 
+@functools.lru_cache(maxsize=1)
+def _is_strix_halo() -> bool:
+    """Detect AMD Strix Halo APU (gfx1151) where mmap causes OOM due to a driver bug."""
+    if not torch.cuda.is_available():
+        return False
+    try:
+        for i in range(torch.cuda.device_count()):
+            props = torch.cuda.get_device_properties(i)
+            if hasattr(props, "gcnArchName") and "gfx1151" in props.gcnArchName:
+                return True
+    except Exception:
+        logger.debug("Failed to detect GPU architecture for Strix Halo check", exc_info=True)
+    return False
+
+
 def _materialize_copy(tensor: torch.Tensor, device=None, dtype=None) -> torch.Tensor:
     # This slicing is what actually loads the tensor from the safetensors slice object
     tensor = tensor[...]
+    # On AMD Strix Halo APUs, safetensors mmap triggers OOM due to a driver issue with
+    # unified memory. Force a CPU copy to release the mmap reference. See GH-44756.
+    if _is_strix_halo() and tensor.device.type == "cpu":
+        tensor = tensor.to(device="cpu", copy=True)
     if dtype is not None or device is not None:
         tensor = tensor.to(device=device, dtype=dtype)
     return tensor


### PR DESCRIPTION
# What does this PR do?

AMD Strix Halo APUs (gfx1151) have a driver bug where safetensors mmap doesn't release memory properly with the unified memory architecture. This causes OOM errors when loading models that should fit in memory (e.g. a 67 GB model with 125 GB available).

The fix adds lazy detection of Strix Halo hardware via `gcnArchName` (cached with `lru_cache` to avoid repeated CUDA calls) and forces a CPU copy of mmap'd tensors before device transfer in `_materialize_copy`. This releases the mmap reference and prevents the memory leak.

Approach matches the workaround described in the issue and is similar to how ComfyUI handles this: https://github.com/Comfy-Org/ComfyUI/blob/593be209a45a8a306c26de550e240a363de405a7/comfy/utils.py#L137

Fixes #44756

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@CyrilVallez (model loading) @ivarflakstad (AMD ROCm)