### PR TITLE
[Trainer] Support multi-loss component logging

### DIFF
--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -592,6 +592,9 @@ class Trainer:
         # Guards one-time LR scheduler creation in create_optimizer_and_scheduler
         self._created_lr_scheduler = False
 
+        self._tr_loss_components = {}
+        self._total_loss_components_scalar = {}
+
         self.control = self.callback_handler.on_init_end(self.args, self.state, self.control)
 
         # ---- 11. Finalize -----------------------------------------------------------
@@ -1736,16 +1739,38 @@ class Trainer:
                 if (
                     self.args.logging_nan_inf_filter
                     and not is_torch_xla_available()
-                    and (torch.isnan(tr_loss_step) or torch.isinf(tr_loss_step))
+                    and (
+                        torch.isnan(tr_loss_step)
+                        if isinstance(tr_loss_step, torch.Tensor)
+                        else any(torch.isnan(v) for v in tr_loss_step.values())
+                    )
+                    or (
+                        torch.isinf(tr_loss_step)
+                        if isinstance(tr_loss_step, torch.Tensor)
+                        else any(torch.isinf(v) for v in tr_loss_step.values())
+                    )
                 ):
                     # if loss is nan or inf simply add the average of previous logged losses
                     self._tr_loss += self._tr_loss / (1 + self.state.global_step - self._globalstep_last_logged)
+                    if isinstance(tr_loss_step, dict):
+                        for k in tr_loss_step:
+                            if k in self._tr_loss_components:
+                                self._tr_loss_components[k] += self._tr_loss_components[k] / (
+                                    1 + self.state.global_step - self._globalstep_last_logged
+                                )
                 else:
-                    if self._tr_loss.device != tr_loss_step.device:
-                        raise ValueError(
-                            f"Calculated loss must be on the original device: {self._tr_loss.device} but device in use is {tr_loss_step.device}"
-                        )
-                    self._tr_loss += tr_loss_step
+                    if isinstance(tr_loss_step, dict):
+                        for k, v in tr_loss_step.items():
+                            if k not in self._tr_loss_components:
+                                self._tr_loss_components[k] = torch.tensor(0.0, device=self.args.device)
+                            self._tr_loss_components[k] += v
+                        self._tr_loss += tr_loss_step["loss"]
+                    else:
+                        if self._tr_loss.device != tr_loss_step.device:
+                            raise ValueError(
+                                f"Calculated loss must be on the original device: {self._tr_loss.device} but device in use is {tr_loss_step.device}"
+                            )
+                        self._tr_loss += tr_loss_step
 
                 self.current_flos += float(self.floating_point_ops(inputs))
                 self._track_num_input_tokens(inputs)
@@ -1902,8 +1927,14 @@ class Trainer:
                 loss_mb = smp_forward_backward(model, inputs, self.args.gradient_accumulation_steps)
                 return loss_mb.reduce_mean().detach().to(self.args.device)
 
+            return_outputs = self.args.logging_loss_components
             with self.compute_loss_context_manager():
-                loss = self.compute_loss(model, inputs, num_items_in_batch=num_items_in_batch)
+                loss = self.compute_loss(
+                    model, inputs, return_outputs=return_outputs, num_items_in_batch=num_items_in_batch
+                )
+
+            if return_outputs:
+                loss, outputs = loss
 
             del inputs
             if (
@@ -1932,6 +1963,18 @@ class Trainer:
                 kwargs["scale_wrt_gas"] = False
 
             self.accelerator.backward(loss, **kwargs)
+
+            if return_outputs and isinstance(outputs, dict):
+                # Extract all loss-like components
+                loss_components = {
+                    k: v.detach()
+                    for k, v in outputs.items()
+                    if ("loss" in k or k in self.label_names) and isinstance(v, torch.Tensor) and v.numel() == 1
+                }
+                # Ensure the main loss is also included if not already
+                if "loss" not in loss_components:
+                    loss_components["loss"] = loss.detach()
+                return loss_components
 
             return loss.detach()
 
@@ -2063,6 +2106,15 @@ class Trainer:
             tr_loss -= tr_loss
 
             logs["loss"] = tr_loss_scalar / (self.state.global_step - self._globalstep_last_logged)
+
+            if self.args.logging_loss_components:
+                for k, v in self._tr_loss_components.items():
+                    v_scalar = nested_gather(v, self.args.parallel_mode).mean().item()
+                    self._tr_loss_components[k] -= self._tr_loss_components[k]
+                    logs[k] = v_scalar / (self.state.global_step - self._globalstep_last_logged)
+                    if k not in self._total_loss_components_scalar:
+                        self._total_loss_components_scalar[k] = 0.0
+                    self._total_loss_components_scalar[k] += v_scalar
             if grad_norm is not None:
                 logs["grad_norm"] = grad_norm.item() if isinstance(grad_norm, torch.Tensor) else grad_norm
             if learning_rate is not None:

--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -976,6 +976,10 @@ class TrainingArguments:
             )
         },
     )
