### PR TITLE
fix: avoid unconditional model_info call in _patch_mistral_regex

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1268,7 +1268,9 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                     return True
             return False
 
-        if is_offline_mode():
+        if is_offline_mode() or local_files_only or (
+            pretrained_model_name_or_path is not None and os.path.isdir(pretrained_model_name_or_path)
+        ):
             is_local = True
 
         if pretrained_model_name_or_path is not None and (


### PR DESCRIPTION
Addresses issue #44843. Verified with isolated repro logic.

Changes made: Updated the logic to properly identify local and offline scenarios upfront. Now, is_local is correctly set to True if:

1. is_offline_mode() is active.
2. The local_files_only flag is True.
3. The provided path is a local directory (os.path.isdir).