### PR TITLE
Fix flash attention crash with 3D position_ids (Qwen3.5)

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -516,6 +516,10 @@ def _is_packed_sequence(position_ids, batch_size):
         1. Position ids exist
         2. Flattened sequences only are supported
         3. Compile-friendly `not (torch.diff(position_ids, dim=-1) >= 0).all()`, i.e. we have multiple increasing sequences
+    Note: Multi-dimensional position_ids (e.g. 3D for multi-dim RoPE in Qwen3.5) are handled by extracting
+    the temporal dimension before checking. See https://github.com/huggingface/transformers/issues/44910
+    and https://github.com/QwenLM/Qwen3.5/issues/104 (fix by @ouroborosscr, @JJJYmmm).
+
     """
     if position_ids is None:
         return False

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -519,13 +519,11 @@ def _is_packed_sequence(position_ids, batch_size):
     """
     if position_ids is None:
         return False
-    if position_ids.dim() > 2:
-        return False
-
-    increasing_position_sequences = (
-        torch.arange(position_ids.shape[1], device=position_ids.device) + position_ids.min()
-    )
-    return batch_size == 1 and (increasing_position_sequences - position_ids).abs().sum().bool()
+    
+    # Extract the temporal dimension to support multi-dimensional RoPE
+    t_position_ids = position_ids[0] if position_ids.dim() > 2 else position_ids
+    
+    return batch_size == 1 and (t_position_ids[:, 1:] - t_position_ids[:, :-1] < 0).sum().bool()
 
 
 def fa_peft_integration_check(

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -519,6 +519,8 @@ def _is_packed_sequence(position_ids, batch_size):
     """
     if position_ids is None:
         return False
+    if position_ids.dim() > 2:
+        return False
 
     increasing_position_sequences = (
         torch.arange(position_ids.shape[1], device=position_ids.device) + position_ids.min()

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -519,10 +519,10 @@ def _is_packed_sequence(position_ids, batch_size):
     """
     if position_ids is None:
         return False
-    
+
     # Extract the temporal dimension to support multi-dimensional RoPE
     t_position_ids = position_ids[0] if position_ids.dim() > 2 else position_ids
-    
+
     return batch_size == 1 and (t_position_ids[:, 1:] - t_position_ids[:, :-1] < 0).sum().bool()
 
 


### PR DESCRIPTION
Qwen3.5 uses 3D position_ids [3, batch, seq_len] for multi-dimensional rotary embedding. _is_packed_sequence() misinterprets this as a packed sequence, causing cu_seqlens to be constructed with 3x the actual token count. Flash attention then reads beyond tensor boundaries, resulting in CUDA illegal memory access.

Add a dimensionality check to reject >2D position_ids, since packed sequences always use 2D [batch, seq_len] format.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Qwen3.5 uses a hybrid architecture (GatedDeltaNet + standard attention) with **3D `position_ids`** of shape `[3, batch_size, seq_len]` for multi-dimensional rotary embedding. The function `_is_packed_sequence()` in `modeling_flash_attention_utils.py` does not handle >2D tensors, causing it to misidentify the input as a packed sequence. This leads to `cu_seqlens` being constructed with 3× the actual token count, and `flash_attn_varlen_func` reads beyond tensor boundaries, resulting in `CUDA error: illegal memory access`.

**The fix**: Add `if position_ids.dim() > 2: return False` at the top of `_is_packed_sequence()`, since packed sequences always use 2D `[batch, seq_len]` position_ids.

**Intercepted evidence before crash**:

```
q: torch.Size([256, 16, 256])           ← 256 tokens
cu_seqlens_q: tensor([0, 256, 512, 768]) ← claims 768 tokens (3×256)
q total=256 vs cu_seqlens_q[-1]=768      ← MISMATCH → illegal memory access
```

Fixes #44910


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [[contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [[forum](https://discuss.huggingface.co/)](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [[documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs)](https://github.com/huggingface/transformers/tree/main/docs), and [[here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation)](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@vasqu @ArthurZucker @CyrilVallez (attention)

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
