### PR TITLE
Fix stupid test fetcher

### DIFF
--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -51,7 +51,7 @@ logger = logging.get_logger(__name__)
 
 
 class BertEmbeddings(nn.Module):
-    """Construct the embeddings from word, position and token_type embeddings."""
+    """Construct the embeddings from word, position and token_type embeddings. aaaa"""
 
     def __init__(self, config):
         super().__init__()

--- a/src/transformers/models/bert/modeling_bert.py
+++ b/src/transformers/models/bert/modeling_bert.py
@@ -51,7 +51,7 @@ logger = logging.get_logger(__name__)
 
 
 class BertEmbeddings(nn.Module):
-    """Construct the embeddings from word, position and token_type embeddings. aaaa"""
+    """Construct the embeddings from word, position and token_type embeddings."""
 
     def __init__(self, config):
         super().__init__()

--- a/tests/repo_utils/test_tests_fetcher.py
+++ b/tests/repo_utils/test_tests_fetcher.py
@@ -39,6 +39,7 @@ from tests_fetcher import (  # noqa: E402
     diff_is_docstring_only,
     extract_imports,
     get_all_tests,
+    get_diff,
     get_module_dependencies,
     get_repo_utils_tests,
     get_tree_starting_at,
@@ -312,6 +313,23 @@ class TestFetcherTester(unittest.TestCase):
 
             commit_changes(bert_file, BERT_MODEL_FILE_NEW_CODE, repo)
             assert not diff_is_docstring_only(repo, branching_point, bert_file)
+
+    def test_get_diff_ignores_docstring_only_changes(self):
+        """Files whose diff is only in docstrings/comments should be excluded from get_diff results."""
+        with tempfile.TemporaryDirectory() as tmp_folder:
+            tmp_folder = Path(tmp_folder)
+            repo = create_tmp_repo(tmp_folder)
+            branching_commit = repo.head.commit
+
+            # Docstring-only change: should NOT appear in diff
+            commit_changes(BERT_MODELING_FILE, BERT_MODEL_FILE_NEW_DOCSTRING, repo)
+            diff = get_diff(repo, repo.head.commit, [branching_commit])
+            assert BERT_MODELING_FILE not in diff
+
+            # Real code change: should appear in diff
+            commit_changes(BERT_MODELING_FILE, BERT_MODEL_FILE_NEW_CODE, repo)
+            diff = get_diff(repo, repo.head.commit, [branching_commit])
+            assert BERT_MODELING_FILE in diff
 
     def test_extract_imports_relative(self):
         with tempfile.TemporaryDirectory() as tmp_folder:

--- a/utils/tests_fetcher.py
+++ b/utils/tests_fetcher.py
@@ -354,7 +354,7 @@ def get_diff(repo: Repo, base_commit: str, commits: list[str]) -> list[str]:
                 # In case of renames, we'll look at the tests using both the old and new name.
                 if diff_obj.a_path != diff_obj.b_path:
                     code_diff.extend([diff_obj.a_path, diff_obj.b_path])
-                else:
+                elif not diff_is_docstring_only(repo, commit, diff_obj.a_path):
                     code_diff.append(diff_obj.a_path)
 
     return code_diff


### PR DESCRIPTION
# What does this PR do?

Really stupid ...

Currently, change a docstring will count as "modified files", then the impacted files and test files to run are computed.

Say, we add a comment to bert, many files impacted (via dependency) then many test files to run.

This PR avoid this waste.