### PR TITLE
Add anthropic style of function schema

### DIFF
--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -243,7 +243,7 @@ def parse_google_format_docstring(docstring: str) -> tuple[str | None, dict | No
     return description, args_dict, returns
 
 
-def get_json_schema(func: Callable) -> dict:
+def get_json_schema(func: Callable, style: str = "openai") -> dict:
     """
     This function generates a JSON schema for a given function, based on its docstring and type hints. This is
     mostly used for passing lists of tools to a chat template. The JSON schema contains the name and description of
@@ -257,9 +257,14 @@ def get_json_schema(func: Callable) -> dict:
 
     Args:
         func: The function to generate a JSON schema for.
+        style: The style of the JSON schema to generate. Can be "openai" (default) or "anthropic".
+            - "openai": Returns schema wrapped in {"type": "function", "function": {...}} format
+            - "anthropic": Returns schema in {"name": "...", "description": "...", "input_schema": {...}} format
 
     Returns:
-        A dictionary containing the JSON schema for the function.
+        A dictionary containing the JSON schema for the function. The format depends on the style parameter:
+        - For "openai" style: {"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
+        - For "anthropic" style: {"name": "...", "description": "...", "input_schema": {...}}
 
     Examples:
     ```python
@@ -375,10 +380,19 @@ def get_json_schema(func: Callable) -> dict:
             desc = enum_choices.string[: enum_choices.start()].strip()
         schema["description"] = desc
 
-    output = {"name": func_name, "description": main_doc, "parameters": json_schema}
-    if return_dict is not None:
-        output["return"] = return_dict
-    return {"type": "function", "function": output}
+    if style == "anthropic":
+        # Anthropic style uses 'input_schema' instead of 'parameters' and doesn't wrap in "function" key
+        return {
+            "name": func_name,
+            "description": main_doc,
+            "input_schema": json_schema
+        }
+    else:
+        # OpenAI style
+        output = {"name": func_name, "description": main_doc, "parameters": json_schema}
+        if return_dict is not None:
+            output["return"] = return_dict
+        return {"type": "function", "function": output}
 
 
 @lru_cache

--- a/src/transformers/utils/chat_template_utils.py
+++ b/src/transformers/utils/chat_template_utils.py
@@ -382,11 +382,7 @@ def get_json_schema(func: Callable, style: str = "openai") -> dict:
 
     if style == "anthropic":
         # Anthropic style uses 'input_schema' instead of 'parameters' and doesn't wrap in "function" key
-        return {
-            "name": func_name,
-            "description": main_doc,
-            "input_schema": json_schema
-        }
+        return {"name": func_name, "description": main_doc, "input_schema": json_schema}
     else:
         # OpenAI style
         output = {"name": func_name, "description": main_doc, "parameters": json_schema}


### PR DESCRIPTION
# What does this PR do?

This PR adds support for [Anthropic's JSON function style](https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools):

`{"name": "...", "description": "...", "input_schema": {...}}`



## Usage Example - Anthropic Demo

```py
import anthropic
from transformers.utils import get_json_schema

def multiply(a: float, b: float) -> float:
    """
    A function that multiplies two numbers

    Args:
        a: The first number to multiply
        b: The second number to multiply
    """
    return a * b

anthropic_tools = [get_json_schema(multiply, style="anthropic")]  #

client = anthropic.Anthropic()
response = client.messages.create(
    model="claude",
    max_tokens=1024,
    tools=anthropic_tools,
    messages=messages,
)
```

## Related Implementations

[vLLM supports Anthropic format](https://github.com/vllm-project/vllm/blob/v0.19.0/vllm/entrypoints/anthropic/serving.py#L132)
```py
    def _convert_anthropic_to_openai_request(
        cls, anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest
    ) -> ChatCompletionRequest:
        """Convert Anthropic message format to OpenAI format"""
        ...
        cls._convert_tools(anthropic_request, req)
        return req


    def _convert_tools(
        cls,
        anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
        req: ChatCompletionRequest,
    ) -> None:
        """Convert Anthropic tools to OpenAI format"""
        ...
        for tool in anthropic_request.tools:
            tools.append(
                ChatCompletionToolsParam.model_validate(
                    {
                        "type": "function",
                        "function": {
                            "name": tool.name,
                            "description": tool.description,
                            "parameters": tool.input_schema,
                        },
                    }
                )
            )
```

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

- tokenizers: @ArthurZucker and @itazap

