### PR TITLE
Save model config in Trainer checkpoints for non-PreTrainedModel models

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -4138,6 +4138,9 @@ class Trainer:
                     )
                 else:
                     torch.save(state_dict, os.path.join(output_dir, WEIGHTS_NAME))
+                unwrapped_model = self.accelerator.unwrap_model(self.model, keep_torch_compile=False)
+                if hasattr(unwrapped_model, "config") and unwrapped_model.config is not None:
+                    unwrapped_model.config.save_pretrained(output_dir)
         else:
             self.model.save_pretrained(
                 output_dir, state_dict=state_dict, safe_serialization=self.args.save_safetensors


### PR DESCRIPTION
## What does this PR do?

When `Trainer` saves a checkpoint for a model that is not a `PreTrainedModel` (e.g. a custom `nn.Module`), it only saves the state dict but not the model config. This means `Model.from_pretrained(ckpt_path)` requires the caller to pass all the original init arguments again, which is inconvenient.

This PR saves the model's `config.json` in the checkpoint directory when the model has a `config` attribute, even when it falls through to the state-dict-only saving path. This enables argumentless loading from Trainer checkpoints:

```python
# Before: needed init args
model = MyModel.from_pretrained(ckpt_path, **init_args)

# After: just works
model = MyModel.from_pretrained(ckpt_path)
```

The change is a 3-line addition in `Trainer._save()` that calls `config.save_pretrained(output_dir)` on the unwrapped model's config when available. This does not affect the existing `PreTrainedModel` path, which already saves config via `save_pretrained()`.

Fixes #44450