### PR TITLE
fix: improve processor loading performance by avoiding redundant tokenizer parsing

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -123,19 +123,23 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
             # Build a minimal tokenizer (empty vocab/merges) to cheaply extract post_processor,
             # padding and truncation as Rust objects — avoids parsing the full vocab via from_file.
-            minimal_tokenizer_json = dict(tokenizer_json)
-            minimal_model = dict(tokenizer_json["model"])
-            model_type = minimal_model["type"]
-            if model_type == "BPE":
-                minimal_model["vocab"] = {}
-                minimal_model["merges"] = []
-            elif model_type in ("WordPiece", "WordLevel"):
-                minimal_model["vocab"] = {}
-            elif model_type == "Unigram":
-                minimal_model["vocab"] = []
-            minimal_tokenizer_json["model"] = minimal_model
-            minimal_tokenizer_json["added_tokens"] = []
-            tok_from_file = TokenizerFast.from_str(json.dumps(minimal_tokenizer_json))
+            # Fall back to from_file if the model type is missing (older tokenizer.json formats).
+            model_type = tokenizer_json.get("model", {}).get("type")
+            if model_type is not None:
+                minimal_tokenizer_json = dict(tokenizer_json)
+                minimal_model = dict(tokenizer_json["model"])
+                if model_type == "BPE":
+                    minimal_model["vocab"] = {}
+                    minimal_model["merges"] = []
+                elif model_type in ("WordPiece", "WordLevel"):
+                    minimal_model["vocab"] = {}
+                elif model_type == "Unigram":
+                    minimal_model["vocab"] = []
+                minimal_tokenizer_json["model"] = minimal_model
+                minimal_tokenizer_json["added_tokens"] = []
+                tok_from_file = TokenizerFast.from_str(json.dumps(minimal_tokenizer_json))
+            else:
+                tok_from_file = TokenizerFast.from_file(fast_tokenizer_file)
 
             local_kwargs["post_processor"] = tok_from_file.post_processor
             local_kwargs["tokenizer_padding"] = tok_from_file.padding

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -132,7 +132,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             #   "type" field in the "model" section, so we cannot determine the model type from JSON.
             # In both cases we fall back to the original from_file path (no performance improvement).
             model_type = tokenizer_json.get("model", {}).get("type")
-            if model_type != "Unigram":
+            if model_type not in (None, "Unigram"):
                 minimal_tokenizer_json = dict(tokenizer_json)
                 minimal_model = dict(tokenizer_json["model"])
                 minimal_model["vocab"] = {}

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -123,8 +123,14 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
             # Build a minimal tokenizer (empty vocab/merges) to cheaply extract post_processor,
             # padding and truncation as Rust objects — avoids parsing the full vocab via from_file.
-            # Only applies to BPE/WordPiece/WordLevel; fall back to from_file for Unigram (requires
-            # non-empty vocab) and for older tokenizer.json formats that omit the "type" field.
+            # This optimization applies to BPE, WordPiece, and WordLevel only:
+            # - Unigram (SentencePiece) requires a non-empty vocab to initialize correctly in Rust
+            #   (e.g. AlbertTokenizer, CamembertTokenizer, LlamaTokenizer, T5Tokenizer); passing an
+            #   empty vocab causes "Unable to load vocab EmptyVocabulary". TODO: investigate if keeping
+            #   just the UNK token is sufficient to make Unigram work with a minimal vocab.
+            # - Older tokenizer.json formats (e.g. XLNetTokenizer, DistilBertTokenizer) omit the
+            #   "type" field in the "model" section, so we cannot determine the model type from JSON.
+            # In both cases we fall back to the original from_file path (no performance improvement).
             model_type = tokenizer_json.get("model", {}).get("type")
             if model_type in ("BPE", "WordPiece", "WordLevel"):
                 minimal_tokenizer_json = dict(tokenizer_json)

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -132,14 +132,12 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             #   "type" field in the "model" section, so we cannot determine the model type from JSON.
             # In both cases we fall back to the original from_file path (no performance improvement).
             model_type = tokenizer_json.get("model", {}).get("type")
-            if model_type in ("BPE", "WordPiece", "WordLevel"):
+            if model_type != "Unigram":
                 minimal_tokenizer_json = dict(tokenizer_json)
                 minimal_model = dict(tokenizer_json["model"])
+                minimal_model["vocab"] = {}
                 if model_type == "BPE":
-                    minimal_model["vocab"] = {}
                     minimal_model["merges"] = []
