### PR TITLE
refactor: shard checkers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,20 @@ jobs:
                   path: ~/transformers/installed.txt
             - run: make check-repository-consistency
 
+    check_imports:
+        working_directory: ~/transformers
+        docker:
+            - image: huggingface/transformers-consistency
+        resource_class: large
+        environment:
+            TRANSFORMERS_IS_CI: yes
+        parallelism: 1
+        steps:
+            - checkout
+            - run: apt-get update && apt-get install -y make
+            - run: uv pip install -e ".[quality]"
+            - run: make check-imports
+
     check_modular:
         working_directory: ~/transformers
         docker:
@@ -202,6 +216,7 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
+            - check_imports
             - check_modular
             - fetch_tests
 
@@ -213,6 +228,7 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
+            - check_imports
             - check_modular
             - fetch_tests:
                 # [reference] https://circleci.com/docs/contexts/
@@ -225,5 +241,6 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
+            - check_imports
             - check_modular
             - fetch_all_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,27 +175,6 @@ jobs:
             - store_artifacts:
                   path: ~/transformers/installed.txt
             - run: make check-repository-consistency
-            - run:
-                name: "Test import with all backends (torch + PIL + torchvision)"
-                command: python -c "from transformers import *" || (echo '🚨 import failed with all backends. Fix unprotected imports!! 🚨'; exit 1)
-            - run:
-                name: "Test import with torch only (no PIL, no torchvision)"
-                command: |
-                    uv pip uninstall Pillow torchvision -q
-                    python -c "from transformers import *" || (echo '🚨 import failed with torch only (no PIL). Fix unprotected imports!! 🚨'; exit 1)
-                    uv pip install -e ".[quality]" -q
-            - run:
-                name: "Test import with PIL only (no torch, no torchvision)"
-                command: |
-                    uv pip uninstall torch torchvision torchaudio -q
-                    python -c "from transformers import *" || (echo '🚨 import failed with PIL only (no torch). Fix unprotected imports!! 🚨'; exit 1)
-                    uv pip install -e ".[quality]" -q
-            - run:
-                name: "Test import with torch + PIL, no torchvision"
-                command: |
-                    uv pip uninstall torchvision -q
-                    python -c "from transformers import *" || (echo '🚨 import failed with torch+PIL but no torchvision. Fix unprotected imports!! 🚨'; exit 1)
-                    uv pip install -e ".[quality]" -q
 
     check_modular:
         working_directory: ~/transformers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,6 +197,20 @@ jobs:
                     python -c "from transformers import *" || (echo '🚨 import failed with torch+PIL but no torchvision. Fix unprotected imports!! 🚨'; exit 1)
                     uv pip install -e ".[quality]" -q
 
+    check_modular:
+        working_directory: ~/transformers
+        docker:
+            - image: huggingface/transformers-consistency
+        resource_class: large
+        environment:
+            TRANSFORMERS_IS_CI: yes
+        parallelism: 1
+        steps:
+            - checkout
+            - run: apt-get update && apt-get install -y make
+            - run: uv pip install -e ".[quality]"
+            - run: make check-modular
+
 
 workflows:
     version: 2
@@ -209,6 +223,7 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
+            - check_modular
             - fetch_tests
 
     setup_and_quality_2:
@@ -219,6 +234,7 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
+            - check_modular
             - fetch_tests:
                 # [reference] https://circleci.com/docs/contexts/
                 context:
@@ -230,4 +246,5 @@ workflows:
             - check_circleci_user
             - check_code_quality
             - check_repository_consistency
+            - check_modular
             - fetch_all_tests

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # make sure to test the local checkout in scripts and not the pre-installed one (don't use quotes!)
 export PYTHONPATH = src
 
-.PHONY: style typing check-code-quality check-repository-consistency check-repo fix-repo test test-examples benchmark codex claude clean-ai
+.PHONY: style typing check-code-quality check-modular check-repository-consistency check-repo fix-repo test test-examples benchmark codex claude clean-ai
 
 
 # Runs all linting/formatting scripts, most notably ruff
@@ -29,12 +29,15 @@ check-code-quality:
 		init_isort,\
 		auto_mappings
 
-# Runs a full repository consistency check.
+# Runs modular file conversion check (split out for parallel CI).
+check-modular:
+	@python utils/checkers.py modular_conversion
+
+# Runs a full repository consistency check (without modular conversion).
 check-repository-consistency:
 	@python utils/checkers.py \
 		imports,\
 		copies,\
