### PR TITLE
fix: remove Copied from comments between @torch.jit.script and def for Python 3.13 compat

### DIFF
--- a/src/transformers/models/deberta_v2/modeling_deberta_v2.py
+++ b/src/transformers/models/deberta_v2/modeling_deberta_v2.py
@@ -102,19 +102,16 @@ def build_relative_position(query_layer, key_layer, bucket_size: int = -1, max_p
 
 
 @torch.jit.script
-# Copied from transformers.models.deberta.modeling_deberta.c2p_dynamic_expand
 def c2p_dynamic_expand(c2p_pos, query_layer, relative_pos):
     return c2p_pos.expand([query_layer.size(0), query_layer.size(1), query_layer.size(2), relative_pos.size(-1)])
 
 
 @torch.jit.script
-# Copied from transformers.models.deberta.modeling_deberta.p2c_dynamic_expand
 def p2c_dynamic_expand(c2p_pos, query_layer, key_layer):
     return c2p_pos.expand([query_layer.size(0), query_layer.size(1), key_layer.size(-2), key_layer.size(-2)])
 
 
 @torch.jit.script
-# Copied from transformers.models.deberta.modeling_deberta.pos_dynamic_expand
 def pos_dynamic_expand(pos_index, p2c_att, key_layer):
     return pos_index.expand(p2c_att.size()[:2] + (pos_index.size(-2), key_layer.size(-2)))
 

--- a/src/transformers/models/sew_d/modeling_sew_d.py
+++ b/src/transformers/models/sew_d/modeling_sew_d.py
@@ -202,19 +202,16 @@ def build_relative_position(query_size, key_size, bucket_size=-1, max_position=-
 
 
 @torch.jit.script
-# Copied from transformers.models.deberta.modeling_deberta.c2p_dynamic_expand
 def c2p_dynamic_expand(c2p_pos, query_layer, relative_pos):
     return c2p_pos.expand([query_layer.size(0), query_layer.size(1), query_layer.size(2), relative_pos.size(-1)])
 
 
 @torch.jit.script
-# Copied from transformers.models.deberta.modeling_deberta.p2c_dynamic_expand
 def p2c_dynamic_expand(c2p_pos, query_layer, key_layer):
     return c2p_pos.expand([query_layer.size(0), query_layer.size(1), key_layer.size(-2), key_layer.size(-2)])
 
 
 @torch.jit.script
-# Copied from transformers.models.deberta.modeling_deberta.pos_dynamic_expand
 def pos_dynamic_expand(pos_index, p2c_att, key_layer):
     return pos_index.expand(p2c_att.size()[:2] + (pos_index.size(-2), key_layer.size(-2)))
 


### PR DESCRIPTION
## Summary

Fixes #44855

On Python 3.13, placing a `# Copied from` comment between `@torch.jit.script` and the function definition causes an `IndentationError`. This happens because `torch.jit.script` calls `inspect.getsource()` followed by `ast.parse()`, and Python 3.13's stricter parser fails to associate the function body with the `def` when a comment intervenes between the decorator and the function signature.

As [suggested by @Rocketknight1](https://github.com/huggingface/transformers/issues/44855#issuecomment-4095403028), the fix is to remove the `# Copied from` comments entirely from these locations. The three affected functions (`c2p_dynamic_expand`, `p2c_dynamic_expand`, `pos_dynamic_expand`) are identical to their source in `modeling_deberta.py` and will remain in sync without the copy markers.

### Changes

- **`modeling_deberta_v2.py`**: Removed 3 `# Copied from` comments between `@torch.jit.script` decorators and `def` statements
- **`modeling_sew_d.py`**: Removed the same 3 `# Copied from` comments (same bug pattern)

### Coordination

- Issue discussion and maintainer approval: https://github.com/huggingface/transformers/issues/44855#issuecomment-4122734140
- Previous PRs #44856 and #44916 were closed because they moved the comments instead of removing them, which is not what was requested
- No existing open PRs address this fix

### Testing

- Verified `DebertaV2Model` imports successfully after the change
- Verified `sew_d` module imports successfully after the change
- Ruff linting and formatting checks pass

### AI assistance disclosure

This PR was prepared with AI assistance (Claude Code). The change was reviewed line-by-line by the submitter before opening.