### PR TITLE
Fix: Add correct return behaviour when output_hidden_states=True for CLIP and SIGLIP vision models

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -495,7 +495,7 @@ class CLIPEncoder(nn.Module):
                 [What are attention masks?](../glossary#attention-mask)
         """
         hidden_states = inputs_embeds
-        all_hidden_states = [hidden_states] if  self.config.output_hidden_states else None
+        all_hidden_states = [hidden_states] if self.config.output_hidden_states else None
         for encoder_layer in self.layers:
             hidden_states = encoder_layer(
                 hidden_states,
@@ -506,8 +506,7 @@ class CLIPEncoder(nn.Module):
                 all_hidden_states.append(hidden_states)
 
         return BaseModelOutput(
-            last_hidden_state=hidden_states,
-            hidden_states=tuple(all_hidden_states) if all_hidden_states else None
+            last_hidden_state=hidden_states, hidden_states=tuple(all_hidden_states) if all_hidden_states else None
         )
 
 

--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -495,15 +495,19 @@ class CLIPEncoder(nn.Module):
                 [What are attention masks?](../glossary#attention-mask)
         """
         hidden_states = inputs_embeds
+        all_hidden_states = [hidden_states] if  self.config.output_hidden_states else None
         for encoder_layer in self.layers:
             hidden_states = encoder_layer(
                 hidden_states,
                 attention_mask,
                 **kwargs,
             )
+            if all_hidden_states:
+                all_hidden_states.append(hidden_states)
 
         return BaseModelOutput(
             last_hidden_state=hidden_states,
+            hidden_states=tuple(all_hidden_states) if all_hidden_states else None
         )
 
 

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -460,7 +460,7 @@ class SiglipEncoder(nn.Module):
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutput:
         hidden_states = inputs_embeds
-        all_hidden_states = [hidden_states] if  self.config.output_hidden_states else None
+        all_hidden_states = [hidden_states] if self.config.output_hidden_states else None
         for encoder_layer in self.layers:
             hidden_states = encoder_layer(
                 hidden_states,
@@ -471,9 +471,8 @@ class SiglipEncoder(nn.Module):
                 all_hidden_states.append(hidden_states)
 
         return BaseModelOutput(
-            last_hidden_state=hidden_states,
-            hidden_states=tuple(all_hidden_states) if all_hidden_states else None
-            )
+            last_hidden_state=hidden_states, hidden_states=tuple(all_hidden_states) if all_hidden_states else None
+        )
 
 
 class SiglipTextTransformer(SiglipPreTrainedModel):

--- a/src/transformers/models/siglip/modeling_siglip.py
+++ b/src/transformers/models/siglip/modeling_siglip.py
@@ -460,14 +460,20 @@ class SiglipEncoder(nn.Module):
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutput:
         hidden_states = inputs_embeds
+        all_hidden_states = [hidden_states] if  self.config.output_hidden_states else None
         for encoder_layer in self.layers:
             hidden_states = encoder_layer(
                 hidden_states,
                 attention_mask,
                 **kwargs,
             )
+            if all_hidden_states:
+                all_hidden_states.append(hidden_states)
 
-        return BaseModelOutput(last_hidden_state=hidden_states)
+        return BaseModelOutput(
+            last_hidden_state=hidden_states,
+            hidden_states=tuple(all_hidden_states) if all_hidden_states else None
+            )
 
 
 class SiglipTextTransformer(SiglipPreTrainedModel):


### PR DESCRIPTION
# What does this PR do?

Fixes the non existence of output dictionary change, when parameter output_hidden_states=True is passed to models like CLIP or SigLip. This is especially pertinent for the vision model config. 

According to #42759 not sure what the behaviour should be for text model, it seems that the SiglipModel class does not successfully cascade this config to the vision and text model.

Reproduction Code
```python
import torch
from PIL import Image
import requests
from transformers import AutoProcessor, AutoModel, AutoConfig

model_id= "google/medsiglip-448"

model = AutoModel.from_pretrained(
    model_id, device_map=torch.device('cuda'),
    output_hidden_states=True, output_attentions=True)

processor = AutoProcessor.from_pretrained(model_id)

images = [Image.open(requests.get("http://images.cocodataset.org/val2017/000000039769.jpg", stream=True).raw)]
texts = ["a photo of 2 cats"]
inputs = processor(text=texts, images=images, padding="max_length", return_tensors="pt")

with torch.no_grad():
    outputs = model.get_image_features(**inputs)

print(len(outputs.hidden_states))  # 28 for MedSigLip
```

Fixes #42759 #43618 

# System Info
transformers 5.3.0
python 3.10.6

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

 @yonigozlan @zucchini-nlp
