### PR TITLE
Fix backward compatibility for CommonKwargs in processing_utils (brea…

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -418,6 +418,14 @@ class AudioKwargs(TypedDict, total=False):
     return_tensors: Annotated[str | TensorType | None, tensor_type_validator()]
 
 
+class CommonKwargs(TypedDict, total=False):
+    """
+    Backward-compatible common processor kwargs shared across modalities.
+    """
+
+    return_tensors: Annotated[str | TensorType | None, tensor_type_validator()]
+
+
 class ProcessingKwargs(TypedDict, total=False):
     """
     Base class for kwargs passing to processors.


### PR DESCRIPTION
Fixes #44964

## Summary
This PR restores backward compatibility for `CommonKwargs` in `transformers.processing_utils`, which is still referenced by some remote processor implementations.

## Problem
After the typed-dict cleanup (commit `5339f72b9b`), `CommonKwargs` is no longer exposed from `transformers.processing_utils`.

However, some remote code, for example `microsoft/Phi-4-multimodal-instruct` at `refs/pr/70`, still imports it:

```python
from transformers.processing_utils import CommonKwargs
```

This results in:

```python
ImportError: cannot import name 'CommonKwargs'
```

## Reproduction

```python
from transformers import AutoProcessor

AutoProcessor.from_pretrained(
    "microsoft/Phi-4-multimodal-instruct",
    revision="refs/pr/70",
    trust_remote_code=True,
)
```

- Before: `ImportError`
- After: loads successfully (`Phi4MultimodalProcessor`)

## Solution
Restore a minimal compatibility export for `CommonKwargs` in `processing_utils.py`.

This preserves existing remote code behavior without modifying core logic.

## Notes
- This is a backward compatibility fix for `trust_remote_code` workflows
- No changes to internal functionality
- Full integration test requires `torchcodec` + FFmpeg, which is unrelated to this issue
- AI assistance was used for diagnosis and drafting, but the change was reviewed and verified locally