-                else:
-                    minimal_model["vocab"] = {}
                 minimal_tokenizer_json["model"] = minimal_model
                 minimal_tokenizer_json["added_tokens"] = []
                 tok_from_file = TokenizerFast.from_str(json.dumps(minimal_tokenizer_json))

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -123,18 +123,17 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
             # Build a minimal tokenizer (empty vocab/merges) to cheaply extract post_processor,
             # padding and truncation as Rust objects — avoids parsing the full vocab via from_file.
-            # Fall back to from_file if the model type is missing (older tokenizer.json formats).
+            # Only applies to BPE/WordPiece/WordLevel; fall back to from_file for Unigram (requires
+            # non-empty vocab) and for older tokenizer.json formats that omit the "type" field.
             model_type = tokenizer_json.get("model", {}).get("type")
-            if model_type is not None:
+            if model_type in ("BPE", "WordPiece", "WordLevel"):
                 minimal_tokenizer_json = dict(tokenizer_json)
                 minimal_model = dict(tokenizer_json["model"])
                 if model_type == "BPE":
                     minimal_model["vocab"] = {}
                     minimal_model["merges"] = []
-                elif model_type in ("WordPiece", "WordLevel"):
+                else:
                     minimal_model["vocab"] = {}
-                elif model_type == "Unigram":
-                    minimal_model["vocab"] = []
                 minimal_tokenizer_json["model"] = minimal_model
                 minimal_tokenizer_json["added_tokens"] = []
                 tok_from_file = TokenizerFast.from_str(json.dumps(minimal_tokenizer_json))

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -118,7 +118,25 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         elif fast_tokenizer_file is not None and os.path.isfile(fast_tokenizer_file):
             # we extract vocab/merges and pass decoder/pre_tokenizer/post_processor
             # from the file so the reconstructed tokenizer matches the tokenizer.json
-            tok_from_file = TokenizerFast.from_file(fast_tokenizer_file)
+            with open(fast_tokenizer_file, encoding="utf-8") as tokenizer_handle:
+                tokenizer_json = json.load(tokenizer_handle)
+
+            # Build a minimal tokenizer (empty vocab/merges) to cheaply extract post_processor,
+            # padding and truncation as Rust objects — avoids parsing the full vocab via from_file.
+            minimal_tokenizer_json = dict(tokenizer_json)
+            minimal_model = dict(tokenizer_json["model"])
+            model_type = minimal_model["type"]
+            if model_type == "BPE":
+                minimal_model["vocab"] = {}
+                minimal_model["merges"] = []
+            elif model_type in ("WordPiece", "WordLevel"):
+                minimal_model["vocab"] = {}
+            elif model_type == "Unigram":
+                minimal_model["vocab"] = []
+            minimal_tokenizer_json["model"] = minimal_model
+            minimal_tokenizer_json["added_tokens"] = []
+            tok_from_file = TokenizerFast.from_str(json.dumps(minimal_tokenizer_json))
+
             local_kwargs["post_processor"] = tok_from_file.post_processor
             local_kwargs["tokenizer_padding"] = tok_from_file.padding
             local_kwargs["tokenizer_truncation"] = tok_from_file.truncation
@@ -129,9 +147,6 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 local_kwargs["_json_truncation"] = tok_from_file.truncation
             if tok_from_file.padding is not None:
                 local_kwargs["_json_padding"] = tok_from_file.padding
-
-            with open(fast_tokenizer_file, encoding="utf-8") as tokenizer_handle:
-                tokenizer_json = json.load(tokenizer_handle)
 
             # Extract precompiled SentencePiece charsmap from tokenizer.json normalizer
             # when present (e.g. T5 tokenizers converted with SentencePiece >= 2.x).


### PR DESCRIPTION
## Problem

In `TokenizersBackend.convert_to_native_format()`, when a tokenizer has a custom `__init__` (the `elif` branch), `tokenizer.json` was parsed **twice**:

1. `TokenizerFast.from_file(fast_tokenizer_file)` — full Rust parse including the entire vocab (~0.6s for large tokenizers like `CohereTokenizer` with 256k entries) — used only to extract `post_processor`, `padding`, `truncation`
2. `json.load(tokenizer_handle)` — Python parse of the **same file** — to extract `vocab` and `merges`

## Fix

Read the file once with `json.load`, then build a minimal tokenizer (same structure but empty vocab/merges) via `TokenizerFast.from_str` to cheaply obtain the Rust `post_processor`/`padding`/`truncation` objects — without parsing the full vocab.

## Benchmark

Measured over **300 runs** of `AyaVisionProcessor.from_pretrained("local")` (`AyaVisionProcessor` uses `CohereTokenizer` which has a custom `__init__`):

```
With fix    : avg=1.151s  min=0.987s  max=1.422s
Without fix : avg=1.545s  min=1.311s  max=2.513s
Speedup     : 1.34x  (~0.4s saved per load on average)
```