### PR TITLE
Update some type hints

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -26,6 +26,7 @@ from huggingface_hub import create_repo
 from huggingface_hub.dataclasses import strict
 from packaging import version
 
+from .tokenization_utils_base import PreTrainedTokenizer
 from . import __version__
 from .dynamic_module_utils import custom_object_save
 from .generation.configuration_utils import GenerationConfig
@@ -189,7 +190,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
     problem_type: Literal["regression", "single_label_classification", "multi_label_classification"] | None = None
 
     # Tokenizer kwargs
-    tokenizer_class: str | None = None
+    tokenizer_class: str | PreTrainedTokenizer | None = None
 
     def __post_init__(self, **kwargs):
         # BC for the `torch_dtype` argument instead of the simpler `dtype`
@@ -1265,3 +1266,18 @@ if PreTrainedConfig.push_to_hub.__doc__ is not None:
 
 # The alias is only here for BC - we did not have the correct CamelCasing before
 PretrainedConfig = PreTrainedConfig
+
+
+def layer_type_validation(layer_types: list[str], num_hidden_layers: int | None = None, attention: bool = True):
+    logger.warning(
+        "`layer_type_validation` is deprecated and will be removed in v5.20. "
+        "Use `PreTrainedConfig.validate_layer_type` instead"
+    )
+
+    if not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in layer_types):
+        raise ValueError(f"The `layer_types` entries must be in {ALLOWED_LAYER_TYPES}")
+    if num_hidden_layers is not None and num_hidden_layers != len(layer_types):
+        raise ValueError(
+            f"`num_hidden_layers` ({num_hidden_layers}) must be equal to the number of layer types "
+            f"({len(layer_types)})"
+        )

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -26,12 +26,12 @@ from huggingface_hub import create_repo
 from huggingface_hub.dataclasses import strict
 from packaging import version
 
-from .tokenization_utils_base import PreTrainedTokenizer
 from . import __version__
 from .dynamic_module_utils import custom_object_save
 from .generation.configuration_utils import GenerationConfig
 from .modeling_gguf_pytorch_utils import load_gguf_checkpoint
 from .modeling_rope_utils import RotaryEmbeddingConfigMixin
