### PR TITLE
fix(config): annotate PreTrainedConfig.dtype as Any to fix pydantic schema generation (#45070)

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -224,7 +224,11 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
     # Common attributes for all models
     output_hidden_states: bool | None = False
     return_dict: bool | None = True
-    dtype: Union[str, "torch.dtype"] | None = None
+    # NOTE: annotated as Any (rather than Union[str, "torch.dtype"] | None) so that pydantic can
+    # build a schema for classes that include PreTrainedConfig as a field without needing torch
+    # in the resolution namespace. The runtime type is still Union[str, torch.dtype] | None.
+    # See https://github.com/huggingface/transformers/issues/45070
+    dtype: Any = None
     chunk_size_feed_forward: int = 0
     is_encoder_decoder: bool = False
 


### PR DESCRIPTION
## Problem

Fixes #45070. `PreTrainedConfig.dtype` was annotated as `Union[str, "torch.dtype"] | None`. Since `torch` is only imported under `TYPE_CHECKING`, pydantic's schema builder encounters the `"torch.dtype"` forward reference at runtime and fails with:

```
PydanticUndefinedAnnotation: name 'torch' is not defined
```

This breaks any user code that includes `PreTrainedConfig` as a field in a pydantic model (e.g. vLLM speculator configs, config validators).

The repro from the issue:
```python
from pydantic import BaseModel, ConfigDict, Field
from transformers import PretrainedConfig

class MyModelConfig(BaseModel):
    model_config = ConfigDict(arbitrary_types_allowed=True)
    sub_config: PretrainedConfig = Field(...)

MyModelConfig.model_rebuild(force=True)  # PydanticUndefinedAnnotation
```

## Fix

Change `dtype: Union[str, "torch.dtype"] | None = None` to `dtype: Any = None` as suggested by @zucchini-nlp in the issue.

`Any` is semantically correct for pydantic's purposes — the field accepts string or `torch.dtype` values at runtime. The forward reference is now only needed for static type checkers (which still see the correct type through `TYPE_CHECKING`-gated imports in user code). The runtime behaviour is unchanged.

## Test Plan

- [ ] `MyModelConfig.model_rebuild(force=True)` no longer raises `PydanticUndefinedAnnotation`
- [ ] `PreTrainedConfig` can be used as a pydantic field with `arbitrary_types_allowed=True`
- [ ] Existing dtype handling in `__post_init__` still works (assigns `torch.dtype` objects at runtime)
- [ ] Existing model loading tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)