### PR TITLE
feature: added import complexity checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ check-code-quality:
 check-repository-consistency:
 	@python utils/checkers.py \
 		imports,\
+		import_complexity,\
 		copies,\
 		modular_conversion,\
 		doc_toc,\
@@ -58,6 +59,7 @@ check-repo:
 		init_isort,\
 		auto_mappings,\
 		imports,\
+		import_complexity,\
 		copies,\
 		modular_conversion,\
 		doc_toc,\

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -47,10 +47,6 @@ else:
 if is_vision_available():
     from PIL.Image import Image
 
-if is_torch_available():
-    from torch import Tensor
-
-
 ChatType = list[dict[str, Any]]
 
 
@@ -93,7 +89,9 @@ def _get_json_schema_type(param_type: type) -> dict[str, str]:
     if is_vision_available():
         type_mapping[Image] = {"type": "image"}
     if is_torch_available():
-        type_mapping[Tensor] = {"type": "audio"}
+        import torch
+
+        type_mapping[torch.Tensor] = {"type": "audio"}
     return type_mapping.get(param_type, {"type": "object"})
 
 

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -44,23 +44,11 @@ if TYPE_CHECKING:
 logger = logging.get_logger(__name__)
 
 
-_is_torch_available = is_torch_available()
+_is_torch_available = False
+if is_torch_available():
+    _is_torch_available = True
+
 _registered_model_output_types: set[type[Any]] = set()
-
-
-def _get_torch():
-    if not _is_torch_available:
-        return None
-
-    import torch
-
-    return torch
-
-
-def _get_model_addition_debugger_context():
-    from ..model_debugging_utils import model_addition_debugger_context
-
-    return model_addition_debugger_context
 
 
 def _register_model_output_pytree_node(output_type: type[ModelOutput]) -> None:
@@ -163,7 +151,8 @@ def is_torch_tensor(x) -> bool:
     if not _is_torch_available:
         return False
 
-    torch = _get_torch()
+    import torch
+
     return isinstance(x, torch.Tensor)
 
 
@@ -174,7 +163,8 @@ def is_torch_device(x) -> bool:
     if not _is_torch_available:
         return False
 
-    torch = _get_torch()
+    import torch
+
     return isinstance(x, torch.device)
 
 
@@ -185,7 +175,8 @@ def is_torch_dtype(x) -> bool:
     if not _is_torch_available:
         return False
 
-    torch = _get_torch()
+    import torch
+
     if isinstance(x, str):
         if hasattr(torch, x):
             x = getattr(torch, x)
