### PR TITLE
Fix type hint for `attention_chunk_size` in `Llama4TextConfig`

### DIFF
--- a/src/transformers/models/llama4/configuration_llama4.py
+++ b/src/transformers/models/llama4/configuration_llama4.py
@@ -165,7 +165,7 @@ class Llama4TextConfig(PreTrainedConfig):
     rope_parameters: RopeParameters | dict | None = None
     no_rope_layers: list[int] | None = None
     no_rope_layer_interval: int = 4
-    attention_chunk_size: int = 8192
+    attention_chunk_size: int | None = 8192
     layer_types: list[str] | None = None
     attn_temperature_tuning: bool = True
     floor_scale: int = 8192


### PR DESCRIPTION
`None` is a valid value that can be used to disable chunked attention in `DynamicCache` and Flex Attention.

hf.co/morgendave/EAGLE-Llama-4-Scout-17B-16E-Instruct is an example of a checkpoint which does this.