### PR TITLE
[CB] Add per-request logits processors

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1591,6 +1591,10 @@ class ContinuousBatchingConfig:
             Whether to return log probabilities along with the generated tokens.
         max_queue_size (`int`, *optional*, defaults to 0):
             Maximum request queue size for serving. 0 means unlimited.
+        per_request_processors (`bool`, *optional*, defaults to `False`):
+            Enable per-request logits processor parameters. Default is False.
+        drop_unsupported_processors (`bool`, *optional*, defaults to `True`):
+            Remove unsupported logits processors instead of erroring. Default is True.
     """
 
     # Size of each KV cache block
@@ -1641,6 +1645,13 @@ class ContinuousBatchingConfig:
 
     # The parameters below are mostly useful in the context of serving
     max_queue_size: int = 0
+
+    # Enables per-request logits processor parameters. When enabled, each request can specify its own values (e.g.,
+    # temperature) via logits_processor_kwargs. When disabled, all requests use the default values.
+    per_request_processors: bool = False
+    # When True, processors explicitly marked as unsupported are removed with a warning. When False, all processors
+    # are kept but warnings are logged for unsupported/unknown ones.
+    drop_unsupported_processors: bool = True
 
     def account_for_cb_deprecated_arguments(
         self,

--- a/src/transformers/generation/continuous_batching/cb_logits_processors.py
+++ b/src/transformers/generation/continuous_batching/cb_logits_processors.py
@@ -1,0 +1,323 @@
+# Copyright 2025 The HuggingFace Inc. team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from abc import ABC, abstractmethod
+
+import torch
+
+from ..logits_process import (
+    LogitsProcessorList,
+    TemperatureLogitsWarper,
+    TopKLogitsWarper,
+    TopPLogitsWarper,
+)
+from .requests import FutureRequestState, logger
+
+
+# Abstract base class for all continuous batching logits processors
+class ContinuousBatchingLogitsProcessor(ABC):
+    # Kwargs that this processor uses, mapped to their expected type. Only the type is checked at runtime, value-range
+    # validation (e.g. temperature > 0) is not performed to keep a light API. You can open a PR if this is needed.
+    supported_kwargs: dict[str, type]
+    # Kwargs that this processor recognizes but ignores
+    ignored_kwargs: tuple[str, ...]
+
+    @abstractmethod
+    def fill_defaults(self, int32_tensor: torch.Tensor) -> None:
+        """Fills the given tensor int32 tensor with the default values for this processor."""
+        pass
+
+    @abstractmethod
+    def prepare_tensor_args(self, requests_in_batch: list[FutureRequestState]) -> torch.Tensor:
+        pass
+
+    @abstractmethod
+    def __call__(self, scores: torch.FloatTensor, tensor_arg: torch.Tensor) -> torch.FloatTensor:
+        """Applies the logits processor in a per-token manner.
+        Args:
+            - scores (torch.FloatTensor): The scores to process, with shape [num_tokens, vocab_size]
+            - tensor_arg (torch.Tensor): The tensor argument to use for the logits processor, with shape
+                [max_num_tokens] and dtype torch.int32. The dtype might not be representative of the actual data, for
+                instance it's common to have a float32 tensor viewed as int32 (eg. temperature)
+        Returns:
+            - torch.FloatTensor: The processed scores, with shape [num_tokens, vocab_size]
+        """
+        pass
+
+
+# Main class for managing a list of processors (CB version or not) for batched generation
+class ContinuousBatchingLogitsProcessorList:
+    """A class to hold logits processors for continuous batching (CB).
+
+    Each processor has a base class, which is the one used in regular `generate` and some have a per-request version
+    adapted for CB. The list of logits processors present is generated using  the `_get_logits_processor` method from
+    the model, which will only include processors if their presence is required by the generation config. For instance,
+    if you want to use temperature scaling, you need to specify a temperature that's neither None nor 1.0. Otherwise
+    no processors will be created for temperature, and per-request temperature scaling will not be available.
+
+    On support of base processors:
+        Some base processors are not supported by CB and will be dropped when this class is instantiated. Some
+        processors have not yet been categorized as supported or not and will be kept but with a warning. All processors
+        can be kept by setting the flag `drop_unsupported_processors` to False.
+    On per-request processors:
+        Some base processors have a per-request version adapted for CB and will be converted to their per-request
+        version when this class is instantiated. This is the default behavior unless the flag `per_request_processors`
+        is set to False.
+    """
+
+    def __init__(
+        self,
+        logits_processor: LogitsProcessorList,
+        per_request_processors: bool = False,
+        drop_unsupported_processors: bool = True,
+    ) -> None:
+        self.logits_processor = logits_processor
+        self.tensors_required = 0  # number of tensors required to store CB logits processors arguments
+        # If needed, convert compatible logits processors to their per-request versions
+        if per_request_processors:
+            self._convert_to_per_request_processors()
+        # Validate and optionally filter processors based on their CB support
+        self._validate_processors(drop_unsupported_processors)
+        self._retrieve_processors_kwargs()
+
+    def __repr__(self) -> str:
+        return f"ContinuousBatchingLogitsProcessorList(logits_processor={self.logits_processor}, tensors_required={self.tensors_required})"
+
+    def clear(self) -> None:
+        self.logits_processor = LogitsProcessorList()
+        self.tensors_required = 0
+        self.supported_keys = {}
+        self.ignored_keys = set()
+
+    def _convert_to_per_request_processors(self) -> None:
+        """Replaces the compatible logits processors with their per-request versions."""
+        for i, processor in enumerate(self.logits_processor):
+            for regular_cls, cb_cls in CLASSIC_TO_CB_PROCESSORS_MAP.items():
+                if isinstance(processor, regular_cls):
+                    self.logits_processor[i] = cb_cls(processor)
+                    self.tensors_required += 1  # in the future, this might be more than 1 (will be stored in mapping)
+                    break
+
+    def _validate_processors(self, drop_unsupported: bool) -> None:
+        """Validates the logits processors and optionally removes unsupported ones. When drop_unsupported is True,
+        processors explicitly marked as unsupported are removed. Otherwise, all processors are kept but warnings are
+        logged for unsupported or unknown ones.
+        """
+        filtered_processors = []
+        for processor in self.logits_processor:
+            class_name = processor.__class__.__name__
+            supported = getattr(processor, "supports_continuous_batching", None)
+
+            # Keep all ContinuousBatchingLogitsProcessor or supported processors
+            if isinstance(processor, ContinuousBatchingLogitsProcessor) or supported:
+                filtered_processors.append(processor)
+            # Keep processors with support status unknown
+            elif supported is None:
+                logger.warning(f"Processor {class_name} might not be supported by CB.")
+                filtered_processors.append(processor)
+            # Otherwise, processor is not supported, then behavior depends on the flag drop_unsupported
+            elif drop_unsupported:
+                logger.warning(f"Processor {class_name} isn't supported by CB. Dropping it.")
+            else:
+                logger.warning(f"Processor {class_name} isn't supported by CB. Kept it because {drop_unsupported = }.")
+                filtered_processors.append(processor)
+
+        # Update the list of logits processors (preserve LogitsProcessorList type)
+        self.logits_processor = LogitsProcessorList(filtered_processors)
+
+    def __bool__(self) -> bool:
+        return bool(self.logits_processor)
+
+    def _retrieve_processors_kwargs(self) -> None:
+        """Retrieves the supported (with types) and ignored kwargs from continuous batching processors."""
+        self.supported_keys: dict[str, type] = {}
+        self.ignored_keys = set()
+        for processor in self.logits_processor:
+            if isinstance(processor, ContinuousBatchingLogitsProcessor):
+                self.supported_keys.update(processor.supported_kwargs)
+                self.ignored_keys.update(processor.ignored_kwargs)
+
+    def check_kwargs(self, kwargs: dict) -> None:
+        """Checks that the provided kwargs are compatible with the current CB processors. Warn for ignored kwargs."""
+        if not kwargs:
+            return None
+        # Validate types for supported keys, detect unsupported keys
+        problematic_keys = set()
+        for key, value in kwargs.items():
+            if key not in self.supported_keys:
+                problematic_keys.add(key)
+            else:
+                expected_type = self.supported_keys[key]
+                if not isinstance(value, expected_type):
+                    raise TypeError(
+                        f"logit_processor_kwargs['{key}'] has type {type(value).__name__}, expected {expected_type.__name__}"
+                    )
+        # Stop if there are only supported keys
+        if not problematic_keys:
+            return
+        # Check if there are unknown keys
+        unknown_keys = problematic_keys - self.ignored_keys
+        if unknown_keys:
+            raise ValueError(
+                f"Unknown logit_processor_kwargs: {unknown_keys}. {self.supported_keys = } and {self.ignored_keys = }"
+                "If you expect a key to not be ignored, make sure its default value (in the generation config) is not "
+                "None. Eg. if temperature is None or 1.0 at creation time, no processor will be created for temperature"
+            )
+        # If there are none, throw a warning about the ignored keys
+        logger.warning(
+            f"Ignored logit_processor_kwargs: {problematic_keys}. {self.supported_keys = } and {self.ignored_keys = }"
+        )
+
+    def fill_defaults(self, int32_tensor: torch.Tensor) -> None:
+        """Fills the given tensor int32 tensor with the default values for this processor."""
+        i = 0
+        for processor in self.logits_processor:
+            if isinstance(processor, ContinuousBatchingLogitsProcessor):
+                processor.fill_defaults(int32_tensor[i])
+                i += 1
+
+    def prepare_tensor_args(
+        self, requests_in_batch: list[FutureRequestState], arg_storage: torch.Tensor
+    ) -> torch.Tensor:
+        current_arg_id = 0
+        for processor in self.logits_processor:
+            if isinstance(processor, ContinuousBatchingLogitsProcessor):
+                tensorized_arg = processor.prepare_tensor_args(requests_in_batch)
+                arg_storage[current_arg_id, : tensorized_arg.size(0)] = tensorized_arg.to(arg_storage.device)
+                current_arg_id += 1
+        return arg_storage
+
+    def __call__(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor, logits_processor_args: torch.Tensor
+    ) -> torch.FloatTensor:
+        current_arg_id = 0
+        for processor in self.logits_processor:
+            if isinstance(processor, ContinuousBatchingLogitsProcessor):
+                scores = processor(scores, logits_processor_args[current_arg_id])
+                current_arg_id += 1
+            else:
+                scores = processor(input_ids, scores)
+        return scores
+
+
+# Here are all the continuous batching logits processors that are supported
+class ContinuousBatchingTemperatureLogitsWarper(ContinuousBatchingLogitsProcessor):
+    supported_kwargs: dict[str, type] = {"temperature": float}
+    ignored_kwargs: tuple[str, ...] = ()
+
+    def __init__(self, temperature_processor: TemperatureLogitsWarper) -> None:
+        self.temperature = temperature_processor.temperature
+
+    def fill_defaults(self, int32_tensor: torch.Tensor) -> None:
+        """Fills the given tensor int32 tensor with the default temperature."""
+        default = torch.empty_like(int32_tensor, dtype=torch.float32)
+        default.fill_(self.temperature)
+        int32_tensor.copy_(default.view(dtype=torch.int32))
+
+    def prepare_tensor_args(self, requests_in_batch: list[FutureRequestState]) -> torch.Tensor:
+        data = []
+        for request in requests_in_batch:
+            temp = request.state.logit_processor_kwargs.get("temperature", self.temperature)
+            data.extend([temp] * request.query_length)
+        tensorized = torch.tensor(data, dtype=torch.float32, device="cpu")
+        # View the output with the bulk storage dtype (int32) but keeps the underlying data the same
+        return tensorized.view(dtype=torch.int32)
+
+    def __call__(self, scores: torch.FloatTensor, tensor_arg: torch.Tensor) -> torch.FloatTensor:
+        temperatures = tensor_arg[: scores.size(0)].view(dtype=torch.float32)  # shape [N]
+        return scores / temperatures.unsqueeze(-1)  # broadcast [N, 1] over [N, V]
+
+
+class ContinuousBatchingTopKLogitsWarper(ContinuousBatchingLogitsProcessor):
+    supported_kwargs: dict[str, type] = {"top_k": int}
+    ignored_kwargs: tuple[str, ...] = ("filter_value", "min_tokens_to_keep")
+
+    def __init__(self, top_k_processor: TopKLogitsWarper):
+        self.top_k = top_k_processor.top_k
+        self.filter_value = top_k_processor.filter_value
+        self.min_tokens_to_keep = top_k_processor.min_tokens_to_keep
+
+    def fill_defaults(self, int32_tensor: torch.Tensor) -> None:
+        """Fills the given tensor int32 tensor with the default top_k."""
+        int32_tensor.fill_(self.top_k)
+
+    def prepare_tensor_args(self, requests_in_batch: list[FutureRequestState]) -> torch.Tensor:
+        top_ks = []
+        for request in requests_in_batch:
+            top_k = request.state.logit_processor_kwargs.get("top_k", self.top_k)
+            top_k = max(top_k, self.min_tokens_to_keep)
+            top_ks.extend([top_k] * request.query_length)
+        # Prepare tensor arg with int32 as the main type
+        tensor_args = torch.tensor(top_ks, dtype=torch.int32, device="cpu")
+        return tensor_args
+
+    def __call__(self, scores: torch.FloatTensor, tensor_arg: torch.Tensor) -> torch.FloatTensor:
+        """Applies top-k selection to the scores tensor (shape [N, V])."""
+        top_k = tensor_arg[: scores.size(0)]  # shape [N]
+        # Sort descending, get threshold at position (top_k - 1) which is the k-th largest
+        sorted_scores = torch.sort(scores, dim=-1, descending=True)[0]  # [N, V]
+        top_k_indices = (top_k - 1).unsqueeze(-1).to(dtype=torch.int64)  # [N, 1]
+        thresholds = sorted_scores.gather(dim=-1, index=top_k_indices)  # [N, 1]
+        return scores.masked_fill(scores < thresholds, self.filter_value)
+
+
+class ContinuousBatchingTopPLogitsWarper(ContinuousBatchingLogitsProcessor):
+    supported_kwargs: dict[str, type] = {"top_p": float}
+    ignored_kwargs: tuple[str, ...] = ("filter_value", "min_tokens_to_keep")
+
+    def __init__(self, top_p_processor: TopPLogitsWarper):
+        self.top_p = top_p_processor.top_p
+        self.filter_value = top_p_processor.filter_value
+        self.min_tokens_to_keep = top_p_processor.min_tokens_to_keep
+
+    def fill_defaults(self, int32_tensor: torch.Tensor) -> None:
+        """Fills the given tensor int32 tensor with the default top_p."""
+        default = torch.empty_like(int32_tensor, dtype=torch.float32)
+        default.fill_(self.top_p)
+        int32_tensor.copy_(default.view(dtype=torch.int32))
+
+    def prepare_tensor_args(self, requests_in_batch: list[FutureRequestState]) -> torch.Tensor:
+        top_ps = []
+        for request in requests_in_batch:
+            # Retrieve config for this request
+            top_p = request.state.logit_processor_kwargs.get("top_p", self.top_p)
+            top_ps.extend([top_p] * request.query_length)
+        # Store top_p as float32 viewed as int32 to match the bulk storage dtype
+        tensorized = torch.tensor(top_ps, dtype=torch.float32, device="cpu")
+        return tensorized.view(dtype=torch.int32)
+
+    def __call__(self, scores: torch.FloatTensor, tensor_arg: torch.Tensor) -> torch.FloatTensor:
+        """Applies top-p (nucleus) sampling to the scores tensor (shape [N, V])."""
+        top_p = tensor_arg[: scores.size(0)].view(dtype=torch.float32)  # shape [N]
+
+        # Sort logits in ascending order
+        sorted_logits, sorted_indices = torch.sort(scores, descending=False, dim=-1)  # [N, V]
+        cumulative_probs = sorted_logits.softmax(dim=-1).cumsum(dim=-1)  # [N, V]
+
+        # Remove tokens with cumulative probability <= (1 - top_p)
+        threshold = (1 - top_p).unsqueeze(-1)  # [N, 1]
+        sorted_indices_to_remove = cumulative_probs <= threshold  # [N, V]
+
+        # Keep at least min_tokens_to_keep (always keep the last tokens in sorted order = highest prob)
+        sorted_indices_to_remove[..., -self.min_tokens_to_keep :] = False
+
+        # Scatter sorted mask back to original indexing
+        indices_to_remove = sorted_indices_to_remove.scatter(-1, sorted_indices, sorted_indices_to_remove)
+        return scores.masked_fill(indices_to_remove, self.filter_value)
+
+
+CLASSIC_TO_CB_PROCESSORS_MAP = {
+    TemperatureLogitsWarper: ContinuousBatchingTemperatureLogitsWarper,
+    TopKLogitsWarper: ContinuousBatchingTopKLogitsWarper,
+    TopPLogitsWarper: ContinuousBatchingTopPLogitsWarper,
+}

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -30,12 +30,13 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from ...configuration_utils import PretrainedConfig
 from ...generation.configuration_utils import ContinuousBatchingConfig, GenerationConfig
-from ...generation.logits_process import LogitsProcessorList
 from ...modeling_flash_attention_utils import lazy_import_paged_flash_attention
 from ...utils.generic import is_flash_attention_requested
 from ...utils.logging import logging
 from ...utils.metrics import ContinuousBatchProcessorMetrics, attach_tracer, traced
+from ..logits_process import LogitsProcessorList
 from .cache import PagedAttentionCache
+from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
 from .input_outputs import ContinuousBatchingAsyncIOs, ContinuousBatchingIOs
 from .requests import GenerationOutput, RequestState, RequestStatus, logger
 from .scheduler import SCHEDULER_MAPPING, FIFOScheduler, Scheduler
@@ -138,6 +139,7 @@ class ContinuousBatchProcessor:
         config: PretrainedConfig,
         generation_config: GenerationConfig,
         continuous_batching_config: ContinuousBatchingConfig,
+        logit_processor: ContinuousBatchingLogitsProcessorList,
         input_queue: queue.Queue,
         output_router: OutputRouter,
         stop_event: threading.Event,
@@ -151,6 +153,8 @@ class ContinuousBatchProcessor:
             cache: A [`PagedAttentionCache`] object
             config: The model configuration
             generation_config: The generation configuration
+            continuous_batching_config: The continuous batching configuration
+            logit_processor: The [`ContinuousBatchingLogitsProcessorList`] object used to process the logits.
             input_queue: Queue for incoming requests
             output_router: An [`OutputRouter`] object that routes outputs to handlers or the output queue.
             stop_event: Event to signal processing should stop
@@ -161,6 +165,7 @@ class ContinuousBatchProcessor:
         self.cache = cache
         self.config = config
         self.cb_config = continuous_batching_config
+        self.logit_processor = logit_processor
         self.input_queue = input_queue
         self.output_router = output_router
         self.stop_event = stop_event
@@ -214,11 +219,23 @@ class ContinuousBatchProcessor:
             # Since in async there are 2 IO pairs, there are also 2 graph buffers: we divide the max_cached_graphs by 2
             max_cached_graphs = ceil(self.max_cached_graphs / 2)
             self.inputs_and_outputs = ContinuousBatchingAsyncIOs(
-                cache, config, model_device, model_dtype, max_cached_graphs, self.return_logprobs
+                cache=cache,
+                config=config,
+                device=model_device,
+                model_dtype=model_dtype,
+                max_graphs=max_cached_graphs,
+                return_logprobs=self.return_logprobs,
+                logit_processor=self.logit_processor,
             )
         else:
             self.inputs_and_outputs = ContinuousBatchingIOs(
-                cache, config, model_device, model_dtype, self.max_cached_graphs, self.return_logprobs
+                cache=cache,
+                config=config,
+                device=model_device,
+                model_dtype=model_dtype,
+                max_graphs=self.max_cached_graphs,
+                return_logprobs=self.return_logprobs,
+                logit_processor=self.logit_processor,
             )
         # Set up the graph pool. This allows all graphs to share the same memory pool, which is fine because they never
         # run concurrently. This greatly saves memory.
@@ -276,6 +293,7 @@ class ContinuousBatchProcessor:
                 state = self.input_queue.get_nowait()
                 if state is None:  # Sentinel value
                     continue
+                self.logit_processor.check_kwargs(state.logit_processor_kwargs)
                 self.scheduler.add_waiting_request(state)
 
             except queue.Empty:
@@ -371,7 +389,7 @@ class ContinuousBatchProcessor:
             max_kv_read = pad_to_interval(max_kv_read, self.kv_padding_interval_size, self.cache.num_pages)
 
         self.inputs_and_outputs.prepare_batch_tensors(
-            requests_in_batch, use_decode_fast_path, num_q_tokens, max_kv_read
+            requests_in_batch, self.logit_processor, use_decode_fast_path, num_q_tokens, max_kv_read
         )
         self.metrics.record_kv_cache_memory_metrics(self.cache)
         return True
@@ -482,7 +500,7 @@ class ContinuousBatchProcessor:
 
     @traced
     @torch.no_grad()
-    def _generation_step(self, model: nn.Module, logit_processor: LogitsProcessorList) -> None:
+    def _generation_step(self, model: nn.Module) -> None:
         """Perform a single generation step."""
 
         # Retrieve the model kwargs with or without padding
@@ -500,7 +518,7 @@ class ContinuousBatchProcessor:
         if not self.use_cuda_graph:
             maybe_stream = torch.cuda.stream(compute_stream) if compute_stream is not None else nullcontext()
             with maybe_stream:
-                forward_fn(model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
+                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids)
 
         # Otherwise, we use create or replay the graph (cuda is available in this path)
         else:
@@ -511,7 +529,7 @@ class ContinuousBatchProcessor:
                     graph.replay()
             # Otherwise, the graph does not exist, so we create it
             else:
-                args = (model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
+                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
                 self.capture_graph(forward_fn, compute_stream, *args)
 
         # In any case, we transfer the outputs to the host
@@ -536,7 +554,6 @@ class ContinuousBatchProcessor:
         self,
         model: nn.Module,
         batch_data: dict,
-        logit_processor: LogitsProcessorList,
         carry_over_ids: torch.Tensor,
         prev_output_ids: torch.Tensor,
         output_ids: torch.Tensor,
@@ -544,40 +561,34 @@ class ContinuousBatchProcessor:
         """This function performs the forward pass, logits processing, and sampling; which are broken down into smaller
         function to be easier to trace with OpenTelemetry."""
         self.inputs_and_outputs.carry_over_tokens(batch_data["input_ids"], carry_over_ids, prev_output_ids)
-        logits = self._model_forward(model, batch_data)
-        probs = self._process_logit(batch_data, logits, logit_processor)
-        self._sample(probs, batch_data["logits_indices"], output_ids)
+        logits = self._model_forward(model, batch_data).float()  # convert to fp32 to match generate
+        scores = self._process_logit(batch_data, logits) if self.logit_processor else logits
+        self._sample(scores, batch_data["logits_indices"], output_ids)
 
     @traced(span_name="model_forward")
     def _model_forward(self, model: nn.Module, batch_data: dict) -> torch.Tensor:
         return model(**batch_data).logits
 
     @traced(span_name="logit_processing")
-    def _process_logit(
-        self, batch_data: dict, logits: torch.Tensor, logit_processor: LogitsProcessorList
-    ) -> torch.Tensor:
-        # Pass continuous batching context to logits processor if it supports it.
-        if hasattr(logit_processor, "set_continuous_batching_context"):
-            logit_processor.set_continuous_batching_context(batch_data["logits_indices"], batch_data["cu_seq_lens_q"])
+    def _process_logit(self, batch_data: dict, logits: torch.Tensor) -> torch.Tensor:
         # Handle shape compatibility: logit processors expect 2D tensors [batch_size, vocab_size]
         # but continuous batching always produces 3D tensors [batch_size, seq_len, vocab_size]
         batch_size, seq_len, vocab_size = logits.shape
-        # NOTE: to be an exact match with generate, we should also convert logits2d to float32 here, but it's not needed in practice
         logits_2d = logits.view(batch_size * seq_len, vocab_size)
         input_ids_2d = batch_data["input_ids"].view(batch_size * seq_len)
-        # Process with 2D tensors#
-        processed_logits_2d = logit_processor(input_ids_2d, logits_2d)
+        # Process with 2D tensors
+        processed_logits_2d = self.logit_processor(input_ids_2d, logits_2d, batch_data["logits_processor_args"])
         # Reshape back to 3D
         return processed_logits_2d.view(batch_size, seq_len, vocab_size)
 
     @traced(span_name="sampling")
-    def _sample(self, probs: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
+    def _sample(self, scores: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
         # Apply softmax if we are sampling or if we are generating log probabilities
         if self.do_sample or self.return_logprobs:
-            probs = nn.functional.softmax(probs[0], dim=-1)  # shape [seq_len, vocab_size]
+            probs = nn.functional.softmax(scores[0], dim=-1)  # shape [seq_len, vocab_size]
         # Otherwise just remove the batch size dimension, which is always 1
         else:
-            probs = probs.squeeze(0)  # shape [seq_len, vocab_size]
+            probs = scores.squeeze(0)  # shape [seq_len, vocab_size]
 
         # Retrieve next tokens through sampling or argmax
         if self.do_sample:
@@ -588,7 +599,7 @@ class ContinuousBatchProcessor:
         # Maybe retrieve log probabilities
         if self.return_logprobs:
             per_token_probs = probs.gather(dim=1, index=next_tokens).squeeze(-1)
-            logprobs = per_token_probs.float().log()  # shape [seq_len]
+            logprobs = per_token_probs.log()  # shape [seq_len]
         # And always remove the extra dimension for the gather
         next_tokens = next_tokens.squeeze(-1)  # shape [seq_len]
 
@@ -647,11 +658,13 @@ class ContinuousBatchProcessor:
             )
             try:
                 start = perf_counter()
-                self.inputs_and_outputs.prepare_batch_tensors(future_states, False, padded_q, padded_kv - padded_q)
+                self.inputs_and_outputs.prepare_batch_tensors(
+                    future_states, self.logit_processor, False, padded_q, padded_kv - padded_q
+                )
                 batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=True)
                 carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
                 forward_fn = self._compiled_varlen or self._forward_process_and_sample
-                forward_fn_args = (model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
+                forward_fn_args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
                 if self.use_cuda_graph:
                     self.capture_graph(forward_fn, compute_stream, *forward_fn_args)
                 else:
@@ -683,11 +696,13 @@ class ContinuousBatchProcessor:
                     continue
                 try:
                     padded_q = pad_to_interval(len(future_states), q_interval, self.max_batch_tokens)
-                    self.inputs_and_outputs.prepare_batch_tensors(future_states, True, padded_q, 0)
+                    self.inputs_and_outputs.prepare_batch_tensors(
+                        future_states, self.logit_processor, True, padded_q, 0
+                    )
                     batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=True)
                     carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
                     forward_fn = self._compiled_decode or self._forward_process_and_sample
-                    forward_fn_args = (model, batch_data, logit_processor, carry_over_ids, prev_output_ids, output_ids)
+                    forward_fn_args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
                     if self.use_cuda_graph:
                         self.capture_graph(forward_fn, compute_stream, *forward_fn_args)
                     else:
@@ -752,9 +767,14 @@ class ContinuousBatchingManager:
         self._request_lock = threading.Lock()
 
         # Generation config related arguments
-        self.logit_processor: LogitsProcessorList = self.model._get_logits_processor(generation_config)
         num_return_sequences = getattr(generation_config, "num_return_sequences", None)
         self.num_return_sequences = num_return_sequences if num_return_sequences is not None else 1
+
+        self.logit_processor = ContinuousBatchingLogitsProcessorList(
+            logits_processor=self.model._get_logits_processor(generation_config),
+            per_request_processors=self.continuous_batching_config.per_request_processors,
+            drop_unsupported_processors=self.continuous_batching_config.drop_unsupported_processors,
+        )
 
         # Cuda graph behavior is determined below using either user-specified arguments or heuristics
         is_attn_mask_needed = attn_mask_is_needed(self.model.config)
@@ -858,13 +878,18 @@ class ContinuousBatchingManager:
         streaming: bool = False,
         record_timestamps: bool = False,
         eos_token_id: int | list[int] | None = None,
+        **logit_processor_kwargs: Any,
     ) -> str:
         """Add a new generation request to the queue.
 
         Args:
             input_ids: Input token IDs to use as prompt
             request_id: Optional custom request ID (auto-generated if None)
