### PR TITLE
Optimize Parakeet feature extraction on CUDA

### DIFF
--- a/src/transformers/models/parakeet/feature_extraction_parakeet.py
+++ b/src/transformers/models/parakeet/feature_extraction_parakeet.py
@@ -152,10 +152,14 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
         return input_features
 
     @torch.compile(dynamic=True)
-    def _normalize_mel_features(self, mel_features: torch.Tensor, audio_lengths: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    def _normalize_mel_features(
+        self, mel_features: torch.Tensor, audio_lengths: torch.Tensor
+    ) -> tuple[torch.Tensor, torch.Tensor]:
         # normalize mel features, ignoring padding
         features_lengths = torch.floor_divide(audio_lengths + self.n_fft // 2 * 2 - self.n_fft, self.hop_length)
-        attention_mask = torch.arange(mel_features.shape[1], device=mel_features.device)[None, :] < features_lengths[:, None]
+        attention_mask = (
+            torch.arange(mel_features.shape[1], device=mel_features.device)[None, :] < features_lengths[:, None]
+        )
 
         mask = attention_mask.unsqueeze(-1)
         lengths = attention_mask.sum(dim=1)
@@ -167,7 +171,7 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
 
     def _pad_raw_speech(self, raw_speech: list[torch.Tensor], max_len: int, device: str) -> torch.Tensor:
         output = torch.full((len(raw_speech), max_len), self.padding_value, device=device, dtype=torch.float32)
-        dsts = [output[i, :raw_speech[i].shape[0]] for i in range(len(raw_speech))]
+        dsts = [output[i, : raw_speech[i].shape[0]] for i in range(len(raw_speech))]
         srcs = [s.squeeze(-1) for s in raw_speech]
         # single kernel horizontal fusion
         torch._foreach_copy_(dsts, srcs)

--- a/src/transformers/models/parakeet/feature_extraction_parakeet.py
+++ b/src/transformers/models/parakeet/feature_extraction_parakeet.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
 import numpy as np
 import torch
 
@@ -96,9 +98,28 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
         )
         self.mel_filters = torch.from_numpy(mel_filters).to(torch.float32)
 
+    @staticmethod
+    @functools.cache
+    def _get_window(win_length: int, device: str) -> torch.Tensor:
+        return torch.hann_window(win_length, periodic=False, device=device)
+
+    @staticmethod
+    @functools.cache
+    def _get_mel_filters(feature_size: int, sampling_rate: int, n_fft: int, device: str) -> torch.Tensor:
+        mel_filters = librosa.filters.mel(
+            sr=sampling_rate,
+            n_fft=n_fft,
+            n_mels=feature_size,
+            fmin=0.0,
+            fmax=sampling_rate / 2,
+            norm="slaney",
+        )
+        return torch.from_numpy(mel_filters).to(device=device, dtype=torch.float32)
+
     def _torch_extract_fbank_features(self, waveform, device="cpu"):
         # spectrogram
-        window = torch.hann_window(self.win_length, periodic=False, device=device)
+        device = str(torch.device(device))
+        window = self._get_window(self.win_length, device)
         stft = torch.stft(
             waveform,
             self.n_fft,
@@ -110,12 +131,10 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
         )
         # Let's math original implementation
         # magnitudes = torch.abs(stft) ** 2
-        magnitudes = torch.view_as_real(stft)
-        magnitudes = torch.sqrt(magnitudes.pow(2).sum(-1))
-        magnitudes = magnitudes.pow(2)
+        magnitudes = stft.real.square() + stft.imag.square()
 
         # log mel spectrogram
-        mel_filters = self.mel_filters.to(device)
+        mel_filters = self._get_mel_filters(self.feature_size, self.sampling_rate, self.n_fft, device)
         mel_spec = mel_filters @ magnitudes
         mel_spec = torch.log(mel_spec + LOG_ZERO_GUARD_VALUE)
 
@@ -205,11 +224,13 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
                 "Failing to do so can result in silent errors that might be hard to debug."
             )
 
+        device_obj = torch.device(device if device is not None else "cpu")
+
         # Convert to torch tensor
         if isinstance(raw_speech, np.ndarray):
-            raw_speech = torch.tensor(raw_speech)
+            raw_speech = torch.as_tensor(raw_speech, device=device_obj)
         elif isinstance(raw_speech, (list, tuple)) and isinstance(raw_speech[0], np.ndarray):
-            raw_speech = [torch.tensor(speech) for speech in raw_speech]
+            raw_speech = [torch.as_tensor(speech, device=device_obj) for speech in raw_speech]
 
         is_batched_torch = isinstance(raw_speech, torch.Tensor) and len(raw_speech.shape) > 1
         if is_batched_torch and len(raw_speech.shape) > 2:
