### PR TITLE
Fix: Skip meta device initialization for remote code models

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -3616,7 +3616,11 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             elif is_quantized:
                 init_contexts.extend([torch.device("meta"), set_quantized_state()])
         else:
-            init_contexts.append(torch.device("meta"))
+            # Skip meta device initialization for remote code models, as they may perform
+            # real-tensor operations during model construction (e.g., calling .item() on tensors).
+            # See https://github.com/huggingface/transformers/issues/45092
+            if not cls.is_remote_code():
+                init_contexts.append(torch.device("meta"))
 
         return init_contexts
 


### PR DESCRIPTION
## Problem

Old remote-code checkpoints (like InternVL2) perform real-tensor operations during model construction (e.g., calling `.item()` on tensors). This causes `RuntimeError: Tensor.item() cannot be called on meta tensors` when models are initialized on the meta device, which is the default behavior in Transformers v5+.

This was reported in #45092 and blocks vLLM's Transformers v5 upgrade work.

## Solution

Skip meta device initialization for models loaded with `trust_remote_code=True`. This allows remote code models to work correctly while preserving the memory-efficient initialization for standard models.

## Changes

- Modified `get_init_context()` in `modeling_utils.py` to check `cls.is_remote_code()` before adding the meta device context
- Regular models still use meta device initialization for memory efficiency
- Remote code models skip meta device initialization to avoid compatibility issues

## Testing

- Verified that regular models still use meta device initialization
- Verified that remote code models skip meta device initialization
- The fix is minimal and targeted, reducing risk of regression

Fixes #45092