-            **kwargs: Additional generation parameters
+            max_new_tokens: Maximum number of new tokens to generate
+            streaming: Whether to stream tokens as they're generated
+            record_timestamps: Whether to record timestamps for each generated token
+            eos_token_id: End-of-sequence token ID(s)
+            logit_processor_kwargs: Keyword arguments for the logits processor.
 
         Returns:
             str: The request ID
@@ -886,6 +911,7 @@ class ContinuousBatchingManager:
             max_new_tokens=max_new_tokens,
             eos_token_id=eos_token_id,
             streaming=streaming,
+            logit_processor_kwargs=logit_processor_kwargs,
         )
 
         # Use block=True with timeout to handle backpressure if queue is full
@@ -899,6 +925,7 @@ class ContinuousBatchingManager:
         max_new_tokens: int | None = None,
         streaming: bool = False,
         record_timestamps: bool = False,
+        **logit_processor_kwargs: Any,
     ) -> None:
         # Infer the request ids of all incoming requests
         with self._request_lock:
@@ -915,7 +942,15 @@ class ContinuousBatchingManager:
         eos_token_id = -1 if eos_token_id is None else eos_token_id
         # Add requests in order
         for request_id, input_ids in ids_and_inputs:
-            self.add_request(input_ids, request_id, max_new_tokens, streaming, record_timestamps, eos_token_id)
+            self.add_request(
+                input_ids=input_ids,
+                request_id=request_id,
+                max_new_tokens=max_new_tokens,
+                streaming=streaming,
+                record_timestamps=record_timestamps,
+                eos_token_id=eos_token_id,
+                **logit_processor_kwargs,
+            )
 
     def cancel_request(self, request_id: str) -> None:
         """Cancel a request by its ID.
@@ -997,7 +1032,7 @@ class ContinuousBatchingManager:
         """Perform a single generation step. This is mostly cuda graphed"""
         if self.batch_processor is None:
             raise RuntimeError("Tried to perform a generation step before the batch processor was initialized.")
-        self.batch_processor._generation_step(self.model, self.logit_processor)
+        self.batch_processor._generation_step(self.model)
 
     def _create_batch_processor(self) -> ContinuousBatchProcessor:
         # Create the PagedAttentionCache
@@ -1023,6 +1058,7 @@ class ContinuousBatchingManager:
             config=self.model.config,
             generation_config=self.generation_config,
             continuous_batching_config=self.continuous_batching_config,
+            logit_processor=self.logit_processor,
             input_queue=self.input_queue,
             output_router=self.output_router,
             stop_event=self.stop_event,

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -24,6 +24,7 @@ from transformers.configuration_utils import PretrainedConfig
 from ...utils import get_available_devices
 from ...utils.metrics import traced
 from .cache import PagedAttentionCache
+from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
 from .requests import TMP_TOKEN_ID, FutureRequestState, logger
 from .utils import CudaGraphBuffer, aligned_divide, attn_mask_is_needed, build_attention_mask
 
@@ -48,6 +49,7 @@ class PagedAttentionArgs:
         cache: The [`PagedAttentionCache`] instance managing the KV cache.
         block_table: Block table for paged KV cache. If provided, uses `flash_attn_with_kvcache` for fused attention +
             cache update. More information in src/transformers/integrations/flash_paged.py
+        logits_processor_args: List of tensors containing the arguments for the logits processors, one per request.
         use_cache: Whether to use caching (always `False` in continuous batching as the cache is managed externally).
     """
 
