### PR TITLE
Fix PretrainedConfig type checking with mypy

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -75,6 +75,11 @@ ALLOWED_LAYER_TYPES = (
 def wrap_init_to_accept_kwargs(cls: dataclass):
     original_init = cls.__init__
 
+    # During type checking, don't wrap the __init__ to preserve the dataclass signature
+    # This allows mypy to see the actual field types instead of **kwargs: Any
+    if TYPE_CHECKING:
+        return cls
+
     @wraps(original_init)
     def __init__(self, *args, **kwargs: Any) -> None:
         # Extract only the fields that are part of the dataclass


### PR DESCRIPTION
This PR fixes issue #45071 where mypy type checking was broken for PretrainedConfig subclasses.

## Problem
In transformers v5.4.0, the PretrainedConfig class was converted to a dataclass with a wrapper around __init__ to accept arbitrary kwargs. This wrapper had the signature `*args, **kwargs: Any`, which caused mypy to not recognize the actual field names and types.

## Solution
Added a TYPE_CHECKING guard in the wrap_init_to_accept_kwargs function. During type checking (when TYPE_CHECKING is True), the wrapper is not applied, so mypy sees the original dataclass __init__ with proper type annotations. At runtime, the wrapper is still applied for backward compatibility.

## Changes
- Modified src/transformers/configuration_utils.py to skip wrapping __init__ during type checking

Fixes #45071