### PR TITLE
[CB] Add an option to return logprobs

### DIFF
--- a/examples/pytorch/continuous_batching.py
+++ b/examples/pytorch/continuous_batching.py
@@ -215,15 +215,7 @@ if __name__ == "__main__":
 
     # Choose attention implementation
     if args.attn is None:
-        if args.compile:
-            args.attn = "kernels-community/flash-attn3@fake-ops-return-probs"
-            logger.warning(
-                "No attention implementation was provided and compile is enabled. Using experimental kernel: "
-                "kernels-community/flash-attn3@fake-ops-return-probs because compile is not supported on main. Change "
-                "this when main supports it."  # TODO: cf comment
-            )
-        else:
-            args.attn = "kernels-community/flash-attn3"
+        args.attn = "kernels-community/flash-attn3"
 
     # Set seed
     if args.seed is not None:

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1633,7 +1633,7 @@ class ContinuousBatchingConfig:
     # Scheduler type used
     scheduler: str = "fifo"
 
-    # Whether to generate log probabilities, which is the log of the softmax of the processed logits. If True, the log 
+    # Whether to generate log probabilities, which is the log of the softmax of the processed logits. If True, the log
     # probabilities will be returned along with the generated tokens in the generation output.
     return_logprobs: bool = False
 

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1587,6 +1587,8 @@ class ContinuousBatchingConfig:
             If True, a default compile config will be used for paths that are not explicitly set.
         scheduler (`str`, *optional*, defaults to `"fifo"`):
             Scheduler type to use.
+        return_logprobs (`bool`, *optional*, defaults to `False`):
+            Whether to return log probabilities along with the generated tokens.
         max_queue_size (`int`, *optional*, defaults to 0):
             Maximum request queue size for serving. 0 means unlimited.
     """

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1633,6 +1633,10 @@ class ContinuousBatchingConfig:
     # Scheduler type used
     scheduler: str = "fifo"
 
+    # Whether to generate log probabilities, which is the log of the softmax of the processed logits. If True, the log 
+    # probabilities will be returned along with the generated tokens in the generation output.
+    return_logprobs: bool = False
+
     # The parameters below are mostly useful in the context of serving
     max_queue_size: int = 0
 

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -143,22 +143,17 @@ class ContinuousBatchProcessor:
             is_flash_attn=is_flash_attention_requested(config=config),
             decode_fast_path_available=self.cache.max_blocks_per_request > 0,
         )
+        varlen_config, decode_config = self.cb_config.varlen_compile_config, self.cb_config.decode_compile_config
 
         # Compile the varlen path if config provided
         self._compiled_varlen = None
-        if self.cb_config.varlen_compile_config is not None:
-            self._compiled_varlen = torch.compile(
-                self._forward_process_and_sample,
-                **self.cb_config.varlen_compile_config.to_dict()
-            )
+        if varlen_config is not None:
+            self._compiled_varlen = torch.compile(self._forward_process_and_sample, **varlen_config.to_dict())
 
         # Compile the decode path if config provided
         self._compiled_decode = None
-        if self.cb_config.decode_compile_config is not None:
-            self._compiled_decode = torch.compile(
-                self._forward_process_and_sample,
-                **self.cb_config.decode_compile_config.to_dict()
-            )
+        if decode_config is not None:
+            self._compiled_decode = torch.compile(self._forward_process_and_sample, **decode_config.to_dict())
 
         # Padding is turned on when either cuda graphs or compile is used
         self._pad_inputs = self.use_cuda_graph or (varlen_config is not None or decode_config is not None)

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -348,7 +348,7 @@ class ContinuousBatchProcessor:
                     state.status = RequestStatus.DECODING
 
                 token = new_tokens[current_logits_index]
-                logprob = logprobs[current_logits_index] if self.return_logprobs else None
+                logprob = logprobs[current_logits_index] if logprobs is not None else None
                 current_logits_index += 1
 
                 # Update the request and stop if it is complete
@@ -528,7 +528,7 @@ class ContinuousBatchProcessor:
         # Apply softmax if we are sampling or if we are generating log probabilities
         if self.do_sample or self.return_logprobs:
             probs = nn.functional.softmax(probs[0], dim=-1)  # shape [seq_len, vocab_size]
-        # Otherwise just remove the bastch size dimension, which is always 1
+        # Otherwise just remove the batch size dimension, which is always 1
         else:
             probs = probs.squeeze(0)  # shape [seq_len, vocab_size]
 
@@ -540,7 +540,8 @@ class ContinuousBatchProcessor:
 
         # Maybe retrieve log probabilities
         if self.return_logprobs:
-            logprobs = probs.gather(dim=1, index=next_tokens).squeeze(-1).log()  # shape [seq_len]
+            per_token_probs = probs.gather(dim=1, index=next_tokens).squeeze(-1)
+            logprobs = per_token_probs.float().log()  # shape [seq_len]
         # And always remove the extra dimension for the gather
         next_tokens = next_tokens.squeeze(-1)  # shape [seq_len]
 
@@ -554,8 +555,9 @@ class ContinuousBatchProcessor:
         if self.return_logprobs:
             # Shuffle the logprobs the same way as the next tokens
             logprobs = logprobs[indices]
-            # In order to match the dtype of the output ids, we convert them to fp32 and cast them as int32
-            output_ids[1, :tokens].copy_(logprobs.float().view(dtype=torch.int32))
+            # In order to match the dtype of output_ids, we cast the fp32 logprobs as int32 without changing the
+            # underlying data. It's just a trick to use the same storage for both tensors.
+            output_ids[1, :tokens].copy_(logprobs.view(dtype=torch.int32))
 
 
 # Manager Class (User Interface)

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -110,7 +110,6 @@ class ContinuousBatchProcessor:
         """
         self.cache = cache
         self.config = config
-        self.generation_config = generation_config
         self.cb_config = continuous_batching_config
         self.input_queue = input_queue
         self.output_queue = output_queue
@@ -142,33 +141,36 @@ class ContinuousBatchProcessor:
         )
 
         # Compile the varlen path if config provided
