### PR TITLE
Fix auto_docstring crash with from __future__ import annotations

### DIFF
--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -19,6 +19,7 @@ from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 from types import UnionType
+import typing
 from typing import ClassVar, Union, get_args, get_origin
 
 import regex as re
@@ -3578,6 +3579,18 @@ def _process_kwargs_parameters(sig, func, parent_class, documented_kwargs, inden
         # If kwargs not typed, skip
         if kwarg_param.annotation == inspect.Parameter.empty:
             continue
+
+        # If annotation is a string (from `from __future__ import annotations`),
+        # try to resolve it via get_type_hints(); skip if resolution fails.
+        if isinstance(kwarg_param.annotation, str):
+            try:
+                kwarg_name = next(n for n, p in sig.parameters.items() if p is kwarg_param)
+                resolved = typing.get_type_hints(func).get(kwarg_name)
+                if resolved is None:
+                    continue
+                kwarg_param = kwarg_param.replace(annotation=resolved)
+            except Exception:
+                continue
 
         if kwarg_param.annotation.__args__[0].__name__ not in BASIC_KWARGS_TYPES:
             # Extract documentation for kwargs


### PR DESCRIPTION
## Description

Fixes #45103

The `@auto_docstring` decorator crashes at import time when applied to a class in a module that uses `from __future__ import annotations`. This is because `from __future__ import annotations` makes all annotations strings at runtime, and the code was trying to access `__args__` on a string, which doesn't have that attribute.

## Changes

In `_process_kwargs_parameters`, after the `inspect.Parameter.empty` check, resolve string annotations before accessing `.\_\_args\_\_`:

- If annotation is a string (from `from __future__ import annotations`), try to resolve it via `typing.get_type_hints()`
- If resolution fails, skip gracefully
- Leave all existing behaviour for non-string annotations unchanged

## Testing

- All existing tests in `tests/utils/test_auto_docstring.py` pass
- Tested with modules using `from __future__ import annotations`
- Tested with normal modules (without future annotations) to ensure no regression