### PR TITLE
[Qwen3.5 MoE] Add _tp_plan to ForConditionalGeneration

### DIFF
--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -2088,6 +2088,7 @@ class Qwen3_5MoeForConditionalGeneration(Qwen3_5MoePreTrainedModel, GenerationMi
     # Reference: fix gemma3 grad acc #37208
     accepts_loss_kwargs = False
     config: Qwen3_5MoeConfig
+    _tp_plan = {"lm_head": "colwise_gather_output"}
 
     def __init__(self, config):
         super().__init__(config)

--- a/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
@@ -253,6 +253,8 @@ class Qwen3_5MoeForCausalLM(Qwen3NextForCausalLM):
 
 
 class Qwen3_5MoeForConditionalGeneration(Qwen3VLMoeForConditionalGeneration):
+    _tp_plan = {"lm_head": "colwise_gather_output"}
+
     def forward(self, **super_kwargs):
         r"""
         labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):


### PR DESCRIPTION
# What does this PR do?

Adds `_tp_plan = {"lm_head": "colwise_gather_output"}` to `Qwen3_5MoeForConditionalGeneration` (the VL wrapper class).

The text-only `Qwen3_5MoeForCausalLM` already had `_tp_plan`, but the VL variant was missing it. This meant that when using `tp_plan="auto"`, the `lm_head` on the VL model was not sharded — each GPU held a full copy and the all-gather behavior (`colwise_gather_output`) was not applied, which could produce incorrect logits under tensor parallelism.

**Change:** Applied in `modular_qwen3_5_moe.py` (source of truth) and regenerated `modeling_qwen3_5_moe.py`.

**Already in place (no changes needed):**
- `base_model_tp_plan` on `Qwen3_5MoeTextConfig` covers full attention (q/k/v/o_proj, q/k_norm), MoE experts, and shared experts.

**Out of scope (future work):**
- Linear attention (GatedDeltaNet) TP — blocked on `causal_conv1d` DTensor support.
- Vision block TP — pending path resolution investigation.

Fixes #45125

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@3outeille @ArthurZucker (distributed / model loading)