### PR TITLE
fix: move comments before @torch.jit.script decorator for Python 3.13 compatibility

### DIFF
--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -101,20 +101,20 @@ def build_relative_position(query_layer, key_layer, bucket_size: int = -1, max_p
     return rel_pos_ids
 
 
-@torch.jit.script
 # Copied from transformers.models.deberta.modeling_deberta.c2p_dynamic_expand
+@torch.jit.script
 def c2p_dynamic_expand(c2p_pos, query_layer, relative_pos):
     return c2p_pos.expand([query_layer.size(0), query_layer.size(1), query_layer.size(2), relative_pos.size(-1)])
 
 
-@torch.jit.script
 # Copied from transformers.models.deberta.modeling_deberta.p2c_dynamic_expand
+@torch.jit.script
 def p2c_dynamic_expand(c2p_pos, query_layer, key_layer):
     return c2p_pos.expand([query_layer.size(0), query_layer.size(1), key_layer.size(-2), key_layer.size(-2)])
 
 
-@torch.jit.script
 # Copied from transformers.models.deberta.modeling_deberta.pos_dynamic_expand
+@torch.jit.script
 def pos_dynamic_expand(pos_index, p2c_att, key_layer):
     return pos_index.expand(p2c_att.size()[:2] + (pos_index.size(-2), key_layer.size(-2)))
 


### PR DESCRIPTION
## Summary

Python 3.13's stricter parser fails when there's a comment between the `@torch.jit.script` decorator and the function definition, causing an IndentationError when importing DebertaV2Model.

## Changes

- Moved comments before the `@torch.jit.script` decorator for three functions in modeling_deberta_v2.py:
  - `c2p_dynamic_expand`
  - `p2c_dynamic_expand`
  - `pos_dynamic_expand`

## Testing

- Verified Python AST parsing succeeds
- Syntax check passed
- All functions with @torch.jit.script decorator are parseable

Fixes huggingface/transformers#44855