### PR TITLE
refactor: speed up docstring checker

### DIFF
--- a/tests/repo_utils/test_check_docstrings.py
+++ b/tests/repo_utils/test_check_docstrings.py
@@ -25,7 +25,6 @@ git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(
 sys.path.append(os.path.join(git_repo_path, "utils"))
 
 from check_docstrings import (  # noqa: E402
-    _auto_docstring_cache,
     _build_ast_indexes,
     _find_typed_dict_classes,
     _get_auto_docstring_names,
@@ -113,10 +112,7 @@ class TestGetAutoDocstringNames(unittest.TestCase):
     """Tests for _get_auto_docstring_names and has_auto_docstring_decorator."""
 
     def setUp(self):
-        _auto_docstring_cache.clear()
-
-    def tearDown(self):
-        _auto_docstring_cache.clear()
+        self.cache = {}
 
     def _write_temp(self, source):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
@@ -135,7 +131,7 @@ class TestGetAutoDocstringNames(unittest.TestCase):
                 pass
         """)
         )
-        names = _get_auto_docstring_names(path)
+        names = _get_auto_docstring_names(path, cache=self.cache)
         self.assertEqual(names, {"Foo"})
 
     def test_detects_decorator_with_call(self):
@@ -147,7 +143,7 @@ class TestGetAutoDocstringNames(unittest.TestCase):
                 pass
         """)
         )
-        names = _get_auto_docstring_names(path)
+        names = _get_auto_docstring_names(path, cache=self.cache)
         self.assertEqual(names, {"Bar"})
 
     def test_ignores_other_decorators(self):
@@ -159,7 +155,7 @@ class TestGetAutoDocstringNames(unittest.TestCase):
                 pass
         """)
         )
-        names = _get_auto_docstring_names(path)
+        names = _get_auto_docstring_names(path, cache=self.cache)
         self.assertEqual(names, set())
 
     def test_multiple_classes(self):
@@ -178,7 +174,7 @@ class TestGetAutoDocstringNames(unittest.TestCase):
                 pass
         """)
         )
-        names = _get_auto_docstring_names(path)
+        names = _get_auto_docstring_names(path, cache=self.cache)
         self.assertEqual(names, {"A", "func_c"})
 
     def test_caching(self):
@@ -190,14 +186,14 @@ class TestGetAutoDocstringNames(unittest.TestCase):
                 pass
         """)
         )
-        result1 = _get_auto_docstring_names(path)
-        result2 = _get_auto_docstring_names(path)
+        result1 = _get_auto_docstring_names(path, cache=self.cache)
+        result2 = _get_auto_docstring_names(path, cache=self.cache)
         self.assertIs(result1, result2)
 
     def test_syntax_error_returns_empty(self):
         """Test that a file with a syntax error returns an empty set instead of raising."""
         path = self._write_temp("def broken(\n")
-        names = _get_auto_docstring_names(path)
+        names = _get_auto_docstring_names(path, cache=self.cache)
         self.assertEqual(names, set())
 
     def test_has_auto_docstring_decorator_uses_cache(self):
@@ -211,15 +207,15 @@ class TestGetAutoDocstringNames(unittest.TestCase):
                 pass
         """)
         )
-        _auto_docstring_cache[path] = {"Cached"}
+        self.cache[path] = {"Cached"}
 
         # Create classes whose __name__ matches/doesn't match the cache
         Cached = type("Cached", (), {})
         Other = type("Other", (), {})
 
         with patch.object(inspect, "getfile", return_value=path):
-            self.assertTrue(has_auto_docstring_decorator(Cached))
-            self.assertFalse(has_auto_docstring_decorator(Other))
+            self.assertTrue(has_auto_docstring_decorator(Cached, cache=self.cache))
+            self.assertFalse(has_auto_docstring_decorator(Other, cache=self.cache))
 
 
 class TestBuildAstIndexes(unittest.TestCase):

--- a/tests/repo_utils/test_check_docstrings.py
+++ b/tests/repo_utils/test_check_docstrings.py
@@ -17,6 +17,7 @@ import inspect
 import os
 import sys
 import tempfile
+import textwrap
 import unittest
 
 
@@ -118,49 +119,86 @@ class TestGetAutoDocstringNames(unittest.TestCase):
         _auto_docstring_cache.clear()
 
     def _write_temp(self, source):
-        f = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
-        f.write(source)
-        f.close()
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+            f.write(source)
         self.addCleanup(os.unlink, f.name)
         return f.name
 
     def test_detects_simple_decorator(self):
-        path = self._write_temp("from transformers import auto_docstring\n\n@auto_docstring\nclass Foo:\n    pass\n")
+        """Test that a class decorated with @auto_docstring is detected."""
+        path = self._write_temp(textwrap.dedent("""\
+            from transformers import auto_docstring
+
+            @auto_docstring
+            class Foo:
+                pass
+        """))
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, {"Foo"})
 
     def test_detects_decorator_with_call(self):
