### PR TITLE
[`fix`] Use the correct _tied_weights_keys for CamembertForCausalLM

### DIFF
--- a/src/transformers/models/camembert/modeling_camembert.py
+++ b/src/transformers/models/camembert/modeling_camembert.py
@@ -1154,7 +1154,7 @@ class CamembertForQuestionAnswering(CamembertPreTrainedModel):
 )
 class CamembertForCausalLM(CamembertPreTrainedModel, GenerationMixin):
     _tied_weights_keys = {
-        "lm_head.decoder.weight": "camembert.embeddings.word_embeddings.weight",
+        "lm_head.decoder.weight": "roberta.embeddings.word_embeddings.weight",
         "lm_head.decoder.bias": "lm_head.bias",
     }
 

--- a/src/transformers/models/camembert/modular_camembert.py
+++ b/src/transformers/models/camembert/modular_camembert.py
@@ -427,6 +427,11 @@ class CamembertForQuestionAnswering(RobertaForQuestionAnswering):
 
 
 class CamembertForCausalLM(RobertaForCausalLM):
+    _tied_weights_keys = {
+        "lm_head.decoder.weight": "roberta.embeddings.word_embeddings.weight",
+        "lm_head.decoder.bias": "lm_head.bias",
+    }
+
     def __init__(self, config):
         super().__init__(config)
         del self.camembert


### PR DESCRIPTION
# What does this PR do?

Follow-up for https://github.com/huggingface/transformers/pull/44931, which added weight tying for Camembert. 
Only the CamembertForMaskedLM class had the right _tied_weights_keys, the CamembertForCausalLM had the incorrect weight key. 

## Details
```python
from transformers import AutoModelForCausalLM

model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-camembert")
print(type(model))
```

On main:
```
Traceback (most recent call last):
  File "[sic]\demo_camembert.py", line 4, in <module>
    model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-camembert")
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[sic]\src\transformers\models\auto\auto_factory.py", line 381, in from_pretrained
    return model_class.from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[sic]\src\transformers\modeling_utils.py", line 4087, in from_pretrained
    model = cls(config, *model_args, **model_kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "[sic]\src\transformers\models\camembert\modeling_camembert.py", line 1171, in __init__
    self.post_init()
  File "[sic]\src\transformers\modeling_utils.py", line 1298, in post_init   
    self.all_tied_weights_keys = self.get_expanded_tied_weights_keys(all_submodels=False)   
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^   
  File "[sic]\src\transformers\modeling_utils.py", line 2490, in get_expanded_tied_weights_keys
    raise ValueError(
ValueError: There is an issue with your definition of `tie_weights_keys` for ^camembert.embeddings.word_embeddings.weight:^lm_head.decoder.weight. We found [] to tie into ['lm_head.decoder.weight']
```

On this PR:
```
<class 'transformers.models.camembert.modeling_camembert.CamembertForCausalLM'>
```

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

I wrote the code and PR description myself

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @Cyrilvallez

- Tom Aarsen
