### PR TITLE
fix `test_register_result_handler`

### DIFF
--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -847,11 +847,11 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
         inputs = get_generation_inputs(user_messages, tokenizer, for_continuous_batching=True)[0]
 
         async def collect_results():
-            results = []
+            token_counts = []
             future = asyncio.get_running_loop().create_future()
 
             def on_result(output):
-                results.append(output)
+                token_counts.append(len(output.generated_tokens))
                 if output.is_finished():
                     future.set_result(True)
 
@@ -859,15 +859,12 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
             manager.register_result_handler(request_id, on_result)
 
             await asyncio.wait_for(future, timeout=30)
-            return results
+            return token_counts
 
-        results = asyncio.run(collect_results())
+        token_counts = asyncio.run(collect_results())
 
         # Streaming via handler: incremental token count, same as request_id_iter
-        self.assertEqual(len(results[0].generated_tokens), 1)
-        self.assertEqual(len(results[1].generated_tokens), 2)
-        self.assertEqual(len(results[2].generated_tokens), 3)
-        self.assertTrue(results[-1].is_finished())
+        self.assertEqual(token_counts, [1, 2, 3])
         # Queue should be empty — everything went through the handler
         self.assertTrue(manager.output_router.output_queue.empty())
 


### PR DESCRIPTION
# What does this PR do ? 

This PR fixes the `test_register_result_handler`. Not sure how it passed in the past when i added it but since CB returns `generated_tokens` from the same list to avoid copy, len(results[i].generated_tokens) for i =0,1,2 will always be the same after the got all the results. I reworked a bit the test to properly test. 