### PR TITLE
Add Turkish (tr) translation for Get Started section

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -28,7 +28,7 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: transformers
       notebook_folder: transformers_doc
-      languages: ar de es fr hi it ja ko pt zh
+      languages: ar de es fr hi it ja ko pt tr zh
       custom_container: huggingface/transformers-doc-builder
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/docs/source/tr/_config.py
+++ b/docs/source/tr/_config.py
@@ -1,0 +1,14 @@
+# docstyle-ignore
+INSTALL_CONTENT = """
+# Transformers installation
+! pip install transformers datasets evaluate accelerate
+# To install from source instead of the last release, comment the command above and uncomment the following one.
+# ! pip install git+https://github.com/huggingface/transformers.git
+"""
+
+notebook_first_cells = [{"type": "code", "content": INSTALL_CONTENT}]
+black_avoid_patterns = {
+    "{processor_class}": "FakeProcessorClass",
+    "{model_class}": "FakeModelClass",
+    "{object_class}": "FakeObjectClass",
+}

--- a/docs/source/tr/_toctree.yml
+++ b/docs/source/tr/_toctree.yml
@@ -1,0 +1,8 @@
+- sections:
+  - local: index
+    title: Transformers
+  - local: installation
+    title: Kurulum
+  - local: quicktour
+    title: Hızlı Başlangıç
+  title: Başlarken