-        varlen_config = self.cb_config.varlen_compile_config
-        if varlen_config is not None:
-            self._compiled_varlen = torch.compile(self._forward_process_and_sample, **varlen_config.to_dict())
-        else:
-            self._compiled_varlen = None
+        self._compiled_varlen = None
+        if self.cb_config.varlen_compile_config is not None:
+            self._compiled_varlen = torch.compile(
+                self._forward_process_and_sample,
+                **self.cb_config.varlen_compile_config.to_dict()
+            )
 
         # Compile the decode path if config provided
-        decode_config = self.cb_config.decode_compile_config
-        if decode_config is not None:
-            self._compiled_decode = torch.compile(self._forward_process_and_sample, **decode_config.to_dict())
-        else:
-            self._compiled_decode = None
+        self._compiled_decode = None
+        if self.cb_config.decode_compile_config is not None:
+            self._compiled_decode = torch.compile(
+                self._forward_process_and_sample,
+                **self.cb_config.decode_compile_config.to_dict()
+            )
 
         # Padding is turned on when either cuda graphs or compile is used
         self._pad_inputs = self.use_cuda_graph or (varlen_config is not None or decode_config is not None)
 
         # Setup inputs and outputs
+        self.log_prob_generation = getattr(generation_config, "log_prob_generation", False)
         self.use_async_batching = self.cb_config.use_async_batching
         if self.use_async_batching:
             # Since in async there are 2 IO pairs, there are also 2 graph buffers: we divide the max_cached_graphs by 2
             max_cached_graphs = ceil(self.max_cached_graphs / 2)
             self.inputs_and_outputs = ContinuousBatchingAsyncIOs(
-                cache, config, model_device, model_dtype, max_cached_graphs
+                cache, config, model_device, model_dtype, max_cached_graphs, self.log_prob_generation
             )
         else:
             self.inputs_and_outputs = ContinuousBatchingIOs(
-                cache, config, model_device, model_dtype, self.max_cached_graphs
+                cache, config, model_device, model_dtype, self.max_cached_graphs, self.log_prob_generation
             )
         # Set up the graph pool. This allows all graphs to share the same memory pool, which is fine because they never
         # run concurrently. This greatly saves memory.
@@ -328,7 +330,7 @@ class ContinuousBatchProcessor:
     @traced
     def update_batch(self) -> None:
         """Update request states based on generated tokens."""
-        requests_in_batch, new_tokens = self.inputs_and_outputs.prepare_batch_update()
+        requests_in_batch, new_tokens, logprobs = self.inputs_and_outputs.prepare_batch_update()
         current_logits_index = 0
         for future_state in requests_in_batch:
             state = future_state.state
@@ -348,10 +350,11 @@ class ContinuousBatchProcessor:
                     state.status = RequestStatus.DECODING
 
                 token = new_tokens[current_logits_index]
+                logprob = logprobs[current_logits_index] if self.log_prob_generation else None
                 current_logits_index += 1
 
                 # Update the request and stop if it is complete
-                is_finished = state.update_and_check_completion(token)
+                is_finished = state.update_and_check_completion(token, logprob)
                 # We mark the completed blocks as such
                 self.cache.mark_shareable_blocks_as_complete(state, future_state.complete_blocks)
                 if is_finished:
@@ -525,18 +528,38 @@ class ContinuousBatchProcessor:
 
     @traced(span_name="sampling")
     def _sample(self, probs: torch.Tensor, batch_data: dict, do_sample: bool, output_ids: torch.Tensor) -> None:
-        if do_sample:
-            probs = nn.functional.softmax(probs, dim=-1)
-            # probs[0] has shape [seq_len, vocab_size], multinomial returns [seq_len, 1]
-            next_tokens = torch.multinomial(probs[0], num_samples=1).squeeze(-1)  # Now [seq_len]
+
+        # Apply softmax if we are sampling or if we are generating log probabilities
+        if do_sample or self.log_prob_generation:
+            probs = nn.functional.softmax(probs[0], dim=-1)  # shape [seq_len, vocab_size]
+        # Otherwise just remove the bastch size dimension, which is always 1
         else:
-            next_tokens = torch.argmax(probs, dim=-1)  # shape is [1, seq_len]
-            next_tokens = next_tokens.squeeze(0)  # shape is [seq_len]
-        tokens = next_tokens.size(0)  # Get seq_len dimension
-        #
+            probs = probs.squeeze(0)  # shape [seq_len, vocab_size]
+
+        # Retrieve next tokens through sampling or argmax
+        if do_sample:
+            next_tokens = torch.multinomial(probs, num_samples=1)  # shape [seq_len, 1]
+        else:
+            next_tokens = torch.argmax(probs, dim=-1, keepdim=True)  # shape [seq_len, 1]
+
+        # Maybe retrieve log probabilities
+        if self.log_prob_generation:
+            logprobs = probs.gather(dim=1, index=next_tokens).squeeze(-1).log()  # shape [seq_len]
+        # And always remove the extra dimension for the gather
+        next_tokens = next_tokens.squeeze(-1)  # shape [seq_len]
+
+        # Get seq_len dimension to slice the logits indices
+        tokens = next_tokens.size(0)
+        # Shuffle the next tokens to match the order of the batch's requests
         indices = batch_data["logits_indices"][:tokens]
         next_tokens = next_tokens[indices]
-        output_ids[:tokens].copy_(next_tokens)
+        # Copy the next tokens and maybe their logprobs to the static output tensor
+        output_ids[0, :tokens].copy_(next_tokens)
+        if self.log_prob_generation:
+            # Shuffle the logprobs the same way as the next tokens
+            logprobs = logprobs[indices]
+            # In order to match the dtype of the output ids, we convert them to fp32 and cast them as int32
+            output_ids[1, :tokens].copy_(logprobs.float().view(dtype=torch.int32))
 
 
 # Manager Class (User Interface)
