### PR TITLE
Add big angry code agent warnings!

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,16 @@ Once you're done, someone will review your PR shortly (see the section "Who can 
 
 Fixes # (issue)
 
+## Code Agent Policy
+
+The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
+code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
+to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
+You may use code agents in drafting or to help you diagnose issues, but 
+**new users should not submit PRs written by code agents under any circumstances**. The same prohibition applies to
+autonomous "OpenClaw"-like agents.
+
+- [ ] I confirm that this PR was written by a human.
 
 ## Before submitting
 - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,9 +19,10 @@ Fixes # (issue)
 The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
 code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
 to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
-You may use code agents in drafting or to help you diagnose issues, but 
-**new users should not submit PRs written by code agents under any circumstances**. The same prohibition applies to
-autonomous "OpenClaw"-like agents.
+You may use code agents in drafting or to help you diagnose issues, but **new users should not submit PRs written
+by code agents under any circumstances**. The same prohibition applies to autonomous "OpenClaw"-like agents.
+
+Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
 
 - [ ] I confirm that this PR was written by a human.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,7 +26,7 @@ PRs that appear to be fully agent-written will probably be closed without review
 repeatedly or maliciously. 
 
 This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
-this policy is likely to be updated regularly in the near future. For more information, please read `CONTRIBUTING.md`.
+this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).
 
 - [ ] I confirm that this is not a pure code agent PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,8 @@ to them. As a result, we are **not accepting pure code agent contributions from 
 You may use code agents in drafting or to help you diagnose issues, but **new users should not submit PRs written
 by code agents under any circumstances**. The same prohibition applies to autonomous "OpenClaw"-like agents.
 
-Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
+PRs that appear to be fully agent-written will probably be closed without review. Repeated violations of this policy
+may result in a ban from contributing across the entire Hugging Face organization.
 
 - [ ] I confirm that this PR was written by a human.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,8 @@ You may use code agents in drafting or to help you diagnose issues, but **new us
 by code agents under any circumstances**. The same prohibition applies to autonomous "OpenClaw"-like agents.
 
 PRs that appear to be fully agent-written will probably be closed without review. Repeated violations of this policy
-may result in a ban from contributing across the entire Hugging Face organization.
+may result in a ban from contributing across the entire Hugging Face organization. For more information on this policy,
+please read `CONTRIBUTING.md`.
 
 - [ ] I confirm that this PR was written by a human.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,16 +17,18 @@ Fixes # (issue)
 ## Code Agent Policy
 
 The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
-code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
-to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
-You may use code agents in drafting or to help you diagnose issues, but **new users should not submit PRs written
-by code agents under any circumstances**. The same prohibition applies to autonomous "OpenClaw"-like agents.
+code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
+**we ask that new users do not submit pure code agent PRs** at this time. 
+You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
+not to open any PRs or issues for the moment.
 
-PRs that appear to be fully agent-written will probably be closed without review. Repeated violations of this policy
-may result in a ban from contributing across the entire Hugging Face organization. For more information on this policy,
-please read `CONTRIBUTING.md`.
+PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
+repeatedly or maliciously. 
 
-- [ ] I confirm that this PR was written by a human.
+This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
+this policy is likely to be updated regularly in the near future. For more information, please read `CONTRIBUTING.md`.
+
+- [ ] I confirm that this is not a pure code agent PR.
 
 ## Before submitting
 - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,8 +23,7 @@ code agents. Many of these are low quality, and we are currently bottlenecked by
 to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
 You may use code agents in drafting or to help you diagnose issues, but 
 **new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
-to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents.
-
+to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents. 
 Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
 
 </Tip>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,17 +16,14 @@ limitations under the License.
 
 # Contribute to 🤗 Transformers
 
-<Tip warning={true}>
-
-As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and issue comments written by
-code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
-to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
-You may use code agents in drafting or to help you diagnose issues, but 
-**new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
-to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents. 
-Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
-
-</Tip>
+>[!WARNING]
+>As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and issue comments written by
+>code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
+>to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
+>You may use code agents in drafting or to help you diagnose issues, but 
+>**new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
+>to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents. 
+>Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
 
 Everyone is welcome to contribute, and we value everybody's contribution. Code
 contributions are not the only way to help the community. Answering questions, helping

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,19 @@ limitations under the License.
 
 # Contribute to 🤗 Transformers
 
