### PR TITLE
doc: fix TokenizersBackend.convert_to_native_format docstring

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -100,7 +100,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
 
     @classmethod
     def convert_to_native_format(cls, trust_remote_code=False, **kwargs):
-        """s
+        """
         Build a `tokenizers.Tokenizer` backend from the available serialization files (tokenizer.json, sentencepiece
         models, tekken.json, vocab/merges).
         """


### PR DESCRIPTION
# What does this PR do?

Fix docstring spelling mistake TokenizersBackend.convert_to_native_format. 

```python
    @classmethod
    def convert_to_native_format(cls, trust_remote_code=False, **kwargs):
        """s          <---- additional s
```

Likely caused by mistyped <kbd>ctrl/cmd + s</kbd> command.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?

## Who can review?

Documentation: @stevhliu
