### PR TITLE
Fix: Update outdated sampler comment in generation/utils.py

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1194,7 +1194,8 @@ class GenerationMixin(ContinuousMixin):
                 min_tokens_to_keep = 1
 
             # the following idea is largely copied from this PR: https://github.com/huggingface/transformers/pull/5420/files
-            # all samplers can be found in `generation_utils_samplers.py`
+            # Apply logits processors for sampling strategies
+            # All logits processors are defined in `generation/logits_process.py`
             if generation_config.temperature is not None and generation_config.temperature != 1.0:
                 processors.append(TemperatureLogitsWarper(generation_config.temperature))
             if generation_config.top_h is not None:


### PR DESCRIPTION
## Description
Update outdated comment that references non-existent file `generation_utils_samplers.py`

## Changes Detail
- The comment on line 1200 states "all samplers can be found in `generation_utils_samplers.py`"
- In reality, all sampling processors are now defined in `logits_process.py`
- Updated the comment to point to the correct file location

## Type of Change
- [x] Documentation improvements