### PR TITLE
[fix] BC for legacy configs with top-level rope_theta when rope_parameters is set via rope_scaling

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -287,6 +287,21 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
                     logger.error(f"Can't set {key} with value {value} for {self}")
                     raise err
 
+        # BC for legacy configs where rope_theta is defined at the top level while rope_parameters is
+        # set via the rope_scaling property setter (from kwargs) without including rope_theta.
+        # This happens when rope_parameters is not a declared dataclass field, so convert_rope_params_to_dict
+        # was not called before the kwargs loop, but rope_scaling/rope_theta were then set as attrs.
+        rope_params = getattr(self, "rope_parameters", None)
+        if (
+            isinstance(rope_params, dict)
+            and "rope_theta" not in rope_params
+            and hasattr(self, "rope_theta")
+        ):
+            rope_type = rope_params.get("rope_type", rope_params.get("type", "default"))
+            if rope_type == "default":
+                rope_params.setdefault("rope_type", "default")
+                rope_params["rope_theta"] = self.rope_theta
+
     def __init_subclass__(cls, *args, **kwargs):
         super().__init_subclass__(*args, **kwargs)
         cls_has_custom_init = "__init__" in cls.__dict__


### PR DESCRIPTION

# What does this PR do?

Fixes #45030

Configs like `tiny-random/glm-4v` store `rope_theta` at the top level of `config.json` alongside a `rope_scaling` dict (legacy format). For config classes that don't declare `rope_parameters` as a dataclass field (e.g. `Glm4vConfig`), `convert_rope_params_to_dict` is skipped because `hasattr(self, "rope_parameters")` is `False` before the kwargs loop.

During initialization, the kwargs loop sets `self.rope_parameters` via the `rope_scaling` property setter — but **without `rope_theta`** — and assigns `self.rope_theta` as a separate attribute. When `@strict`'s `validate_rope` runs after `__init__`, it expects `rope_theta` inside `rope_parameters` and raises a `KeyError`.


### Fix

Add a normalization step in `PreTrainedConfig.__post_init__` after the kwargs loop:

- If `rope_parameters` is a dict  
- AND `rope_theta` is missing from it  
- AND `self.rope_theta` exists  
- AND the rope type is `"default"`  

→ Inject `rope_theta` into `rope_parameters`.

This ensures backward compatibility with legacy configs while keeping behavior
unchanged for newer ones.


### Why this is safe


- New configs already:
  - declare `rope_parameters` as a field → go through
    `convert_rope_params_to_dict`, or
  - include `rope_theta` inside `rope_parameters`
- The fix only applies to legacy edge cases
- No change to validation logic (`modeling_rope_utils.py` untouched)


### Test


```
python -c "from transformers import AutoConfig; AutoConfig.from_pretrained('tiny-random/glm-4v'); print('ok')"
```


## Code Agent Policy


The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.


## Before submitting


- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #45030
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?


Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Tagging: @ArthurZucker @CyrilVallez (model loading)