### PR TITLE
fix: use sys.modules.get() to avoid KeyError in modeling_utils

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1948,9 +1948,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Detect whether the class supports setting its attention implementation dynamically. It is an ugly check based on
         opening the file, but avoids maintaining yet another property flag.
         """
-        class_module = sys.modules[cls.__module__]
+        class_module = sys.modules.get(cls.__module__)
         # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
-        if not hasattr(class_module, "__file__"):
+        if class_module is None or not hasattr(class_module, "__file__"):
             return False
         class_file = class_module.__file__
         with open(class_file, "r", encoding="utf-8") as f:
@@ -1967,9 +1967,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Detect whether the class supports setting its experts implementation dynamically. It is an ugly check based on
         opening the file, but avoids maintaining yet another property flag.
         """
-        class_module = sys.modules[cls.__module__]
+        class_module = sys.modules.get(cls.__module__)
         # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
-        if not hasattr(class_module, "__file__"):
+        if class_module is None or not hasattr(class_module, "__file__"):
             return False
         class_file = class_module.__file__
         with open(class_file, "r", encoding="utf-8") as f:


### PR DESCRIPTION
## Summary

Fixes #45003

`_can_set_attn_implementation` and `_can_set_experts_implementation` in `PreTrainedModel` use `sys.modules[cls.__module__]`, which raises `KeyError` when a module has been removed from `sys.modules` at runtime. This can happen with:
- **vLLM CI** (modules deleted during cleanup)
- **Griptape Nodes** and similar tools that manipulate `sys.modules` for dependency management
- Any lazy-loading or packaging tool that removes modules from the registry

### Changes
- Replace `sys.modules[cls.__module__]` with `sys.modules.get(cls.__module__)` (2 locations)
- Add `class_module is None` guard before the existing `hasattr(class_module, "__file__")` check
- When the module is missing, returns `False` — the same safe fallback already used for modules without `__file__` (e.g., Jupyter notebooks)

### Why not a broader fix?
This is intentionally minimal (4 lines changed). The existing comment already acknowledges that module lookup can fail ("This can happen for a custom model in a jupyter notebook or repl"), and `sys.modules.get()` is the standard safe-access pattern.

## Test plan
- [x] Verified the fix matches the approach discussed by maintainers in #45003
- [x] Confirmed no open PRs exist for this issue
- [x] `sys.modules.get()` returns `None` (not `KeyError`) when module is absent — `None` check short-circuits to `return False`
- [x] Normal-case behavior is unchanged (module exists → same flow as before)

AI assistance was used in preparing this PR.