@@ -230,9 +221,10 @@ def maybe_autocast(
     Which makes graph splitting in `torch.compile` more flexible as it removes the
     requirement that partition IDs be monotonically increasing.
     """
-    torch = _get_torch()
-    if torch is None:
+    if not _is_torch_available:
         raise ImportError("`maybe_autocast` requires PyTorch to be installed.")
+
+    import torch
 
     if device_type == "meta":
         return nullcontext()
@@ -677,7 +669,8 @@ def torch_int(x):
     if not _is_torch_available:
         return int(x)
 
-    torch = _get_torch()
+    import torch
+
     return x.to(torch.int64) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
 
 
@@ -688,7 +681,8 @@ def torch_float(x):
     if not _is_torch_available:
         return int(x)
 
-    torch = _get_torch()
+    import torch
+
     return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
 
 
@@ -948,7 +942,8 @@ def merge_with_config_defaults(func):
         # Call the original forward with the updated kwargs/config
         try:
             if kwargs.get("debug_io", False):
-                model_addition_debugger_context = _get_model_addition_debugger_context()
+                from ..model_debugging_utils import model_addition_debugger_context
+
                 with model_addition_debugger_context(
                     self, kwargs.get("debug_io_dir", "model_debug"), kwargs.get("prune_layers")
                 ):

--- a/src/transformers/utils/generic.py
+++ b/src/transformers/utils/generic.py
@@ -36,22 +36,46 @@ from ..utils import logging
 from .import_utils import is_mlx_available, is_torch_available, is_torch_fx_proxy
 
 
-_is_torch_available = False
-if is_torch_available():
-    # required for @can_return_tuple decorator to work with torchdynamo
-    import torch
-    from torch.types import _dtype
-
-    from ..model_debugging_utils import model_addition_debugger_context
-
-    _is_torch_available = True
-
-
 if TYPE_CHECKING:
+    import torch
     from torch import nn
 
 
 logger = logging.get_logger(__name__)
+
+
+_is_torch_available = is_torch_available()
+_registered_model_output_types: set[type[Any]] = set()
+
+
+def _get_torch():
+    if not _is_torch_available:
+        return None
+
+    import torch
+
+    return torch
+
+
+def _get_model_addition_debugger_context():
+    from ..model_debugging_utils import model_addition_debugger_context
+
+    return model_addition_debugger_context
+
+
+def _register_model_output_pytree_node(output_type: type[ModelOutput]) -> None:
+    if not _is_torch_available or output_type in _registered_model_output_types:
+        return
+
+    import torch.utils._pytree as torch_pytree
+
+    torch_pytree.register_pytree_node(
+        output_type,
+        _model_output_flatten,
+        partial(_model_output_unflatten, output_type=output_type),
+        serialized_type_name=f"{output_type.__module__}.{output_type.__name__}",
+    )
+    _registered_model_output_types.add(output_type)
 
 
 # required for @can_return_tuple decorator to work with torchdynamo
@@ -136,14 +160,22 @@ def is_torch_tensor(x) -> bool:
     """
     Tests if `x` is a torch tensor or not. Safe to call even if torch is not installed.
     """
-    return _is_torch_available and isinstance(x, torch.Tensor)
+    if not _is_torch_available:
+        return False
+
+    torch = _get_torch()
+    return isinstance(x, torch.Tensor)
 
 
 def is_torch_device(x) -> bool:
     """
     Tests if `x` is a torch device or not. Safe to call even if torch is not installed.
     """
-    return _is_torch_available and isinstance(x, torch.device)
+    if not _is_torch_available:
+        return False
+
+    torch = _get_torch()
+    return isinstance(x, torch.device)
 
 
 def is_torch_dtype(x) -> bool:
@@ -152,6 +184,8 @@ def is_torch_dtype(x) -> bool:
     """
     if not _is_torch_available:
         return False
+
+    torch = _get_torch()
     if isinstance(x, str):
         if hasattr(torch, x):
             x = getattr(torch, x)
@@ -182,7 +216,7 @@ def _is_tensor_or_array_like(value):
 
 def maybe_autocast(
     device_type: str,
-    dtype: _dtype | None = None,
+    dtype: torch.dtype | None = None,
     enabled: bool = True,
     cache_enabled: bool | None = None,
 ):
@@ -196,6 +230,10 @@ def maybe_autocast(
     Which makes graph splitting in `torch.compile` more flexible as it removes the
     requirement that partition IDs be monotonically increasing.
     """
+    torch = _get_torch()
+    if torch is None:
+        raise ImportError("`maybe_autocast` requires PyTorch to be installed.")
+
     if device_type == "meta":
         return nullcontext()
     if torch.is_autocast_enabled(device_type) or enabled:
@@ -342,18 +380,11 @@ class ModelOutput(OrderedDict):
         This is necessary to synchronize gradients when using `torch.nn.parallel.DistributedDataParallel` with
         `static_graph=True` with modules that output `ModelOutput` subclasses.
         """
-        if _is_torch_available:
-            from torch.utils._pytree import register_pytree_node
-
-            register_pytree_node(
-                cls,
-                _model_output_flatten,
-                partial(_model_output_unflatten, output_type=cls),
-                serialized_type_name=f"{cls.__module__}.{cls.__name__}",
-            )
+        _register_model_output_pytree_node(cls)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        _register_model_output_pytree_node(type(self))
 
         # Subclasses of ModelOutput must use the @dataclass decorator
         # This check is done in __init__ because the @dataclass decorator operates after __init_subclass__
@@ -372,6 +403,7 @@ class ModelOutput(OrderedDict):
 
         Only occurs if @dataclass decorator has been used.
         """
+        _register_model_output_pytree_node(type(self))
         class_fields = fields(self)
 
         # Safety and consistency checks
@@ -468,25 +500,16 @@ class ModelOutput(OrderedDict):
         return tuple(self[k] for k in self.keys())
 
 
-if _is_torch_available:
-    import torch.utils._pytree as _torch_pytree
+def _model_output_flatten(output: ModelOutput) -> tuple[list[Any], list[str]]:
+    return list(output.values()), list(output.keys())
 
-    def _model_output_flatten(output: ModelOutput) -> tuple[list[Any], _torch_pytree.Context]:
-        return list(output.values()), list(output.keys())
 
-    def _model_output_unflatten(
-        values: Iterable[Any],
-        context: _torch_pytree.Context,
-        output_type: type[ModelOutput] | None = None,
-    ) -> ModelOutput:
-        return output_type(**dict(zip(context, values)))
-
-    _torch_pytree.register_pytree_node(
-        ModelOutput,
-        _model_output_flatten,
-        partial(_model_output_unflatten, output_type=ModelOutput),
-        serialized_type_name=f"{ModelOutput.__module__}.{ModelOutput.__name__}",
-    )
+def _model_output_unflatten(
+    values: Iterable[Any],
+    context: list[str],
+    output_type: type[ModelOutput] | None = None,
+) -> ModelOutput:
+    return output_type(**dict(zip(context, values)))
 
 
 class ExplicitEnum(str, Enum):
@@ -654,6 +677,7 @@ def torch_int(x):
     if not _is_torch_available:
         return int(x)
 
+    torch = _get_torch()
     return x.to(torch.int64) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
 
 
@@ -664,6 +688,7 @@ def torch_float(x):
     if not _is_torch_available:
         return int(x)
 
+    torch = _get_torch()
     return x.to(torch.float32) if torch.jit.is_tracing() and isinstance(x, torch.Tensor) else int(x)
 
 
@@ -923,6 +948,7 @@ def merge_with_config_defaults(func):
         # Call the original forward with the updated kwargs/config
         try:
             if kwargs.get("debug_io", False):
+                model_addition_debugger_context = _get_model_addition_debugger_context()
                 with model_addition_debugger_context(
                     self, kwargs.get("debug_io_dir", "model_debug"), kwargs.get("prune_layers")
                 ):

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from ..utils import PushToHubMixin, is_torch_available
-
-
-if is_torch_available():
-    import torch
+from ..utils import PushToHubMixin
 
 
 def infer_device(model):
@@ -48,6 +44,8 @@ def infer_device(model):
     dev_type = param.device.type
     if dev_type == "cuda":
         # Refine based on actual platform
+        import torch
+
         if getattr(torch, "version").hip is not None:
             return "rocm"
 

--- a/src/transformers/utils/kernel_config.py
+++ b/src/transformers/utils/kernel_config.py
@@ -44,10 +44,13 @@ def infer_device(model):
     dev_type = param.device.type
     if dev_type == "cuda":
         # Refine based on actual platform
-        import torch
+        from ..utils import is_torch_available
 
-        if getattr(torch, "version").hip is not None:
-            return "rocm"
+        if is_torch_available():
+            import torch
+
+            if getattr(torch, "version").hip is not None:
+                return "rocm"
 
     return dev_type
 

--- a/utils/check_import_complexity.py
+++ b/utils/check_import_complexity.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Check that `import transformers` does not pull in too many modules.
+
+Traces the full import tree triggered by `import transformers` using a custom
+``importlib.abc.MetaPathFinder`` and counts every module that gets loaded.
+If the count exceeds ``MAX_IMPORT_COUNT`` the check fails, signalling a
+potential regression in import speed.
+
+Usage:
+    python utils/check_import_complexity.py            # CI check mode
+    python utils/check_import_complexity.py --display   # show the full import tree
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.abc
+import sys
+import threading
+from dataclasses import dataclass, field
+from types import ModuleType
+from typing import Any
+
+
+MAX_IMPORT_COUNT = 1500
+
+
+# ---------------------------------------------------------------------------
+# Import-tree data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ImportNode:
+    name: str
+    children: list[ImportNode] = field(default_factory=list)
+
+
+class LoaderProxy(importlib.abc.Loader):
+    """Wrap a real loader to track the import stack during exec_module."""
+
+    def __init__(self, wrapped: Any, tracer: ImportTreeTracer, fullname: str):
+        self._wrapped = wrapped
+        self._tracer = tracer
+        self._fullname = fullname
+
+    def create_module(self, spec):
+        if hasattr(self._wrapped, "create_module"):
+            return self._wrapped.create_module(spec)
+        return None
+
+    def exec_module(self, module: ModuleType) -> None:
+        self._tracer.push(self._fullname)
+        try:
+            if hasattr(self._wrapped, "exec_module"):
+                self._wrapped.exec_module(module)
+            elif hasattr(self._wrapped, "load_module"):
+                self._wrapped.load_module(self._fullname)
+            else:
+                raise ImportError(f"Loader for {self._fullname!r} has neither exec_module nor load_module")
+        finally:
+            self._tracer.pop()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+
+class ImportTreeFinder(importlib.abc.MetaPathFinder):
+    """Intercept imports to build a parent/child tree of loaded modules."""
+
+    def __init__(self, tracer: ImportTreeTracer, original_meta_path: list[Any]):
+        self._tracer = tracer
+        self._original = list(original_meta_path)
+
+    def find_spec(self, fullname: str, path=None, target=None):
+        if self._tracer.is_seen(fullname):
+            return None
+
+        for finder in self._original:
+            try:
+                spec = finder.find_spec(fullname, path, target) if hasattr(finder, "find_spec") else None
+            except Exception:
+                continue
+
+            if spec is None:
+                continue
+
+            self._tracer.record(fullname)
+
+            if spec.loader is not None:
+                spec.loader = LoaderProxy(spec.loader, self._tracer, fullname)
+
+            return spec
+
+        return None
+
+
+class ImportTreeTracer:
+    def __init__(self) -> None:
+        self._local = threading.local()
+        self._nodes: dict[str, ImportNode] = {}
+        self._roots: list[ImportNode] = []
+        self._seen: set[str] = set()
+
+    def _stack(self) -> list[str]:
+        stack = getattr(self._local, "stack", None)
+        if stack is None:
+            stack = []
+            self._local.stack = stack
+        return stack
+
+    def is_seen(self, fullname: str) -> bool:
+        return fullname in self._seen
+
+    def _get_or_create(self, fullname: str) -> ImportNode:
+        if fullname not in self._nodes:
+            self._nodes[fullname] = ImportNode(name=fullname)
+        return self._nodes[fullname]
+
+    def record(self, fullname: str) -> None:
+        if fullname in self._seen:
+            return
+        self._seen.add(fullname)
+        node = self._get_or_create(fullname)
+        stack = self._stack()
+        if stack:
+            parent = self._get_or_create(stack[-1])
+            if all(c.name != fullname for c in parent.children):
+                parent.children.append(node)
+        else:
+            if all(r.name != fullname for r in self._roots):
+                self._roots.append(node)
+
+    def push(self, fullname: str) -> None:
+        self._stack().append(fullname)
+
+    def pop(self) -> None:
+        stack = self._stack()
+        if stack:
+            stack.pop()
+
+    @property
+    def count(self) -> int:
+        return len(self._seen)
+
+    @property
+    def roots(self) -> list[ImportNode]:
+        return self._roots
+
+
+# ---------------------------------------------------------------------------
+# Tracing entry-point
+# ---------------------------------------------------------------------------
+
+
+def trace_import(target: str) -> ImportTreeTracer:
+    tracer = ImportTreeTracer()
+    original_meta_path = list(sys.meta_path)
+    finder = ImportTreeFinder(tracer, original_meta_path)
+    sys.meta_path.insert(0, finder)
+    try:
+        importlib.import_module(target)
+    finally:
+        try:
+            sys.meta_path.remove(finder)
+        except ValueError:
+            pass
+    return tracer
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+
+def format_tree(nodes: list[ImportNode]) -> str:
+    lines: list[str] = []
+
+    def _walk(node: ImportNode, prefix: str, is_last: bool) -> None:
+        connector = "└── " if is_last else "├── "
+        lines.append(f"{prefix}{connector}{node.name}")
+        child_prefix = prefix + ("    " if is_last else "│   ")
+        for i, child in enumerate(node.children):
+            _walk(child, child_prefix, i == len(node.children) - 1)
+
+    for i, root in enumerate(nodes):
+        _walk(root, "", i == len(nodes) - 1)
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Check import complexity for `import transformers`.")
+    parser.add_argument(
+        "--display",
+        action="store_true",
+        help="Display the full import tree (for debugging regressions).",
+    )
+    parser.add_argument(
+        "--max-count",
+        type=int,
+        default=MAX_IMPORT_COUNT,
+        help=f"Maximum allowed number of imported modules (default: {MAX_IMPORT_COUNT}).",
+    )
+    args = parser.parse_args()
+
+    try:
+        tracer = trace_import("transformers")
+    except Exception as exc:
+        print(f"ERROR: `import transformers` failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.display:
+        print(format_tree(tracer.roots))
+        print()
+        print(f"Total modules imported: {tracer.count}")
+        return 0
+
+    if tracer.count > args.max_count:
+        print(
+            f"Import complexity regression: `import transformers` triggered {tracer.count} module imports "
+            f"(maximum allowed: {args.max_count}).\n"
+            f"\n"
+            f"Run the following command to display the full import tree and identify the cause:\n"
+            f"\n"
+            f"    python utils/check_import_complexity.py --display\n"
+        )
+        return 1
+
+    print(f"Import complexity OK: {tracer.count} modules (max {args.max_count})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/check_import_complexity.py
+++ b/utils/check_import_complexity.py
@@ -36,7 +36,7 @@ from types import ModuleType
 from typing import Any
 
 
-MAX_IMPORT_COUNT = 1500
+MAX_IMPORT_COUNT = 700
 
 
 # ---------------------------------------------------------------------------

--- a/utils/check_import_complexity.py
+++ b/utils/check_import_complexity.py
@@ -36,7 +36,7 @@ from types import ModuleType
 from typing import Any
 
 
-MAX_IMPORT_COUNT = 700
+MAX_IMPORT_COUNT = 1000
 
 
 # ---------------------------------------------------------------------------

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -70,6 +70,7 @@ CHECKERS = {
     "modeling_structure": ("Modeling file structure", "check_modeling_structure.py", [], None),
     "deps_table": ("Dependency versions table", None, None, None),
     "imports": ("Public imports", None, None, None),
+    "import_complexity": ("Import complexity", "check_import_complexity.py", [], None),
     "ruff_check": ("Ruff linting", None, None, None),
     "ruff_format": ("Ruff formatting", None, None, None),
 }


### PR DESCRIPTION
# What does this PR do?

- Adds a new checker in `make chek-repo` that will `import transformers` and count the number of imported module. 
- Lazy import of torch when doing `import transformers`

The change will reduce the import time from ~1.5s to ~0.7s (+3000 modules to 619 modules)
The checker will error out when it goes over a threshold - for instance if our code imports a lib like `torch` not lazily
This will prevent imports slowdowns regression. 

Can be used directly to display the import counts and import tree:

```
✗ python utils/check_import_complexity.py
Import complexity regression: `import transformers` triggered 1890 module imports (maximum allowed: 1500).

Run the following command to display the full import tree and identify the cause:

    python utils/check_import_complexity.py --display

✗ python utils/check_import_complexity.py --display
...
    │   │   │   │   ├── tqdm.contrib
    │   │   │   │   ├── tqdm.contrib.concurrent
    │   │   │   │   ├── huggingface_hub._buckets
    │   │   │   │   ├── huggingface_hub._commit_api
    │   │   │   │   │   └── huggingface_hub.lfs
    │   │   │   │   ├── huggingface_hub._dataset_viewer
    │   │   │   │   ├── huggingface_hub._eval_results
    │   │   │   │   ├── huggingface_hub._inference_endpoints
    │   │   │   │   ├── huggingface_hub._jobs_api
    │   │   │   │   │   └── huggingface_hub._space_api
    │   │   │   │   ├── huggingface_hub._upload_large_folder
    │   │   │   │   ├── huggingface_hub.community
    │   │   │   │   ├── huggingface_hub.repocard_data
    │   │   │   │   ├── huggingface_hub.utils._deprecation
    │   │   │   │   ├── huggingface_hub.utils._verification
    │   │   │   │   └── huggingface_hub.utils.endpoint_helpers
    │   │   │   ├── huggingface_hub.repocard
    │   │   │   └── huggingface_hub._snapshot_download
    │   │   ├── transformers.utils.kernel_config
    │   │   └── transformers.utils.peft_utils
    │   ├── transformers.utils.versions
    │   ├── tokenizers
    │   └── accelerate
    ├── sentencepiece
    ├── mistral_common
    ├── torchvision
    ├── torchaudio
    ├── librosa
    ├── timm
    └── scipy

Total modules imported: 1890
``` 