### PR TITLE
Bump kernels version dependency to avoid crashes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ _deps = [
     "jinja2>=3.1.0",
     "jmespath>=1.0.1",
     "kenlm",
-    "kernels>=0.11",
+    "kernels>=0.12.0",
     "librosa",
     "mistral-common[image]>=1.10.0",
     "nltk<=3.8.1",

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ _deps = [
     "jinja2>=3.1.0",
     "jmespath>=1.0.1",
     "kenlm",
-    "kernels>=0.12.0",
+    "kernels>=0.12.0,<0.13",
     "librosa",
     "mistral-common[image]>=1.10.0",
     "nltk<=3.8.1",

--- a/setup.py
+++ b/setup.py
@@ -91,7 +91,7 @@ _deps = [
     "jinja2>=3.1.0",
     "jmespath>=1.0.1",
     "kenlm",
-    "kernels>=0.10.2,<0.11",
+    "kernels>=0.11",
     "librosa",
     "mistral-common[image]>=1.10.0",
     "nltk<=3.8.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -23,7 +23,7 @@ deps = {
     "jinja2": "jinja2>=3.1.0",
     "jmespath": "jmespath>=1.0.1",
     "kenlm": "kenlm",
-    "kernels": "kernels>=0.10.2,<0.11",
+    "kernels": "kernels>=0.12.0",
     "librosa": "librosa",
     "mistral-common[image]": "mistral-common[image]>=1.10.0",
     "nltk": "nltk<=3.8.1",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -23,7 +23,7 @@ deps = {
     "jinja2": "jinja2>=3.1.0",
     "jmespath": "jmespath>=1.0.1",
     "kenlm": "kenlm",
-    "kernels": "kernels>=0.12.0",
+    "kernels": "kernels>=0.12.0,<0.13",
     "librosa": "librosa",
     "mistral-common[image]": "mistral-common[image]>=1.10.0",
     "nltk": "nltk<=3.8.1",


### PR DESCRIPTION
# What does this PR do?

As per the title. On currently pinned version, when we run this small snippet (which is called on some model's `__init__` functions 😅):

```python
from transformers.integrations.hub_kernels import lazy_load_kernel

causal_conv1d = lazy_load_kernel("causal-conv1d")
```

We end up with the following error:

```py
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[1], [line 3](vscode-notebook-cell:?execution_count=1&line=3)
      1 from transformers.integrations.hub_kernels import lazy_load_kernel
----> [3](vscode-notebook-cell:?execution_count=1&line=3) causal_conv1d = lazy_load_kernel("causal-conv1d")

File /fsx/cyril/transformers/src/transformers/integrations/hub_kernels.py:373, in lazy_load_kernel(kernel_name, mapping)
    371     revision = _HUB_KERNEL_MAPPING[kernel_name].get("revision", None)
    372     version = _HUB_KERNEL_MAPPING[kernel_name].get("version", None)
--> [373](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2269702d32362d302d3137312d323330222c2275736572223a22637972696c5f76616c6c657a227d.vscode-resource.vscode-cdn.net/fsx/cyril/transformers/src/transformers/integrations/hub_kernels.py:373)     kernel = get_kernel(repo_id, revision=revision, version=version)
    374     mapping[kernel_name] = kernel
    375 except FileNotFoundError:

File /fsx/cyril/transformers/src/transformers/integrations/hub_kernels.py:432, in get_kernel(kernel_name, revision, version, allow_all_kernels)
    430 kernels_version = importlib.metadata.version("kernels")
    431 if pkg_version.parse(kernels_version) >= pkg_version.parse("0.10.4"):
--> [432](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2269702d32362d302d3137312d323330222c2275736572223a22637972696c5f76616c6c657a227d.vscode-resource.vscode-cdn.net/fsx/cyril/transformers/src/transformers/integrations/hub_kernels.py:432)     return get_kernel_hub(kernel_name, revision=revision, version=version, user_agent=user_agent)
    433 else:
    434     return get_kernel_hub(kernel_name, revision=revision, version=version)

File /fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/kernels/utils.py:285, in get_kernel(repo_id, revision, version, user_agent)
    248 def get_kernel(
    249     repo_id: str,
    250     revision: Optional[str] = None,
    251     version: Optional[str] = None,
    252     user_agent: Optional[Union[str, dict]] = None,
    253 ) -> ModuleType:
    254     """
    255     Load a kernel from the kernel hub.
    256 
   (...)    283         ```
    284     """
--> [285](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2269702d32362d302d3137312d323330222c2275736572223a22637972696c5f76616c6c657a227d.vscode-resource.vscode-cdn.net/fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/kernels/utils.py:285)     revision = select_revision_or_version(repo_id, revision, version)
    286     package_name, package_path = install_kernel(
    287         repo_id, revision=revision, user_agent=user_agent
    288     )
    289     return import_from_path(package_name, package_path / package_name / "__init__.py")

File /fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/kernels/_versions.py:50, in select_revision_or_version(repo_id, revision, version)
     48     revision = "main"
     49 elif version is not None:
---> [50](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2269702d32362d302d3137312d323330222c2275736572223a22637972696c5f76616c6c657a227d.vscode-resource.vscode-cdn.net/fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/kernels/_versions.py:50)     revision = resolve_version_spec_as_ref(repo_id, version).target_commit
     51 assert revision is not None
     52 return revision

File /fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/kernels/_versions.py:31, in resolve_version_spec_as_ref(repo_id, version_spec)
     24 """
     25 Get the locks for a kernel with the given version spec.
     26 
     27 The version specifier can be any valid Python version specifier:
     28 https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers
     29 """
     30 versions = _get_available_versions(repo_id)
---> [31](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2269702d32362d302d3137312d323330222c2275736572223a22637972696c5f76616c6c657a227d.vscode-resource.vscode-cdn.net/fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/kernels/_versions.py:31) requirement = SpecifierSet(version_spec)
     32 accepted_versions = sorted(requirement.filter(versions.keys()))
     34 if len(accepted_versions) == 0:

File /fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/packaging/specifiers.py:778, in SpecifierSet.__init__(self, specifiers, prereleases)
    775     self._specs = frozenset(map(Specifier, split_specifiers))
    776 else:
    777     # Save the supplied specifiers in a frozen set.
--> [778](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2269702d32362d302d3137312d323330222c2275736572223a22637972696c5f76616c6c657a227d.vscode-resource.vscode-cdn.net/fsx/cyril/miniforge3/envs/dev/lib/python3.13/site-packages/packaging/specifiers.py:778)     self._specs = frozenset(specifiers)
    780 # Store our prereleases value so we can use it later to determine if
    781 # we accept prereleases or not.
    782 self._prereleases = prereleases

TypeError: 'int' object is not iterable
```

All this is fixed on 0.12!
