### PR TITLE
Fix: ObjectDetectionPipeline batch inference only returns first image results

### DIFF
--- a/src/transformers/pipelines/object_detection.py
+++ b/src/transformers/pipelines/object_detection.py
@@ -159,21 +159,21 @@ class ObjectDetectionPipeline(Pipeline):
         else:
             # This is a regular ForObjectDetectionModel
             raw_annotations = self.image_processor.post_process_object_detection(model_outputs, threshold, target_size)
-            raw_annotation = raw_annotations[0]
-            scores = raw_annotation["scores"]
-            labels = raw_annotation["labels"]
-            boxes = raw_annotation["boxes"]
+            annotation = []
+            for raw_annotation in raw_annotations:
+                scores = raw_annotation["scores"]
+                labels = raw_annotation["labels"]
+                boxes = raw_annotation["boxes"]
 
-            raw_annotation["scores"] = scores.tolist()
-            raw_annotation["labels"] = [self.model.config.id2label[label.item()] for label in labels]
-            raw_annotation["boxes"] = [self._get_bounding_box(box) for box in boxes]
+                raw_annotation["scores"] = scores.tolist()
+                raw_annotation["labels"] = [self.model.config.id2label[label.item()] for label in labels]
+                raw_annotation["boxes"] = [self._get_bounding_box(box) for box in boxes]
 
-            # {"scores": [...], ...} --> [{"score":x, ...}, ...]
-            keys = ["score", "label", "box"]
-            annotation = [
-                dict(zip(keys, vals))
-                for vals in zip(raw_annotation["scores"], raw_annotation["labels"], raw_annotation["boxes"])
-            ]
+                keys = ["score", "label", "box"]
+                annotation.append([
+                    dict(zip(keys, vals))
+                    for vals in zip(raw_annotation["scores"], raw_annotation["labels"], raw_annotation["boxes"])
+                ])
 
         return annotation
 

--- a/src/transformers/pipelines/object_detection.py
+++ b/src/transformers/pipelines/object_detection.py
@@ -170,10 +170,12 @@ class ObjectDetectionPipeline(Pipeline):
                 raw_annotation["boxes"] = [self._get_bounding_box(box) for box in boxes]
 
                 keys = ["score", "label", "box"]
-                annotation.append([
-                    dict(zip(keys, vals))
-                    for vals in zip(raw_annotation["scores"], raw_annotation["labels"], raw_annotation["boxes"])
-                ])
+                annotation.append(
+                    [
+                        dict(zip(keys, vals))
+                        for vals in zip(raw_annotation["scores"], raw_annotation["labels"], raw_annotation["boxes"])
+                    ]
+                )
 
         return annotation
 


### PR DESCRIPTION
Fixes #31356

## What does this PR do?

The `postprocess` method in `ObjectDetectionPipeline` was hardcoding 
`raw_annotations[0]`, which caused batch inference to only return 
results for the first image, ignoring all others.

This PR replaces the single-item access with a loop over all 
`raw_annotations`, so every image in a batch gets processed correctly.

## Changes
- `src/transformers/pipelines/object_detection.py`: replaced 
  `raw_annotation = raw_annotations[0]` with a for loop over 
  all annotations

- [x] I confirm that this is not a pure code agent PR.

@Rocketknight1