### PR TITLE
Fix Gemma4 `use_cache=False` producing bad logits

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1592,6 +1592,11 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
                 "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
             }
 
+        # Ensure a cache exists for KV sharing between layers, even when use_cache=False.
+        # This must happen after mask creation to avoid affecting causal mask computation.
+        if past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
         # embed positions
         hidden_states = inputs_embeds
         position_embeddings = {}
@@ -1616,7 +1621,7 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=past_key_values,
+            past_key_values=past_key_values if use_cache else None,
         )
 
     def get_per_layer_inputs(self, input_ids: torch.Tensor | None, inputs_embeds: torch.Tensor | None) -> torch.Tensor:

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -1361,6 +1361,11 @@ class Gemma4TextModel(Gemma3TextModel):
                 "sliding_attention": create_sliding_window_causal_mask(**mask_kwargs),
             }
 
+        # Ensure a cache exists for KV sharing between layers, even when use_cache=False.
+        # This must happen after mask creation to avoid affecting causal mask computation.
+        if past_key_values is None:
+            past_key_values = DynamicCache(config=self.config)
+
         # embed positions
         hidden_states = inputs_embeds
         position_embeddings = {}
@@ -1385,7 +1390,7 @@ class Gemma4TextModel(Gemma3TextModel):
 
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
-            past_key_values=past_key_values,
+            past_key_values=past_key_values if use_cache else None,
         )
 
 

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -114,6 +114,27 @@ class Gemma4TextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_generate_from_random_inputs_embeds(self):
         pass
 
+    def test_use_cache_false_with_kv_sharing(self):
+        """Regression test: use_cache=False must produce the same logits as use_cache=True.
+
+        Gemma4 uses KV sharing (num_kv_shared_layers) where later layers reuse K/V from earlier
+        layers via the cache object. When use_cache=False the cache was not created, breaking the
+        sharing mechanism and causing receiver layers to use keys as values (garbage logits).
+        See https://github.com/huggingface/transformers/issues/45242
+        """
+        config = self.model_tester.get_config()
+        config.attention_k_eq_v = True
+        config.num_global_key_value_heads = config.num_key_value_heads
+        model = Gemma4ForCausalLM(config).to(torch_device).eval()
+        input_ids = ids_tensor([1, 16], config.vocab_size).to(torch_device)
+
+        with torch.no_grad():
+            out_cached = model(input_ids, use_cache=True)
+            out_uncached = model(input_ids, use_cache=False)
+
+        torch.testing.assert_close(out_cached.logits, out_uncached.logits, atol=1e-4, rtol=1e-4)
+        self.assertIsNone(out_uncached.past_key_values, "past_key_values should be None when use_cache=False")
+
     @unittest.skip(
         "Flaky on CI, but not locally on Mac. If model is set to fp32 instead of bf16, not flaky anymore."
         "TODO Cyril: investigate where the loss of precision between bf16 and fp32 comes from."


### PR DESCRIPTION
# What does this PR do?

Fixes a bug where `use_cache=False` produces garbage logits in Gemma 4 models due to broken KV sharing between layers.

Fixes #45242 

## Root cause of the issue
Gemma 4 introduces two architectural features not present in Gemma 3:

1. **KV sharing** (`num_kv_shared_layers`): The last N decoder layers ("receiver" layers) don't compute their own keys/values, instead they reuse K/V states from earlier "donor" layers.

2. **K=V attention** (`attention_k_eq_v`): On global attention layers, keys and values share the same projection weights, so `v_proj` is set to `None`.

Both mechanisms were implemented by piggybacking on `past_key_values` (the KV cache object):
- Donor layers store their K/V into `past_key_values.shared_layers[layer_idx]`
- Receiver layers retrieve shared K/V from `past_key_values.shared_layers[donor_layer_idx]`

Both code paths are guarded by `if past_key_values is not None`.

When `use_cache=True`, a `DynamicCache` is created, `past_key_values` is not `None`, and everything works correctly.

When `use_cache=False`, `past_key_values` remains `None`, so:
1. **Donor layers never store** their K/V, thus the `past_key_values is not None` guard fails
2. **Receiver layers can't retrieve** shared K/V, thus the same guard fails, so they fall into the `else` branch and try to compute their own K/V
3. But receiver layers with `attention_k_eq_v=True` have `v_proj = None`, so the fallback `value_states = self.v_proj(hidden_states) if self.v_proj is not None else key_states` **uses keys as values**
4. The attention now computes with corrupted value states, producing garbage output

## The current fix
The fix creates a `DynamicCache` even when `use_cache=False`, but **after** causal mask creation to avoid affecting mask computation (which also depends on `past_key_values`). The cache is then available internally for KV sharing between layers. The return value is set to `None` when `use_cache=False` to preserve the expected API behavior.

```python
# Before (broken): cache only created when use_cache=True
if use_cache and past_key_values is None:
    past_key_values = DynamicCache(config=self.config)
# ... mask creation uses past_key_values ...
# ... decoder layers use past_key_values for KV sharing ...

# After (fixed): cache always created, but after masks and only returned when use_cache=True
if use_cache and past_key_values is None:
    past_key_values = DynamicCache(config=self.config)
# ... mask creation uses past_key_values (unchanged) ...

# NEW: ensure cache exists for KV sharing even when use_cache=False
if past_key_values is None:
    past_key_values = DynamicCache(config=self.config)
# ... decoder layers use past_key_values for KV sharing ...

return BaseModelOutputWithPast(
    last_hidden_state=hidden_states,
    past_key_values=past_key_values if use_cache else None,  # don't leak internal cache
)
```

## Alternative approach considered

A more memory-efficient approach would decouple KV sharing from `past_key_values` entirely by introducing
a lightweight `shared_kv` dict passed through `kwargs`. This would avoid allocating a full `DynamicCache`
when `use_cache=False`, preserving the memory savings that users expect during training. However, this
changes the gradient flow: KV-shared receiver layers would no longer exercise their own `k_proj`/`k_norm`/
`v_proj`/`v_norm` params (since they correctly skip computing their own K/V), causing
`test_training_gradient_checkpointing` to fail. Those params are architecturally unused on receiver layers,
so the missing gradients are semantically correct, but it requires updating the test expectations.

The current fix (always creating a `DynamicCache` after mask creation) was chosen for simplicity and
because it passes all existing tests without modification. Happy to switch to the `shared_kv` approach
if reviewers prefer it.


## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?

## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker @Cyrilvallez @zucchini-nlp 
