### PR TITLE
Pass packed boundary metadata to Qwen3.5 linear-attention fast kernels

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -32,7 +32,7 @@ from ...activations import ACT2FN
 from ...cache_utils import Cache
 from ...generation import GenerationMixin
 from ...integrations import use_kernelized_func
-from ...masking_utils import create_causal_mask
+from ...masking_utils import create_causal_mask, find_packed_sequence_indices
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import (
@@ -513,6 +513,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         hidden_states: torch.Tensor,
         cache_params: Qwen3_5DynamicCache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
+        cu_seqlens: torch.IntTensor | None = None,
     ):
         hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
 
@@ -555,7 +557,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=None,
+                    seq_idx=seq_idx,
                 )
             else:
                 mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
@@ -583,6 +585,10 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
         if not use_precomputed_states:
+            chunk_kwargs = {}
+            if getattr(self.chunk_gated_delta_rule, "__module__", "").startswith("fla."):
+                chunk_kwargs["cu_seqlens"] = cu_seqlens
+
             core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
                 query,
                 key,
@@ -592,6 +598,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 initial_state=None,
                 output_final_state=cache_params is not None,
                 use_qk_l2norm_in_kernel=True,
+                **chunk_kwargs,
             )
 
         else:
@@ -847,6 +854,8 @@ class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
                 attention_mask=attention_mask,
+                seq_idx=kwargs.pop("seq_idx", None),
+                cu_seqlens=kwargs.pop("cu_seqlens", None),
             )
         elif self.layer_type == "full_attention":
             # Self Attention
@@ -1293,6 +1302,23 @@ class Qwen3_5ModelOutputWithPast(ModelOutput):
     rope_deltas: torch.LongTensor | None = None
 
 
+def _prepare_linear_attention_packed_kwargs(
+    position_ids: torch.LongTensor | None,
+    past_key_values: Cache | None,
+) -> dict[str, torch.Tensor]:
+    if position_ids is None or past_key_values is not None or position_ids.shape[0] != 1:
+        return {}
+
+    seq_idx = find_packed_sequence_indices(position_ids)
+    if seq_idx is None:
+        return {}
+
+    seq_idx = seq_idx.to(device=position_ids.device, dtype=torch.int32)
+    lengths = torch.bincount(seq_idx[0].to(torch.int64))
+    cu_seqlens = torch.cat([lengths.new_zeros(1), lengths.cumsum(0)]).to(device=position_ids.device, dtype=torch.int32)
+    return {"seq_idx": seq_idx, "cu_seqlens": cu_seqlens}
+
+
 class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
     config: Qwen3_5TextConfig
 
@@ -1352,6 +1378,7 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
             position_ids=text_position_ids,
         )
         linear_attn_mask = self._update_linear_attn_mask(attention_mask, past_key_values)
+        linear_attn_kwargs = _prepare_linear_attention_packed_kwargs(text_position_ids, past_key_values)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -1366,6 +1393,7 @@ class Qwen3_5TextModel(Qwen3_5PreTrainedModel):
                 position_ids=text_position_ids,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
+                **linear_attn_kwargs,
                 **kwargs,
             )
 

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -22,7 +22,7 @@ from torch import nn
 
 from ... import initialization as init
 from ...cache_utils import Cache
-from ...masking_utils import create_causal_mask
+from ...masking_utils import create_causal_mask, find_packed_sequence_indices
 from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
 from ...modeling_utils import PreTrainedModel
@@ -185,6 +185,23 @@ class Qwen3_5TextRotaryEmbedding(Qwen3VLTextRotaryEmbedding):
         return inv_freq, attention_factor
 
 
