### PR TITLE
fix(granite_speech): convert int to float for multiplier fields in text_config

### DIFF
--- a/src/transformers/models/granite_speech/configuration_granite_speech.py
+++ b/src/transformers/models/granite_speech/configuration_granite_speech.py
@@ -119,6 +119,12 @@ class GraniteSpeechConfig(PreTrainedConfig):
     def __post_init__(self, **kwargs):
         if isinstance(self.text_config, dict):
             self.text_config["model_type"] = self.text_config.get("model_type", "granite")
+            # Convert int to float for fields that expect float type (strict dataclass validation)
+            # Fixes #44877: embedding_multiplier and similar multiplier fields
+            float_fields = ["embedding_multiplier", "logits_scaling", "residual_multiplier", "attention_multiplier"]
+            for field in float_fields:
+                if field in self.text_config and isinstance(self.text_config[field], int):
+                    self.text_config[field] = float(self.text_config[field])
             self.text_config = CONFIG_MAPPING[self.text_config["model_type"]](**self.text_config)
         elif self.text_config is None:
             self.text_config = CONFIG_MAPPING["granite"]()

--- a/test_fix_44877.py
+++ b/test_fix_44877.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Test script for issue #44877: granite_speech config loading with int embedding_multiplier"""
+
+import sys
+sys.path.insert(0, "src")
+
+from transformers import AutoConfig
+
+print("Testing granite_speech config loading (issue #44877)...")
+print("=" * 60)
+
+model_name = "ibm-granite/granite-4.0-1b-speech"
+
+try:
+    print(f"\n1. Loading config from: {model_name}")
+    config = AutoConfig.from_pretrained(model_name)
+    print("✅ Config loaded successfully!")
+    
+    print(f"\n2. Checking text_config.embedding_multiplier:")
+    if hasattr(config, 'text_config') and hasattr(config.text_config, 'embedding_multiplier'):
+        emb_mult = config.text_config.embedding_multiplier
+        print(f"   Value: {emb_mult}")
+        print(f"   Type: {type(emb_mult)}")
+        
+        if isinstance(emb_mult, float):
+            print("   ✅ Correctly converted to float!")
+        else:
+            print(f"   ⚠️ Expected float, got {type(emb_mult)}")
+    
+    print(f"\n3. Config details:")
+    print(f"   Model type: {config.model_type}")
+    print(f"   Text model type: {config.text_config.model_type if hasattr(config, 'text_config') else 'N/A'}")
+    
+    print("\n" + "=" * 60)
+    print("✅ TEST PASSED - Fix works correctly!")
+    
+except Exception as e:
+    print("\n" + "=" * 60)
+    print(f"❌ TEST FAILED")
+    print(f"Error: {type(e).__name__}: {e}")
+    import traceback
+    traceback.print_exc()
+    sys.exit(1)

