### PR TITLE
fix(gemma3, gemma4): default token_type_ids to zeros for text-only training

### DIFF
--- a/src/transformers/models/gemma3/modeling_gemma3.py
+++ b/src/transformers/models/gemma3/modeling_gemma3.py
@@ -751,7 +751,9 @@ def create_causal_mask_mapping(
     Uses `pixel_values` as an optional input to disambiguate edge cases.
     """
     if is_training and token_type_ids is None:
-        raise ValueError("`token_type_ids` is required as a model input when training")
+        token_type_ids = torch.zeros(
+            inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device
+        )
 
     mask_kwargs = {
         "config": config.get_text_config(),

--- a/src/transformers/models/gemma3/modular_gemma3.py
+++ b/src/transformers/models/gemma3/modular_gemma3.py
@@ -624,7 +624,9 @@ def create_causal_mask_mapping(
     Uses `pixel_values` as an optional input to disambiguate edge cases.
     """
     if is_training and token_type_ids is None:
-        raise ValueError("`token_type_ids` is required as a model input when training")
+        token_type_ids = torch.zeros(
+            inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device
+        )
 
     mask_kwargs = {
         "config": config.get_text_config(),

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2002,7 +2002,9 @@ def create_causal_mask_mapping(
     Uses `pixel_values` as an optional input to disambiguate edge cases.
     """
     if is_training and mm_token_type_ids is None:
-        raise ValueError("`mm_token_type_ids` is required as a model input when training")
+        mm_token_type_ids = torch.zeros(
+            inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device
+        )
 
     mask_kwargs = {
         "config": config.get_text_config(),

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -1624,7 +1624,9 @@ def create_causal_mask_mapping(
     Uses `pixel_values` as an optional input to disambiguate edge cases.
     """
     if is_training and mm_token_type_ids is None:
-        raise ValueError("`mm_token_type_ids` is required as a model input when training")
+        mm_token_type_ids = torch.zeros(
+            inputs_embeds.shape[:2], dtype=torch.long, device=inputs_embeds.device
+        )
 
     mask_kwargs = {
         "config": config.get_text_config(),


### PR DESCRIPTION
## Summary

When using Gemma 3 or Gemma 4 for text-only supervised fine-tuning (no images), the forward pass raises a `ValueError` because `token_type_ids` / `mm_token_type_ids` is not provided. This happens because `AutoTokenizer` does not produce these fields -- only the multimodal `Processor` does.

The fix defaults to all-zeros when `token_type_ids` / `mm_token_type_ids` is `None` during training, instead of raising. When all zeros, `is_vision` is entirely `False`, so the bidirectional vision mask branch is skipped and a standard causal mask is produced -- which is exactly correct for text-only input.

## Changes

- `modeling_gemma4.py` / `modular_gemma4.py`: default `mm_token_type_ids` to `torch.zeros(...)` instead of raising `ValueError`
- `modeling_gemma3.py` / `modular_gemma3.py`: same fix for `token_type_ids` (same root cause)

Fixes #45200