### PR TITLE
fix: allow AutoImageProcessor to load from URL

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -21,6 +21,7 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeVar, Union
+from urllib.parse import urlparse
 
 from huggingface_hub import create_repo
 from huggingface_hub.dataclasses import strict
@@ -48,6 +49,28 @@ if TYPE_CHECKING:
 
 
 logger = logging.get_logger(__name__)
+
+
+def _is_url(path: str) -> bool:
+    """Check if a path is a URL."""
+    try:
+        result = urlparse(path)
+        return bool(result.scheme and result.netloc)
+    except Exception:
+        return False
+
+
+def _load_dict_from_file_or_url(file_path: str) -> dict:
+    """Load dict from a local file or a URL."""
+    if _is_url(file_path):
+        import requests
+        response = requests.get(file_path)
+        response.raise_for_status()
+        return json.loads(response.text)
+    else:
+        with open(file_path, encoding="utf-8") as reader:
+            text = reader.read()
+        return json.loads(text)
 
 
 # type hinting: specifying the type of config class that inherits from PreTrainedConfig
@@ -652,8 +675,8 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         pretrained_model_name_or_path = str(pretrained_model_name_or_path)
 
         is_local = os.path.isdir(pretrained_model_name_or_path)
-        if os.path.isfile(os.path.join(subfolder, pretrained_model_name_or_path)):
-            # Special case when pretrained_model_name_or_path is a local file
+        if os.path.isfile(os.path.join(subfolder, pretrained_model_name_or_path)) or _is_url(pretrained_model_name_or_path):
+            # Special case when pretrained_model_name_or_path is a local file or URL
             resolved_config_file = pretrained_model_name_or_path
             is_local = True
         else:
@@ -693,6 +716,10 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         try:
             if gguf_file:
                 config_dict = load_gguf_checkpoint(resolved_config_file, return_tensors=False)["config"]
+            elif _is_url(resolved_config_file):
+                # Load config dict from URL
+                config_dict = _load_dict_from_file_or_url(resolved_config_file)
+                config_dict = cls._decode_special_floats(config_dict)
             else:
                 # Load config dict
                 config_dict = cls._dict_from_json_file(resolved_config_file)

--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -16,6 +16,7 @@ import copy
 import json
 import os
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 import numpy as np
 from huggingface_hub import create_repo, is_offline_mode
@@ -38,6 +39,28 @@ ImageProcessorType = TypeVar("ImageProcessorType", bound="ImageProcessingMixin")
 
 
 logger = logging.get_logger(__name__)
+
+
+def _is_url(path: str) -> bool:
+    """Check if a path is a URL."""
+    try:
+        result = urlparse(path)
+        return bool(result.scheme and result.netloc)
+    except Exception:
+        return False
+
+
+def _load_json_from_file_or_url(file_path: str) -> dict:
+    """Load JSON from a local file or a URL."""
+    if _is_url(file_path):
+        import requests
+        response = requests.get(file_path)
+        response.raise_for_status()
+        return json.loads(response.text)
+    else:
+        with open(file_path, encoding="utf-8") as reader:
+            text = reader.read()
+        return json.loads(text)
 
 
 # TODO: Move BatchFeature to be imported by both image_processing_utils and image_processing_utils_fast
@@ -272,7 +295,7 @@ class ImageProcessingMixin(PushToHubMixin):
         is_local = os.path.isdir(pretrained_model_name_or_path)
         if os.path.isdir(pretrained_model_name_or_path):
             image_processor_file = os.path.join(pretrained_model_name_or_path, image_processor_filename)
-        if os.path.isfile(pretrained_model_name_or_path):
+        if os.path.isfile(pretrained_model_name_or_path) or _is_url(pretrained_model_name_or_path):
             resolved_image_processor_file = pretrained_model_name_or_path
             resolved_processor_file = None
             is_local = True
@@ -323,12 +346,12 @@ class ImageProcessingMixin(PushToHubMixin):
         # not all of these are nested. We need to check if it was saved recebtly as nested or if it is legacy style
         image_processor_dict = None
         if resolved_processor_file is not None:
-            processor_dict = safe_load_json_file(resolved_processor_file)
+            processor_dict = _load_json_from_file_or_url(resolved_processor_file)
             if "image_processor" in processor_dict:
                 image_processor_dict = processor_dict["image_processor"]
 
         if resolved_image_processor_file is not None and image_processor_dict is None:
-            image_processor_dict = safe_load_json_file(resolved_image_processor_file)
+            image_processor_dict = _load_json_from_file_or_url(resolved_image_processor_file)
 
         if image_processor_dict is None:
             raise OSError(


### PR DESCRIPTION
Fixes #44821

This PR fixes the issue where `AutoImageProcessor.from_pretrained()` was unable to load from a URL (e.g., `https://huggingface.co/.../raw/main/config.json`).

The bug was introduced in transformers>=5.3.0. Prior versions (e.g., 4.57.6) supported loading from URLs.

## Changes

- Added `_is_url()` helper function to detect URLs using `urllib.parse.urlparse`
- Added `_load_json_from_file_or_url()` helper to load JSON from both local files and URLs
- Modified `ImageProcessingMixin.get_image_processor_dict()` to handle URLs
- Modified `PreTrainedConfig._get_config_dict()` to handle URLs

## Testing

Tested with the example from the issue:
```python
import transformers
url = 'https://huggingface.co/jinfengxie/BFMS_1014/raw/main/config.json'
processor = transformers.AutoImageProcessor.from_pretrained(url)  # Now works
```

Also verified that local file paths continue to work correctly.