### PR TITLE
fix(janus): handle None values in image generation mode

### DIFF
--- a/src/transformers/models/janus/modeling_janus.py
+++ b/src/transformers/models/janus/modeling_janus.py
@@ -1285,7 +1285,7 @@ class JanusForConditionalGeneration(JanusPreTrainedModel, GenerationMixin):
         input_ids, model_kwargs = self._expand_inputs_for_generation(
             input_ids=input_ids,
             attention_mask=attention_mask,
-            expand_size=generation_config.num_return_sequences,
+            expand_size=generation_config.num_return_sequences or 1,
             **model_kwargs,
         )
 
@@ -1315,7 +1315,7 @@ class JanusForConditionalGeneration(JanusPreTrainedModel, GenerationMixin):
                 # batch_size should account for both conditional/unconditional input; hence multiplied by 2.
                 batch_size=batch_size * 2,
                 # we should have at least a cache len of seq_len + num_image_tokens.
-                max_cache_len=max(generation_config.max_length, num_image_tokens + seq_len),
+                max_cache_len=max(generation_config.max_length or 0, num_image_tokens + seq_len),
                 model_kwargs=model_kwargs,
             )
 


### PR DESCRIPTION
Fixes #44792

This PR fixes the failing test `test_model_generate_images` for the Janus model.

## Problem
When generating images with the Janus model, `generation_config.num_return_sequences` and `generation_config.max_length` can be `None`, causing the following errors:
- `TypeError` when `num_return_sequences` is `None` and used as `expand_size`
- `TypeError` when `max_length` is `None` and used in `max()` comparison

## Fix
- Added null check for `generation_config.num_return_sequences` with default value of 1
- Added null check for `generation_config.max_length` with default value of 0

These changes ensure that the image generation mode works correctly when these configuration values are not explicitly set.