### PR TITLE
[Bugfix] Propagate interpolate_pos_encoding through Pixio model

### DIFF
--- a/src/transformers/models/pixio/modeling_pixio.py
+++ b/src/transformers/models/pixio/modeling_pixio.py
@@ -132,10 +132,12 @@ class PixioEmbeddings(nn.Module):
 
         return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
 
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, _, height, width = pixel_values.shape
         target_dtype = self.patch_embeddings.projection.weight.dtype
-        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
+        embeddings = self.patch_embeddings(
+            pixel_values.to(dtype=target_dtype), interpolate_pos_encoding=interpolate_pos_encoding
+        )
 
         cls_tokens = self.cls_token.expand(batch_size, -1, -1)
         embeddings = torch.cat((cls_tokens, embeddings), dim=1)
@@ -407,12 +409,13 @@ class PixioModel(PixioPreTrainedModel):
     def forward(
         self,
         pixel_values: torch.Tensor | None = None,
+        interpolate_pos_encoding: bool | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
 
         encoder_outputs: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         sequence_output = encoder_outputs.last_hidden_state
@@ -451,7 +454,12 @@ class PixioBackbone(BackboneMixin, PixioPreTrainedModel):
     @can_return_tuple
     @filter_output_hidden_states
     @auto_docstring
-    def forward(self, pixel_values: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> BackboneOutput:
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        interpolate_pos_encoding: bool | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BackboneOutput:
         r"""
         Examples:
 
@@ -480,7 +488,7 @@ class PixioBackbone(BackboneMixin, PixioPreTrainedModel):
         ```"""
         kwargs["output_hidden_states"] = True  # required to extract layers for the stages
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
         output: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         hidden_states = output.hidden_states
 

--- a/src/transformers/models/pixio/modular_pixio.py
+++ b/src/transformers/models/pixio/modular_pixio.py
@@ -134,10 +134,12 @@ class PixioEmbeddings(nn.Module):
 
         return torch.cat((class_pos_embed, patch_pos_embed), dim=1)
 
-    def forward(self, pixel_values: torch.Tensor) -> torch.Tensor:
+    def forward(self, pixel_values: torch.Tensor, interpolate_pos_encoding: bool = False) -> torch.Tensor:
         batch_size, _, height, width = pixel_values.shape
         target_dtype = self.patch_embeddings.projection.weight.dtype
-        embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
+        embeddings = self.patch_embeddings(
+            pixel_values.to(dtype=target_dtype), interpolate_pos_encoding=interpolate_pos_encoding
+        )
 
         cls_tokens = self.cls_token.expand(batch_size, -1, -1)
         embeddings = torch.cat((cls_tokens, embeddings), dim=1)
@@ -236,12 +238,13 @@ class PixioModel(PixioPreTrainedModel):
     def forward(
         self,
         pixel_values: torch.Tensor | None = None,
+        interpolate_pos_encoding: bool | None = None,
         **kwargs: Unpack[TransformersKwargs],
     ) -> BaseModelOutputWithPooling:
         if pixel_values is None:
             raise ValueError("You have to specify pixel_values")
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
 
         encoder_outputs: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         sequence_output = encoder_outputs.last_hidden_state
@@ -262,7 +265,12 @@ class PixioModel(PixioPreTrainedModel):
     """
 )
 class PixioBackbone(Dinov2Backbone):
-    def forward(self, pixel_values: torch.Tensor, **kwargs: Unpack[TransformersKwargs]) -> BackboneOutput:
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        interpolate_pos_encoding: bool | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> BackboneOutput:
         r"""
         Examples:
 
@@ -291,7 +299,7 @@ class PixioBackbone(Dinov2Backbone):
         ```"""
         kwargs["output_hidden_states"] = True  # required to extract layers for the stages
 
-        embedding_output = self.embeddings(pixel_values)
+        embedding_output = self.embeddings(pixel_values, interpolate_pos_encoding=interpolate_pos_encoding)
         output: BaseModelOutput = self.encoder(embedding_output, **kwargs)
         hidden_states = output.hidden_states
 


### PR DESCRIPTION
## Summary

Fixes #44716

- Propagate `interpolate_pos_encoding` parameter through `PixioModel.forward()`, `PixioBackbone.forward()`, and `PixioEmbeddings.forward()` down to `PixioPatchEmbeddings.forward()`
- Follows the same pattern used by ViT (`ViTModel`) and CLIP (`CLIPVisionTransformer`), where this parameter is already correctly propagated
- Changes applied to both `modular_pixio.py` (source of truth) and `modeling_pixio.py` (auto-generated)

### Root cause

`PixioPatchEmbeddings` (inherited from `ViTPatchEmbeddings`) already accepts `interpolate_pos_encoding` in its `forward()`, but the callers (`PixioEmbeddings.forward()`, `PixioModel.forward()`, `PixioBackbone.forward()`) did not expose or pass this parameter, so users could not control position encoding interpolation for different resolution images.

### Fix (3 call sites, same pattern as ViT/CLIP)

1. `PixioEmbeddings.forward()` — add `interpolate_pos_encoding: bool = False`, pass to `self.patch_embeddings()`
2. `PixioModel.forward()` — add `interpolate_pos_encoding: bool | None = None`, pass to `self.embeddings()`
3. `PixioBackbone.forward()` — add `interpolate_pos_encoding: bool | None = None`, pass to `self.embeddings()`

## Verification

<details>
<summary>End-to-end test script</summary>

```python
"""
End-to-end verification script for Pixio interpolate_pos_encoding propagation.

Tests:
1. Default behavior (same image size as config) - should always work
2. interpolate_pos_encoding=True with different image size - the bug fix target
3. PixioBackbone with interpolate_pos_encoding
4. Parameter signature check
"""
import inspect
import sys
import traceback

import torch

from transformers import PixioBackbone, PixioConfig, PixioModel
from transformers.models.pixio.modeling_pixio import PixioEmbeddings


def separator(title):
    print(f"\n{'='*70}")
    print(f"  {title}")
    print(f"{'='*70}\n")


def main():
    config = PixioConfig(
        image_size=32, patch_size=8, num_channels=3, hidden_size=64,
        num_hidden_layers=2, num_attention_heads=4, intermediate_size=128, n_cls_tokens=4,
    )

    # Test 1: Parameter signature check
    separator("Test 1: Parameter signature check")
    for cls_name, cls in [("PixioEmbeddings", PixioEmbeddings), ("PixioModel", PixioModel), ("PixioBackbone", PixioBackbone)]:
        sig = inspect.signature(cls.forward)
        has = "interpolate_pos_encoding" in sig.parameters
        print(f"  {cls_name}.forward() has 'interpolate_pos_encoding': {has}")

    # Test 2: Default behavior
    separator("Test 2: Default behavior (image_size matches config)")
    model = PixioModel(config); model.eval()
    pixel_values = torch.randn(1, 3, 32, 32)
    with torch.no_grad():
        output = model(pixel_values)
    print(f"  Input: {pixel_values.shape}, Output: {output.last_hidden_state.shape}")

    # Test 3: Different image size with interpolation (PixioModel)
    separator("Test 3: interpolate_pos_encoding=True with 64x64 (PixioModel)")
    pixel_values_big = torch.randn(1, 3, 64, 64)
    try:
        with torch.no_grad():
            output_big = model(pixel_values_big, interpolate_pos_encoding=True)
        print(f"  Input: {pixel_values_big.shape}, Output: {output_big.last_hidden_state.shape}")
        print("  [PASS]")
    except Exception as e:
        print(f"  [FAIL] {e}")

    # Test 4: PixioBackbone
    separator("Test 4: interpolate_pos_encoding=True with 64x64 (PixioBackbone)")
    backbone = PixioBackbone(config); backbone.eval()
    try:
        with torch.no_grad():
            output_backbone = backbone(pixel_values_big, interpolate_pos_encoding=True)
        for i, fm in enumerate(output_backbone.feature_maps):
            print(f"  Feature map {i}: {fm.shape}")
        print("  [PASS]")
    except Exception as e:
        print(f"  [FAIL] {e}")

    # Test 5: Non-square image
    separator("Test 5: Non-square image 48x64 with interpolation")
    pixel_values_rect = torch.randn(1, 3, 48, 64)
    try:
        with torch.no_grad():
            output_rect = model(pixel_values_rect, interpolate_pos_encoding=True)
        print(f"  Input: {pixel_values_rect.shape}, Output: {output_rect.last_hidden_state.shape}")
        print("  [PASS]")
    except Exception as e:
        print(f"  [FAIL] {e}")


if __name__ == "__main__":
    main()
```

</details>

<details>
<summary>BEFORE fix — Tests 3, 4, 5 all FAIL (parameter not propagated)</summary>

```
======================================================================
  Test 1: Parameter signature check
======================================================================

Checking PixioEmbeddings.forward() signature...
  Parameters: ['self', 'pixel_values']
  Has 'interpolate_pos_encoding': False

Checking PixioModel.forward() signature...
  Parameters: ['self', 'pixel_values', 'kwargs']
  Has 'interpolate_pos_encoding': False

Checking PixioBackbone.forward() signature...
  Parameters: ['self', 'pixel_values', 'kwargs']
  Has 'interpolate_pos_encoding': False

[FAIL] Missing 'interpolate_pos_encoding' in some forward() methods

======================================================================
  Test 2: Default behavior (image_size matches config)
======================================================================

  Input shape: torch.Size([1, 3, 32, 32])
  Output shape: torch.Size([1, 20, 64])
  Expected seq_len: 20
  Pooler output shape: torch.Size([1, 64])

[PASS] Default behavior works correctly

======================================================================
  Test 3: interpolate_pos_encoding=True with different image size (PixioModel)
======================================================================

  [FAIL] Unexpected error: Input image size (64*64) doesn't match model (32*32).
Traceback (most recent call last):
  File "/tmp/test_pixio_interpolate.py", line 104, in main
    output_big = model(pixel_values_big, interpolate_pos_encoding=True)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/utils/generic.py", line 857, in wrapper
    output = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 415, in forward
    embedding_output = self.embeddings(pixel_values)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 138, in forward
    embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 71, in forward
    raise ValueError(
ValueError: Input image size (64*64) doesn't match model (32*32).

======================================================================
  Test 4: interpolate_pos_encoding=True with different image size (PixioBackbone)
======================================================================

  [FAIL] Unexpected error: Input image size (64*64) doesn't match model (32*32).
Traceback (most recent call last):
  File "/tmp/test_pixio_interpolate.py", line 137, in main
    output_backbone = backbone(pixel_values_big, interpolate_pos_encoding=True)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/utils/generic.py", line 857, in wrapper
    output = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/backbone_utils.py", line 172, in wrapper
    output = forward_function(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 483, in forward
    embedding_output = self.embeddings(pixel_values)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 138, in forward
    embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 71, in forward
    raise ValueError(
ValueError: Input image size (64*64) doesn't match model (32*32).

======================================================================
  Test 5: Non-square image with interpolation (48x64)
======================================================================

  [FAIL] Unexpected error: Input image size (48*64) doesn't match model (32*32).
Traceback (most recent call last):
  File "/tmp/test_pixio_interpolate.py", line 163, in main
    output_rect = model(pixel_values_rect, interpolate_pos_encoding=True)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/utils/generic.py", line 857, in wrapper
    output = func(self, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 415, in forward
    embedding_output = self.embeddings(pixel_values)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 138, in forward
    embeddings = self.patch_embeddings(pixel_values.to(dtype=target_dtype))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1776, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/myenv-vllm/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1787, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/ssd1/jianglidang/workspace/transformers/src/transformers/models/pixio/modeling_pixio.py", line 71, in forward
    raise ValueError(
ValueError: Input image size (48*64) doesn't match model (32*32).

======================================================================
  Summary
======================================================================

All tests completed. See results above.
Python version: 3.12.12 (main, Jan 14 2026, 19:35:58) [Clang 21.1.4 ]
PyTorch version: 2.10.0+cu128
```

</details>

<details>
<summary>AFTER fix — All 5 tests PASS</summary>

```
======================================================================
  Test 1: Parameter signature check
======================================================================

Checking PixioEmbeddings.forward() signature...
  Parameters: ['self', 'pixel_values', 'interpolate_pos_encoding']
  Has 'interpolate_pos_encoding': True

Checking PixioModel.forward() signature...
  Parameters: ['self', 'pixel_values', 'interpolate_pos_encoding', 'kwargs']
  Has 'interpolate_pos_encoding': True

Checking PixioBackbone.forward() signature...
  Parameters: ['self', 'pixel_values', 'interpolate_pos_encoding', 'kwargs']
  Has 'interpolate_pos_encoding': True

[PASS] All forward() methods have 'interpolate_pos_encoding' parameter

======================================================================
  Test 2: Default behavior (image_size matches config)
======================================================================

  Input shape: torch.Size([1, 3, 32, 32])
  Output shape: torch.Size([1, 20, 64])
  Expected seq_len: 20
  Pooler output shape: torch.Size([1, 64])

[PASS] Default behavior works correctly

======================================================================
  Test 3: interpolate_pos_encoding=True with different image size (PixioModel)
======================================================================

  Input shape: torch.Size([1, 3, 64, 64])
  Output shape: torch.Size([1, 68, 64])
  Expected seq_len: 68
  Pooler output shape: torch.Size([1, 64])

[PASS] interpolate_pos_encoding works with different image size

======================================================================
  Test 4: interpolate_pos_encoding=True with different image size (PixioBackbone)
======================================================================

  Input shape: torch.Size([1, 3, 64, 64])
  Number of feature maps: 1
  Feature map 0 shape: torch.Size([1, 64, 8, 8])

[PASS] PixioBackbone works with interpolate_pos_encoding=True

======================================================================
  Test 5: Non-square image with interpolation (48x64)
======================================================================

  Input shape: torch.Size([1, 3, 48, 64])
  Output shape: torch.Size([1, 52, 64])
  Expected seq_len: 52

[PASS] Non-square image interpolation works correctly

======================================================================
  Summary
======================================================================

All tests completed. See results above.
Python version: 3.12.12 (main, Jan 14 2026, 19:35:58) [Clang 21.1.4 ]
PyTorch version: 2.10.0+cu128
```

</details>

<details>
<summary>Existing unit tests — 109 passed, 0 failed</summary>

```
$ python -m pytest tests/models/pixio/test_modeling_pixio.py -v

tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_load_with_global_device_set PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_all_tensors_are_parameter_or_buffer PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_attention_outputs PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_backbone PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_batching_equivalence PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_bc_torch_dtype PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_be_initialized_on_meta PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_init_all_missing_weights PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_load_ignoring_mismatched_shapes PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_load_with_device_context_manager PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_set_attention_dynamically PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_can_use_safetensors PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_cannot_load_with_meta_device_context_manager PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_capture_outputs_decorator PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_config PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_config_attn_implementation_setter PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_correct_missing_keys PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_cpu_offload PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_determinism PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_disk_offload_bin PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_disk_offload_safetensors PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_eager_matches_sdpa_inference_00_fp16_pad_left_sdpa_kernels PASSED
... (24 more sdpa tests all PASSED)
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_enable_input_require_grads PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_feed_forward_chunking PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_flex_attention_with_grads PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_from_pretrained_no_checkpoint PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_generation_tester_mixin_inheritance PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_gradient_checkpointing_backward_compatibility PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_gradient_checkpointing_enable_disable PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_hidden_states_output PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_init_weights_can_init_buffers PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_load_contiguous_weights PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_load_save_without_tied_weights PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_load_with_mismatched_shapes PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_base_model_prefix PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_forward_default_config_values PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_get_set_embeddings PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_is_small PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_main_input_name PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_outputs_equivalence PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_parallelism PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_model_weights_reload_no_missing_tied_weights PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_multi_gpu_data_parallel_forward PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_num_layers_is_small PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_peft_gradient_checkpointing_enable_disable PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_problem_types PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_retain_grad_hidden_states_attentions PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_save_load PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_save_load_keys_to_ignore_on_save PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_sdpa_can_dispatch_non_composite_models PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_tied_weights_keys PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_torch_save_load PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_training PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_training_gradient_checkpointing PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_training_gradient_checkpointing_use_reentrant_false PASSED
tests/models/pixio/test_modeling_pixio.py::PixioModelTest::test_training_gradient_checkpointing_use_reentrant_true PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_backbone_common_attributes PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_backbone_outputs PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_backbone_stage_selection PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_channels PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_config PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_config_save_pretrained PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_create_from_modified_config PASSED
tests/models/pixio/test_modeling_pixio.py::PixioBackboneTest::test_forward_signature PASSED

================ 109 passed, 91 skipped, 39 warnings in 46.58s =================
```

</details>

<details>
<summary>Consistency checks</summary>

```
$ make fix-repo
All 13 checks passed.

$ make style
OK
```

</details>

## Test plan

- [x] Verify `interpolate_pos_encoding` parameter exists in `PixioModel.forward()`, `PixioBackbone.forward()`, and `PixioEmbeddings.forward()` signatures
- [x] Verify default behavior (matching image size) still works
- [x] Verify `interpolate_pos_encoding=True` with larger image (64x64 on 32x32 config)
- [x] Verify `interpolate_pos_encoding=True` with non-square image (48x64)
- [x] Verify `PixioBackbone` with `interpolate_pos_encoding=True`
- [x] Run all existing Pixio tests (109 passed, 0 failed)
- [x] Run `make fix-repo` (all 13 checks passed)

## Notes

- AI assistance was used (Claude Code) in drafting this fix
- Coordinated on issue #44716 before opening this PR
- The fix follows the exact same pattern as ViT (`src/transformers/models/vit/modeling_vit.py`) and CLIP, where `interpolate_pos_encoding` is already correctly propagated through the full call chain
- Both `modular_pixio.py` (source of truth) and `modeling_pixio.py` were updated because the modular converter has a pre-existing issue with Pixio's `AttributeError()` config attributes (`layerscale_value`, `use_swiglu_ffn`, `use_mask_token`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)