-        path = self._write_temp("@auto_docstring(custom_args='x')\nclass Bar:\n    pass\n")
+        """Test that a class decorated with @auto_docstring(args) (called form) is detected."""
+        path = self._write_temp(textwrap.dedent("""\
+            @auto_docstring(custom_args='x')
+            class Bar:
+                pass
+        """))
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, {"Bar"})
 
     def test_ignores_other_decorators(self):
-        path = self._write_temp("@dataclass\nclass Baz:\n    pass\n")
+        """Test that classes with non-auto_docstring decorators are not detected."""
+        path = self._write_temp(textwrap.dedent("""\
+            @dataclass
+            class Baz:
+                pass
+        """))
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, set())
 
     def test_multiple_classes(self):
-        path = self._write_temp(
-            "@auto_docstring\nclass A:\n    pass\n\nclass B:\n    pass\n\n@auto_docstring()\ndef func_c():\n    pass\n"
-        )
+        """Test that only decorated classes and functions are returned when multiple definitions exist."""
+        path = self._write_temp(textwrap.dedent("""\
+            @auto_docstring
+            class A:
+                pass
+
+            class B:
+                pass
+
+            @auto_docstring()
+            def func_c():
+                pass
+        """))
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, {"A", "func_c"})
 
     def test_caching(self):
-        path = self._write_temp("@auto_docstring\nclass X:\n    pass\n")
+        """Test that repeated calls for the same file return the cached (identical) result object."""
+        path = self._write_temp(textwrap.dedent("""\
+            @auto_docstring
+            class X:
+                pass
+        """))
         result1 = _get_auto_docstring_names(path)
         result2 = _get_auto_docstring_names(path)
         self.assertIs(result1, result2)
 
     def test_syntax_error_returns_empty(self):
+        """Test that a file with a syntax error returns an empty set instead of raising."""
         path = self._write_temp("def broken(\n")
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, set())
 
     def test_has_auto_docstring_decorator_uses_cache(self):
+        """Test that has_auto_docstring_decorator looks up names from the pre-populated cache."""
         from unittest.mock import patch
 
-        path = self._write_temp("@auto_docstring\nclass Cached:\n    pass\n")
+        path = self._write_temp(textwrap.dedent("""\
+            @auto_docstring
+            class Cached:
+                pass
+        """))
         _auto_docstring_cache[path] = {"Cached"}
 
         # Create classes whose __name__ matches/doesn't match the cache
@@ -176,12 +214,13 @@ class TestBuildAstIndexes(unittest.TestCase):
     """Tests for _build_ast_indexes with pre-parsed tree."""
 
     def test_finds_decorated_items(self):
-        source = (
-            "@auto_docstring\n"
-            "class MyModel:\n"
-            "    def __init__(self, hidden_size=768):\n"
-            "        self.hidden_size = hidden_size\n"
-        )
+        """Test that _build_ast_indexes finds a decorated class and extracts its __init__ args."""
+        source = textwrap.dedent("""\
+            @auto_docstring
+            class MyModel:
+                def __init__(self, hidden_size=768):
+                    self.hidden_size = hidden_size
+        """)
         items = _build_ast_indexes(source)
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].name, "MyModel")
@@ -189,7 +228,12 @@ class TestBuildAstIndexes(unittest.TestCase):
         self.assertIn("hidden_size", items[0].args)
 
     def test_shared_tree(self):
-        source = "@auto_docstring\nclass A:\n    pass\n"
+        """Test that passing a pre-parsed AST tree produces the same results as letting the function parse internally."""
+        source = textwrap.dedent("""\
+            @auto_docstring
+            class A:
+                pass
+        """)
         tree = ast.parse(source)
         items_with_tree = _build_ast_indexes(source, tree=tree)
         items_without = _build_ast_indexes(source)
@@ -197,12 +241,21 @@ class TestBuildAstIndexes(unittest.TestCase):
         self.assertEqual(items_with_tree[0].name, items_without[0].name)
 
     def test_no_decorated_items(self):
-        source = "class Plain:\n    pass\n"
+        """Test that a class without the auto_docstring decorator is not indexed."""
+        source = textwrap.dedent("""\
+            class Plain:
+                pass
+        """)
         items = _build_ast_indexes(source)
         self.assertEqual(items, [])
 
     def test_function_decorated(self):
-        source = "@auto_docstring\ndef my_func(x, y=10):\n    pass\n"
+        """Test that a decorated function is indexed with its arguments."""
+        source = textwrap.dedent("""\
+            @auto_docstring
+            def my_func(x, y=10):
+                pass
+        """)
         items = _build_ast_indexes(source)
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].name, "my_func")
@@ -211,14 +264,15 @@ class TestBuildAstIndexes(unittest.TestCase):
         self.assertIn("y", items[0].args)
 
     def test_custom_args_from_variable(self):
