### PR TITLE
fix: handle dict vocab in CamembertTokenizer for tokenizer.json (#44488)

### DIFF
--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -114,8 +114,16 @@ class CamembertTokenizer(TokenizersBackend):
             additional_special_tokens = ["<s>NOTUSED", "</s>NOTUSED", "<unk>NOTUSED"]
 
         if vocab is not None:
-            self._vocab = vocab
-            unk_index = next((i for i, (tok, _) in enumerate(self._vocab) if tok == str(unk_token)), 0)
+            if isinstance(vocab, dict):
+                # Vocab from tokenizer.json (BPE format) is dict {token: id}.
+                # Unigram expects list of (token, score) tuples.
+                id_to_token = {i: token for token, i in vocab.items()}
+                sorted_ids = sorted(id_to_token.keys())
+                self._vocab = [(id_to_token[i], 0.0) for i in sorted_ids]
+                unk_id = vocab.get(str(unk_token)); unk_index = sorted_ids.index(unk_id) if unk_id is not None and unk_id in sorted_ids else 0
+            else:
+                self._vocab = vocab
+                unk_index = next((i for i, (tok, _) in enumerate(self._vocab) if tok == str(unk_token)), 0)
             self._tokenizer = Tokenizer(Unigram(self._vocab, unk_id=unk_index, byte_fallback=False))
         else:
             self._vocab = [

--- a/src/transformers/models/camembert/tokenization_camembert.py
+++ b/src/transformers/models/camembert/tokenization_camembert.py
@@ -120,7 +120,11 @@ class CamembertTokenizer(TokenizersBackend):
                 id_to_token = {i: token for token, i in vocab.items()}
                 sorted_ids = sorted(id_to_token.keys())
                 self._vocab = [(id_to_token[i], 0.0) for i in sorted_ids]
-                unk_id = vocab.get(str(unk_token)); unk_index = sorted_ids.index(unk_id) if unk_id is not None and unk_id in sorted_ids else 0
+                unk_id = vocab.get(str(unk_token))
+                if unk_id is not None and unk_id in sorted_ids:
+                    unk_index = sorted_ids.index(unk_id)
+                else:
+                    unk_index = 0
             else:
                 self._vocab = vocab
                 unk_index = next((i for i, (tok, _) in enumerate(self._vocab) if tok == str(unk_token)), 0)

--- a/tests/models/camembert/test_tokenization_camembert.py
+++ b/tests/models/camembert/test_tokenization_camembert.py
@@ -15,3 +15,25 @@ class CamembertTokenizationTest(TokenizerTesterMixin, unittest.TestCase):
     integration_expected_token_ids = [17526, 2856, 33, 2006, 21, 3, 551, 15760, 21, 24900, 378, 419, 13233, 7, 1168, 9098, 2856, 19289, 5100, 9, 21, 3, 5108, 9774, 5108, 9774, 9774, 5, 7874, 5, 808, 346, 908, 21, 31189, 402, 20468, 52, 133, 19306, 2446, 909, 1399, 1107, 22, 14420, 204, 92, 9774, 9, 10503, 1723, 6682, 1168, 21, 3, 1723, 6682, 21, 3, 20128, 616, 3168, 9581, 4835, 7503, 402]  # fmt: skip
     expected_tokens_from_ids = ['▁This', '▁is', '▁a', '▁test', '▁', '<unk>', '▁I', '▁was', '▁', 'born', '▁in', '▁9', '2000', ',', '▁and', '▁this', '▁is', '▁fal', 'sé', '.', '▁', '<unk>', '▁Hi', '▁Hello', '▁Hi', '▁Hello', '▁Hello', '<s>', '▁hi', '<s>', '▁the', 're', '▁The', '▁', 'follow', 'ing', '▁string', '▁s', 'h', 'ould', '▁be', '▁pro', 'per', 'ly', '▁en', 'code', 'd', ':', '▁Hello', '.', '▁But', '▁i', 'rd', '▁and', '▁', '<unk>', '▁i', 'rd', '▁', '<unk>', '▁Hey', '▁h', 'ow', '▁are', '▁you', '▁do', 'ing']  # fmt: skip
     integration_expected_decoded_text = "This is a test <unk> I was born in 92000, and this is falsé. <unk> Hi Hello Hi Hello Hello<s> hi<s> there The following string should be properly encoded: Hello. But ird and <unk> ird <unk> Hey how are you doing"
+
+
+@require_tokenizers
+class CamembertDictVocabTest(unittest.TestCase):
+    """Test CamembertTokenizer with dict vocab (from tokenizer.json BPE format)."""
+
+    def test_camembert_tokenizer_with_dict_vocab(self):
+        """Vocab from tokenizer.json is dict {token: id}; Camembert expects list of (token, score)."""
+        vocab = {
+            "<s>NOTUSED": 0,
+            "<pad>": 1,
+            "</s>NOTUSED": 2,
+            "<unk>": 3,
+            "<unk>NOTUSED": 4,
+            "<mask>": 5,
+            "▁hello": 6,
+            "▁world": 7,
+        }
+        tokenizer = CamembertTokenizer(vocab=vocab)
+        self.assertEqual(tokenizer.vocab_size, 8)
+        result = tokenizer("hello world", add_special_tokens=False)
+        self.assertGreater(len(result["input_ids"]), 0)


### PR DESCRIPTION
## Summary
Fixes #44488

`CamembertTokenizer` raised `ValueError: too many values to unpack (expected 2)` when loading models like `cjvt/sleng-bert` that provide vocab as a dict `{token: id}` from `tokenizer.json` (BPE format). The tokenizer expected a list of `(token, score)` tuples for Unigram.

## Root cause
When `AutoTokenizer.from_pretrained` loads a model with `tokenizer.json`, `convert_to_native_format` passes vocab as a dict. `CamembertTokenizer` assumed list format and unpacked `(tok, _) = token_string`, causing the error.

## Fix
Handle dict vocab by converting to list of `(token, 0.0)` tuples in id order before passing to Unigram.

## Testing
- Added `test_camembert_tokenizer_with_dict_vocab` in `test_tokenization_camembert.py`
- Manually verified `CamembertTokenizer(vocab=dict_from_sleng_bert)` loads successfully

Made with [Cursor](https://cursor.com)