### PR TITLE
fix: prevent IndexError in Whisper word timestamp decode

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -1331,7 +1331,8 @@ def _split_tokens_on_unicode(tokenizer, tokens: list[int]):
 
         if (
             replacement_char not in decoded
-            or decoded_full[unicode_offset + decoded.index(replacement_char)] == replacement_char
+            or (unicode_offset + decoded.index(replacement_char) < len(decoded_full)
+                and decoded_full[unicode_offset + decoded.index(replacement_char)] == replacement_char)
         ):
             words.append(decoded)
             word_tokens.append(current_tokens)


### PR DESCRIPTION
## Problem

In _split_tokens_on_unicode(), when the decoded token stream ends with a dangling Unicode replacement character (U+FFFD), the computed index can equal len(decoded_full), causing IndexError: string index out of range.

The failing line:
```python
decoded_full[unicode_offset + decoded.index(replacement_char)] == replacement_char
```

When unicode_offset + decoded.index(replacement_char) >= len(decoded_full), this crashes.

## Fix

Add bounds check before indexing into decoded_full:

```python
if (
    replacement_char not in decoded
    or (unicode_offset + decoded.index(replacement_char) < len(decoded_full)
        and decoded_full[unicode_offset + decoded.index(replacement_char)] == replacement_char)
):
```

This ensures we only access decoded_full when the index is valid.