### PR TITLE
chore: Fix mlinter cache location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,7 +171,7 @@ tags
 .ruff_cache
 
 # modeling structure lint cache
-utils/.check_modeling_structure_cache.json
+utils/mlinter/.mlinter_cache.json
 
 # modular conversion
 *.modular_backup


### PR DESCRIPTION
# What does this PR do?

`.gitignore` was not updated when `mlinter` was refactored