+def _prepare_linear_attention_packed_kwargs(
+    position_ids: torch.LongTensor | None,
+    past_key_values: Cache | None,
+) -> dict[str, torch.Tensor]:
+    if position_ids is None or past_key_values is not None or position_ids.shape[0] != 1:
+        return {}
+
+    seq_idx = find_packed_sequence_indices(position_ids)
+    if seq_idx is None:
+        return {}
+
+    seq_idx = seq_idx.to(device=position_ids.device, dtype=torch.int32)
+    lengths = torch.bincount(seq_idx[0].to(torch.int64))
+    cu_seqlens = torch.cat([lengths.new_zeros(1), lengths.cumsum(0)]).to(device=position_ids.device, dtype=torch.int32)
+    return {"seq_idx": seq_idx, "cu_seqlens": cu_seqlens}
+
+
 class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
     def __init__(self, config: Qwen3_5Config, layer_idx: int):
         super().__init__(config, layer_idx)
@@ -207,6 +224,8 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
         hidden_states: torch.Tensor,
         cache_params: Qwen3_5DynamicCache | None = None,
         attention_mask: torch.Tensor | None = None,
+        seq_idx: torch.IntTensor | None = None,
+        cu_seqlens: torch.IntTensor | None = None,
     ):
         hidden_states = apply_mask_to_padding_states(hidden_states, attention_mask)
 
@@ -249,7 +268,7 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
                     weight=self.conv1d.weight.squeeze(1),
                     bias=self.conv1d.bias,
                     activation=self.activation,
-                    seq_idx=None,
+                    seq_idx=seq_idx,
                 )
             else:
                 mixed_qkv = F.silu(self.conv1d(mixed_qkv)[:, :, :seq_len])
@@ -277,6 +296,10 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
             key = key.repeat_interleave(self.num_v_heads // self.num_k_heads, dim=2)
 
         if not use_precomputed_states:
+            chunk_kwargs = {}
+            if getattr(self.chunk_gated_delta_rule, "__module__", "").startswith("fla."):
+                chunk_kwargs["cu_seqlens"] = cu_seqlens
+
             core_attn_out, last_recurrent_state = self.chunk_gated_delta_rule(
                 query,
                 key,
@@ -286,6 +309,7 @@ class Qwen3_5GatedDeltaNet(Qwen3NextGatedDeltaNet):
                 initial_state=None,
                 output_final_state=cache_params is not None,
                 use_qk_l2norm_in_kernel=True,
+                **chunk_kwargs,
             )
 
         else:
@@ -360,6 +384,8 @@ class Qwen3_5DecoderLayer(GradientCheckpointingLayer):
                 hidden_states=hidden_states,
                 cache_params=past_key_values,
                 attention_mask=attention_mask,
+                seq_idx=kwargs.pop("seq_idx", None),
+                cu_seqlens=kwargs.pop("cu_seqlens", None),
             )
         elif self.layer_type == "full_attention":
             # Self Attention
@@ -518,6 +544,7 @@ class Qwen3_5TextModel(Qwen3NextModel):
             position_ids=text_position_ids,
         )
         linear_attn_mask = self._update_linear_attn_mask(attention_mask, past_key_values)
+        linear_attn_kwargs = _prepare_linear_attention_packed_kwargs(text_position_ids, past_key_values)
 
         hidden_states = inputs_embeds
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
@@ -532,6 +559,7 @@ class Qwen3_5TextModel(Qwen3NextModel):
                 position_ids=text_position_ids,
                 past_key_values=past_key_values,
                 use_cache=use_cache,
+                **linear_attn_kwargs,
                 **kwargs,
             )
 

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -46,7 +46,10 @@ if is_torch_available():
         Qwen3_5TextConfig,
         Qwen3_5TextModel,
     )
-    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5DynamicCache
+    from transformers.models.qwen3_5.modeling_qwen3_5 import (
+        Qwen3_5DynamicCache,
+        _prepare_linear_attention_packed_kwargs,
+    )
 
 
 class Qwen3_5TextModelTester(CausalLMModelTester):
@@ -156,6 +159,40 @@ class Qwen3_5TextModelTest(CausalLMModelTest, unittest.TestCase):
     @unittest.skip("Intentionally not reversable (no changes) as only load time within a VLM depends on this")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
