### PR TITLE
Add missing dunder methods to `SizeDict`

### DIFF
--- a/src/transformers/image_utils.py
+++ b/src/transformers/image_utils.py
@@ -1001,3 +1001,17 @@ class SizeDict:
                 getattr(other, f.name) for f in fields(self)
             )
         return NotImplemented
+
+    def __or__(self, other) -> "SizeDict":
+        if isinstance(other, dict | SizeDict):
+            merged = dict(self)
+            merged.update(dict(other))
+            return SizeDict(**merged)
+        return NotImplemented
+
+    def __ror__(self, other) -> dict:
+        if isinstance(other, dict):
+            merged = dict(other)
+            merged.update(dict(self))
+            return merged
+        return NotImplemented


### PR DESCRIPTION
Some libraries that use Transformers (i.e. vLLM) use `|` on the `size` config.

This PR adds `__or__` and `__ror__` so that the following works:

```console
$ {"longest_edge": 20} | SizeDict(height=10, width=20)
{'longest_edge': 20, 'height': 10, 'width': 20}
$ SizeDict(height=10, width=20) | {"longest_edge": 20}
SizeDict(height=10, width=20, longest_edge=20, shortest_edge=None, max_height=None, max_width=None)
$ SizeDict(height=10, width=20) | SizeDict(longest_edge=20)
SizeDict(height=10, width=20, longest_edge=20, shortest_edge=None, max_height=None, max_width=None)
```