+    logging_loss_components: bool = field(
+        default=False,
+        metadata={"help": "Whether to log all loss components when the model returns a dictionary of losses."},
+    )
     logging_first_step: bool = field(
         default=False, metadata={"help": "Whether to log the first `global_step` or not."}
     )

--- a/tests/trainer/test_multi_loss.py
+++ b/tests/trainer/test_multi_loss.py
@@ -1,0 +1,99 @@
+import tempfile
+
+from torch import nn
+
+from transformers import Trainer, TrainingArguments, is_torch_available
+from transformers.testing_utils import TestCasePlus, require_torch
+
+
+if is_torch_available():
+    from .trainer_test_utils import RegressionDataset
+
+
+class MultiLossModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.classifier = nn.Linear(1, 1)
+        self.config = None
+
+    def forward(self, input_x, labels=None, **kwargs):
+        logits = self.classifier(input_x.unsqueeze(-1))
+        if labels is None:
+            return {"logits": logits}
+
+        # Main loss
+        loss = nn.functional.mse_loss(logits.squeeze(), labels)
+
+        # Additional components
+        loss_part_a = loss * 0.1
+        loss_part_b = loss * 0.2
+
+        return {"loss": loss, "loss_part_a": loss_part_a, "loss_part_b": loss_part_b, "logits": logits}
+
+
+@require_torch
+class TrainerMultiLossTest(TestCasePlus):
+    def test_multi_loss_logging(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = MultiLossModel()
+            train_dataset = RegressionDataset(length=16)
+
+            args = TrainingArguments(
+                output_dir=tmp_dir,
+                logging_steps=1,
+                max_steps=3,
+                logging_loss_components=True,
+                report_to="none",
+            )
+
+            trainer = Trainer(
+                model=model,
+                args=args,
+                train_dataset=train_dataset,
+            )
+
+            trainer.train()
+
+            # Check log history
+            log_history = trainer.state.log_history
+            # Usually the last log is train metrics, earlier ones are step logs
+            step_logs = [log for log in log_history if "loss" in log and "train_runtime" not in log]
+
+            self.assertGreater(len(step_logs), 0)
+            for log in step_logs:
+                self.assertIn("loss", log)
+                self.assertIn("loss_part_a", log)
+                self.assertIn("loss_part_b", log)
+                self.assertIsInstance(log["loss_part_a"], float)
+                self.assertIsInstance(log["loss_part_b"], float)
+
+    def test_multi_loss_logging_disabled(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            model = MultiLossModel()
+            train_dataset = RegressionDataset(length=16)
+
+            args = TrainingArguments(
+                output_dir=tmp_dir,
+                logging_steps=1,
+                max_steps=3,
+                logging_loss_components=False,
+                report_to="none",
+            )
+
+            trainer = Trainer(
+                model=model,
+                args=args,
+                train_dataset=train_dataset,
+            )
+
+            trainer.train()
+
+            # Check log history
+            log_history = trainer.state.log_history
+            step_logs = [log for log in log_history if "loss" in log and "train_runtime" not in log]
+
+            self.assertGreater(len(step_logs), 0)
+            for log in step_logs:
+                self.assertIn("loss", log)
+                self.assertNotIn("loss_part_a", log)
+                self.assertNotIn("loss_part_b", log)


### PR DESCRIPTION
Introduce logging of individual loss components when models return a dict of losses.

- Add TrainingArguments.logging_loss_components flag to enable/disable this behavior.
- Track per-component running sums with _tr_loss_components and aggregate scalars in _total_loss_components_scalar.
- Extend NaN/Inf filtering to handle dict-form losses and preserve previous logged averages per component.
- When enabled, compute_loss is called to return outputs; Trainer extracts scalar loss-like tensors (components and main loss), accumulates them, and includes them in logs.
- Add tests (tests/trainer/test_multi_loss.py) to verify logging enabled/disabled behavior and presence/absence of loss_part_* entries in training logs.

This lets users surface and monitor auxiliary loss terms alongside the main loss during training.

# What does this PR do?

This PR introduces the ability for the Trainer to automatically log individual loss components when a model returns a dictionary of losses. This is particularly useful for multi-task learning or models with auxiliary loss terms (e.g., Distillation, MoE).

Adds TrainingArguments.logging_loss_components to toggle this behavior.
Extends training_step to extract and accumulate scalar loss components.
Handles distributed training by using nested_gather to aggregate components across processes before logging.
Updates the NaN/Inf filter to support dictionary-based losses.

Fixes: This work is coordinated on issue #31081 (also addresses the duplicate #30725).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

Test Results
I created a dedicated test file tests/trainer/test_multi_loss.py and ran it in a python 3.12 venv:

```
PYTHONPATH=src python -m pytest tests/trainer/test_multi_loss.py
```

Results:
test_multi_loss_logging: PASSED (Verified components appear in log_history)
test_multi_loss_logging_disabled: PASSED (Verified backward compatibility)

## Who can review?

@SunMarc @ArthurZucker (Trainer and Distributed expertise)