### PR TITLE
Fix explicit local code resolution for tokenizers and image processors

### DIFF
--- a/src/transformers/models/auto/image_processing_auto.py
+++ b/src/transformers/models/auto/image_processing_auto.py
@@ -725,7 +725,7 @@ class AutoImageProcessor:
         has_remote_code = image_processor_auto_map is not None
         has_local_code = image_processor_class is not None or type(config) in IMAGE_PROCESSOR_MAPPING
         explicit_local_code = has_local_code and not (
-            image_processor_class or IMAGE_PROCESSOR_MAPPING[type(config)]
+            image_processor_class or _load_class_with_fallback(IMAGE_PROCESSOR_MAPPING[type(config)], backend)
         ).__module__.startswith("transformers.")
         if has_remote_code:
             class_ref = _resolve_auto_map_class_ref(image_processor_auto_map, backend)

--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -738,11 +738,15 @@ class AutoTokenizer:
                 or tokenizer_class_from_name(tokenizer_config_class + "Fast") is not None
             )
         )
-        explicit_local_code = has_local_code and (
-            tokenizer_config_class is not None
-            and not (
-                tokenizer_class_from_name(tokenizer_config_class).__module__.startswith("transformers.")
-                and tokenizer_class_from_name(tokenizer_config_class + "Fast").__module__.startswith("transformers.")
+        explicit_local_code = (
+            has_local_code
+            and type(config) not in TOKENIZER_MAPPING
+            and (
+                tokenizer_config_class is not None
+                and not (
+                    tokenizer_class_from_name(tokenizer_config_class)
+                    or tokenizer_class_from_name(tokenizer_config_class + "Fast")
+                ).__module__.startswith("transformers.")
             )
         )
         # V5: Skip remote tokenizer for custom models with incorrect hub tokenizer class


### PR DESCRIPTION
In https://github.com/huggingface/transformers/pull/45094 I introduced some errors to the remote code resolution when trying to detect if local code belonged to Transformers or not.

These tests were:

```bash
pytest tests/models/cohere_asr/test_modeling_cohere_asr.py::CohereAsrIntegrationTest::test_longform_english
pytest tests/models/cohere_asr/test_modeling_cohere_asr.py::CohereAsrIntegrationTest::test_non_english_with_punctuation
pytest tests/models/pp_ocrv5_mobile_rec/test_modeling_pp_ocrv5_mobile_rec.py::PPOCRV5MobileRecModelIntegrationTest::test_inference_text_recognition_head
pytest tests/models/pp_ocrv5_server_rec/test_modeling_pp_ocrv5_server_rec.py::PPOCRV5ServerRecModelIntegrationTest::test_inference_text_recognition_head
pytest tests/models/slanext/test_modeling_slanext.py::SLANeXtModelIntegrationTest::test_inference_table_recognition_head
pytest tests/models/timm_wrapper/test_modeling_timm_wrapper.py::TimmWrapperModelIntegrationTest::test_inference_with_pipeline
```

This PR fixes all of these.

(The timm test still appears to fail, but not for the reason that was caused by the linked PR)