@@ -604,10 +627,6 @@ class ContinuousBatchingManager:
         self.q_padding_interval_size = self.continuous_batching_config.q_padding_interval_size
         self.kv_padding_interval_size = self.continuous_batching_config.kv_padding_interval_size
         self.max_cached_graphs = self.continuous_batching_config.max_cached_graphs
-
-        # Log probability generation is not supported yet (TODO)
-        if self.log_prob_generation:
-            raise NotImplementedError("log_prob_generation is not supported yet")
 
     @traced
     def start(self) -> None:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -517,7 +517,6 @@ class ContinuousBatchProcessor:
 
     @traced(span_name="sampling")
     def _sample(self, probs: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
-
         # Apply softmax if we are sampling or if we are generating log probabilities
         if self.do_sample or self.return_logprobs:
             probs = nn.functional.softmax(probs[0], dim=-1)  # shape [seq_len, vocab_size]

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -118,6 +118,10 @@ class ContinuousBatchProcessor:
         self.model_dtype = model_dtype
         self.scheduler = scheduler
 
+        # Generation-related attributes
+        self.do_sample = getattr(generation_config, "do_sample", True)
+        self.log_prob_generation = getattr(generation_config, "log_prob_generation", False)
+
         # Retrieve the size of the sliding window if there is one
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
         # Cuda graphs for the generation step
@@ -160,7 +164,6 @@ class ContinuousBatchProcessor:
         self._pad_inputs = self.use_cuda_graph or (varlen_config is not None or decode_config is not None)
 
         # Setup inputs and outputs
-        self.log_prob_generation = getattr(generation_config, "log_prob_generation", False)
         self.use_async_batching = self.cb_config.use_async_batching
         if self.use_async_batching:
             # Since in async there are 2 IO pairs, there are also 2 graph buffers: we divide the max_cached_graphs by 2
@@ -428,7 +431,7 @@ class ContinuousBatchProcessor:
 
     @traced
     @torch.no_grad()
-    def _generation_step(self, model: nn.Module, logit_processor: LogitsProcessorList, do_sample: bool) -> None:
+    def _generation_step(self, model: nn.Module, logit_processor: LogitsProcessorList) -> None:
         """Perform a single generation step."""
 
         # Retrieve the model kwargs with or without padding
@@ -446,7 +449,7 @@ class ContinuousBatchProcessor:
         if not self.use_cuda_graph:
             maybe_stream = torch.cuda.stream(compute_stream) if compute_stream is not None else nullcontext()
             with maybe_stream:
-                forward_fn(model, batch_data, logit_processor, do_sample, carry_over_ids, prev_output_ids, output_ids)
+                forward_fn(model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
 
         # Otherwise, we use create or replay the graph (cuda is available in this path)
         else:
@@ -462,7 +465,7 @@ class ContinuousBatchProcessor:
                 # Warmup
                 with torch.cuda.stream(compute_stream):
                     forward_fn(
-                        model, batch_data, logit_processor, do_sample, carry_over_ids, prev_output_ids, output_ids
+                        model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids
                     )
                 # torch.cuda.current_stream().wait_stream(compute_stream)
                 # Capture
@@ -477,7 +480,7 @@ class ContinuousBatchProcessor:
                     capture_error_mode="thread_local",
                 ):
                     forward_fn(
-                        model, batch_data, logit_processor, do_sample, carry_over_ids, prev_output_ids, output_ids
+                        model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids
                     )
                 # Store
                 self.inputs_and_outputs.set_graph(graph)
@@ -491,7 +494,6 @@ class ContinuousBatchProcessor:
         model: nn.Module,
         batch_data: dict,
         logit_processor: LogitsProcessorList,
-        do_sample: bool,
         carry_over_ids: torch.Tensor,
         prev_output_ids: torch.Tensor,
         output_ids: torch.Tensor,
@@ -500,9 +502,8 @@ class ContinuousBatchProcessor:
         function to be easier to trace with OpenTelemetry."""
         self.inputs_and_outputs.carry_over_tokens(batch_data["input_ids"], carry_over_ids, prev_output_ids)
         logits = self._model_forward(model, batch_data)
-        # if self.log_prob_generation:    batch_processor.output_probs.copy_(logits)  # TODO
         probs = self._process_logit(batch_data, logits, logit_processor)
-        self._sample(probs, batch_data, do_sample, output_ids)
+        self._sample(probs, batch_data["logits_indices"], output_ids)
 
     @traced(span_name="model_forward")
     def _model_forward(self, model: nn.Module, batch_data: dict) -> torch.Tensor:
@@ -527,17 +528,17 @@ class ContinuousBatchProcessor:
         return processed_logits_2d.view(batch_size, seq_len, vocab_size)
 
     @traced(span_name="sampling")
-    def _sample(self, probs: torch.Tensor, batch_data: dict, do_sample: bool, output_ids: torch.Tensor) -> None:
+    def _sample(self, probs: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
 
         # Apply softmax if we are sampling or if we are generating log probabilities
-        if do_sample or self.log_prob_generation:
+        if self.do_sample or self.log_prob_generation:
             probs = nn.functional.softmax(probs[0], dim=-1)  # shape [seq_len, vocab_size]
         # Otherwise just remove the bastch size dimension, which is always 1
         else:
             probs = probs.squeeze(0)  # shape [seq_len, vocab_size]
 
         # Retrieve next tokens through sampling or argmax
-        if do_sample:
+        if self.do_sample:
             next_tokens = torch.multinomial(probs, num_samples=1)  # shape [seq_len, 1]
         else:
             next_tokens = torch.argmax(probs, dim=-1, keepdim=True)  # shape [seq_len, 1]
@@ -551,7 +552,7 @@ class ContinuousBatchProcessor:
         # Get seq_len dimension to slice the logits indices
         tokens = next_tokens.size(0)
         # Shuffle the next tokens to match the order of the batch's requests
-        indices = batch_data["logits_indices"][:tokens]
+        indices = logits_indices[:tokens]
         next_tokens = next_tokens[indices]
         # Copy the next tokens and maybe their logprobs to the static output tensor
         output_ids[0, :tokens].copy_(next_tokens)
@@ -606,8 +607,6 @@ class ContinuousBatchingManager:
         self._request_lock = threading.Lock()
 
         # Generation config related arguments
-        self.log_prob_generation = getattr(generation_config, "log_prob_generation", False)
-        self.do_sample = getattr(generation_config, "do_sample", True)
         self.logit_processor: LogitsProcessorList = self.model._get_logits_processor(generation_config)
         num_return_sequences = getattr(generation_config, "num_return_sequences", None)
         self.num_return_sequences = num_return_sequences if num_return_sequences is not None else 1
@@ -810,7 +809,7 @@ class ContinuousBatchingManager:
         """Perform a single generation step. This is mostly cuda graphed"""
         if self.batch_processor is None:
             raise RuntimeError("Tried to perform a generation step before the batch processor was initialized.")
-        self.batch_processor._generation_step(self.model, self.logit_processor, self.do_sample)
+        self.batch_processor._generation_step(self.model, self.logit_processor)
 
     def _run_generation_loop(self) -> None:
         """Main processing loop running in the background thread."""

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -459,24 +459,17 @@ class ContinuousBatchProcessor:
                 # compute_stream.wait_stream(torch.cuda.current_stream())
                 # Warmup
                 with torch.cuda.stream(compute_stream):
-                    forward_fn(
-                        model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids
-                    )
+                    forward_fn(model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
                 # torch.cuda.current_stream().wait_stream(compute_stream)
                 # Capture
                 graph = torch.cuda.CUDAGraph()
-                # Continuous batching can run multiple manager threads concurrently in one process.
-                # PyTorch's default capture mode ("global") errors on CUDA actions from other threads,
-                # which invalidates unrelated captures even when each manager uses a different device.
+                # Continuous batching can run multiple manager threads concurrently in one process, but PyTorch's
+                # default capture mode ("global") errors on CUDA actions from other threads. This means capture can be
+                # invalidated even when each manager uses a different device. To avoid this, we use "thread_local" mode.
                 with torch.cuda.graph(
-                    graph,
-                    stream=compute_stream,
-                    pool=self.graph_pool,
-                    capture_error_mode="thread_local",
+                    graph, stream=compute_stream, pool=self.graph_pool, capture_error_mode="thread_local"
                 ):
-                    forward_fn(
-                        model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids
-                    )
+                    forward_fn(model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
                 # Store
                 self.inputs_and_outputs.set_graph(graph)
 

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -120,7 +120,7 @@ class ContinuousBatchProcessor:
 
         # Generation-related attributes
         self.do_sample = getattr(generation_config, "do_sample", True)
-        self.log_prob_generation = getattr(generation_config, "log_prob_generation", False)
+        self.return_logprobs = continuous_batching_config.return_logprobs
 
         # Retrieve the size of the sliding window if there is one
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
@@ -169,11 +169,11 @@ class ContinuousBatchProcessor:
             # Since in async there are 2 IO pairs, there are also 2 graph buffers: we divide the max_cached_graphs by 2
             max_cached_graphs = ceil(self.max_cached_graphs / 2)
             self.inputs_and_outputs = ContinuousBatchingAsyncIOs(
-                cache, config, model_device, model_dtype, max_cached_graphs, self.log_prob_generation
+                cache, config, model_device, model_dtype, max_cached_graphs, self.return_logprobs
             )
         else:
             self.inputs_and_outputs = ContinuousBatchingIOs(
-                cache, config, model_device, model_dtype, self.max_cached_graphs, self.log_prob_generation
+                cache, config, model_device, model_dtype, self.max_cached_graphs, self.return_logprobs
             )
         # Set up the graph pool. This allows all graphs to share the same memory pool, which is fine because they never
         # run concurrently. This greatly saves memory.
@@ -353,7 +353,7 @@ class ContinuousBatchProcessor:
                     state.status = RequestStatus.DECODING
 
                 token = new_tokens[current_logits_index]
-                logprob = logprobs[current_logits_index] if self.log_prob_generation else None
+                logprob = logprobs[current_logits_index] if self.return_logprobs else None
                 current_logits_index += 1
 
                 # Update the request and stop if it is complete
@@ -531,7 +531,7 @@ class ContinuousBatchProcessor:
     def _sample(self, probs: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
 
         # Apply softmax if we are sampling or if we are generating log probabilities
-        if self.do_sample or self.log_prob_generation:
+        if self.do_sample or self.return_logprobs:
             probs = nn.functional.softmax(probs[0], dim=-1)  # shape [seq_len, vocab_size]
         # Otherwise just remove the bastch size dimension, which is always 1
         else:
@@ -544,7 +544,7 @@ class ContinuousBatchProcessor:
             next_tokens = torch.argmax(probs, dim=-1, keepdim=True)  # shape [seq_len, 1]
 
         # Maybe retrieve log probabilities
-        if self.log_prob_generation:
+        if self.return_logprobs:
             logprobs = probs.gather(dim=1, index=next_tokens).squeeze(-1).log()  # shape [seq_len]
         # And always remove the extra dimension for the gather
         next_tokens = next_tokens.squeeze(-1)  # shape [seq_len]
@@ -556,7 +556,7 @@ class ContinuousBatchProcessor:
         next_tokens = next_tokens[indices]
         # Copy the next tokens and maybe their logprobs to the static output tensor
         output_ids[0, :tokens].copy_(next_tokens)
-        if self.log_prob_generation:
+        if self.return_logprobs:
             # Shuffle the logprobs the same way as the next tokens
             logprobs = logprobs[indices]
             # In order to match the dtype of the output ids, we convert them to fp32 and cast them as int32

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -95,7 +95,8 @@ class ContinuousBatchingIOs:
         config: PretrainedConfig,
         device: torch.device,
         model_dtype: torch.dtype,
-        max_graphs: int = 32,
+        max_graphs: int,
+        log_prob_generation: bool,
     ) -> None:
         """Initialize the continuous batching I/O manager. Args:
         - cache: The [`PagedAttentionCache`] instance managing the KV cache. Meant to be unique.
@@ -103,6 +104,7 @@ class ContinuousBatchingIOs:
         - device: The device to allocate tensors on. If the device is CPU, then the memory is pinned.
         - model_dtype: The data type for model computations.
         - max_graphs: Maximum number of CUDA graphs to cache. Uses LRU eviction when full.
+        - log_prob_generation: Whether to generate log probabilities along with the token IDs.
         """
         # Memoize attributes
         self.cache = cache
@@ -110,6 +112,7 @@ class ContinuousBatchingIOs:
         self.config = config
         self.model_dtype = model_dtype
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
+        self.log_prob_generation = log_prob_generation
         # Setup input-related accumulators
         self.num_q_tokens = 0  # number of query tokens in the batch. Can be padded.
         self.max_kv_read = 0  # number of KV tokens read from cache (maxed across all groups). Can be padded.
@@ -136,7 +139,7 @@ class ContinuousBatchingIOs:
           `logits_indices`, `cumulative_seqlens_k`, `carry_over_ids`.
         - `attention_mask`: Optional attention masks (only for eager/SDPA implementations)
         - `write_index` and `read_index` storage: Cache indexing tensors for each attention group
-        - `output_ids`: Storage for generated token IDs
+        - `output_ids`: Storage for generated token IDs and maybe log probabilities if log_prob_generation is True
         """
         num_groups = self.cache.num_groups
         max_batch_tokens = self.cache.max_batch_tokens
@@ -167,8 +170,9 @@ class ContinuousBatchingIOs:
             self.cumulative_seqlens_k["sliding_attention"] = sliding_attention_cumulative_seqlens_k
 
         # Output tensor and scalars
+        num_output_rows = 2 if self.log_prob_generation else 1
         self.output_ids = torch.empty(
-            (max_batch_tokens + 1,), dtype=torch.int32, device=self.device, pin_memory=pin_memory
+            (num_output_rows, max_batch_tokens + 1), dtype=torch.int32, device=self.device, pin_memory=pin_memory
         )
         # Last output token is never changed and set to 0 for async carry on purpose
         self.output_ids.zero_()
@@ -254,7 +258,7 @@ class ContinuousBatchingIOs:
 
         # Reset the logits indices and output ids
         self.logits_indices[:q_len].zero_()
-        self.output_ids[:q_len].zero_()
+        self.output_ids[:, :q_len].zero_()
 
         # Reset the attributes that are either tensors or dict of tensors
         for layer_type in self.cumulative_seqlens_k:
@@ -291,10 +295,16 @@ class ContinuousBatchingIOs:
         if self.compute_stream is not None:
             self.compute_stream.synchronize()
 
-    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int]]:
+    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int], list[float]]:
         requests_in_batch = self.requests_in_batch