+from .tokenization_utils_base import PreTrainedTokenizerBase
 from .utils import (
     CONFIG_NAME,
     PushToHubMixin,
@@ -190,7 +190,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
     problem_type: Literal["regression", "single_label_classification", "multi_label_classification"] | None = None
 
     # Tokenizer kwargs
-    tokenizer_class: str | PreTrainedTokenizer | None = None
+    tokenizer_class: str | PreTrainedTokenizerBase | None = None
 
     def __post_init__(self, **kwargs):
         # BC for the `torch_dtype` argument instead of the simpler `dtype`

--- a/src/transformers/models/blenderbot/configuration_blenderbot.py
+++ b/src/transformers/models/blenderbot/configuration_blenderbot.py
@@ -73,7 +73,7 @@ class BlenderbotConfig(PreTrainedConfig):
     bos_token_id: int | None = 1
     eos_token_id: int | list[int] | None = 2
     encoder_no_repeat_ngram_size: int = 3
-    forced_eos_token_id: int | None = 2
+    forced_eos_token_id: int | list[int] | None = 2
     is_decoder: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
+++ b/src/transformers/models/blenderbot_small/configuration_blenderbot_small.py
@@ -69,7 +69,7 @@ class BlenderbotSmallConfig(PreTrainedConfig):
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
     eos_token_id: int | list[int] | None = 2
-    forced_eos_token_id: int | None = 2
+    forced_eos_token_id: int | list[int] | None = 2
     is_decoder: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/clvp/configuration_clvp.py
+++ b/src/transformers/models/clvp/configuration_clvp.py
@@ -174,7 +174,7 @@ class ClvpDecoderConfig(PreTrainedConfig):
     summary_first_dropout: float | int = 0.1
     use_cache: bool = True
     bos_token_id: int | None = 8192
-    eos_token_id: int | None = 8193
+    eos_token_id: int | list[int] | None = 8193
     pad_token_id: int | None = None
     feature_size: int = 80
     use_attention_bias: bool = True

--- a/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
@@ -78,7 +78,7 @@ class DeepseekV3Config(PreTrainedConfig):
     n_routed_experts: int = 256
     routed_scaling_factor: float = 2.5
     kv_lora_rank: int = 512
-    q_lora_rank: int = 1536
+    q_lora_rank: int | None = 1536
     qk_rope_head_dim: int = 64
     v_head_dim: int | None = 128
     qk_nope_head_dim: int = 128

--- a/src/transformers/models/dia/configuration_dia.py
+++ b/src/transformers/models/dia/configuration_dia.py
@@ -78,7 +78,7 @@ class DiaDecoderConfig(PreTrainedConfig):
     use_cache: bool = True
     is_encoder_decoder: bool = True
     pad_token_id: int | None = 1025
-    eos_token_id: int | None = 1024
+    eos_token_id: int | list[int] | None = 1024
     bos_token_id: int | None = 1026
 
 

--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -61,7 +61,7 @@ class EuroBertConfig(LlamaConfig):
     initializer_range: float = 0.02
     rms_norm_eps: float = 1e-05
     bos_token_id: int | None = 128000
-    eos_token_id: int | None = 128001
+    eos_token_id: int | list[int] | None = 128001
     pad_token_id: int | None = 128001
     mask_token_id: int = 128002
     pretraining_tp: int = 1

--- a/src/transformers/models/eurobert/modular_eurobert.py
+++ b/src/transformers/models/eurobert/modular_eurobert.py
@@ -63,7 +63,7 @@ class EuroBertConfig(LlamaConfig):
     initializer_range: float = 0.02
     rms_norm_eps: float = 1e-05
     bos_token_id: int | None = 128000
-    eos_token_id: int | None = 128001
+    eos_token_id: int | list[int] | None = 128001
     pad_token_id: int | None = 128001
     mask_token_id: int = 128002
     pretraining_tp: int = 1

--- a/src/transformers/models/exaone_moe/configuration_exaone_moe.py
+++ b/src/transformers/models/exaone_moe/configuration_exaone_moe.py
@@ -94,7 +94,7 @@ class ExaoneMoeConfig(PreTrainedConfig):
     rms_norm_eps: float = 1e-5
     use_cache: bool = True
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 53
+    eos_token_id: int | list[int] | None = 53
     pad_token_id: int | None = 0
     tie_word_embeddings: bool = False
     rope_parameters: dict | None = None

--- a/src/transformers/models/exaone_moe/modular_exaone_moe.py
+++ b/src/transformers/models/exaone_moe/modular_exaone_moe.py
@@ -92,7 +92,7 @@ class ExaoneMoeConfig(Exaone4Config):
     rms_norm_eps: float = 1e-5
     use_cache: bool = True
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 53
+    eos_token_id: int | list[int] | None = 53
     pad_token_id: int | None = 0
     tie_word_embeddings: bool = False
     rope_parameters: dict | None = None

--- a/src/transformers/models/flaubert/configuration_flaubert.py
+++ b/src/transformers/models/flaubert/configuration_flaubert.py
@@ -136,7 +136,7 @@ class FlaubertConfig(PreTrainedConfig):
     lang_id: int = 0
     pad_token_id: int | None = 2
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/fnet/configuration_fnet.py
+++ b/src/transformers/models/fnet/configuration_fnet.py
@@ -62,7 +62,7 @@ class FNetConfig(PreTrainedConfig):
     tpu_short_seq_length: int = 512
     pad_token_id: int | None = 3
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/fsmt/configuration_fsmt.py
+++ b/src/transformers/models/fsmt/configuration_fsmt.py
@@ -97,8 +97,8 @@ class FSMTConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
-    forced_eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
+    forced_eos_token_id: int | list[int] | None = 2
 
     def __post_init__(self, **kwargs):
         kwargs.pop("decoder", None)  # delete unused kwargs

--- a/src/transformers/models/git/configuration_git.py
+++ b/src/transformers/models/git/configuration_git.py
@@ -98,7 +98,7 @@ class GitConfig(PreTrainedConfig):
     use_cache: bool = True
     tie_word_embeddings: bool = False
     bos_token_id: int | None = 101
-    eos_token_id: int | None = 102
+    eos_token_id: int | list[int] | None = 102
     num_image_with_embedding: int | None = None
 
     def __post_init__(self, **kwargs):

--- a/src/transformers/models/glm4_moe_lite/configuration_glm4_moe_lite.py
+++ b/src/transformers/models/glm4_moe_lite/configuration_glm4_moe_lite.py
@@ -84,7 +84,7 @@ class Glm4MoeLiteConfig(PreTrainedConfig):
     n_routed_experts: int = 64
     routed_scaling_factor: float = 1.8
     kv_lora_rank: int = 512
-    q_lora_rank: int = 768
+    q_lora_rank: int | None = 768
     qk_rope_head_dim: int = 64
     v_head_dim: int = 256
     qk_nope_head_dim: int = 192

--- a/src/transformers/models/glm4_moe_lite/modular_glm4_moe_lite.py
+++ b/src/transformers/models/glm4_moe_lite/modular_glm4_moe_lite.py
@@ -92,7 +92,7 @@ class Glm4MoeLiteConfig(PreTrainedConfig):
     n_routed_experts: int = 64
     routed_scaling_factor: float = 1.8
     kv_lora_rank: int = 512
-    q_lora_rank: int = 768
+    q_lora_rank: int | None = 768
     qk_rope_head_dim: int = 64
     v_head_dim: int = 256
     qk_nope_head_dim: int = 192

--- a/src/transformers/models/gpt2/configuration_gpt2.py
+++ b/src/transformers/models/gpt2/configuration_gpt2.py
@@ -95,7 +95,7 @@ class GPT2Config(PreTrainedConfig):
     scale_attn_weights: bool = True
     use_cache: bool = True
     bos_token_id: int | None = 50256
-    eos_token_id: int | None = 50256
+    eos_token_id: int | list[int] | None = 50256
     pad_token_id: int | None = None
     scale_attn_by_inverse_layer_idx: bool = False
     reorder_and_upcast_attn: bool = False

--- a/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
+++ b/src/transformers/models/gpt_bigcode/configuration_gpt_bigcode.py
@@ -73,7 +73,7 @@ class GPTBigCodeConfig(PreTrainedConfig):
     scale_attn_weights: bool = True
     use_cache: bool = True
     bos_token_id: int | None = 50256
-    eos_token_id: int | None = 50256
+    eos_token_id: int | list[int] | None = 50256
     pad_token_id: int | None = None
     attention_softmax_in_fp32: bool = True
     scale_attention_softmax_in_fp32: bool = True

--- a/src/transformers/models/gpt_neo/configuration_gpt_neo.py
+++ b/src/transformers/models/gpt_neo/configuration_gpt_neo.py
@@ -66,7 +66,7 @@ class GPTNeoConfig(PreTrainedConfig):
     initializer_range: float = 0.02
     use_cache: bool = True
     bos_token_id: int | None = 50256
-    eos_token_id: int | None = 50256
+    eos_token_id: int | list[int] | None = 50256
     pad_token_id: int | None = None
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/gptj/configuration_gptj.py
+++ b/src/transformers/models/gptj/configuration_gptj.py
@@ -64,7 +64,7 @@ class GPTJConfig(PreTrainedConfig):
     initializer_range: float = 0.02
     use_cache: bool = True
     bos_token_id: int | None = 50256
-    eos_token_id: int | None = 50256
+    eos_token_id: int | list[int] | None = 50256
     pad_token_id: int | None = None
     tie_word_embeddings: bool = False
 

--- a/src/transformers/models/groupvit/configuration_groupvit.py
+++ b/src/transformers/models/groupvit/configuration_groupvit.py
@@ -57,7 +57,7 @@ class GroupViTTextConfig(PreTrainedConfig):
     initializer_factor: float = 1.0
     pad_token_id: int | None = 1
     bos_token_id: int | None = 49406
-    eos_token_id: int | None = 49407
+    eos_token_id: int | list[int] | None = 49407
 
 
 @auto_docstring(checkpoint="nvidia/groupvit-gcc-yfcc")

--- a/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
@@ -86,7 +86,7 @@ class HiggsAudioV2Config(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 128001
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 128009
+    eos_token_id: int | list[int] | None = 128009
     pretraining_tp: int | None = 1
     tie_word_embeddings: bool = False
     rope_parameters: RopeParameters | dict | None = None

--- a/src/transformers/models/higgs_audio_v2/modular_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/modular_higgs_audio_v2.py
@@ -75,7 +75,7 @@ class HiggsAudioV2Config(LlamaConfig):
     num_attention_heads: int = 24
     num_key_value_heads: int = 8
     pad_token_id: int | None = 128001
-    eos_token_id: int | None = 128009
+    eos_token_id: int | list[int] | None = 128009
     head_dim: int | None = 128
     num_codebooks: int = 8
     codebook_size: int = 1024

--- a/src/transformers/models/hubert/configuration_hubert.py
+++ b/src/transformers/models/hubert/configuration_hubert.py
@@ -159,7 +159,7 @@ class HubertConfig(PreTrainedConfig):
     classifier_proj_size: int = 256
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
 
     def __post_init__(self, **kwargs):
         self.num_feat_extract_layers = len(self.conv_dim)

--- a/src/transformers/models/ibert/configuration_ibert.py
+++ b/src/transformers/models/ibert/configuration_ibert.py
@@ -53,7 +53,7 @@ class IBertConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-12
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     quant_mode: bool = False
     force_dequant: str = "none"
 

--- a/src/transformers/models/idefics/configuration_idefics.py
+++ b/src/transformers/models/idefics/configuration_idefics.py
@@ -133,7 +133,7 @@ class IdeficsConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = False
     cross_layer_interval: int = 1
     qk_layer_norms: bool = False

--- a/src/transformers/models/jamba/configuration_jamba.py
+++ b/src/transformers/models/jamba/configuration_jamba.py
@@ -62,7 +62,7 @@ class JambaConfig(PreTrainedConfig):
     router_aux_loss_coef: float = 0.001
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     max_position_embeddings: int = 262144
     attention_dropout: float | int = 0.0
     num_experts_per_tok: int = 2

--- a/src/transformers/models/jina_embeddings_v3/configuration_jina_embeddings_v3.py
+++ b/src/transformers/models/jina_embeddings_v3/configuration_jina_embeddings_v3.py
@@ -61,7 +61,7 @@ class JinaEmbeddingsV3Config(PreTrainedConfig):
     layer_norm_eps: float = 1e-5
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     use_cache: bool = True
     classifier_dropout: float | int | None = None
     tie_word_embeddings: bool = True

--- a/src/transformers/models/kosmos2/configuration_kosmos2.py
+++ b/src/transformers/models/kosmos2/configuration_kosmos2.py
@@ -56,7 +56,7 @@ class Kosmos2TextConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_cross_attention: bool = False
 
 

--- a/src/transformers/models/kosmos2_5/configuration_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/configuration_kosmos2_5.py
@@ -56,7 +56,7 @@ class Kosmos2_5TextConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
 
 
 @auto_docstring(checkpoint="microsoft/kosmos-2.5")

--- a/src/transformers/models/layoutlmv3/configuration_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/configuration_layoutlmv3.py
@@ -80,7 +80,7 @@ class LayoutLMv3Config(PreTrainedConfig):
     layer_norm_eps: float = 1e-5
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     max_2d_position_embeddings: int = 1024
     coordinate_size: int = 128
     shape_size: int = 128

--- a/src/transformers/models/led/configuration_led.py
+++ b/src/transformers/models/led/configuration_led.py
@@ -78,7 +78,7 @@ class LEDConfig(PreTrainedConfig):
     classifier_dropout: float | int = 0.0
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     attention_window: list[int] | int = 512
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/llama4/configuration_llama4.py
+++ b/src/transformers/models/llama4/configuration_llama4.py
@@ -151,7 +151,7 @@ class Llama4TextConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = None
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = False
     attention_dropout: float | int = 0.0
     num_experts_per_tok: int = 1

--- a/src/transformers/models/longcat_flash/configuration_longcat_flash.py
+++ b/src/transformers/models/longcat_flash/configuration_longcat_flash.py
@@ -91,7 +91,7 @@ class LongcatFlashConfig(PreTrainedConfig):
     attention_bias: bool = False
     attention_dropout: float | int = 0.0
     ffn_hidden_size: int = 12288
-    q_lora_rank: int = 1536
+    q_lora_rank: int | None = 1536
     kv_lora_rank: int = 512
     qk_nope_head_dim: int = 128
     qk_rope_head_dim: int = 64

--- a/src/transformers/models/longt5/configuration_longt5.py
+++ b/src/transformers/models/longt5/configuration_longt5.py
@@ -72,7 +72,7 @@ class LongT5Config(PreTrainedConfig):
     encoder_attention_type: str = "local"
     use_cache: bool = True
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     bos_token_id: int | None = None
     is_decoder: bool = False
     tie_word_embeddings: bool = True

--- a/src/transformers/models/luke/configuration_luke.py
+++ b/src/transformers/models/luke/configuration_luke.py
@@ -68,7 +68,7 @@ class LukeConfig(PreTrainedConfig):
     classifier_dropout: float | int | None = None
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/m2m_100/configuration_m2m_100.py
+++ b/src/transformers/models/m2m_100/configuration_m2m_100.py
@@ -68,7 +68,7 @@ class M2M100Config(PreTrainedConfig):
     scale_embedding: int = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/mamba2/configuration_mamba2.py
+++ b/src/transformers/models/mamba2/configuration_mamba2.py
@@ -68,7 +68,7 @@ class Mamba2Config(PreTrainedConfig):
     layer_norm_epsilon: float = 1e-5
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     expand: int = 2
     conv_kernel: int = 4
     n_groups: int = 8

--- a/src/transformers/models/marian/configuration_marian.py
+++ b/src/transformers/models/marian/configuration_marian.py
@@ -73,9 +73,9 @@ class MarianConfig(PreTrainedConfig):
     decoder_start_token_id: int = 58100
     scale_embedding: bool = False
     pad_token_id: int | None = 58100
-    eos_token_id: int | None = 0
+    eos_token_id: int | list[int] | None = 0
     bos_token_id: int | None = None
-    forced_eos_token_id: int | None = 0
+    forced_eos_token_id: int | list[int] | None = 0
     share_encoder_decoder_embeddings: bool = True
     is_decoder: bool = False
     tie_word_embeddings: bool = True

--- a/src/transformers/models/markuplm/configuration_markuplm.py
+++ b/src/transformers/models/markuplm/configuration_markuplm.py
@@ -75,7 +75,7 @@ class MarkupLMConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-12
     pad_token_id: int | None = 0
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     max_xpath_tag_unit_embeddings: int = 256
     max_xpath_subs_unit_embeddings: int = 1024
     tag_pad_id: int = 216

--- a/src/transformers/models/mbart/configuration_mbart.py
+++ b/src/transformers/models/mbart/configuration_mbart.py
@@ -68,9 +68,9 @@ class MBartConfig(PreTrainedConfig):
     scale_embedding: int = False
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     decoder_start_token_id: int | None = None
-    forced_eos_token_id: int | None = 2
+    forced_eos_token_id: int | list[int] | None = 2
     is_decoder: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/mistral4/configuration_mistral4.py
+++ b/src/transformers/models/mistral4/configuration_mistral4.py
@@ -77,7 +77,7 @@ class Mistral4Config(PreTrainedConfig):
     n_routed_experts: int = 128
     routed_scaling_factor: float = 1.0
     kv_lora_rank: int = 256
-    q_lora_rank: int = 1024
+    q_lora_rank: int | None = 1024
     qk_rope_head_dim: int = 64
     v_head_dim: int | None = 128
     qk_nope_head_dim: int = 64
@@ -93,7 +93,7 @@ class Mistral4Config(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 11
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     pretraining_tp: int | None = 1
     tie_word_embeddings: bool = False
     rope_parameters: RopeParameters | dict | None = None

--- a/src/transformers/models/mpnet/configuration_mpnet.py
+++ b/src/transformers/models/mpnet/configuration_mpnet.py
@@ -58,7 +58,7 @@ class MPNetConfig(PreTrainedConfig):
     relative_attention_num_buckets: int = 32
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/mra/configuration_mra.py
+++ b/src/transformers/models/mra/configuration_mra.py
@@ -68,7 +68,7 @@ class MraConfig(PreTrainedConfig):
     initial_prior_diagonal_n_blocks: int = 0
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_cross_attention: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/mt5/configuration_mt5.py
+++ b/src/transformers/models/mt5/configuration_mt5.py
@@ -61,7 +61,7 @@ class MT5Config(PreTrainedConfig):
     tie_word_embeddings: bool = True
     bos_token_id: int | None = None
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     decoder_start_token_id: int | None = 0
     classifier_dropout: float | int = 0.0
     is_decoder: bool = False

--- a/src/transformers/models/mvp/configuration_mvp.py
+++ b/src/transformers/models/mvp/configuration_mvp.py
@@ -74,7 +74,7 @@ class MvpConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     is_encoder_decoder: int = True
     decoder_start_token_id: int | None = 2
     use_prompt: bool = False

--- a/src/transformers/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/configuration_nemotron_h.py
@@ -90,7 +90,7 @@ class NemotronHConfig(PreTrainedConfig):
     num_logits_to_keep: int = 1
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     num_attention_heads: int = 32
     num_key_value_heads: int = 8
     head_dim: int = 128

--- a/src/transformers/models/nllb_moe/configuration_nllb_moe.py
+++ b/src/transformers/models/nllb_moe/configuration_nllb_moe.py
@@ -114,7 +114,7 @@ class NllbMoeConfig(PreTrainedConfig):
     moe_token_dropout: float | int = 0.2
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
     output_router_logits: bool = False
 

--- a/src/transformers/models/nystromformer/configuration_nystromformer.py
+++ b/src/transformers/models/nystromformer/configuration_nystromformer.py
@@ -69,7 +69,7 @@ class NystromformerConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-5
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_cross_attention: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/olmo_hybrid/configuration_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/configuration_olmo_hybrid.py
@@ -100,7 +100,7 @@ class OlmoHybridConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 100277
     bos_token_id: int | None = None
-    eos_token_id: int | None = 100257
+    eos_token_id: int | list[int] | None = 100257
     tie_word_embeddings: bool = False
     rope_parameters: RopeParameters | dict | None = None
     attention_bias: bool = False

--- a/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
@@ -138,7 +138,7 @@ class OlmoHybridConfig(LlamaConfig):
     max_position_embeddings: int = 65536
     pad_token_id: int | None = 100277
     bos_token_id: int | None = None
-    eos_token_id: int | None = 100257
+    eos_token_id: int | list[int] | None = 100257
     rms_norm_eps: float = 1e-06
     layer_types: list[str] | None = None
     linear_num_key_heads: int | None = None

--- a/src/transformers/models/opt/configuration_opt.py
+++ b/src/transformers/models/opt/configuration_opt.py
@@ -70,7 +70,7 @@ class OPTConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 2
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     enable_bias: bool = True
     layer_norm_elementwise_affine: bool = True
     tie_word_embeddings: bool = True

--- a/src/transformers/models/owlv2/configuration_owlv2.py
+++ b/src/transformers/models/owlv2/configuration_owlv2.py
@@ -58,7 +58,7 @@ class Owlv2TextConfig(PreTrainedConfig):
     initializer_factor: float = 1.0
     pad_token_id: int | None = 0
     bos_token_id: int | None = 49406
-    eos_token_id: int | None = 49407
+    eos_token_id: int | list[int] | None = 49407
 
 
 @strict(accept_kwargs=True)

--- a/src/transformers/models/owlvit/configuration_owlvit.py
+++ b/src/transformers/models/owlvit/configuration_owlvit.py
@@ -57,7 +57,7 @@ class OwlViTTextConfig(PreTrainedConfig):
     initializer_factor: float = 1.0
     pad_token_id: int | None = 0
     bos_token_id: int | None = 49406
-    eos_token_id: int | None = 49407
+    eos_token_id: int | list[int] | None = 49407
 
 
 @auto_docstring(checkpoint="google/owlvit-base-patch16")

--- a/src/transformers/models/pegasus/configuration_pegasus.py
+++ b/src/transformers/models/pegasus/configuration_pegasus.py
@@ -67,8 +67,8 @@ class PegasusConfig(PreTrainedConfig):
     decoder_start_token_id: int | None = 0
     scale_embedding: bool = False
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
-    forced_eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
+    forced_eos_token_id: int | list[int] | None = 1
     is_decoder: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/pegasus_x/configuration_pegasus_x.py
+++ b/src/transformers/models/pegasus_x/configuration_pegasus_x.py
@@ -75,8 +75,8 @@ class PegasusXConfig(PreTrainedConfig):
     decoder_start_token_id: int | None = 0
     scale_embedding: bool = True
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
-    forced_eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
+    forced_eos_token_id: int | list[int] | None = 1
     num_global_tokens: int = 32
     block_size: int = 512
     stagger_local_blocks: bool = True

--- a/src/transformers/models/pix2struct/configuration_pix2struct.py
+++ b/src/transformers/models/pix2struct/configuration_pix2struct.py
@@ -75,7 +75,7 @@ class Pix2StructTextConfig(PreTrainedConfig):
     decoder_start_token_id: int = 0
     use_cache: bool = False
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     bos_token_id: int | None = None
     tie_word_embeddings: bool = False
     is_decoder: bool = True

--- a/src/transformers/models/plbart/configuration_plbart.py
+++ b/src/transformers/models/plbart/configuration_plbart.py
@@ -69,8 +69,8 @@ class PLBartConfig(PreTrainedConfig):
     scale_embedding: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
-    forced_eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
+    forced_eos_token_id: int | list[int] | None = 2
     is_decoder: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/pop2piano/configuration_pop2piano.py
+++ b/src/transformers/models/pop2piano/configuration_pop2piano.py
@@ -56,7 +56,7 @@ class Pop2PianoConfig(PreTrainedConfig):
     is_encoder_decoder: bool = True
     use_cache: bool = True
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     dense_act_fn: str = "relu"
     is_decoder: bool = False
     tie_word_embeddings: bool = True

--- a/src/transformers/models/reformer/configuration_reformer.py
+++ b/src/transformers/models/reformer/configuration_reformer.py
@@ -120,7 +120,7 @@ class ReformerConfig(PreTrainedConfig):
     axial_pos_shape: list[int] | tuple[int, ...] = (64, 64)
     axial_pos_embds_dim: list[int] | tuple[int, ...] = (64, 192)
     chunk_size_lm_head: int = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     feed_forward_size: int = 512
     hash_seed: int | None = None
     hidden_act: str = "relu"

--- a/src/transformers/models/rembert/configuration_rembert.py
+++ b/src/transformers/models/rembert/configuration_rembert.py
@@ -63,7 +63,7 @@ class RemBertConfig(PreTrainedConfig):
     use_cache: bool = True
     pad_token_id: int | None = 0
     bos_token_id: int | None = 312
-    eos_token_id: int | None = 313
+    eos_token_id: int | list[int] | None = 313
     is_decoder: bool = False
     add_cross_attention: bool = False
     tie_word_embeddings: bool = False

--- a/src/transformers/models/roberta/configuration_roberta.py
+++ b/src/transformers/models/roberta/configuration_roberta.py
@@ -55,7 +55,7 @@ class RobertaConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-12
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     use_cache: bool = True
     classifier_dropout: float | int | None = None
     is_decoder: bool = False

--- a/src/transformers/models/roberta_prelayernorm/configuration_roberta_prelayernorm.py
+++ b/src/transformers/models/roberta_prelayernorm/configuration_roberta_prelayernorm.py
@@ -56,7 +56,7 @@ class RobertaPreLayerNormConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-12
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     use_cache: bool = True
     classifier_dropout: float | int | None = None
     is_decoder: bool = False

--- a/src/transformers/models/rwkv/configuration_rwkv.py
+++ b/src/transformers/models/rwkv/configuration_rwkv.py
@@ -59,7 +59,7 @@ class RwkvConfig(PreTrainedConfig):
     intermediate_size: int | None = None
     layer_norm_epsilon: float = 1e-5
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 0
+    eos_token_id: int | list[int] | None = 0
     rescale_every: int = 6
     tie_word_embeddings: bool = False
     use_cache: bool = True

--- a/src/transformers/models/seamless_m4t/configuration_seamless_m4t.py
+++ b/src/transformers/models/seamless_m4t/configuration_seamless_m4t.py
@@ -181,7 +181,7 @@ class SeamlessM4TConfig(PreTrainedConfig):
     max_new_tokens: int | None = 256
     pad_token_id: int | None = 0
     bos_token_id: int | None = 2
-    eos_token_id: int | None = 3
+    eos_token_id: int | list[int] | None = 3
     speech_encoder_layers: int = 24
     speech_encoder_attention_heads: int = 16
     speech_encoder_intermediate_size: int = 4096
@@ -202,7 +202,7 @@ class SeamlessM4TConfig(PreTrainedConfig):
     conv_depthwise_kernel_size: int = 31
     t2u_bos_token_id: int | None = 0
     t2u_pad_token_id: int | None = 1
-    t2u_eos_token_id: int | None = 2
+    t2u_eos_token_id: int | list[int] | None = 2
     t2u_decoder_start_token_id: int = 2
     t2u_max_new_tokens: int = 1024
     t2u_encoder_layers: int = 6

--- a/src/transformers/models/seamless_m4t_v2/configuration_seamless_m4t_v2.py
+++ b/src/transformers/models/seamless_m4t_v2/configuration_seamless_m4t_v2.py
@@ -185,7 +185,7 @@ class SeamlessM4Tv2Config(PreTrainedConfig):
     max_new_tokens: int | None = 256
     pad_token_id: int | None = 0
     bos_token_id: int | None = 2
-    eos_token_id: int | None = 3
+    eos_token_id: int | list[int] | None = 3
     speech_encoder_layers: int = 24
     speech_encoder_attention_heads: int = 16
     speech_encoder_intermediate_size: int = 4096
@@ -206,7 +206,7 @@ class SeamlessM4Tv2Config(PreTrainedConfig):
     speech_encoder_left_chunk_num: int = 128
     t2u_bos_token_id: int | None = 0
     t2u_pad_token_id: int | None = 1
-    t2u_eos_token_id: int | None = 2
+    t2u_eos_token_id: int | list[int] | None = 2
     t2u_encoder_layers: int = 6
     t2u_encoder_ffn_dim: int = 8192
     t2u_encoder_attention_heads: int = 16

--- a/src/transformers/models/sew/configuration_sew.py
+++ b/src/transformers/models/sew/configuration_sew.py
@@ -148,7 +148,7 @@ class SEWConfig(PreTrainedConfig):
     classifier_proj_size: int = 256
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
 
     def __post_init__(self, **kwargs):
         self.num_feat_extract_layers = len(self.conv_dim)

--- a/src/transformers/models/sew_d/configuration_sew_d.py
+++ b/src/transformers/models/sew_d/configuration_sew_d.py
@@ -168,7 +168,7 @@ class SEWDConfig(PreTrainedConfig):
     classifier_proj_size: int = 256
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
 
     def __post_init__(self, **kwargs):
         self.num_feat_extract_layers = len(self.conv_dim)

--- a/src/transformers/models/speech_to_text/configuration_speech_to_text.py
+++ b/src/transformers/models/speech_to_text/configuration_speech_to_text.py
@@ -84,7 +84,7 @@ class Speech2TextConfig(PreTrainedConfig):
     scale_embedding: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     max_source_positions: int = 6000
     max_target_positions: int = 1024
     num_conv_layers: int = 2

--- a/src/transformers/models/speecht5/configuration_speecht5.py
+++ b/src/transformers/models/speecht5/configuration_speecht5.py
@@ -175,7 +175,7 @@ class SpeechT5Config(PreTrainedConfig):
     mask_feature_min_masks: int = 0
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     decoder_start_token_id: int | None = 2
     num_mel_bins: int = 80
     speech_decoder_prenet_layers: int = 2

--- a/src/transformers/models/switch_transformers/configuration_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/configuration_switch_transformers.py
@@ -84,7 +84,7 @@ class SwitchTransformersConfig(PreTrainedConfig):
     add_router_probs: bool = False
     use_cache: bool = True
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     bos_token_id: int | None = None
     tie_word_embeddings: bool = True
     is_decoder: bool = False

--- a/src/transformers/models/t5/configuration_t5.py
+++ b/src/transformers/models/t5/configuration_t5.py
@@ -57,7 +57,7 @@ class T5Config(PreTrainedConfig):
     is_encoder_decoder: bool = True
     use_cache: bool = True
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     classifier_dropout: float | int = 0.0
     is_decoder: bool = False
 

--- a/src/transformers/models/trocr/configuration_trocr.py
+++ b/src/transformers/models/trocr/configuration_trocr.py
@@ -70,7 +70,7 @@ class TrOCRConfig(PreTrainedConfig):
     layernorm_embedding: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     cross_attention_hidden_size: int | None = None
     is_decoder: bool = False
     tie_word_embeddings: bool = True

--- a/src/transformers/models/udop/configuration_udop.py
+++ b/src/transformers/models/udop/configuration_udop.py
@@ -59,7 +59,7 @@ class UdopConfig(PreTrainedConfig):
     is_encoder_decoder: bool = True
     use_cache: bool = True
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     max_2d_position_embeddings: int = 1024
     image_size: int | list[int] | tuple[int, int] = 224
     patch_size: int | list[int] | tuple[int, int] = 16

--- a/src/transformers/models/umt5/configuration_umt5.py
+++ b/src/transformers/models/umt5/configuration_umt5.py
@@ -59,7 +59,7 @@ class UMT5Config(PreTrainedConfig):
     use_cache: bool = True
     tokenizer_class: str = "T5Tokenizer"
     pad_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     decoder_start_token_id: int | None = 0
     classifier_dropout: float | int = 0.0
     is_decoder: bool = False

--- a/src/transformers/models/unispeech/configuration_unispeech.py
+++ b/src/transformers/models/unispeech/configuration_unispeech.py
@@ -180,7 +180,7 @@ class UniSpeechConfig(PreTrainedConfig):
     num_ctc_classes: int = 80
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     replace_prob: float = 0.5
 
     def __post_init__(self, **kwargs):

--- a/src/transformers/models/visual_bert/configuration_visual_bert.py
+++ b/src/transformers/models/visual_bert/configuration_visual_bert.py
@@ -68,7 +68,7 @@ class VisualBertConfig(PreTrainedConfig):
     special_visual_initialize: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -212,7 +212,7 @@ class Wav2Vec2Config(PreTrainedConfig):
     xvector_output_dim: int = 512
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_adapter: bool = False
     adapter_kernel_size: int = 3
     adapter_stride: int = 2

--- a/src/transformers/models/wav2vec2_bert/configuration_wav2vec2_bert.py
+++ b/src/transformers/models/wav2vec2_bert/configuration_wav2vec2_bert.py
@@ -167,7 +167,7 @@ class Wav2Vec2BertConfig(PreTrainedConfig):
     xvector_output_dim: int = 512
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_adapter: bool = False
     adapter_kernel_size: int = 3
     adapter_stride: int = 2

--- a/src/transformers/models/wav2vec2_conformer/configuration_wav2vec2_conformer.py
+++ b/src/transformers/models/wav2vec2_conformer/configuration_wav2vec2_conformer.py
@@ -212,7 +212,7 @@ class Wav2Vec2ConformerConfig(PreTrainedConfig):
     xvector_output_dim: int = 512
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_adapter: bool = False
     adapter_kernel_size: int = 3
     adapter_stride: int = 2

--- a/src/transformers/models/wavlm/configuration_wavlm.py
+++ b/src/transformers/models/wavlm/configuration_wavlm.py
@@ -205,7 +205,7 @@ class WavLMConfig(PreTrainedConfig):
     num_ctc_classes: int = 80
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_adapter: bool = False
     adapter_kernel_size: int = 3
     adapter_stride: int = 2

--- a/src/transformers/models/whisper/configuration_whisper.py
+++ b/src/transformers/models/whisper/configuration_whisper.py
@@ -148,7 +148,7 @@ class WhisperConfig(PreTrainedConfig):
     max_target_positions: int = 448
     pad_token_id: int | None = 50256
     bos_token_id: int | None = 50256
-    eos_token_id: int | None = 50256
+    eos_token_id: int | list[int] | None = 50256
     suppress_tokens: list | None = None
     begin_suppress_tokens: list[int] | tuple[int, ...] | None = (220, 50256)
     use_weighted_layer_sum: bool = False

--- a/src/transformers/models/x_clip/configuration_x_clip.py
+++ b/src/transformers/models/x_clip/configuration_x_clip.py
@@ -57,7 +57,7 @@ class XCLIPTextConfig(PreTrainedConfig):
     initializer_factor: float = 1.0
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
 
 
 @auto_docstring(checkpoint="microsoft/xclip-base-patch32")

--- a/src/transformers/models/xglm/configuration_xglm.py
+++ b/src/transformers/models/xglm/configuration_xglm.py
@@ -64,7 +64,7 @@ class XGLMConfig(PreTrainedConfig):
     decoder_start_token_id: int = 2
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_cross_attention: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/xlm/configuration_xlm.py
+++ b/src/transformers/models/xlm/configuration_xlm.py
@@ -138,7 +138,7 @@ class XLMConfig(PreTrainedConfig):
     lang_id: int = 0
     pad_token_id: int | None = 2
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 1
+    eos_token_id: int | list[int] | None = 1
     tie_word_embeddings: bool = True
 
 

--- a/src/transformers/models/xlm_roberta/configuration_xlm_roberta.py
+++ b/src/transformers/models/xlm_roberta/configuration_xlm_roberta.py
@@ -55,7 +55,7 @@ class XLMRobertaConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-12
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     use_cache: bool = True
     classifier_dropout: float | int | None = None
     is_decoder: bool = False

--- a/src/transformers/models/xlm_roberta_xl/configuration_xlm_roberta_xl.py
+++ b/src/transformers/models/xlm_roberta_xl/configuration_xlm_roberta_xl.py
@@ -54,7 +54,7 @@ class XLMRobertaXLConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-05
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     use_cache: bool = True
     classifier_dropout: float | int | None = None
     is_decoder: bool = False

--- a/src/transformers/models/xlnet/configuration_xlnet.py
+++ b/src/transformers/models/xlnet/configuration_xlnet.py
@@ -132,7 +132,7 @@ class XLNetConfig(PreTrainedConfig):
     end_n_top: int = 5
     pad_token_id: int | None = 5
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     tie_word_embeddings: bool = True
 
     def __post_init__(self, **kwargs):

--- a/src/transformers/models/xmod/configuration_xmod.py
+++ b/src/transformers/models/xmod/configuration_xmod.py
@@ -71,7 +71,7 @@ class XmodConfig(PreTrainedConfig):
     layer_norm_eps: float = 1e-12
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     use_cache: bool = True
     classifier_dropout: float | int | None = None
     pre_norm: bool = False

--- a/src/transformers/models/yoso/configuration_yoso.py
+++ b/src/transformers/models/yoso/configuration_yoso.py
@@ -73,7 +73,7 @@ class YosoConfig(PreTrainedConfig):
     lsh_backward: bool = True
     pad_token_id: int | None = 1
     bos_token_id: int | None = 0
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     add_cross_attention: bool = False
     tie_word_embeddings: bool = True
 

--- a/src/transformers/models/youtu/configuration_youtu.py
+++ b/src/transformers/models/youtu/configuration_youtu.py
@@ -69,7 +69,7 @@ class YoutuConfig(PreTrainedConfig):
     num_attention_heads: int = 16
     num_key_value_heads: int = 16
     kv_lora_rank: int = 512
-    q_lora_rank: int = 1536
+    q_lora_rank: int | None = 1536
     qk_rope_head_dim: int = 64
     v_head_dim: int | None = 128
     qk_nope_head_dim: int = 128

--- a/src/transformers/models/zamba/configuration_zamba.py
+++ b/src/transformers/models/zamba/configuration_zamba.py
@@ -72,7 +72,7 @@ class ZambaConfig(PreTrainedConfig):
     num_logits_to_keep: int = 1
     pad_token_id: int | None = 0
     bos_token_id: int | None = 1
-    eos_token_id: int | None = 2
+    eos_token_id: int | list[int] | None = 2
     max_position_embeddings: int = 4096
     attention_dropout: float | int = 0.0
     attn_layer_period: int = 6


### PR DESCRIPTION
An eos token can also be a list on most recent models, so this PR allows all `EOS` in config be a list as well. Same for q-lora-rank which apparently can be an explicit `None` for some model

Also bring back `layer_type_validation` and add deprecation message. I realized it's actually used a lot and will break remote code as well

WIP, will collect more type hint fixes during the day from vLLM CI jobs