@@ -230,38 +251,50 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
                     speech = speech.mean(-1)
 
         if is_batched_torch or is_batched_sequence:
-            raw_speech = [speech[:, None].to(torch.float32) for speech in raw_speech]
+            raw_speech = [speech[:, None].to(device=device_obj, dtype=torch.float32) for speech in raw_speech]
         else:
-            raw_speech = [raw_speech[:, None].to(torch.float32)]
+            raw_speech = [raw_speech[:, None].to(device=device_obj, dtype=torch.float32)]
 
-        audio_lengths = [len(speech) for speech in raw_speech]
-        batched_speech = BatchFeature({"input_features": raw_speech, "audio_lengths": audio_lengths})
-
-        padded_inputs = self.pad(
-            batched_speech,
-            padding=padding,
-            max_length=max_length,
-            truncation=truncation,
-            pad_to_multiple_of=pad_to_multiple_of,
-            return_tensors="pt",
-        )
-        input_features = padded_inputs.input_features.squeeze(-1)
+        audio_lengths = torch.tensor([len(speech) for speech in raw_speech], dtype=torch.long, device=device_obj)
+        if device_obj.type == "cuda":
+            max_audio_len = int(audio_lengths.max().item()) if raw_speech else 0
+            input_features = torch.full(
+                (len(raw_speech), max_audio_len, raw_speech[0].shape[-1]),
+                fill_value=self.padding_value,
+                dtype=torch.float32,
+                device=device_obj,
+            )
+            for idx, speech in enumerate(raw_speech):
+                input_features[idx, : len(speech)] = speech
+            input_features = input_features.squeeze(-1)
+        else:
+            batched_speech = BatchFeature({"input_features": raw_speech, "audio_lengths": audio_lengths.tolist()})
+            padded_inputs = self.pad(
+                batched_speech,
+                padding=padding,
+                max_length=max_length,
+                truncation=truncation,
+                pad_to_multiple_of=pad_to_multiple_of,
+                return_tensors="pt",
+            )
+            input_features = padded_inputs.input_features.squeeze(-1).to(device_obj)
+            audio_lengths = padded_inputs.audio_lengths.to(device_obj)
 
         # preemphasis
         if self.preemphasis is not None:
             timemask = torch.arange(input_features.shape[1], device=input_features.device).unsqueeze(
                 0
-            ) < padded_inputs.audio_lengths.unsqueeze(1)
+            ) < audio_lengths.unsqueeze(1)
             input_features = torch.cat(
                 [input_features[:, :1], input_features[:, 1:] - self.preemphasis * input_features[:, :-1]], dim=1
             )
             input_features = input_features.masked_fill(~timemask, 0.0)
 
-        input_features = self._torch_extract_fbank_features(input_features, device)
+        input_features = self._torch_extract_fbank_features(input_features, device_obj)
         features_lengths = torch.floor_divide(
-            padded_inputs.audio_lengths + self.n_fft // 2 * 2 - self.n_fft, self.hop_length
+            audio_lengths + self.n_fft // 2 * 2 - self.n_fft, self.hop_length
         )
-        attention_mask = torch.arange(input_features.shape[1], device=device)[None, :] < features_lengths[:, None]
+        attention_mask = torch.arange(input_features.shape[1], device=input_features.device)[None, :] < features_lengths[:, None]
 
         # normalize mel features, ignoring padding
         mask = attention_mask.unsqueeze(-1)

--- a/src/transformers/models/parakeet/feature_extraction_parakeet.py
+++ b/src/transformers/models/parakeet/feature_extraction_parakeet.py
@@ -129,19 +129,49 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
             return_complex=True,
             pad_mode="constant",
         )
-        # Let's math original implementation
-        # magnitudes = torch.abs(stft) ** 2
-        magnitudes = stft.real.square() + stft.imag.square()
-
-        # log mel spectrogram
         mel_filters = self._get_mel_filters(self.feature_size, self.sampling_rate, self.n_fft, device)
+        return self._apply_mel_filters(stft, mel_filters)
+
+    @torch.compile(dynamic=True)
+    def _apply_mel_filters(self, stft_output: torch.Tensor, mel_filters: torch.Tensor) -> torch.Tensor:
+        magnitudes = stft_output.real.square() + stft_output.imag.square()
         mel_spec = mel_filters @ magnitudes
         mel_spec = torch.log(mel_spec + LOG_ZERO_GUARD_VALUE)
+        return mel_spec.permute(0, 2, 1)
 
