### PR TITLE
Don't run `tests_hub` if no tests found

### DIFF
--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1106,16 +1106,27 @@ JOB_TO_TEST_FILE = {
 def create_test_list_from_filter(full_test_list, out_path):
     os.makedirs(out_path, exist_ok=True)
     all_test_files = "\n".join(full_test_list)
+
+    to_output = []
     for job_name, _filter in JOB_TO_TEST_FILE.items():
         file_name = os.path.join(out_path, f"{job_name}_test_list.txt")
         if job_name == "tests_hub":
             files_to_test = ["tests"]
         else:
             files_to_test = list(re.findall(_filter, all_test_files))
-        print(job_name, file_name)
+
+        print(job_name, file_name, len(files_to_test))
+
         if len(files_to_test) > 0:  # No tests -> no file with test list
-            with open(file_name, "w") as f:
-                f.write("\n".join(files_to_test))
+            to_output.append((job_name, file_name, files_to_test))
+
+    # Only get `tests_hub`, which means we have 0 test file for all other jobs --> No job at all to run.
+    if len(to_output) == 1:
+        to_output = []
+
+    for _, file_name, files_to_test in to_output:
+        with open(file_name, "w") as f:
+            f.write("\n".join(files_to_test))
 
 
 if __name__ == "__main__":

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1107,6 +1107,7 @@ def create_test_list_from_filter(full_test_list, out_path):
     os.makedirs(out_path, exist_ok=True)
     all_test_files = "\n".join(full_test_list)
 
+    # Collect info: job_name, file_name and files_to_test, so we can process after the loop
     to_output = []
     for job_name, _filter in JOB_TO_TEST_FILE.items():
         file_name = os.path.join(out_path, f"{job_name}_test_list.txt")

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -1123,6 +1123,7 @@ def create_test_list_from_filter(full_test_list, out_path):
 
     # Only get `tests_hub`, which means we have 0 test file for all other jobs --> No job at all to run.
     if len(to_output) == 1:
+        print("No test file found for any job, skipping `tests_hub` as well.")
         to_output = []
 
     for _, file_name, files_to_test in to_output:


### PR DESCRIPTION
# What does this PR do?

#30674 refactors the way we obtain CircleCI test files to run for each job.

It always puts ["tests"] for `tests_hub`, so each commit of each PR will run it, no matter if there is any change to codebase.

Let's reduce the CI load by running an `Empty` job instead (just what it did before #30674), see

https://app.circleci.com/pipelines/github/huggingface/transformers/169582/workflows/506f301e-600c-4717-9c70-3edd9b48275c