### PR TITLE
feat: trainer resume_from_checkpoint support hub downloads (#43375)

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -1330,9 +1330,10 @@ class Trainer:
 
         Args:
             resume_from_checkpoint (`str` or `bool`, *optional*):
-                If a `str`, local path to a saved checkpoint as saved by a previous instance of [`Trainer`]. If a
-                `bool` and equals `True`, load the last checkpoint in *args.output_dir* as saved by a previous instance
-                of [`Trainer`]. If present, training will resume from the model/optimizer/scheduler states loaded here.
+                If a `str`, local path to a saved checkpoint as saved by a previous instance of [`Trainer`] or a config
+                on the Hugging Face Hub (e.g. `"user/repo-id@checkpoint-1000"`). If a `bool` and equals `True`, load the
+                last checkpoint in *args.output_dir* as saved by a previous instance of [`Trainer`]. If present,
+                training will resume from the model/optimizer/scheduler states loaded here.
             trial (`optuna.Trial` or `dict[str, Any]`, *optional*):
                 The trial run or the hyperparameter dictionary for hyperparameter search.
             ignore_keys_for_eval (`list[str]`, *optional*)
@@ -1403,6 +1404,24 @@ class Trainer:
             resume_from_checkpoint = get_last_checkpoint(args.output_dir)
             if resume_from_checkpoint is None:
                 raise ValueError(f"No valid checkpoint found in output directory ({args.output_dir})")
+
+        if isinstance(resume_from_checkpoint, str) and not os.path.isdir(resume_from_checkpoint):
+            revision = None
+            if "@" in resume_from_checkpoint:
+                resume_from_checkpoint, revision = resume_from_checkpoint.split("@", 1)
+
+            from huggingface_hub import snapshot_download
+
+            try:
+                resume_from_checkpoint = snapshot_download(
+                    repo_id=resume_from_checkpoint,
+                    revision=revision,
+                    token=args.hub_token if hasattr(args, "hub_token") else None,
+                )
+            except Exception as e:
+                raise ValueError(
+                    f"Can't find a valid checkpoint at `{resume_from_checkpoint}` locally or on the Hub. Error: {e}"
+                )
 
         if resume_from_checkpoint is not None:
             # Load model checkpoint before accelerator.prepare() for regular models,


### PR DESCRIPTION
### what does this PR do?

this pr enables `trainer.train(resume_from_checkpoint=...)` to accept hugging face hub repository ids. 

instead of only local paths, users can now pass `user/repo@revision` and the trainer will automatically download the checkpoint using `snapshot_download` and resume training from it. this is particularly useful for preemptible cloud training where checkpoints are automatically pushed to the hub.

fixes #43375

### code agent policy
- [x] I confirm that this is not a pure code agent PR.

### before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


### who can review?

@SunMarc
