### PR TITLE
fix(camembert): add tie_word_embeddings=True to CamembertConfig

### DIFF
--- a/src/transformers/models/camembert/configuration_camembert.py
+++ b/src/transformers/models/camembert/configuration_camembert.py
@@ -60,6 +60,7 @@ class CamembertConfig(PreTrainedConfig):
     classifier_dropout: float | int | None = None
     is_decoder: bool = False
     add_cross_attention: bool = False
+    tie_word_embeddings: bool = True
 
 
 __all__ = ["CamembertConfig"]


### PR DESCRIPTION
## What does this PR do?

Fixes a v5 regression where `CamembertForMaskedLM` (and all CamemBERT masked-LM tasks) produces near-zero, near-uniform logits, making the model completely non-functional.

### Root cause

In v5, `modeling_utils.get_expanded_tied_weights_keys()` gates all weight tying on `config.tie_word_embeddings`:

```python
tie_word_embeddings = getattr(self.config, "tie_word_embeddings", False)
if not tie_word_embeddings:
    return {}   # <-- skips ALL tying when attribute is missing
```

`CamembertConfig` was missing `tie_word_embeddings: bool = True`, so the method returned `{}` and `lm_head.decoder.weight` was randomly initialized instead of being tied to `roberta.embeddings.word_embeddings.weight`.

Sibling configs `RobertaConfig` and `BertConfig` already declare `tie_word_embeddings: bool = True`. CamemBERT is RoBERTa-based and its modeling code already defines `_tied_weights_keys` mapping `lm_head.decoder.weight → roberta.embeddings.word_embeddings.weight` — but that mapping was silently ignored.

### Before fix (transformers v5.3.0)

```python
>>> pipeline("fill-mask", model="camembert-base")("Le camembert est un délicieux fromage <mask>.")
# score=0.000108  totalité    ← near-uniform logits (broken)
# score=0.000106  Mat
# score=0.000104  Populaire
```

The LOAD REPORT also showed `lm_head.decoder.weight: MISSING` (randomly initialized).

### After fix

```python
>>> pipeline("fill-mask", model="camembert-base")("Le camembert est un délicieux fromage <mask>.")
# score=0.1819  suisse    ← matches v4 exactly ✅
# score=0.0937  français
# score=0.0495  italien
```

### Change

One line added to `CamembertConfig`:

```python
tie_word_embeddings: bool = True
```

Fixes #44671

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [x] Was this discussed/approved via a Github issue? #44671
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @Cyrilvallez
