### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -16,14 +16,14 @@ jobs:
     name: "Add new model like template tests"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install dependencies
         run: |
           sudo apt -y update && sudo apt install -y libsndfile1-dev
 
       - name: Load cached virtual environment
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
         id: cache
         with:
           path: ~/venv/
@@ -74,7 +74,7 @@ jobs:
 
       - name: Test suite reports artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: run_all_tests_new_models_test_reports
           path: reports/tests_new_models

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -11,9 +11,9 @@ jobs:
        pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.13'
       - name: Install dependencies

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -32,7 +32,7 @@ jobs:
       options: --gpus all --privileged --ipc host
     steps:
       - name: Get repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/build-ci-docker-images.yml
+++ b/.github/workflows/build-ci-docker-images.yml
@@ -42,19 +42,19 @@ jobs:
               fi
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
       -
         name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       -
         name: Login to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       -
         name: Build ${{ matrix.file }}.dockerfile
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           context: ./docker
           build-args: |
@@ -69,7 +69,7 @@ jobs:
     steps:
       - name: Post to Slack
         if: ${{ contains(github.event.head_commit.message, '[push-ci-image]') && github.event_name != 'schedule' }}
-        uses: huggingface/hf-workflows/.github/actions/post-slack@main
+        uses: huggingface/hf-workflows/.github/actions/post-slack@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
         with:
           slack_channel: "#transformers-ci-circleci-images"
           title: 🤗 New docker images for CircleCI are pushed.

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.sha }}
       package: transformers
@@ -23,7 +23,7 @@ jobs:
       hf_token: ${{ secrets.HF_DOC_BUILD_PUSH }}
 
    build_other_lang:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.sha }}
       package: transformers

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   build:
     if: github.event_name == 'pull_request'
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/check-workflow-permissions.yml
+++ b/.github/workflows/check-workflow-permissions.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   advisor:
-    uses: huggingface/security-workflows/.github/workflows/permissions-advisor-reusable.yml@main
+    uses: huggingface/security-workflows/.github/workflows/permissions-advisor-reusable.yml@1b6a139c28db347498b30338da6a602e0a06f56c  # main
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/circleci-failure-summary-comment.yml
+++ b/.github/workflows/circleci-failure-summary-comment.yml
@@ -15,10 +15,10 @@ jobs:
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.13"
 
@@ -177,7 +177,7 @@ jobs:
         if: steps.circleci.outputs.artifact_found == 'true'
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
         with:
           script: |
             const PR_NUMBER = parseInt(process.env.PR_NUMBER, 10);

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   codeql:
     name: CodeQL Analysis
-    uses: huggingface/security-workflows/.github/workflows/codeql-reusable.yml@main
+    uses: huggingface/security-workflows/.github/workflows/codeql-reusable.yml@1b6a139c28db347498b30338da6a602e0a06f56c  # main
     permissions:
       security-events: write
       packages: read

