### PR TITLE
refactoring: speedup static checks with disk cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,6 +172,7 @@ tags
 
 # modeling structure lint cache
 utils/mlinter/.mlinter_cache.json
+utils/.checkers_cache.json
 
 # modular conversion
 *.modular_backup

--- a/tests/repo_utils/test_checkers.py
+++ b/tests/repo_utils/test_checkers.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+import sys
+import tempfile
+import unittest
+from contextlib import ExitStack, contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
+
+git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+utils_path = os.path.join(git_repo_path, "utils")
+if utils_path not in sys.path:
+    sys.path.append(utils_path)
+
+import checkers  # noqa: E402
+
+
+@contextmanager
+def patch_checkers_paths(repo_root: Path):
+    cache_path = repo_root / "utils" / ".checkers_cache.json"
+    with ExitStack() as stack:
+        stack.enter_context(patch.object(checkers, "REPO_ROOT", repo_root))
+        stack.enter_context(patch.object(checkers, "CACHE_PATH", cache_path))
+        stack.enter_context(patch.object(checkers, "CHECKERS", {"demo": ("Demo checker", "fake_checker.py", [], [])}))
+        stack.enter_context(patch.object(checkers, "CHECKER_FILE_GLOBS", {"demo": ["tracked/**/*.txt"]}))
+        yield cache_path
+
+
+class CheckersCacheTest(unittest.TestCase):
+    def _create_fake_repo(self, tmpdir: str) -> Path:
+        """Create a minimal repo layout for exercising checker cache inputs."""
+        repo_root = Path(tmpdir)
+        (repo_root / "tracked").mkdir()
+        (repo_root / "tracked" / "input.txt").write_text("tracked\n", encoding="utf-8")
+        (repo_root / "utils").mkdir()
+        (repo_root / "utils" / "fake_checker.py").write_text("# fake checker\n", encoding="utf-8")
+        return repo_root
+
+    def _run_main(self, *args: str) -> str:
+        """Run `checkers.main()` with patched argv/stdout and return captured output."""
+        with (
+            patch.object(sys, "argv", ["checkers.py", *args]),
+            patch.object(sys, "stdout", new=io.StringIO()) as stdout,
+        ):
+            checkers.main()
+            return stdout.getvalue()
+
+    def test_checker_cache_detects_checker_script_changes(self):
+        """Cache entries should become stale when the checker implementation file changes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = self._create_fake_repo(tmpdir)
+            with patch_checkers_paths(repo_root) as cache_path:
+                cache = checkers.CheckerCache(path=cache_path)
+                self.assertFalse(cache.is_current("demo"))
+
+                cache.update("demo")
+                self.assertTrue(cache.is_current("demo"))
+
+                (repo_root / "utils" / "fake_checker.py").write_text("# fake checker changed\n", encoding="utf-8")
+                self.assertFalse(cache.is_current("demo"))
+
+    def test_main_skips_cached_runs_unless_no_cache_is_used(self):
+        """Main should reuse cached results by default and rerun when `--no-cache` is passed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = self._create_fake_repo(tmpdir)
+            with (
+                patch_checkers_paths(repo_root),
+                patch.object(
+                    checkers,
+                    "run_checker",
+                    side_effect=[(0, "first run"), (0, "forced rerun")],
+                ) as run_checker,
+            ):
+                self._run_main("demo")
+                self.assertEqual(run_checker.call_count, 1)
+
+                output = self._run_main("demo")
+                self.assertEqual(run_checker.call_count, 1)
+                self.assertIn("(cached)", output)
+
+                self._run_main("demo", "--no-cache")
+                self.assertEqual(run_checker.call_count, 2)

--- a/tests/repo_utils/test_checkers.py
+++ b/tests/repo_utils/test_checkers.py
@@ -74,8 +74,27 @@ class CheckersCacheTest(unittest.TestCase):
                 (repo_root / "utils" / "fake_checker.py").write_text("# fake checker changed\n", encoding="utf-8")
                 self.assertFalse(cache.is_current("demo"))
 
