### PR TITLE
fix: handle unpicklable tokenizers in ProcessorMixin.to_dict()

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -701,7 +701,15 @@ class ProcessorMixin(PushToHubMixin):
         Returns:
             `dict[str, Any]`: Dictionary of all the attributes that make up this processor instance.
         """
-        output = copy.deepcopy(self.__dict__)
+        try:
+            output = copy.deepcopy(self.__dict__)
+        except Exception:
+            output = {}
+            for k, v in self.__dict__.items():
+                try:
+                    output[k] = copy.deepcopy(v)
+                except Exception:
+                    pass
 
         # Get the kwargs in `__init__`.
         sig = inspect.signature(self.__init__)


### PR DESCRIPTION
## Summary
Fixes #44841.
**Root cause:** `ProcessorMixin.to_dict()` calls `copy.deepcopy(self.__dict__)` which fails when the processor contains tokenizers that cannot be pickled (e.g. MistralCommonBackend in Voxtral raises "Token out of vocabulary" during unpickling). The tokenizers are removed from output later in the method, but the deepcopy fails before reaching that cleanup code.
**Fix:** Wrapped the deepcopy in a try/except that falls back to per-attribute deepcopy, skipping attributes that cannot be pickled. This ensures unpicklable tokenizers are gracefully excluded while all other attributes are still properly deep-copied.
## Changes
- `src/transformers/processing_utils.py`: Added fallback for unpicklable attributes in `to_dict()`
## Testing
- Verified fix addresses reported scenario (Voxtral processor loads without error)
- Change is minimal and follows existing code patterns
- Backward compatible — all picklable attributes are still deep-copied

Made with [Cursor](https://cursor.com)