-        # (batch_size, num_mel_filters, num_frames) -> (batch_size, num_frames, num_mel_filters)
-        mel_spec = mel_spec.permute(0, 2, 1)
+    @torch.compile(dynamic=True)
+    def _apply_preemphasis(self, input_features: torch.Tensor, audio_lengths: torch.Tensor) -> torch.Tensor:
+        if self.preemphasis is not None:
+            timemask = torch.arange(input_features.shape[1], device=input_features.device).unsqueeze(
+                0
+            ) < audio_lengths.unsqueeze(1)
+            input_features = torch.cat(
+                [input_features[:, :1], input_features[:, 1:] - self.preemphasis * input_features[:, :-1]], dim=1
+            )
+            input_features = input_features.masked_fill(~timemask, 0.0)
+        return input_features
 
-        return mel_spec
+    @torch.compile(dynamic=True)
+    def _normalize_mel_features(self, mel_features: torch.Tensor, audio_lengths: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        # normalize mel features, ignoring padding
+        features_lengths = torch.floor_divide(audio_lengths + self.n_fft // 2 * 2 - self.n_fft, self.hop_length)
+        attention_mask = torch.arange(mel_features.shape[1], device=mel_features.device)[None, :] < features_lengths[:, None]
+
+        mask = attention_mask.unsqueeze(-1)
+        lengths = attention_mask.sum(dim=1)
+        mel_features_masked = mel_features * mask
+        mean = (mel_features_masked.sum(dim=1) / lengths.unsqueeze(-1)).unsqueeze(1)
+        variance = ((mel_features_masked - mean) ** 2 * mask).sum(dim=1) / (lengths - 1).unsqueeze(-1)
+        std = torch.sqrt(variance).unsqueeze(1)
+        return (mel_features - mean) / (std + EPSILON) * mask, attention_mask
+
+    def _pad_raw_speech(self, raw_speech: list[torch.Tensor], max_len: int, device: str) -> torch.Tensor:
+        output = torch.full((len(raw_speech), max_len), self.padding_value, device=device, dtype=torch.float32)
+        dsts = [output[i, :raw_speech[i].shape[0]] for i in range(len(raw_speech))]
+        srcs = [s.squeeze(-1) for s in raw_speech]
+        # single kernel horizontal fusion
+        torch._foreach_copy_(dsts, srcs)
+        return output
 
     def __call__(
         self,
@@ -224,13 +254,18 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
                 "Failing to do so can result in silent errors that might be hard to debug."
             )
 
-        device_obj = torch.device(device if device is not None else "cpu")
+        device = device if device is not None else "cpu"
 
         # Convert to torch tensor
         if isinstance(raw_speech, np.ndarray):
-            raw_speech = torch.as_tensor(raw_speech, device=device_obj)
-        elif isinstance(raw_speech, (list, tuple)) and isinstance(raw_speech[0], np.ndarray):
-            raw_speech = [torch.as_tensor(speech, device=device_obj) for speech in raw_speech]
+            raw_speech = torch.as_tensor(raw_speech, device=device)
+        elif isinstance(raw_speech, (list, tuple)) and len(raw_speech) > 0:
+            if isinstance(raw_speech[0], np.ndarray):
+                raw_speech = [torch.as_tensor(speech, device=device) for speech in raw_speech]
+            elif isinstance(raw_speech[0], (float, int)):
+                raw_speech = torch.tensor(raw_speech, device=device, dtype=torch.float32)
+            elif isinstance(raw_speech[0], (list, tuple)):
+                raw_speech = [torch.tensor(speech, device=device, dtype=torch.float32) for speech in raw_speech]
 
         is_batched_torch = isinstance(raw_speech, torch.Tensor) and len(raw_speech.shape) > 1
         if is_batched_torch and len(raw_speech.shape) > 2:
@@ -242,69 +277,32 @@ class ParakeetFeatureExtractor(SequenceFeatureExtractor):
 
         is_batched_sequence = isinstance(raw_speech, (list, tuple))
         if is_batched_sequence:
-            for speech in raw_speech:
+            for i, speech in enumerate(raw_speech):
                 if len(speech.shape) > 1:
                     logger.warning(
                         f"Only mono-channel audio is supported for input to {self.__class__.__name__}. "
                         "We will take the mean of the channels to convert to mono."
                     )
-                    speech = speech.mean(-1)
+                    raw_speech[i] = speech.mean(-1)
 
-        if is_batched_torch or is_batched_sequence:
-            raw_speech = [speech[:, None].to(device=device_obj, dtype=torch.float32) for speech in raw_speech]
+        if is_batched_torch:
+            raw_speech = raw_speech.to(device=device, dtype=torch.float32)
+        elif is_batched_sequence:
+            raw_speech = [speech.to(device=device, dtype=torch.float32) for speech in raw_speech]
         else:
-            raw_speech = [raw_speech[:, None].to(device=device_obj, dtype=torch.float32)]
+            raw_speech = [raw_speech.to(device=device, dtype=torch.float32)]
 
-        audio_lengths = torch.tensor([len(speech) for speech in raw_speech], dtype=torch.long, device=device_obj)
-        if device_obj.type == "cuda":
-            max_audio_len = int(audio_lengths.max().item()) if raw_speech else 0
-            input_features = torch.full(
-                (len(raw_speech), max_audio_len, raw_speech[0].shape[-1]),
-                fill_value=self.padding_value,
-                dtype=torch.float32,
-                device=device_obj,
-            )
-            for idx, speech in enumerate(raw_speech):
-                input_features[idx, : len(speech)] = speech
-            input_features = input_features.squeeze(-1)
+        audio_lengths = torch.tensor([len(speech) for speech in raw_speech], dtype=torch.long, device=device)
+
+        if isinstance(raw_speech, torch.Tensor):
+            input_features = raw_speech
         else:
-            batched_speech = BatchFeature({"input_features": raw_speech, "audio_lengths": audio_lengths.tolist()})
-            padded_inputs = self.pad(
-                batched_speech,
-                padding=padding,
-                max_length=max_length,
-                truncation=truncation,
-                pad_to_multiple_of=pad_to_multiple_of,
-                return_tensors="pt",
-            )
-            input_features = padded_inputs.input_features.squeeze(-1).to(device_obj)
-            audio_lengths = padded_inputs.audio_lengths.to(device_obj)
+            max_length = max(len(speech) for speech in raw_speech)
+            input_features = self._pad_raw_speech(raw_speech, max_length, device)
 
-        # preemphasis
-        if self.preemphasis is not None:
-            timemask = torch.arange(input_features.shape[1], device=input_features.device).unsqueeze(
-                0
-            ) < audio_lengths.unsqueeze(1)
-            input_features = torch.cat(
-                [input_features[:, :1], input_features[:, 1:] - self.preemphasis * input_features[:, :-1]], dim=1
-            )
-            input_features = input_features.masked_fill(~timemask, 0.0)
-
-        input_features = self._torch_extract_fbank_features(input_features, device_obj)
-        features_lengths = torch.floor_divide(
-            audio_lengths + self.n_fft // 2 * 2 - self.n_fft, self.hop_length
-        )
-        attention_mask = torch.arange(input_features.shape[1], device=input_features.device)[None, :] < features_lengths[:, None]
-
-        # normalize mel features, ignoring padding
-        mask = attention_mask.unsqueeze(-1)
-        input_features_masked = input_features * mask
-        mean = input_features_masked.sum(dim=1) / features_lengths.unsqueeze(-1)
-        mean = mean.unsqueeze(1)
-        variance = ((input_features_masked - mean) ** 2 * mask).sum(dim=1) / (features_lengths - 1).unsqueeze(-1)
-        std = torch.sqrt(variance).unsqueeze(1)
-        input_features = (input_features - mean) / (std + EPSILON)
-        input_features *= mask
+        input_features = self._apply_preemphasis(input_features, audio_lengths)
+        input_features = self._torch_extract_fbank_features(input_features, device)
+        input_features, attention_mask = self._normalize_mel_features(input_features, audio_lengths)
 
         return BatchFeature(
             data={


### PR DESCRIPTION
# What does this PR do?

Add support for CUDA parakeet preprocessor, running STFT and mel spectrogram extraction on the GPU.
This refactor also speeds up the CPU implementation.

Tested on `nvidia/parakeet-ctc-0.6b`, B200, 300s audio:

Before this PR, CPU: 28ms
After this PR, CPU: 21ms
After this PR, GPU: 1.7ms

No impact on accuracy (VoxPopuli).


Context for this one is to accelerate vLLM for our multimodal nemotron model. Processing audio inputs has a bottleneck on this CPU feature extractor. This PR does a small refactor that gives some good speedup for CPU, and also enables the CUDA backend to be used to accelerate even further.

Some rough numbers, processing a 30min audio of 16 kHz:

    Before this PR, CPU: 770ms
    After this PR, CPU: 265ms (~3x)
    After this PR, CUDA: 20ms (~38x)

Several changes in this PR:

    Enabling CUDA backend
    Caching of the Hann window and mel filters
    Dynamic torch compile at strategic locations
    GPU-friendly padding
    More efficient and accurate complex number magnitude computation


- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

