### PR TITLE
[`Mllama`] Fix workaround compile

### DIFF
--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -1389,7 +1389,7 @@ class MllamaModel(MllamaPreTrainedModel):
             )
             cross_attention_states = vision_outputs.last_hidden_state
             cross_attention_states = self.multi_modal_projector(cross_attention_states).reshape(
-                -1, cross_attention_states.shape[-2], self.hidden_size
+                vision_outputs.last_hidden_state.shape[0], -1, self.hidden_size
             )
 
         if cross_attention_mask is not None:

--- a/src/transformers/models/mllama/modeling_mllama.py
+++ b/src/transformers/models/mllama/modeling_mllama.py
@@ -1404,11 +1404,10 @@ class MllamaModel(MllamaPreTrainedModel):
         if cross_attention_mask is not None:
             past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
             seq_len = input_ids.shape[1] if input_ids is not None else inputs_embeds.shape[1]
-            device = input_ids.device if input_ids is not None else inputs_embeds.device
-            current_pos = torch.arange(seq_len, device=device) + past_seen_tokens
-
-            cross_attention_mask = cross_attention_mask[:, :, current_pos]
-            full_text_row_masked_out_mask = full_text_row_masked_out_mask[:, :, current_pos]
+            cross_attention_mask = cross_attention_mask[:, :, past_seen_tokens : past_seen_tokens + seq_len]
+            full_text_row_masked_out_mask = full_text_row_masked_out_mask[
+                :, :, past_seen_tokens : past_seen_tokens + seq_len
+            ]
 
         outputs = self.language_model(
             input_ids=input_ids,


### PR DESCRIPTION
See #44458

This is a deep issue tbh - the cross attentions are reshaped into a different shape than the text input leading to a mismatch between batch sizes. This only gets noticed during compile as it is more strict about the concrete shapes and indices. Tested locally that it works.