-    def test_main_skips_cached_runs_unless_no_cache_is_used(self):
-        """Main should reuse cached results by default and rerun when `--no-cache` is passed."""
+    def test_main_skips_cached_runs(self):
+        """Main should reuse cached results for repeated runs."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = self._create_fake_repo(tmpdir)
+            with (
+                patch_checkers_paths(repo_root),
+                patch.object(
+                    checkers,
+                    "run_checker",
+                    return_value=(0, "first run"),
+                ) as run_checker,
+            ):
+                self._run_main("demo")
+                self.assertEqual(run_checker.call_count, 1)
+
+                output = self._run_main("demo")
+                self.assertEqual(run_checker.call_count, 1)
+                self.assertIn("(cached)", output)
+
+    def test_main_reruns_with_no_cache(self):
+        """Main should rerun when `--no-cache` is passed."""
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = self._create_fake_repo(tmpdir)
             with (
@@ -88,10 +107,6 @@ class CheckersCacheTest(unittest.TestCase):
             ):
                 self._run_main("demo")
                 self.assertEqual(run_checker.call_count, 1)
-
-                output = self._run_main("demo")
-                self.assertEqual(run_checker.call_count, 1)
-                self.assertIn("(cached)", output)
 
                 self._run_main("demo", "--no-cache")
                 self.assertEqual(run_checker.call_count, 2)

--- a/utils/add_dates.py
+++ b/utils/add_dates.py
@@ -11,6 +11,16 @@ from huggingface_hub import paper_info
 from transformers import logging
 
 
+CHECKER_CONFIG = {
+    "name": "add_dates",
+    "label": "Model dates",
+    # Approximate: also reads docs/source/en/model_doc/*.md and uses git log + network
+    # calls to GitHub/HuggingFace for commit dates and paper metadata.
+    "file_globs": ["src/transformers/models/**/__init__.py", "docs/source/en/model_doc/**/*.md"],
+    "check_args": ["--check-only"],
+    "fix_args": [],
+}
+
 logger = logging.get_logger(__name__)
 
 

--- a/utils/check_config_attributes.py
+++ b/utils/check_config_attributes.py
@@ -20,6 +20,16 @@ from transformers.configuration_utils import PreTrainedConfig
 from transformers.utils import direct_transformers_import
 
 
+CHECKER_CONFIG = {
+    "name": "config_attributes",
+    "label": "Config attributes",
+    # Approximate: iterates CONFIG_MAPPING at runtime and also reads modeling_*.py files
+    # in each config's directory via os.listdir(). Deprecated models are skipped.
+    "file_globs": ["src/transformers/models/**/configuration_*.py", "src/transformers/models/**/modeling_*.py"],
+    "check_args": [],
+    "fix_args": None,
+}
+
 # All paths are set with the intent you should run this script from the root of the repo with the command
 # python utils/check_config_docstrings.py
 PATH_TO_TRANSFORMERS = "src/transformers"

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -18,6 +18,16 @@ import re
 from transformers.utils import direct_transformers_import
 
 
+CHECKER_CONFIG = {
+    "name": "config_docstrings",
+    "label": "Config docstrings",
+    # Approximate: iterates CONFIG_MAPPING at runtime via inspect.getsource(), not file globs.
+    # Only configs registered in CONFIG_MAPPING are checked; deprecated models are skipped.
+    "file_globs": ["src/transformers/models/**/configuration_*.py"],
+    "check_args": [],
+    "fix_args": None,
+}
+
 # All paths are set with the intent you should run this script from the root of the repo with the command
 # python utils/check_config_docstrings.py
 PATH_TO_TRANSFORMERS = "src/transformers"

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -45,6 +45,15 @@ from collections import OrderedDict
 from transformers.utils import direct_transformers_import, logging
 
 
+CHECKER_CONFIG = {
+    "name": "copies",
+    "label": "Copied code consistency",
+    # Actual scope: all of src/transformers/**/*.py and tests/models/**/*.py via glob.glob().
+    "file_globs": ["src/transformers/**/*.py", "tests/models/**/*.py"],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
 logger = logging.get_logger(__name__)
 
 

--- a/utils/check_doc_toc.py
+++ b/utils/check_doc_toc.py
@@ -37,6 +37,15 @@ from collections import defaultdict
 import yaml
 
 
+CHECKER_CONFIG = {
+    "name": "doc_toc",
+    "label": "Documentation table of contents",
+    # Also reads docs/source/en/_toctree.yml; the .md glob catches new/renamed doc files.
+    "file_globs": ["docs/**/*.md", "docs/source/en/_toctree.yml"],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
 ROOT = os.path.dirname(os.path.dirname(__file__))
 TOCTREE_PATH = os.path.join(ROOT, "docs", "source", "en", "_toctree.yml")
 DOC_PATH = os.path.join(ROOT, "docs", "source", "en", "model_doc")

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -62,6 +62,22 @@ from transformers.utils.auto_docstring import (
 )
 
 
+CHECKER_CONFIG = {
+    "name": "docstrings",
+    "label": "Docstring formatting",
+    # Approximate: at runtime the checker also introspects the live transformers module for
+    # @auto_docstring-decorated objects. These globs cover the files it reads via glob.glob().
+    "file_globs": [
+        "src/transformers/models/**/modeling_*.py",
+        "src/transformers/models/**/modular_*.py",
+        "src/transformers/models/**/configuration_*.py",
+        "src/transformers/models/**/processing_*.py",
+        "src/transformers/models/**/image_processing_*_fast.py",
+    ],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
 logger = logging.get_logger(__name__)
 
 

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -36,9 +36,7 @@ import argparse
 import ast
 import enum
 import glob
-import hashlib
 import inspect
-import json
 import operator as op
 import os
 import re
@@ -385,26 +383,6 @@ MATH_OPERATORS = {
     ast.BitXor: op.xor,
     ast.USub: op.neg,
 }
-
-_DISK_CACHE_PATH = Path(__file__).parent / ".check_docstrings_cache.json"
-
-
-def _content_hash(text: str) -> str:
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def _load_disk_cache() -> dict[str, str]:
-    try:
-        return json.loads(_DISK_CACHE_PATH.read_text(encoding="utf-8"))
-    except (FileNotFoundError, json.JSONDecodeError, OSError):
-        return {}
-
-
-def _save_disk_cache(cache: dict[str, str]) -> None:
-    try:
-        _DISK_CACHE_PATH.write_text(json.dumps(cache, sort_keys=True, indent=2) + "\n", encoding="utf-8")
-    except OSError:
-        pass
 
 
 def _get_auto_docstring_names(file_path: str, cache: dict[str, set[str]] | None = None) -> set[str]:
@@ -1964,7 +1942,7 @@ def update_file_with_new_docstrings(
     )
 
 
-def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cache: dict[str, set[str]] | None = None, use_cache: bool = True):
+def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cache: dict[str, set[str]] | None = None):
     """
     Check docstrings of all public objects that are decorated with `@auto_docstrings`.
     This function orchestrates the process by finding relevant files, scanning for decorators,
@@ -2196,8 +2174,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--check_all", action="store_true", help="Whether to check all files. By default, only checks the diff"
     )
-    parser.add_argument("--no-cache", action="store_true", help="Ignore the disk cache and re-check every file.")
     args = parser.parse_args()
     auto_docstring_cache: dict[str, set[str]] = {}
-    check_auto_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache, use_cache=not args.no_cache)
+    check_auto_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache)
     check_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache)

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -36,7 +36,9 @@ import argparse
 import ast
 import enum
 import glob
+import hashlib
 import inspect
+import json
 import operator as op
 import os
 import re
@@ -383,6 +385,26 @@ MATH_OPERATORS = {
     ast.BitXor: op.xor,
     ast.USub: op.neg,
 }