+<Tip warning={true}>
+
+As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and issue comments written by
+code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
+to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
+You may use code agents in drafting or to help you diagnose issues, but 
+**new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
+to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents.
+
+Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
+
+</Tip>
+
 Everyone is welcome to contribute, and we value everybody's contribution. Code
 contributions are not the only way to help the community. Answering questions, helping
 others, and improving the documentation are also immensely valuable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,28 +19,25 @@ limitations under the License.
 ## Code agent contributions
 
 >[!WARNING]
->As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and comments written by
->code agents. Please read this section and the one below in their entirety if you intend to use code agents to contribute to Transformers. 
->The rest of this document predates the "agent era", and parts of it may be out of date as a result.
-
-Because of the rise of code agents, the Transformers maintainers are currently bottlenecked by our ability to review
-and respond to issues and PRs. As a result, we are **not accepting pure code agent contributions from new users** 
-at this time. You may use code agents in drafting or to help you diagnose issues, but 
-**new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
-to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents. 
-
-Pure agent PRs will probably be closed without review, and repeated violations of this policy may result in a ban
-from contributing across the entire Hugging Face organization. 
+>The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
+>code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
+>**we ask that new users do not submit pure code agent PRs** at this time. 
+>You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
+>not to open any PRs or issues for the moment.
+>
+>PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
+>repeatedly or maliciously. 
 
 ## Our code agent philosophy
 
 We understand that code agents are extremely powerful tools, and many people at Hugging Face use them in their work.
-This is exactly the reason that pure code agent PRs are unhelpful to us, though - if you simply run a code agent
-and generate a PR, you are acting as a pointless middleman between maintainers and the agent. There's no reason
-for you to be involved; we could simply run a code agent ourselves and save time.
+However, it's important to realize that **if you simply run a code agent
+and generate a PR to an open-source project, you are merely a middleman between the reviewers and the agent**. 
+Although doing this creates something that looks very much like a useful contribution, in reality there was no reason 
+for you to be involved; the reviewers could have simply run the code agent themselves.
 
