### PR TITLE
Fix unexpected TF32 being enabled in testing

### DIFF
--- a/tests/models/youtu/test_modeling_youtu.py
+++ b/tests/models/youtu/test_modeling_youtu.py
@@ -33,7 +33,7 @@ from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 if is_torch_available():
     import torch
 
-    torch.set_float32_matmul_precision("high")
+    torch.set_float32_matmul_precision("highest")
 
     from transformers import (
         Cache,
@@ -99,8 +99,8 @@ class YoutuIntegrationTest(unittest.TestCase):
     def test_dynamic_cache(self):
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = [
-            "Simply put, the theory of relativity states that , the speed of light is constant in all reference frames. This means that if you are traveling at the speed of light, you will never reach the speed of light. This is because the speed of",
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love",
+            "Simply put, the theory of relativity states that , time is relative. It is the speed of light is constant in all reference frames. This means that if you are moving at a certain speed, you will experience time differently than someone who is stationary",
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love"
         ]
 
         prompts = [
@@ -123,8 +123,8 @@ class YoutuIntegrationTest(unittest.TestCase):
     def test_static_cache(self):
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = [
-            "Simply put, the theory of relativity states that , the speed of light is constant in all reference frames. This means that if you are traveling at the speed of light, you will never reach the speed of light. This is because the speed of",
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love",
+            "Simply put, the theory of relativity states that , time is relative. It is the speed of light is constant in all reference frames. This means that if you are moving at a certain speed, you will experience time differently than someone who is stationary",
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love"
         ]
 
         prompts = [
@@ -151,8 +151,8 @@ class YoutuIntegrationTest(unittest.TestCase):
     def test_compile_static_cache(self):
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = [
-            "Simply put, the theory of relativity states that , the speed of light is constant in all reference frames. This means that if you are traveling at the speed of light, you will never reach the speed of light. This is because the speed of",
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love",
+            "Simply put, the theory of relativity states that , time is relative. It is the speed of light is constant in all reference frames. This means that if you are moving at a certain speed, you will experience time differently than someone who is stationary",
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love"
         ]
 
         prompts = [

--- a/tests/models/youtu/test_modeling_youtu.py
+++ b/tests/models/youtu/test_modeling_youtu.py
@@ -100,7 +100,7 @@ class YoutuIntegrationTest(unittest.TestCase):
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = [
             "Simply put, the theory of relativity states that , time is relative. It is the speed of light is constant in all reference frames. This means that if you are moving at a certain speed, you will experience time differently than someone who is stationary",
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love"
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love",
         ]
 
         prompts = [
@@ -124,7 +124,7 @@ class YoutuIntegrationTest(unittest.TestCase):
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = [
             "Simply put, the theory of relativity states that , time is relative. It is the speed of light is constant in all reference frames. This means that if you are moving at a certain speed, you will experience time differently than someone who is stationary",
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love"
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love",
         ]
 
         prompts = [
@@ -152,7 +152,7 @@ class YoutuIntegrationTest(unittest.TestCase):
         NUM_TOKENS_TO_GENERATE = 40
         EXPECTED_TEXT_COMPLETION = [
             "Simply put, the theory of relativity states that , time is relative. It is the speed of light is constant in all reference frames. This means that if you are moving at a certain speed, you will experience time differently than someone who is stationary",
-            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love"
+            "My favorite all time favorite condiment is ketchup. I love it on everything. I love it on burgers, hot dogs, and even on my fries. I also love it on my french fries. I love it on my french fries. I love",
         ]
 
         prompts = [


### PR DESCRIPTION
# What does this PR do?

#43166 used `torch.set_float32_matmul_precision("high")` which causes (likely) TF32 being used

> “high”, float32 matrix multiplications either use the TensorFloat32 datatype (10 mantissa bits explicitly stored) or treat each float32 number as the sum of two bfloat16 numbers (approximately 16 mantissa bits with 14 bits explicitly stored)

(see [this doc](https://docs.pytorch.org/docs/stable/generated/torch.set_float32_matmul_precision.html))

In #45248, we fixed an issue introduced #42428, which bring us back to the original setting: no TF32 used. This change works well and fixes all failing `test_batching_equivalence`, if we apply the change in #45248 back to #42428.

Somehow, even with the fix from #45248,  the change `torch.set_float32_matmul_precision("high")` in the file `tests/models/youtu/test_modeling_youtu.py` in the later PR  #43166 causes some failing tests (`test_batching_equivalence`, see [this comment](https://github.com/huggingface/transformers/pull/45248#issuecomment-4188677910)), because TF32 being used (or because `treat each float32 number as the sum of two bfloat16 numbers` is not good for us).

This PR set it to `highest` , i.e.

> `torch.set_float32_matmul_precision("highest")

which fixes all `test_batching_equivalence` again, and achieve [the goal mentioned by the PR author](https://github.com/huggingface/transformers/pull/43166#discussion_r3036927627).

The expected output values in the integration tests are updated, because the PR **Prepare and keep track of position ids in `generate`** (#43734) changed the actual outputs. The new outputs look making sense and very similar to the previous ones, so I think it's safe.