+
+_DISK_CACHE_PATH = Path(__file__).parent / ".check_docstrings_cache.json"
+
+
+def _content_hash(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _load_disk_cache() -> dict[str, str]:
+    try:
+        return json.loads(_DISK_CACHE_PATH.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_disk_cache(cache: dict[str, str]) -> None:
+    try:
+        _DISK_CACHE_PATH.write_text(json.dumps(cache, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+    except OSError:
+        pass
 
 
 def _get_auto_docstring_names(file_path: str, cache: dict[str, set[str]] | None = None) -> set[str]:
@@ -1942,7 +1964,7 @@ def update_file_with_new_docstrings(
     )
 
 
-def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cache: dict[str, set[str]] | None = None):
+def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cache: dict[str, set[str]] | None = None, use_cache: bool = True):
     """
     Check docstrings of all public objects that are decorated with `@auto_docstrings`.
     This function orchestrates the process by finding relevant files, scanning for decorators,
@@ -1964,6 +1986,10 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
     # 2. Find files that contain the @auto_docstring decorator
     auto_docstrings_files = find_files_with_auto_docstring(matching_files)
 
+    # Load disk cache for skipping unchanged files
+    disk_cache = _load_disk_cache() if use_cache else {}
+    new_disk_cache: dict[str, str] = {}
+
     # Collect all errors before raising
     has_errors = False
 
@@ -1971,6 +1997,14 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
     for candidate_file in auto_docstrings_files:
         with open(candidate_file, "r", encoding="utf-8") as f:
             content = f.read()
+
+        # Skip unchanged files that passed on the previous run
+        file_key = str(Path(candidate_file).relative_to(PATH_TO_REPO))
+        digest = _content_hash(content)
+        if use_cache and disk_cache.get(file_key) == digest:
+            new_disk_cache[file_key] = digest
+            continue
+
         lines = content.split("\n")
 
         # Parse file once and share the AST tree across all analysis passes
@@ -2008,9 +2042,12 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             _process_typed_dict_docstrings(candidate_file, overwrite=overwrite, tree=tree)
         )
 
+        # Track whether this file had any errors
+        file_has_errors = False
+
         # Report TypedDict errors
         if typed_dict_missing_warnings:
-            has_errors = True
+            file_has_errors = True
             if not overwrite:
                 print(
                     "Some TypedDict fields are undocumented. Run `make fix-copies` or "
@@ -2020,7 +2057,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in typed_dict_missing_warnings:
                 print(warning)
         if typed_dict_redundant_warnings:
-            has_errors = True
+            file_has_errors = True
             if not overwrite:
                 print(
                     "Some TypedDict fields are redundant (same as source or have placeholders). "
@@ -2030,12 +2067,12 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in typed_dict_redundant_warnings:
                 print(warning)
         if typed_dict_fill_warnings:
-            has_errors = True
+            file_has_errors = True
             print(f"[ERROR] TypedDict docstrings need to be filled in {candidate_file}:")
             for warning in typed_dict_fill_warnings:
                 print(warning)
         if missing_docstring_args_warnings:
-            has_errors = True
+            file_has_errors = True
             if not overwrite:
                 print(
                     "Some docstrings are missing. Run `make fix-repo` or `python utils/check_docstrings.py --fix_and_overwrite` to generate the docstring templates where needed."
@@ -2044,7 +2081,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in missing_docstring_args_warnings:
                 print(warning)
         if docstring_args_ro_remove_warnings:
-            has_errors = True
+            file_has_errors = True
             if not overwrite:
                 print(
                     "Some docstrings are redundant with the ones in `auto_docstring.py` and will be removed. Run `make fix-repo` or `python utils/check_docstrings.py --fix_and_overwrite` to remove the redundant docstrings."
@@ -2053,10 +2090,19 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in docstring_args_ro_remove_warnings:
                 print(warning)
         if fill_docstring_args_warnings:
-            has_errors = True
+            file_has_errors = True
             print(f"[ERROR] Docstring needs to be filled for the following arguments in {candidate_file}:")
             for warning in fill_docstring_args_warnings:
                 print(warning)
+
+        if file_has_errors:
+            has_errors = True
+        else:
+            # Only cache files that passed cleanly
+            new_disk_cache[file_key] = digest
+
+    if use_cache:
+        _save_disk_cache(new_disk_cache)
 
     # Raise error after processing all files
     if has_errors:
@@ -2174,7 +2220,8 @@ if __name__ == "__main__":
     parser.add_argument(
         "--check_all", action="store_true", help="Whether to check all files. By default, only checks the diff"
     )
+    parser.add_argument("--no-cache", action="store_true", help="Ignore the disk cache and re-check every file.")
     args = parser.parse_args()
     auto_docstring_cache: dict[str, set[str]] = {}
-    check_auto_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache)
+    check_auto_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache, use_cache=not args.no_cache)
     check_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache)

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -1986,10 +1986,6 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
     # 2. Find files that contain the @auto_docstring decorator
     auto_docstrings_files = find_files_with_auto_docstring(matching_files)
 
-    # Load disk cache for skipping unchanged files
-    disk_cache = _load_disk_cache() if use_cache else {}
-    new_disk_cache: dict[str, str] = {}
-
     # Collect all errors before raising
     has_errors = False
 
@@ -1997,14 +1993,6 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
     for candidate_file in auto_docstrings_files:
         with open(candidate_file, "r", encoding="utf-8") as f:
             content = f.read()
-
-        # Skip unchanged files that passed on the previous run
-        file_key = str(Path(candidate_file).relative_to(PATH_TO_REPO))
-        digest = _content_hash(content)
-        if use_cache and disk_cache.get(file_key) == digest:
-            new_disk_cache[file_key] = digest
-            continue
-
         lines = content.split("\n")
 
         # Parse file once and share the AST tree across all analysis passes
@@ -2042,12 +2030,9 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             _process_typed_dict_docstrings(candidate_file, overwrite=overwrite, tree=tree)
         )
 
-        # Track whether this file had any errors
-        file_has_errors = False
-
         # Report TypedDict errors
         if typed_dict_missing_warnings:
-            file_has_errors = True
+            has_errors = True
             if not overwrite:
                 print(
                     "Some TypedDict fields are undocumented. Run `make fix-copies` or "
@@ -2057,7 +2042,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in typed_dict_missing_warnings:
                 print(warning)
         if typed_dict_redundant_warnings:
-            file_has_errors = True
+            has_errors = True
             if not overwrite:
                 print(
                     "Some TypedDict fields are redundant (same as source or have placeholders). "
@@ -2067,12 +2052,12 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in typed_dict_redundant_warnings:
                 print(warning)
         if typed_dict_fill_warnings:
-            file_has_errors = True
+            has_errors = True
             print(f"[ERROR] TypedDict docstrings need to be filled in {candidate_file}:")
             for warning in typed_dict_fill_warnings:
                 print(warning)
         if missing_docstring_args_warnings:
-            file_has_errors = True
+            has_errors = True
             if not overwrite:
                 print(
                     "Some docstrings are missing. Run `make fix-repo` or `python utils/check_docstrings.py --fix_and_overwrite` to generate the docstring templates where needed."
@@ -2081,7 +2066,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in missing_docstring_args_warnings:
                 print(warning)
         if docstring_args_ro_remove_warnings:
-            file_has_errors = True
+            has_errors = True
             if not overwrite:
                 print(
                     "Some docstrings are redundant with the ones in `auto_docstring.py` and will be removed. Run `make fix-repo` or `python utils/check_docstrings.py --fix_and_overwrite` to remove the redundant docstrings."
@@ -2090,19 +2075,10 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cach
             for warning in docstring_args_ro_remove_warnings:
                 print(warning)
         if fill_docstring_args_warnings:
-            file_has_errors = True
+            has_errors = True
             print(f"[ERROR] Docstring needs to be filled for the following arguments in {candidate_file}:")
             for warning in fill_docstring_args_warnings:
                 print(warning)
-
-        if file_has_errors:
-            has_errors = True
-        else:
-            # Only cache files that passed cleanly
-            new_disk_cache[file_key] = digest
-
-    if use_cache:
-        _save_disk_cache(new_disk_cache)
 
     # Raise error after processing all files
     if has_errors:

--- a/utils/check_doctest_list.py
+++ b/utils/check_doctest_list.py
@@ -34,6 +34,21 @@ import argparse
 import os
 
 
+CHECKER_CONFIG = {
+    "name": "doctest_list",
+    "label": "Doctest list",
+    # Over-approximation: the checker validates that paths in .txt list files exist and are
+    # sorted. The broad globs ensure cache invalidation when source files are added/removed.
+    "file_globs": [
+        "utils/not_doctested.txt",
+        "utils/slow_documentation_tests.txt",
+        "src/transformers/**/*.py",
+        "docs/**/*.md",
+    ],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
 # All paths are set with the intent you should run this script from the root of the repo with the command
 # python utils/check_doctest_list.py
 REPO_PATH = "."

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -38,6 +38,17 @@ import os
 import re
 
 
+CHECKER_CONFIG = {
+    "name": "dummies",
+    "label": "Dummy objects",
+    # Over-approximation: only reads __init__.py and utils/dummy_*_objects.py, but any
+    # new public object added anywhere could require a dummy update.
+    "file_globs": ["src/transformers/**/*.py"],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
+
 # All paths are set with the intent you should run this script from the root of the repo with the command
 # python utils/check_dummies.py
 PATH_TO_TRANSFORMERS = "src/transformers"

--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -40,6 +40,14 @@ import re
 from pathlib import Path
 
 
+CHECKER_CONFIG = {
+    "name": "inits",
+    "label": "Init files",
+    "file_globs": ["src/transformers/**/__init__.py"],
+    "check_args": [],
+    "fix_args": None,
+}
+
 # Path is set with the intent you should run this script from the root of the repo.
 PATH_TO_TRANSFORMERS = "src/transformers"
 

--- a/utils/check_modeling_structure.py
+++ b/utils/check_modeling_structure.py
@@ -48,6 +48,20 @@ from utils.mlinter.mlinter import (  # noqa: E402, F401
 )
 
 
+CHECKER_CONFIG = {
+    "name": "modeling_structure",
+    "label": "Modeling file structure",
+    # mlinter scans modeling_*.py, modular_*.py, and configuration_*.py via MODELING_PATTERNS.
+    "file_globs": [
+        "src/transformers/models/**/modeling_*.py",
+        "src/transformers/models/**/modular_*.py",
+        "src/transformers/models/**/configuration_*.py",
+    ],
+    "check_args": [],
+    "fix_args": None,
+}
+
+
 # Expose rule-id string constants (e.g. cms.TRF001 == "TRF001") for test compatibility.
 for _rule_id in TRF_RULE_CHECKS:
     globals()[_rule_id] = _rule_id

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -16,6 +16,15 @@ from rich.console import Console
 from rich.syntax import Syntax
 
 
+CHECKER_CONFIG = {
+    "name": "modular_conversion",
+    "label": "Modular file conversions",
+    # Globs the modular sources; also reads generated modeling_*.py at runtime for diffing.
+    "file_globs": ["src/transformers/models/**/modular_*.py", "src/transformers/models/**/modeling_*.py"],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
 logging.basicConfig()
 logging.getLogger().setLevel(logging.ERROR)
 console = Console()

--- a/utils/check_pipeline_typing.py
+++ b/utils/check_pipeline_typing.py
@@ -3,6 +3,14 @@ import re
 from transformers.pipelines import SUPPORTED_TASKS, Pipeline
 
 
+CHECKER_CONFIG = {
+    "name": "pipeline_typing",
+    "label": "Pipeline type hints",
+    "file_globs": ["src/transformers/pipelines/__init__.py"],
+    "check_args": [],
+    "fix_args": ["--fix_and_overwrite"],
+}
+
 HEADER = """
 # fmt: off
 #                🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -31,7 +31,6 @@ It has no auto-fix mode.
 """
 
 import ast
-import functools
 import os
 import re
 import types
@@ -566,7 +565,6 @@ def check_model_list():
 
 # If some modeling modules should be ignored for all checks, they should be added in the nested list
 # _ignore_modules of this function.
-@functools.lru_cache(maxsize=1)
 def get_model_modules() -> list[str]:
     """Get all the model modules inside the transformers library (except deprecated models)."""
     _ignore_modules = [
@@ -1341,11 +1339,11 @@ def check_models_have_kwargs():
             with open(modeling_file, "r", encoding="utf-8") as f:
                 tree = ast.parse(f.read())
 
-            # Map all classes in the file to their base classes (only top-level classes)
+            # Map all classes in the file to their base classes
             class_bases = {}
             all_class_nodes = {}
 
-            for node in tree.body:
+            for node in ast.walk(tree):
                 if isinstance(node, ast.ClassDef):
                     # We only care about base classes that are simple names
                     bases = [b.id for b in node.bases if isinstance(b, ast.Name)]

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -50,6 +50,22 @@ from transformers.testing_utils import _COMMON_MODEL_NAMES_MAP, _VLM_COMMON_MODE
 from transformers.utils import ENV_VARS_TRUE_VALUES, direct_transformers_import
 
 
+CHECKER_CONFIG = {
+    "name": "repo",
+    "label": "Repository structure",
+    # Approximate: the checker also introspects the live transformers module at runtime
+    # (e.g. dir(transformers.models), CONFIG_MAPPING_NAMES) and walks tests/ broadly.
+    "file_globs": [
+        "src/transformers/models/**/*.py",
+        "src/transformers/models/auto/*.py",
+        "src/transformers/**/__init__.py",
+        "tests/**/test_modeling_*.py",
+        "docs/**/*.md",
+    ],
+    "check_args": [],
+    "fix_args": None,
+}
+
 # All paths are set with the intent you should run this script from the root of the repo with the command
 # python utils/check_repo.py
 PATH_TO_TRANSFORMERS = "src/transformers"

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -31,6 +31,7 @@ It has no auto-fix mode.
 """
 
 import ast
+import functools
 import os
 import re
 import types
@@ -581,6 +582,7 @@ def check_model_list():
 
 # If some modeling modules should be ignored for all checks, they should be added in the nested list
 # _ignore_modules of this function.
+@functools.lru_cache(maxsize=1)
 def get_model_modules() -> list[str]:
     """Get all the model modules inside the transformers library (except deprecated models)."""
     _ignore_modules = [
@@ -1359,7 +1361,7 @@ def check_models_have_kwargs():
             class_bases = {}
             all_class_nodes = {}
 
-            for node in ast.walk(tree):
+            for node in tree.body:
                 if isinstance(node, ast.ClassDef):
                     # We only care about base classes that are simple names
                     bases = [b.id for b in node.bases if isinstance(b, ast.Name)]

--- a/utils/check_types.py
+++ b/utils/check_types.py
@@ -8,6 +8,27 @@ import subprocess
 import sys
 
 
+CHECKER_CONFIG = {
+    "name": "types",
+    "label": "Type annotations",
+    # Approximate: ty follows imports beyond the listed directories; these globs cover
+    # the explicitly targeted paths but not transitive dependencies.
+    "file_globs": [
+        "src/transformers/_typing.py",
+        "src/transformers/utils/**/*.py",
+        "src/transformers/generation/**/*.py",
+        "src/transformers/quantizers/**/*.py",
+    ],
+    "check_args": [
+        "src/transformers/_typing.py",
+        "src/transformers/utils",
+        "src/transformers/generation",
+        "src/transformers/quantizers",
+    ],
+    "fix_args": None,
+}
+
+
 def main():
     if len(sys.argv) < 2:
         print(f"Usage: {sys.argv[0]} <directory> [<directory> ...]")

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -94,6 +94,12 @@ CHECKER_FILE_GLOBS = {
     "auto_mappings": [
         "src/transformers/models/auto/*.py",
     ],
+    "repo": [
+        "src/transformers/models/**/*.py",
+        "src/transformers/models/auto/*.py",
+        "tests/models/**/test_modeling_*.py",
+        "docs/**/*.md",
+    ],
 }
 
 

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -100,6 +100,12 @@ CHECKER_FILE_GLOBS = {
         "tests/models/**/test_modeling_*.py",
         "docs/**/*.md",
     ],
+    "imports": ["src/transformers/**/__init__.py", "src/transformers/**/*.py"],
+    "pipeline_typing": ["src/transformers/pipelines/__init__.py"],
+    "doctest_list": ["src/transformers/**/*.py", "docs/**/*.md"],
+    "update_metadata": ["src/transformers/models/**/*.py", "docs/**/*.md"],
+    "add_dates": ["src/transformers/models/**/__init__.py"],
+    "deps_table": ["setup.py", "pyproject.toml"],
 }
 
 

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -31,6 +31,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from collections import deque
 from pathlib import Path
 
@@ -205,6 +206,14 @@ RESET = "\033[0m"
 SPINNER_CHARS = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
 
 
+def format_elapsed(seconds: float) -> str:
+    """Format a duration for status output."""
+    if seconds >= 60:
+        minutes, seconds = divmod(seconds, 60)
+        return f"{int(minutes)}m{seconds:05.2f}s"
+    return f"{seconds:.2f}s"
+
+
 class SlidingWindow:
     """Displays a spinning title + sliding window of the last N output lines in a TTY."""
 
@@ -251,7 +260,7 @@ class SlidingWindow:
             self.lines.append(line.rstrip()[: self.term_width])
             self._redraw()
 
-    def finish(self, success):
+    def finish(self, success, elapsed=None):
         """Stop spinner and print final status title."""
         self._stop.set()
         self._thread.join()
@@ -262,10 +271,11 @@ class SlidingWindow:
             self._title_on_screen = False
             self.displayed = 0
             # Print final title with status
+            suffix = f" ({format_elapsed(elapsed)})" if elapsed is not None else ""
             if success:
-                print(f"{GREEN}✓ {self.label}{RESET}")
+                print(f"{GREEN}✓ {self.label}{suffix}{RESET}")
             else:
-                print(f"{RED}✗ {self.label}{RESET}")
+                print(f"{RED}✗ {self.label}{suffix}{RESET}")
             # Reprint output lines
             for line in self.lines:
                 print(line)
@@ -432,11 +442,15 @@ def main():
     is_ci = os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CIRCLECI") == "true"
     is_tty = sys.stdout.isatty() and not is_ci
 
+    if not is_tty and hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(line_buffering=True)
+
     use_cache = not args.no_cache and not args.fix
     cache = CheckerCache() if use_cache else None
 
     failures = []
     skipped = 0
+    total_start = time.perf_counter()
     for name in names:
         label = CHECKERS[name][0]
 
@@ -446,17 +460,19 @@ def main():
             if is_tty:
                 print(f"{GREEN}✓ {label} (cached){RESET}\n")
             else:
-                print(f"{label} (cached)\n")
+                print(f"{label} (cached)\n", flush=True)
             continue
 
         cmd_str = get_checker_command(name, fix=args.fix)
+        checker_start = time.perf_counter()
 
         if is_tty:
             window = SlidingWindow(label, max_lines=10)
             if cmd_str:
                 window.add_line(f"$ {cmd_str}")
             rc, output = run_checker(name, fix=args.fix, line_callback=window.add_line)
-            window.finish(success=(rc == 0))
+            elapsed = time.perf_counter() - checker_start
+            window.finish(success=(rc == 0), elapsed=elapsed)
             print()
             if rc == 0 and cache is not None:
                 cache.update(name)
@@ -469,16 +485,22 @@ def main():
                         cache.save()
                     sys.exit(1)
         else:
-            print(f"{label}")
+            print(f"{label}", flush=True)
             if cmd_str:
-                print(f"$ {cmd_str}")
-            rc, output = run_checker(name, fix=args.fix)
-            tail = output.splitlines()[-10:]
-            if tail:
-                print("\n".join(tail))
+                print(f"$ {cmd_str}", flush=True)
+            if is_ci:
+                rc, output = run_checker(
+                    name, fix=args.fix, line_callback=lambda line: print(line, end="", flush=True)
+                )
+            else:
+                rc, output = run_checker(name, fix=args.fix)
+                tail = output.splitlines()[-10:]
+                if tail:
+                    print("\n".join(tail), flush=True)
+            elapsed = time.perf_counter() - checker_start
             status = "OK" if rc == 0 else "FAILED"
-            print(status)
-            print()
+            print(f"{status} ({format_elapsed(elapsed)})", flush=True)
+            print(flush=True)
             if rc == 0 and cache is not None:
                 cache.update(name)
             elif rc != 0:
@@ -494,14 +516,15 @@ def main():
         cache.save()
 
     if failures:
-        print(f"\n{len(failures)} failed: {', '.join(failures)}")
+        print(f"\n{len(failures)} failed: {', '.join(failures)}", flush=True)
         sys.exit(1)
 
+    total_elapsed = format_elapsed(time.perf_counter() - total_start)
     passed = len(names) - skipped
     if skipped:
-        print(f"\nAll {len(names)} checks passed ({passed} ran, {skipped} cached).")
+        print(f"\nAll {len(names)} checks passed in {total_elapsed} ({passed} ran, {skipped} cached).", flush=True)
     else:
-        print(f"\nAll {len(names)} checks passed.")
+        print(f"\nAll {len(names)} checks passed in {total_elapsed}.", flush=True)
 
 
 if __name__ == "__main__":

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -24,7 +24,8 @@ Usage:
 Plugin system
 -------------
 Each checker module declares a ``CHECKER_CONFIG`` dict (extracted via ``ast.literal_eval``,
-no import needed). See any ``check_*.py`` file for the schema.
+no import needed — this keeps discovery fast and avoids executing checker code at scan time).
+See any ``check_*.py`` file for the schema.
 
 Cache semantics of ``file_globs``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -106,6 +106,34 @@ CHECKER_FILE_GLOBS = {
     "update_metadata": ["src/transformers/models/**/*.py", "docs/**/*.md"],
     "add_dates": ["src/transformers/models/**/__init__.py"],
     "deps_table": ["setup.py", "pyproject.toml"],
+    "ruff_check": [
+        "examples/**/*.py",
+        "tests/**/*.py",
+        "src/**/*.py",
+        "utils/**/*.py",
+        "scripts/**/*.py",
+        "benchmark/**/*.py",
+        "benchmark_v2/**/*.py",
+        "setup.py",
+        "conftest.py",
+    ],
+    "ruff_format": [
+        "examples/**/*.py",
+        "tests/**/*.py",
+        "src/**/*.py",
+        "utils/**/*.py",
+        "scripts/**/*.py",
+        "benchmark/**/*.py",
+        "benchmark_v2/**/*.py",
+        "setup.py",
+        "conftest.py",
+    ],
+    "types": [
+        "src/transformers/_typing.py",
+        "src/transformers/utils/**/*.py",
+        "src/transformers/generation/**/*.py",
+        "src/transformers/quantizers/**/*.py",
+    ],
 }
 
 

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -25,6 +25,7 @@ Usage:
 import argparse
 import hashlib
 import itertools
+import json
 import os
 import shutil
 import subprocess
@@ -36,6 +37,7 @@ from pathlib import Path
 
 UTILS_DIR = Path(__file__).parent
 REPO_ROOT = UTILS_DIR.parent
+CACHE_PATH = UTILS_DIR / ".checkers_cache.json"
 
 # Each checker maps to (label, script_path, extra_check_args, extra_fix_args).
 # When fix_args is None, the checker has no fix mode.
@@ -74,6 +76,81 @@ CHECKERS = {
     "ruff_check": ("Ruff linting", None, None, None),
     "ruff_format": ("Ruff formatting", None, None, None),
 }
+
+# File glob patterns that each checker depends on.
+# If all matched files are unchanged since the last clean run, the checker is skipped.
+# Checkers not listed here are always run.
+CHECKER_FILE_GLOBS = {
+    "copies": ["src/transformers/models/**/*.py"],
+    "modular_conversion": ["src/transformers/models/**/modular_*.py"],
+    "docstrings": ["src/transformers/models/**/modeling_*.py", "src/transformers/models/**/modular_*.py"],
+    "doc_toc": ["docs/**/*.md"],
+    "dummies": ["src/transformers/**/*.py"],
+    "inits": ["src/transformers/**/__init__.py"],
+    "init_isort": ["src/transformers/**/__init__.py"],
+    "config_docstrings": ["src/transformers/models/**/configuration_*.py"],
+    "config_attributes": ["src/transformers/models/**/configuration_*.py"],
+    "modeling_structure": ["src/transformers/models/**/modeling_*.py"],
+    "auto_mappings": [
+        "src/transformers/models/auto/*.py",
+    ],
+}
+
+
+class CheckerCache:
+    """Disk-backed cache that tracks file content hashes per checker.
+
+    For each checker that declares file globs in CHECKER_FILE_GLOBS, we compute
+    a single digest over all matching files.  If the digest matches the stored
+    value from the last clean (rc == 0) run, the checker can be skipped.
+    """
+
+    def __init__(self, path: Path = CACHE_PATH):
+        self._path = path
+        self._data = self._load()
+
+    def _load(self) -> dict:
+        try:
+            return json.loads(self._path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, json.JSONDecodeError, OSError):
+            return {}
+
+    def save(self) -> None:
+        try:
+            self._path.write_text(json.dumps(self._data, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+        except OSError:
+            pass
+
+    @staticmethod
+    def _digest_files(globs: list[str]) -> str:
+        """Compute a single SHA-256 over sorted file paths + contents."""
+        h = hashlib.sha256()
+        paths = set()
+        for pattern in globs:
+            paths.update(REPO_ROOT.glob(pattern))
+        for p in sorted(paths):
+            if p.is_file():
+                h.update(str(p.relative_to(REPO_ROOT)).encode())
+                h.update(p.read_bytes())
+        return h.hexdigest()
+
+    def is_current(self, checker_name: str) -> bool:
+        """Return True if the checker's files haven't changed since last clean run."""
+        globs = CHECKER_FILE_GLOBS.get(checker_name)
+        if globs is None:
+            return False
+        return self._data.get(checker_name) == self._digest_files(globs)
+
+    def update(self, checker_name: str) -> None:
+        """Record current digest for a checker (call after a clean run)."""
+        globs = CHECKER_FILE_GLOBS.get(checker_name)
+        if globs is None:
+            return
+        self._data[checker_name] = self._digest_files(globs)
+
+    def invalidate(self, checker_name: str) -> None:
+        """Remove a checker from the cache (call after a failed run)."""
+        self._data.pop(checker_name, None)
 
 
 def _file_md5(path):
@@ -287,6 +364,7 @@ def main():
         "--keep-going", action="store_true", help="Run all checkers even if some fail (report failures at the end)."
     )
     parser.add_argument("--list", action="store_true", help="List available checkers and exit.")
+    parser.add_argument("--no-cache", action="store_true", help="Ignore the disk cache and re-run every checker.")
 
     args = parser.parse_args()
 
@@ -314,9 +392,23 @@ def main():
     is_ci = os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CIRCLECI") == "true"
     is_tty = sys.stdout.isatty() and not is_ci
 
+    use_cache = not args.no_cache and not args.fix
+    cache = CheckerCache() if use_cache else None
+
     failures = []
+    skipped = 0
     for name in names:
         label = CHECKERS[name][0]
+
+        # Skip if all relevant files are unchanged since last clean run
+        if cache is not None and cache.is_current(name):
+            skipped += 1
+            if is_tty:
+                print(f"{GREEN}✓ {label} (cached){RESET}\n")
+            else:
+                print(f"{label} (cached)\n")
+            continue
+
         cmd_str = get_checker_command(name, fix=args.fix)
 
         if is_tty:
@@ -326,9 +418,15 @@ def main():
             rc, output = run_checker(name, fix=args.fix, line_callback=window.add_line)
             window.finish(success=(rc == 0))
             print()
-            if rc != 0:
+            if rc == 0 and cache is not None:
+                cache.update(name)
+            elif rc != 0:
+                if cache is not None:
+                    cache.invalidate(name)
                 failures.append(name)
                 if not args.keep_going:
+                    if cache is not None:
+                        cache.save()
                     sys.exit(1)
         else:
             print(f"{label}")
@@ -341,16 +439,29 @@ def main():
             status = "OK" if rc == 0 else "FAILED"
             print(status)
             print()
-            if rc != 0:
+            if rc == 0 and cache is not None:
+                cache.update(name)
+            elif rc != 0:
+                if cache is not None:
+                    cache.invalidate(name)
                 failures.append(name)
                 if not args.keep_going:
+                    if cache is not None:
+                        cache.save()
                     sys.exit(1)
+
+    if cache is not None:
+        cache.save()
 
     if failures:
         print(f"\n{len(failures)} failed: {', '.join(failures)}")
         sys.exit(1)
 
-    print(f"\nAll {len(names)} checks passed.")
+    passed = len(names) - skipped
+    if skipped:
+        print(f"\nAll {len(names)} checks passed ({passed} ran, {skipped} cached).")
+    else:
+        print(f"\nAll {len(names)} checks passed.")
 
 
 if __name__ == "__main__":

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -20,9 +20,32 @@ Usage:
     python utils/checkers.py copies,doc_toc --keep-going
     python utils/checkers.py all
     python utils/checkers.py all --fix
+
+Plugin system
+-------------
+Each checker module declares a ``CHECKER_CONFIG`` dict (extracted via ``ast.literal_eval``,
+no import needed). See any ``check_*.py`` file for the schema.
+
+Cache semantics of ``file_globs``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``file_globs`` lists the file patterns whose content is hashed to decide whether a checker
+can be skipped. **Not all globs are exact reflections of the checker's runtime behaviour.**
+
+* Some checkers introspect the live ``transformers`` module (``check_repo``,
+  ``check_config_docstrings``, ``check_config_attributes``, ``update_metadata``), so their
+  globs are necessarily *approximations* of the true dependency set.
+* Some checkers over-approximate (``check_dummies``, ``check_doctest_list``): any change
+  inside the broad glob forces a re-run even if the checker wouldn't look at that file.
+  This is safe—just less cache-efficient.
+* Some checkers rely on external state (network, git history, installed packages) that
+  cannot be captured by file globs at all (``add_dates``, ``imports``).
+
+Each ``CHECKER_CONFIG`` that is an approximation has an inline comment explaining the
+gap. When in doubt, use ``--no-cache`` to force a full run.
 """
 
 import argparse
+import ast
 import hashlib
 import itertools
 import json
@@ -32,6 +55,7 @@ import subprocess
 import sys
 import threading
 import time
+import warnings
 from collections import deque
 from pathlib import Path
 
@@ -40,37 +64,77 @@ UTILS_DIR = Path(__file__).parent
 REPO_ROOT = UTILS_DIR.parent
 CACHE_PATH = UTILS_DIR / ".checkers_cache.json"
 
-# Each checker maps to (label, script_path, extra_check_args, extra_fix_args).
-# When fix_args is None, the checker has no fix mode.
-# Custom checkers use None instead of the tuple.
-CHECKERS = {
-    "copies": ("Copied code consistency", "check_copies.py", [], ["--fix_and_overwrite"]),
-    "modular_conversion": ("Modular file conversions", "check_modular_conversion.py", [], ["--fix_and_overwrite"]),
-    "doc_toc": ("Documentation table of contents", "check_doc_toc.py", [], ["--fix_and_overwrite"]),
-    "docstrings": ("Docstring formatting", "check_docstrings.py", [], ["--fix_and_overwrite"]),
-    "dummies": ("Dummy objects", "check_dummies.py", [], ["--fix_and_overwrite"]),
-    "pipeline_typing": ("Pipeline type hints", "check_pipeline_typing.py", [], ["--fix_and_overwrite"]),
-    "doctest_list": ("Doctest list", "check_doctest_list.py", [], ["--fix_and_overwrite"]),
-    "repo": ("Repository structure", "check_repo.py", [], None),
-    "inits": ("Init files", "check_inits.py", [], None),
-    "config_docstrings": ("Config docstrings", "check_config_docstrings.py", [], None),
-    "config_attributes": ("Config attributes", "check_config_attributes.py", [], None),
-    "init_isort": ("Import ordering", "custom_init_isort.py", ["--check_only"], []),
-    "auto_mappings": ("Auto mappings", "sort_auto_mappings.py", ["--check_only"], []),
-    "update_metadata": ("Model metadata", "update_metadata.py", ["--check-only"], []),
-    "add_dates": ("Model dates", "add_dates.py", ["--check-only"], []),
-    "types": (
-        "Type annotations",
-        "check_types.py",
-        [
-            "src/transformers/_typing.py",
-            "src/transformers/utils",
-            "src/transformers/generation",
-            "src/transformers/quantizers",
-        ],
-        None,
-    ),
-    "modeling_structure": ("Modeling file structure", "check_modeling_structure.py", [], None),
+# Required keys in each module's CHECKER_CONFIG dict.
+_CHECKER_CONFIG_KEYS = {"name", "label", "file_globs", "check_args", "fix_args"}
+
+
+def _discover_checkers() -> tuple[dict, dict]:
+    """Scan utils/*.py for CHECKER_CONFIG dicts using AST (no imports).
+
+    Each checker module may define a top-level ``CHECKER_CONFIG`` dict with
+    keys: name, label, file_globs, check_args, fix_args.
+
+    Returns (checkers_dict, file_globs_dict) matching the shapes of
+    the old CHECKERS and CHECKER_FILE_GLOBS registries.
+    """
+    checkers = {}
+    file_globs = {}
+
+    for py_file in sorted(UTILS_DIR.glob("*.py")):
+        if py_file.name == Path(__file__).name:
+            continue
+
+        try:
+            tree = ast.parse(py_file.read_text(encoding="utf-8"), filename=str(py_file))
+        except SyntaxError:
+            continue
+
+        config = None
+        for node in ast.iter_child_nodes(tree):
+            if (
+                isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "CHECKER_CONFIG"
+            ):
+                try:
+                    config = ast.literal_eval(node.value)
+                except (ValueError, TypeError):
+                    pass
+                break
+
+        if config is None:
+            continue
+
+        missing = _CHECKER_CONFIG_KEYS - set(config)
+        if missing:
+            warnings.warn(
+                f"CHECKER_CONFIG in {py_file.name} is missing keys: {', '.join(sorted(missing))}. Skipping.",
+                stacklevel=1,
+            )
+            continue
+
+        name = config["name"]
+        if name in checkers:
+            warnings.warn(
+                f"Duplicate checker name {name!r} in {py_file.name}, already defined by {checkers[name][1]}",
+                stacklevel=1,
+            )
+
+        checkers[name] = (
+            config["label"],
+            py_file.name,
+            config["check_args"],
+            config["fix_args"],
+        )
+        if config["file_globs"] is not None:
+            file_globs[name] = config["file_globs"]
+
+    return checkers, file_globs
+
+
+# Inline checkers have no separate script file; they use custom runner functions below.
+_INLINE_CHECKERS = {
     "deps_table": ("Dependency versions table", None, None, None),
     "imports": ("Public imports", None, None, None),
     "import_complexity": ("Import complexity", "check_import_complexity.py", [], None),
@@ -78,35 +142,13 @@ CHECKERS = {
     "ruff_format": ("Ruff formatting", None, None, None),
 }
 
-# File glob patterns that each checker depends on.
-# If all matched files are unchanged since the last clean run, the checker is skipped.
-# Checkers not listed here are always run.
-CHECKER_FILE_GLOBS = {
-    "copies": ["src/transformers/models/**/*.py"],
-    "modular_conversion": ["src/transformers/models/**/modular_*.py"],
-    "docstrings": ["src/transformers/models/**/modeling_*.py", "src/transformers/models/**/modular_*.py"],
-    "doc_toc": ["docs/**/*.md"],
-    "dummies": ["src/transformers/**/*.py"],
-    "inits": ["src/transformers/**/__init__.py"],
-    "init_isort": ["src/transformers/**/__init__.py"],
-    "config_docstrings": ["src/transformers/models/**/configuration_*.py"],
-    "config_attributes": ["src/transformers/models/**/configuration_*.py"],
-    "modeling_structure": ["src/transformers/models/**/modeling_*.py"],
-    "auto_mappings": [
-        "src/transformers/models/auto/*.py",
-    ],
-    "repo": [
-        "src/transformers/models/**/*.py",
-        "src/transformers/models/auto/*.py",
-        "tests/models/**/test_modeling_*.py",
-        "docs/**/*.md",
-    ],
+_INLINE_FILE_GLOBS = {
+    # Also generates/checks src/transformers/dependency_versions_table.py.
+    "deps_table": ["setup.py", "pyproject.toml", "src/transformers/dependency_versions_table.py"],
+    # Approximate: runs `from transformers import *` at runtime; depends on the full
+    # Python environment, not just these files. Broad globs used as a safe upper bound.
     "imports": ["src/transformers/**/__init__.py", "src/transformers/**/*.py"],
-    "pipeline_typing": ["src/transformers/pipelines/__init__.py"],
-    "doctest_list": ["src/transformers/**/*.py", "docs/**/*.md"],
-    "update_metadata": ["src/transformers/models/**/*.py", "docs/**/*.md"],
-    "add_dates": ["src/transformers/models/**/__init__.py"],
-    "deps_table": ["setup.py", "pyproject.toml"],
+    # Approximate: ruff applies its own ignore rules from pyproject.toml at runtime.
     "ruff_check": [
         "examples/**/*.py",
         "tests/**/*.py",
@@ -129,13 +171,13 @@ CHECKER_FILE_GLOBS = {
         "setup.py",
         "conftest.py",
     ],
-    "types": [
-        "src/transformers/_typing.py",
-        "src/transformers/utils/**/*.py",
-        "src/transformers/generation/**/*.py",
-        "src/transformers/quantizers/**/*.py",
-    ],
 }
+
+# Build the registries: discovered modules + inline custom runners.
+_discovered_checkers, _discovered_globs = _discover_checkers()
+
+CHECKERS = {**_discovered_checkers, **_INLINE_CHECKERS}
+CHECKER_FILE_GLOBS = {**_discovered_globs, **_INLINE_FILE_GLOBS}
 
 
 def get_checker_cache_globs(checker_name: str) -> list[str] | None:

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -138,6 +138,19 @@ CHECKER_FILE_GLOBS = {
 }
 
 
+def get_checker_cache_globs(checker_name: str) -> list[str] | None:
+    """Return the cache inputs for a checker, including its implementation files."""
+    globs = CHECKER_FILE_GLOBS.get(checker_name)
+    if globs is None:
+        return None
+
+    cache_globs = [*globs, str(Path("utils") / Path(__file__).name)]
+    script = CHECKERS[checker_name][1]
+    if script is not None:
+        cache_globs.append(str(Path("utils") / script))
+    return cache_globs
+
+
 class CheckerCache:
     """Disk-backed cache that tracks file content hashes per checker.
 
@@ -146,8 +159,8 @@ class CheckerCache:
     value from the last clean (rc == 0) run, the checker can be skipped.
     """
 
-    def __init__(self, path: Path = CACHE_PATH):
-        self._path = path
+    def __init__(self, path: Path | None = None):
+        self._path = CACHE_PATH if path is None else path
         self._data = self._load()
 
     def _load(self) -> dict:
@@ -177,14 +190,14 @@ class CheckerCache:
 
     def is_current(self, checker_name: str) -> bool:
         """Return True if the checker's files haven't changed since last clean run."""
-        globs = CHECKER_FILE_GLOBS.get(checker_name)
+        globs = get_checker_cache_globs(checker_name)
         if globs is None:
             return False
         return self._data.get(checker_name) == self._digest_files(globs)
 
     def update(self, checker_name: str) -> None:
         """Record current digest for a checker (call after a clean run)."""
-        globs = CHECKER_FILE_GLOBS.get(checker_name)
+        globs = get_checker_cache_globs(checker_name)
         if globs is None:
             return
         self._data[checker_name] = self._digest_files(globs)

--- a/utils/custom_init_isort.py
+++ b/utils/custom_init_isort.py
@@ -41,6 +41,14 @@ from collections.abc import Callable
 from typing import Any
 
 
+CHECKER_CONFIG = {
+    "name": "init_isort",
+    "label": "Import ordering",
+    "file_globs": ["src/transformers/**/__init__.py"],
+    "check_args": ["--check_only"],
+    "fix_args": [],
+}
+
 # Path is defined with the intent you should run this script from the root of the repo.
 PATH_TO_TRANSFORMERS = "src/transformers"
 

--- a/utils/sort_auto_mappings.py
+++ b/utils/sort_auto_mappings.py
@@ -34,6 +34,14 @@ import os
 import re
 
 
+CHECKER_CONFIG = {
+    "name": "auto_mappings",
+    "label": "Auto mappings",
+    "file_globs": ["src/transformers/models/auto/*.py"],
+    "check_args": ["--check_only"],
+    "fix_args": [],
+}
+
 # Path are set with the intent you should run this script from the root of the repo.
 PATH_TO_AUTO_MODULE = "src/transformers/models/auto"
 

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -41,6 +41,16 @@ from huggingface_hub import hf_hub_download, upload_folder
 from transformers.utils import direct_transformers_import
 
 
+CHECKER_CONFIG = {
+    "name": "update_metadata",
+    "label": "Model metadata",
+    # Approximate: imports the transformers module and inspects pipeline/auto mappings
+    # at runtime. Does not iterate over files matching these globs directly.
+    "file_globs": ["src/transformers/models/**/*.py", "docs/**/*.md"],
+    "check_args": ["--check-only"],
+    "fix_args": [],
+}
+
 # All paths are set with the intent you should run this script from the root of the repo with the command
 # python utils/update_metadata.py
 TRANSFORMERS_PATH = "src/transformers"


### PR DESCRIPTION
# What does this PR do?

`make check-repo` can be quite slow, this patch adds file-level cache to speed up checks.

We get up to a 27x speedup
- cold cache : 46s
- warm cache : 1.6s