-        new_tokens = self.output_ids[: len(self.requests_in_batch)].tolist()
-        return requests_in_batch, new_tokens
+        new_tokens = self.output_ids[0, : len(self.requests_in_batch)].tolist()
+        # If logprobs are generated, we retrieve them from the output tensor and cast them to the right dtype
+        if self.log_prob_generation:
+            logprobs = self.output_ids[1, : len(self.requests_in_batch)].view(dtype=torch.float32).tolist()
+        # Otherwise, we can return an empty list because they wont be used
+        else:
+            logprobs = []
+        return requests_in_batch, new_tokens, logprobs
 
     @traced
     def prepare_batch_tensors(
@@ -507,11 +517,12 @@ class HostDeviceIOPair:
         config: PretrainedConfig,
         device: torch.device,
         model_dtype: torch.dtype,
-        max_graphs: int = 32,
+        max_graphs: int,
+        log_prob_generation: bool,
     ) -> None:
         # The host IO has automatic pinned memory because it is created on the CPU
-        self.host_io = ContinuousBatchingIOs(cache, config, torch.device("cpu"), model_dtype, max_graphs)
-        self.device_io = ContinuousBatchingIOs(cache, config, device, model_dtype, max_graphs)
+        self.host_io = ContinuousBatchingIOs(cache, config, torch.device("cpu"), model_dtype, max_graphs, log_prob_generation)
+        self.device_io = ContinuousBatchingIOs(cache, config, device, model_dtype, max_graphs, log_prob_generation)
         # Create events only on CUDA devices
         self.h2d_over = torch.cuda.Event() if torch.cuda.is_available() else None
         self.compute_over = torch.cuda.Event() if torch.cuda.is_available() else None
