### PR TITLE
Fix AutoImageProcessor.from_pretrained failing with URL input

### DIFF
--- a/src/transformers/image_processing_base.py
+++ b/src/transformers/image_processing_base.py
@@ -15,7 +15,9 @@
 import copy
 import json
 import os
+import tempfile
 from typing import Any, TypeVar
+from urllib.parse import urlparse
 
 import numpy as np
 from huggingface_hub import create_repo, is_offline_mode
@@ -276,6 +278,24 @@ class ImageProcessingMixin(PushToHubMixin):
             resolved_image_processor_file = pretrained_model_name_or_path
             resolved_processor_file = None
             is_local = True
+        elif urlparse(pretrained_model_name_or_path).scheme in ("http", "https"):
+            image_processor_file = pretrained_model_name_or_path
+            resolved_processor_file = None
+            try:
+                import requests
+
+                response = requests.get(pretrained_model_name_or_path, proxies=proxies)
+                response.raise_for_status()
+                content = response.content
+            except Exception as e:
+                raise OSError(
+                    f"Can't load image processor from URL '{pretrained_model_name_or_path}'. "
+                    f"Error: {e}"
+                )
+            tmp_fd, tmp_file = tempfile.mkstemp()
+            with os.fdopen(tmp_fd, "wb") as f:
+                f.write(content)
+            resolved_image_processor_file = tmp_file
         else:
             image_processor_file = image_processor_filename
             try:

--- a/tests/utils/test_image_processing_utils.py
+++ b/tests/utils/test_image_processing_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import sys
 import tempfile
 import unittest
@@ -54,6 +55,26 @@ class ImageProcessorUtilTester(unittest.TestCase):
             _ = ViTImageProcessorFast.from_pretrained("hf-internal-testing/tiny-random-vit")
             # This check we did call the fake head request
             mock_head.assert_called()
+
+    def test_image_processor_from_pretrained_url(self):
+        # Test that AutoImageProcessor.from_pretrained works with a URL (issue #44821)
+        image_processor_config = {
+            "image_processor_type": "ViTImageProcessor",
+            "size": {"height": 224, "width": 224},
+            "do_resize": True,
+        }
+        fake_response = mock.Mock()
+        fake_response.status_code = 200
+        fake_response.content = json.dumps(image_processor_config).encode("utf-8")
+        fake_response.raise_for_status = mock.Mock()
+
+        with mock.patch("requests.get", return_value=fake_response) as mock_get:
+            processor = AutoImageProcessor.from_pretrained(
+                "https://huggingface.co/some-user/some-model/raw/main/preprocessor_config.json"
+            )
+            mock_get.assert_called()
+            self.assertIsNotNone(processor)
+            self.assertEqual(processor.size, {"height": 224, "width": 224})
 
     def test_image_processor_from_pretrained_subfolder(self):
         with self.assertRaises(OSError):


### PR DESCRIPTION
## Summary
- Fixes #44821 — `AutoImageProcessor.from_pretrained` fails with `OSError: Repo id must be in the form 'repo_name' or 'namespace/repo_name'` when given a URL
- The URL handling branch (`is_remote_url` check) in `get_image_processor_dict` was accidentally removed during the v5 cleanup
- Restores URL support by adding an `elif` branch that detects HTTP(S) URLs, downloads the JSON content directly, and writes it to a temp file for parsing
- Adds a unit test with mocked HTTP to verify URL-based loading works

## Test plan
- [x] New test `test_image_processor_from_pretrained_url` passes — verifies that a mocked URL returns a valid `ViTImageProcessor`
- [x] Existing `ImageProcessorUtilTester` tests still pass
- [ ] Manually test with `transformers.AutoImageProcessor.from_pretrained("https://huggingface.co/jinfengxie/BFMS_1014/raw/main/config.json")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>