### PR TITLE
fix: AutoImageProcessor from URL loading

### DIFF
--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -31,7 +31,7 @@ from .utils import (
     logging,
     safe_load_json_file,
 )
-from .utils.hub import cached_file
+from .utils.hub import cached_file, get_session
 
 
 ImageProcessorType = TypeVar("ImageProcessorType", bound="ImageProcessingMixin")
@@ -276,6 +276,22 @@ class ImageProcessingMixin(PushToHubMixin):
             resolved_image_processor_file = pretrained_model_name_or_path
             resolved_processor_file = None
             is_local = True
+        elif pretrained_model_name_or_path.startswith("http://") or pretrained_model_name_or_path.startswith("https://"):
+            # Handle URL case: download the file directly
+            if local_files_only:
+                raise OSError(
+                    f"Cannot load from URL '{pretrained_model_name_or_path}' when local_files_only=True."
+                )
+            try:
+                session = get_session()
+                response = session.get(pretrained_model_name_or_path, follow_redirects=True)
+                response.raise_for_status()
+                image_processor_dict = response.json()
+                return image_processor_dict, kwargs
+            except Exception as e:
+                raise OSError(
+                    f"Failed to download image processor config from URL '{pretrained_model_name_or_path}'."
+                ) from e
         else:
             image_processor_file = image_processor_filename
             try:

--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -37,6 +37,7 @@ from ...utils import (
 from ...utils.import_utils import requires
 from .auto_factory import _LazyAutoMapping
 from .configuration_auto import (
+    CONFIG_MAPPING,
     CONFIG_MAPPING_NAMES,
     AutoConfig,
     model_type_to_module_name,
@@ -540,16 +541,35 @@ class AutoImageProcessor:
 
         # If we don't find the image processor class in the image processor config, let's try the model config.
         if image_processor_type is None and image_processor_auto_map is None:
-            if not isinstance(config, PreTrainedConfig):
+            # Check if this is a URL to a model config file
+            is_url = pretrained_model_name_or_path.startswith("http://") or pretrained_model_name_or_path.startswith("https://")
+            if is_url:
+                # For URLs, the config_dict may contain model_type directly
+                # Use it to look up the image processor from IMAGE_PROCESSOR_MAPPING
+                model_type = config_dict.get("model_type", None)
+                if model_type is not None and model_type in CONFIG_MAPPING:
+                    config_class = CONFIG_MAPPING[model_type]
+                    if config_class in IMAGE_PROCESSOR_MAPPING:
+                        image_processor_tuple = IMAGE_PROCESSOR_MAPPING[config_class]
+                        # Select the appropriate processor based on use_fast
+                        image_processor_class_py, image_processor_class_fast = image_processor_tuple
+                        if use_fast is None:
+                            use_fast = is_torchvision_available()
+                        if use_fast and image_processor_class_fast is not None:
+                            return image_processor_class_fast.from_pretrained(pretrained_model_name_or_path, **kwargs)
+                        elif image_processor_class_py is not None:
+                            return image_processor_class_py.from_pretrained(pretrained_model_name_or_path, **kwargs)
+            elif not isinstance(config, PreTrainedConfig):
                 config = AutoConfig.from_pretrained(
                     pretrained_model_name_or_path,
                     trust_remote_code=trust_remote_code,
                     **kwargs,
                 )
             # It could be in `config.image_processor_type``
-            image_processor_type = getattr(config, "image_processor_type", None)
-            if hasattr(config, "auto_map") and "AutoImageProcessor" in config.auto_map:
-                image_processor_auto_map = config.auto_map["AutoImageProcessor"]
+            if config is not None:
+                image_processor_type = getattr(config, "image_processor_type", None)
+                if hasattr(config, "auto_map") and "AutoImageProcessor" in config.auto_map:
+                    image_processor_auto_map = config.auto_map["AutoImageProcessor"]
 
         image_processor_class = None
         if image_processor_type is not None:


### PR DESCRIPTION
This PR fixes #44821 where `AutoImageProcessor.from_pretrained()` couldn't load from a direct URL to a config file.

## Problem
When passing a URL like `https://huggingface.co/jinfengxie/BFMS_1014/raw/main/config.json` to `AutoImageProcessor.from_pretrained()`, it failed with:
> Repo id must be in the form 'repo_name' or 'namespace/repo_name'

## Solution
- Added URL detection in `ImageProcessingMixin.get_image_processor_dict()` to download the config file directly when a URL is provided
- Added URL handling in `AutoImageProcessor.from_pretrained()` to:
  - Skip the `AutoConfig.from_pretrained()` call which doesn't support URLs
  - Use the `model_type` from the downloaded config to look up the appropriate image processor class via `CONFIG_MAPPING` and `IMAGE_PROCESSOR_MAPPING`

## Testing
- All 13 existing tests in `tests/models/auto/test_image_processing_auto.py` pass
- Loading from URLs, local files, and repo IDs all work correctly