### PR TITLE
Add `hasattr(torch.backends.cudnn, "conv")` to `conftest.py`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -163,7 +163,7 @@ if is_torch_available():
         torch.backends.cudnn.allow_tf32 = False
 
     # This is necessary to make several `test_batching_equivalence` pass (within the tolerance `1e-5`)
-    if hasattr(torch.backends.cudnn.conv, "fp32_precision"):
+    if hasattr(torch.backends.cudnn, "conv") and hasattr(torch.backends.cudnn.conv, "fp32_precision"):
         torch.backends.cudnn.conv.fp32_precision = "ieee"
 
     # patch `torch.compile`: if `TORCH_COMPILE_FORCE_FULLGRAPH=1` (or values considered as true, e.g. yes, y, etc.),


### PR DESCRIPTION
# What does this PR do?

**Fix tf32 issue: set `torch.backends.cudnn.conv.fp32_precision` explicitly.** (#45248) breaks when running on torch 2.8 or older ...