-        source = (
-            'MY_ARGS = "custom param docs"\n'
-            "\n"
-            "@auto_docstring(custom_args=MY_ARGS)\n"
-            "class WithCustom:\n"
-            "    def __init__(self):\n"
-            "        pass\n"
-        )
+        """Test that custom_args passed as a module-level variable are resolved to their string value."""
+        source = textwrap.dedent("""\
+            MY_ARGS = "custom param docs"
+
+            @auto_docstring(custom_args=MY_ARGS)
+            class WithCustom:
+                def __init__(self):
+                    pass
+        """)
         items = _build_ast_indexes(source)
         self.assertEqual(len(items), 1)
         self.assertEqual(items[0].custom_args_text, "custom param docs")
@@ -228,7 +282,14 @@ class TestFindTypedDictClasses(unittest.TestCase):
     """Tests for _find_typed_dict_classes with pre-parsed tree."""
 
     def test_finds_typed_dict(self):
-        source = "from typing import TypedDict\n\nclass MyKwargs(TypedDict):\n    field_a: str\n    field_b: int\n"
+        """Test that a TypedDict subclass is found and its public fields are extracted."""
+        source = textwrap.dedent("""\
+            from typing import TypedDict
+
+            class MyKwargs(TypedDict):
+                field_a: str
+                field_b: int
+        """)
         result = _find_typed_dict_classes(source)
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["name"], "MyKwargs")
@@ -236,7 +297,11 @@ class TestFindTypedDictClasses(unittest.TestCase):
         self.assertIn("field_b", result[0]["all_fields"])
 
     def test_shared_tree(self):
-        source = "class MyKwargs(TypedDict):\n    x: int\n"
+        """Test that passing a pre-parsed AST tree produces the same results as internal parsing."""
+        source = textwrap.dedent("""\
+            class MyKwargs(TypedDict):
+                x: int
+        """)
         tree = ast.parse(source)
         r1 = _find_typed_dict_classes(source, tree=tree)
         r2 = _find_typed_dict_classes(source)
@@ -244,17 +309,30 @@ class TestFindTypedDictClasses(unittest.TestCase):
         self.assertEqual(r1[0]["name"], r2[0]["name"])
 
     def test_skips_standard_kwargs(self):
-        source = "class TextKwargs(TypedDict):\n    field: str\n"
+        """Test that well-known kwargs TypedDicts (e.g. TextKwargs) are excluded from results."""
+        source = textwrap.dedent("""\
+            class TextKwargs(TypedDict):
+                field: str
+        """)
         result = _find_typed_dict_classes(source)
         self.assertEqual(result, [])
 
     def test_no_typed_dicts(self):
-        source = "class Regular:\n    pass\n"
+        """Test that source with no TypedDict subclasses returns an empty list."""
+        source = textwrap.dedent("""\
+            class Regular:
+                pass
+        """)
         result = _find_typed_dict_classes(source)
         self.assertEqual(result, [])
 
     def test_skips_private_fields(self):
-        source = "class MyKwargs(TypedDict):\n    public: int\n    _private: str\n"
+        """Test that fields starting with an underscore are excluded from the extracted TypedDict fields."""
+        source = textwrap.dedent("""\
+            class MyKwargs(TypedDict):
+                public: int
+                _private: str
+        """)
         result = _find_typed_dict_classes(source)
         self.assertEqual(len(result), 1)
         self.assertIn("public", result[0]["all_fields"])

--- a/tests/repo_utils/test_check_docstrings.py
+++ b/tests/repo_utils/test_check_docstrings.py
@@ -12,16 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
 import inspect
 import os
 import sys
+import tempfile
 import unittest
 
 
 git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 sys.path.append(os.path.join(git_repo_path, "utils"))
 
-from check_docstrings import get_default_description, replace_default_in_arg_description  # noqa: E402
+from check_docstrings import (  # noqa: E402
+    _auto_docstring_cache,
+    _build_ast_indexes,
+    _find_typed_dict_classes,
+    _get_auto_docstring_names,
+    get_default_description,
+    has_auto_docstring_decorator,
+    replace_default_in_arg_description,
+)
 
 
 class CheckDostringsTested(unittest.TestCase):
@@ -96,3 +106,156 @@ class CheckDostringsTested(unittest.TestCase):
         assert get_default_description(params["c"]) == "`<fill_type>`, *optional*, defaults to 1"
         assert get_default_description(params["d"]) == "`float`, *optional*, defaults to 2.0"
         assert get_default_description(params["e"]) == '`str`, *optional*, defaults to `"blob"`'
