### PR TITLE
fix: handle trailing replacement character in Whisper word timestamp decoding

### DIFF
--- a/src/transformers/models/whisper/tokenization_whisper.py
+++ b/src/transformers/models/whisper/tokenization_whisper.py
@@ -1329,9 +1329,9 @@ def _split_tokens_on_unicode(tokenizer, tokens: list[int]):
         current_indices.append(token_idx)
         decoded = tokenizer.decode(current_tokens, decode_with_timestamps=True)
 
-        if (
-            replacement_char not in decoded
-            or decoded_full[unicode_offset + decoded.index(replacement_char)] == replacement_char
+        if replacement_char not in decoded or (
+            unicode_offset + decoded.index(replacement_char) < len(decoded_full)
+            and decoded_full[unicode_offset + decoded.index(replacement_char)] == replacement_char
         ):
             words.append(decoded)
             word_tokens.append(current_tokens)


### PR DESCRIPTION
## Summary

- Fixes an `IndexError: string index out of range` crash in `_split_tokens_on_unicode()` when the decoded token stream ends with a dangling Unicode replacement character (U+FFFD)
- Adds a bounds check so that when `unicode_offset + decoded.index(replacement_char) >= len(decoded_full)`, the out-of-bounds access is avoided
- The trailing replacement character token is still collected and flushed correctly

Closes #44869

## Test plan

- [ ] Verify that Whisper word-level timestamp decoding no longer crashes when the final token(s) decode to U+FFFD
- [ ] Verify that normal (non-trailing-replacement-char) inputs produce identical results

🤖 Generated with [Claude Code](https://claude.com/claude-code)