### PR TITLE
Fix PreTrainedConfig as Pydantic field type after dataclass conversion

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -233,6 +233,19 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
     label2id: dict[str, int] | dict[str, str] | None = None
     problem_type: Literal["regression", "single_label_classification", "multi_label_classification"] | None = None
 
+    @classmethod
+    def __get_pydantic_core_schema__(cls, source_type, handler):
+        """Allow PreTrainedConfig to be used as a field type in Pydantic models.
+
+        Without this, Pydantic treats the dataclass as introspectable and tries to resolve
+        all field annotations — including forward references like `torch.dtype` that are
+        only available under TYPE_CHECKING. Returning an ``is-instance`` schema tells
+        Pydantic to accept any instance of this class without inspecting its fields.
+        """
+        from pydantic_core import core_schema
+
+        return core_schema.is_instance_schema(cls)
+
     def __post_init__(self, **kwargs):
         # BC for the `torch_dtype` argument instead of the simpler `dtype`
         # Do not warn, as it would otherwise always be triggered since most configs on the hub have `torch_dtype`


### PR DESCRIPTION
## Root cause

The v5.4.0 release converted `PreTrainedConfig` from a regular class to a `@dataclass`. This changes how Pydantic handles it when used as a field type in a `BaseModel`: instead of treating it as an opaque arbitrary type, Pydantic now introspects the dataclass fields and attempts to resolve all type annotations.

The `dtype` field is annotated as `Union[str, "torch.dtype"] | None`, where `"torch.dtype"` is a forward reference that depends on `torch` being in the namespace. Since `torch` is only imported under `TYPE_CHECKING`, Pydantic raises `PydanticUndefinedAnnotation: name 'torch' is not defined`.

## Fix

Add `__get_pydantic_core_schema__` to `PreTrainedConfig` that returns a `core_schema.is_instance_schema(cls)`. This tells Pydantic to validate values by type-checking rather than introspecting the dataclass fields, restoring the pre-v5.4.0 behavior.

The method is inherited by all subclasses (e.g. `BertConfig`), so they also work as Pydantic field types.

## Reproduction

```python
from pydantic import BaseModel, ConfigDict, Field
from transformers import PretrainedConfig

class MyModelConfig(BaseModel):
    model_config = ConfigDict(arbitrary_types_allowed=True)
    sub_config: PretrainedConfig = Field(description="Configuration for the sub_config")

MyModelConfig.model_rebuild(force=True)  # raises PydanticSchemaGenerationError on v5.4.0
```

After this fix, the above passes.

Fixes #45070