### PR TITLE
Nvidia CI with `torch 2.11`

### DIFF
--- a/docker/transformers-all-latest-gpu/Dockerfile
+++ b/docker/transformers-all-latest-gpu/Dockerfile
@@ -9,12 +9,12 @@ SHELL ["sh", "-lc"]
 # The following `ARG` are mainly used to specify the versions explicitly & directly in this docker file, and not meant
 # to be used as arguments for docker build (so far).
 
-ARG PYTORCH='2.10.0'
+ARG PYTORCH='2.11.0'
 # Example: `cu102`, `cu113`, etc.
 ARG CUDA='cu126'
 
 # This needs to be compatible with the above `PYTORCH`.
-ARG TORCHCODEC='0.10.0'
+ARG TORCHCODEC='0.11.0'
 
 ARG FLASH_ATTN='false'
 


### PR DESCRIPTION
# What does this PR do?

Use torch 2.11 for our (daily) CI since it's released for 2 weeks already.

For CircleCI, we need to fix something regarding `torchvision.io.read_video`.

For daily CI, torch 2.11 doesn't cause issues (for those `torchvision.io.read_video`).