### PR TITLE
Fix failing job `Update Transformers metadata` after #43514

### DIFF
--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - fix_minor_failing_job
+      - update_transformers_metadata*
 
 jobs:
   build_and_package:

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - update_transformers_metadata*
+      - fix_minor_failing_job
 
 jobs:
   build_and_package:

--- a/src/transformers/video_processing_utils.py
+++ b/src/transformers/video_processing_utils.py
@@ -28,8 +28,8 @@ from .image_processing_backends import TorchvisionBackend
 from .image_processing_utils import BatchFeature
 from .image_utils import (
     ChannelDimension,
-    PILImageResampling,
     SizeDict,
+    is_vision_available,
     validate_kwargs,
 )
 from .processing_utils import Unpack, VideosKwargs
@@ -66,6 +66,9 @@ if is_torch_available():
 
 if is_torchvision_v2_available():
     import torchvision.transforms.v2.functional as tvF
+
+if is_vision_available():
+    from .image_utils import PILImageResampling
 
 
 logger = logging.get_logger(__name__)


### PR DESCRIPTION
# What does this PR do?

Fix the failing job  after #43514

(the fix is effefctive, see [here](https://github.com/huggingface/transformers/actions/runs/23433395911/job/68165255513?pr=44941))

[Update Transformers metadata](https://github.com/huggingface/transformers/actions/workflows/update_metdata.yml)

https://github.com/huggingface/transformers/actions/runs/23300744413/job/67760811968

```bash
Run python utils/update_metadata.py --token *** --commit_sha 884333368ff329090c73bd00e57996727f301de3
Traceback (most recent call last):
  File "/home/runner/work/transformers/transformers/utils/update_metadata.py", line 347, in <module>
    update_metadata(args.token, args.commit_sha)
  File "/home/runner/work/transformers/transformers/utils/update_metadata.py", line 238, in update_metadata
    frameworks_table = get_frameworks_table()
  File "/home/runner/work/transformers/transformers/utils/update_metadata.py", line 183, in get_frameworks_table
    if t in transformers_module.models.auto.processing_auto.PROCESSOR_MAPPING_NAMES:
  File "/home/runner/.local/lib/python3.10/site-packages/transformers/utils/import_utils.py", line 2254, in __getattr__
    value = self._get_module(name)
  File "/home/runner/.local/lib/python3.10/site-packages/transformers/utils/import_utils.py", line 2394, in _get_module
    raise e
  File "/home/runner/.local/lib/python3.10/site-packages/transformers/utils/import_utils.py", line 2392, in _get_module
    return importlib.import_module("." + module_name, self.__name__)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/runner/work/transformers/transformers/src/transformers/models/auto/processing_auto.py", line 30, in <module>
    from ...video_processing_utils import BaseVideoProcessor
  File "/home/runner/work/transformers/transformers/src/transformers/video_processing_utils.py", line 29, in <module>
    from .image_utils import (
ImportError: cannot import name 'PILImageResampling' from 'transformers.image_utils' (/home/runner/work/transformers/transformers/src/transformers/image_utils.py)
Error: Process completed with exit code 1.
```