### PR TITLE
Fix T5Attention shape mismatch under Tensor Parallelism

### DIFF
--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -433,8 +433,10 @@ class LongT5Attention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
         is_cross_attention = key_value_states is not None
 
+        q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
+
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -454,14 +456,11 @@ class LongT5Attention(nn.Module):
             key_states = curr_past_key_values.layers[self.layer_idx].keys
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
-                1, 2
-            )
-            value_states = value_states.view(
-                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
-            ).transpose(1, 2)
+            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
+            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -434,9 +434,7 @@ class LongT5Attention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
-
-        query_states = self.q(hidden_states)
-        query_states = query_states.view(*q_input_shape).transpose(1, 2)
+        query_states = self.q(hidden_states).view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -457,10 +455,8 @@ class LongT5Attention(nn.Module):
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
             kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
-            key_states = self.k(current_states)
-            value_states = self.v(current_states)
-            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
-            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
+            key_states = self.k(current_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v(current_states).view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/longt5/modeling_longt5.py
+++ b/src/transformers/models/longt5/modeling_longt5.py
@@ -434,7 +434,7 @@ class LongT5Attention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -456,8 +456,12 @@ class LongT5Attention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
+                1, 2
+            )
+            value_states = value_states.view(
+                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
+            ).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)
@@ -472,7 +476,7 @@ class LongT5Attention(nn.Module):
             key_length = key_states.shape[-2]
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, query_states.shape[1], seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
@@ -495,7 +499,7 @@ class LongT5Attention(nn.Module):
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.view(batch_size, -1, self.inner_dim)
+        attn_output = attn_output.view(batch_size, seq_length, -1)
         attn_output = self.o(attn_output)
 
         outputs = (attn_output, position_bias)

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -266,7 +266,7 @@ class MT5Attention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -288,8 +288,12 @@ class MT5Attention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
+                1, 2
+            )
+            value_states = value_states.view(
+                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
+            ).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)
@@ -304,7 +308,7 @@ class MT5Attention(nn.Module):
             key_length = key_states.shape[-2]
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, query_states.shape[1], seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
@@ -327,7 +331,7 @@ class MT5Attention(nn.Module):
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.view(batch_size, -1, self.inner_dim)
+        attn_output = attn_output.view(batch_size, seq_length, -1)
         attn_output = self.o(attn_output)
 
         outputs = (attn_output, position_bias)

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -265,8 +265,10 @@ class MT5Attention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
         is_cross_attention = key_value_states is not None
 
+        q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
+
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -286,14 +288,11 @@ class MT5Attention(nn.Module):
             key_states = curr_past_key_values.layers[self.layer_idx].keys
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
-                1, 2
-            )
-            value_states = value_states.view(
-                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
-            ).transpose(1, 2)
+            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
+            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/mt5/modeling_mt5.py
+++ b/src/transformers/models/mt5/modeling_mt5.py
@@ -266,9 +266,7 @@ class MT5Attention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
-
-        query_states = self.q(hidden_states)
-        query_states = query_states.view(*q_input_shape).transpose(1, 2)
+        query_states = self.q(hidden_states).view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -289,10 +287,8 @@ class MT5Attention(nn.Module):
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
             kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
-            key_states = self.k(current_states)
-            value_states = self.v(current_states)
-            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
-            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
+            key_states = self.k(current_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v(current_states).view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -278,7 +278,7 @@ class Pop2PianoAttention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -300,8 +300,12 @@ class Pop2PianoAttention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
+                1, 2
+            )
+            value_states = value_states.view(
+                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
+            ).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)
@@ -316,7 +320,7 @@ class Pop2PianoAttention(nn.Module):
             key_length = key_states.shape[-2]
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, query_states.shape[1], seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
@@ -339,7 +343,7 @@ class Pop2PianoAttention(nn.Module):
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.view(batch_size, -1, self.inner_dim)
+        attn_output = attn_output.view(batch_size, seq_length, -1)
         attn_output = self.o(attn_output)
 
         outputs = (attn_output, position_bias)

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -277,8 +277,10 @@ class Pop2PianoAttention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
         is_cross_attention = key_value_states is not None
 
