### PR TITLE
Copy the template resolution logic from the base apply_chat_template to Voxtral

### DIFF
--- a/src/transformers/models/voxtral/processing_voxtral.py
+++ b/src/transformers/models/voxtral/processing_voxtral.py
@@ -168,6 +168,26 @@ class VoxtralProcessor(ProcessorMixin):
             is_batched = False
             conversations = [conversation]
 
+        # Resolve chat_template=None to the processor's default template
+        if chat_template is None:
+            if isinstance(self.chat_template, dict) and "default" in self.chat_template:
+                chat_template = self.chat_template["default"]
+            elif isinstance(self.chat_template, dict):
+                raise ValueError(
+                    'The processor has multiple chat templates but none of them are named "default". You need to specify'
+                    " which one to use by passing the `chat_template` argument. Available templates are: "
+                    f"{', '.join(self.chat_template.keys())}"
+                )
+            elif self.chat_template is not None:
+                chat_template = self.chat_template
+            else:
+                raise ValueError(
+                    "Cannot use apply_chat_template because this processor does not have a chat template."
+                )
+        else:
+            if isinstance(self.chat_template, dict) and chat_template in self.chat_template:
+                chat_template = self.chat_template[chat_template]
+
         # Users might still be passing processing kwargs in `**kwargs` so we need to filter
         # out additional kwargs that the template expects via Jinja2 template introspection
         # We strip unrelated kwargs to avoid passing unrecognized kwargs to `_merge_kwargs`.

--- a/src/transformers/models/voxtral/processing_voxtral.py
+++ b/src/transformers/models/voxtral/processing_voxtral.py
@@ -168,26 +168,6 @@ class VoxtralProcessor(ProcessorMixin):
             is_batched = False
             conversations = [conversation]
 
-        # Resolve chat_template=None to the processor's default template
-        if chat_template is None:
-            if isinstance(self.chat_template, dict) and "default" in self.chat_template:
-                chat_template = self.chat_template["default"]
-            elif isinstance(self.chat_template, dict):
-                raise ValueError(
-                    'The processor has multiple chat templates but none of them are named "default". You need to specify'
-                    " which one to use by passing the `chat_template` argument. Available templates are: "
-                    f"{', '.join(self.chat_template.keys())}"
-                )
-            elif self.chat_template is not None:
-                chat_template = self.chat_template
-            else:
-                raise ValueError(
-                    "Cannot use apply_chat_template because this processor does not have a chat template."
-                )
-        else:
-            if isinstance(self.chat_template, dict) and chat_template in self.chat_template:
-                chat_template = self.chat_template[chat_template]
-
         # Users might still be passing processing kwargs in `**kwargs` so we need to filter
         # out additional kwargs that the template expects via Jinja2 template introspection
         # We strip unrelated kwargs to avoid passing unrecognized kwargs to `_merge_kwargs`.

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -383,7 +383,7 @@ def get_json_schema(func: Callable) -> dict:
 
 @lru_cache
 @no_type_check
-def _get_template_variables(chat_template: str) -> frozenset[str]:
+def _get_template_variables(chat_template: str | None) -> frozenset[str]:
     """Return the set of undeclared variables referenced by a chat template.
 
     Uses ``jinja2.meta.find_undeclared_variables`` so that callers can
@@ -391,6 +391,8 @@ def _get_template_variables(chat_template: str) -> frozenset[str]:
     without maintaining a manual allowlist. Needed only to support BC as we
     allowed all `kwargs` to be merged into one in the past
     """
+    if chat_template is None:
+        return frozenset()
     compiled = _compile_jinja_template(chat_template)
     ast = compiled.environment.parse(chat_template)
     return frozenset(jinja2.meta.find_undeclared_variables(ast))


### PR DESCRIPTION
Fixes #45084. We need to resolve the chat template in the Voxtral code to avoid `None` being passed to `_get_template_variables()`!

cc @zucchini-nlp, follow-up to #44881