### PR TITLE
Fix `Wav2Vec2Config.vocab_size` type to allow `None`

### DIFF
--- a/src/transformers/models/wav2vec2/configuration_wav2vec2.py
+++ b/src/transformers/models/wav2vec2/configuration_wav2vec2.py
@@ -162,7 +162,7 @@ class Wav2Vec2Config(PreTrainedConfig):
 
     model_type = "wav2vec2"
 
-    vocab_size: int = 32
+    vocab_size: int | None = 32
     hidden_size: int = 768
     num_hidden_layers: int = 12
     num_attention_heads: int = 12


### PR DESCRIPTION
## Description

Some wav2vec2 models (e.g. audio classification variants) have `vocab_size: null` in their `config.json`. The current type annotation `vocab_size: int = 32` causes `huggingface_hub`'s strict dataclass validation to reject `None`, making these models fail to load.

The fix changes the type annotation to `int | None`.

## Reproduction

```python
from transformers import pipeline

pipe = pipeline("audio-classification", "audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim")
```

```
huggingface_hub.errors.StrictDataclassFieldValidationError: Validation error for field 'vocab_size':
    TypeError: Field 'vocab_size' expected int, got NoneType (value: None)
```

## Fix

```diff
- vocab_size: int = 32
+ vocab_size: int | None = 32
```