-		modular_conversion,\
 		doc_toc,\
 		docstrings,\
 		dummies,\

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # make sure to test the local checkout in scripts and not the pre-installed one (don't use quotes!)
 export PYTHONPATH = src
 
-.PHONY: style typing check-code-quality check-modular check-repository-consistency check-repo fix-repo test test-examples benchmark codex claude clean-ai
+.PHONY: style typing check-code-quality check-imports check-modular check-repository-consistency check-repo fix-repo test test-examples benchmark codex claude clean-ai
 
 
 # Runs all linting/formatting scripts, most notably ruff
@@ -29,14 +29,17 @@ check-code-quality:
 		init_isort,\
 		auto_mappings
 
+# Runs import tests under various backend combinations (split out for parallel CI).
+check-imports:
+	@python utils/checkers.py imports
+
 # Runs modular file conversion check (split out for parallel CI).
 check-modular:
 	@python utils/checkers.py modular_conversion
 
-# Runs a full repository consistency check (without modular conversion).
+# Runs a full repository consistency check (without imports and modular conversion).
 check-repository-consistency:
 	@python utils/checkers.py \
-		imports,\
 		copies,\
 		doc_toc,\
 		docstrings,\

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -30,6 +30,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import time
 from collections import deque
 from pathlib import Path
 
@@ -349,6 +350,7 @@ def main():
     is_tty = sys.stdout.isatty() and not is_ci
 
     failures = []
+    total_t0 = time.monotonic()
     for name in names:
         label = CHECKERS[name][0]
         cmd_str = get_checker_command(name, fix=args.fix)
@@ -357,9 +359,11 @@ def main():
             window = SlidingWindow(label, max_lines=10)
             if cmd_str:
                 window.add_line(f"$ {cmd_str}")
+            t0 = time.monotonic()
             rc, output = run_checker(name, fix=args.fix, line_callback=window.add_line)
+            elapsed = time.monotonic() - t0
             window.finish(success=(rc == 0))
-            print()
+            print(f"  ({elapsed:.1f}s)")
             if rc != 0:
                 failures.append(name)
                 if not args.keep_going:
@@ -368,23 +372,27 @@ def main():
             print(f"{label}")
             if cmd_str:
                 print(f"$ {cmd_str}")
+            t0 = time.monotonic()
             rc, output = run_checker(name, fix=args.fix)
+            elapsed = time.monotonic() - t0
             tail = output.splitlines()[-10:]
             if tail:
                 print("\n".join(tail))
             status = "OK" if rc == 0 else "FAILED"
-            print(status)
+            print(f"{status} ({elapsed:.1f}s)")
             print()
             if rc != 0:
                 failures.append(name)
                 if not args.keep_going:
                     sys.exit(1)
 
+    total_elapsed = time.monotonic() - total_t0
+
     if failures:
-        print(f"\n{len(failures)} failed: {', '.join(failures)}")
+        print(f"\n{len(failures)} failed: {', '.join(failures)} (total: {total_elapsed:.1f}s)")
         sys.exit(1)
 
-    print(f"\nAll {len(names)} checks passed.")
+    print(f"\nAll {len(names)} checks passed. (total: {total_elapsed:.1f}s)")
 
 
 if __name__ == "__main__":

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -29,6 +29,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from collections import deque
@@ -196,45 +197,49 @@ def run_deps_table_checker(fix=False, line_callback=None):
     return 0, output
 
 
-def _restore_env(line_callback=None):
-    """Reinstall the quality extras to restore the environment."""
-    return _run_cmd(["uv", "pip", "install", "-e", ".[quality]", "-q"], line_callback=line_callback)
-
-
+# Each scenario: (label, extra packages to install alongside transformers)
 _IMPORT_SCENARIOS = [
-    ("Import failed with all backends", None),
-    ("Import failed with torch only (no PIL)", ["Pillow", "torchvision"]),
-    ("Import failed with PIL only (no torch)", ["torch", "torchvision", "torchaudio"]),
-    ("Import failed with torch+PIL but no torchvision", ["torchvision"]),
+    ("all backends (torch + PIL + torchvision)", ["torch", "Pillow", "torchvision"]),
+    ("torch only (no PIL, no torchvision)", ["torch"]),
+    ("PIL only (no torch, no torchvision)", ["Pillow"]),
+    ("torch + PIL, no torchvision", ["torch", "Pillow"]),
 ]
 
 
 def run_imports_checker(fix=False, line_callback=None):