--- a/.github/workflows/extras-smoke-test.yml
+++ b/.github/workflows/extras-smoke-test.yml
@@ -15,7 +15,7 @@ jobs:
       versions: ${{ steps.extract-versions.outputs.versions }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install setuptools
         run: |
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: ${{ matrix.python-version }}
           allow-prereleases: true
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload failure report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: failure-report-${{ matrix.python-version }}
           path: failure_reports/
@@ -130,15 +130,15 @@ jobs:
     if: always() && needs.precheck-slack.outputs.has_slack_token == 'true' && needs.test-extras.result != 'success'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: '3.11'
 
       - name: Download all failure reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           pattern: failure-report-*
           path: failure_reports/

--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: "Test suite reports artifacts: ${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports"
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: ${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
           path: /transformers/reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports
@@ -207,7 +207,7 @@ jobs:
     name: Collated Reports
     if: ${{ always() && inputs.runner_type != '' }}
     needs: run_models_gpu
-    uses: huggingface/transformers/.github/workflows/collated-reports.yml@main
+    uses: huggingface/transformers/.github/workflows/collated-reports.yml@6abd9725ee7d809dc974991f8ff6c958afb63a3a  # main
     with:
       job: run_models_gpu
       report_repo_id: ${{ inputs.report_repo_id }}

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install miniconda
-        uses: conda-incubator/setup-miniconda@v2
+        uses: conda-incubator/setup-miniconda@9f54435e0e72c53962ee863144e47a4b094bfd35  # v2
         with:
           auto-update-conda: true
           auto-activate-base: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     name: build release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.13"
 
@@ -31,7 +31,7 @@ jobs:
       - run: python -c "from transformers import pipeline; classifier = pipeline('text-classification'); assert classifier('What a nice release')[0]['score'] > 0"
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
           name: python-dist
           path: |
@@ -47,14 +47,14 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           name: python-dist
           path: .
 
       - name: Publish package distributions to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e  # release/v1
 

--- a/.github/workflows/self-scheduled-amd-mi250-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi250-caller.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   model-ci:
     name: Model CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_models_gpu
       slack_report_channel: "#transformers-ci-daily-amd"
@@ -24,7 +24,7 @@ jobs:
 
   torch-pipeline:
     name: Torch pipeline CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_pipelines_torch_gpu
       slack_report_channel: "#transformers-ci-daily-amd"
@@ -36,7 +36,7 @@ jobs:
 
   example-ci:
     name: Example CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_examples_gpu
       slack_report_channel: "#transformers-ci-daily-amd"
@@ -48,7 +48,7 @@ jobs:
 
   deepspeed-ci:
     name: DeepSpeed CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_torch_cuda_extensions_gpu
       slack_report_channel: "#transformers-ci-daily-amd"

--- a/.github/workflows/self-scheduled-amd-mi325-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi325-caller.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   model-ci:
     name: Model CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_models_gpu
       slack_report_channel: "#amd-hf-ci"
@@ -29,7 +29,7 @@ jobs:
 
   torch-pipeline:
     name: Torch pipeline CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_pipelines_torch_gpu
       slack_report_channel: "#amd-hf-ci"
@@ -42,7 +42,7 @@ jobs:
 
   example-ci:
     name: Example CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_examples_gpu
       slack_report_channel: "#amd-hf-ci"
@@ -55,7 +55,7 @@ jobs:
 
   deepspeed-ci:
     name: DeepSpeed CI
-    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@main
+    uses: huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml@a88e7fa2eaee28de5a4d6142381b1fb792349b67  # main
     with:
       job: run_torch_cuda_extensions_gpu
       slack_report_channel: "#amd-hf-ci"

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -169,7 +169,7 @@ jobs:
           fi
         
       - name: Tailscale # In order to be able to SSH when a test fails
-        uses: huggingface/tailscale-action@main
+        uses: huggingface/tailscale-action@7d53c9737e53934c30290b5524d1c9b4a7c98c8a  # main
         with:
           authkey: ${{ secrets.TAILSCALE_SSH_AUTHKEY }}
           slackChannel: ${{ env.SLACKCHANNEL }}

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
       - name: Secret Scanning
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main
         with:
           extra_args: --results=verified,unknown

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       package_name: transformers
     secrets:


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `add-model-like.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `add-model-like.yml` | `actions/cache` | `v4` | `v4` | `0057852bfaa8…` |
| `add-model-like.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `benchmark.yml` | `actions/checkout` | `v5` | `v6.0.2` | `de0fac2e4500…` |
| `extras-smoke-test.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `extras-smoke-test.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `extras-smoke-test.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `extras-smoke-test.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `extras-smoke-test.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `extras-smoke-test.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `extras-smoke-test.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `circleci-failure-summary-comment.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `circleci-failure-summary-comment.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `circleci-failure-summary-comment.yml` | `actions/github-script` | `v7` | `v7` | `f28e40c7f34b…` |
| `assign-reviewers.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `assign-reviewers.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `release-conda.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `release-conda.yml` | `conda-incubator/setup-miniconda` | `v2` | `v2` | `9f54435e0e72…` |
| `build-ci-docker-images.yml` | `docker/setup-buildx-action` | `v3` | `v3` | `8d2750c68a42…` |
| `build-ci-docker-images.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `build-ci-docker-images.yml` | `docker/login-action` | `v3` | `v3` | `c94ce9fb4685…` |
| `build-ci-docker-images.yml` | `docker/build-push-action` | `v5` | `v5` | `ca052bb54ab0…` |
| `build-ci-docker-images.yml` | `huggingface/hf-workflows/.github/actions/post-slack` | `main` | `main` | `a88e7fa2eaee…` |
| `build_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_main_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `build_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_main_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `build_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/build_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `upload_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `self-scheduled-amd-mi250-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi250-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi250-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi250-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi325-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi325-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi325-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `self-scheduled-amd-mi325-caller.yml` | `huggingface/hf-workflows/.github/workflows/transformers_amd_ci_scheduled_arc_scale_set.yaml` | `main` | `main` | `a88e7fa2eaee…` |
| `codeql.yml` | `huggingface/security-workflows/.github/workflows/codeql-reusable.yml` | `main` | `main` | `1b6a139c28db…` |
| `check-workflow-permissions.yml` | `huggingface/security-workflows/.github/workflows/permissions-advisor-reusable.yml` | `main` | `main` | `1b6a139c28db…` |
| `ssh-runner.yml` | `huggingface/tailscale-action` | `main` | `main` | `7d53c9737e53…` |
| `model_jobs.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `model_jobs.yml` | `huggingface/transformers/.github/workflows/collated-reports.yml` | `main` | `main` | `6abd9725ee7d…` |
| `release.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `release.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `release.yml` | `actions/upload-artifact` | `v4` | `v4` | `ea165f8d65b6…` |
| `release.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `release.yml` | `actions/download-artifact` | `v4` | `v4` | `d3f86a106a0b…` |
| `release.yml` | `pypa/gh-action-pypi-publish` | `release/v1` | `release/v1` | `ed0c53931b1d…` |
| `trufflehog.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `trufflehog.yml` | `trufflesecurity/trufflehog` | `main` | `main` | `6bd2d14f7a4b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]

---
Closes #45182

Closes huggingface/tracking-issues#43