### PR TITLE
fix: guard sys.modules access in _can_set_attn/experts_implementation

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1948,9 +1948,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Detect whether the class supports setting its attention implementation dynamically. It is an ugly check based on
         opening the file, but avoids maintaining yet another property flag.
         """
-        class_module = sys.modules[cls.__module__]
-        # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
-        if not hasattr(class_module, "__file__"):
+        class_module = sys.modules.get(cls.__module__)
+        # This can happen for a custom model in a jupyter notebook or repl for example, or when the module was removed
+        # from sys.modules by lazy loaders or frozen importers - simply do not allow to set it then
+        if class_module is None or not hasattr(class_module, "__file__"):
             return False
         class_file = class_module.__file__
         with open(class_file, "r", encoding="utf-8") as f:
@@ -1967,9 +1968,10 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Detect whether the class supports setting its experts implementation dynamically. It is an ugly check based on
         opening the file, but avoids maintaining yet another property flag.
         """
-        class_module = sys.modules[cls.__module__]
-        # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
-        if not hasattr(class_module, "__file__"):
+        class_module = sys.modules.get(cls.__module__)
+        # This can happen for a custom model in a jupyter notebook or repl for example, or when the module was removed
+        # from sys.modules by lazy loaders or frozen importers - simply do not allow to set it then
+        if class_module is None or not hasattr(class_module, "__file__"):
             return False
         class_file = class_module.__file__
         with open(class_file, "r", encoding="utf-8") as f:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2949,6 +2949,53 @@ class TestAttentionImplementation(unittest.TestCase):
 
 
 @require_torch
+class TestCanSetImplementationWithMissingSysModule(unittest.TestCase):
+    """Regression test for https://github.com/huggingface/transformers/issues/45003.
+
+    When a module is absent from sys.modules (e.g. lazy loaders, frozen importers),
+    _can_set_attn_implementation and _can_set_experts_implementation should return
+    False instead of raising a KeyError.
+    """
+
+    def test_can_set_attn_implementation_missing_sys_module(self):
+        from transformers.models.clip.modeling_clip import CLIPTextModel
+
+        module_key = CLIPTextModel.__module__
+        original = sys.modules.pop(module_key, None)
+        try:
+            result = CLIPTextModel._can_set_attn_implementation()
+            self.assertFalse(result)
+        finally:
+            if original is not None:
+                sys.modules[module_key] = original
+
+    def test_can_set_experts_implementation_missing_sys_module(self):
+        from transformers.models.clip.modeling_clip import CLIPTextModel
+
+        module_key = CLIPTextModel.__module__
+        original = sys.modules.pop(module_key, None)
+        try:
+            result = CLIPTextModel._can_set_experts_implementation()
+            self.assertFalse(result)
+        finally:
+            if original is not None:
+                sys.modules[module_key] = original
+
+    def test_model_init_with_missing_sys_module(self):
+        from transformers.models.clip.modeling_clip import CLIPTextConfig, CLIPTextModel
+
+        module_key = CLIPTextModel.__module__
+        original = sys.modules.pop(module_key, None)
+        try:
+            config = CLIPTextConfig()
+            model = CLIPTextModel(config)
+            self.assertIsNotNone(model)
+        finally:
+            if original is not None:
+                sys.modules[module_key] = original
+
+
+@require_torch
 class TestTensorSharing(TestCasePlus):
     def test_disjoint(self):
         main = torch.zeros(10)


### PR DESCRIPTION
## What does this PR do?

Fixes a `KeyError` in `_can_set_attn_implementation` and `_can_set_experts_implementation` when a model's module is absent from `sys.modules`.

Fixes #45003

## Root Cause

Both `_can_set_attn_implementation` (line 1951) and `_can_set_experts_implementation` (line 1970) use a direct dictionary subscript:

```python
class_module = sys.modules[cls.__module__]
```

This raises `KeyError` when the module is not registered in `sys.modules` — which happens with lazy loaders, frozen importers, or tools like [Griptape Nodes](https://github.com/griptape-ai/griptape-nodes) that manipulate the module registry.

The existing comment on the very next line already acknowledges this class of scenario ("This can happen for a custom model in a jupyter notebook or repl"), but the `__file__` guard only runs **after** the dictionary access, so it never fires.

## Fix

Replace `sys.modules[cls.__module__]` with `sys.modules.get(cls.__module__)` and add a `class_module is None` check alongside the existing `hasattr` guard. Both functions now gracefully return `False` instead of crashing.

## Tests

Added `TestCanSetImplementationWithMissingSysModule` with 3 tests:
- `_can_set_attn_implementation` returns `False` when module is missing from `sys.modules`
- `_can_set_experts_implementation` returns `False` when module is missing from `sys.modules`
- Full model initialization succeeds when module is missing from `sys.modules`

All existing `TestAttentionImplementation` tests continue to pass.

## Code Agent Policy

- [X] I confirm that this is not a pure code agent PR.