-    """Check that public imports work under various backend combinations."""
-    all_output: list[str] = []
-    for label, uninstall in _IMPORT_SCENARIOS:
-        output_parts: list[str] = []
+    """Check that public imports work under various backend combinations.
 
-        if uninstall:
-            rc, out = _run_cmd(["uv", "pip", "uninstall", *uninstall, "-q"], line_callback=line_callback)
-            output_parts.append(out)
+    Each scenario runs in an isolated temporary venv so the caller's
+    environment is never modified.
+    """
+    all_output: list[str] = []
+
+    for label, extras in _IMPORT_SCENARIOS:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            venv_dir = os.path.join(tmpdir, ".venv")
+
+            # Create venv
+            rc, out = _run_cmd(["uv", "venv", venv_dir, "--python", sys.executable, "-q"], line_callback=line_callback)
+            all_output.append(out)
             if rc != 0:
-                # Restore before returning
-                _, out_restore = _restore_env(line_callback=line_callback)
-                output_parts.append(out_restore)
-                all_output.append("".join(output_parts) + f"Failed to uninstall {', '.join(uninstall)}\n")
+                all_output.append(f"Failed to create venv for scenario: {label}\n")
                 return rc, "".join(all_output)
 
-        rc, out = _run_cmd([sys.executable, "-c", "from transformers import *"], line_callback=line_callback)
-        output_parts.append(out)
+            # Install transformers (editable) + the scenario-specific packages
+            install_cmd = ["uv", "pip", "install", "-e", str(REPO_ROOT), *extras, "-q", "--python", venv_dir]
+            rc, out = _run_cmd(install_cmd, line_callback=line_callback)
+            all_output.append(out)
+            if rc != 0:
+                all_output.append(f"Failed to install packages for scenario: {label}\n")
+                return rc, "".join(all_output)
 
-        if uninstall:
-            _, out_restore = _restore_env(line_callback=line_callback)
-            output_parts.append(out_restore)
-
-        all_output.append("".join(output_parts))
-        if rc != 0:
-            return rc, "".join(all_output) + f"🚨 {label}. Fix unprotected imports!! 🚨\n"
+            # Run the import test inside the venv
+            venv_python = os.path.join(venv_dir, "bin", "python")
+            rc, out = _run_cmd([venv_python, "-c", "from transformers import *"], line_callback=line_callback)
+            all_output.append(out)
+            if rc != 0:
+                all_output.append(f"🚨 Import failed with {label}. Fix unprotected imports!! 🚨\n")
+                return rc, "".join(all_output)
 
     return 0, "".join(all_output)
 

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -195,12 +195,50 @@ def run_deps_table_checker(fix=False, line_callback=None):
     return 0, output
 
 
-def run_imports_checker(fix=False, line_callback=None):
-    """Check that all public imports work."""
-    rc, output = _run_cmd([sys.executable, "-c", "from transformers import *"], line_callback=line_callback)
+def _import_test(label, uninstall=None, line_callback=None):
+    """Run ``from transformers import *`` after optionally removing packages.
+
+    When *uninstall* is given the environment is restored afterwards.
+    """
+    output_parts: list[str] = []
+
+    if uninstall:
+        rc, out = _run_cmd(["uv", "pip", "uninstall", *uninstall, "-q"], line_callback=line_callback)
+        output_parts.append(out)
+        if rc != 0:
+            return rc, "".join(output_parts) + f"Failed to uninstall {', '.join(uninstall)}\n"
+
+    rc, out = _run_cmd([sys.executable, "-c", "from transformers import *"], line_callback=line_callback)
+    output_parts.append(out)
+
+    if uninstall:
+        rc_restore, out_restore = _run_cmd(
+            ["uv", "pip", "install", "-e", ".[quality]", "-q"], line_callback=line_callback
+        )
+        output_parts.append(out_restore)
+
     if rc != 0:
