### PR TITLE
Fix: Update optimization.py

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -1031,6 +1031,8 @@ def get_scheduler(
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
 
     if name == SchedulerType.INVERSE_SQRT:
+        if scheduler_specific_kwargs is None:
+            scheduler_specific_kwargs = {}
         scheduler_specific_kwargs.pop("num_training_steps", None)
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
 

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -1031,7 +1031,7 @@ def get_scheduler(
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
 
     if name == SchedulerType.INVERSE_SQRT:
-        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
+        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
 
     # wsd scheduler requires either num_training_steps or num_stable_steps
     if name == SchedulerType.WARMUP_STABLE_DECAY:

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -1031,6 +1031,7 @@ def get_scheduler(
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
 
     if name == SchedulerType.INVERSE_SQRT:
+        scheduler_specific_kwargs.pop("num_training_steps", None)
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
 
     # wsd scheduler requires either num_training_steps or num_stable_steps

--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -1031,9 +1031,6 @@ def get_scheduler(
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
 
     if name == SchedulerType.INVERSE_SQRT:
-        if scheduler_specific_kwargs is None:
-            scheduler_specific_kwargs = {}
-        scheduler_specific_kwargs.pop("num_training_steps", None)
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
 
     # wsd scheduler requires either num_training_steps or num_stable_steps


### PR DESCRIPTION
The `get_scheduler` function was identifying the `inverse_sqrt` scheduler type but failing to pass `**scheduler_specific_kwargs` to the underlying `get_inverse_sqrt_schedule` function. 

This caused user-defined parameters like `timescale` to be silently ignored. This commit adds the missing kwargs to the function call at line 664.

Fixes #44908