@@ -63,6 +65,7 @@ class PagedAttentionArgs:
     logits_indices: torch.Tensor
     cache: PagedAttentionCache
     block_table: torch.Tensor | None
+    logits_processor_args: torch.Tensor
     use_cache: bool = False
 
     def asdict(self) -> dict[str, Any]:
@@ -79,6 +82,7 @@ class PagedAttentionArgs:
             "logits_indices": self.logits_indices,
             "cache": self.cache,
             "block_table": self.block_table,
+            "logits_processor_args": self.logits_processor_args,
             "use_cache": self.use_cache,
         }
 
@@ -89,6 +93,8 @@ class ContinuousBatchingIOs:
     batch alone.
     """
 
+    static_inputs: int = 7  # Number of static inputs always present in the bulk tensor
+
     def __init__(
         self,
         cache: PagedAttentionCache,
@@ -97,6 +103,7 @@ class ContinuousBatchingIOs:
         model_dtype: torch.dtype,
         max_graphs: int,
         return_logprobs: bool,
+        logit_processor: ContinuousBatchingLogitsProcessorList,
     ) -> None:
         """Initialize the continuous batching I/O manager. Args:
         - cache: The [`PagedAttentionCache`] instance managing the KV cache. Meant to be unique.
@@ -105,6 +112,7 @@ class ContinuousBatchingIOs:
         - model_dtype: The data type for model computations.
         - max_graphs: Maximum number of CUDA graphs to cache. Uses LRU eviction when full.
         - return_logprobs: Whether to return log probabilities along with the token IDs.