-        return rc, output + "Import failed, this means you introduced unprotected imports!\n"
-    return 0, output
+        return rc, "".join(output_parts) + f"🚨 {label}. Fix unprotected imports!! 🚨\n"
+    return 0, "".join(output_parts)
+
+
+_IMPORT_SCENARIOS = [
+    ("Import failed with all backends", None),
+    ("Import failed with torch only (no PIL)", ["Pillow", "torchvision"]),
+    ("Import failed with PIL only (no torch)", ["torch", "torchvision", "torchaudio"]),
+    ("Import failed with torch+PIL but no torchvision", ["torchvision"]),
+]
+
+
+def run_imports_checker(fix=False, line_callback=None):
+    """Check that public imports work under various backend combinations."""
+    all_output: list[str] = []
+    for label, uninstall in _IMPORT_SCENARIOS:
+        rc, output = _import_test(label, uninstall=uninstall, line_callback=line_callback)
+        all_output.append(output)
+        if rc != 0:
+            return rc, "".join(all_output)
+    return 0, "".join(all_output)
 
 
 RUFF_TARGETS = ["examples", "tests", "src", "utils", "scripts", "benchmark", "benchmark_v2", "setup.py", "conftest.py"]

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -195,31 +195,9 @@ def run_deps_table_checker(fix=False, line_callback=None):
     return 0, output
 
 
-def _import_test(label, uninstall=None, line_callback=None):
-    """Run ``from transformers import *`` after optionally removing packages.
-
-    When *uninstall* is given the environment is restored afterwards.
-    """
-    output_parts: list[str] = []
-
-    if uninstall:
-        rc, out = _run_cmd(["uv", "pip", "uninstall", *uninstall, "-q"], line_callback=line_callback)
-        output_parts.append(out)
-        if rc != 0:
-            return rc, "".join(output_parts) + f"Failed to uninstall {', '.join(uninstall)}\n"
-
-    rc, out = _run_cmd([sys.executable, "-c", "from transformers import *"], line_callback=line_callback)
-    output_parts.append(out)
-
-    if uninstall:
-        rc_restore, out_restore = _run_cmd(
-            ["uv", "pip", "install", "-e", ".[quality]", "-q"], line_callback=line_callback
-        )
-        output_parts.append(out_restore)
-
-    if rc != 0:
-        return rc, "".join(output_parts) + f"🚨 {label}. Fix unprotected imports!! 🚨\n"
-    return 0, "".join(output_parts)
+def _restore_env(line_callback=None):
+    """Reinstall the quality extras to restore the environment."""
+    return _run_cmd(["uv", "pip", "install", "-e", ".[quality]", "-q"], line_callback=line_callback)
 
 
 _IMPORT_SCENARIOS = [
@@ -234,10 +212,29 @@ def run_imports_checker(fix=False, line_callback=None):
     """Check that public imports work under various backend combinations."""
     all_output: list[str] = []
     for label, uninstall in _IMPORT_SCENARIOS:
-        rc, output = _import_test(label, uninstall=uninstall, line_callback=line_callback)
-        all_output.append(output)
+        output_parts: list[str] = []
+
+        if uninstall:
+            rc, out = _run_cmd(["uv", "pip", "uninstall", *uninstall, "-q"], line_callback=line_callback)
+            output_parts.append(out)
+            if rc != 0:
+                # Restore before returning
+                _, out_restore = _restore_env(line_callback=line_callback)
+                output_parts.append(out_restore)
+                all_output.append("".join(output_parts) + f"Failed to uninstall {', '.join(uninstall)}\n")
+                return rc, "".join(all_output)
+
+        rc, out = _run_cmd([sys.executable, "-c", "from transformers import *"], line_callback=line_callback)
+        output_parts.append(out)
+
+        if uninstall:
+            _, out_restore = _restore_env(line_callback=line_callback)
+            output_parts.append(out_restore)
+
+        all_output.append("".join(output_parts))
         if rc != 0:
-            return rc, "".join(all_output)
+            return rc, "".join(all_output) + f"🚨 {label}. Fix unprotected imports!! 🚨\n"
+
     return 0, "".join(all_output)
 
 


### PR DESCRIPTION
# What does this PR do?

check modular import can be extremely slow (8mn in CI) we're investigating speeding it up in https://github.com/huggingface/transformers/pull/45046

But we can also shard jobs in CI to mitigate a little bit. 

This patch:
- Run slower steps on their own
- Reunite all new import checks in the same checker 

