### PR TITLE
Fix @auto_docstring crash with from __future__ import annotations in _process_kwargs_parameters

### DIFF
--- a/src/transformers/utils/auto_docstring.py
+++ b/src/transformers/utils/auto_docstring.py
@@ -19,7 +19,7 @@ from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
 from types import UnionType
-from typing import ClassVar, Union, get_args, get_origin
+from typing import ClassVar, Union, get_args, get_origin, get_type_hints
 
 import regex as re
 import typing_extensions
@@ -3574,9 +3574,27 @@ def _process_kwargs_parameters(sig, func, parent_class, documented_kwargs, inden
         for _, kwargs_param in sig.parameters.items()
         if kwargs_param.kind == inspect.Parameter.VAR_KEYWORD
     ]
+
+    # Resolve string annotations once (from `from __future__ import annotations`).
+    try:
+        resolved_hints = get_type_hints(func)
+    except Exception:
+        resolved_hints = {}
+
     for kwarg_param in kwargs_parameters:
         # If kwargs not typed, skip
         if kwarg_param.annotation == inspect.Parameter.empty:
+            continue
+
+        # If annotation is a string, resolve it; skip if resolution fails.
+        if isinstance(kwarg_param.annotation, str):
+            kwarg_name = next((n for n, p in sig.parameters.items() if p is kwarg_param), None)
+            resolved = resolved_hints.get(kwarg_name) if kwarg_name else None
+            if resolved is None:
+                continue
+            kwarg_param = kwarg_param.replace(annotation=resolved)
+
+        if not hasattr(kwarg_param.annotation, "__args__"):
             continue
 
         if kwarg_param.annotation.__args__[0].__name__ not in BASIC_KWARGS_TYPES:

--- a/tests/utils/test_auto_docstring.py
+++ b/tests/utils/test_auto_docstring.py
@@ -681,6 +681,7 @@ Args:
 
         See: https://github.com/huggingface/transformers/issues/45103
         """
+
         # Case 1: string annotation that resolves successfully via get_type_hints().
         # Inject CustomKwargs and Optional into the function's globals so get_type_hints() can find them.
         # (get_type_hints resolves against func.__globals__, i.e. the module scope, not the local test scope.)

--- a/tests/utils/test_auto_docstring.py
+++ b/tests/utils/test_auto_docstring.py
@@ -669,6 +669,57 @@ Args:
 
         self.assertEqual(actual_class_docstring, expected_class_docstring)
 
+    def test_process_kwargs_parameters_with_string_annotations(self):
+        """Test that _process_kwargs_parameters handles string annotations from `from __future__ import annotations`.
+
+        `from __future__ import annotations` makes all annotations strings at runtime.
+        _process_kwargs_parameters must resolve them via get_type_hints() rather than
+        crashing when accessing annotation.__args__.
+
+        See: https://github.com/huggingface/transformers/issues/45103
+        """
+        import inspect
+
+        from transformers.utils.auto_docstring import _process_kwargs_parameters
+
+        # Case 1: string annotation that resolves successfully via get_type_hints().
+        # Inject CustomKwargs into the function's globals so get_type_hints() can find it.
+        class CustomKwargs:
+            """
+            Custom kwargs.
+
+            Args:
+                image_size (`int`):
+                    Size of the image.
+            """
+
+            image_size: int = 224
+
+        def func_with_string_annotation(self, **kwargs):
+            pass
+
+        func_with_string_annotation.__annotations__["kwargs"] = "Optional[CustomKwargs]"
+        func_with_string_annotation.__globals__["CustomKwargs"] = CustomKwargs
+
+        sig = inspect.signature(func_with_string_annotation)
+        self.assertIsInstance(sig.parameters["kwargs"].annotation, str)  # confirm string at runtime
+
+        docstring, summary = _process_kwargs_parameters(sig, func_with_string_annotation, ProcessorMixin, {}, 4, [])
+        self.assertIn("image_size", docstring, "Expected resolved kwargs docstring to include 'image_size'")
+
+        # Case 2: string annotation that cannot be resolved — must skip gracefully, not crash.
+        def func_with_unresolvable_annotation(self, **kwargs):
+            pass
+
+        func_with_unresolvable_annotation.__annotations__["kwargs"] = "UnresolvableTypeXYZ"
+
+        sig2 = inspect.signature(func_with_unresolvable_annotation)
+        docstring2, summary2 = _process_kwargs_parameters(
+            sig2, func_with_unresolvable_annotation, ProcessorMixin, {}, 4, []
+        )
+        self.assertEqual(docstring2, "", "Expected empty docstring when annotation cannot be resolved")
+        self.assertEqual(summary2, "", "Expected empty summary when annotation cannot be resolved")
+
 
 # ---------------------------------------------------------------------------
 # Performance tests for auto_docstring

--- a/tests/utils/test_auto_docstring.py
+++ b/tests/utils/test_auto_docstring.py
@@ -679,11 +679,13 @@ Args:
         See: https://github.com/huggingface/transformers/issues/45103
         """
         import inspect