@@ -578,14 +589,15 @@ class ContinuousBatchingAsyncIOs:
         config: PretrainedConfig,
         device: torch.device,
         model_dtype: torch.dtype,
-        max_graphs: int = 32,
+        max_graphs: int,
+        log_prob_generation: bool,
     ) -> None:
         # Async batching needs streams to function, so check is CUDA is available
         if not torch.cuda.is_available():
             raise RuntimeError(f"Async batching requires CUDA, but {torch.cuda.is_available() = }")
         # IO pairs used to avoid race conditions
         self.current_pair = 0
-        self.io_pairs = [HostDeviceIOPair(cache, config, device, model_dtype, max_graphs) for _ in range(2)]
+        self.io_pairs = [HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, log_prob_generation) for _ in range(2)]
         # CUDA streams
         self.h2d_stream = torch.cuda.Stream(device=device)
         self.d2h_stream = torch.cuda.Stream(device=device)
@@ -664,7 +676,7 @@ class ContinuousBatchingAsyncIOs:
         before launching the forwar pass of batch N+1. This method performs the carry over, and is recorded in CUDA
         graphs if they are enabled."""
         # Compute tokens to carry over and the corresponding mask
-        carried_over_ids = prev_output_ids[carry_over_ids]
+        carried_over_ids = prev_output_ids[0, carry_over_ids]
         carried_over_mask = (carry_over_ids != -1).int()
         # Truncate everything to the right size
         carried_over_ids = carried_over_ids[: input_ids.size(1)]
@@ -701,7 +713,7 @@ class ContinuousBatchingAsyncIOs:
         self.current_pair = 1 - self.current_pair
 
     # This method is called after the switch and not during the first batch
-    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int]]:
+    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int], list[float]]:
         io_pair = self.io_pairs[self.current_pair]
         io_pair.d2h_over.synchronize()  # ty:ignore[unresolved-attribute]  <- this is always a CUDA event
         return io_pair.host_io.prepare_batch_update()

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -96,7 +96,7 @@ class ContinuousBatchingIOs:
         device: torch.device,
         model_dtype: torch.dtype,
         max_graphs: int,
-        log_prob_generation: bool,
+        return_logprobs: bool,
     ) -> None:
         """Initialize the continuous batching I/O manager. Args:
         - cache: The [`PagedAttentionCache`] instance managing the KV cache. Meant to be unique.
