### PR TITLE
[Gemma4] Add docstrings for Per-Layer Embeddings (PLE) pipeline

### DIFF
--- a/docs/source/en/model_doc/gemma4.md
+++ b/docs/source/en/model_doc/gemma4.md
@@ -57,6 +57,24 @@ To encode positional information for each patch in the image, Gemma 4 uses a lea
 
 
 
+### Per-Layer Embeddings (PLE)
+
+Gemma 4 introduces a **Per-Layer Embeddings (PLE)** system that feeds an auxiliary residual signal into each decoder layer, rather than relying solely on a single shared embedding at the input.
+
+#### Key config parameters
+
+- `vocab_size_per_layer_input` (default 262144): vocabulary size for PLE.
+- `hidden_size_per_layer_input` (default 256): per-layer embedding dimension. The actual embedding weight has shape `[vocab_size_per_layer_input, num_hidden_layers * hidden_size_per_layer_input]` (e.g. `[262144, 8960]` for 35 layers × 256 dims) because all layers are packed into a single embedding table.
+
+#### Pipeline
+
+PLE combines two components that are summed and scaled by `1/√2` before being fed to each decoder layer:
+
+1. **Token-identity** (`get_per_layer_inputs`): looks up `input_ids` in `embed_tokens_per_layer`, a `Gemma4TextScaledWordEmbedding` that multiplies by `√(hidden_size_per_layer_input)`. The packed output is reshaped from `[batch, seq, num_hidden_layers * hidden_size_per_layer_input]` to `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`.
+2. **Context-aware** (`project_per_layer_inputs`): projects `inputs_embeds` through `per_layer_model_projection` (a Linear layer), scales by `1/√(hidden_size)`, reshapes to `[batch, seq, num_layers, ple_dim]`, and normalizes with `per_layer_projection_norm` (RMSNorm).
+
+When both components are available, the final per-layer input is `(token_identity + context_aware) * (1/√2)`. For multimodal inputs where `input_ids` are not available, only the context-aware projection is used.
+
 ## Usage examples
 
 The example below demonstrates how to generate text based on an image with [`Pipeline`] or the [`AutoModel`] class.

--- a/docs/source/en/model_doc/gemma4.md
+++ b/docs/source/en/model_doc/gemma4.md
@@ -59,19 +59,12 @@ To encode positional information for each patch in the image, Gemma 4 uses a lea
 
 ### Per-Layer Embeddings (PLE)
 
-Gemma 4 introduces a **Per-Layer Embeddings (PLE)** system that feeds an auxiliary residual signal into each decoder layer, rather than relying solely on a single shared embedding at the input.
-
-#### Key config parameters
-
-- `vocab_size_per_layer_input` (default 262144): vocabulary size for PLE.
-- `hidden_size_per_layer_input` (default 256): per-layer embedding dimension. The actual embedding weight has shape `[vocab_size_per_layer_input, num_hidden_layers * hidden_size_per_layer_input]` (e.g. `[262144, 8960]` for 35 layers × 256 dims) because all layers are packed into a single embedding table.
-
-#### Pipeline
+Gemma 4 introduces a Per-Layer Embeddings (PLE) system that feeds an auxiliary residual signal into each decoder layer, rather than relying solely on a single shared embedding at the input.
 
 PLE combines two components that are summed and scaled by `1/√2` before being fed to each decoder layer:
 
-1. **Token-identity** (`get_per_layer_inputs`): looks up `input_ids` in `embed_tokens_per_layer`, a `Gemma4TextScaledWordEmbedding` that multiplies by `√(hidden_size_per_layer_input)`. The packed output is reshaped from `[batch, seq, num_hidden_layers * hidden_size_per_layer_input]` to `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`.
-2. **Context-aware** (`project_per_layer_inputs`): projects `inputs_embeds` through `per_layer_model_projection` (a Linear layer), scales by `1/√(hidden_size)`, reshapes to `[batch, seq, num_layers, ple_dim]`, and normalizes with `per_layer_projection_norm` (RMSNorm).
+1. Token-identity (`get_per_layer_inputs`): looks up `input_ids` in `embed_tokens_per_layer`, a `Gemma4TextScaledWordEmbedding` that multiplies by `√(hidden_size_per_layer_input)`. The packed output is reshaped from `[batch, seq, num_hidden_layers * hidden_size_per_layer_input]` to `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`.
+2. Context-aware (`project_per_layer_inputs`): projects `inputs_embeds` through `per_layer_model_projection` (a Linear layer), scales by `1/√(hidden_size)`, reshapes to `[batch, seq, num_layers, ple_dim]`, and normalizes with `per_layer_projection_norm` (RMSNorm).
 
 When both components are available, the final per-layer input is `(token_identity + context_aware) * (1/√2)`. For multimodal inputs where `input_ids` are not available, only the context-aware projection is used.
 

