### PR TITLE
fix: set `clean_up_tokenization_spaces=False` in Llama 3 tokenizer conversion

### DIFF
--- a/src/transformers/models/llama/convert_llama_weights_to_hf.py
+++ b/src/transformers/models/llama/convert_llama_weights_to_hf.py
@@ -465,7 +465,7 @@ class Llama3Converter(TikTokenConverter):
             eos_token="<|end_of_text|>" if not instruct else "<|eot_id|>",
             model_input_names=["input_ids", "attention_mask"],
             model_max_length=CONTEXT_LENGTH_FOR_VERSION[llama_version],
-            clean_up_tokenization_spaces=True,
+            clean_up_tokenization_spaces=False,
             **additional_kwargs,
         )
         self.update_post_processor(self.converted_tokenizer)


### PR DESCRIPTION
## What does this PR do?

The `Llama3Converter` in `convert_llama_weights_to_hf.py` hardcodes `clean_up_tokenization_spaces=True` (line 468). This causes `tokenizer.decode()` to silently strip spaces before punctuation for all converted Llama 3 models, producing incorrect decoded text.

`clean_up_tokenization_spaces` applies BERT-era string replacements (` .` → `.`, ` ?` → `?`, etc.) that are destructive for Llama 3's BPE tokenizer. Llama 2's `LlamaTokenizer` explicitly set this to `False`, and Llama 4 ships with `False`. The `True` was introduced in #30334 by inheriting the library default, then explicitly hardcoded in #33778 for backward compatibility.

### Minimal reproduction

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-3.1-8B-Instruct")
text = "x != y and a.b == c"
ids = tokenizer.encode(text, add_special_tokens=False)
print(repr(tokenizer.decode(ids)))
# 'x!= y and a.b == c'  ← space before != silently dropped
print(repr(tokenizer.decode(ids, clean_up_tokenization_spaces=False)))
# 'x != y and a.b == c'  ← correct
```

Tested across every version of `transformers` from 4.40.0 through 5.3.0 — all produce incorrect decoded text.

Companion fix PRs have been opened on all 24 affected `meta-llama` model repos on the Hub: [Llama-3.1-8B-Instruct discussion #356](https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/discussions/356).

Fixes #35175
Fixes #31187

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. — #35175, #31187, #32575
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @itazap — tokenizer maintainers. Arthur previously acknowledged this should be `False` in #35175.