@@ -104,7 +104,7 @@ class ContinuousBatchingIOs:
         - device: The device to allocate tensors on. If the device is CPU, then the memory is pinned.
         - model_dtype: The data type for model computations.
         - max_graphs: Maximum number of CUDA graphs to cache. Uses LRU eviction when full.
-        - log_prob_generation: Whether to generate log probabilities along with the token IDs.
+        - return_logprobs: Whether to return log probabilities along with the token IDs.
         """
         # Memoize attributes
         self.cache = cache
@@ -112,7 +112,7 @@ class ContinuousBatchingIOs:
         self.config = config
         self.model_dtype = model_dtype
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
-        self.log_prob_generation = log_prob_generation
+        self.return_logprobs = return_logprobs
         # Setup input-related accumulators
         self.num_q_tokens = 0  # number of query tokens in the batch. Can be padded.
         self.max_kv_read = 0  # number of KV tokens read from cache (maxed across all groups). Can be padded.
@@ -139,7 +139,7 @@ class ContinuousBatchingIOs:
           `logits_indices`, `cumulative_seqlens_k`, `carry_over_ids`.
         - `attention_mask`: Optional attention masks (only for eager/SDPA implementations)
         - `write_index` and `read_index` storage: Cache indexing tensors for each attention group
-        - `output_ids`: Storage for generated token IDs and maybe log probabilities if log_prob_generation is True
+        - `output_ids`: Storage for generated token IDs and maybe log probabilities if return_logprobs is True
         """
         num_groups = self.cache.num_groups
         max_batch_tokens = self.cache.max_batch_tokens
@@ -170,7 +170,7 @@ class ContinuousBatchingIOs:
             self.cumulative_seqlens_k["sliding_attention"] = sliding_attention_cumulative_seqlens_k
 
         # Output tensor and scalars
-        num_output_rows = 2 if self.log_prob_generation else 1
+        num_output_rows = 2 if self.return_logprobs else 1
         self.output_ids = torch.empty(
             (num_output_rows, max_batch_tokens + 1), dtype=torch.int32, device=self.device, pin_memory=pin_memory
         )
@@ -295,15 +295,15 @@ class ContinuousBatchingIOs:
         if self.compute_stream is not None:
             self.compute_stream.synchronize()
 
-    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int], list[float]]:
+    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int], list[float] | None]:
         requests_in_batch = self.requests_in_batch
         new_tokens = self.output_ids[0, : len(self.requests_in_batch)].tolist()
         # If logprobs are generated, we retrieve them from the output tensor and cast them to the right dtype
-        if self.log_prob_generation:
+        if self.return_logprobs:
             logprobs = self.output_ids[1, : len(self.requests_in_batch)].view(dtype=torch.float32).tolist()
         # Otherwise, we can return an empty list because they wont be used
         else:
-            logprobs = []
+            logprobs = None
         return requests_in_batch, new_tokens, logprobs
 
     @traced
@@ -518,11 +518,13 @@ class HostDeviceIOPair:
         device: torch.device,
         model_dtype: torch.dtype,
         max_graphs: int,
-        log_prob_generation: bool,
+        return_logprobs: bool,
     ) -> None:
         # The host IO has automatic pinned memory because it is created on the CPU
-        self.host_io = ContinuousBatchingIOs(cache, config, torch.device("cpu"), model_dtype, max_graphs, log_prob_generation)
-        self.device_io = ContinuousBatchingIOs(cache, config, device, model_dtype, max_graphs, log_prob_generation)
+        self.host_io = ContinuousBatchingIOs(
+            cache, config, torch.device("cpu"), model_dtype, max_graphs, return_logprobs
+        )
+        self.device_io = ContinuousBatchingIOs(cache, config, device, model_dtype, max_graphs, return_logprobs)
         # Create events only on CUDA devices
         self.h2d_over = torch.cuda.Event() if torch.cuda.is_available() else None
         self.compute_over = torch.cuda.Event() if torch.cuda.is_available() else None
@@ -590,14 +592,14 @@ class ContinuousBatchingAsyncIOs:
         device: torch.device,
         model_dtype: torch.dtype,
         max_graphs: int,
-        log_prob_generation: bool,
+        return_logprobs: bool,
     ) -> None:
         # Async batching needs streams to function, so check is CUDA is available
         if not torch.cuda.is_available():
             raise RuntimeError(f"Async batching requires CUDA, but {torch.cuda.is_available() = }")
         # IO pairs used to avoid race conditions
         self.current_pair = 0
-        self.io_pairs = [HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, log_prob_generation) for _ in range(2)]
+        self.io_pairs = [HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, return_logprobs) for _ in range(2)]
         # CUDA streams
         self.h2d_stream = torch.cuda.Stream(device=device)
         self.d2h_stream = torch.cuda.Stream(device=device)
@@ -713,7 +715,7 @@ class ContinuousBatchingAsyncIOs:
         self.current_pair = 1 - self.current_pair
 
     # This method is called after the switch and not during the first batch
