### PR TITLE
Add BC for `_further_process_kwargs`

### DIFF
--- a/src/transformers/image_processing_utils.py
+++ b/src/transformers/image_processing_utils.py
@@ -346,6 +346,9 @@ class BaseImageProcessor(ImageProcessingMixin):
 
         return kwargs
 
+    # Backwards compatibility for method that was renamed
+    _further_process_kwargs = _standardize_kwargs
+
     def _validate_preprocess_kwargs(
         self,
         do_rescale: bool | None = None,


### PR DESCRIPTION
In https://github.com/huggingface/transformers/pull/43514, `BaseImageProcessorFast` became `BaseImageProcessor` and `_further_process_kwargs` was renamed to `_standardize_kwargs`

This PR adds some BC for the old name of this method.