### PR TITLE
fix config type

### DIFF
--- a/src/transformers/models/llama4/configuration_llama4.py
+++ b/src/transformers/models/llama4/configuration_llama4.py
@@ -166,7 +166,7 @@ class Llama4TextConfig(PreTrainedConfig):
     no_rope_layers: list[int] | None = None
     no_rope_layer_interval: int = 4
     attention_chunk_size: int = 8192
-    layer_types: list[int] | None = None
+    layer_types: list[str] | None = None
     attn_temperature_tuning: bool = True
     floor_scale: int = 8192
     attn_scale: float = 0.1


### PR DESCRIPTION
fixes 

```python
model = "meta-llama/Llama-4-Maverick-17B-128E-Instruct"

tok_auto = AutoTokenizer.from_pretrained(model)

print(f"AutoTokenizer: {tok_auto('hello')}")
```

```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/itazaporozhets/Documents/Repos/transformers/debug_script.py", line 11, in <module>
    tok_auto = AutoTokenizer.from_pretrained(model)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/Documents/Repos/transformers/src/transformers/models/auto/tokenization_auto.py", line 670, in from_pretrained
    config = AutoConfig.from_pretrained(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/Documents/Repos/transformers/src/transformers/models/auto/configuration_auto.py", line 1494, in from_pretrained
    return config_class.from_dict(config_dict, **unused_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/Documents/Repos/transformers/src/transformers/configuration_utils.py", line 758, in from_dict
    config = cls(**config_dict)
             ^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/.pyenv/versions/3.12.3/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 279, in init_with_validate
    initial_init(self, *args, **kwargs)  # type: ignore [call-arg]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/.pyenv/versions/3.12.3/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 194, in __init__
    self.__post_init__(**additional_kwargs)
  File "/Users/itazaporozhets/Documents/Repos/transformers/src/transformers/models/llama4/configuration_llama4.py", line 256, in __post_init__
    self.text_config = Llama4TextConfig(**self.text_config)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/.pyenv/versions/3.12.3/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 279, in init_with_validate
    initial_init(self, *args, **kwargs)  # type: ignore [call-arg]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/.pyenv/versions/3.12.3/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 194, in __init__
    self.__post_init__(**additional_kwargs)
  File "/Users/itazaporozhets/Documents/Repos/transformers/src/transformers/models/llama4/configuration_llama4.py", line 198, in __post_init__
    self.layer_types = [
    ^^^^^^^^^^^^^^^^
  File "/Users/itazaporozhets/.pyenv/versions/3.12.3/lib/python3.12/site-packages/huggingface_hub/dataclasses.py", line 150, in __strict_setattr__
    raise StrictDataclassFieldValidationError(field=name, cause=e) from e
huggingface_hub.errors.StrictDataclassFieldValidationError: Validation error for field 'layer_types':
    TypeError: Field 'layer_types' with value ['chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention'] doesn't match any type in (list[int], <class 'NoneType'>). Errors: Invalid item at index 0 in list 'layer_types'; Field 'layer_types' expected NoneType, got list (value: ['chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention', 'chunked_attention', 'chunked_attention', 'chunked_attention', 'full_attention'])
(base) itazaporozhets@Huggingfaces-MacBook-Pro-2 transformers % 
```