-    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int], list[float]]:
+    def prepare_batch_update(self) -> tuple[list[FutureRequestState], list[int], list[float] | None]:
         io_pair = self.io_pairs[self.current_pair]
         io_pair.d2h_over.synchronize()  # ty:ignore[unresolved-attribute]  <- this is always a CUDA event
         return io_pair.host_io.prepare_batch_update()

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -599,7 +599,9 @@ class ContinuousBatchingAsyncIOs:
             raise RuntimeError(f"Async batching requires CUDA, but {torch.cuda.is_available() = }")
         # IO pairs used to avoid race conditions
         self.current_pair = 0
-        self.io_pairs = [HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, return_logprobs) for _ in range(2)]
+        self.io_pairs = [
+            HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, return_logprobs) for _ in range(2)
+        ]
         # CUDA streams
         self.h2d_stream = torch.cuda.Stream(device=device)
         self.d2h_stream = torch.cuda.Stream(device=device)

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -248,7 +248,6 @@ class RequestState:
                 self.logprobs.append(logprob)
         else:
             logger.warning(f"Request {self.request_id} generated a useless token: {token_id}")
-            self.generated_tokens.pop()
 
         if is_eos or current_len >= self._new_tokens_limit:
             self.status = RequestStatus.FINISHED
@@ -315,7 +314,7 @@ class RequestState:
     def create_equivalent_initial_request(self) -> "RequestState":
         """Creates an equivalent new request by removing the generated tokens and adding them to the initial prompt. The
         created request has THE SAME request_id. Notably, we can retrieve the original request from the created one with
-        the _true_initial_tokens attribute."""
+        the _true_initial_tokens attribute. The logprobs of the generated tokens are kept in the new request."""
         max_new_tokens = None if self.max_new_tokens is None else (self.max_new_tokens - len(self.generated_tokens))
         new_state = RequestState(
             request_id=self.request_id,

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -224,14 +224,8 @@ class RequestState:
     # TODO: this logic seems one token off, check it out
     @traced
     def update_and_check_completion(self, token_id: int, logprob: float | None) -> bool:
-        """Update the request with a newly generated token and check for completion.
-
-        Args:
-            token_id: The token ID to add to the output sequence
-
-        Returns:
-            bool: True if the request is now complete, False otherwise
-        """
+        """Update the request with a newly generated token (and optional log probability of the token) and check for
+        completion. Returns True if the request is now complete, False otherwise."""
         # Only update if we're in decoding state # TODO: seems useless (always true) -- remove this
         if self.status != RequestStatus.DECODING:
             return False

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -153,6 +153,7 @@ class RequestState:
         default_factory=list
     )  # Initial tokens left to process (initialized in __post_init__)
     generated_tokens: list[int] = field(default_factory=list)  # Generated tokens
+    logprobs: list[float] = field(default_factory=list)  # Log probabilities of the generated tokens
     allocated_blocks: int = 0  # Number of blocks allocated to the request
     position_offset: int = 0  # Current position in the sequence for position_ids
     _status: RequestStatus = RequestStatus.PENDING  # Status of the request, hidden behind a property
@@ -222,7 +223,7 @@ class RequestState:
 
     # TODO: this logic seems one token off, check it out
     @traced
-    def update_and_check_completion(self, token_id: int) -> bool:
+    def update_and_check_completion(self, token_id: int, logprob: float | None) -> bool:
         """Update the request with a newly generated token and check for completion.
 
         Args:
@@ -249,6 +250,8 @@ class RequestState:
             self.generated_tokens.append(token_id)
             self.tokens_to_process = [token_id]  # this works for 2 levels of pipelines, but not sure for more
             current_len += 1
+            if logprob is not None:
+                self.logprobs.append(logprob)
         else:
             logger.warning(f"Request {self.request_id} generated a useless token: {token_id}")
             self.generated_tokens.pop()
@@ -281,7 +284,7 @@ class RequestState:
             request_id=self.request_id,
             prompt_ids=self.initial_tokens,
             generated_tokens=self.generated_tokens,
-            logprobs=[],
+            logprobs=self.logprobs,
             error=self.error,
             status=self.status,
             created_time=self.created_time,
@@ -298,6 +301,7 @@ class RequestState:
             num_children=self.num_children,
             tokens_to_process=self.tokens_to_process[:],
             generated_tokens=self.generated_tokens[:],
+            logprobs=self.logprobs[:],
             allocated_blocks=self.allocated_blocks,
             position_offset=self.position_offset,
             _status=self.status,
@@ -322,13 +326,19 @@ class RequestState:
         new_state = RequestState(
             request_id=self.request_id,
             initial_tokens=self.initial_tokens + self.generated_tokens,
+            logprobs=self.logprobs[:],
             num_children=self.num_children,
             record_timestamps=self.record_timestamps,
             max_new_tokens=max_new_tokens,
             eos_token_id=self.eos_token_id,
             streaming=self.streaming,
         )
-        new_state._true_initial_tokens = self._true_initial_tokens + len(self.initial_tokens)
+        # If the request has been soft reset once already, this stays the same
+        if self._true_initial_tokens:
+            new_state._true_initial_tokens = self._true_initial_tokens
+        # Otherwise, we set the true initial tokens to the number of initial tokens
+        else:
+            new_state._true_initial_tokens = len(self.initial_tokens)
         return new_state
 
 

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -679,7 +679,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             # Find the corresponding CB output by matching prompt tokens
             input_tokens = inputs.input_ids[i][inputs.attention_mask[i] == 1].tolist()
             cb_output = None
-            for key, state in cb_outputs.items():
+            for state in cb_outputs.values():
                 if state.prompt_ids == input_tokens:
                     cb_output = state
                     break

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -700,7 +700,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             # Compare with tolerance for floating point differences
             for j, (cb_lp, exp_lp) in enumerate(zip(cb_logprobs, expected_logprobs)):
                 self.assertAlmostEqual(
-                    cb_lp, exp_lp, places=5,
+                    cb_lp, exp_lp, places=4 if use_cuda_graph else 5,  # cuda graphs add padding, hence lower precision
                     msg=f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}"
                 )
 

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -626,7 +626,9 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             max_new_tokens=80,
         )
 