--- a/docs/source/tr/index.md
+++ b/docs/source/tr/index.md
@@ -1,0 +1,60 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+-->
+
+# Transformers
+
+<h3 align="center">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/transformers_as_a_model_definition.png"/>
+</h3>
+
+Transformers; metin, bilgisayar görüşü, ses, video ve multimodal modeller için en gelişmiş makine öğrenmesi modellerinin hem çıkarsama hem de eğitim için model tanımlama çerçevesi olarak çalışır.
+
+Model tanımını merkezileştirerek bu tanımın ekosistem genelinde kabul görmesini sağlar. `transformers`, çerçeveler arası bir köprü görevindedir: eğer bir model tanımı destekleniyorsa, eğitim çerçevelerinin büyük çoğunluğuyla (Axolotl, Unsloth, DeepSpeed, FSDP, PyTorch-Lightning, ...), çıkarsama motorlarıyla (vLLM, SGLang, TGI, ...) ve `transformers`'daki model tanımını kullanan bitişik modelleme kütüphaneleriyle (llama.cpp, mlx, ...) uyumlu olacaktır.
+
+Yeni en gelişmiş modelleri desteklemeye ve model tanımlarını basit, özelleştirilebilir ve verimli tutarak kullanımlarını demokratikleştirmeye söz veriyoruz.
+
+Hugging Face [Hub](https://huggingface.com/models)'da kullanabileceğin 1 milyondan fazla Transformers [model kontrol noktası](https://huggingface.co/models?library=transformers&sort=trending) bulunuyor.
+
+Bir model bulmak için [Hub](https://huggingface.com/)'ı keşfet ve hemen başlamak için Transformers'ı kullan.
+
+Transformers'daki en son metin, görüntü, ses ve multimodal model mimarilerini keşfetmek için [Model Zaman Çizelgesi](./models_timeline)'ne göz at.
+
+## Özellikler
+
+Transformers, en gelişmiş önceden eğitilmiş modellerle çıkarsama veya eğitim için ihtiyacın olan her şeyi sağlar. Ana özelliklerden bazıları şunlardır:
+
+- [Pipeline](./pipeline_tutorial): Metin üretimi, görüntü segmentasyonu, otomatik konuşma tanıma, belge soru cevaplama ve daha birçok makine öğrenmesi görevi için basit ve optimize edilmiş çıkarsama sınıfı.
+- [Trainer](./trainer): PyTorch modelleri için karışık hassasiyet, torch.compile ve FlashAttention gibi özellikleri destekleyen, eğitim ve dağıtık eğitim için kapsamlı bir eğitici.
+- [generate](./llm_tutorial): Büyük dil modelleri (LLM'ler) ve görsel dil modelleri (VLM'ler) ile hızlı metin üretimi; akış ve birden fazla çözümleme stratejisi desteği dahil.
+
+## Tasarım
+
+> [!TIP]
+> Transformers'ın tasarım ilkeleri hakkında daha fazla bilgi edinmek için [Felsefe](./philosophy) sayfasını oku.
+
+Transformers, geliştiriciler, makine öğrenmesi mühendisleri ve araştırmacılar için tasarlanmıştır. Temel tasarım ilkeleri şunlardır:
+
+1. Hızlı ve kullanımı kolay: Her model yalnızca üç ana sınıftan (yapılandırma, model ve ön işleyici) oluşturulur ve [`Pipeline`] veya [`Trainer`] ile hızlıca çıkarsama veya eğitim için kullanılabilir.
+2. Önceden eğitilmiş modeller: Tamamen yeni bir model eğitmek yerine önceden eğitilmiş bir model kullanarak karbon ayak izini, hesaplama maliyetini ve zamanı azalt. Her önceden eğitilmiş model, orijinal modele olabildiğince yakın şekilde yeniden üretilmiştir ve en gelişmiş performansı sunar.
+
+<div class="flex justify-center">
+  <a target="_blank" href="https://huggingface.co/support">
+      <img alt="HuggingFace Expert Acceleration Program" src="https://hf.co/datasets/huggingface/documentation-images/resolve/81d7d9201fd4ceb537fc4cebc22c29c37a2ed216/transformers/transformers-index.png" style="width: 100%; max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
+  </a>
+</div>
+
+## Öğren
+
+Transformers'a yeni başlıyor ya da transformer modelleri hakkında daha fazla bilgi edinmek istiyorsan, [LLM kursu](https://huggingface.co/learn/llm-course/chapter1/1?fw=pt) ile başlamanı öneririz. Bu kapsamlı kurs, transformer modellerinin nasıl çalıştığından çeşitli görevler için pratik uygulamalara kadar her şeyi kapsar. Yüksek kaliteli veri kümelerinin derlenmesinden büyük dil modellerinin ince ayarlanmasına ve akıl yürütme yeteneklerinin uygulanmasına kadar tam iş akışını öğreneceksin. Kurs, öğrenirken sağlam bir temel bilgi oluşturmak için hem teorik hem de uygulamalı alıştırmalar içermektedir.

--- a/docs/source/tr/installation.md
+++ b/docs/source/tr/installation.md
@@ -1,0 +1,164 @@
+<!---
+Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Kurulum
+
+Transformers, [PyTorch](https://pytorch.org/get-started/locally/) ile çalışır. Python 3.10+ ve PyTorch 2.4+ üzerinde test edilmiştir.
+
+## Sanal ortam
+
+[uv](https://docs.astral.sh/uv/), Rust tabanlı son derece hızlı bir Python paket ve proje yöneticisidir ve farklı projeleri yönetmek ile bağımlılıklar arasındaki uyumluluk sorunlarını önlemek için varsayılan olarak bir [sanal ortam](https://docs.astral.sh/uv/pip/environments/) gerektirir.
+
+[pip](https://pip.pypa.io/en/stable/) yerine doğrudan kullanılabilir, ancak pip'i tercih ediyorsan aşağıdaki komutlardan `uv` kısmını kaldırman yeterli.
+
+> [!TIP]
+> uv'yi kurmak için uv [kurulum](https://docs.astral.sh/uv/guides/install-python/) belgelerine bak.
+
+Transformers'ı kurmak için bir sanal ortam oluştur.
+
+```bash
+uv venv .env
+source .env/bin/activate
+```
+
+## Python
+
+Aşağıdaki komutla Transformers'ı kur.
+
+[uv](https://docs.astral.sh/uv/), Rust tabanlı hızlı bir Python paket ve proje yöneticisidir.
+
+```bash
+uv pip install transformers
+```
+
+GPU hızlandırması için [PyTorch](https://pytorch.org/get-started/locally) ile uyumlu CUDA sürücülerini kur.
+
+Sisteminin bir NVIDIA GPU algılayıp algılamadığını kontrol etmek için aşağıdaki komutu çalıştır.
+
+```bash
+nvidia-smi
+```
+
+Transformers'ın yalnızca CPU sürümünü kurmak için aşağıdaki komutu çalıştır.
+
+```bash
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+uv pip install transformers
+```
+
+Kurulumun başarılı olup olmadığını aşağıdaki komutla test et. Verilen metin için bir etiket ve skor döndürmesi gerekir.
+
+```bash
+python -c "from transformers import pipeline; print(pipeline('sentiment-analysis')('hugging face is the best'))"
+[{'label': 'POSITIVE', 'score': 0.9998704791069031}]
+```
+
+### Kaynaktan kurulum
+
+Kaynaktan kurulum, kütüphanenin *kararlı* sürümü yerine *en son* sürümünü kurar. En güncel Transformers değişikliklerine sahip olmanı sağlar ve en son özelliklerle deney yapmak veya henüz kararlı sürümde resmi olarak yayınlanmamış bir hatayı düzeltmek için kullanışlıdır.
+
+Dezavantajı, en son sürümün her zaman kararlı olmayabilmesidir. Herhangi bir sorunla karşılaşırsan, lütfen en kısa sürede düzeltebilmemiz için bir [GitHub Issue](https://github.com/huggingface/transformers/issues) aç.
+
+Aşağıdaki komutla kaynaktan kur.
+
+```bash
+uv pip install git+https://github.com/huggingface/transformers
+```
+
+Kurulumun başarılı olup olmadığını aşağıdaki komutla kontrol et. Verilen metin için bir etiket ve skor döndürmesi gerekir.
+
+```bash
+python -c "from transformers import pipeline; print(pipeline('sentiment-analysis')('hugging face is the best'))"
+[{'label': 'POSITIVE', 'score': 0.9998704791069031}]
+```
+
+### Düzenlenebilir kurulum
+
+[Düzenlenebilir kurulum](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs), Transformers ile yerel olarak geliştirme yapıyorsan kullanışlıdır. Dosyaları kopyalamak yerine yerel Transformers kopyanı Transformers [deposuna](https://github.com/huggingface/transformers) bağlar. Dosyalar Python'ın import yoluna eklenir.
+
+```bash
+git clone https://github.com/huggingface/transformers.git
+cd transformers
+uv pip install -e .
+```
+
+> [!WARNING]
+> Kullanmaya devam etmek için yerel Transformers klasörünü saklamalısın.
+
+Ana depodaki en son değişikliklerle yerel Transformers sürümünü güncellemek için aşağıdaki komutu çalıştır.
+
+```bash
+cd ~/transformers/
+git pull
+```
+
+## conda
+
+[conda](https://docs.conda.io/projects/conda/en/stable/#), dilden bağımsız bir paket yöneticisidir. Yeni oluşturduğun sanal ortamda [conda-forge](https://anaconda.org/conda-forge/transformers) kanalından Transformers'ı kur.
+
+```bash
+conda install conda-forge::transformers
+```
+
+## Yapılandırma
+
+Kurulumdan sonra Transformers önbellek konumunu yapılandırabilir veya kütüphaneyi çevrimdışı kullanım için ayarlayabilirsin.
+
+### Önbellek dizini
+
+Önceden eğitilmiş bir modeli [`~PreTrainedModel.from_pretrained`] ile yüklediğinde, model Hub'dan indirilir ve yerel olarak önbelleğe alınır.
+
+Bir modeli her yüklediğinde, önbelleğe alınmış modelin güncel olup olmadığı kontrol edilir. Aynıysa yerel model yüklenir. Değilse yeni model indirilir ve önbelleğe alınır.
+
+Varsayılan dizin, `HF_HUB_CACHE` kabuk ortam değişkeni tarafından belirlenir ve `~/.cache/huggingface/hub` şeklindedir. Windows'ta varsayılan dizin `C:\Users\kullaniciadi\.cache\huggingface\hub` şeklindedir.
+
+Bir modeli farklı bir dizine önbelleğe almak için aşağıdaki kabuk ortam değişkenlerindeki yolu değiştir (öncelik sırasına göre listelenmiştir).
+
+1. [HF_HUB_CACHE](https://hf.co/docs/huggingface_hub/package_reference/environment_variables#hfhubcache) (varsayılan)
+2. [HF_HOME](https://hf.co/docs/huggingface_hub/package_reference/environment_variables#hfhome)
+3. [XDG_CACHE_HOME](https://hf.co/docs/huggingface_hub/package_reference/environment_variables#xdgcachehome) + `/huggingface` (yalnızca `HF_HOME` ayarlanmamışsa)
+
+### Çevrimdışı mod
+
+Transformers'ı çevrimdışı veya güvenlik duvarı olan bir ortamda kullanmak için indirilen ve önbelleğe alınmış dosyaların önceden hazır olması gerekir. [`~huggingface_hub.snapshot_download`] yöntemiyle Hub'dan bir model deposunu indir.
+
+> [!TIP]
+> Hub'dan dosya indirmek için daha fazla seçenek hakkında [Hub'dan dosya indirme](https://hf.co/docs/huggingface_hub/guides/download) rehberine bak. Belirli sürümlerden dosya indirebilir, CLI'dan indirebilir ve hatta bir depodan hangi dosyaların indirileceğini filtreleyebilirsin.
+
+```py
+from huggingface_hub import snapshot_download
+
+snapshot_download(repo_id="meta-llama/Llama-2-7b-hf", repo_type="model")
+```
+
+Bir model yüklerken Hub'a HTTP çağrılarını engellemek için `HF_HUB_OFFLINE=1` ortam değişkenini ayarla.
+
+```bash
+HF_HUB_OFFLINE=1 \
+python examples/pytorch/language-modeling/run_clm.py --model_name_or_path meta-llama/Llama-2-7b-hf --dataset_name wikitext ...
+```
+
+Yalnızca önbelleğe alınmış dosyaları yüklemek için başka bir seçenek de [`~PreTrainedModel.from_pretrained`] içinde `local_files_only=True` ayarlamaktır.
+
+```py
+from transformers import LlamaForCausalLM
+
+model = LlamaForCausalLM.from_pretrained("./path/to/local/directory", local_files_only=True)
+```

--- a/docs/source/tr/quicktour.md
+++ b/docs/source/tr/quicktour.md
@@ -110,7 +110,7 @@ tokenizer.batch_decode(generated_ids)[0]
 ```
 
 > [!TIP]
-> Bir modeli nasıl ince ayarlayacağını öğrenmek için [Trainer](#trainer-apisi) bölümüne atla.
+> Bir modeli nasıl ince ayarlayacağını öğrenmek için [Trainer](#trainer-api) bölümüne atla.
 
 ## Pipeline
 

--- a/docs/source/tr/quicktour.md
+++ b/docs/source/tr/quicktour.md
@@ -1,0 +1,278 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Hızlı Başlangıç
+
+[[open-in-colab]]
+
+Transformers, herkesin transformer modelleriyle öğrenmeye veya geliştirmeye başlayabilmesi için hızlı ve kullanımı kolay olacak şekilde tasarlanmıştır.
+
+Kullanıcıya yönelik soyutlamalar yalnızca üç model oluşturma sınıfı ve iki çıkarsama veya eğitim API'si ile sınırlıdır. Bu hızlı başlangıç rehberi, Transformers'ın temel özelliklerini tanıtır ve sana şunları nasıl yapacağını gösterir:
+
+- önceden eğitilmiş bir model yükleme
+- [`Pipeline`] ile çıkarsama yapma
+- [`Trainer`] ile bir modeli ince ayarlama
+
+## Kurulum
+
+Başlamak için bir Hugging Face [hesabı](https://hf.co/join) oluşturmanı öneririz. Hesap, Hugging Face [Hub](https://hf.co/docs/hub/index)'da sürüm kontrollü modelleri, veri kümelerini ve [Spaces](https://hf.co/spaces)'leri barındırmanı ve erişmeni sağlar. Hub, keşif ve geliştirme için işbirlikçi bir platformdur.
+
+Bir [Kullanıcı Erişim Jetonu](https://hf.co/docs/hub/security-tokens#user-access-tokens) oluştur ve hesabına giriş yap.
+
+<hfoptions id="authenticate">
+<hfoption id="notebook">
+
+İstendiğinde Kullanıcı Erişim Jetonunu [`~huggingface_hub.notebook_login`] fonksiyonuna yapıştır.
+
+```py
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+</hfoption>
+<hfoption id="CLI">
+
+[huggingface_hub[cli]](https://huggingface.co/docs/huggingface_hub/guides/cli#getting-started) paketinin kurulu olduğundan emin ol ve aşağıdaki komutu çalıştır. İstendiğinde Kullanıcı Erişim Jetonunu yapıştır.
+
+```bash
+hf auth login
+```
+
+</hfoption>
+</hfoptions>
+
+PyTorch'u kur.
+
+```bash
+!pip install torch
+```
+
+Ardından Transformers'ın güncel bir sürümünü ve Hugging Face ekosisteminden veri kümelerine ve görüntü modellerine erişmek, eğitimi değerlendirmek ve büyük modeller için eğitimi optimize etmek için bazı ek kütüphaneleri kur.
+
+```bash
+!pip install -U transformers datasets evaluate accelerate timm
+```
+
+## Önceden eğitilmiş modeller
+
+Her önceden eğitilmiş model üç temel sınıftan türetilir.
+
+| **Sınıf** | **Açıklama** |
+|---|---|
+| [`PreTrainedConfig`] | Dikkat başlığı sayısı veya kelime hazinesi boyutu gibi model özelliklerini belirten bir dosya. |
+| [`PreTrainedModel`] | Yapılandırma dosyasındaki model özellikleri tarafından tanımlanan bir model (veya mimari). Önceden eğitilmiş bir model yalnızca ham gizli durumları döndürür. Belirli bir görev için, ham gizli durumları anlamlı bir sonuca dönüştürmek üzere uygun model başlığını kullan (örneğin, [`LlamaModel`] ile [`LlamaForCausalLM`] karşılaştırması). |
+| Ön işleyici | Ham girdileri (metin, görüntü, ses, multimodal) modele sayısal girdilere dönüştüren bir sınıf. Örneğin, [`PreTrainedTokenizer`] metni tensörlere, [`ImageProcessingMixin`] ise pikselleri tensörlere dönüştürür. |
+
+Her görev ve makine öğrenmesi çerçevesi için uygun mimariyi otomatik olarak çıkarsadığından, modelleri ve ön işleyicileri yüklemek için [AutoClass](./model_doc/auto) API'sini kullanmanı öneririz.
+
+Hub'dan ağırlıkları ve yapılandırma dosyasını model ve ön işleyici sınıfına yüklemek için [`~PreTrainedModel.from_pretrained`] kullan.
+
+Bir model yüklerken, modelin en uygun şekilde yüklenmesini sağlamak için aşağıdaki parametreleri yapılandır.
+
+- `device_map="auto"` model ağırlıklarını otomatik olarak en hızlı cihazına atar.
+- `dtype="auto"` model ağırlıklarını doğrudan depolandıkları veri tipinde başlatır; bu da ağırlıkların iki kez yüklenmesini önlemeye yardımcı olabilir (PyTorch, ağırlıkları varsayılan olarak `torch.float32` ile yükler).
+
+```py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b-hf", dtype="auto", device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+```
+
+Metni tokenizer ile tokenleştir ve PyTorch tensörleri olarak döndür. Çıkarsamayı hızlandırmak için varsa modeli bir hızlandırıcıya taşı.
+
+```py
+model_inputs = tokenizer(["The secret to baking a good cake is "], return_tensors="pt").to(model.device)
+```
+
+Model artık çıkarsama veya eğitim için hazır.
+
+Çıkarsama için, tokenleştirilmiş girdileri metin üretmek üzere [`~GenerationMixin.generate`] fonksiyonuna geçir. Token kimliklerini [`~PreTrainedTokenizerBase.batch_decode`] ile tekrar metne çevir.
+
+```py
+generated_ids = model.generate(**model_inputs, max_length=30)
+tokenizer.batch_decode(generated_ids)[0]
+'<s> The secret to baking a good cake is 100% in the preparation. There are so many recipes out there,'
+```
+
+> [!TIP]
+> Bir modeli nasıl ince ayarlayacağını öğrenmek için [Trainer](#trainer-apisi) bölümüne atla.
+
+## Pipeline
+
+[`Pipeline`] sınıfı, önceden eğitilmiş bir modelle çıkarsama yapmanın en kolay yoludur. Metin üretimi, görüntü segmentasyonu, otomatik konuşma tanıma, belge soru cevaplama ve daha birçok görevi destekler.
+
+> [!TIP]
+> Mevcut görevlerin tam listesi için [Pipeline](./main_classes/pipelines) API referansına bak.
+
+Bir [`Pipeline`] nesnesi oluştur ve bir görev seç. Varsayılan olarak, [`Pipeline`] belirli bir görev için varsayılan önceden eğitilmiş modeli indirir ve önbelleğe alır. Belirli bir model seçmek için model adını `model` parametresine geçir.
+
+<hfoptions id="pipeline-tasks">
+<hfoption id="metin üretimi">
+
+Çıkarsama için uygun bir hızlandırıcıyı otomatik olarak algılamak üzere [`Accelerator`] kullan.
+
+```py
+from transformers import pipeline
+from accelerate import Accelerator
+
+device = Accelerator().device
+
+pipeline = pipeline("text-generation", model="meta-llama/Llama-2-7b-hf", device=device)
+```
+
+Daha fazla metin üretmek için [`Pipeline`]'a bir başlangıç metni ver.
+
+```py
+pipeline("The secret to baking a good cake is ", max_length=50)
+[{'generated_text': 'The secret to baking a good cake is 100% in the batter. The secret to a great cake is the icing.\nThis is why we\'ve created the best buttercream frosting reci'}]
+```
+
+</hfoption>
+<hfoption id="görüntü segmentasyonu">
+
+Çıkarsama için uygun bir hızlandırıcıyı otomatik olarak algılamak üzere [`Accelerator`] kullan.
+
+```py
+from transformers import pipeline
+from accelerate import Accelerator
+
+device = Accelerator().device
+
+pipeline = pipeline("image-segmentation", model="facebook/detr-resnet-50-panoptic", device=device)
+```
+
+[`Pipeline`]'a bir görüntü (URL veya yerel dosya yolu) geçir.
+
+<div class="flex justify-center">
+   <img src="https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"/>
+</div>
+
+```py
+segments = pipeline("https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png")
+segments[0]["label"]
+'bird'
+segments[1]["label"]
+'bird'
+```
+
+</hfoption>
+<hfoption id="otomatik konuşma tanıma">
+
+Çıkarsama için uygun bir hızlandırıcıyı otomatik olarak algılamak üzere [`Accelerator`] kullan.
+
+```py
+from transformers import pipeline
+from accelerate import Accelerator
+
+device = Accelerator().device
+
+pipeline = pipeline("automatic-speech-recognition", model="openai/whisper-large-v3", device=device)
+```
+
+[`Pipeline`]'a bir ses dosyası geçir.
+
+```py
+pipeline("https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/1.flac")
+{'text': ' He hoped there would be stew for dinner, turnips and carrots and bruised potatoes and fat mutton pieces to be ladled out in thick, peppered flour-fatten sauce.'}
+```
+
+</hfoption>
+</hfoptions>
+
+## Trainer
+
+[`Trainer`], PyTorch modelleri için eksiksiz bir eğitim ve değerlendirme döngüsüdür. Bir eğitim döngüsünü elle yazmakla ilişkili birçok şablon kodu soyutlar, böylece daha hızlı eğitime başlayabilir ve eğitim tasarımı seçimlerine odaklanabilirsin. Bir modelden, veri kümesinden, ön işleyiciden ve veri kümesinden veri grupları oluşturmak için bir veri toplayıcıdan ihtiyacın var.
+
+Eğitim sürecini özelleştirmek için [`TrainingArguments`] sınıfını kullan. Eğitim, değerlendirme ve daha fazlası için birçok seçenek sunar. Eğitim ihtiyaçlarını karşılamak için grup boyutu, öğrenme hızı, karışık hassasiyet, torch.compile ve daha fazlası gibi eğitim hiperparametreleri ve özelliklerini dene. Hızlı bir temel sonuç elde etmek için varsayılan eğitim parametrelerini de kullanabilirsin.
+
+Eğitim için bir model, tokenizer ve veri kümesi yükle.
+
+```py
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from datasets import load_dataset
+
+model = AutoModelForSequenceClassification.from_pretrained("distilbert/distilbert-base-uncased")
+tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased")
+dataset = load_dataset("rotten_tomatoes")
+```
+
+Metni tokenleştirmek ve PyTorch tensörlerine dönüştürmek için bir fonksiyon oluştur. Bu fonksiyonu [`~datasets.Dataset.map`] yöntemiyle tüm veri kümesine uygula.
+
+```py
+def tokenize_dataset(dataset):
+    return tokenizer(dataset["text"])
+dataset = dataset.map(tokenize_dataset, batched=True)
+```
+
+Veri grupları oluşturmak için bir veri toplayıcı yükle ve tokenizer'ı ona geçir.
+
+```py
+from transformers import DataCollatorWithPadding
+
+data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
+```
+
+Ardından, eğitim özellikleri ve hiperparametreleri ile [`TrainingArguments`] ayarla.
+
+```py
+from transformers import TrainingArguments
+
+training_args = TrainingArguments(
+    output_dir="distilbert-rotten-tomatoes",
+    learning_rate=2e-5,
+    per_device_train_batch_size=8,
+    per_device_eval_batch_size=8,
+    num_train_epochs=2,
+    push_to_hub=True,
+)
+```
+
+Son olarak, tüm bu bileşenleri [`Trainer`]'a geçir ve eğitimi başlatmak için [`~Trainer.train`] fonksiyonunu çağır.
+
+```py
+from transformers import Trainer
+
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    processing_class=tokenizer,
+    data_collator=data_collator,
+)
+
+trainer.train()
+```
+
+Modelini ve tokenizer'ını [`~Trainer.push_to_hub`] ile Hub'a paylaş.
+
+```py
+trainer.push_to_hub()
+```
+
+Tebrikler, Transformers ile ilk modelini eğittin!
+
+## Sonraki adımlar
+
+Artık Transformers'ı ve sunduklarını daha iyi anladığına göre, en çok ilgini çekeni keşfetmeye ve öğrenmeye devam etmenin zamanı geldi.
+
+- **Temel sınıflar**: Yapılandırma, model ve işlemci sınıfları hakkında daha fazla bilgi edin. Bu, modellerin nasıl oluşturulacağını ve özelleştirileceğini, farklı girdi türlerinin (ses, görüntü, multimodal) nasıl ön işleneceğini ve modelinin nasıl paylaşılacağını anlamana yardımcı olacaktır.
+- **Çıkarsama**: [`Pipeline`]'ı daha derinlemesine keşfet, LLM'lerle çıkarsama ve sohbet, ajanlar ve makine öğrenmesi çerçeven ve donanımınla çıkarsamayı nasıl optimize edeceğini öğren.
+- **Eğitim**: [`Trainer`]'ı daha ayrıntılı incele, dağıtık eğitim ve belirli donanım üzerinde eğitimi optimize etme hakkında bilgi edin.
+- **Kuantizasyon**: Kuantizasyon ile bellek ve depolama gereksinimlerini azalt ve ağırlıkları daha az bit ile temsil ederek çıkarsamayı hızlandır.
+- **Kaynaklar**: Belirli bir görev için bir modelin nasıl eğitileceğine ve çıkarsama yapılacağına dair uçtan uca tarifler mi arıyorsun? Görev tariflerine göz at!


### PR DESCRIPTION
## Summary

This PR re-creates the Turkish (`tr`) documentation for the Transformers library, starting with the **Get Started** section. The original Turkish translation was accidentally removed in commit fce74651 (#40999). This contribution follows the tracking issue #27088.

**Files added:**
- `docs/source/tr/_toctree.yml` - Table of contents for Turkish docs
- `docs/source/tr/index.md` - Main landing page (translated from `en/index.md`)
- `docs/source/tr/quicktour.md` - Quick start guide (translated from `en/quicktour.md`)
- `docs/source/tr/installation.md` - Installation guide (translated from `en/installation.md`)

**Files modified:**
- `.github/workflows/build_documentation.yml` - Added `tr` to the languages list

**Translation notes:**
- Informal tone (as specified in #27088)
- Gender-neutral language throughout
- Proper Turkish characters (ş, ğ, ü, ö, ç, ı, İ)
- Code blocks, imports, variable names, function names, and brand names kept in English
- Comments in code blocks translated to Turkish

Refs #27088