+
+
+class TestGetAutoDocstringNames(unittest.TestCase):
+    """Tests for _get_auto_docstring_names and has_auto_docstring_decorator."""
+
+    def setUp(self):
+        _auto_docstring_cache.clear()
+
+    def tearDown(self):
+        _auto_docstring_cache.clear()
+
+    def _write_temp(self, source):
+        f = tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False)
+        f.write(source)
+        f.close()
+        self.addCleanup(os.unlink, f.name)
+        return f.name
+
+    def test_detects_simple_decorator(self):
+        path = self._write_temp("from transformers import auto_docstring\n\n@auto_docstring\nclass Foo:\n    pass\n")
+        names = _get_auto_docstring_names(path)
+        self.assertEqual(names, {"Foo"})
+
+    def test_detects_decorator_with_call(self):
+        path = self._write_temp("@auto_docstring(custom_args='x')\nclass Bar:\n    pass\n")
+        names = _get_auto_docstring_names(path)
+        self.assertEqual(names, {"Bar"})
+
+    def test_ignores_other_decorators(self):
+        path = self._write_temp("@dataclass\nclass Baz:\n    pass\n")
+        names = _get_auto_docstring_names(path)
+        self.assertEqual(names, set())
+
+    def test_multiple_classes(self):
+        path = self._write_temp(
+            "@auto_docstring\nclass A:\n    pass\n\nclass B:\n    pass\n\n@auto_docstring()\ndef func_c():\n    pass\n"
+        )
+        names = _get_auto_docstring_names(path)
+        self.assertEqual(names, {"A", "func_c"})
+
+    def test_caching(self):
+        path = self._write_temp("@auto_docstring\nclass X:\n    pass\n")
+        result1 = _get_auto_docstring_names(path)
+        result2 = _get_auto_docstring_names(path)
+        self.assertIs(result1, result2)
+
+    def test_syntax_error_returns_empty(self):
+        path = self._write_temp("def broken(\n")
+        names = _get_auto_docstring_names(path)
+        self.assertEqual(names, set())
+
+    def test_has_auto_docstring_decorator_uses_cache(self):
+        from unittest.mock import patch
+
+        path = self._write_temp("@auto_docstring\nclass Cached:\n    pass\n")
+        _auto_docstring_cache[path] = {"Cached"}
+
+        # Create classes whose __name__ matches/doesn't match the cache
+        Cached = type("Cached", (), {})
+        Other = type("Other", (), {})
+
+        with patch.object(inspect, "getfile", return_value=path):
+            self.assertTrue(has_auto_docstring_decorator(Cached))
+            self.assertFalse(has_auto_docstring_decorator(Other))
+
+
+class TestBuildAstIndexes(unittest.TestCase):
+    """Tests for _build_ast_indexes with pre-parsed tree."""
+
+    def test_finds_decorated_items(self):
+        source = (
+            "@auto_docstring\n"
+            "class MyModel:\n"
+            "    def __init__(self, hidden_size=768):\n"
+            "        self.hidden_size = hidden_size\n"
+        )
+        items = _build_ast_indexes(source)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].name, "MyModel")
+        self.assertEqual(items[0].kind, "class")
+        self.assertIn("hidden_size", items[0].args)
+
+    def test_shared_tree(self):
+        source = "@auto_docstring\nclass A:\n    pass\n"
+        tree = ast.parse(source)
+        items_with_tree = _build_ast_indexes(source, tree=tree)
+        items_without = _build_ast_indexes(source)
+        self.assertEqual(len(items_with_tree), len(items_without))
+        self.assertEqual(items_with_tree[0].name, items_without[0].name)
+
+    def test_no_decorated_items(self):
+        source = "class Plain:\n    pass\n"
+        items = _build_ast_indexes(source)
+        self.assertEqual(items, [])
+
+    def test_function_decorated(self):
+        source = "@auto_docstring\ndef my_func(x, y=10):\n    pass\n"
+        items = _build_ast_indexes(source)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].name, "my_func")
+        self.assertEqual(items[0].kind, "function")
+        self.assertIn("x", items[0].args)
+        self.assertIn("y", items[0].args)
+
+    def test_custom_args_from_variable(self):
+        source = (
+            'MY_ARGS = "custom param docs"\n'
+            "\n"
+            "@auto_docstring(custom_args=MY_ARGS)\n"
+            "class WithCustom:\n"
+            "    def __init__(self):\n"
+            "        pass\n"
+        )
+        items = _build_ast_indexes(source)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].custom_args_text, "custom param docs")
+
+
+class TestFindTypedDictClasses(unittest.TestCase):
+    """Tests for _find_typed_dict_classes with pre-parsed tree."""
+
+    def test_finds_typed_dict(self):
+        source = "from typing import TypedDict\n\nclass MyKwargs(TypedDict):\n    field_a: str\n    field_b: int\n"
+        result = _find_typed_dict_classes(source)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["name"], "MyKwargs")
+        self.assertIn("field_a", result[0]["all_fields"])
+        self.assertIn("field_b", result[0]["all_fields"])
+
+    def test_shared_tree(self):
+        source = "class MyKwargs(TypedDict):\n    x: int\n"
+        tree = ast.parse(source)
+        r1 = _find_typed_dict_classes(source, tree=tree)
+        r2 = _find_typed_dict_classes(source)
+        self.assertEqual(len(r1), len(r2))
+        self.assertEqual(r1[0]["name"], r2[0]["name"])
+
+    def test_skips_standard_kwargs(self):
+        source = "class TextKwargs(TypedDict):\n    field: str\n"
+        result = _find_typed_dict_classes(source)
+        self.assertEqual(result, [])
+
+    def test_no_typed_dicts(self):
+        source = "class Regular:\n    pass\n"
+        result = _find_typed_dict_classes(source)
+        self.assertEqual(result, [])
+
+    def test_skips_private_fields(self):
+        source = "class MyKwargs(TypedDict):\n    public: int\n    _private: str\n"
+        result = _find_typed_dict_classes(source)
+        self.assertEqual(len(result), 1)
+        self.assertIn("public", result[0]["all_fields"])
+        self.assertNotIn("_private", result[0]["all_fields"])