+        q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
+
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -298,14 +300,11 @@ class Pop2PianoAttention(nn.Module):
             key_states = curr_past_key_values.layers[self.layer_idx].keys
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
-                1, 2
-            )
-            value_states = value_states.view(
-                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
-            ).transpose(1, 2)
+            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
+            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/pop2piano/modeling_pop2piano.py
+++ b/src/transformers/models/pop2piano/modeling_pop2piano.py
@@ -278,9 +278,7 @@ class Pop2PianoAttention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
-
-        query_states = self.q(hidden_states)
-        query_states = query_states.view(*q_input_shape).transpose(1, 2)
+        query_states = self.q(hidden_states).view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -301,10 +299,8 @@ class Pop2PianoAttention(nn.Module):
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
             kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
-            key_states = self.k(current_states)
-            value_states = self.v(current_states)
-            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
-            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
+            key_states = self.k(current_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v(current_states).view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -345,7 +345,7 @@ class SwitchTransformersAttention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -367,8 +367,12 @@ class SwitchTransformersAttention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
+                1, 2
+            )
+            value_states = value_states.view(
+                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
+            ).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)
@@ -383,7 +387,7 @@ class SwitchTransformersAttention(nn.Module):
             key_length = key_states.shape[-2]
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, query_states.shape[1], seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
@@ -406,7 +410,7 @@ class SwitchTransformersAttention(nn.Module):
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.view(batch_size, -1, self.inner_dim)
+        attn_output = attn_output.view(batch_size, seq_length, -1)
         attn_output = self.o(attn_output)
 
         outputs = (attn_output, position_bias)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -345,9 +345,7 @@ class SwitchTransformersAttention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
-
-        query_states = self.q(hidden_states)
-        query_states = query_states.view(*q_input_shape).transpose(1, 2)
+        query_states = self.q(hidden_states).view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -368,10 +366,8 @@ class SwitchTransformersAttention(nn.Module):
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
             kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
-            key_states = self.k(current_states)
-            value_states = self.v(current_states)
-            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
-            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
+            key_states = self.k(current_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v(current_states).view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/switch_transformers/modeling_switch_transformers.py
+++ b/src/transformers/models/switch_transformers/modeling_switch_transformers.py
@@ -344,8 +344,10 @@ class SwitchTransformersAttention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
         is_cross_attention = key_value_states is not None
 
+        q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
+
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -365,14 +367,11 @@ class SwitchTransformersAttention(nn.Module):
             key_states = curr_past_key_values.layers[self.layer_idx].keys
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
-                1, 2
-            )
-            value_states = value_states.view(
-                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
-            ).transpose(1, 2)
+            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
+            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -296,8 +296,12 @@ class T5Attention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
+                1, 2
+            )
+            value_states = value_states.view(
+                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
+            ).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -274,7 +274,7 @@ class T5Attention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -296,8 +296,8 @@ class T5Attention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(1, 2)
+            value_states = value_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)
@@ -312,7 +312,7 @@ class T5Attention(nn.Module):
             key_length = key_states.shape[-2]
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, query_states.shape[1], seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
@@ -335,7 +335,7 @@ class T5Attention(nn.Module):
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.view(batch_size, -1, self.inner_dim)
+        attn_output = attn_output.view(batch_size, seq_length, -1)
         attn_output = self.o(attn_output)
 
         outputs = (attn_output, position_bias)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -274,9 +274,7 @@ class T5Attention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
-
-        query_states = self.q(hidden_states)
-        query_states = query_states.view(*q_input_shape).transpose(1, 2)
+        query_states = self.q(hidden_states).view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -297,10 +295,8 @@ class T5Attention(nn.Module):
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
             kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