+        - logit_processor: The [`ContinuousBatchingLogitsProcessorList`] object used to process the logits.
         """
         # Memoize attributes
         self.cache = cache
@@ -126,12 +134,12 @@ class ContinuousBatchingIOs:
         self.graphs: CudaGraphBuffer = CudaGraphBuffer(max_graphs)
         self._trash_index = cache.trash_index
         # Setup static tensors and compute stream
-        self._setup_static_tensors()
+        self._setup_static_tensors(logit_processor=logit_processor)
         self._reset_static_tensors(full_reset=True)
         self.compute_stream = torch.cuda.Stream(device=self.device) if device.type == "cuda" else None
 
     @traced(standalone=True)
-    def _setup_static_tensors(self) -> None:
+    def _setup_static_tensors(self, logit_processor: ContinuousBatchingLogitsProcessorList) -> None:
         """Allocates static tensors for generation inputs and outputs. This is called only once at init time, to avoid
         repeated allocations and enable CUDA graphs. All tensors are allocated with maximum possible sizes.
         The allocated tensors are:
@@ -150,10 +158,16 @@ class ContinuousBatchingIOs:
 
         # Small inputs are allocated as slices in a larget tensor aligned to 128 bytes (32 * 4b). This reduces the
         # reduces fragmentation, so it lowers the number of D2H transfers and speeds up transfers.
-        bulk_size = aligned_divide(max_batch_tokens + 1, 1, 32)
+        bulk_lines = self.static_inputs + logit_processor.tensors_required
+        bulk_columns = aligned_divide(max_batch_tokens + 1, 1, 32)
         self._bulk_input_tensor = torch.empty(
-            (7, bulk_size), dtype=torch.int32, device=self.device, pin_memory=pin_memory
+            (bulk_lines, bulk_columns), dtype=torch.int32, device=self.device, pin_memory=pin_memory
         )
+        # Prepare a tensor to hold the default values for the logits processors
+        self.logits_processors_defaults = torch.empty(
+            (logit_processor.tensors_required, 1), dtype=torch.int32, device=self.device
+        )
+        logit_processor.fill_defaults(self.logits_processors_defaults)
 
         self.input_ids = self._bulk_input_tensor[0, :max_batch_tokens]
         self.position_ids = self._bulk_input_tensor[1, :max_batch_tokens]
@@ -254,7 +268,9 @@ class ContinuousBatchingIOs:
         kv_len = self.read_index_storage.size(-1) if full_reset else self.max_kv_read
 
         # Reset the attributes part of the bulk input tensor in one kernel
-        self._bulk_input_tensor[:, : q_len + 1].zero_()
+        self._bulk_input_tensor[: self.static_inputs, : q_len + 1].zero_()
+        if full_reset:
+            self._bulk_input_tensor[self.static_inputs :] = self.logits_processors_defaults
         self.max_seqlen_q = 0
 
         # Reset the logits indices and output ids
@@ -319,6 +335,7 @@ class ContinuousBatchingIOs:
     def prepare_batch_tensors(
         self,
         requests_in_batch: list[FutureRequestState],
+        logits_processors: ContinuousBatchingLogitsProcessorList,
         use_decode_fast_path: bool,
         num_q_tokens: int,
         max_kv_read: int,
@@ -367,7 +384,7 @@ class ContinuousBatchingIOs:
             # First we retrieve the lengths related to the request
             state = future_state.state
             past_length = state.position_offset
-            query_length = len(state.tokens_to_process)
+            query_length = future_state.query_length
             seqlens_k = self.cache.get_seqlens_k(past_length, query_length)
 
             # Update the internal state of the request
@@ -399,6 +416,12 @@ class ContinuousBatchingIOs:
                 self.req_id_to_new_token_position[state.request_id] = logits_indices[-1]
 
             self.requests_in_batch.append(future_state)
+
+        # Also prepare the tensor arguments for the logits processors
+        logits_processors.prepare_tensor_args(
+            requests_in_batch=requests_in_batch,
+            arg_storage=self._bulk_input_tensor[self.static_inputs :],
+        )
 
         # When looping over request is done, we can build the actual tensors. This is faster than modifying the static
         # tensors inside the loop.
@@ -446,6 +469,7 @@ class ContinuousBatchingIOs:
             cu_seq_lens_q=self.cumulative_seqlens_q[: batch_size + 1],
             max_seqlen_q=self.max_seqlen_q,
             logits_indices=self.logits_indices[:q_size],
+            logits_processor_args=self._bulk_input_tensor[self.static_inputs :, :q_size],
             cu_seq_lens_k={},
             max_seqlen_k={},
             attention_mask={},
@@ -529,12 +553,15 @@ class HostDeviceIOPair:
         model_dtype: torch.dtype,
         max_graphs: int,
         return_logprobs: bool,
+        logit_processor: ContinuousBatchingLogitsProcessorList,
     ) -> None:
         # The host IO has automatic pinned memory because it is created on the CPU
         self.host_io = ContinuousBatchingIOs(
-            cache, config, torch.device("cpu"), model_dtype, max_graphs, return_logprobs
+            cache, config, torch.device("cpu"), model_dtype, max_graphs, return_logprobs, logit_processor
         )
-        self.device_io = ContinuousBatchingIOs(cache, config, device, model_dtype, max_graphs, return_logprobs)
+        self.device_io = ContinuousBatchingIOs(
+            cache, config, device, model_dtype, max_graphs, return_logprobs, logit_processor
+        )
         # Create events only on CUDA devices
         self.h2d_over = torch.cuda.Event() if torch.cuda.is_available() else None
         self.compute_over = torch.cuda.Event() if torch.cuda.is_available() else None
@@ -598,7 +625,7 @@ class ContinuousBatchingAsyncIOs:
           - <-N: device to host transfer of batch N
           - UP N: update of batch N
 
-    You can see that the GPU is almost always busy, execpt where the █ is.
+    You can see that the GPU is almost always busy, except where the █ is.
     Proper ordering of steps is ensured through the use of CUDA events and streams.
     """
 
@@ -610,6 +637,7 @@ class ContinuousBatchingAsyncIOs:
         model_dtype: torch.dtype,
         max_graphs: int,
         return_logprobs: bool,
+        logit_processor: ContinuousBatchingLogitsProcessorList,
     ) -> None:
         # Async batching needs streams to function, so check is CUDA is available
         if not torch.cuda.is_available():
@@ -617,7 +645,8 @@ class ContinuousBatchingAsyncIOs:
         # IO pairs used to avoid race conditions
         self.current_pair = 0
         self.io_pairs = [
-            HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, return_logprobs) for _ in range(2)
+            HostDeviceIOPair(cache, config, device, model_dtype, max_graphs, return_logprobs, logit_processor)
+            for _ in range(2)
         ]
         # CUDA streams
         self.h2d_stream = torch.cuda.Stream(device=device)
@@ -639,12 +668,15 @@ class ContinuousBatchingAsyncIOs:
     def prepare_batch_tensors(
         self,
         requests_in_batch: list[FutureRequestState],
+        logits_processors: ContinuousBatchingLogitsProcessorList,
         use_decode_fast_path: bool,
         num_q_tokens: int,
         max_kv_read: int,
     ) -> None:
         io_pair = self.io_pairs[self.current_pair]
-        io_pair.host_io.prepare_batch_tensors(requests_in_batch, use_decode_fast_path, num_q_tokens, max_kv_read)
+        io_pair.host_io.prepare_batch_tensors(
+            requests_in_batch, logits_processors, use_decode_fast_path, num_q_tokens, max_kv_read
+        )
         io_pair.host_io.carry_over_ids.copy_(self.infer_carry_over_ids())
 
     def infer_carry_over_ids(self) -> torch.Tensor:

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -455,9 +455,8 @@ class ContinuousBatchingIOs:
                 self.true_write_sizes[i] = len(group_write_indices)
 
     def get_model_kwargs(self, use_padding: bool = False) -> dict[str, Any]:
-        """Get model keyword arguments for the current batch, eventually padding the query dimension to (padded_q_size)
-        and the keys/values dimension to (padded_kv_cache_size). The padding is only useful if we want static shapes,
-        like when using cuda graphs AND only activated if both Q and KV are padded."""
+        """Get model keyword arguments for the current batch, eventually padding the query dimension and KV dimensions
+        if use_padding is True. The padding is only useful if we want static shapes, like when using cuda graphs."""
         q_size = self.num_q_tokens
         kv_size = self.max_kv_read + self.num_q_tokens
         batch_size = self.num_q_tokens if use_padding else self.true_batch_size

--- a/src/transformers/generation/continuous_batching/requests.py
+++ b/src/transformers/generation/continuous_batching/requests.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import time
+from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import IntEnum
 
@@ -144,30 +145,38 @@ class RequestState:
     # Required fields
     request_id: str
     initial_tokens: list[int]  # Initial prompt tokens # TODO: rename this as prefill tokens
-    # Optional fields
+
+    # Optional fields (CB parameters)
+    streaming: bool = False  # Whether to stream tokens as they're generated
     record_timestamps: bool = False  # Whether to record timestamps for the generated tokens
-    num_children: int = 0  # Number of children requests
-    # Internal fields
-    tokens_to_process: list[int] = field(default_factory=list)  # Tokens IDs currently being processed
-    remaining_prefill_tokens: list[int] = field(
-        default_factory=list
-    )  # Initial tokens left to process (initialized in __post_init__)
-    generated_tokens: list[int] = field(default_factory=list)  # Generated tokens
-    logprobs: list[float] = field(default_factory=list)  # Log probabilities of the generated tokens
-    allocated_blocks: int = 0  # Number of blocks allocated to the request
-    position_offset: int = 0  # Current position in the sequence for position_ids
-    _status: RequestStatus = RequestStatus.PENDING  # Status of the request, hidden behind a property
+
+    # Optional fields (generation parameters)
     max_new_tokens: int | None = 20  # Maximum number of new tokens to generate. None means no limit. Default to 20.
     eos_token_id: int | list[int] | None = None  # ID(s) of the end-of-sequence tokens. Only used in post-init.
+    num_children: int = 0  # Number of children requests
+    logit_processor_kwargs: dict = field(default_factory=dict)  # Keyword arguments for the logits processor.
+
+    # Internal fields (for scheduling)
+    tokens_to_process: list[int] = field(default_factory=list)  # Tokens IDs currently being processed
+    generated_tokens: list[int] = field(default_factory=list)  # Generated tokens
+    logprobs: list[float] = field(default_factory=list)  # Log probabilities of the generated tokens
+    position_offset: int = 0  # Current position in the sequence for position_ids
+    allocated_blocks: int = 0  # Number of blocks allocated to the request
+
+    _status: RequestStatus = RequestStatus.PENDING  # Status of the request, hidden behind a property
     _eos_token_ids: set[int] = field(default_factory=set)  # IDs of the end-of-sequence tokens, formatted as a set
-    streaming: bool = False  # Whether to stream tokens as they're generated
+
+    # Internal fields (for tracking)
     created_time: float = field(default_factory=time.perf_counter)  # Time the request was created
     error: str | None = None  # Error message if the request failed
     lifespan: tuple[float, float] = (-1, -1)  # (time request was no longer pending, time request finished)
     _timestamps: list[float] = field(default_factory=list)  # Timestamps of the generated tokens
     _true_initial_tokens: int = 0  # The true number of initial tokens, useful when soft resetting requests
     # TODO: remove the attribute above to _num_initial_tokens once initial_tokens is renamed
+
+    # Fields overwritten in __post_init__
     _new_tokens_limit: int = 2147483647  # An int to check the max number of new tokens w/out always comparing w/ None
+    remaining_prefill_tokens: list[int] = field(default_factory=list)  # Initial tokens left to process
 
     def __post_init__(self):
         # If no max length is set, we set an absurdly high value which will never be reached
@@ -265,6 +274,7 @@ class RequestState:
             f"full_prompt_length={len(self.initial_tokens)}",
             f"allocated_blocks={self.allocated_blocks}",
             f"generated_tokens={self.generated_tokens}",
+            f"logit_processor_kwargs={self.logit_processor_kwargs}",
         ]
         return "RequestState(\n\t" + ",\n\t".join(msg) + "\n)"
 
@@ -287,44 +297,43 @@ class RequestState:
 
     def fork(self, new_request_id: str) -> "RequestState":
         """Fork the request into a new request with the same state except for request_id, created_time and lifespan."""
-        t = time.perf_counter()
-        new_request = RequestState(
-            request_id=new_request_id,
-            initial_tokens=self.initial_tokens,
-            num_children=self.num_children,
-            tokens_to_process=self.tokens_to_process[:],
-            generated_tokens=self.generated_tokens[:],
-            logprobs=self.logprobs[:],
-            allocated_blocks=self.allocated_blocks,
-            position_offset=self.position_offset,
-            _status=self.status,
-            max_new_tokens=self.max_new_tokens,
-            eos_token_id=self.eos_token_id,
-            streaming=self.streaming,
-            created_time=t,
-            lifespan=(t, -1),
-            _timestamps=[],
-            error=self.error,
-            record_timestamps=self.record_timestamps,
-        )
-        # Modified by __post_init__
+        new_request = deepcopy(self)
+        # Update tracking fields
+        new_request.request_id = new_request_id
+        new_request.created_time = time.perf_counter()
+        new_request.lifespan = (new_request.created_time, -1)
+        new_request._timestamps = []
+        # Update fields overwritten in __post_init__
         new_request.remaining_prefill_tokens = self.remaining_prefill_tokens[:]
         return new_request
+
+    def get_request_config(self) -> dict:
+        """Get all the fields necessary to create a request that would have the same configuration."""
+        return {
+            "streaming": self.streaming,
+            "record_timestamps": self.record_timestamps,
+            "max_new_tokens": self.max_new_tokens,
+            "eos_token_id": self.eos_token_id,
+            "num_children": self.num_children,
+            "logit_processor_kwargs": deepcopy(self.logit_processor_kwargs),
+        }
 
     def create_equivalent_initial_request(self) -> "RequestState":
         """Creates an equivalent new request by removing the generated tokens and adding them to the initial prompt. The
         created request has THE SAME request_id. Notably, we can retrieve the original request from the created one with
         the _true_initial_tokens attribute. The logprobs of the generated tokens are kept in the new request."""
-        max_new_tokens = None if self.max_new_tokens is None else (self.max_new_tokens - len(self.generated_tokens))
+
+        request_config = self.get_request_config()
+        # If there is a number of max new tokens, we update it to account for the already generated tokens
+        if self.max_new_tokens is not None:
+            request_config["max_new_tokens"] = self.max_new_tokens - len(self.generated_tokens)
+        # Create new request state
         new_state = RequestState(
             request_id=self.request_id,
             initial_tokens=self.initial_tokens + self.generated_tokens,
             logprobs=self.logprobs[:],
-            num_children=self.num_children,
-            record_timestamps=self.record_timestamps,
-            max_new_tokens=max_new_tokens,
-            eos_token_id=self.eos_token_id,
-            streaming=self.streaming,
+            _true_initial_tokens=self._true_initial_tokens + len(self.initial_tokens),
+            **request_config,
         )
         # If the request has been soft reset once already, this stays the same
         if self._true_initial_tokens:
@@ -339,9 +348,10 @@ class FutureRequestState:
     """Tracks the current state of a request and the relevant information to update it."""
 
     # This makes instantiating this class faster
-    __slots__ = ("state", "has_new_token", "complete_blocks")
+    __slots__ = ("state", "has_new_token", "complete_blocks", "query_length")
 
-    def __init__(self, state: RequestState, has_new_token: bool, complete_blocks: int) -> None:
+    def __init__(self, state: RequestState, has_new_token: bool, complete_blocks: int, query_length: int) -> None:
         self.state = state
         self.has_new_token = has_new_token
         self.complete_blocks = complete_blocks
+        self.query_length = query_length

--- a/src/transformers/generation/continuous_batching/scheduler.py
+++ b/src/transformers/generation/continuous_batching/scheduler.py
@@ -264,7 +264,7 @@ class Scheduler(ABC):
 
             # Store the future request state
             has_new_token = not state.remaining_prefill_tokens
-            scheduled_requests.append(FutureRequestState(state, has_new_token, complete_blocks))
+            scheduled_requests.append(FutureRequestState(state, has_new_token, complete_blocks, request_len))
 
             # Remove the request from the waiting queue and mark it as removed
             req_id = state.request_id

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -184,5 +184,7 @@ def create_warmup_future_states(
         allocated = cache.allocate_blocks(blocks_needed, state.request_id, 0)
         if allocated is None:
             return future_states
-        future_states.append(FutureRequestState(state, has_new_token=True, complete_blocks=0))
+        future_states.append(
+            FutureRequestState(state, has_new_token=True, complete_blocks=0, query_length=num_query_tokens)
+        )
     return future_states

--- a/src/transformers/generation/logits_process.py
+++ b/src/transformers/generation/logits_process.py
@@ -49,6 +49,10 @@ LOGITS_PROCESSOR_INPUTS_DOCSTRING = r"""
 class LogitsProcessor:
     """Abstract base class for all logit processors that can be applied during generation."""
 
