### PR TITLE
fix `processing_utils.py`: avoid deepcopying tokenizer in `ProcessorMixin` to improve performance

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -704,7 +704,16 @@ class ProcessorMixin(PushToHubMixin):
         Returns:
             `dict[str, Any]`: Dictionary of all the attributes that make up this processor instance.
         """
-        output = copy.deepcopy(self.__dict__)
+        # Exclude tokenizer attributes before deepcopying to avoid copying large vocab/token structures.
+        tokenizer_attributes = set()
+        for attribute in self.__class__.get_attributes():
+            if attribute in self.__dict__:
+                modality = _get_modality_for_attribute(attribute)
+                if modality == "tokenizer":
+                    tokenizer_attributes.add(attribute)
+
+        dict_to_copy = {k: v for k, v in self.__dict__.items() if k not in tokenizer_attributes}
+        output = copy.deepcopy(dict_to_copy)
 
         # Get the kwargs in `__init__`.
         sig = inspect.signature(self.__init__)
@@ -713,14 +722,6 @@ class ProcessorMixin(PushToHubMixin):
         attrs_to_save = list(sig.parameters) + self.__class__.get_attributes()
         # extra attributes to be kept
         attrs_to_save += ["auto_map"]
-
-        # Remove tokenizers from output - they have their own vocab files and are saved separately.
-        # All other sub-processors (image_processor, feature_extractor, etc.) are kept in processor_config.json.
-        for attribute in self.__class__.get_attributes():
-            if attribute in output:
-                modality = _get_modality_for_attribute(attribute)
-                if modality == "tokenizer":
-                    del output[attribute]
 
         if "chat_template" in output:
             del output["chat_template"]


### PR DESCRIPTION
## Problem

`ProcessorMixin.to_dict()` was calling `copy.deepcopy(self.__dict__)` on the entire processor, including the tokenizer, even though the tokenizer is always deleted from the output immediately after (since tokenizers are saved separately via their own files).

For tokenizers with large vocabularies (e.g. `CohereTokenizer`), this caused ~2.5 million unnecessary recursive `deepcopy` calls, adding ~2.5s of overhead every time `to_dict()` was called (e.g. during `save_pretrained`).

## Fix

Identify and exclude tokenizer attributes *before* the `deepcopy`, so only the attributes that are actually needed in the output are copied.

## Impact

| | Primitive deepcopy calls | deepcopy total time |
|---|---|---|
| Before | 1,272,277 | 2.446s |
| After | 1,335 | 0.002s |

**~1000x reduction in deepcopy calls. No behavior change** — the resulting `output` dict is identical in both cases.