+        from typing import Optional
 
         from transformers.utils.auto_docstring import _process_kwargs_parameters
 
         # Case 1: string annotation that resolves successfully via get_type_hints().
-        # Inject CustomKwargs into the function's globals so get_type_hints() can find it.
+        # Inject CustomKwargs and Optional into the function's globals so get_type_hints() can find them.
+        # (get_type_hints resolves against func.__globals__, i.e. the module scope, not the local test scope.)
         class CustomKwargs:
             """
             Custom kwargs.
@@ -700,6 +702,7 @@ Args:
 
         func_with_string_annotation.__annotations__["kwargs"] = "Optional[CustomKwargs]"
         func_with_string_annotation.__globals__["CustomKwargs"] = CustomKwargs
+        func_with_string_annotation.__globals__["Optional"] = Optional
 
         sig = inspect.signature(func_with_string_annotation)
         self.assertIsInstance(sig.parameters["kwargs"].annotation, str)  # confirm string at runtime

--- a/tests/utils/test_auto_docstring.py
+++ b/tests/utils/test_auto_docstring.py
@@ -16,6 +16,7 @@ Tests for auto_docstring decorator and check_auto_docstrings function.
 """
 
 import importlib
+import inspect
 import os
 import statistics
 import sys
@@ -24,6 +25,7 @@ import textwrap
 import time
 import unittest
 from pathlib import Path
+from typing import Optional
 
 import torch
 from huggingface_hub.dataclasses import strict
@@ -38,6 +40,7 @@ from transformers.processing_utils import ImagesKwargs, ProcessingKwargs, Proces
 from transformers.testing_utils import require_torch
 from transformers.tokenization_utils_base import PreTokenizedInput, TextInput
 from transformers.utils.auto_docstring import (
+    _process_kwargs_parameters,
     auto_docstring,
 )
 from transformers.utils.import_utils import is_torch_available
@@ -678,11 +681,6 @@ Args:
 
         See: https://github.com/huggingface/transformers/issues/45103
         """
-        import inspect
-        from typing import Optional
-
-        from transformers.utils.auto_docstring import _process_kwargs_parameters
-
         # Case 1: string annotation that resolves successfully via get_type_hints().
         # Inject CustomKwargs and Optional into the function's globals so get_type_hints() can find them.
         # (get_type_hints resolves against func.__globals__, i.e. the module scope, not the local test scope.)


### PR DESCRIPTION
# What does this PR do?

Fixes `_process_kwargs_parameters` crashing with `AttributeError` when `@auto_docstring` is applied in a module that uses `from __future__ import annotations`.

Fixes #45103

## Root cause

`from __future__ import annotations` defers all annotations to strings at runtime. `_process_kwargs_parameters` accessed `kwarg_param.annotation.__args__` directly, which fails when the annotation is a string instead of a type object:

```python
# annotation is "Optional[IsaacKwargs]" (str), not the actual type — crashes here
if kwarg_param.annotation.__args__[0].__name__ not in BASIC_KWARGS_TYPES: