### PR TITLE
Fix TypeError in rope validation when ignore_keys is a list

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -916,7 +916,7 @@ class RotaryEmbeddingConfigMixin:
 
         # Some models need to store model-specific keys, and we don't want to throw warning at them
         if ignore_keys is not None:
-            received_keys -= ignore_keys
+            received_keys -= set(ignore_keys)
 
         missing_keys = required_keys - received_keys
         if missing_keys:


### PR DESCRIPTION
## What does this PR do?

Fixes a `TypeError` in `_check_received_keys` (line 919 of `modeling_rope_utils.py`) where `received_keys -= ignore_keys` fails when `ignore_keys` is a `list` instead of a `set`.

## Root cause

Model configs (Qwen3.5, ErnieVLMoe, GLM4V, Ministral3) define `ignore_keys_at_rope_validation` as a Python `set`. JSON has no set type, so when configs are serialized/deserialized (e.g. via `huggingface_hub` strict dataclass validation), sets become lists. The `-=` operator on `set` doesn't accept `list` operands.

## Fix

```diff
- received_keys -= ignore_keys
+ received_keys -= set(ignore_keys)
```

`set()` is a no-op for set inputs and correctly converts lists.

## Error

```
huggingface_hub.errors.StrictDataclassClassValidationError: 
  Class validation error for validator 'validate_rope':
    TypeError: unsupported operand type(s) for -=: 'set' and 'list'
```

Triggered by vLLM 0.18.0 serving `Qwen/Qwen3.5-35B-A3B`.

Fixes #45068