### PR TITLE
Fix tf32 issue: set `torch.backends.cudnn.conv.fp32_precision` explicitly.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -153,7 +153,18 @@ if is_torch_available():
     # TODO: Considering move this to `enable_tf32`, or report a bug to `torch`.
     import torch
 
-    torch.backends.cudnn.conv.fp32_precision = "ieee"
+    # In order to set `torch.backends.cudnn.conv.fp32_precision = "ieee"` below (new API), we still need to set this
+    # (old API) because it defaults to `True` (and not changed automatically when we change `cudnn.conv.fp32_precision`)
+    # and such inconsistency cause `torch` to complain `RuntimeError: PyTorch is checking whether allow_tf32 is enabled for cuDNN without a specific operator name,but the current flag(s) indica
+    # te that cuDNN conv and cuDNN RNN have different TF32 flags.This combination indicates that you have used a mix of the legacy and new APIs
+    #  to set the TF32 flags. We suggest only using the new API to set the TF32 flag(s).`.
+    # TODO: report a bug to `torch`
+    if hasattr(torch.backends.cudnn, "allow_tf32"):
+        torch.backends.cudnn.allow_tf32 = False
+
+    # This is necessary to make several `test_batching_equivalence` pass (within the tolerance `1e-5`)
+    if hasattr(torch.backends.cudnn.conv, "fp32_precision"):
+        torch.backends.cudnn.conv.fp32_precision = "ieee"
 
     # patch `torch.compile`: if `TORCH_COMPILE_FORCE_FULLGRAPH=1` (or values considered as true, e.g. yes, y, etc.),
     # the patched version will always run with `fullgraph=True`.

--- a/conftest.py
+++ b/conftest.py
@@ -149,6 +149,10 @@ if is_torch_available():
     # The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
     # We set it to `False` for CI. See https://github.com/pytorch/pytorch/issues/157274#issuecomment-3090791615
     enable_tf32(False)
+    # # torch.backends.fp32_precision does not cascade to torch.backends.cudnn.conv.fp32_precision and torch.backends.cudnn.rnn.fp32_precision
+    # TODO: Considering move this to `enable_tf32`, or report a bug to `torch`.
+    import torch
+    torch.backends.cudnn.conv.fp32_precision = "ieee"
 
     # patch `torch.compile`: if `TORCH_COMPILE_FORCE_FULLGRAPH=1` (or values considered as true, e.g. yes, y, etc.),
     # the patched version will always run with `fullgraph=True`.

--- a/conftest.py
+++ b/conftest.py
@@ -152,6 +152,7 @@ if is_torch_available():
     # # torch.backends.fp32_precision does not cascade to torch.backends.cudnn.conv.fp32_precision and torch.backends.cudnn.rnn.fp32_precision
     # TODO: Considering move this to `enable_tf32`, or report a bug to `torch`.
     import torch
+
     torch.backends.cudnn.conv.fp32_precision = "ieee"
 
     # patch `torch.compile`: if `TORCH_COMPILE_FORCE_FULLGRAPH=1` (or values considered as true, e.g. yes, y, etc.),


### PR DESCRIPTION
# What does this PR do?

PR #42428 change the way to enable / disable torch's TF32 using torch new API. It turns out set 

> torch.backends.fp32_precision = False

would still have

> torch.backends.cudnn.conv.fp32_precision = "tf32"
> torch.backends.cudnn.rnn.fp32_precision = "tf32"

It's not clear if it's a bug or a design in `torch`, I will talk to people at torch conference next week.

For now, this issue causes ~60 `test_batching_equivalence` failing. Set `torch.backends.cudnn.conv.fp32_precision = "ieee"` explicitly will have no such failing tests (on the commit of the linked PR).

I will merge this PR directly to move fast. If `torch` team says that it's a design instead of a bug, we could move the logic to our `enable_tf32`.

Keep in mind, even with this fix, there are still 37 failing `test_batching_equivalence`, which are caused by other issues introduced after #42428 , which should be fixed in separated PR(s).

Note: this PR bring the `vit` and `clip` CI back to ✅ 