### PR TITLE
chore: remove old extras

### DIFF
--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           pip install --upgrade pip
           pip install datasets pandas
-          pip install .[torch,tf,flax]
+          pip install .[torch]
 
       - name: Update metadata
         run: |


### PR DESCRIPTION
# What does this PR do?

`tf` and `flax` are long gone (unknown extras generate only warnings so this slipped through the cracks)