--- a/tests/repo_utils/test_check_docstrings.py
+++ b/tests/repo_utils/test_check_docstrings.py
@@ -126,39 +126,46 @@ class TestGetAutoDocstringNames(unittest.TestCase):
 
     def test_detects_simple_decorator(self):
         """Test that a class decorated with @auto_docstring is detected."""
-        path = self._write_temp(textwrap.dedent("""\
+        path = self._write_temp(
+            textwrap.dedent("""\
             from transformers import auto_docstring
 
             @auto_docstring
             class Foo:
                 pass
-        """))
+        """)
+        )
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, {"Foo"})
 
     def test_detects_decorator_with_call(self):
         """Test that a class decorated with @auto_docstring(args) (called form) is detected."""
-        path = self._write_temp(textwrap.dedent("""\
+        path = self._write_temp(
+            textwrap.dedent("""\
             @auto_docstring(custom_args='x')
             class Bar:
                 pass
-        """))
+        """)
+        )
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, {"Bar"})
 
     def test_ignores_other_decorators(self):
         """Test that classes with non-auto_docstring decorators are not detected."""
-        path = self._write_temp(textwrap.dedent("""\
+        path = self._write_temp(
+            textwrap.dedent("""\
             @dataclass
             class Baz:
                 pass
-        """))
+        """)
+        )
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, set())
 
     def test_multiple_classes(self):
         """Test that only decorated classes and functions are returned when multiple definitions exist."""
-        path = self._write_temp(textwrap.dedent("""\
+        path = self._write_temp(
+            textwrap.dedent("""\
             @auto_docstring
             class A:
                 pass
@@ -169,17 +176,20 @@ class TestGetAutoDocstringNames(unittest.TestCase):
             @auto_docstring()
             def func_c():
                 pass
-        """))
+        """)
+        )
         names = _get_auto_docstring_names(path)
         self.assertEqual(names, {"A", "func_c"})
 
     def test_caching(self):
         """Test that repeated calls for the same file return the cached (identical) result object."""
-        path = self._write_temp(textwrap.dedent("""\
+        path = self._write_temp(
+            textwrap.dedent("""\
             @auto_docstring
             class X:
                 pass
-        """))
+        """)
+        )
         result1 = _get_auto_docstring_names(path)
         result2 = _get_auto_docstring_names(path)
         self.assertIs(result1, result2)
@@ -194,11 +204,13 @@ class TestGetAutoDocstringNames(unittest.TestCase):
         """Test that has_auto_docstring_decorator looks up names from the pre-populated cache."""
         from unittest.mock import patch
 
-        path = self._write_temp(textwrap.dedent("""\
+        path = self._write_temp(
+            textwrap.dedent("""\
             @auto_docstring
             class Cached:
                 pass
-        """))
+        """)
+        )
         _auto_docstring_cache[path] = {"Cached"}
 
         # Create classes whose __name__ matches/doesn't match the cache

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -388,6 +388,7 @@ MATH_OPERATORS = {
 def _get_auto_docstring_names(file_path: str) -> set[str]:
     """
     Parse a source file once and return the set of class/function names decorated with @auto_docstring.
+    Walks top-level definitions and one level into class bodies (methods).
     Results are cached per file path.
     """
     if file_path in _auto_docstring_cache:
@@ -398,17 +399,16 @@ def _get_auto_docstring_names(file_path: str) -> set[str]:
         with open(file_path) as f:
             source = f.read()
         tree = ast.parse(source, filename=file_path)
-        for node in ast.iter_child_nodes(tree):
+        for node in tree.body:
             if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
-                for decorator in node.decorator_list:
-                    dec_name = None
-                    if isinstance(decorator, ast.Name):
-                        dec_name = decorator.id
-                    elif isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name):
-                        dec_name = decorator.func.id
-                    if dec_name == "auto_docstring":
-                        names.add(node.name)
-                        break
+                if any(_is_auto_docstring_decorator(dec) for dec in node.decorator_list):
+                    names.add(node.name)
+                # Also check methods inside classes
+                if isinstance(node, ast.ClassDef):
+                    for class_item in node.body:
+                        if isinstance(class_item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                            if any(_is_auto_docstring_decorator(dec) for dec in class_item.decorator_list):
+                                names.add(class_item.name)
     except (OSError, SyntaxError):
         pass
 
@@ -1970,8 +1970,8 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False):
         tree = ast.parse(content)
         decorated_items = _build_ast_indexes(content, tree=tree)
 