-    def test_continuous_batching_log_probs(self) -> None:
+    @parameterized.expand([(False, False), (False, True), (True, False), (True, True)])
+    @slow
+    def test_continuous_batching_log_probs(self, use_cuda_graph: bool, use_async_batching: bool) -> None:
         """Test that log probabilities match between continuous batching and regular generate."""
         model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
         max_new_tokens = 10
@@ -646,7 +648,10 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
         gen_config = GenerationConfig(max_new_tokens=max_new_tokens, do_sample=False, eos_token_id=eos_token_id)
 
         continuous_batching_config = ContinuousBatchingConfig(
-            use_cuda_graph=False, use_async_batching=False, allow_block_sharing=False, return_logprobs=True
+            use_cuda_graph=use_cuda_graph,
+            use_async_batching=use_async_batching,
+            allow_block_sharing=False,
+            return_logprobs=True,
         )
 
         cb_outputs = model.generate_batch(

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -700,8 +700,10 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             # Compare with tolerance for floating point differences
             for j, (cb_lp, exp_lp) in enumerate(zip(cb_logprobs, expected_logprobs)):
                 self.assertAlmostEqual(
-                    cb_lp, exp_lp, places=4 if use_cuda_graph else 5,  # cuda graphs add padding, hence lower precision
-                    msg=f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}"
+                    cb_lp,
+                    exp_lp,
+                    places=4 if use_cuda_graph else 5,  # cuda graphs add padding, hence lower precision
+                    msg=f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}",
                 )
 
     def test_continuous_batching_with_default_compile_configs(self) -> None:

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -626,6 +626,79 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             max_new_tokens=80,
         )
 
+    def test_continuous_batching_log_probs(self) -> None:
+        """Test that log probabilities match between continuous batching and regular generate."""
+        model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+        max_new_tokens = 10
+
+        tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
+        tokenizer.pad_token = tokenizer.eos_token
+        user_messages = ["What is 2+2?", "Hello world"]
+        chats = [[{"role": "user", "content": msg}] for msg in user_messages]
+        tokenized = [tokenizer.apply_chat_template(chat, add_generation_prompt=True) for chat in chats]
+        input_ids = [(x if isinstance(x, list) else x["input_ids"]) for x in tokenized]
+
+        # Load model for CB generation
+        model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="sdpa", torch_dtype=torch.float32)
+        model = model.to(torch_device).eval()
+        eos_token_id = model.config.eos_token_id
+
+        gen_config = GenerationConfig(max_new_tokens=max_new_tokens, do_sample=False, eos_token_id=eos_token_id)
+
+        continuous_batching_config = ContinuousBatchingConfig(
+            use_cuda_graph=False, use_async_batching=False, allow_block_sharing=False, return_logprobs=True
+        )
+
+        cb_outputs = model.generate_batch(
+            inputs=input_ids, generation_config=gen_config, continuous_batching_config=continuous_batching_config
+        )
+
+        # Load fresh model for regular generate (same pattern as parity tests)
+        model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="sdpa", torch_dtype=torch.float32)
+        model = model.to(torch_device).eval()
+
+        # Run regular generate with output_scores to get logits
+        inputs = tokenizer.apply_chat_template(
+            chats, add_generation_prompt=True, return_tensors="pt", padding=True, return_dict=True
+        )
+        gen_config_regular = GenerationConfig(
+            max_new_tokens=max_new_tokens, do_sample=False, output_scores=True, eos_token_id=eos_token_id
+        )
+        generate_outputs = model.generate(
+            **inputs.to(torch_device), generation_config=gen_config_regular, return_dict_in_generate=True
+        )
+
+        # Compare log_probs for each request, matching by prompt_ids
+        num_input_tokens = inputs.input_ids.shape[1]
+        for i in range(len(user_messages)):
+            # Find the corresponding CB output by matching prompt tokens
+            input_tokens = inputs.input_ids[i][inputs.attention_mask[i] == 1].tolist()
+            cb_output = None
+            for key, state in cb_outputs.items():
+                if state.prompt_ids == input_tokens:
+                    cb_output = state
+                    break
+            self.assertIsNotNone(cb_output, f"Could not find CB output for request {i}")
+
+            # Compute log_probs from regular generate scores
+            expected_logprobs = []
+            generated_tokens = generate_outputs.sequences[i, num_input_tokens:].tolist()
+            for step, (score, token) in enumerate(zip(generate_outputs.scores, generated_tokens)):
+                probs = torch.nn.functional.softmax(score[i], dim=-1)
+                expected_logprobs.append(probs[token].log().item())
+
+            # Truncate to same length (in case of padding differences)
+            min_len = min(len(cb_output.logprobs), len(expected_logprobs))
+            cb_logprobs = cb_output.logprobs[:min_len]
+            expected_logprobs = expected_logprobs[:min_len]
+
+            # Compare with tolerance for floating point differences
+            for j, (cb_lp, exp_lp) in enumerate(zip(cb_logprobs, expected_logprobs)):
+                self.assertAlmostEqual(
+                    cb_lp, exp_lp, places=5,
+                    msg=f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}"
+                )
+
     def test_continuous_batching_with_default_compile_configs(self) -> None:
         """Test continuous batching with use_default_compile_configs=True in ContinuousBatchingConfig.
 

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -683,7 +683,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             # Compute log_probs from regular generate scores
             expected_logprobs = []
             generated_tokens = generate_outputs.sequences[i, num_input_tokens:].tolist()
-            for step, (score, token) in enumerate(zip(generate_outputs.scores, generated_tokens)):
+            for score, token in zip(generate_outputs.scores, generated_tokens):
                 probs = torch.nn.functional.softmax(score[i], dim=-1)
                 expected_logprobs.append(probs[token].log().item())
 


### PR DESCRIPTION
## Summary 

This PR adds the `return_logprobs` flag to the continuous batching, enabling the user to retrieve the log probabilites of the tokens generated. 

# Tests
Added a test to compare with regular generate and it passes. All tests pass.

# Performance
No noticeable impact. 