### PR TITLE
Fix TypeError when chat_template is None in VoxtralProcessor

### DIFF
--- a/src/transformers/models/voxtral/processing_voxtral.py
+++ b/src/transformers/models/voxtral/processing_voxtral.py
@@ -168,6 +168,23 @@ class VoxtralProcessor(ProcessorMixin):
             is_batched = False
             conversations = [conversation]
 
+        # Resolve chat_template if not provided
+        if chat_template is None:
+            if isinstance(self.chat_template, dict) and "default" in self.chat_template:
+                chat_template = self.chat_template["default"]
+            elif isinstance(self.chat_template, dict):
+                raise ValueError(
+                    'The processor has multiple chat templates but none of them are named "default". You need to specify'
+                    " which one to use by passing the `chat_template` argument. Available templates are: "
+                    f"{', '.join(self.chat_template.keys())}"
+                )
+            elif self.chat_template is not None:
+                chat_template = self.chat_template
+            else:
+                raise ValueError(
+                    "Cannot use apply_chat_template because this processor does not have a chat template."
+                )
+
         # Users might still be passing processing kwargs in `**kwargs` so we need to filter
         # out additional kwargs that the template expects via Jinja2 template introspection
         # We strip unrelated kwargs to avoid passing unrecognized kwargs to `_merge_kwargs`.


### PR DESCRIPTION
## Description

Fixes #45084

The `VoxtralProcessor.apply_chat_template` method was calling `_get_template_variables(chat_template)` without first checking if `chat_template` was None. This caused a `TypeError: Can't compile non template nodes` when users called `apply_chat_template` without explicitly providing a chat_template, even when the processor had a default chat template configured.

## Changes

This PR adds the same chat_template resolution logic that exists in the base `ProcessingMixin.apply_chat_template` method, ensuring that:

1. If chat_template is None, it uses the processor's default template
2. If the processor has multiple templates, it uses the 'default' one
3. Proper error messages are shown if no template is available

## Testing

- Verified the fix with a test script that confirms the resolution logic is in place
- The fix follows the same pattern used in the base ProcessingMixin class