### PR TITLE
fix(tokenizer): add deepseek_v2 and deepseek_v3 to incorrect hub tokenizer class list

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -342,6 +342,8 @@ TOKENIZER_MAPPING_NAMES = OrderedDict[str, str | None](
 MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "arctic",
     "chameleon",
+    "deepseek_v2",
+    "deepseek_v3",
     "deepseek_vl",
     "deepseek_vl_v2",
     "deepseek_vl_hybrid",


### PR DESCRIPTION
## Description

This PR fixes the DeepSeek tokenizer issue (#44779) where tokenization produces incorrect results in v5.

### Problem
In transformers v5, the DeepSeek tokenizer (DeepSeek-R1) was producing incorrect results:
- Input: "How are you doing?"
- v5 output:  with tokens 
- v5 decode:  (spaces missing!)

### Root Cause
The  and  model types were not in , so they were being loaded with  based on the  in their tokenizer_config.json. However,  overwrites the pre-tokenizer and decoder configuration from the tokenizer.json file, causing the DeepSeek-specific tokenization behavior to be lost.

### Solution
Add  and  to  so they use  directly, which respects the pre-tokenizer and decoder configuration from tokenizer.json.

### After Fix
- Output:  with tokens 
- Decode:  (spaces preserved!)

Fixes #44779