### PR TITLE
Fix failing `XCLIPModelIntegrationTest`

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -674,9 +674,8 @@ class ProcessorMixin(PushToHubMixin):
             "feature_extractor": (audio, "audio_kwargs"),
         }
         outputs = {}
-        for attribute_name in self.get_attributes():
+        for attribute_name, (input_data, input_kwargs) in attribute_to_kwargs.items():
             attribute = getattr(self, attribute_name, None)
-            input_data, input_kwargs = attribute_to_kwargs[attribute_name]
             if input_data is not None and attribute is not None:
                 attribute_output = attribute(input_data, **kwargs[input_kwargs])
                 outputs.update(attribute_output)


### PR DESCRIPTION
# What does this PR do?
Fixes failing [`XCLIPModelIntegrationTests`](https://github.com/huggingface/transformers/actions/runs/23230643883/job/67524760869#step:14:1384).

[`self.get_attributes()`](https://github.com/huggingface/transformers/blob/0573124fc15c8969b19054c297ab094b096fdff1/src/transformers/processing_utils.py#L677) will not return all the processor instance attributes, for example in case of `x_clip` because `video_processor` is added [like this](https://github.com/huggingface/transformers/blob/0573124fc15c8969b19054c297ab094b096fdff1/src/transformers/models/x_clip/processing_x_clip.py#L26).
```py
processor = XCLIPProcessor.from_pretrained(
    "microsoft/xclip-base-patch32", size=180, crop_size={"height": 180, "width": 180}
)
processor.get_attributes()
# ['image_processor', 'tokenizer']
```

Iterating directly over the [`attribute_to_kwargs`](https://github.com/huggingface/transformers/blob/0573124fc15c8969b19054c297ab094b096fdff1/src/transformers/processing_utils.py#L670) in `__call__` will check for all types at run-time.



## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?
@Rocketknight1 @vasqu @zucchini-nlp