-If you want to contribute usefully, **you need to do things that agents can't do on their own**. In particular,
-we've found the following to be very helpful:
+If you want to contribute usefully to open-source in the agent era, **you need to do things that agents can't do on
+their own**. In particular, we've found the following to be very helpful:
 - Clear diagnosis of bugs. Code agents like to quickly fix problems with a workaround that often causes code bloat
 or incompatibilities with other models. Spending time to track down the exact cause of a problem, and in particular
 locating the first commit where it appeared (for example with [git bisect](https://git-scm.com/docs/git-bisect)) is valuable.
@@ -65,6 +62,11 @@ agent simply by having good taste about what's really important.
 see a list of tests that cover the files you have changed in your PR branch. Run those tests locally, and make sure 
 they pass before you open a PR. After you open your PR, please verify that the CI is green and fix any issues before 
 pinging anyone for review! This reduces notification spam a lot, which keeps maintainers sane.
+
+Please bear in mind that this is an exciting, rapidly-changing but challenging era for open-source development, and indeed
+for the software industry as a whole. We will likely be rapidly updating these guidelines as we learn more about
+dealing effectively with code agents. Have patience with us if reviews are slower than normal, or if some
+PRs are closed without review!
 
 
 ## Welcome to the 🤗 Transformers community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,32 +37,33 @@ from contributing across the entire Hugging Face organization.
 We understand that code agents are extremely powerful tools, and many people at Hugging Face use them in their work.
 This is exactly the reason that pure code agent PRs are unhelpful to us, though - if you simply run a code agent
 and generate a PR, you are acting as a pointless middleman between maintainers and the agent. There's no reason
-for you to be involved; we could simply run a code agent ourselves and get the same output.
+for you to be involved; we could simply run a code agent ourselves and save time.
 
 If you want to contribute usefully, you need to provide value beyond what an agent can do on its own. In particular,
 we've found the following to be very helpful:
 - Clear diagnosis of bugs. Code agents like to quickly fix problems with a workaround that often causes code bloat
 or incompatibilities with other models. Spending time to track down the exact cause of a problem, and in particular
 locating the first commit where it appeared (for example with [git bisect](https://git-scm.com/docs/git-bisect)) is valuable.
+- Minimize the diff. Check your PR to eliminate any unnecessary changes. Add comments only if they're really necessary;
+code agents love multi-line comments to draw attention to all the hard work they did. If your PR can be a 1-line fix,
+make it a 1-line fix. This makes the PR much easier to review and improves the chances that it will be accepted.
 - Taking the time to reproduce the problem. Very often when a user reports an issue, the issue is actually caused by
 environment issues on their machine, or they misdiagnose the problem and suggest an invalid solution. Many code agents
 trust the user comments too much, which results in bad solutions, sometimes for problems that 
 do not exist! Writing a simple reproducer script and running it to make sure you see the problem is valuable.
 - Compare against other models. The Transformers repo is very large, and many models are doing similar things. When
 fixing a bug, it's valuable to see if the bug exists in other models. If your PR says
-"fixed by using the same approach as [other model]", with a link to the relevant code, that is very helpful for maintainers,
+"fixed by using the same approach as (other model)", with a link to the relevant code, that is very helpful for maintainers,
 because it tells us that the fix is likely to be correct and compatible with the rest of the codebase. Code agents often
 look at the code "narrowly", and make a fix that causes models to diverge from the rest of the codebase.
 - Avoid small or "busywork" PRs. In the past, we used to accept these, but given the current flood, we simply don't
-have time for small typo fixes in comments. Please do not ask your code agent to "find issues and fix them" or anything
+have time for small style changes or typo fixes in comments. Please do not ask your code agent to "find issues and fix them" or anything
 like that, because the things it finds are usually trivial or invalid like this. You can provide value beyond a code
-agent simply by having good taste about what's really important, and what isn't.
-- Verify tests locally and in the CI. Before opening a PR 
-
-We could summarize this as "You need to give the reviewer confidence that your solution is necessary and correct".
-Now that the bottleneck for contributions is reviewing code, not writing code, the best way to contribute is to support
-the reviewers as much as possible.
-
+agent simply by having good taste about what's really important.
+- Verify tests locally and in the CI. Before opening a PR, run `make fix-repo` and use `utils/tests_fetcher.py` to 
+see a list of tests that cover the files you have changed in your PR branch. Run those tests locally, and make sure 
+they pass before you open a PR. After you open your PR, please verify that the CI is green and fix any issues before 
+pinging anyone for review! This reduces notification spam a lot, which keeps maintainers sane.
 
 
 ## Welcome to the 🤗 Transformers community!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,8 +57,7 @@ fixing a bug, it's valuable to see if the bug exists in other models. If your PR
 because it tells us that the fix is likely to be correct and compatible with the rest of the codebase. Code agents often
 look at the code "narrowly", and make a fix that causes models to diverge from the rest of the codebase.
 - Avoid small or "busywork" PRs. In the past, we used to accept these, but given the current flood, we simply don't
-have time for small style changes or typo fixes in comments. Please do not ask your code agent to "find issues and fix them" or anything
-like that, because the things it finds are usually trivial or invalid like this. You can provide value beyond a code
+have time for small style changes or typo fixes in comments. You can provide value beyond a code
 agent simply by having good taste about what's really important.
 - Verify tests locally and in the CI. Before opening a PR, run `make fix-repo` and use `utils/tests_fetcher.py` to 
 see a list of tests that cover the files you have changed in your PR branch. Run those tests locally, and make sure 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Contribute to 🤗 Transformers
 
-## Code agent contributions
+## Code agent policy
 
 >[!WARNING]
 >The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
@@ -26,9 +26,7 @@ limitations under the License.
 >not to open any PRs or issues for the moment.
 >
 >PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
->repeatedly or maliciously. 
-
-## Our code agent philosophy
+>repeatedly or maliciously.
 
 We understand that code agents are extremely powerful tools, and many people at Hugging Face use them in their work.
 However, it's important to realize that **if you simply run a code agent

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,8 +44,9 @@ we've found the following to be very helpful:
 - Clear diagnosis of bugs. Code agents like to quickly fix problems with a workaround that often causes code bloat
 or incompatibilities with other models. Spending time to track down the exact cause of a problem, and in particular
 locating the first commit where it appeared (for example with [git bisect](https://git-scm.com/docs/git-bisect)) is valuable.
-- Minimize the diff. Check your PR to eliminate any unnecessary changes. Add comments only if they're really necessary;
-code agents love adding three new functions and multi-line comments to draw attention to all the hard work they did. If your PR can be a 1-line fix,
+- Minimize the diff. Check your PR to eliminate any unnecessary changes. Ensure that you did not commit any testing scripts
+or unrelated files. Add comments only if they're really necessary; code agents love adding three new functions and
+multi-line comments to draw attention to all the hard work they did. If your PR can be a 1-line fix,
 make it a 1-line fix. This makes the PR much easier to review and improves the chances that it will be accepted.
 - Take the time to reproduce the problem. Very often when a user reports an issue, the issue is actually caused by
 environment issues on their machine, or they misdiagnose the problem and suggest an invalid solution. Many code agents

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,11 +22,15 @@ limitations under the License.
 >The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
 >code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
 >**we ask that new users do not submit pure code agent PRs** at this time. 
->You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
+>You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous agents
 >not to open any PRs or issues for the moment.
 >
 >PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
 >repeatedly or maliciously.
+
+<details>
+
+<summary> Our code agent philosophy in detail </summary>
 
 We understand that code agents are extremely powerful tools, and many people at Hugging Face use them in their work.
 However, it's important to realize that **if you simply run a code agent
@@ -66,6 +70,7 @@ for the software industry as a whole. We will likely be rapidly updating these g
 dealing effectively with code agents. Have patience with us if reviews are slower than normal, or if some
 PRs are closed without review!
 
+</details>
 
 ## Welcome to the 🤗 Transformers community!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,14 +16,56 @@ limitations under the License.
 
 # Contribute to 🤗 Transformers
 
+## Code agent contributions
+
 >[!WARNING]
 >As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and issue comments written by
->code agents. Many of these are low quality, and we are currently bottlenecked by our ability to review and respond 
->to them. As a result, we are **not accepting pure code agent contributions from new users** at this time. 
->You may use code agents in drafting or to help you diagnose issues, but 
->**new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
->to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents. 
->Violations of this policy will get you blocked across the entire Hugging Face GitHub organization.
+>code agents. Please read the code sections in their entirety if you intend to use code agents to contribute to Transformers. 
+>The rest of this document predates the "agent era", and parts of it may be out of date as a result.
+
+Because of the rise of code agents, the Transformers maintainers are currently bottlenecked by our ability to review
+and respond to issues and PRs. As a result, we are **not accepting pure code agent contributions from new users** 
+at this time. You may use code agents in drafting or to help you diagnose issues, but 
+**new users should not submit PRs written by code agents under any circumstances**. Using LLMs or code agents
+to post reviews on other users' issues is banned. These prohibitions also apply to autonomous "OpenClaw"-like agents. 
+
+Pure agent PRs will probably be closed without review, and repeated violations of this policy may result in a ban
+from contributing across the entire Hugging Face organization. 
+
+## Our code agent philosophy
+
+We understand that code agents are extremely powerful tools, and many people at Hugging Face use them in their work.
+This is exactly the reason that pure code agent PRs are unhelpful to us, though - if you simply run a code agent
+and generate a PR, you are acting as a pointless middleman between maintainers and the agent. There's no reason
+for you to be involved; we could simply run a code agent ourselves and get the same output.
+
+If you want to contribute usefully, you need to provide value beyond what an agent can do on its own. In particular,
+we've found the following to be very helpful:
+- Clear diagnosis of bugs. Code agents like to quickly fix problems with a workaround that often causes code bloat
+or incompatibilities with other models. Spending time to track down the exact cause of a problem, and in particular
+locating the first commit where it appeared (for example with [git bisect](https://git-scm.com/docs/git-bisect)) is valuable.
+- Taking the time to reproduce the problem. Very often when a user reports an issue, the issue is actually caused by
+environment issues on their machine, or they misdiagnose the problem and suggest an invalid solution. Many code agents
+trust the user comments too much, which results in bad solutions, sometimes for problems that 
+do not exist! Writing a simple reproducer script and running it to make sure you see the problem is valuable.
+- Compare against other models. The Transformers repo is very large, and many models are doing similar things. When
+fixing a bug, it's valuable to see if the bug exists in other models. If your PR says
+"fixed by using the same approach as [other model]", with a link to the relevant code, that is very helpful for maintainers,
+because it tells us that the fix is likely to be correct and compatible with the rest of the codebase. Code agents often
+look at the code "narrowly", and make a fix that causes models to diverge from the rest of the codebase.
+- Avoid small or "busywork" PRs. In the past, we used to accept these, but given the current flood, we simply don't
+have time for small typo fixes in comments. Please do not ask your code agent to "find issues and fix them" or anything
+like that, because the things it finds are usually trivial or invalid like this. You can provide value beyond a code
+agent simply by having good taste about what's really important, and what isn't.
+- Verify tests locally and in the CI. Before opening a PR 
+
+We could summarize this as "You need to give the reviewer confidence that your solution is necessary and correct".
+Now that the bottleneck for contributions is reviewing code, not writing code, the best way to contribute is to support
+the reviewers as much as possible.
+
+
+
+## Welcome to the 🤗 Transformers community!
 
 Everyone is welcome to contribute, and we value everybody's contribution. Code
 contributions are not the only way to help the community. Answering questions, helping

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,15 +39,15 @@ This is exactly the reason that pure code agent PRs are unhelpful to us, though 
 and generate a PR, you are acting as a pointless middleman between maintainers and the agent. There's no reason
 for you to be involved; we could simply run a code agent ourselves and save time.
 
-If you want to contribute usefully, you need to provide value beyond what an agent can do on its own. In particular,
+If you want to contribute usefully, **you need to do things that agents can't do on their own**. In particular,
 we've found the following to be very helpful:
 - Clear diagnosis of bugs. Code agents like to quickly fix problems with a workaround that often causes code bloat
 or incompatibilities with other models. Spending time to track down the exact cause of a problem, and in particular
 locating the first commit where it appeared (for example with [git bisect](https://git-scm.com/docs/git-bisect)) is valuable.
 - Minimize the diff. Check your PR to eliminate any unnecessary changes. Add comments only if they're really necessary;
-code agents love multi-line comments to draw attention to all the hard work they did. If your PR can be a 1-line fix,
+code agents love adding three new functions and multi-line comments to draw attention to all the hard work they did. If your PR can be a 1-line fix,
 make it a 1-line fix. This makes the PR much easier to review and improves the chances that it will be accepted.
-- Taking the time to reproduce the problem. Very often when a user reports an issue, the issue is actually caused by
+- Take the time to reproduce the problem. Very often when a user reports an issue, the issue is actually caused by
 environment issues on their machine, or they misdiagnose the problem and suggest an invalid solution. Many code agents
 trust the user comments too much, which results in bad solutions, sometimes for problems that 
 do not exist! Writing a simple reproducer script and running it to make sure you see the problem is valuable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ limitations under the License.
 ## Code agent contributions
 
 >[!WARNING]
->As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and issue comments written by
+>As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and comments written by
 >code agents. Please read this section and the one below it in their entirety if you intend to use code agents to contribute to Transformers. 
 >The rest of this document predates the "agent era", and parts of it may be out of date as a result.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 >[!WARNING]
 >As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and issue comments written by
->code agents. Please read the code sections in their entirety if you intend to use code agents to contribute to Transformers. 
+>code agents. Please read this section and the one below it in their entirety if you intend to use code agents to contribute to Transformers. 
 >The rest of this document predates the "agent era", and parts of it may be out of date as a result.
 
 Because of the rise of code agents, the Transformers maintainers are currently bottlenecked by our ability to review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ limitations under the License.
 
 >[!WARNING]
 >As of early 2026, the Transformers repo is being overwhelmed by a large number of PRs and comments written by
->code agents. Please read this section and the one below it in their entirety if you intend to use code agents to contribute to Transformers. 
+>code agents. Please read this section and the one below in their entirety if you intend to use code agents to contribute to Transformers. 
 >The rest of this document predates the "agent era", and parts of it may be out of date as a result.
 
 Because of the rise of code agents, the Transformers maintainers are currently bottlenecked by our ability to review


### PR DESCRIPTION
As discussed on Slack, this is the first phase of our approach to controlling the code agent epidemic. This PR places large warnings in both the pull request template and `CONTRIBUTING.md`, which should hopefully be seen by most contributors.

A lot of code agent contributions come from naïve users who are not trying to harm the repo, but are simply trying to fix open issues they see, mixed in with more autonomous or malicious agents. The goal here is to ensure that new users know our policy, reducing the number of innocent mistakes, giving us more freedom to use more automated bans and filters to detect and control the rest.