### PR TITLE
Fix: Pass scheduler_specific_kwargs to inverse_sqrt scheduler

### DIFF
--- a/src/transformers/optimization.py
+++ b/src/transformers/optimization.py
@@ -1031,7 +1031,7 @@ def get_scheduler(
         return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
 
     if name == SchedulerType.INVERSE_SQRT:
-        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
+        return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
 
     # wsd scheduler requires either num_training_steps or num_stable_steps
     if name == SchedulerType.WARMUP_STABLE_DECAY:


### PR DESCRIPTION
## What does this PR do?

Fixes #44908

The `get_inverse_sqrt_schedule` function accepts `timescale` and `last_epoch` parameters, but `get_scheduler` was not forwarding `scheduler_specific_kwargs` to it. This caused user-provided kwargs like `timescale` to be silently ignored.

## Before/After

**Before:**
```python
if name == SchedulerType.INVERSE_SQRT:
    return schedule_func(optimizer, num_warmup_steps=num_warmup_steps)
```

**After:**
```python
if name == SchedulerType.INVERSE_SQRT:
    return schedule_func(optimizer, num_warmup_steps=num_warmup_steps, **scheduler_specific_kwargs)
```

## How to reproduce

Trigger a training job with `lr_scheduler_type="inverse_sqrt"` and set `lr_scheduler_kwargs={"timescale": 100}`. Before this fix, `timescale` is silently ignored and defaults to `num_warmup_steps`. After this fix, the user-provided `timescale` takes effect.
