### PR TITLE
Allow advanced users to override `model_type` in `AutoConfig.from_pretrained`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -760,6 +760,15 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         if "model_type" not in config_dict and is_timm_config_dict(config_dict):
             config_dict["model_type"] = "timm_wrapper"
 
+        # Some checkpoints may contain the wrong model_type in the config file.
+        # Allow the user to override it but warn them that it might not work.
+        if "model_type" in kwargs and config_dict["model_type"] != kwargs["model_type"]:
+            logger.warning(
+                f"{configuration_file} has 'model_type={config_dict['model_type']}' but you overrode "
+                f"it with 'model_type={kwargs['model_type']}'. This may lead to unexpected behavior."
+            )
+            config_dict["model_type"] = kwargs["model_type"]
+
         return config_dict, kwargs
 
     @classmethod


### PR DESCRIPTION
Some checkpoints, such as https://huggingface.co/omni-research/Tarsier2-Recap-7b, have the wrong `model_type` in their `config.json`.

This PR allows advanced users (vLLM) to pass `model_type` into `AutoConfig.from_pretrained` via `kwargs` to override what's in the `config.json`.