### PR TITLE
[docs] continuous batching

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -89,6 +89,8 @@
       title: Experts backends
     - local: continuous_batching
       title: Continuous batching
+    - local: continuous_batching_architecture
+      title: Continuous batching architecture
     - local: paged_attention
       title: Paged attention
     - sections:
@@ -415,6 +417,8 @@
       title: Callbacks
     - local: main_classes/configuration
       title: Configuration
+    - local: main_classes/continuous_batching
+      title: Continuous batching
     - local: main_classes/data_collator
       title: Data Collator
     - local: main_classes/logging

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -16,134 +16,261 @@ rendered properly in your Markdown viewer.
 
 # Continuous batching
 
-Continuous batching maximizes GPU utilization. It increases throughput and reduces latency by using dynamic scheduling to rearrange the batch at each step. The system removes completed requests and adds new requests immediately to prevent GPU idling. Chunked prefill prevents expensive prefill work from stalling the batch while still allowing new requests still join.
+Continuous batching maximizes GPU utilization by dynamically rescheduling the batch at every generation step. As requests finish, new ones join immediately so you don't need to wait for the whole batch to complete. The GPU stays full and throughput stays high.
 
-Continuous batching works with [transformers serve](./serving), a server for deploying local models, and [`~ContinuousMixin.generate_batch`].
+> [!TIP]
+> For production deployments, use [transformers serve](./serve-cli/serving_optims#continuous-batching). It builds on [`ContinuousBatchingManager`] and exposes an OpenAI-compatible HTTP endpoint.
 
 ## generate_batch
 
-The [`~ContinuousMixin.generate_batch`] method works with all autoregressive text models. It accepts a list of tokenized inputs and a [`GenerationConfig`] to configure generation settings.
+Continuous batching is supported through [`~ContinuousMixin.generate_batch`]. Pass a list of tokenized prompts and get back results for all of them when they're done. `generate_batch` handles scheduling internally and blocks until all requests are complete. For serving and streaming use cases, use [`ContinuousBatchingManager`] directly to manage requests.
 
 ```py
-import datasets
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
-from transformers.generation import GenerationConfig
+from transformers.generation import ContinuousBatchingConfig, GenerationConfig
 
 model = AutoModelForCausalLM.from_pretrained(
-    "Qwen/Qwen3-4B-Instruct-2507",
-    attn_implementation="sdpa_paged",
+    "Qwen/Qwen3-4B",
+    attn_implementation="paged|flash_attention_2",
     device_map="cuda",
     dtype=torch.bfloat16,
 )
-tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B-Instruct-2507", padding_side="left")
+tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-4B")
 
-dataset = datasets.load_dataset("openai/gsm8k", "socratic", split="test")
-dataset = dataset.select(range(args.samples))
-tokenized_datasets = dataset.map(lambda x: tokenizer(x["question"]), batched=True)
-simple_batch_inputs = [item["input_ids"] for item in tokenized_datasets]
+prompts = [
+    "Whats up?",
+    "Name a cat breed.",
+    "Write a detailed history of quantum mechanics.",
+]
+inputs = [tokenizer.encode(p) for p in prompts]
 
 generation_config = GenerationConfig(
-    max_new_tokens=32,
-    use_cuda_graph=False,
+    max_new_tokens=64,
     eos_token_id=tokenizer.eos_token_id,
-    pad_token_id=tokenizer.pad_token_id,
-    do_sample=False,
-    max_batch_tokens=512,
 )
 
-batch_outputs = model.generate_batch(
-    inputs=simple_batch_inputs,
-    generation_config=generation_config,
-)
+outputs = model.generate_batch(inputs=inputs, generation_config=generation_config)
 
-for request_id, output in batch_outputs.items():
-    generated_text = tokenizer.decode(output.generated_tokens, skip_special_tokens=True)
-    print(f"Request {request_id} output: {generated_text}")
+for request_id, output in outputs.items():
+    text = tokenizer.decode(output.generated_tokens, skip_special_tokens=True)
+    print(f"[{request_id}] {text}")
 ```
+
 
 ## ContinuousBatchingManager
 
-The [`ContinuousBatchingManager`] orchestrates the background thread by pulling requests from the queue and filling the GPU to capacity. Every iteration checks for finished requests and schedules new ones to join the batch. Use this manager to customize request scheduling.
+[`ContinuousBatchingManager`] runs a background thread and lets you submit requests and retrieve results independently. Every iteration checks for finished requests and schedules new ones to join the batch. This is useful for streaming, real-time serving, or submitting requests as they arrive.
 
-Call [`~ContinuousMixin.init_continuous_batching`] to initialize the manager with a [`GenerationConfig`] and [`~ContinuousBatchingManager.start`] the background thread.
+Use [`~ContinuousMixin.continuous_batching_context_manager`] to start and stop the manager safely. The example below contains variable length inputs. As soon as the shortest prompt is complete, it leaves the batch while the longer prompts continue generating. With static batching, you'd have to pad them all to the same length. Continuous batching frees up the completed prompt so you can start processing the next prompt immediately.
 
 ```py
-from transformers.generation.continuous_batching import RequestStatus
+with model.continuous_batching_context_manager(generation_config=generation_config) as manager:
+    manager.add_request(
+        input_ids=tokenizer.encode("Write a detailed history of quantum mechanics."),
+        request_id="long",
+        max_new_tokens=512,
+    )
+    manager.add_request(
+        input_ids=tokenizer.encode("What's up?"),
+        request_id="short_0",
+        max_new_tokens=32,
+    )
+    manager.add_request(
+        input_ids=tokenizer.encode("Name a cat breed."),
+        request_id="short_1",
+        max_new_tokens=32,
+    )
 
+    for result in manager:
+        text = tokenizer.decode(result.generated_tokens, skip_special_tokens=True)
+        print(f"[{result.request_id}] {text}")
+```
+
+You could also call [`~ContinuousMixin.init_continuous_batching`] to manage the lifecycle yourself.
+
+```py
 manager = model.init_continuous_batching(generation_config=generation_config)
 manager.start()
+
+# submit and retrieve requests...
 ```
 
-Use [`~ContinuousBatchingManager.add_request`] to asynchronously submit individual requests. Provide a specific request id or the manager wgenerates one automatically.
-
-```py
-for i, input_ids in enumerate(simple_batch_inputs):
-    request_id = manager.add_request(input_ids=input_ids, request_id=f"request_{i}")
-```
-
-Retrieve *all* results as they arrive with [`~ContinuousBatchingManager.get_result`].
-
-```py
-for request_id, request in manager.get_result():
-    generated_text = tokenizer.decode(request.generated_tokens, skip_special_tokens=True)
-    print(f"Request {request_id} output: {generated_text}")
-```
-
-Use the `request_id` of a specific request to get its results. This is a blocking operation that waits until the result is ready.
-
-```py
-result = manager.get_result(request_id="request_5")
-```
-
-Stream partial results for a specific request with [`~ContinuousBatchingManager.request_id_iter`].
-
-```py
-manager.add_request(
-    input_ids=input_ids,
-    request_id="streaming_request",
-    stream=True,
-)
-for chunk in manager.request_id_iter(request_id="streaming_request"):
-    generated_text = tokenizer.decode(chunk.generated_tokens, skip_special_tokens=True)
-    print(generated_text)
-    # FIXME: stop iteration in `request_id_iter` when finished instead of doing it externally
-    if chunk.status == RequestStatus.FINISHED:
-        break
-```
-
-Call [`~ContinuousBatchingManager.stop`] to terminate the manager.
+Call [`ContinuousBatchingManager.stop`] to terminate the manager.
 
 ```py
 manager.stop()
 ```
 
-## PagedAttention
+### Adding requests
 
-PagedAttention breaks large key-value caches into smaller, non-contiguous fixed-size pages to avoid GPU memory fragmentation and support variable-length requests. Transformers automatically enables PagedAttention when using continuous batching.
-
-You could explicitly enable PagedAttention when instantiating a model rather than waiting for [`~ContinuousMixin.generate_batch`] to dynamically enable it.
+[`~ContinuousBatchingManager.add_request`] submits a single request. Provide a `request_id` or let the manager generate one automatically.
 
 ```py
-import torch
-from transformers import AutoModelForCausalLM
+manager.add_request(input_ids=input_ids, request_id="my_request")
+```
 
+[`~ContinuousBatchingManager.add_requests`] submits a batch at once. It sorts inputs automatically to maximize prefix cache hits.
+
+It sorts inputs automatically to maximize prefix cache hits when block sharing is enabled.
+
+```py
+manager.add_requests(inputs=inputs)
+```
+
+Cancel a request with [`~ContinuousBatchingManager.cancel_request`].
+
+```py
+manager.cancel_request(request_id="my_request")
+```
+
+### Retrieving results
+
+Iterate over the manager to receive results as they arrive.
+
+```py
+for result in manager:
+    print(tokenizer.decode(result.generated_tokens, skip_special_tokens=True))
+```
+
+[`~ContinuousBatchingManager.get_result`] fetches the next result from the output queue. Pass a `request_id` to filter for a specific request. If the next result in the queue doesn't match, it's requeued and the method returns `None`.
+
+```py
+# next available result
+result = manager.get_result()
+
+# filter for a specific request
+result = manager.get_result(request_id="my_request")
+```
+
+### Streaming
+
+Set `streaming=True` on a request, then use [`~ContinuousBatchingManager.request_id_iter`] to iterate over partial outputs as tokens are generated.
+
+```py
+from transformers.generation.continuous_batching import RequestStatus
+
+manager.add_request(input_ids=input_ids, request_id="streamed", streaming=True)
+
+for chunk in manager.request_id_iter(request_id="streamed"):
+    token = tokenizer.decode(chunk.generated_tokens[-1:], skip_special_tokens=True)
+    print(token, end="", flush=True)
+    if chunk.status == RequestStatus.FINISHED:
+        break
+```
+
+## ContinuousBatchingConfig
+
+[`ContinuousBatchingConfig`] controls the KV cache, scheduling, CUDA graphs, memory usage, and more. Pass it alongside [`GenerationConfig`] to customize continuous batching.
+
+By default, `num_blocks` and `max_batch_tokens` are inferred automatically from available GPU memory. Use the table below to help you pick the appropriate features.
+
+| Feature | Memory | Throughput | Latency |
+|---|---|---|---|
+| `max_memory_percent` / `block_size` | ✓ controls KV budget | | |
+| `scheduler` | | ✓ scheduling policy | ✓ TTFT |
+| CUDA graphs | ↑ graph storage | ✓ less dispatch overhead | ✓ |
+| Async batching | ↑ ~2× I/O buffers | ✓ overlaps CPU/GPU | |
+| Prefix caching | ↓ shared KV blocks | ✓ skips redundant prefill | ✓ TTFT |
+| Paged attention | ↓ no fragmentation | ✓ dynamic batch membership | |
+| Sliding window | ↓ bounded KV per layer | | |
+
+```py
+from transformers.generation import ContinuousBatchingConfig
+
+cb_config = ContinuousBatchingConfig(
+    max_memory_percent=0.8,  # fraction of free GPU memory to use for the KV cache
+    block_size=256,          # KV cache block size in tokens
+    scheduler="fifo",        # "fifo" or "prefill_first"
+)
+
+outputs = model.generate_batch(
+    inputs=inputs,
+    generation_config=generation_config,
+    continuous_batching_config=cb_config,
+)
+```
+
+## Log probabilities
+
+ContinuousBatching returns each generated token's log probability when `return_logprobs=True`. This is useful for RL where logprobs are an input to some of the training loops.
+
+```py
+cb_config = ContinuousBatchingConfig(return_logprobs=True)
+
+# generate_batch()
+
+for request_id, output in outputs.items():
+    for token_id, log_prob in zip(output.generated_tokens, output.logprobs):
+        token = tokenizer.decode([token_id])
+        print(f"{token} | logprob: {log_prob}")
+```
+
+### CUDA graphs
+
+CUDA graphs eliminate CPU dispatch overhead by recording the GPU execution graph once and replaying it for batches with matching shapes. Enable them explicitly with `use_cuda_graph=True`.
+
+```py
+cb_config = ContinuousBatchingConfig(use_cuda_graph=True)
+```
+
+When active, the manager pads query and KV lengths to fixed intervals so shapes repeat and graphs reuse. Smaller values of `q_padding_interval_size` and `kv_padding_interval_size` reduce wasted compute on padding, but this means there are more unique shapes the graph has to record and store which costs more memory.
+
+```py
+cb_config = ContinuousBatchingConfig(
+    use_cuda_graph=True,
+    q_padding_interval_size=64,
+    kv_padding_interval_size=16384,
+    max_cached_graphs=32,
+)
+```
+
+### Async batching
+
+Async batching overlaps CPU scheduling of the next batch with GPU computation of the current one. It requires CUDA graphs and roughly doubles the VRAM usage.
+
+```py
+cb_config = ContinuousBatchingConfig(
+    use_cuda_graph=True,
+    use_async_batching=True,
+)
+```
+
+### Prefix caching
+
+When multiple requests share a common prefix, like a system prompt, the manager reuses their KV cache blocks instead of recomputing them. This is enabled by default and requires all model layers to use full attention (it's automatically disabled for sliding window models).
+
+```py
+cb_config = ContinuousBatchingConfig(
+    allow_block_sharing=True,  # default
+)
+```
+
+## Paged attention
+
+Continuous batching requires a paged attention backend. Set `attn_implementation` when loading the model.
+
+| Backend | `attn_implementation` | Requirements |
+|---|---|---|
+| FlashAttention | <code>"paged&#124;flash_attention_2"</code> | `flash-attn` package |
+| SDPA (PyTorch native) | <code>"paged&#124;sdpa"</code> | None |
+| Eager | <code>"paged&#124;eager"</code> | None |
+
+```py
 model = AutoModelForCausalLM.from_pretrained(
-    "Qwen/Qwen3-4B-Instruct-2507",
+    "Qwen/Qwen3-4B",
     attn_implementation="paged|flash_attention_2",
     device_map="cuda",
-    torch_dtype=torch.bfloat16
+    dtype=torch.bfloat16,
 )
 ```
 
 ## Sliding window attention
 
-Sliding window attention limits the backward context of a token to save compute. Generation cost stays proportional to window size. This reduces compute per step and simplifies continuous batching.
-
-Transformers models like Mistral and Gemma 2 natively support sliding window attention. Manually enable it in the model config if the architecture supports it. This helps with fine-tuning or running custom experiments.
+Models with sliding window attention (Mistral, Gemma 2) work with continuous batching. To manually configure a sliding window for fine-tuning or custom experiments, set it in the model config before loading.
 
 ```py
-from transformers import AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM
 
 config = AutoConfig.from_pretrained("google/gemma-2-2b")
 config.sliding_window = 4096
@@ -151,32 +278,15 @@ config.sliding_window = 4096
 model = AutoModelForCausalLM.from_pretrained(
     "google/gemma-2-2b",
     config=config,
-    attn_implementation="paged|flash_attention_2",
+    attn_implementation="paged|sdpa",
     device_map="cuda",
     dtype=torch.bfloat16,
 )
 ```
 
-Usage remains the same with [`~ContinuousMixin.generate_batch`].
+Prefix caching is disabled automatically when sliding window attention is active.
 
-## How it works
+## Next steps
 
-The [`ContinuousMixin`] class serves as the main interface for continuous batching through [`~ContinuousMixin.generate_batch`]. This method internally creates a [`ContinuousBatchingManager`].
-
-[`ContinuousBatchingManager`] manages requests by creating a background thread for the generation loop and adding requests to the queue. The manager is thread-safe, allowing asynchronous request additions while the model generates.
-
-The [`Scheduler`] selects requests for processing at each step based on the token budget. [`FIFOScheduler`] is the default scheduler. It prioritizes decoding requests over prefilling requests and assigns them to specific memory blocks. [`PrefillFirstScheduler`] prioritizes prefill requests instead.
-
-[`ContinuousBatchingManager`] runs the model forward pass for the scheduled requests. It then collects and returns the results.
-
-[`ContinuousBatchingConfig`] is the object used to store all parameters needed for continuous batching, that are not already in [`GenerationConfig`]
-
-## Continuous batching config
-
-[[autodoc]] ContinuousBatchingConfig
-    - __call__
-
-
-## Resources
-
-The [Continuous batching](https://huggingface.co/blog/continuous_batching) blog post explains KV caching, chunked prefill, and ragged batching with dynamic scheduling in more detail.
+- The [Continuous batching blog post](https://huggingface.co/blog/continuous_batching) covers KV caching, chunked prefill, and dynamic scheduling with performance benchmark numbers.
+- For a deeper look at how the continuous batching system works, see the [Continuous batching architecture](./continuous_batching_architecture) doc.

--- a/docs/source/en/continuous_batching.md
+++ b/docs/source/en/continuous_batching.md
@@ -16,14 +16,16 @@ rendered properly in your Markdown viewer.
 
 # Continuous batching
 
-Continuous batching maximizes GPU utilization by dynamically rescheduling the batch at every generation step. As requests finish, new ones join immediately so you don't need to wait for the whole batch to complete. The GPU stays full and throughput stays high.
+Continuous batching maximizes GPU utilization by dynamically rescheduling the batch at every generation step. As requests finish, new ones join immediately instead of waiting for the whole batch to complete. The GPU stays full and throughput stays high.
 
 > [!TIP]
 > For production deployments, use [transformers serve](./serve-cli/serving_optims#continuous-batching). It builds on [`ContinuousBatchingManager`] and exposes an OpenAI-compatible HTTP endpoint.
 
 ## generate_batch
 
-Continuous batching is supported through [`~ContinuousMixin.generate_batch`]. Pass a list of tokenized prompts and get back results for all of them when they're done. `generate_batch` handles scheduling internally and blocks until all requests are complete. For serving and streaming use cases, use [`ContinuousBatchingManager`] directly to manage requests.
+Continuous batching is supported through [`~ContinuousMixin.generate_batch`]. Pass a list of tokenized prompts and get back results for all of them when they're done. `generate_batch` handles scheduling internally and blocks until all requests are complete.
+
+For serving and streaming use cases, use [ContinuousBatchingManager](#continuousbatchingmanager) directly to manage requests.
 
 ```py
 import torch
@@ -32,7 +34,7 @@ from transformers.generation import ContinuousBatchingConfig, GenerationConfig
 
 model = AutoModelForCausalLM.from_pretrained(
     "Qwen/Qwen3-4B",
-    attn_implementation="paged|flash_attention_2",
+    attn_implementation="flash_attention_2",
     device_map="cuda",
     dtype=torch.bfloat16,
 )
@@ -60,7 +62,7 @@ for request_id, output in outputs.items():
 
 ## ContinuousBatchingManager
 
-[`ContinuousBatchingManager`] runs a background thread and lets you submit requests and retrieve results independently. Every iteration checks for finished requests and schedules new ones to join the batch. This is useful for streaming, real-time serving, or submitting requests as they arrive.
+[`ContinuousBatchingManager`] runs a background thread and lets you submit requests and retrieve results independently. Every generation step, it checks for finished requests and schedules new ones to join the batch. This is useful for streaming, real-time serving, or submitting requests as they arrive.
 
 Use [`~ContinuousMixin.continuous_batching_context_manager`] to start and stop the manager safely. The example below contains variable length inputs. As soon as the shortest prompt is complete, it leaves the batch while the longer prompts continue generating. With static batching, you'd have to pad them all to the same length. Continuous batching frees up the completed prompt so you can start processing the next prompt immediately.
 
@@ -110,9 +112,7 @@ manager.stop()
 manager.add_request(input_ids=input_ids, request_id="my_request")
 ```
 
-[`~ContinuousBatchingManager.add_requests`] submits a batch at once. It sorts inputs automatically to maximize prefix cache hits.
-
-It sorts inputs automatically to maximize prefix cache hits when block sharing is enabled.
+[`~ContinuousBatchingManager.add_requests`] submits a batch at once. It sorts inputs automatically to maximize prefix cache hits when block sharing is enabled.
 
 ```py
 manager.add_requests(inputs=inputs)
@@ -181,7 +181,7 @@ from transformers.generation import ContinuousBatchingConfig
 cb_config = ContinuousBatchingConfig(
     max_memory_percent=0.8,  # fraction of free GPU memory to use for the KV cache
     block_size=256,          # KV cache block size in tokens
-    scheduler="fifo",        # "fifo" or "prefill_first"
+    scheduler_type="fifo",        # "fifo" or "prefill_first"
 )
 
 outputs = model.generate_batch(
@@ -191,9 +191,9 @@ outputs = model.generate_batch(
 )
 ```
 
-## Log probabilities
+### Log probabilities
 
-ContinuousBatching returns each generated token's log probability when `return_logprobs=True`. This is useful for RL where logprobs are an input to some of the training loops.
+[`ContinuousBatchingConfig`] returns each generated token's log probability when `return_logprobs=True`. This is useful for RL where logprobs are an input to some of the training loops.
 
 ```py
 cb_config = ContinuousBatchingConfig(return_logprobs=True)
@@ -227,7 +227,7 @@ cb_config = ContinuousBatchingConfig(
 
 ### Async batching
 
-Async batching overlaps CPU scheduling of the next batch with GPU computation of the current one. It requires CUDA graphs and roughly doubles the VRAM usage.
+Async batching overlaps CPU scheduling of the next batch with GPU computation of the current one. It requires CUDA graphs and roughly doubles the VRAM used for input tensors.
 
 ```py
 cb_config = ContinuousBatchingConfig(
@@ -248,7 +248,7 @@ cb_config = ContinuousBatchingConfig(
 
 ## Paged attention
 
-Continuous batching requires a paged attention backend. Set `attn_implementation` when loading the model.
+Continuous batching requires a paged attention backend. Set `attn_implementation` when loading the model. If you load a model with a non-paged backend (`"flash_attention_2"`), the `"paged|"` prefix is added automatically when continuous batching starts.
 
 | Backend | `attn_implementation` | Requirements |
 |---|---|---|

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -1,0 +1,125 @@
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Continuous batching architecture
+
+Traditional batching processes a fixed group of requests together and waits for every one to finish before starting the next group. Even if the shorter requests are completed, each batch is only as fast as the longest request in it. This causes the GPU to idle between batches.
+
+With continuous batching, at every generation step, the scheduler checks for finished requests and replaces them immediately with waiting ones. Short requests are kicked out as soon as they're done, and the GPU stays occupied the entire time. The result is significantly higher throughput and lower average latency.
+
+## Request lifecycle
+
+A request moves through four states from submission to completion.
+
+```text
+       WAIT IN QUEUE          LOAD PROMPT INTO KV       STREAM OUTPUT           DONE
+    ┌────────────────┐    ┌─────────────────────┐    ┌─────────────────┐    ┌────────┐
+    │    PENDING     │───▶│     PREFILLING      │───▶│    DECODING     │───▶│FINISHED│
+    │  ○ ○ ○ · · ·   │    │ ████████░░░░░░░░░░  │    │  → → → → · ·    │    │   ✓    │
+    └────────────────┘    └─────────────────────┘    └─────────────────┘    └────────┘
+         others ahead            prompt chunks              +1 token/step
+```
+
+1. Pending — the request is queued and waiting to be scheduled.
+2. Prefilling — prompt tokens are processed in a forward pass.
+3. Decoding — output tokens are generated one at a time.
+4. Finished — generation is complete and the result is available.
+
+A request is moved from pending to prefilling when the scheduler finds enough token budget and cache space to admit the request. If the prompt is too long to fit in a single step, the scheduler splits it across multiple forward passes (chunk prefill).
+
+## Chunked prefill
+
+Processing a long prompt in a single step is expensive because it blocks other requests from generating. Chunked prefill solves this by splitting large prefills across multiple steps.
+
+```text
+Blocking (long prefill blocks the batch)
+  Step:   1        2        3        4
+  Req A  [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓]   ← one huge prefill
+  Req B  ················ wait ················
+  Req C  ················ wait ················
+
+Chunked (same prompt split and interleave with decode)
+  Step:   1          2          3          4
+  Req A  [▓▓ pre]    [▓▓ pre]   [▓▓ pre]   [→ dec]
+  Req B  [→ dec]     [→ dec]    [▓▓ pre]   [→ dec]
+  Req C  [→ dec]     · idle ·   [→ dec]    · idle ·
+```
+
+When a new request's prompt exceeds the available token budget, the scheduler processes as many tokens as possible and holds the rest. On subsequent steps, it continues from where it left off, interleaving prefill work with ongoing decode steps. This keeps the batch productive and reduces time-to-first-token for other requests.
+
+## Scheduler
+
+The scheduler decides which requests join each forward pass based on two budgets.
+
+- Token budget — the maximum number of query tokens processed in a single forward pass, set by `max_batch_tokens` in [`ContinuousBatchingConfig`].
+- Cache budget — the total number of KV pages that can be read in a single pass, which is bounded by the total cache size.
+
+### FIFO
+
+[`FIFOScheduler`] is the default scheduler. It fills the batch in priority order. Active decode requests are processed first, then active prefill requests, and then new waiting requests in arrival order. This maximizes throughput by pushing existing requests through before pulling in new ones.
+
+### PrefillFirst
+
+[`PrefillFirstScheduler`] completes chunked prefill operations before resuming decode. This reduces fragmentation for workloads dominated by long prompts.
+
+Set the scheduler in [`ContinuousBatchingConfig`].
+
+```py
+cb_config = ContinuousBatchingConfig(scheduler="prefill_first")
+```
+
+## CUDA graphs
+
+Every generation step involves CPU overhead, from assembling the batch to dispatching GPU kernels and reading the results. CUDA graphs eliminate the overhead by recording the full GPU execution sequence once and replaying it for batches with matching shapes.
+
+Because the batch shapes change every step, the continuous batching system handles this with padding and caching.
+
+1. Query lengths are padded to the nearest multiple of `q_padding_interval_size`.
+2. KV lengths are padded to the nearest multiple of `kv_padding_interval_size`.
+3. Recorded graphs are stored in an LRU cache of up to `max_cached_graphs` entries.
+
+When a batch's padded shape matches a cached graph, the graph replays without any CPU dispatch. New shapes trigger a new graph capture.
+
+CUDA graphs require static control flow and are incompatible with attention masks. They're auto-detected by default and disabled when conditions aren't met.
+
+## Async batching
+
+Async batching uses two I/O buffer pairs and two CUDA streams to overlap CPU and GPU work.
+
+```text
+Sequential
+  CPU  ── [prep N] ·········idle········· [prep N+1] ·········idle·········
+  GPU  ·········idle········· [compute N] ·········idle········· [compute N+1]
+
+Async
+  CPU  ── [prep N] [prep N+1] [prep N+2] ──
+  GPU  ── ········ [compute N] [compute N+1] ──
+```
+
+While the GPU computes batch N, the CPU prepares batch N+1. However, overlapping the two requires roughly double the VRAM.
+
+Async batching requires CUDA graphs to be active, since graph replay provides the stable tensor addresses needed for stream overlap to be correct.
+
+## Soft reset
+
+If the KV cache fills completely during a long session, because requests are generating very long outputs, the manager triggers a soft reset rather than crashing. It selects the oldest active request (or the newest, if a previous soft reset already blocked new requests from joining), appends its generated tokens to its original prompt, frees its cache blocks, and adds it back to the queue.
+
+When the cache has space again, the request resumes from where it left off with its generation history encoded in the prompt.
+
+## Next steps
+
+- The [Continuous batching blog post](https://huggingface.co/blog/continuous_batching) covers KV caching, chunked prefill, and dynamic scheduling with performance benchmark numbers.
+- For practical usage examples of how to use continuous batching, see the [Continuous batching](./continuous_batching) doc.

--- a/docs/source/en/continuous_batching_architecture.md
+++ b/docs/source/en/continuous_batching_architecture.md
@@ -16,7 +16,7 @@ rendered properly in your Markdown viewer.
 
 # Continuous batching architecture
 
-Traditional batching processes a fixed group of requests together and waits for every one to finish before starting the next group. Even if the shorter requests are completed, each batch is only as fast as the longest request in it. This causes the GPU to idle between batches.
+Traditional batching processes a fixed group of requests together and waits for the slowest one to finish before starting the next group. This causes the GPU to idle between batches.
 
 With continuous batching, at every generation step, the scheduler checks for finished requests and replaces them immediately with waiting ones. Short requests are kicked out as soon as they're done, and the GPU stays occupied the entire time. The result is significantly higher throughput and lower average latency.
 
@@ -58,7 +58,7 @@ Chunked (same prompt split and interleave with decode)
   Req C  [→ dec]     · idle ·   [→ dec]    · idle ·
 ```
 
-When a new request's prompt exceeds the available token budget, the scheduler processes as many tokens as possible and holds the rest. On subsequent steps, it continues from where it left off, interleaving prefill work with ongoing decode steps. This keeps the batch productive and reduces time-to-first-token for other requests.
+When a new request's prompt exceeds the available token budget (set by `max_batch_tokens` in [`ContinuousBatchingConfig`]), the scheduler processes as many tokens as possible and holds the rest. On subsequent steps, it continues from where it left off, interleaving prefill work with ongoing decode steps. This keeps the batch productive and reduces time-to-first-token for other requests.
 
 ## Scheduler
 
@@ -78,7 +78,7 @@ The scheduler decides which requests join each forward pass based on two budgets
 Set the scheduler in [`ContinuousBatchingConfig`].
 
 ```py
-cb_config = ContinuousBatchingConfig(scheduler="prefill_first")
+cb_config = ContinuousBatchingConfig(scheduler_type="prefill_first")
 ```
 
 ## CUDA graphs
@@ -122,4 +122,4 @@ When the cache has space again, the request resumes from where it left off with 
 ## Next steps
 
 - The [Continuous batching blog post](https://huggingface.co/blog/continuous_batching) covers KV caching, chunked prefill, and dynamic scheduling with performance benchmark numbers.
-- For practical usage examples of how to use continuous batching, see the [Continuous batching](./continuous_batching) doc.
+- For usage examples, see the [Continuous batching](./continuous_batching) doc.

--- a/docs/source/en/main_classes/continuous_batching.md
+++ b/docs/source/en/main_classes/continuous_batching.md
@@ -1,0 +1,34 @@
+<!--Copyright 2026 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Continuous batching
+
+This page documents the classes behind continuous batching inference: submitting prompts, configuring scheduling and memory limits, and retrieving results.
+
+For usage examples, see the [Continuous batching](../continuous_batching) guide and for how scheduling and memory interact, see the [Continuous batching architecture](../continuous_batching_architecture) doc.
+
+## ContinuousMixin.generate_batch
+
+[[autodoc]] ContinuousMixin.generate_batch
+
+## ContinuousBatchingManager
+
+[[autodoc]] ContinuousBatchingManager
+
+## Continuous batching config
+
+[[autodoc]] ContinuousBatchingConfig
+    - __call__


### PR DESCRIPTION
updates the continuous batching docs

- new page for the API reference
- adds sections for new features like CUDA graphs, async batching, prefix caching, logprobs (depending on when its merged)
- clearer example of generation with varying loads using `continuous_batching_context_manager`
- new page explaining how the system works underneath. it explains the scheduling half of the system, but doesn't cover the memory side yet. i'm thinking it may make more sense to move the [paged attention](https://huggingface.co/docs/transformers/main/en/paged_attention) doc in here to fill the gap. what do you think @remi-or ?