+
+    def test_prepare_linear_attention_packed_kwargs(self):
+        position_ids = torch.tensor([[0, 1, 2, 0, 1, 2, 3]])
+
+        packed_kwargs = _prepare_linear_attention_packed_kwargs(position_ids, past_key_values=None)
+
+        self.assertEqual(packed_kwargs["seq_idx"].tolist(), [[0, 0, 0, 1, 1, 1, 1]])
+        self.assertEqual(packed_kwargs["seq_idx"].dtype, torch.int32)
+        self.assertEqual(packed_kwargs["cu_seqlens"].tolist(), [0, 3, 7])
+        self.assertEqual(packed_kwargs["cu_seqlens"].dtype, torch.int32)
+
+        self.assertDictEqual(
+            _prepare_linear_attention_packed_kwargs(torch.arange(4).unsqueeze(0), past_key_values=None), {}
+        )
+
+    def test_prepare_linear_attention_packed_kwargs_multi_segment(self):
+        position_ids = torch.tensor([[0, 1, 0, 1, 2, 0]])
+
+        packed_kwargs = _prepare_linear_attention_packed_kwargs(position_ids, past_key_values=None)
+
+        self.assertEqual(packed_kwargs["seq_idx"].tolist(), [[0, 0, 1, 1, 1, 2]])
+        self.assertEqual(packed_kwargs["cu_seqlens"].tolist(), [0, 2, 5, 6])
+
+    def test_prepare_linear_attention_packed_kwargs_ignored_with_cache_or_batch(self):
+        position_ids = torch.tensor([[0, 1, 2, 0, 1, 2, 3]])
+
+        self.assertDictEqual(
+            _prepare_linear_attention_packed_kwargs(position_ids, past_key_values=object()),
+            {},
+        )
+        self.assertDictEqual(
+            _prepare_linear_attention_packed_kwargs(position_ids.expand(2, -1), past_key_values=None),
+            {},
+        )
 
 
 class Qwen3_5VisionText2TextModelTester:


### PR DESCRIPTION


# What does this PR do?
Fixes #44717

This PR fixes packed-sequence handling for the Qwen3.5 linear-attention fast path.

Before this change, Qwen3.5 produced different outputs for:
a padded representation of multiple sequences
a packed representation of the same sequences using reset position_ids

The issue was specific to the linear-attention fast path. Full-attention layers already respected packed boundaries through the shared masking logic, but the Qwen3.5 fast linear-attention path was not passing packed-boundary metadata into its kernels.

This PR fixes that by:

deriving packed boundary metadata from packed position_ids
passing seq_idx to the causal convolution fast path
passing cu_seqlens to the FLA gated-delta-rule fast path
The change is intentionally scoped to the Qwen3.5 fast path for packed prefill inputs. The slow fallback path is not changed in this PR.

# How was this tested?

Manual validation:

Reproduced the bug before the fix on Qwen3.5 using a tiny local config with one full-attention layer and one linear-attention layer.
Compared:
padded inputs for multiple sequences
packed inputs for the same sequences with reset position_ids
Before the fix on the fast path:
allclose: False
max abs diff was about 8e-3
After the fix on the fast path:
the original 2-segment packed-vs-padded repro matches
a multi-segment packed-vs-padded repro also matches with max abs diff around 6e-8
Sanity checks:

Verified Qwen3.5 was using the fast kernels:
causal_conv1d_fn present: True
fla.ops.gated_delta_rule.chunk
fla.ops.gated_delta_rule.fused_recurrent
Verified a normal unpacked Qwen3.5 forward still works after the change.

Unit tests:
Added tests for the packed-metadata helper in tests/models/qwen3_5/test_modeling_qwen3_5.py, including:
simple packed input
multi-segment packed input
cases where packed metadata should be skipped, such as cached inputs or unsupported batch layouts


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ Y] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ Y] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
https://github.com/huggingface/transformers/issues/44717#issuecomment-4087937920
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ Y] Did you write any new necessary tests?


## Who can review?
@vasqu 

