### PR TITLE
fix: handle list-type _tied_weights_keys in _get_tied_weight_keys

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -333,8 +333,11 @@ def _end_ptr(tensor: torch.Tensor) -> int:
 def _get_tied_weight_keys(module: nn.Module) -> list[str]:
     tied_weight_keys: list[str] = []
     for name, submodule in module.named_modules():
-        tied = getattr(submodule, "_tied_weights_keys", {}) or {}
-        tied_weight_keys.extend([f"{name}.{k}" if name else k for k in tied.keys()])
+        tied = getattr(submodule, "_tied_weights_keys", []) or []
+        if isinstance(tied, (list, tuple)):
+            tied_weight_keys.extend([f"{name}.{k}" if name else k for k in tied])
+        else:
+            tied_weight_keys.extend([f"{name}.{k}" if name else k for k in tied.keys()])
     return tied_weight_keys
 
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -1579,6 +1579,20 @@ class ModelUtilsTest(TestCasePlus):
             # They should still be tied though
             self.assertIs(new_model.linear.weight, new_model.linear_2.weight, msg="Weights are not tied!")
 
+    def test_get_tied_weight_keys_with_list_type(self):
+        """Test that _get_tied_weight_keys handles _tied_weights_keys as a list (not just dict).
+
+        Some models (e.g. Nemotron-H) define _tied_weights_keys as a list, which caused
+        an AttributeError: 'list' object has no attribute 'keys' when saving full finetunes.
+        """
+        from transformers.modeling_utils import _get_tied_weight_keys
+
+        model = BaseModelWithTiedWeights(PreTrainedConfig(tie_word_embeddings=True))
+        # Simulate a submodule that uses a list for _tied_weights_keys (as some models do)
+        model.linear._tied_weights_keys = ["weight"]
+        result = _get_tied_weight_keys(model)
+        self.assertIn("linear.weight", result)
+
     def test_tied_weights_are_always_tied_from_config(self):
         """Test that if a model is initialized from config it's always tied, and that the context `no_tie_weights` works
         as expected"""


### PR DESCRIPTION
  Some models (e.g. Nemotron-H) define `_tied_weights_keys` as a list, which caused `AttributeError: 'list' object has
  no attribute 'keys'` when calling `save_pretrained` during full finetuning.

  # What does this PR do?

  `_get_tied_weight_keys` in `modeling_utils.py` calls `.keys()` on the `_tied_weights_keys` attribute, assuming it's
  always a dict. However, some models (e.g. Nemotron-H) define `_tied_weights_keys` as a list, causing an
  `AttributeError` when saving checkpoints during full finetuning.

  This fix handles both list/tuple and dict types for `_tied_weights_keys`.

  **Traceback:**
  File "transformers/modeling_utils.py", line 341, in _get_tied_weight_keys
      tied_weight_keys.extend([f"{name}.{k}" if name else k for k in tied.keys()])
  AttributeError: 'list' object has no attribute 'keys'

  **Reproduction:** Full finetune of `NVIDIA-Nemotron-3-Nano-4B` via Unsloth Studio with Transformers 5.3.0 crashes at
  checkpoint save.

  Fixes #44861

  ## Before submitting
  - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
  - [x] Did you read the [contributor
  guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
        Pull Request section?
  - [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a
  link
        to it if that's the case.
  - [ ] Did you make sure to update the documentation with your changes? Here are the
        [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
        [here are tips on formatting
  docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
  - [x] Did you write any new necessary tests?

  **AI Disclosure:** This PR was developed with assistance from Claude Code (Claude Opus 4.6). All changes were reviewed
   and validated by a human.

  ## Who can review?

  @Cyrilvallez — model loading / `save_pretrained` code path