### PR TITLE
Fix when RoPE params are in kwargs

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -263,6 +263,12 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         # BC for rotary embeddings. We will pop out legacy keys from kwargs and rename to new format
         if hasattr(self, "rope_parameters"):
             kwargs = self.convert_rope_params_to_dict(**kwargs)
+        elif "rope_scaling" in kwargs and "rope_theta" in kwargs:
+            logger.warning(
+                f"{self.__class__.__name__} got `key=rope_scaling` in kwargs but hasn't set it as attribute. "
+                "For RoPE standardization you need to set `self.rope_parameters` in model's config. "
+            )
+            kwargs = self.convert_rope_params_to_dict(**kwargs)
 
         # Parameters for sequence generation saved in the config are popped instead of loading them.
         for parameter_name in GenerationConfig._get_default_generation_params().keys():

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -263,7 +263,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         # BC for rotary embeddings. We will pop out legacy keys from kwargs and rename to new format
         if hasattr(self, "rope_parameters"):
             kwargs = self.convert_rope_params_to_dict(**kwargs)
-        elif "rope_scaling" in kwargs and "rope_theta" in kwargs:
+        elif kwargs.get("rope_scaling") and kwargs.get("rope_theta"):
             logger.warning(
                 f"{self.__class__.__name__} got `key=rope_scaling` in kwargs but hasn't set it as attribute. "
                 "For RoPE standardization you need to set `self.rope_parameters` in model's config. "


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/45030

After the config validation, all validations are now run after config is initialized. So this config has been wrong from the beginning but we didn't complain

I added a small patch and warning, we will support it in case there are actually valid remote config that still use old-format RoPE. After some time we will start popping it from `kwargs` and assume it is not used by model