### PR TITLE
Fix variable shadowing in pipeline example and typo in BART docs (BERT → BART)

### DIFF
--- a/docs/source/en/model_doc/bart.md
+++ b/docs/source/en/model_doc/bart.md
@@ -37,7 +37,7 @@ The example below demonstrates how to predict the `[MASK]` token with [`Pipeline
 import torch
 from transformers import pipeline
 
-pipeline = pipeline(
+fill_mask_pipeline = pipeline(
     task="fill-mask",
     model="facebook/bart-large",
     dtype=torch.float16,
@@ -81,7 +81,7 @@ print(f"The predicted token is: {predicted_token}")
 
 ## Notes
 
-- Inputs should be padded on the right because BERT uses absolute position embeddings.
+- Inputs should be padded on the right because BART uses absolute position embeddings.
 - The [facebook/bart-large-cnn](https://huggingface.co/facebook/bart-large-cnn) checkpoint doesn't include `mask_token_id` which means it can't perform mask-filling tasks.
 - BART doesn't use `token_type_ids` for sequence classification. Use [`BartTokenizer`] or [`~PreTrainedTokenizerBase.encode`] to get the proper splitting.
 - The forward pass of [`BartModel`] creates the `decoder_input_ids` if they're not passed. This can be different from other model APIs, but it is a useful feature for mask-filling tasks.


### PR DESCRIPTION
## What does this PR do?

Fixes two small but impactful bugs in the BART documentation:

1. **Variable shadowing bug**: In the Pipeline example, the variable 
   was named `pipeline` which shadows the imported `pipeline` function. 
   Renamed to `fill_mask_pipeline` to avoid confusion and potential errors.

2. **Typo in Notes**: "BERT uses absolute position embeddings" 
   should be "BART uses absolute position embeddings".

## Before / After

# Before:
`pipeline = pipeline(task="fill-mask", ...)`
`"because BERT uses absolute position embeddings"`

# After:
`fill_mask_pipeline = pipeline(task="fill-mask", ...)`
`"because BART uses absolute position embeddings"`

## Related Issue
N/A - documentation fix

## Testing
Manually verified the corrected code runs without variable shadowing issues.