### PR TITLE
Fix _get_feat_extract_output_lengths in qwen3_omni_moe

### DIFF
--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -147,9 +147,8 @@ def _get_feat_extract_output_lengths(input_lengths):
     Computes the output length of the convolutional layers and the output length of the audio encoder
     """
 
-    input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+    feat_lengths = (input_lengths - 1) // 2 + 1
+    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1
     return output_lengths
 
 

--- a/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
@@ -119,9 +119,8 @@ def _get_feat_extract_output_lengths(input_lengths):
     Computes the output length of the convolutional layers and the output length of the audio encoder
     """
 
-    input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+    feat_lengths = (input_lengths - 1) // 2 + 1
+    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1
     return output_lengths
 
 

--- a/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -109,9 +109,8 @@ def _get_feat_extract_output_lengths(input_lengths):
     Computes the output length of the convolutional layers and the output length of the audio encoder
     """
 
-    input_lengths_leave = input_lengths % 100
-    feat_lengths = (input_lengths_leave - 1) // 2 + 1
-    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1 + (input_lengths // 100) * 13
+    feat_lengths = (input_lengths - 1) // 2 + 1
+    output_lengths = ((feat_lengths - 1) // 2 + 1 - 1) // 2 + 1
     return output_lengths
 
 


### PR DESCRIPTION
This PR fixes the unexpected behaviour of helper function `_get_feat_extract_output_lengths` in qwen3_omni_moe as reported in #45083.

## Problem
The current implementation incorrectly calculates the output length of the convolutional layers by:
1. Taking modulo 100 of input lengths
2. Adding a correction factor of `(input_lengths // 100) * 13`

This does not align with the official PyTorch Conv2d formula.

## Fix
Updated the function to correctly calculate the output length based on the PyTorch Conv2d formula:
- For Conv2d with kernel_size=3, stride=2, padding=1: output = (input - 1) // 2 + 1
- Applied sequentially for the 3 conv layers in the audio encoder

## Files Changed
- src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
- src/transformers/models/qwen3_omni_moe/modular_qwen3_omni_moe.py
- src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py

Fixes #45083