### PR TITLE
Fix dtype mismatches in SwitchTransformers and TimmWrapperModel for bfloat16

### DIFF
--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -95,14 +95,14 @@ class SwitchTransformersTop1Router(nn.Module):
 
         # Apply Softmax and cast back to the original `dtype`
         router_probs = nn.functional.softmax(router_logits, dim=-1, dtype=self.dtype).to(self.input_dtype)
-        router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
+        router_max_probs, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
         expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
         token_priority = torch.cumsum(expert_index, dim=-2)
         # mask if the token routed to the expert will overflow
         expert_capacity_mask = token_priority <= self.expert_capacity
         expert_index = expert_index * expert_capacity_mask
-        router_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)
-        return router_probs, expert_index, router_logits
+        router_max_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)
+        return router_max_probs, expert_index, router_logits
 
 
 class SwitchTransformersLayerNorm(nn.Module):

--- a/src/transformers/models/switch_transformers/modular_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modular_switch_transformers.py
@@ -162,14 +162,14 @@ class SwitchTransformersTop1Router(nn.Module):
 
         # Apply Softmax and cast back to the original `dtype`
         router_probs = nn.functional.softmax(router_logits, dim=-1, dtype=self.dtype).to(self.input_dtype)
-        router_logits, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
+        router_max_probs, expert_index = torch.max(router_probs, dim=-1, keepdim=True)
         expert_index = torch.nn.functional.one_hot(expert_index, num_classes=self.num_experts)
         token_priority = torch.cumsum(expert_index, dim=-2)
         # mask if the token routed to the expert will overflow
         expert_capacity_mask = token_priority <= self.expert_capacity
         expert_index = expert_index * expert_capacity_mask
-        router_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)
-        return router_probs, expert_index, router_logits
+        router_max_probs = torch.max(router_probs, dim=-1).values.unsqueeze(-1)
+        return router_max_probs, expert_index, router_logits
 
 
 class SwitchTransformersLayerNorm(T5LayerNorm):

--- a/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
+++ b/src/transformers/models/timm_wrapper/modeling_timm_wrapper.py
@@ -243,7 +243,7 @@ class TimmWrapperModel(TimmWrapperPreTrainedModel):
                 "different architecture or updating the timm package to a compatible version."
             )
 
-        pixel_values = pixel_values.to(self.device)
+        pixel_values = pixel_values.to(self.device, self.dtype)
 
         if self.features_only:
             last_hidden_state = self.timm_model.forward(pixel_values, **kwargs)


### PR DESCRIPTION
This PR fixes #45072.

## Changes

### SwitchTransformers
- Fixed a bug in `SwitchTransformersTop1Router.forward()` where `router_logits` was being reassigned to the max probability values instead of keeping the raw logits from the classifier. This caused dtype mismatches when using bfloat16.
- The fix introduces `router_max_probs` as a new variable to hold the max probability values, while `router_logits` now correctly retains the raw logits for computing the router z-loss.

### TimmWrapperModel
- Fixed a bug where `pixel_values` was only being cast to the device but not to the model's dtype in `TimmWrapperModel.forward()`. This caused dtype mismatches when the model was loaded in bfloat16 but the input was float32.
- The fix aligns `TimmWrapperModel` with `TimmWrapperForImageClassification` which already had the correct behavior.

## Testing
Both fixes have been verified to resolve the dtype mismatch issues described in #45072.