--- a/src/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/transformers/models/gemma4/configuration_gemma4.py
@@ -94,19 +94,10 @@ class Gemma4TextConfig(PreTrainedConfig):
         Vocabulary size for the per-layer input embeddings (PLE). Used by models with
         per-layer residual streams where a smaller embedding is added at each decoder layer.
     hidden_size_per_layer_input (`int`, defaults to 256):
-        Per-layer hidden dimension for the per-layer input embeddings (PLE). This is the
-        dimension of each layer's individual embedding slice. Note: the actual embedding
-        weight has shape `[vocab_size_per_layer_input, num_hidden_layers * hidden_size_per_layer_input]`
-        (e.g. `[262144, 8960]` for 35 layers x 256 dims) because all layers are packed into
-        a single embedding table. The embedding is also a `Gemma4TextScaledWordEmbedding`
-        that scales lookups by `sqrt(hidden_size_per_layer_input)`.
-
-        The full PLE pipeline in `Gemma4TextModel` combines two components:
-        1. **Token-identity**: `embed_tokens_per_layer(input_ids)` (scaled), reshaped to
-           `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`
-        2. **Context-aware**: `per_layer_model_projection(inputs_embeds)` scaled by
-           `1/sqrt(hidden_size)`, reshaped, then normalized by `per_layer_projection_norm`
-        These are summed and scaled by `1/sqrt(2)` before being passed to each decoder layer.
+        Per-layer hidden dimension for the PLE system. The actual embedding weight has shape
+        `[vocab_size_per_layer_input, num_hidden_layers * hidden_size_per_layer_input]`
+        because all layers are packed into a single table. See the [Gemma4](https://huggingface.co/docs/transformers/main/en/model_doc/gemma4#per-layer-embeddings-ple) docs
+        for a description of the full PLE pipeline.
     num_global_key_value_heads (`int`, *optional*):
         Number of key-value heads for global (full) attention layers. If `None`, defaults
         to `num_key_value_heads`.

--- a/src/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/transformers/models/gemma4/configuration_gemma4.py
@@ -91,11 +91,22 @@ class Gemma4TextConfig(PreTrainedConfig):
         attend bidirectionally while text tokens use causal attention. When set to `"all"`,
         all tokens use bidirectional attention.
     vocab_size_per_layer_input (`int`, defaults to 262144):
-        Vocabulary size for the per-layer input embeddings. Used by models with per-layer
-        residual streams where a smaller embedding is added at each decoder layer.
+        Vocabulary size for the per-layer input embeddings (PLE). Used by models with
+        per-layer residual streams where a smaller embedding is added at each decoder layer.
     hidden_size_per_layer_input (`int`, defaults to 256):
-        Hidden dimension for the per-layer input embeddings. Controls the width of the
-        per-layer residual embedding vectors.
+        Per-layer hidden dimension for the per-layer input embeddings (PLE). This is the
+        dimension of each layer's individual embedding slice. Note: the actual embedding
+        weight has shape `[vocab_size_per_layer_input, num_hidden_layers * hidden_size_per_layer_input]`
+        (e.g. `[262144, 8960]` for 35 layers x 256 dims) because all layers are packed into
+        a single embedding table. The embedding is also a `Gemma4TextScaledWordEmbedding`
+        that scales lookups by `sqrt(hidden_size_per_layer_input)`.
+
+        The full PLE pipeline in `Gemma4TextModel` combines two components:
+        1. **Token-identity**: `embed_tokens_per_layer(input_ids)` (scaled), reshaped to
+           `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`
+        2. **Context-aware**: `per_layer_model_projection(inputs_embeds)` scaled by
+           `1/sqrt(hidden_size)`, reshaped, then normalized by `per_layer_projection_norm`
+        These are summed and scaled by `1/sqrt(2)` before being passed to each decoder layer.
     num_global_key_value_heads (`int`, *optional*):
         Number of key-value heads for global (full) attention layers. If `None`, defaults
         to `num_key_value_heads`.

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1513,9 +1513,6 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         self.gradient_checkpointing = False
         self.unique_layer_types = set(self.config.layer_types)
 
-        # Per-Layer Embeddings (PLE): auxiliary embedding that feeds a residual signal
-        # into each decoder layer. See `get_per_layer_inputs()` and `project_per_layer_inputs()`
-        # for the full pipeline. The embedding is packed: total dim = num_layers * per_layer_dim.
         self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
         if self.hidden_size_per_layer_input:
             self.embed_tokens_per_layer = Gemma4TextScaledWordEmbedding(
@@ -1623,16 +1620,6 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         )
 
     def get_per_layer_inputs(self, input_ids: torch.Tensor | None, inputs_embeds: torch.Tensor | None) -> torch.Tensor:
-        """Compute the token-identity component of Per-Layer Embeddings (PLE).
-
-        Looks up `input_ids` in `embed_tokens_per_layer` (a scaled embedding that multiplies
-        by `sqrt(hidden_size_per_layer_input)`) and reshapes the packed output from
-        `[batch, seq, num_hidden_layers * hidden_size_per_layer_input]` to
-        `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`.
-
-        If only `inputs_embeds` is provided (no `input_ids`), reverses the main embedding
-        to recover `input_ids` for the PLE lookup.
-        """
         if not self.hidden_size_per_layer_input:
             raise RuntimeError(
                 "Attempting to call get_per_layer_inputs() from a model initialized with a config that does not support"
@@ -1671,17 +1658,6 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         inputs_embeds: torch.Tensor,
         per_layer_inputs: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        """Compute the context-aware component of PLE and combine with token-identity.
-
-        Projects `inputs_embeds` through `per_layer_model_projection` (Linear), scales by
-        `1/sqrt(hidden_size)`, reshapes to `[batch, seq, num_layers, ple_dim]`, and normalizes
-        with `per_layer_projection_norm` (RMSNorm).
-
-        If `per_layer_inputs` (the token-identity component from `get_per_layer_inputs()`)
-        is provided, combines both: `(context_projection + token_identity) * (1/sqrt(2))`.
-        If `per_layer_inputs` is None (e.g. for multimodal inputs where input_ids are not
-        available), returns just the context projection.
-        """
         if not self.hidden_size_per_layer_input:
             raise RuntimeError(
                 "Attempting to call project_per_layer_inputs() from a model initialized with a config that does not"

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1513,6 +1513,9 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         self.gradient_checkpointing = False
         self.unique_layer_types = set(self.config.layer_types)
 
+        # Per-Layer Embeddings (PLE): auxiliary embedding that feeds a residual signal
+        # into each decoder layer. See `get_per_layer_inputs()` and `project_per_layer_inputs()`
+        # for the full pipeline. The embedding is packed: total dim = num_layers * per_layer_dim.
         self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
         if self.hidden_size_per_layer_input:
             self.embed_tokens_per_layer = Gemma4TextScaledWordEmbedding(
@@ -1620,6 +1623,16 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         )
 
     def get_per_layer_inputs(self, input_ids: torch.Tensor | None, inputs_embeds: torch.Tensor | None) -> torch.Tensor:
+        """Compute the token-identity component of Per-Layer Embeddings (PLE).
+
+        Looks up `input_ids` in `embed_tokens_per_layer` (a scaled embedding that multiplies
+        by `sqrt(hidden_size_per_layer_input)`) and reshapes the packed output from
+        `[batch, seq, num_hidden_layers * hidden_size_per_layer_input]` to
+        `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`.
+
+        If only `inputs_embeds` is provided (no `input_ids`), reverses the main embedding
+        to recover `input_ids` for the PLE lookup.
+        """
         if not self.hidden_size_per_layer_input:
             raise RuntimeError(
                 "Attempting to call get_per_layer_inputs() from a model initialized with a config that does not support"
@@ -1658,6 +1671,17 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         inputs_embeds: torch.Tensor,
         per_layer_inputs: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        """Compute the context-aware component of PLE and combine with token-identity.
+
+        Projects `inputs_embeds` through `per_layer_model_projection` (Linear), scales by
+        `1/sqrt(hidden_size)`, reshapes to `[batch, seq, num_layers, ple_dim]`, and normalizes
+        with `per_layer_projection_norm` (RMSNorm).
+
+        If `per_layer_inputs` (the token-identity component from `get_per_layer_inputs()`)
+        is provided, combines both: `(context_projection + token_identity) * (1/sqrt(2))`.
+        If `per_layer_inputs` is None (e.g. for multimodal inputs where input_ids are not
+        available), returns just the context projection.
+        """
         if not self.hidden_size_per_layer_input:
             raise RuntimeError(
                 "Attempting to call project_per_layer_inputs() from a model initialized with a config that does not"

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -1227,6 +1227,9 @@ class Gemma4TextModel(Gemma3TextModel):
         self.rotary_emb = Gemma4TextRotaryEmbedding(config)
         self.unique_layer_types = set(self.config.layer_types)
 
+        # Per-Layer Embeddings (PLE): auxiliary embedding that feeds a residual signal
+        # into each decoder layer. See `get_per_layer_inputs()` and `project_per_layer_inputs()`
+        # for the full pipeline. The embedding is packed: total dim = num_layers * per_layer_dim.
         self.hidden_size_per_layer_input = config.hidden_size_per_layer_input
         if self.hidden_size_per_layer_input:
             self.embed_tokens_per_layer = Gemma4TextScaledWordEmbedding(
@@ -1245,6 +1248,16 @@ class Gemma4TextModel(Gemma3TextModel):
             self.per_layer_projection_norm = Gemma4RMSNorm(config.hidden_size_per_layer_input, eps=config.rms_norm_eps)
 
     def get_per_layer_inputs(self, input_ids: torch.Tensor | None, inputs_embeds: torch.Tensor | None) -> torch.Tensor:
+        """Compute the token-identity component of Per-Layer Embeddings (PLE).
+
+        Looks up `input_ids` in `embed_tokens_per_layer` (a scaled embedding that multiplies
+        by `sqrt(hidden_size_per_layer_input)`) and reshapes the packed output from
+        `[batch, seq, num_hidden_layers * hidden_size_per_layer_input]` to
+        `[batch, seq, num_hidden_layers, hidden_size_per_layer_input]`.
+
+        If only `inputs_embeds` is provided (no `input_ids`), reverses the main embedding
+        to recover `input_ids` for the PLE lookup.
+        """
         if not self.hidden_size_per_layer_input:
             raise RuntimeError(
                 "Attempting to call get_per_layer_inputs() from a model initialized with a config that does not support"
@@ -1283,6 +1296,17 @@ class Gemma4TextModel(Gemma3TextModel):
         inputs_embeds: torch.Tensor,
         per_layer_inputs: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        """Compute the context-aware component of PLE and combine with token-identity.
+
+        Projects `inputs_embeds` through `per_layer_model_projection` (Linear), scales by
+        `1/sqrt(hidden_size)`, reshapes to `[batch, seq, num_layers, ple_dim]`, and normalizes
+        with `per_layer_projection_norm` (RMSNorm).
+
+        If `per_layer_inputs` (the token-identity component from `get_per_layer_inputs()`)
+        is provided, combines both: `(context_projection + token_identity) * (1/sqrt(2))`.
+        If `per_layer_inputs` is None (e.g. for multimodal inputs where input_ids are not
+        available), returns just the context projection.
+        """
         if not self.hidden_size_per_layer_input:
             raise RuntimeError(
                 "Attempting to call project_per_layer_inputs() from a model initialized with a config that does not"


### PR DESCRIPTION
Fixes #45206

## What does this PR do?

Adds documentation for the Gemma4 Per-Layer Embeddings (PLE) system, which is currently pretty hard to reverse-engineer from the code alone.

I ran into this while implementing Gemma4 inference from scratch in Rust. The PLE system has several non-obvious aspects that aren't documented anywhere:

1. `hidden_size_per_layer_input` (256) is the per-layer dimension, but the actual embedding weight is `[vocab, num_layers * 256]` = `[262144, 8960]` because all layers are packed
2. The embedding is a `Gemma4TextScaledWordEmbedding` that silently multiplies by `sqrt(256) = 16` - this took me a while to track down
3. The full pipeline has a context-aware projection step (`per_layer_model_projection` + scale + RMSNorm) that combines with the token lookup before being passed to layers, with specific scale factors (`1/sqrt(hidden_size)` and `1/sqrt(2)`)

This PR adds:
- Expanded config docstring for `hidden_size_per_layer_input` explaining the packed layout, scaling, and full pipeline
- Docstrings for `get_per_layer_inputs()` and `project_per_layer_inputs()`
- A comment on the PLE init block pointing to the pipeline methods

Hopefully this saves some pain for others implementing Gemma4 outside of transformers.