### PR TITLE
Fix `maybe_autocast` crashing on meta device tensors

### DIFF
--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -196,6 +196,8 @@ def maybe_autocast(
     Which makes graph splitting in `torch.compile` more flexible as it removes the
     requirement that partition IDs be monotonically increasing.
     """
+    if device_type == "meta":
+        return nullcontext()
     if torch.is_autocast_enabled(device_type) or enabled:
         return torch.autocast(device_type, dtype=dtype, enabled=enabled, cache_enabled=cache_enabled)
     else:


### PR DESCRIPTION
## What does this PR do?

`maybe_autocast` calls `torch.is_autocast_enabled(device_type)` which raises a `RuntimeError` when `device_type` is `"meta"`:

```
RuntimeError: unknown device type for autocast in get_autocast_dispatch_key_from_device_type
```

This breaks any code that runs a forward pass on meta tensors — for example, [`nnsight`](https://github.com/ndif-team/nnsight)'s `.scan()` context, which traces the computational graph using meta tensors without materializing weights.

The error path is: `LlamaRotaryEmbedding.forward` → `maybe_autocast(device_type="meta", enabled=False)` → `torch.is_autocast_enabled("meta")` → 💥

Since autocast is meaningless on meta tensors (they don't compute anything), this PR returns `nullcontext()` early when `device_type == "meta"`.

This affects all 20+ model files that use `maybe_autocast` (via RoPE or directly), so fixing it at the source in `maybe_autocast` is preferable to patching each callsite.

## Reproduction

```python
import torch
torch.is_autocast_enabled("meta")  # RuntimeError
```

```python
# With nnsight / any meta-tensor forward pass:
from nnsight import LanguageModel
model = LanguageModel("meta-llama/Llama-3.1-70B")
with model.scan("test"):  # crashes in RoPE forward
    pass
```

## Fix

```python
def maybe_autocast(device_type, dtype=None, enabled=True, cache_enabled=None):
    if device_type == "meta":
        return nullcontext()
    ...
```

## Note on AI usage

🤖 Generated with [Claude Code](https://claude.ai/code)
👨 reviewed by the human:
This bug came out in some mech interp class and I maintain the nnterp library that was used and encounter this issue. claude helped me to traceback the issue to transformers and the fix proposed fix our issue and is clean and minimal