### PR TITLE
bug-fix: do not assume torch.cuda is available when setting up norm values, even if flash linear attention is available

### DIFF
--- a/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
@@ -693,7 +693,7 @@ class OlmoHybridGatedDeltaNet(nn.Module):
         # Output norm - NOTE: FLA's FusedRMSNormGated uses eps=1e-5 by default
         self.o_norm = (
             OlmoHybridRMSNormGated(self.head_v_dim, eps=1e-5)
-            if FusedRMSNormGated is None
+            if FusedRMSNormGated is None or not torch.cuda.is_available()
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=1e-5,

--- a/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modular_olmo_hybrid.py
@@ -463,7 +463,7 @@ class OlmoHybridGatedDeltaNet(nn.Module):
         # Output norm - NOTE: FLA's FusedRMSNormGated uses eps=1e-5 by default
         self.o_norm = (
             OlmoHybridRMSNormGated(self.head_v_dim, eps=1e-5)
-            if FusedRMSNormGated is None
+            if FusedRMSNormGated is None or not torch.cuda.is_available()
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=1e-5,

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -479,7 +479,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
 
         self.norm = (
             Qwen3_5RMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
-            if FusedRMSNormGated is None
+            if FusedRMSNormGated is None or not torch.cuda.is_available()
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -480,7 +480,7 @@ class Qwen3_5MoeGatedDeltaNet(nn.Module):
 
         self.norm = (
             Qwen3_5MoeRMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
-            if FusedRMSNormGated is None
+            if FusedRMSNormGated is None or not torch.cuda.is_available()
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,

--- a/src/transformers/models/qwen3_next/modeling_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modeling_qwen3_next.py
@@ -625,7 +625,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
         self.norm = (
             Qwen3NextRMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
-            if FusedRMSNormGated is None
+            if FusedRMSNormGated is None or not torch.cuda.is_available()
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,

--- a/src/transformers/models/qwen3_next/modular_qwen3_next.py
+++ b/src/transformers/models/qwen3_next/modular_qwen3_next.py
@@ -464,7 +464,7 @@ class Qwen3NextGatedDeltaNet(nn.Module):
 
         self.norm = (
             Qwen3NextRMSNormGated(self.head_v_dim, eps=self.layer_norm_epsilon)
-            if FusedRMSNormGated is None
+            if FusedRMSNormGated is None or not torch.cuda.is_available()
             else FusedRMSNormGated(
                 self.head_v_dim,
                 eps=self.layer_norm_epsilon,


### PR DESCRIPTION
Pre-patch unnecessarily breaks merging a LoRA adapter with a model using CUDA_VISIBLE_DEVICES= e.g. when VRAM is insufficient. It also breaks non-cuda machine operations (such as merging).

# What does this PR do?

This PR un-breaks `CUDA_VISIBLE_DEVICES=` loading of models e.g. for the purposes of merging them with a LoRA adapter and saving to disk, without demanding that the entire model + LoRA fits in VRAM.

## Code Agent Policy

- [X] I confirm that this is not a pure code agent PR.

(The code was 100% human-spat. It is also very trivial. No need to disturb our AI overlords over this.)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @Cyrilvallez