-        # Populate the auto_docstring cache so check_docstrings() won't re-parse these files
-        _auto_docstring_cache[candidate_file] = {item.name for item in decorated_items}
+        # Warm the cache so check_docstrings() won't re-parse this file
+        _get_auto_docstring_names(candidate_file)
 
         missing_docstring_args_warnings = []
         fill_docstring_args_warnings = []

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -385,14 +385,14 @@ MATH_OPERATORS = {
 }
 
 
-def _get_auto_docstring_names(file_path: str) -> set[str]:
+def _get_auto_docstring_names(file_path: str, cache: dict[str, set[str]] | None = None) -> set[str]:
     """
     Parse a source file once and return the set of class/function names decorated with @auto_docstring.
     Walks top-level definitions and one level into class bodies (methods).
-    Results are cached per file path.
+    Results can be cached per file path.
     """
-    if file_path in _auto_docstring_cache:
-        return _auto_docstring_cache[file_path]
+    if cache is not None and file_path in cache:
+        return cache[file_path]
 
     names = set()
     try:
@@ -412,19 +412,17 @@ def _get_auto_docstring_names(file_path: str) -> set[str]:
     except (OSError, SyntaxError):
         pass
 
-    _auto_docstring_cache[file_path] = names
+    if cache is not None:
+        cache[file_path] = names
     return names
 
 
-_auto_docstring_cache: dict[str, set[str]] = {}
-
-
-def has_auto_docstring_decorator(obj) -> bool:
+def has_auto_docstring_decorator(obj, cache: dict[str, set[str]] | None = None) -> bool:
     try:
         source_file = inspect.getfile(obj)
     except (TypeError, OSError):
         return False
-    decorated_names = _get_auto_docstring_names(source_file)
+    decorated_names = _get_auto_docstring_names(source_file, cache=cache)
     return obj.__name__ in decorated_names
 
 
@@ -1944,11 +1942,20 @@ def update_file_with_new_docstrings(
     )
 
 
-def check_auto_docstrings(overwrite: bool = False, check_all: bool = False):
+def check_auto_docstrings(overwrite: bool = False, check_all: bool = False, cache: dict[str, set[str]] | None = None):
     """
     Check docstrings of all public objects that are decorated with `@auto_docstrings`.
     This function orchestrates the process by finding relevant files, scanning for decorators,
     generating new docstrings, and updating files as needed.
+
+    Args:
+        overwrite (`bool`, *optional*, defaults to `False`):
+            Whether to fix inconsistencies or not.
+        check_all (`bool`, *optional*, defaults to `False`):
+            Whether to check all files.
+        cache (Dictionary `str` to `Set[str]`, *optional*):
+            To speed up auto-docstring detection if it was previously called on a file, the cache of all previously
+            computed results.
     """
     # 1. Find all model files to check
     matching_files = find_matching_model_files(check_all)
@@ -1971,7 +1978,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False):
         decorated_items = _build_ast_indexes(content, tree=tree)
 
         # Warm the cache so check_docstrings() won't re-parse this file
-        _get_auto_docstring_names(candidate_file)
+        _get_auto_docstring_names(candidate_file, cache=cache)
 
         missing_docstring_args_warnings = []
         fill_docstring_args_warnings = []
@@ -2058,7 +2065,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False):
         )
 
 
-def check_docstrings(overwrite: bool = False, check_all: bool = False):
+def check_docstrings(overwrite: bool = False, check_all: bool = False, cache: dict[str, set[str]] | None = None):
     """
     Check docstrings of all public objects that are callables and are documented. By default, only checks the diff.
 
@@ -2067,6 +2074,9 @@ def check_docstrings(overwrite: bool = False, check_all: bool = False):
             Whether to fix inconsistencies or not.
         check_all (`bool`, *optional*, defaults to `False`):
             Whether to check all files.
+        cache (Dictionary `str` to `Set[str]`, *optional*):
+            To speed up auto-docstring detection if it was previously called on a file, the cache of all previously
+            computed results.
     """
     module_diff_files = None
     if not check_all:
@@ -2108,7 +2118,7 @@ def check_docstrings(overwrite: bool = False, check_all: bool = False):
                 continue
 
         # Skip objects decorated with @auto_docstring - they have auto-generated documentation
-        if has_auto_docstring_decorator(obj):
+        if has_auto_docstring_decorator(obj, cache=cache):
             continue
 
         # Check docstring
@@ -2165,5 +2175,6 @@ if __name__ == "__main__":
         "--check_all", action="store_true", help="Whether to check all files. By default, only checks the diff"
     )
     args = parser.parse_args()
-    check_auto_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all)
-    check_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all)
+    auto_docstring_cache: dict[str, set[str]] = {}
+    check_auto_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache)
+    check_docstrings(overwrite=args.fix_and_overwrite, check_all=args.check_all, cache=auto_docstring_cache)

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -385,21 +385,47 @@ MATH_OPERATORS = {
 }
 
 
-def has_auto_docstring_decorator(obj) -> bool:
-    try:
-        # Get the source lines for the object
-        source_lines = inspect.getsourcelines(obj)[0]
+def _get_auto_docstring_names(file_path: str) -> set[str]:
+    """
+    Parse a source file once and return the set of class/function names decorated with @auto_docstring.
+    Results are cached per file path.
+    """
+    if file_path in _auto_docstring_cache:
+        return _auto_docstring_cache[file_path]
 
-        # Check the lines before the definition for @auto_docstring decorator
-        for line in source_lines[:10]:  # Check first 10 lines (decorators come before def/class)
-            line = line.strip()
-            if line.startswith("@auto_docstring"):
-                return True
-    except (TypeError, OSError):
-        # Some objects don't have source code available
+    names = set()
+    try:
+        with open(file_path) as f:
+            source = f.read()
+        tree = ast.parse(source, filename=file_path)
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+                for decorator in node.decorator_list:
+                    dec_name = None
+                    if isinstance(decorator, ast.Name):
+                        dec_name = decorator.id
+                    elif isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Name):
+                        dec_name = decorator.func.id
+                    if dec_name == "auto_docstring":
+                        names.add(node.name)
+                        break
+    except (OSError, SyntaxError):
         pass
 
-    return False
+    _auto_docstring_cache[file_path] = names
+    return names
+
+
+_auto_docstring_cache: dict[str, set[str]] = {}
+
+
+def has_auto_docstring_decorator(obj) -> bool:
+    try:
+        source_file = inspect.getfile(obj)
+    except (TypeError, OSError):
+        return False
+    decorated_names = _get_auto_docstring_names(source_file)
+    return obj.__name__ in decorated_names
 
 
 def find_indent(line: str) -> int:
@@ -1359,13 +1385,14 @@ def generate_new_docstring_for_class(
     )
 
 
-def _build_ast_indexes(source: str) -> list[DecoratedItem]:
+def _build_ast_indexes(source: str, tree: ast.Module | None = None) -> list[DecoratedItem]:
     """Parse source once and return list of all @auto_docstring decorated items.
 
     Returns:
         List of DecoratedItem objects, one for each @auto_docstring decorated function or class.
     """
-    tree = ast.parse(source)
+    if tree is None:
+        tree = ast.parse(source)
     # First pass: collect top-level string variables (for resolving custom_args variable references)
     var_to_string: dict[str, str] = {}
     for node in tree.body:
@@ -1380,9 +1407,9 @@ def _build_ast_indexes(source: str) -> list[DecoratedItem]:
             if isinstance(node.value.value, str) and isinstance(node.target, ast.Name):
                 var_to_string[node.target.id] = node.value.value
     # Second pass: find all @auto_docstring decorated functions/classes
-    # First, identify processor classes to track method context
+    # First, identify processor classes to track method context (only top-level classes)
     processor_classes: set[str] = set()
-    for node in ast.walk(tree):
+    for node in tree.body:
         if isinstance(node, ast.ClassDef):
             for base in node.bases:
                 if isinstance(base, ast.Name) and ("ProcessorMixin" in base.id or "Processor" in base.id):
@@ -1525,7 +1552,7 @@ def _extract_type_name(annotation) -> str | None:
     return None
 
 
-def _find_typed_dict_classes(source: str) -> list[dict]:
+def _find_typed_dict_classes(source: str, tree: ast.Module | None = None) -> list[dict]:
     """
     Find all custom TypedDict kwargs classes in the source.
 
@@ -1534,7 +1561,8 @@ def _find_typed_dict_classes(source: str) -> list[dict]:
         - fields: fields that need custom documentation (not in standard args, not nested TypedDicts)
         - all_fields: all fields including those in standard args (for redundancy checking)
     """
-    tree = ast.parse(source)
+    if tree is None:
+        tree = ast.parse(source)
 
     # Get standard args that are already documented in source classes
     standard_args = set()