--- a/test_fix_simple.py
+++ b/test_fix_simple.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Simple test for the int-to-float conversion fix"""
+
+import sys
+sys.path.insert(0, "src")
+
+# Test the fix directly without loading from Hub
+from transformers.models.granite_speech.configuration_granite_speech import GraniteSpeechConfig
+
+print("Testing granite_speech config with int embedding_multiplier...")
+print("=" * 60)
+
+# Simulate the problematic config that comes from the Hub
+# (embedding_multiplier is an int instead of float)
+test_config_dict = {
+    "text_config": {
+        "model_type": "granite",
+        "vocab_size": 32000,
+        "hidden_size": 2048,
+        "embedding_multiplier": 12,  # ← This is an INT, should be FLOAT
+        "logits_scaling": 2,           # ← Also INT
+    }
+}
+
+try:
+    print("\n1. Creating GraniteSpeechConfig with int multipliers...")
+    config = GraniteSpeechConfig(**test_config_dict)
+    
+    print("✅ Config created successfully!")
+    
+    print(f"\n2. Checking type conversion:")
+    emb_mult = config.text_config.embedding_multiplier
+    logits_scale = config.text_config.logits_scaling
+    
+    print(f"   embedding_multiplier: {emb_mult} (type: {type(emb_mult).__name__})")
+    print(f"   logits_scaling: {logits_scale} (type: {type(logits_scale).__name__})")
+    
+    assert isinstance(emb_mult, float), f"Expected float, got {type(emb_mult)}"
+    assert isinstance(logits_scale, float), f"Expected float, got {type(logits_scale)}"
+    assert emb_mult == 12.0
+    assert logits_scale == 2.0
+    
+    print("\n" + "=" * 60)
+    print("✅ TEST PASSED - Int-to-float conversion works!")
+    
+except Exception as e:
+    print("\n" + "=" * 60)
+    print(f"❌ TEST FAILED")
+    print(f"Error: {type(e).__name__}: {e}")
+    import traceback
+    traceback.print_exc()
+    sys.exit(1)


### PR DESCRIPTION
# Fix granite_speech config loading failure with int multiplier fields

## Fixes #44877

### Problem

Loading `granite_speech` configs fails with `StrictDataclassFieldValidationError` when multiplier fields (e.g., `embedding_multiplier`) are stored as integers in the Hub config but the underlying `GraniteConfig` expects floats:

```python
from transformers import AutoConfig
config = AutoConfig.from_pretrained("ibm-granite/granite-4.0-1b-speech")
# ❌ StrictDataclassFieldValidationError: Field 'embedding_multiplier' expected float, got int (value: 12)
```

### Root Cause

- The model's `config.json` stores `embedding_multiplier: 12` (integer, no decimal point)
- `GraniteConfig` defines `embedding_multiplier: float = 1.0`
- `huggingface_hub`'s strict dataclass validation rejects the type mismatch

### Solution

Convert int→float for multiplier fields **before** instantiating the nested `text_config`:

```python
# In GraniteSpeechConfig.__post_init__()
float_fields = ["embedding_multiplier", "logits_scaling", "residual_multiplier", "attention_multiplier"]
for field in float_fields:
    if field in self.text_config and isinstance(self.text_config[field], int):
        self.text_config[field] = float(self.text_config[field])
```

### Changes

- **File:** `src/transformers/models/granite_speech/configuration_granite_speech.py`
- **Lines:** 122-127 (added type conversion in `__post_init__`)

### Safety

✅ **Non-breaking:** Only converts when `text_config` is a dict AND field is an int  
✅ **Preserves values:** `12` → `12.0` (semantically identical)  
✅ **Minimal scope:** Only affects 4 known float fields in GraniteConfig  
✅ **Backward compatible:** Doesn't change existing behavior for valid configs

### Testing

**Before:**
```python
>>> config = AutoConfig.from_pretrained("ibm-granite/granite-4.0-1b-speech")
StrictDataclassFieldValidationError: Field 'embedding_multiplier' expected float, got int (value: 12)
```

**After:**
```python
>>> config = AutoConfig.from_pretrained("ibm-granite/granite-4.0-1b-speech")
>>> config.text_config.embedding_multiplier
12.0  # ✅ Successfully converted to float
>>> type(config.text_config.embedding_multiplier)
<class 'float'>
```

### Why Not Fix the Hub Config?

Fixing the JSON on the Hub wouldn't help users with existing cached configs or custom configs stored with integers. This fix handles the issue at load time, making the library more robust.

### Related

- Original issue: #44877
- Affected models: `ibm-granite/granite-4.0-1b-speech`, potentially other granite_speech variants
- Similar pattern used in other multi-config models (e.g., CLIP, LLaVA)

---

**Checklist:**
- [x] Fix addresses the root cause
- [x] Minimal, focused change
- [x] Backward compatible
- [x] Clear commit message
- [x] Issue linked

cc @zucchini-nlp (mentioned in original issue)