### PR TITLE
Add Turkish documentation: Get Started section

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -28,7 +28,7 @@ jobs:
       commit_sha: ${{ github.sha }}
       package: transformers
       notebook_folder: transformers_doc
-      languages: ar de es fr hi it ja ko pt zh
+      languages: ar de es fr hi it ja ko pt tr zh
       custom_container: huggingface/transformers-doc-builder
     secrets:
       token: ${{ secrets.HUGGINGFACE_PUSH }}

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -16,7 +16,7 @@ jobs:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}
       package: transformers
-      languages: en
+      languages: en tr
 
   # Satisfy required check in merge queue without actually building docs
   skip_merge_queue:

--- a/docs/source/tr/_toctree.yml
+++ b/docs/source/tr/_toctree.yml
@@ -1,0 +1,8 @@
+- sections:
+  - local: index
+    title: 🤗 Transformers
+  - local: quicktour
+    title: Hızlı Tur
+  - local: installation
+    title: Kurulum
+  title: Başlarken

--- a/docs/source/tr/index.md
+++ b/docs/source/tr/index.md
@@ -1,0 +1,61 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Transformers
+
+<h3 align="center">
+    <img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/transformers_as_a_model_definition.png"/>
+</h3>
+
+Transformers; metin, bilgisayar görüşü, ses, video ve multimodal modeller için hem çıkarsama (inference) hem de eğitim (training) amaçlı kullanılan, en gelişmiş makine öğrenmesi modellerinin tanımlandığı bir çerçeve olarak görev yapar.
+
+Model tanımını merkezileştirerek ekosistem genelinde bu tanımın üzerinde uzlaşı sağlanır. `transformers`, framework'ler arasında bir köprü görevi görür: bir model tanımı destekleniyorsa, çoğu eğitim framework'ü (Axolotl, Unsloth, DeepSpeed, FSDP, PyTorch-Lightning, ...), çıkarsama motoru (vLLM, SGLang, TGI, ...) ve yan modelleme kütüphaneleriyle (llama.cpp, mlx, ...) uyumlu olacaktır. Bu kütüphaneler, model tanımını doğrudan `transformers` üzerinden alır.
+
+Yeni ve en gelişmiş modelleri desteklemeyi ve kullanımlarını demokratikleştirmeyi taahhüt ediyoruz. Bunu, model tanımlarını basit, özelleştirilebilir ve verimli hale getirerek yapıyoruz.
+
+Hugging Face Hub üzerinde kullanabileceğin 1 milyondan fazla Transformers [model checkpoint'i](https://huggingface.co/models?library=transformers&sort=trending) bulunmaktadır.
+
+Bir model bulmak ve Transformers ile hemen başlamak için [Hub'ı](https://huggingface.com/) bugünden keşfetmeye başla.
+
+Transformers'daki en yeni metin, görüntü, ses ve multimodal model mimarilerini keşfetmek için [Model Zaman Çizelgesi](./models_timeline) sayfasına göz at.
+
+## Özellikler[[features]]
+
+Transformers, en gelişmiş önceden eğitilmiş modellerle çıkarsama veya eğitim için ihtiyacın olan her şeyi sağlar. Temel özelliklerden bazıları şunlardır:
+
+- [Pipeline](./pipeline_tutorial): Metin üretimi, görüntü segmentasyonu, otomatik konuşma tanıma, belge soru yanıtlama ve daha birçok makine öğrenmesi görevi için basit ve optimize edilmiş çıkarsama sınıfı.
+- [Trainer](./trainer): PyTorch modelleri için karışık hassasiyet (mixed precision), torch.compile ve FlashAttention desteği sunan kapsamlı bir eğitim ve dağıtık eğitim aracı.
+- [generate](./llm_tutorial): Büyük dil modelleri (LLM) ve görsel dil modelleri (VLM) ile hızlı metin üretimi. Akış (streaming) ve birden fazla kod çözme stratejisi desteği içerir.
+
+## Tasarım[[design]]
+
+> [!TIP]
+> Transformers'ın tasarım ilkeleri hakkında daha fazla bilgi edinmek için [Felsefe](./philosophy) sayfasını oku.
+
+Transformers, yazılım geliştiriciler, makine öğrenmesi mühendisleri ve araştırmacılar için tasarlanmıştır. Temel tasarım ilkeleri şunlardır:
+
+1. Hızlı ve kullanımı kolay: Her model yalnızca üç ana sınıftan (yapılandırma, model ve ön işleyici) oluşturulur ve [`Pipeline`] veya [`Trainer`] ile hızlıca çıkarsama veya eğitim için kullanılabilir.
+2. Önceden eğitilmiş modeller: Tamamen yeni bir model eğitmek yerine önceden eğitilmiş bir model kullanarak karbon ayak izini, işlem maliyetini ve zamanını azalt. Her önceden eğitilmiş model, orijinal modele mümkün olduğunca yakın şekilde yeniden üretilir ve en gelişmiş performansı sunar.
+
+<div class="flex justify-center">
+  <a target="_blank" href="https://huggingface.co/support">
+      <img alt="HuggingFace Expert Acceleration Program" src="https://hf.co/datasets/huggingface/documentation-images/resolve/81d7d9201fd4ceb537fc4cebc22c29c37a2ed216/transformers/transformers-index.png" style="width: 100%; max-width: 600px; border: 1px solid #eee; border-radius: 4px; box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);">
+  </a>
+</div>
+
+## Öğren[[learn]]
+
+Transformers'a yeni başlıyorsan veya transformer modelleri hakkında daha fazla bilgi edinmek istiyorsan, [LLM kursuna](https://huggingface.co/learn/llm-course/chapter1/1?fw=pt) başlamanı öneriyoruz. Bu kapsamlı kurs, transformer modellerinin nasıl çalıştığından çeşitli görevlerdeki pratik uygulamalara kadar her şeyi kapsar. Yüksek kaliteli veri kümeleri oluşturmaktan büyük dil modellerini ince ayar yapmaya ve akıl yürütme yeteneklerini uygulamaya kadar tüm iş akışını öğreneceksin. Kurs, öğrenirken sağlam bir temel bilgi oluşturman için hem teorik hem de uygulamalı alıştırmalar içerir.

--- a/docs/source/tr/installation.md
+++ b/docs/source/tr/installation.md
@@ -1,0 +1,164 @@
+<!---
+Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Kurulum
+
+Transformers, [PyTorch](https://pytorch.org/get-started/locally/) ile çalışır. Python 3.10+ ve PyTorch 2.4+ üzerinde test edilmiştir.
+
+## Sanal ortam[[virtual-environment]]
+
+[uv](https://docs.astral.sh/uv/), son derece hızlı, Rust tabanlı bir Python paket ve proje yöneticisidir. Farklı projeleri yönetmek ve bağımlılıklar arasındaki uyumluluk sorunlarını önlemek için varsayılan olarak bir [sanal ortam](https://docs.astral.sh/uv/pip/environments/) gerektirir.
+
+[pip](https://pip.pypa.io/en/stable/) yerine doğrudan kullanılabilir. pip kullanmayı tercih ediyorsan, aşağıdaki komutlardan `uv` kısmını kaldırman yeterli.
+
+> [!TIP]
+> uv'yi yüklemek için uv [kurulum](https://docs.astral.sh/uv/guides/install-python/) belgelerine bak.
+
+Transformers'ı yüklemek için bir sanal ortam oluştur.
+
+```bash
+uv venv .env
+source .env/bin/activate
+```
+
+## Python
+
+Transformers'ı aşağıdaki komut ile yükle.
+
+[uv](https://docs.astral.sh/uv/), hızlı ve Rust tabanlı bir Python paket ve proje yöneticisidir.
+
+```bash
+uv pip install transformers
+```
+
+GPU hızlandırması için [PyTorch](https://pytorch.org/get-started/locally) uygun CUDA sürücülerini yükle.
+
+Sisteminin bir NVIDIA GPU algılayıp algılamadığını kontrol etmek için aşağıdaki komutu çalıştır.
+
+```bash
+nvidia-smi
+```
+
+Transformers'ın yalnızca CPU sürümünü yüklemek için aşağıdaki komutu çalıştır.
+
+```bash
+uv pip install torch --index-url https://download.pytorch.org/whl/cpu
+uv pip install transformers
+```
+
+Yüklemenin başarılı olup olmadığını aşağıdaki komut ile test et. Verilen metin için bir etiket ve skor döndürmesi gerekir.
+
+```bash
+python -c "from transformers import pipeline; print(pipeline('sentiment-analysis')('hugging face is the best'))"
+[{'label': 'POSITIVE', 'score': 0.9998704791069031}]
+```
+
+### Kaynaktan yükleme[[source-install]]
+
+Kaynaktan yükleme, kütüphanenin *kararlı* sürümü yerine *en son* sürümünü yükler. En güncel Transformers değişikliklerine sahip olmanı sağlar ve en son özelliklerle deney yapmak veya henüz kararlı sürümde yayınlanmamış bir hatayı düzeltmek için kullanışlıdır.
+
+Dezavantajı, en son sürümün her zaman kararlı olmayabileceğidir. Herhangi bir sorunla karşılaşırsan, lütfen bir [GitHub Issue](https://github.com/huggingface/transformers/issues) açarak bize bildir, en kısa sürede düzeltelim.
+
+Kaynaktan yüklemek için aşağıdaki komutu çalıştır.
+
+```bash
+uv pip install git+https://github.com/huggingface/transformers
+```
+
+Yüklemenin başarılı olup olmadığını aşağıdaki komut ile kontrol et. Verilen metin için bir etiket ve skor döndürmesi gerekir.
+
+```bash
+python -c "from transformers import pipeline; print(pipeline('sentiment-analysis')('hugging face is the best'))"
+[{'label': 'POSITIVE', 'score': 0.9998704791069031}]
+```
+
+### Düzenlenebilir yükleme[[editable-install]]
+
+[Düzenlenebilir yükleme](https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs), Transformers ile yerel geliştirme yapıyorsan kullanışlıdır. Dosyaları kopyalamak yerine Transformers'ın yerel kopyasını Transformers [deposuna](https://github.com/huggingface/transformers) bağlar. Dosyalar Python'un import yoluna eklenir.
+
+```bash
+git clone https://github.com/huggingface/transformers.git
+cd transformers
+uv pip install -e .
+```
+
+> [!WARNING]
+> Kullanmaya devam etmek için yerel Transformers klasörünü saklamalısın.
+
+Yerel Transformers sürümünü ana depodaki en son değişikliklerle güncellemek için aşağıdaki komutu çalıştır.
+
+```bash
+cd ~/transformers/
+git pull
+```
+
+## conda
+
+[conda](https://docs.conda.io/projects/conda/en/stable/#), dilden bağımsız bir paket yöneticisidir. Transformers'ı yeni oluşturduğun sanal ortamda [conda-forge](https://anaconda.org/conda-forge/transformers) kanalından yükle.
+
+```bash
+conda install conda-forge::transformers
+```
+
+## Ayarlar[[set-up]]
+
+Yüklemeden sonra Transformers önbellek konumunu yapılandırabilir veya kütüphaneyi çevrimdışı kullanım için ayarlayabilirsin.
+
+### Önbellek dizini[[cache-directory]]
+
+Önceden eğitilmiş bir modeli [`~PreTrainedModel.from_pretrained`] ile yüklediğinde, model Hub'dan indirilir ve yerel olarak önbelleğe alınır.
+
+Her model yüklendiğinde, önbelleğe alınmış modelin güncel olup olmadığı kontrol edilir. Aynıysa yerel model yüklenir. Değilse daha yeni model indirilir ve önbelleğe alınır.
+
+`HF_HUB_CACHE` kabuk ortam değişkeni tarafından belirlenen varsayılan dizin `~/.cache/huggingface/hub` şeklindedir. Windows'ta varsayılan dizin `C:\Users\kullaniciadi\.cache\huggingface\hub` olarak ayarlanır.
+
+Modeli farklı bir dizinde önbelleğe almak için aşağıdaki kabuk ortam değişkenlerindeki yolu değiştir (öncelik sırasına göre listelenmiştir).
+
+1. [HF_HUB_CACHE](https://hf.co/docs/huggingface_hub/package_reference/environment_variables#hfhubcache) (varsayılan)
+2. [HF_HOME](https://hf.co/docs/huggingface_hub/package_reference/environment_variables#hfhome)
+3. [XDG_CACHE_HOME](https://hf.co/docs/huggingface_hub/package_reference/environment_variables#xdgcachehome) + `/huggingface` (yalnızca `HF_HOME` ayarlanmamışsa)
+
+### Çevrimdışı mod[[offline-mode]]
+
+Transformers'ı çevrimdışı veya güvenlik duvarı arkasındaki bir ortamda kullanmak için indirilen ve önbelleğe alınmış dosyalara önceden ihtiyaç vardır. Hub'dan bir model deposunu [`~huggingface_hub.snapshot_download`] yöntemi ile indir.
+
+> [!TIP]
+> Hub'dan dosya indirmek için daha fazla seçenek hakkında bilgi almak için [Hub'dan dosya indirme](https://hf.co/docs/huggingface_hub/guides/download) rehberine bak. Belirli revizyonlardan dosya indirebilir, CLI'dan indirebilir ve hatta bir depodan hangi dosyaları indireceğini filtreleyebilirsin.
+
+```py
+from huggingface_hub import snapshot_download
+
+snapshot_download(repo_id="meta-llama/Llama-2-7b-hf", repo_type="model")
+```
+
+Bir model yüklerken Hub'a HTTP çağrılarını önlemek için `HF_HUB_OFFLINE=1` ortam değişkenini ayarla.
+
+```bash
+HF_HUB_OFFLINE=1 \
+python examples/pytorch/language-modeling/run_clm.py --model_name_or_path meta-llama/Llama-2-7b-hf --dataset_name wikitext ...
+```
+
+Yalnızca önbelleğe alınmış dosyaları yüklemek için bir diğer seçenek, [`~PreTrainedModel.from_pretrained`] fonksiyonunda `local_files_only=True` ayarlamaktır.
+
+```py
+from transformers import LlamaForCausalLM
+
+model = LlamaForCausalLM.from_pretrained("./path/to/local/directory", local_files_only=True)
+```

--- a/docs/source/tr/quicktour.md
+++ b/docs/source/tr/quicktour.md
@@ -1,0 +1,278 @@
+<!--Copyright 2024 The HuggingFace Team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+
+⚠️ Note that this file is in Markdown but contain specific syntax for our doc-builder (similar to MDX) that may not be
+rendered properly in your Markdown viewer.
+
+-->
+
+# Hızlı Tur
+
+[[open-in-colab]]
+
+Transformers, herkesin transformer modelleriyle öğrenmeye veya geliştirmeye hızlıca başlayabilmesi için tasarlanmıştır.
+
+Kullanıcıya yönelik soyutlamalar yalnızca üç model sınıfı ve çıkarsama veya eğitim için iki API ile sınırlıdır. Bu hızlı tur, Transformers'ın temel özelliklerini tanıtır ve şunları nasıl yapacağını gösterir:
+
+- önceden eğitilmiş bir model yükleme
+- [`Pipeline`] ile çıkarsama yapma
+- [`Trainer`] ile bir modeli ince ayar (fine-tune) yapma
+
+## Hazırlık[[set-up]]
+
+Başlamak için bir Hugging Face [hesabı](https://hf.co/join) oluşturmanı öneriyoruz. Hesabın sayesinde Hugging Face [Hub](https://hf.co/docs/hub/index) üzerinde sürüm kontrollü modelleri, veri kümelerini ve [Spaces](https://hf.co/spaces) alanlarını barındırabilir ve bunlara erişebilirsin.
+
+Bir [Kullanıcı Erişim Token'ı](https://hf.co/docs/hub/security-tokens#user-access-tokens) oluştur ve hesabına giriş yap.
+
+<hfoptions id="authenticate">
+<hfoption id="notebook">
+
+İstendiğinde Kullanıcı Erişim Token'ını [`~huggingface_hub.notebook_login`] fonksiyonuna yapıştırarak giriş yap.
+
+```py
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+</hfoption>
+<hfoption id="CLI">
+
+[huggingface_hub[cli]](https://huggingface.co/docs/huggingface_hub/guides/cli#getting-started) paketinin yüklü olduğundan emin ol ve aşağıdaki komutu çalıştır. İstendiğinde Kullanıcı Erişim Token'ını yapıştırarak giriş yap.
+
+```bash
+hf auth login
+```
+
+</hfoption>
+</hfoptions>
+
+PyTorch'u yükle.
+
+```bash
+!pip install torch
+```
+
+Ardından Transformers'ın güncel bir sürümünü ve Hugging Face ekosisteminden veri kümelerine ve görüntü modellerine erişmek, eğitimi değerlendirmek ve büyük modeller için eğitimi optimize etmek amacıyla ek kütüphaneleri yükle.
+
+```bash
+!pip install -U transformers datasets evaluate accelerate timm
+```
+
+## Önceden eğitilmiş modeller[[pretrained-models]]
+
+Her önceden eğitilmiş model üç temel sınıftan türetilir.
+
+| **Sınıf** | **Açıklama** |
+|---|---|
+| [`PreTrainedConfig`] | Modelin dikkat başlığı sayısı veya kelime hazinesi boyutu gibi özelliklerini belirten bir dosya. |
+| [`PreTrainedModel`] | Yapılandırma dosyasındaki model özellikleri tarafından tanımlanan bir model (veya mimari). Önceden eğitilmiş bir model yalnızca ham gizli durumları (raw hidden states) döndürür. Belirli bir görev için, ham gizli durumları anlamlı bir sonuca dönüştürmek üzere uygun model başlığını kullan (örneğin, [`LlamaModel`] ile [`LlamaForCausalLM`] karşılaştırması). |
+| Preprocessor | Ham girdileri (metin, görüntü, ses, multimodal) modele uygun sayısal girdilere dönüştüren sınıf. Örneğin, [`PreTrainedTokenizer`] metni tensörlere, [`ImageProcessingMixin`] ise pikselleri tensörlere dönüştürür. |
+
+Modelleri ve ön işleyicileri yüklemek için [AutoClass](./model_doc/auto) API'sini kullanmanı öneriyoruz. Bu API, önceden eğitilmiş ağırlıkların ve yapılandırma dosyasının adına veya yoluna göre her görev ve makine öğrenmesi framework'ü için uygun mimariyi otomatik olarak belirler.
+
+Ağırlıkları ve yapılandırma dosyasını Hub'dan model ve ön işleyici sınıfına yüklemek için [`~PreTrainedModel.from_pretrained`] kullan.
+
+Bir model yüklerken, modelin en uygun şekilde yüklenmesini sağlamak için aşağıdaki parametreleri yapılandır.
+
+- `device_map="auto"` model ağırlıklarını otomatik olarak en hızlı cihazına atar.
+- `dtype="auto"` model ağırlıklarını doğrudan depolandıkları veri türünde başlatır ve ağırlıkların iki kez yüklenmesini önler (PyTorch varsayılan olarak ağırlıkları `torch.float32` ile yükler).
+
+```py
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b-hf", dtype="auto", device_map="auto")
+tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-hf")
+```
+
+Metni tokenizer ile tokenize et ve PyTorch tensörlerini döndür. Çıkarsama hızını artırmak için varsa modeli bir hızlandırıcıya taşı.
+
+```py
+model_inputs = tokenizer(["The secret to baking a good cake is "], return_tensors="pt").to(model.device)
+```
+
+Model artık çıkarsama veya eğitim için hazır.
+
+Çıkarsama için tokenize edilmiş girdileri [`~GenerationMixin.generate`] fonksiyonuna geçirerek metin üret. Token id'lerini [`~PreTrainedTokenizerBase.batch_decode`] ile tekrar metne dönüştür.
+
+```py
+generated_ids = model.generate(**model_inputs, max_length=30)
+tokenizer.batch_decode(generated_ids)[0]
+'<s> The secret to baking a good cake is 100% in the preparation. There are so many recipes out there,'
+```
+
+> [!TIP]
+> Bir modeli nasıl ince ayar yapacağını öğrenmek için [Trainer](#trainer-api) bölümüne atla.
+
+## Pipeline
+
+[`Pipeline`] sınıfı, önceden eğitilmiş bir modelle çıkarsama yapmanın en kolay yoludur. Metin üretimi, görüntü segmentasyonu, otomatik konuşma tanıma, belge soru yanıtlama ve daha birçok görevi destekler.
+
+> [!TIP]
+> Mevcut görevlerin tam listesi için [Pipeline](./main_classes/pipelines) API referansına bak.
+
+Bir [`Pipeline`] nesnesi oluştur ve bir görev seç. Varsayılan olarak [`Pipeline`], verilen görev için varsayılan bir önceden eğitilmiş modeli indirir ve önbelleğe alır. Belirli bir model seçmek için model adını `model` parametresine geçir.
+
+<hfoptions id="pipeline-tasks">
+<hfoption id="text generation">
+
+Çıkarsama için uygun bir hızlandırıcıyı otomatik olarak algılamak için [`Accelerator`] kullan.
+
+```py
+from transformers import pipeline
+from accelerate import Accelerator
+
+device = Accelerator().device
+
+pipeline = pipeline("text-generation", model="meta-llama/Llama-2-7b-hf", device=device)
+```
+
+Daha fazla metin üretmek için [`Pipeline`]'a başlangıç metni ver.
+
+```py
+pipeline("The secret to baking a good cake is ", max_length=50)
+[{'generated_text': 'The secret to baking a good cake is 100% in the batter. The secret to a great cake is the icing.\nThis is why we\'ve created the best buttercream frosting reci'}]
+```
+
+</hfoption>
+<hfoption id="image segmentation">
+
+Çıkarsama için uygun bir hızlandırıcıyı otomatik olarak algılamak için [`Accelerator`] kullan.
+
+```py
+from transformers import pipeline
+from accelerate import Accelerator
+
+device = Accelerator().device
+
+pipeline = pipeline("image-segmentation", model="facebook/detr-resnet-50-panoptic", device=device)
+```
+
+[`Pipeline`]'a bir görüntü geçir. Görüntü bir URL veya yerel dosya yolu olabilir.
+
+<div class="flex justify-center">
+   <img src="https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png"/>
+</div>
+
+```py
+segments = pipeline("https://huggingface.co/datasets/Narsil/image_dummy/raw/main/parrots.png")
+segments[0]["label"]
+'bird'
+segments[1]["label"]
+'bird'
+```
+
+</hfoption>
+<hfoption id="automatic speech recognition">
+
+Çıkarsama için uygun bir hızlandırıcıyı otomatik olarak algılamak için [`Accelerator`] kullan.
+
+```py
+from transformers import pipeline
+from accelerate import Accelerator
+
+device = Accelerator().device
+
+pipeline = pipeline("automatic-speech-recognition", model="openai/whisper-large-v3", device=device)
+```
+
+[`Pipeline`]'a bir ses dosyası geçir.
+
+```py
+pipeline("https://huggingface.co/datasets/Narsil/asr_dummy/resolve/main/1.flac")
+{'text': ' He hoped there would be stew for dinner, turnips and carrots and bruised potatoes and fat mutton pieces to be ladled out in thick, peppered flour-fatten sauce.'}
+```
+
+</hfoption>
+</hfoptions>
+
+## Trainer
+
+[`Trainer`], PyTorch modelleri için eksiksiz bir eğitim ve değerlendirme döngüsüdür. Bir eğitim döngüsünü elle yazmakla ilgili pek çok standart işlemi soyutlar, böylece daha hızlı eğitime başlayabilir ve eğitim tasarımı kararlarına odaklanabilirsin. Bir model, veri kümesi, ön işleyici ve veri kümesinden toplu veri oluşturmak için bir data collator'a ihtiyacın var.
+
+Eğitim sürecini özelleştirmek için [`TrainingArguments`] sınıfını kullan. Eğitim, değerlendirme ve daha fazlası için birçok seçenek sunar. Eğitim ihtiyaçlarını karşılamak için batch boyutu, öğrenme hızı, karışık hassasiyet (mixed precision), torch.compile ve daha fazlası gibi eğitim hiperparametreleri ve özellikleriyle deney yap. Ayrıca hızlıca bir temel sonuç elde etmek için varsayılan eğitim parametrelerini de kullanabilirsin.
+
+Eğitim için bir model, tokenizer ve veri kümesi yükle.
+
+```py
+from transformers import AutoModelForSequenceClassification, AutoTokenizer
+from datasets import load_dataset
+
+model = AutoModelForSequenceClassification.from_pretrained("distilbert/distilbert-base-uncased")
+tokenizer = AutoTokenizer.from_pretrained("distilbert/distilbert-base-uncased")
+dataset = load_dataset("rotten_tomatoes")
+```
+
+Metni tokenize etmek ve PyTorch tensörlerine dönüştürmek için bir fonksiyon oluştur. Bu fonksiyonu [`~datasets.Dataset.map`] metodu ile tüm veri kümesine uygula.
+
+```py
+def tokenize_dataset(dataset):
+    return tokenizer(dataset["text"])
+dataset = dataset.map(tokenize_dataset, batched=True)
+```
+
+Veri kümesinden toplu veri oluşturmak için bir data collator yükle ve tokenizer'ı geçir.
+
+```py
+from transformers import DataCollatorWithPadding
+
+data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
+```
+
+Sonra, eğitim özellikleri ve hiperparametreleri ile [`TrainingArguments`] ayarla.
+
+```py
+from transformers import TrainingArguments
+
+training_args = TrainingArguments(
+    output_dir="distilbert-rotten-tomatoes",
+    learning_rate=2e-5,
+    per_device_train_batch_size=8,
+    per_device_eval_batch_size=8,
+    num_train_epochs=2,
+    push_to_hub=True,
+)
+```
+
+Son olarak, tüm bu bileşenleri [`Trainer`]'a geçir ve eğitimi başlatmak için [`~Trainer.train`] fonksiyonunu çağır.
+
+```py
+from transformers import Trainer
+
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=dataset["train"],
+    eval_dataset=dataset["test"],
+    processing_class=tokenizer,
+    data_collator=data_collator,
+)
+
+trainer.train()
+```
+
+Modelini ve tokenizer'ını Hub'a paylaşmak için [`~Trainer.push_to_hub`] kullan.
+
+```py
+trainer.push_to_hub()
+```
+
+Tebrikler, Transformers ile ilk modelini eğittin!
+
+## Sonraki adımlar[[next-steps]]
+
+Artık Transformers'ı ve sunduklarını daha iyi anladığına göre, seni en çok ilgilendiren konuları keşfetmeye ve öğrenmeye devam etme zamanı.
+
+- **Temel sınıflar**: Yapılandırma, model ve işlemci sınıfları hakkında daha fazla bilgi edin. Bu, modelleri nasıl oluşturacağını ve özelleştireceğini, farklı girdi türlerini (ses, görüntü, multimodal) nasıl ön işleyeceğini ve modelini nasıl paylaşacağını anlamana yardımcı olacaktır.
+- **Çıkarsama**: [`Pipeline`] hakkında daha fazla keşfet, LLM'lerle çıkarsama ve sohbet, ajanlar ve makine öğrenmesi framework'ün ve donanımınla çıkarsama optimizasyonu konularını incele.
+- **Eğitim**: [`Trainer`]'ı daha ayrıntılı incele, dağıtık eğitim ve belirli donanımlarda eğitim optimizasyonu konularını öğren.
+- **Kuantizasyon**: Kuantizasyon ile bellek ve depolama gereksinimlerini azalt ve ağırlıkları daha az bit ile temsil ederek çıkarsama hızını artır.
+- **Kaynaklar**: Belirli bir görev için model eğitimi ve çıkarsama konusunda uçtan uca tarifler mi arıyorsun? Görev tariflerine göz at!


### PR DESCRIPTION
## Description

Re-creates the Turkish documentation that was accidentally removed during the TF/Flax cleanup (commit fce74651). This PR adds the foundational Turkish docs with the complete "Get Started" section.

### Files added
- `docs/source/tr/_toctree.yml` - Table of contents for Turkish docs
- `docs/source/tr/index.md` - Main landing page
- `docs/source/tr/quicktour.md` - Quick tour guide
- `docs/source/tr/installation.md` - Installation guide

### Workflow updates
- Added `tr` to the language list in `build_documentation.yml` and `build_pr_documentation.yml`

Fixes #27088 (partial)

cc @stevhliu @MKhalusova