### PR TITLE
Fix backward compatibility for full path imports of Fast Image Processors

### DIFF
--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -828,10 +828,21 @@ else:
         _target = f".models.{_model}.{_module}"
         _create_module_alias(f"{__name__}.models.{_model}.{_module}_fast", _target)
         # Also map XImageProcessorFast -> XImageProcessor for backward compat with old class names.
-        sys.modules[f"{__name__}.models.{_model}.{_module}_fast"].__getattr__ = lambda name, t=_target: getattr(
-            importlib.import_module(t, __name__), name.removesuffix("Fast")
-        )
+        def getattr_factory(target):
+            def _getattr(name):
+                new_name = name.removesuffix("Fast")
+                logger.warning(
+                    "Accessing `%s` from `%s`. Returning `%s` instead. Behavior may be "
+                    "different and this alias will be removed in future versions.",
+                    name,
+                    target,
+                    new_name,
+                )
+                return getattr(importlib.import_module(target, __name__), new_name)
 
+            return _getattr
+
+        sys.modules[f"{__name__}.models.{_model}.{_module}_fast"].__getattr__ = getattr_factory(_target)
 
 if not is_torch_available():
     logger.warning_advice(

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -827,6 +827,7 @@ else:
         _module = _proc_file.stem
         _target = f".models.{_model}.{_module}"
         _create_module_alias(f"{__name__}.models.{_model}.{_module}_fast", _target)
+
         # Also map XImageProcessorFast -> XImageProcessor for backward compat with old class names.
         def getattr_factory(target):
             def _getattr(name):

--- a/src/transformers/__init__.py
+++ b/src/transformers/__init__.py
@@ -822,6 +822,16 @@ else:
     _create_module_alias(f"{__name__}.tokenization_utils", ".tokenization_utils_sentencepiece")
     _create_module_alias(f"{__name__}.image_processing_utils_fast", ".image_processing_backends")
 
+    for _proc_file in sorted((Path(__file__).parent / "models").rglob("image_processing_*.py")):
+        _model = _proc_file.parent.name
+        _module = _proc_file.stem
+        _target = f".models.{_model}.{_module}"
+        _create_module_alias(f"{__name__}.models.{_model}.{_module}_fast", _target)
+        # Also map XImageProcessorFast -> XImageProcessor for backward compat with old class names.
+        sys.modules[f"{__name__}.models.{_model}.{_module}_fast"].__getattr__ = lambda name, t=_target: getattr(
+            importlib.import_module(t, __name__), name.removesuffix("Fast")
+        )
+
 
 if not is_torch_available():
     logger.warning_advice(

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -1191,6 +1191,9 @@ def ignore_undocumented(name: str) -> bool:
     # BLT models are internal building blocks, tested implicitly through BltForCausalLM
     if name.startswith("Blt"):
         return True
+    # image_processing_*_fast are backward-compat module aliases, not public objects.
+    if name.startswith("image_processing_") and name.endswith("_fast"):
+        return True
     if name in SHOULD_HAVE_THEIR_OWN_PAGE:
         return True
     return False


### PR DESCRIPTION
# What does this PR do?

Solve import errors when trying to import `from transformers.models.llama4.image_processing_llama4_fast import Llama4ImageProcessorFast` for example