-            key_states = self.k(current_states)
-            value_states = self.v(current_states)
-            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
-            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
+            key_states = self.k(current_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v(current_states).view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -273,8 +273,10 @@ class T5Attention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
         is_cross_attention = key_value_states is not None
 
+        q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
+
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -294,14 +296,11 @@ class T5Attention(nn.Module):
             key_states = curr_past_key_values.layers[self.layer_idx].keys
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
-                1, 2
-            )
-            value_states = value_states.view(
-                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
-            ).transpose(1, 2)
+            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
+            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -551,8 +551,10 @@ class UdopAttention(nn.Module):
         # if key_value_states are provided this layer is used as a cross-attention layer for the decoder
         is_cross_attention = key_value_states is not None
 
+        q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
+
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -572,14 +574,11 @@ class UdopAttention(nn.Module):
             key_states = curr_past_key_values.layers[self.layer_idx].keys
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
+            kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
-                1, 2
-            )
-            value_states = value_states.view(
-                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
-            ).transpose(1, 2)
+            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
+            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -552,7 +552,7 @@ class UdopAttention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         query_states = self.q(hidden_states)
-        query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+        query_states = query_states.view(batch_size, seq_length, -1, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -574,8 +574,12 @@ class UdopAttention(nn.Module):
         else:
             key_states = self.k(current_states)
             value_states = self.v(current_states)
-            key_states = key_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
-            value_states = value_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
+            key_states = key_states.view(batch_size, current_states.shape[1], -1, self.key_value_proj_dim).transpose(
+                1, 2
+            )
+            value_states = value_states.view(
+                batch_size, current_states.shape[1], -1, self.key_value_proj_dim
+            ).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)
@@ -590,7 +594,7 @@ class UdopAttention(nn.Module):
             key_length = key_states.shape[-2]
             if not self.has_relative_attention_bias:
                 position_bias = torch.zeros(
-                    (1, self.n_heads, seq_length, key_length), device=scores.device, dtype=scores.dtype
+                    (1, query_states.shape[1], seq_length, key_length), device=scores.device, dtype=scores.dtype
                 )
                 if self.gradient_checkpointing and self.training:
                     position_bias.requires_grad = True
@@ -613,7 +617,7 @@ class UdopAttention(nn.Module):
         attn_output = torch.matmul(attn_weights, value_states)
 
         attn_output = attn_output.transpose(1, 2).contiguous()
-        attn_output = attn_output.view(batch_size, -1, self.inner_dim)
+        attn_output = attn_output.view(batch_size, seq_length, -1)
         attn_output = self.o(attn_output)
 
         outputs = (attn_output, position_bias)

--- a/src/transformers/models/udop/modeling_udop.py
+++ b/src/transformers/models/udop/modeling_udop.py
@@ -552,9 +552,7 @@ class UdopAttention(nn.Module):
         is_cross_attention = key_value_states is not None
 
         q_input_shape = (batch_size, seq_length, -1, self.key_value_proj_dim)
-
-        query_states = self.q(hidden_states)
-        query_states = query_states.view(*q_input_shape).transpose(1, 2)
+        query_states = self.q(hidden_states).view(*q_input_shape).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
         is_updated = False
@@ -575,10 +573,8 @@ class UdopAttention(nn.Module):
             value_states = curr_past_key_values.layers[self.layer_idx].values
         else:
             kv_input_shape = (batch_size, current_states.shape[1], -1, self.key_value_proj_dim)
-            key_states = self.k(current_states)
-            value_states = self.v(current_states)
-            key_states = key_states.view(*kv_input_shape).transpose(1, 2)
-            value_states = value_states.view(*kv_input_shape).transpose(1, 2)
+            key_states = self.k(current_states).view(*kv_input_shape).transpose(1, 2)
+            value_states = self.v(current_states).view(*kv_input_shape).transpose(1, 2)
 
             if past_key_values is not None:
                 key_states, value_states = curr_past_key_values.update(key_states, value_states, self.layer_idx)


