### PR TITLE
Fix: NotebookProgressCallback crash when evaluating with the Trainer

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -106,6 +106,7 @@ from .utils import (
     is_hadamard_available,
     is_hqq_available,
     is_huggingface_hub_greater_or_equal,
+    is_ipython_available,
     is_jinja_available,
     is_jmespath_available,
     is_jumanpp_available,
@@ -1177,6 +1178,11 @@ def require_detectron2(test_case):
 def require_faiss(test_case):
     """Decorator marking a test that requires faiss."""
     return unittest.skipUnless(is_faiss_available(), "test requires `faiss`")(test_case)
+
+
+def require_ipython(test_case):
+    """Decorator marking a test that requires IPython. These tests are skipped when IPython isn't installed."""
+    return unittest.skipUnless(is_ipython_available(), "test requires `IPython`")(test_case)
 
 
 def require_optuna(test_case):

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -150,6 +150,7 @@ from .import_utils import (
     is_hqq_available,
     is_huggingface_hub_greater_or_equal,
     is_in_notebook,
+    is_ipython_available,
     is_jinja_available,
     is_jmespath_available,
     is_jumanpp_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1541,6 +1541,11 @@ def torch_compilable_check(cond: Any, msg: str | Callable[[], str], error_type: 
 
 
 @lru_cache
+def is_ipython_available() -> bool:
+    return importlib.util.find_spec("IPython") is not None
+
+
+@lru_cache
 def is_in_notebook() -> bool:
     try:
         # Check if we are running inside Marimo

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -351,10 +351,7 @@ class NotebookProgressCallback(TrainerCallback):
             tt.write_line(values)
 
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):
-        if self.training_tracker is None:
-            return control
-
-        tt = self.training_tracker
+        self.first_column = "Epoch" if args.eval_strategy == IntervalStrategy.EPOCH else "Step"
 
         values = {"Training Loss": "No log", "Validation Loss": "No log"}
         for log in reversed(state.log_history):
@@ -384,11 +381,18 @@ class NotebookProgressCallback(TrainerCallback):
                 # Single dataset
                 name = "Validation Loss"
             values[name] = v
-        tt.write_line(values)
-        tt.remove_child()
+
+        if self.training_tracker is not None:
+            tt = self.training_tracker
+            tt.write_line(values)
+            tt.remove_child()
+            # Evaluation takes a long time so we should force the next update.
+            self._force_next_update = True
+        else:
+            # No training tracker, but still show the metrics
+            disp.display(disp.HTML(text_to_html_table([list(values.keys()), list(values.values())])))
+
         self.prediction_bar = None
-        # Evaluation takes a long time so we should force the next update.
-        self._force_next_update = True
 
     def on_train_end(self, args, state, control, **kwargs):
         tt = _require(self.training_tracker, "on_train_begin must be called before on_train_end")

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -351,6 +351,8 @@ class NotebookProgressCallback(TrainerCallback):
             tt.write_line(values)
 
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):
+        # Recompute first_column here since on_evaluate can be called before on_train_begin,
+        # where it is normally initialized.
         self.first_column = "Epoch" if args.eval_strategy == IntervalStrategy.EPOCH else "Step"
 
         values = {"Training Loss": "No log", "Validation Loss": "No log"}
@@ -374,6 +376,8 @@ class NotebookProgressCallback(TrainerCallback):
         _ = metrics.pop(f"{metric_key_prefix}_runtime", None)
         _ = metrics.pop(f"{metric_key_prefix}_samples_per_second", None)
         _ = metrics.pop(f"{metric_key_prefix}_steps_per_second", None)
+        _ = metrics.pop(f"{metric_key_prefix}_model_preparation_time", None)
+
         for k, v in metrics.items():
             splits = k.split("_")
             name = " ".join([part.capitalize() for part in splits[1:]])

--- a/src/transformers/utils/notebook.py
+++ b/src/transformers/utils/notebook.py
@@ -351,7 +351,10 @@ class NotebookProgressCallback(TrainerCallback):
             tt.write_line(values)
 
     def on_evaluate(self, args, state, control, metrics=None, **kwargs):
-        tt = _require(self.training_tracker, "on_train_begin must be called before on_evaluate")
+        if self.training_tracker is None:
+            return control
+
+        tt = self.training_tracker
 
         values = {"Training Loss": "No log", "Validation Loss": "No log"}
         for log in reversed(state.log_history):

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -23,6 +23,7 @@ This module tests:
 - Built-in callbacks (DefaultFlowCallback, EarlyStoppingCallback, etc.)
 """
 
+import importlib.util
 import os
 import shutil
 import tempfile
@@ -51,6 +52,9 @@ if is_torch_available():
     from transformers.trainer import DEFAULT_CALLBACKS, TRAINER_STATE_NAME
 
     from .trainer_test_utils import RegressionDataset, RegressionModelConfig, RegressionPreTrainedModel
+
+
+IPYTHON_AVAILABLE = importlib.util.find_spec("IPython") is not None
 
 
 # =============================================================================
@@ -1272,6 +1276,7 @@ class ExportableStateTest(unittest.TestCase):
 
 
 @require_torch
+@unittest.skipUnless(IPYTHON_AVAILABLE, "IPython is required for NotebookProgressCallback")
 class NotebookProgressCallbackTest(unittest.TestCase):
     """Tests for NotebookProgressCallback behavior in notebook environments."""
 

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -1269,3 +1269,74 @@ class ExportableStateTest(unittest.TestCase):
 
         self.assertEqual(instance.name, "test")
         self.assertEqual(instance.counter, 5)
+
+
+@require_torch
+class NotebookProgressCallbackTest(unittest.TestCase):
+    """Tests for NotebookProgressCallback behavior in notebook environments."""
+
+    def setUp(self):
+        self.output_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.output_dir)
+
+    def _create_trainer(self):
+        train_dataset = RegressionDataset(length=16)
+        eval_dataset = RegressionDataset(length=16)
+        config = RegressionModelConfig(a=0, b=0)
+        model = RegressionPreTrainedModel(config)
+
+        args = TrainingArguments(
+            self.output_dir,
+            per_device_train_batch_size=2,
+            per_device_eval_batch_size=2,
+            num_train_epochs=1,
+            logging_strategy="no",
+            report_to=[],
+            eval_strategy="epoch",
+            disable_tqdm=True,
+        )
+
+        from transformers.utils.notebook import NotebookProgressCallback
+
+        trainer = Trainer(
+            model=model,
+            args=args,
+            train_dataset=train_dataset,
+            eval_dataset=eval_dataset,
+            callbacks=[NotebookProgressCallback()],  # force it
+        )
+        return trainer
+
+    def test_evaluate_before_training(self):
+        """Calling evaluate() before training does not crash and returns metrics."""
+        trainer = self._create_trainer()
+        metrics = trainer.evaluate()
+        self.assertIn("eval_loss", metrics)
+        # Check that the notebook callback exists in callback handler
+        from transformers.utils.notebook import NotebookProgressCallback
+
+        cb = next(
+            (c for c in trainer.callback_handler.callbacks if isinstance(c, NotebookProgressCallback)),
+            None,
+        )
+        self.assertIsNotNone(cb)
+
+    def test_evaluate_after_training(self):
+        """Calling evaluate() after training does not crash and returns metrics."""
+        trainer = self._create_trainer()
+        trainer.train()
+        metrics = trainer.evaluate()
+        self.assertIn("eval_loss", metrics)
+
+    def test_multiple_evaluate_calls(self):
+        """Calling evaluate() multiple times in a row works in notebook environment."""
+        trainer = self._create_trainer()
+        metrics1 = trainer.evaluate()
+        trainer.train()
+        metrics2 = trainer.evaluate()
+        metrics3 = trainer.evaluate()
+        self.assertIn("eval_loss", metrics1)
+        self.assertIn("eval_loss", metrics2)
+        self.assertIn("eval_loss", metrics3)

--- a/tests/trainer/test_trainer_callback.py
+++ b/tests/trainer/test_trainer_callback.py
@@ -23,7 +23,6 @@ This module tests:
 - Built-in callbacks (DefaultFlowCallback, EarlyStoppingCallback, etc.)
 """
 
-import importlib.util
 import os
 import shutil
 import tempfile
@@ -44,7 +43,7 @@ from transformers import (
     is_torch_available,
 )
 from transformers.integrations.integration_utils import KubeflowCallback, SwanLabCallback
-from transformers.testing_utils import require_torch
+from transformers.testing_utils import require_ipython, require_torch
 from transformers.trainer_callback import CallbackHandler, ExportableState, TrainerControl
 
 
@@ -52,9 +51,6 @@ if is_torch_available():
     from transformers.trainer import DEFAULT_CALLBACKS, TRAINER_STATE_NAME
 
     from .trainer_test_utils import RegressionDataset, RegressionModelConfig, RegressionPreTrainedModel
-
-
-IPYTHON_AVAILABLE = importlib.util.find_spec("IPython") is not None
 
 
 # =============================================================================
@@ -1276,7 +1272,7 @@ class ExportableStateTest(unittest.TestCase):
 
 
 @require_torch
-@unittest.skipUnless(IPYTHON_AVAILABLE, "IPython is required for NotebookProgressCallback")
+@require_ipython
 class NotebookProgressCallbackTest(unittest.TestCase):
     """Tests for NotebookProgressCallback behavior in notebook environments."""
 


### PR DESCRIPTION
# What does this PR do?

Fixes #44936 

This PR fixes an issue with `NotebookProgressCallback` in the `Trainer` where calling evaluate() before or after training would crash due to the training tracker being `None`. The callback now properly handles evaluation even if training has not yet started or if it has already finished, ensuring metrics can be computed and displayed.

Previously, the `on_evaluate` method assumed that `self.training_tracker` was always initialized, but:
- Before training: `self.training_tracker` has not being initialised by `on_train_begin` yet.
- After training: `on_train_end` sets `self.training_tracker` to `None`, so calling `on_evaluate` afterwards would fail.

**Fix:** `on_evaluate` now checks whether self.training_tracker exists before using it, and safely handles cases where it is `None`. This prevents crashes and ensures evaluation can run regardless of training state.

Additionally, new unit tests were added to ensure that evaluation works in this scenario, and existing notebook callback tests were updated to cover this case. This improves robustness of notebook-based workflows, especially in Jupyter or Colab environments.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?


## Who can review?

@SunMarc 

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.