+    # Whether the logit processor is supported by continuous batching.
+    # True if it is, False if it is not, None if it is not yet known.
+    supports_continuous_batching: bool | None = None
+
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
         raise NotImplementedError(
@@ -93,12 +97,6 @@ class LogitsProcessorList(list):
 
         return scores
 
-    def set_continuous_batching_context(self, logits_indices: torch.Tensor, cu_seq_lens_q: torch.Tensor) -> None:
-        """Forwards the continuous batching metadata to all logit processors that need it."""
-        for processor in self:
-            if hasattr(processor, "set_continuous_batching_context"):
-                processor.set_continuous_batching_context(logits_indices, cu_seq_lens_q)
-
 
 class MinLengthLogitsProcessor(LogitsProcessor):
     r"""
@@ -138,6 +136,8 @@ class MinLengthLogitsProcessor(LogitsProcessor):
     A number: one thousand, nine hundred and ninety-four
     ```
     """
+
+    supports_continuous_batching: bool = False
 
     def __init__(self, min_length: int, eos_token_id: int | list[int] | torch.Tensor, device: str = "cpu"):
         if not isinstance(min_length, int) or min_length < 0:
@@ -197,6 +197,8 @@ class MinNewTokensLengthLogitsProcessor(LogitsProcessor):
     A number: one thousand
     ```
     """
+
+    supports_continuous_batching = False
 
     def __init__(
         self,
@@ -281,6 +283,8 @@ class TemperatureLogitsWarper(LogitsProcessor):
     ```
     """
 
+    supports_continuous_batching = True
+
     def __init__(self, temperature: float):
         if not isinstance(temperature, float) or not (temperature > 0):
             except_msg = (
@@ -349,6 +353,8 @@ class RepetitionPenaltyLogitsProcessor(LogitsProcessor):
     ```
     """
 
+    supports_continuous_batching = False
+
     def __init__(self, penalty: float, prompt_ignore_length: int | None = None):
         if not isinstance(penalty, float) or not (penalty > 0):
             raise ValueError(f"`penalty` has to be a strictly positive float, but is {penalty}")
@@ -362,10 +368,6 @@ class RepetitionPenaltyLogitsProcessor(LogitsProcessor):
         self.prompt_ignore_length = prompt_ignore_length
         self.logits_indices = None
         self.cu_seq_lens_q = None
-
-    def set_continuous_batching_context(self, logits_indices: torch.Tensor, cu_seq_lens_q: torch.Tensor):
-        self.logits_indices = logits_indices
-        self.cu_seq_lens_q = cu_seq_lens_q
 
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:
@@ -448,6 +450,8 @@ class EncoderRepetitionPenaltyLogitsProcessor(LogitsProcessor):
     ```
     """
 
+    supports_continuous_batching: bool = False
+
     def __init__(self, penalty: float, encoder_input_ids: torch.LongTensor):
         if not isinstance(penalty, float) or not (penalty > 0):
             raise ValueError(f"`penalty` has to be a strictly positive float, but is {penalty}")
@@ -505,6 +509,8 @@ class TopPLogitsWarper(LogitsProcessor):
     A sequence: 1, 2, 3, 4, 5, 6, 7, 8, 9
     ```
     """
+
+    supports_continuous_batching = True
 
     def __init__(self, top_p: float, filter_value: float = -float("Inf"), min_tokens_to_keep: int = 1):
         top_p = float(top_p)
@@ -570,12 +576,15 @@ class TopKLogitsWarper(LogitsProcessor):
     ```
     """
 
+    supports_continuous_batching = True
+
     def __init__(self, top_k: int, filter_value: float = -float("Inf"), min_tokens_to_keep: int = 1):
         if not isinstance(top_k, int) or top_k <= 0:
             raise ValueError(f"`top_k` has to be a strictly positive integer, but is {top_k}")
 
         self.top_k = max(top_k, min_tokens_to_keep)
         self.filter_value = filter_value
+        self.min_tokens_to_keep = min_tokens_to_keep  # used for CB processor initialization
 
     @add_start_docstrings(LOGITS_PROCESSOR_INPUTS_DOCSTRING)
     def __call__(self, input_ids: torch.LongTensor, scores: torch.FloatTensor) -> torch.FloatTensor:

--- a/src/transformers/utils/metrics.py
+++ b/src/transformers/utils/metrics.py
@@ -285,20 +285,20 @@ class ContinuousBatchProcessorMetrics:
             logger.warning(f"Failed to record TTFT metric: {e}")
 
     @traced
-    def record_batch_metrics(self, requests_in_batch: list) -> None:
+    def record_batch_metrics(self, future_states: list) -> None:
         """Record metrics about the batch composition including decode/prefill ratio and batch fill percentage.
 
         Args:
             requests_in_batch: List of request states in the current batch
         """
-        if not _has_opentelemetry or not requests_in_batch:
+        if not _has_opentelemetry or not future_states:
             return
 
         decode_tokens = 0
         prefill_tokens = 0
 
-        for request in requests_in_batch:
-            state = request.state
+        for future_state in future_states:
+            state = future_state.state
             if state.status == RequestStatus.DECODING:
                 decode_tokens += 1
             elif state.status in [RequestStatus.PREFILLING, RequestStatus.PREFILLING_SPLIT]:

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -30,7 +30,6 @@ from transformers import (
     ContinuousBatchingConfig,
     GenerationConfig,
     GenerationMixin,
-    LogitsProcessorList,
     StaticCache,
 )
 from transformers.generation.continuous_batching.cache import (
@@ -44,7 +43,6 @@ from transformers.generation.continuous_batching.continuous_api import Continuou
 from transformers.generation.continuous_batching.input_outputs import build_attention_mask
 from transformers.generation.continuous_batching.requests import GenerationOutput, RequestStatus
 from transformers.testing_utils import (
-    Expectations,
     require_deterministic_for_xpu,
     require_flash_attn,
     require_kernels,
@@ -161,6 +159,45 @@ def get_generation_inputs(
             return_attention_mask=True,
         )
         return inputs
+
+
+def regular_generate(
+    model: GenerationMixin,
+    tokenizer: AutoTokenizer,
+    user_messages: list[str],
+    **generate_kwargs,
+) -> tuple[list[list[int]], list[list[float]]]:
+    # Run generation
+    inputs = get_generation_inputs(user_messages, tokenizer, for_continuous_batching=False)
+    generate_outputs = model.generate(**inputs.to(model.device), return_dict_in_generate=True, **generate_kwargs)
+
+    # Keep only generated tokens
+    all_generated_tokens = []
+    num_input_tokens = inputs.input_ids.shape[1]
+    for i in range(len(user_messages)):
+        # Remove left-side input and padding tokens
+        generated_toks = generate_outputs.sequences[i, num_input_tokens:].tolist()
+        # Remove right-side padding tokens
+        while generated_toks[-1] == model.generation_config.pad_token_id:
+            generated_toks.pop()
+        all_generated_tokens.append(generated_toks)
+
+    # Retrieve logprobs if the scores were requested
+    per_prompt_logprobs = []
+    if generate_kwargs.get("output_scores", False):
+        # Loop over prompts
+        for i in range(len(user_messages)):
+            logprobs = []
+            tokens_for_prompt = generate_outputs.sequences[i, num_input_tokens:].tolist()
+            for score, token in zip(generate_outputs.scores, tokens_for_prompt):
+                # Scores already have logits processors applied (including temperature)
+                probs = torch.nn.functional.softmax(score[i], dim=-1)
+                logprobs.append(probs[token].log().item())
+            per_prompt_logprobs.append(logprobs)
+    # Otherwise, return an empty list
+    else:
+        per_prompt_logprobs = []
+    return all_generated_tokens, per_prompt_logprobs
 
 
 # Class for all continuous batching tests that do not require any accelerator. Usualy those test are faster to run.
@@ -636,69 +673,59 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
         """Test that log probabilities match between continuous batching and regular generate."""
         model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
 
+        # Retrieve tokenizer, model and eos_token_id (required otherwise logits will be misaligned)
         tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device, torch.float32)
+        eos_token_id = model.config.eos_token_id  # type: ignore[attr-defined]
+
+        # Run CB generation
         user_messages = ["What is 2+2?", "Hello world"]
         input_ids = get_generation_inputs(user_messages, tokenizer, for_continuous_batching=True)
-
-        eos_token_id = model.config.eos_token_id  # required otherwise logits will be misaligned
         gen_config = GenerationConfig(max_new_tokens=10, do_sample=False, eos_token_id=eos_token_id)
-
         continuous_batching_config = ContinuousBatchingConfig(
             use_cuda_graph=use_cuda_graph,
             use_async_batching=use_async_batching,
             return_logprobs=True,
         )
-
         cb_outputs = model.generate_batch(
             inputs=input_ids, generation_config=gen_config, continuous_batching_config=continuous_batching_config
         )
 
-        # Load fresh model for regular generate (same pattern as parity tests)
-        model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="sdpa", torch_dtype=torch.float32)
-        model = model.to(torch_device).eval()
-
-        # Run regular generate with output_scores to get logits
-        inputs = get_generation_inputs(user_messages, tokenizer, for_continuous_batching=False)
-
-        gen_config_regular = GenerationConfig(
-            max_new_tokens=10, do_sample=False, output_scores=True, eos_token_id=tokenizer.eos_token_id
-        )
-        generate_outputs = model.generate(
-            **inputs.to(torch_device), generation_config=gen_config_regular, return_dict_in_generate=True
+        # Load fresh model for regular generate
+        tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device, torch.float32)
+        # Run regular generate
+        regular_outputs, regular_logprobs = regular_generate(
+            model=model,
+            tokenizer=tokenizer,
+            user_messages=user_messages,
+            max_new_tokens=10,
+            do_sample=False,
+            output_scores=True,
+            eos_token_id=eos_token_id,
         )
 
         # Compare log_probs for each request, matching by prompt_ids
-        num_input_tokens = inputs.input_ids.shape[1]
-        for i in range(len(user_messages)):
-            # Find the corresponding CB output by matching prompt tokens
-            input_tokens = inputs.input_ids[i][inputs.attention_mask[i] == 1].tolist()
-            cb_output = None
-            for state in cb_outputs.values():
-                if state.prompt_ids == input_tokens:
-                    cb_output = state
-                    break
-            self.assertIsNotNone(cb_output, f"Could not find CB output for request {i}")
+        for i, cb_output in enumerate(cb_outputs.values()):
+            # Compare Cb and regular generate outputs
+            cb_output_ids = cb_output.generated_tokens
+            regular_output_ids = regular_outputs[i]
+            self.assertEqual(len(cb_output_ids), len(regular_output_ids))
+            self.assertEqual(cb_output_ids, regular_output_ids)
 
-            # Compute log_probs from regular generate scores
-            expected_logprobs = []
-            generated_tokens = generate_outputs.sequences[i, num_input_tokens:].tolist()
-            for score, token in zip(generate_outputs.scores, generated_tokens):
-                probs = torch.nn.functional.softmax(score[i], dim=-1)
-                expected_logprobs.append(probs[token].log().item())
+            # Retrieve logprobs from CB and regular generate
+            cb_logprobs = cb_output.logprobs
+            expected_logprobs = regular_logprobs[i]
 
-            # Truncate to same length (in case of padding differences)
-            min_len = min(len(cb_output.logprobs), len(expected_logprobs))
-            cb_logprobs = cb_output.logprobs[:min_len]
+            # Because of padding, we need to truncate to the same length
+            min_len = min(len(cb_logprobs), len(expected_logprobs))
+            cb_logprobs = cb_logprobs[:min_len]
             expected_logprobs = expected_logprobs[:min_len]
+            self.assertEqual(len(cb_logprobs), len(expected_logprobs))
 
-            # Compare with tolerance for floating point differences
+            # Compare with tolerance for floating point differences (because of padding, tol is higher for cuda graphs)
+            delta = 2e-5 if use_cuda_graph else 1e-5
             for j, (cb_lp, exp_lp) in enumerate(zip(cb_logprobs, expected_logprobs)):
-                self.assertAlmostEqual(
-                    cb_lp,
-                    exp_lp,
-                    delta=2e-5 if use_cuda_graph else 1e-5,  # cuda graphs add padding, hence lower precision
-                    msg=f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}",
-                )
+                error_msg = f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}"
+                self.assertAlmostEqual(cb_lp, exp_lp, delta=delta, msg=error_msg)
 
     def test_continuous_batching_with_default_compile_configs(self) -> None:
         """Test continuous batching with use_default_compile_configs=True in ContinuousBatchingConfig.
@@ -794,7 +821,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
 
         tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device)
         manager = model.init_continuous_batching()
-        manager.logit_processor = LogitsProcessorList()
+        manager.logit_processor.clear()
         manager.start()
 
         user_messages = ["What is the Transformers library known for?"]
@@ -842,7 +869,7 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
 
         tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device)
         manager = model.init_continuous_batching()
-        manager.logit_processor = LogitsProcessorList()
+        manager.logit_processor.clear()
         manager.start()
 
         user_messages = ["What is the Transformers library known for?"]
@@ -875,18 +902,23 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
     # -----------------------------------------Misc. tests----------------------------------------- #
     #                     Various tests that don't fit into the other categories                    #
     # --------------------------------------------------------------------------------------------- #
-    def _test_block_sharing(
-        self, model_id: str, expected_layer_types: dict[str, int], input_msg: str, expected_output_tokens: list[int]
-    ) -> None:
-        tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device)
+    def _test_block_sharing(self, model_id: str, expected_layer_types: dict[str, int], input_msg: str) -> None:
+        # Use float32 for SDPA to handle precision differences from attention masks (same as parity test)
+        tokenizer, model = get_tokenizer_and_model(model_id, "sdpa", torch_device, dtype=torch.float32)
+
+        # Configure generation for parity: disable processors not supported by CB (like repetition_penalty)
+        model.generation_config.max_new_tokens = 32
+        model.generation_config.do_sample = False
+        model.generation_config.repetition_penalty = None
+
+        # Get expected output from regular generate for parity check
+        expected_output_tokens, _ = regular_generate(model, tokenizer, [input_msg])
 
         cb_context_manager = model.continuous_batching_context_manager(
-            generation_config=GenerationConfig(do_sample=False),
+            generation_config=model.generation_config,
             continuous_batching_config=ContinuousBatchingConfig(block_size=32),
         )
         with cb_context_manager as manager:
-            manager.logit_processor = LogitsProcessorList()
-
             # Create a request with at least 32 tokens but less than 64 so prefill only generates one complete block
             inputs = get_generation_inputs([input_msg], tokenizer, for_continuous_batching=True)[0]
             self.assertGreaterEqual(len(inputs), 32, f"Input length is {len(inputs)} instead of at least 32")
@@ -959,32 +991,23 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
                 f"Expected total prefix length to be {expected_total_prefix_length}, but got {total_prefix_length = }",
             )
 
-        # Check the outputs were the same
+        # Check the outputs were the same (block sharing should produce identical results)
         self.assertEqual(chunk_no_reuse.generated_tokens, chunk_with_reuse.generated_tokens)
 
-        # As an additional sanity check, we also compare to the generated tokens when prefix sharing is disabled
-        print(f"{chunk_no_reuse.generated_tokens = } {expected_output_tokens = }")
-        self.assertEqual(chunk_no_reuse.generated_tokens, expected_output_tokens)
+        # Verify parity with regular generate
+        self.assertEqual(chunk_no_reuse.generated_tokens, expected_output_tokens[0])
 
     def test_prefix_sharing(self) -> None:
         model_id = "Qwen/Qwen2.5-0.5B-Instruct"
         num_layer_groups = {"full_attention": 1, "sliding_window": 0}
         input_msg = "What is the Transformers library known for?"
-        expected_generated_tokens = Expectations({
-            (None, None): [785, 80532, 6733, 374, 3881, 369, 1181, 5726, 311, 1855, 323, 36635, 3460, 12934, 4128, 4119, 11, 2670, 1846, 429, 646, 6923, 1467, 11, 14683, 1467, 11, 323, 2736, 1008, 4128, 13904]
-        }).get_expectation()  # fmt: skip
-
-        return self._test_block_sharing(model_id, num_layer_groups, input_msg, expected_generated_tokens)
+        return self._test_block_sharing(model_id, num_layer_groups, input_msg)
 
     def test_block_sharing_with_hybrid_model(self) -> None:
         model_id = "google/gemma-3-1b-it"
         num_layer_groups = {"full_attention": 2, "sliding_window": 11}
         input_msg = "I am a software engineer looking to use open source software to build a new AI agent. What is the Transformers library known for?"
-        expected_generated_tokens = Expectations({
-            (None, None): [19058, 236764, 1531, 236789, 236751, 2541, 1679, 1144, 506, 128282, 9427, 563, 3224, 573, 236764, 10916, 528, 506, 4403, 529, 3788, 12498, 11362, 236761, 1030, 236789, 236751, 496, 808, 120749, 236829, 532]
-        }).get_expectation()  # fmt: skip
-
-        return self._test_block_sharing(model_id, num_layer_groups, input_msg, expected_generated_tokens)
+        return self._test_block_sharing(model_id, num_layer_groups, input_msg)
 
     @parameterized.expand([True, False])
     @require_flash_attn  # otherwise the test can fail because attention bias has a very slight impact on SDPA and eager
@@ -1094,6 +1117,106 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             text_fa2 = tokenizer.decode(out_fa2.generated_tokens, skip_special_tokens=True)
             text_fa3 = tokenizer.decode(out_fa3.generated_tokens, skip_special_tokens=True)
             self.assertEqual(text_fa2, text_fa3, f"Mismatch:\nFA2: {text_fa2}\nFA3: {text_fa3}")
+
+    @parameterized.expand([(False, False), (False, True), (True, False), (True, True)])
+    @slow
+    def test_per_request_logits_processors(self, use_cuda_graph: bool, use_async_batching: bool) -> None:
+        """Tests that per-request logits processor kwargs (temperature, top_k, top_p) work correctly in generation."""
+        model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
+        max_new_tokens = 10
+        temperatures = [1.0, 1.0]
+        top_ks = [10, 50]
+        top_ps = [0.9, 0.99]
+
+        tokenizer, model = get_tokenizer_and_model(model_id, "flash_attention_2", torch_device)
+        eos_token_id = model.config.eos_token_id  # type: ignore[attr-defined]
+
+        # Same prompt for both requests
+        user_messages = ["Write a random number:"]
+        input_ids = get_generation_inputs(user_messages, tokenizer, for_continuous_batching=True)[0]
+
+        # Use the context manager to add requests with different per-request kwargs
+        generation_config = GenerationConfig(
+            do_sample=True,
+            temperature=max(temperatures) + 1,  # enables temperature warping
+            top_k=max(top_ks) + 1,
+            top_p=min(top_ps) - 0.01,
+            max_new_tokens=max_new_tokens,
+            eos_token_id=eos_token_id,
+        )
+        continuous_batching_config = ContinuousBatchingConfig(
+            use_cuda_graph=use_cuda_graph,
+            use_async_batching=use_async_batching,
+            per_request_processors=True,
+            return_logprobs=True,
+        )
+        manager = model.init_continuous_batching(
+            generation_config=generation_config,
+            continuous_batching_config=continuous_batching_config,
+            q_padding_interval_size=16,  # allows for exact comparison between CB and regular generation
+        )
+
+        # Trick to have temperature, top-k, top-p ... without randomness: diable sampling after manager creation
+        manager.generation_config.do_sample = False
+
+        manager.start()
+        try:
+            # Request 0: low temperature (more deterministic)
+            req0_id = manager.add_request(
+                input_ids, max_new_tokens=max_new_tokens, temperature=temperatures[0], top_k=top_ks[0], top_p=top_ps[0]
+            )
+            # Request 1: high temperature (more random)
+            req1_id = manager.add_request(
+                input_ids, max_new_tokens=max_new_tokens, temperature=temperatures[1], top_k=top_ks[1], top_p=top_ps[1]
+            )
+            # Collect results
+            results = {}
+            while len(results) < 2:
+                result = manager.get_result(timeout=1)
+                if result is not None and result.is_finished():
+                    results[result.request_id] = result
+                elif not manager.is_running():
+                    break
+        finally:
+            manager.stop(block=True)
+
+        # Both requests should complete and have logprobs
+        self.assertEqual(len(results), 2, f"Expected 2 results, got {len(results)}")
+        self.assertGreater(len(results[req0_id].logprobs), 0)
+        self.assertGreater(len(results[req1_id].logprobs), 0)
+        # Also ensure the logprobs were not the same
+        self.assertNotEqual(results[req0_id].logprobs, results[req1_id].logprobs)
+
+        # Compare each request with regular generation
+        # Build logits processor with do_sample=True (so temperature is included), then set do_sample=False for
+        # deterministic generation, which is the same trick that CB uses
+        delta = 2e-5 if use_cuda_graph else 1e-5
+        for i, req_id in enumerate([req0_id, req1_id]):
+            tokenizer, model = get_tokenizer_and_model(model_id, "flash_attention_2", torch_device)
+            gen_config = GenerationConfig(
+                do_sample=True,
+                temperature=temperatures[i],
+                top_k=top_ks[i],
+                top_p=top_ps[i],
+                max_new_tokens=max_new_tokens,
+                eos_token_id=eos_token_id,
+            )
+            logits_processor = model._get_logits_processor(gen_config)
+            gen_config.do_sample = False
+            regular_generated_tokens, regular_logprobs = regular_generate(
+                model=model,
+                tokenizer=tokenizer,
+                user_messages=user_messages,
+                logits_processor=logits_processor,
+                max_new_tokens=max_new_tokens,
+                do_sample=False,
+                output_scores=True,
+                eos_token_id=eos_token_id,
+            )
+            self.assertEqual(results[req_id].generated_tokens, regular_generated_tokens[0])
+            for j, (cb_lp, exp_lp) in enumerate(zip(results[req_id].logprobs, regular_logprobs[0])):
+                error_msg = f"Request {i}: logprob mismatch at position {j}: CB={cb_lp}, expected={exp_lp}"
+                self.assertAlmostEqual(cb_lp, exp_lp, delta=delta, msg=error_msg)
 
 
 @require_torch_gpu

--- a/tests/generation/test_logits_process.py
+++ b/tests/generation/test_logits_process.py
@@ -285,39 +285,6 @@ class LogitsProcessorTest(unittest.TestCase):
         # processor should not change logits in-place
         self.assertFalse(torch.all(scores == processed_scores))
 
-    def test_repetition_penalty_continuous_batching(self):
-        vocab_size = 10
-
-        input_ids = torch.tensor([1, 2, 3, 4, 5, 6], device=torch_device, dtype=torch.long)
-        scores = torch.ones((1, 6, vocab_size), device=torch_device, dtype=torch.float) / vocab_size
-
-        scores[0, 2, 1] = -2.0
-        scores[0, 2, 2] = 3.0
-        scores[0, 2, 3] = 4.0
-        scores[0, 5, 4] = -5.0
-        scores[0, 5, 5] = 6.0
-        scores[0, 5, 6] = 7.0
-
-        logits_indices = torch.tensor([2, 5], device=torch_device, dtype=torch.long)
-        cumulative_seqlens_q = torch.tensor([0, 3, 6], device=torch_device, dtype=torch.long)
-
-        rep_penalty_proc = RepetitionPenaltyLogitsProcessor(penalty=2.0)
-        rep_penalty_proc.set_continuous_batching_context(logits_indices, cumulative_seqlens_q)
-
-        original_scores = scores.clone()
-        processed_scores = rep_penalty_proc(input_ids, scores)
-
-        self.assertAlmostEqual(processed_scores[0, 2, 1].item(), -2.0 * 2.0)
-        self.assertAlmostEqual(processed_scores[0, 2, 2].item(), 3.0 / 2.0)
-        self.assertAlmostEqual(processed_scores[0, 2, 3].item(), 4.0 / 2.0)
-        self.assertAlmostEqual(processed_scores[0, 5, 4].item(), -5.0 * 2.0)
-        self.assertAlmostEqual(processed_scores[0, 5, 5].item(), 6.0 / 2.0)
-        self.assertAlmostEqual(processed_scores[0, 5, 6].item(), 7.0 / 2.0)
-        self.assertAlmostEqual(processed_scores[0, 2, 0].item(), 1.0 / vocab_size)
-        self.assertAlmostEqual(processed_scores[0, 5, 0].item(), 1.0 / vocab_size)
-
-        self.assertFalse(torch.all(original_scores == processed_scores))
-
     def test_top_k_dist_warper(self):
         input_ids = None
         vocab_size = 10


### PR DESCRIPTION
# Summary
This PR adds per-request logits processors and overalls the way CB handles logits processors. 
It introduces batched logits processing with per-request parameters for continuous batching, enabling each request in a batch to use different sampling parameters (temperature, top_k, top_p). This is essential for serving scenarios where different users may request different generation configurations within the same batch.

The main changes are:
  - cb_logits_processors.py (new): Adds `ContinuousBatchingLogitsProcessorList` to manage logits processors and three per-request processor implementations (Temperature, TopK, TopP) that operate on the batched tensor format using vectorized operations
  - continuous_api.py: Integrates the new processor list into the batch processor, passes it through the forward/sampling pipeline, and validates per-request kwargs at request ingestion
  - input_outputs.py: Extends the bulk input tensor to store processor arguments (one row per processor), passes them to PagedAttentionArgs, and prepares tensor args during batch preparation
  - requests.py: Adds logit_processor_kwargs field to RequestState for per-request overrides, reorganizes dataclass fields, and simplifies fork() using deepcopy
  - configuration_utils.py: Adds per_request_processors and drop_unsupported_processors flags to ContinuousBatchingConfig
  - logits_process.py: Adds supports_continuous_batching flag to base processors for compatibility checking
  - Tests: Extends test coverage for per-request temperature, top_k, and top_p sampling

  The processor list validates compatibility at init time, warns about unsupported processors, and efficiently prepares tensor arguments by storing them as views into the bulk input tensor to minimize memory transfers.