@@ -1543,32 +1571,21 @@ def _find_typed_dict_classes(source: str) -> list[dict]:
     except Exception as e:
         logger.debug(f"Could not get standard args from source: {e}")
 
-    # Collect all TypedDict class names first (for excluding nested TypedDicts)
+    # Collect TypedDict class names and nodes (TypedDicts are always top-level)
     typed_dict_names = set()
-    for node in ast.walk(tree):
+    typed_dict_nodes = []
+    for node in tree.body:
         if isinstance(node, ast.ClassDef):
             for base in node.bases:
                 if isinstance(base, ast.Name) and ("TypedDict" in base.id or "Kwargs" in base.id):
                     typed_dict_names.add(node.name)
+                    typed_dict_nodes.append(node)
                     break
 
     typed_dicts = []
 
     # Check each TypedDict class
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
-
-        # Check if this is a TypedDict
-        is_typed_dict = False
-        for base in node.bases:
-            if isinstance(base, ast.Name) and ("TypedDict" in base.id or "Kwargs" in base.id):
-                is_typed_dict = True
-                break
-
-        if not is_typed_dict:
-            continue
-
+    for node in typed_dict_nodes:
         # Skip standard kwargs classes
         if node.name in ["TextKwargs", "ImagesKwargs", "VideosKwargs", "AudioKwargs", "ProcessingKwargs"]:
             continue
@@ -1632,6 +1649,7 @@ def _find_typed_dict_classes(source: str) -> list[dict]:
 def _process_typed_dict_docstrings(
     candidate_file: str,
     overwrite: bool = False,
+    tree: ast.Module | None = None,
 ) -> tuple[list[str], list[str], list[str]]:
     """
     Check and optionally fix TypedDict docstrings.
@@ -1640,6 +1658,7 @@ def _process_typed_dict_docstrings(
     Args:
         candidate_file: Path to the file to process
         overwrite: Whether to fix issues by writing to the file
+        tree: Pre-parsed AST tree to avoid re-parsing the file
 
     Returns:
         Tuple of (missing_warnings, fill_warnings, redundant_warnings)
@@ -1647,7 +1666,7 @@ def _process_typed_dict_docstrings(
     with open(candidate_file, "r", encoding="utf-8") as f:
         content = f.read()
 
-    typed_dicts = _find_typed_dict_classes(content)
+    typed_dicts = _find_typed_dict_classes(content, tree=tree)
     if not typed_dicts:
         return [], [], []
 
@@ -1947,8 +1966,12 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False):
             content = f.read()
         lines = content.split("\n")
 
-        # Parse file once to find all @auto_docstring decorated items
-        decorated_items = _build_ast_indexes(content)
+        # Parse file once and share the AST tree across all analysis passes
+        tree = ast.parse(content)
+        decorated_items = _build_ast_indexes(content, tree=tree)
+
+        # Populate the auto_docstring cache so check_docstrings() won't re-parse these files
+        _auto_docstring_cache[candidate_file] = {item.name for item in decorated_items}
 
         missing_docstring_args_warnings = []
         fill_docstring_args_warnings = []
@@ -1975,7 +1998,7 @@ def check_auto_docstrings(overwrite: bool = False, check_all: bool = False):
         # Process TypedDict kwargs (separate pass to avoid line number conflicts)
         # This runs AFTER @auto_docstring processing is complete
         typed_dict_missing_warnings, typed_dict_fill_warnings, typed_dict_redundant_warnings = (
-            _process_typed_dict_docstrings(candidate_file, overwrite=overwrite)
+            _process_typed_dict_docstrings(candidate_file, overwrite=overwrite, tree=tree)
         )
 
         # Report TypedDict errors
@@ -2077,16 +2100,16 @@ def check_docstrings(overwrite: bool = False, check_all: bool = False):
         if not callable(obj) or not isinstance(obj, type) or getattr(obj, "__doc__", None) is None:
             continue
 
-        # Skip objects decorated with @auto_docstring - they have auto-generated documentation
-        if has_auto_docstring_decorator(obj):
-            continue
-
         # If we are checking against the diff, we skip objects that are not part of the diff.
         if module_diff_files is not None:
             object_file = find_source_file(getattr(transformers, name))
             object_file_relative_path = "src/" + str(object_file).split("/src/")[1]
             if object_file_relative_path not in module_diff_files:
                 continue
+
+        # Skip objects decorated with @auto_docstring - they have auto-generated documentation
+        if has_auto_docstring_decorator(obj):
+            continue
 
         # Check docstring
         try:


### PR DESCRIPTION
# What does this PR do?

This patch improves the docstring checker implementation (redundant AST walks) and adds cache.

For the AST calls, 2.3x speedup check_docstrings.py --check_all on my M1:

- before : 29.3s
 - after: 12.6s