### PR DESCRIPTION
# What does this PR do?

`T5Attention.forward` hard-codes `n_heads` and `inner_dim` in `view()` calls. When using PyTorch Tensor Parallelism, `ColwiseParallel` shards the q/k/v projection output dim from `inner_dim` to `inner_dim / tp_size`, but `n_heads` remains unchanged, causing a shape mismatch.

For example, with `n_heads=128`, `d_kv=128`, and `tp_size=4`, for an input with `seq_length=512`:

```python
# After ColwiseParallel, q output shape: [B, 512, 16384 / 4] = [B, 512, 4096]

# Original code:
q.view(B, -1, 128, 128)
# -1 infers seq_length = 512 * 4096 / (128 * 128) = 128 ≠ 512
```

For comparison, Llama-style attention already uses `view(batch, seq, -1, head_dim)` where `-1` is on the `num_heads` dim, making it TP-transparent. T5 puts `-1` on the `seq_length` dim instead.

This PR moves the `-1` from the `seq_length` dim to the `num_heads` dim, so that `num_heads` is inferred from the actual tensor shape rather than the config value.

## Reproducer

<details>
<summary>repro_t5_tp.py (requires >= 2 GPUs)</summary>

```python
"""
Minimal reproducer: T5Attention view() shape mismatch under Tensor Parallelism.

Uses real T5 model + PyTorch TP APIs. Requires >= 2 GPUs.
Run with: torchrun --nproc_per_node=2 repro_t5_tp.py
"""

import os
import torch
import torch.distributed as dist
from torch.distributed.tensor.parallel import ColwiseParallel, RowwiseParallel, parallelize_module
from transformers import T5Config, T5ForConditionalGeneration


def main():
    dist.init_process_group("nccl")
    rank = dist.get_rank()
    world_size = dist.get_world_size()
    device = torch.device(f"cuda:{rank}")
    torch.cuda.set_device(device)

    # Small T5 config for quick repro
    config = T5Config(
        vocab_size=32128,
        d_model=512,
        d_kv=64,
        d_ff=2048,
        num_heads=8,
        num_layers=2,
        num_decoder_layers=2,
    )
    model = T5ForConditionalGeneration(config).to(device)

    # Apply ColwiseParallel / RowwiseParallel to attention layers
    # (same pattern as PyTorch TP would apply)
    for name, module in model.named_modules():
        if module.__class__.__name__ == "T5Attention":
            plan = {
                "q": ColwiseParallel(),
                "k": ColwiseParallel(),
                "v": ColwiseParallel(),
                "o": RowwiseParallel(),
            }
            if hasattr(module, "relative_attention_bias"):
                plan["relative_attention_bias"] = ColwiseParallel()
            mesh = torch.distributed.device_mesh.init_device_mesh("cuda", (world_size,))
            parallelize_module(module, mesh, plan)
            if rank == 0:
                print(f"  Parallelized: {name}")

    # Forward pass
    input_ids = torch.randint(0, config.vocab_size, (1, 32), device=device)
    decoder_input_ids = torch.randint(0, config.vocab_size, (1, 16), device=device)

    if rank == 0:
        print("\nRunning forward pass...")

    try:
        with torch.no_grad():
            output = model(input_ids=input_ids, decoder_input_ids=decoder_input_ids)
        if rank == 0:
            print(f"SUCCESS — output logits shape: {output.logits.shape}")
    except RuntimeError as e:
        if rank == 0:
            print(f"FAILED — {e}")

    dist.destroy_process_group()


if __name__ == "__main__":
    main()
```

</details>

**Before fix** (transformers 5.3.0, 2x NVIDIA H200, TP=2):
```
FAILED — The size of tensor a (16) must match the size of tensor b (32) at non-singleton dimension 2
```

**After fix**:
```
SUCCESS — output logits shape: torch.Size([1, 16, 32128])
```

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR.