### PR TITLE
[Bugfix] Use sys.modules.get() to avoid KeyError in modeling_utils

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1948,9 +1948,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Detect whether the class supports setting its attention implementation dynamically. It is an ugly check based on
         opening the file, but avoids maintaining yet another property flag.
         """
-        class_module = sys.modules[cls.__module__]
+        class_module = sys.modules.get(cls.__module__)
         # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
-        if not hasattr(class_module, "__file__"):
+        if class_module is None or not hasattr(class_module, "__file__"):
             return False
         class_file = class_module.__file__
         with open(class_file, "r", encoding="utf-8") as f:
@@ -1967,9 +1967,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Detect whether the class supports setting its experts implementation dynamically. It is an ugly check based on
         opening the file, but avoids maintaining yet another property flag.
         """
-        class_module = sys.modules[cls.__module__]
+        class_module = sys.modules.get(cls.__module__)
         # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
-        if not hasattr(class_module, "__file__"):
+        if class_module is None or not hasattr(class_module, "__file__"):
             return False
         class_file = class_module.__file__
         with open(class_file, "r", encoding="utf-8") as f:

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -2986,6 +2986,33 @@ class TestTensorSharing(TestCasePlus):
 
 
 @require_torch
+class TestSysModulesMissing(unittest.TestCase):
+    """Regression test for #45003: KeyError when module absent from sys.modules."""
+
+    def test_can_set_attn_impl_missing_module(self):
+        from transformers.models.bert.modeling_bert import BertModel
+
+        key = BertModel.__module__
+        saved = sys.modules.pop(key, None)
+        try:
+            self.assertFalse(BertModel._can_set_attn_implementation())
+        finally:
+            if saved is not None:
+                sys.modules[key] = saved
+
+    def test_can_set_experts_impl_missing_module(self):
+        from transformers.models.bert.modeling_bert import BertModel
+
+        key = BertModel.__module__
+        saved = sys.modules.pop(key, None)
+        try:
+            self.assertFalse(BertModel._can_set_experts_implementation())
+        finally:
+            if saved is not None:
+                sys.modules[key] = saved
+
+
+@require_torch
 class TestSaveAndLoadModelWithExtraState(TestCasePlus):
     """
     This test checks that a model can be saved and loaded that uses the torch extra state API.


### PR DESCRIPTION
## What does this PR do?

Fixes #45003. `_can_set_attn_implementation` and `_can_set_experts_implementation` in `modeling_utils.py` crash with `KeyError` when `cls.__module__` is absent from `sys.modules`.

This happens in real-world scenarios where frameworks manipulate `sys.modules` (e.g., Griptape Nodes for Flux.1 ControlNets, vLLM CI with renamed image processor modules).

### Fix

Replace `sys.modules[cls.__module__]` with `sys.modules.get(cls.__module__)` and add a `None` check to the existing guard. Returns `False` (safe default = "don't try to dynamically set implementation") instead of crashing. This matches the pattern already used in `dynamic_module_utils.py:293` and `import_utils.py:2373`.

**4 lines changed in production code, 2 regression tests added.**

## Coordination

- Issue discussion and approval: https://github.com/huggingface/transformers/issues/45003#issuecomment-4140232441
- Not duplicating an existing PR: both #44978 and #45015 are closed; no open PR addresses this issue (`gh pr list --state open --search "45003 in:body"` returns empty).

## Before / After

<details>
<summary>Before fix (KeyError on all three calls)</summary>

```
=== BEFORE FIX (using original code) ===

Python version: 3.12.12 (main, Jan 14 2026, 19:35:58) [Clang 21.1.4 ]

Loaded BertModel from: transformers.models.bert.modeling_bert
Module in sys.modules: True

After removing module:
  Module in sys.modules: False

Calling _can_set_attn_implementation()...
  ERROR: KeyError: 'transformers.models.bert.modeling_bert'

Calling _can_set_experts_implementation()...
  ERROR: KeyError: 'transformers.models.bert.modeling_bert'

Calling BertModel(BertConfig()) (full model init)...
  ERROR: KeyError: 'transformers.models.bert.modeling_bert'
```

</details>

<details>
<summary>After fix (no crash, returns False, model init succeeds)</summary>

```
=== AFTER FIX (using patched code) ===

Python version: 3.12.12 (main, Jan 14 2026, 19:35:58) [Clang 21.1.4 ]

Loaded BertModel from: transformers.models.bert.modeling_bert
Module in sys.modules: True

After removing module:
  Module in sys.modules: False

Calling _can_set_attn_implementation()...
  Result: False

Calling _can_set_experts_implementation()...
  Result: False

Calling BertModel(BertConfig()) (full model init)...
  Success! Model created: BertModel
  Parameters: 109482240

All operations completed without KeyError.
```

</details>

<details>
<summary>Regression tests</summary>

```
============================= test session starts ==============================
platform linux -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0 -- /ssd1/jianglidang/workspace/myenv-vllm/bin/python
cachedir: .pytest_cache
rootdir: /ssd1/jianglidang/workspace/transformers-fix-45003
configfile: pyproject.toml
plugins: rerunfailures-15.1, order-1.3.0, anyio-4.13.0, xdist-3.8.0, rich-0.2.0, hypothesis-6.151.9, asyncio-1.3.0, random-order-1.2.0, timeout-2.4.0, env-1.2.0
collecting ... collected 2 items

tests/utils/test_modeling_utils.py::TestSysModulesMissing::test_can_set_attn_impl_missing_module PASSED [ 50%]
tests/utils/test_modeling_utils.py::TestSysModulesMissing::test_can_set_experts_impl_missing_module PASSED [100%]

============================== 2 passed in 10.10s ==============================
```

</details>

## AI disclosure

This PR was developed with Claude Code assistance. I have reviewed every changed line and can defend the approach end-to-end.