### PR TITLE
Fix Nemotron-H: add mlp layer type support

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -70,6 +70,7 @@ ALLOWED_LAYER_TYPES = (
     "dense",
     "hybrid",  # for layers that have both mamba and attention in zamba and zamba2
     "moe",  # for nemotron_h, which uses either attention, mamba or moe
+    "mlp",  # for nemotron_h standalone MLP layers (the "-" in hybrid_override_pattern)
 )
 
 

--- a/src/transformers/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/configuration_nemotron_h.py
@@ -261,7 +261,7 @@ class NemotronHConfig(PreTrainedConfig):
     @staticmethod
     def _list_to_pattern(layers_list: list) -> str:
         """Convert list of layer types back to pattern string (for backward compatibility)."""
-        reverse_mapping = {"mamba": "M", "moe": "E", "attention": "*"}
+        reverse_mapping = {"mamba": "M", "moe": "E", "attention": "*", "mlp": "-"}
         return "".join(reverse_mapping[layer_type] for layer_type in layers_list)
 
     @staticmethod

--- a/src/transformers/models/nemotron_h/configuration_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/configuration_nemotron_h.py
@@ -200,7 +200,7 @@ class NemotronHConfig(PreTrainedConfig):
                 f"`layers_block_type` must be a list of strings. Got type: {type(self.layers_block_type)}"
             )
 
-        valid_types = {"mamba", "attention", "moe"}
+        valid_types = {"mamba", "attention", "moe", "mlp"}
         if not all(block_type in valid_types for block_type in self.layers_block_type):
             invalid = set(self.layers_block_type) - valid_types
             raise ValueError(f"`layers_block_type` contains invalid types: {invalid}. Must be one of: {valid_types}")
@@ -218,7 +218,7 @@ class NemotronHConfig(PreTrainedConfig):
                     f"`mtp_layers_block_type` must be a list of strings. Got type: {type(self.mtp_layers_block_type)}"
                 )
 
-            valid_types = {"mamba", "attention", "moe"}
+            valid_types = {"mamba", "attention", "moe", "mlp"}
             if not all(block_type in valid_types for block_type in self.mtp_layers_block_type):
                 invalid = set(self.mtp_layers_block_type) - valid_types
                 raise ValueError(
@@ -267,7 +267,7 @@ class NemotronHConfig(PreTrainedConfig):
     @staticmethod
     def _pattern_to_list(pattern: str) -> list:
         """Convert pattern string to list of layer types (for backward compatibility)."""
-        pattern_mapping = {"M": "mamba", "E": "moe", "*": "attention"}
+        pattern_mapping = {"M": "mamba", "E": "moe", "*": "attention", "-": "mlp"}
         return [pattern_mapping[char] for char in pattern]
 
 

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -585,7 +585,7 @@ class NemotronHRMSNorm(nn.Module):
 
 
 class NemotronHMLP(nn.Module):
-    def __init__(self, config, intermediate_size=None):
+    def __init__(self, config, intermediate_size=None, **kwargs):
         super().__init__()
         self.config = config
         self.hidden_size = config.hidden_size
@@ -880,6 +880,7 @@ MIXER_TYPES = {
     "mamba": NemotronHMamba2Mixer,
     "attention": NemotronHAttention,
     "moe": NemotronHMoE,
+    "mlp": NemotronHMLP,
 }
 
 
@@ -1072,6 +1073,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
             "mamba": mamba_mask,
             "attention": causal_mask,
             "moe": None,
+            "mlp": None,
         }
 
         for layer_idx, mixer_block in enumerate(self.layers):

--- a/src/transformers/models/nemotron_h/modular_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modular_nemotron_h.py
@@ -107,7 +107,7 @@ class NemotronHRMSNorm(LlamaRMSNorm):
 
 
 class NemotronHMLP(NemotronMLP):
-    def __init__(self, config, intermediate_size=None):
+    def __init__(self, config, intermediate_size=None, **kwargs):
         nn.Module.__init__()
         self.config = config
         self.hidden_size = config.hidden_size
@@ -242,6 +242,7 @@ MIXER_TYPES = {
     "mamba": NemotronHMamba2Mixer,
     "attention": NemotronHAttention,
     "moe": NemotronHMoE,
+    "mlp": NemotronHMLP,
 }
 
 
@@ -434,6 +435,7 @@ class NemotronHModel(NemotronHPreTrainedModel):
             "mamba": mamba_mask,
             "attention": causal_mask,
             "moe": None,
+            "mlp": None,
         }
 
         for layer_idx, mixer_block in enumerate(self.layers):

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -386,8 +386,8 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
 
         # Check each layer has the correct shape
         for layer, layer_type in zip(past_key_values.layers, config.layer_types):
-            # Moe layers have a default mamba cache instantiated, but it stays empty as the layer does not use it
-            if layer_type == "moe":
+            # MoE/MLP layers have a default mamba cache instantiated, but it stays empty as the layer does not use it
+            if layer_type in ("moe", "mlp"):
                 self.assertEqual(layer.conv_states, None)
                 self.assertEqual(layer.recurrent_states, None)
             # Attention layer cache
@@ -399,7 +399,7 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
                 self.assertEqual(layer.conv_states.shape, conv_shape)
                 self.assertEqual(layer.recurrent_states.shape, recurrent_shape)
             else:
-                raise ValueError("Unknown layer type.")
+                raise ValueError(f"Unknown layer type: {layer_type}")
 
     def setUp(self):
         self.model_tester = NemotronHModelTester(self)
@@ -807,6 +807,128 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         original_pattern = "ME*ME*E"
         roundtrip_pattern = NemotronHConfig._list_to_pattern(NemotronHConfig._pattern_to_list(original_pattern))
         self.assertEqual(original_pattern, roundtrip_pattern)
+
+        # Test MLP layer type (dash pattern)
+        pattern_with_mlp = "M-M*"
+        layers = NemotronHConfig._pattern_to_list(pattern_with_mlp)
+        self.assertEqual(layers, ["mamba", "mlp", "mamba", "attention"])
+
+        # Test roundtrip with MLP
+        roundtrip = NemotronHConfig._list_to_pattern(NemotronHConfig._pattern_to_list("M-M-*E"))
+        self.assertEqual(roundtrip, "M-M-*E")
+
+    def test_mlp_layer_type_config(self):
+        """Test that 'mlp' is accepted as a valid layer type in config (regression test for Nemotron-H models
+        that use '-' / 'mlp' standalone layers in their hybrid_override_pattern)."""
+        # Config with mlp layers via layers_block_type list
+        config = NemotronHConfig(
+            vocab_size=100, hidden_size=32, layers_block_type=["mamba", "mlp", "mamba", "attention", "mlp"]
+        )
+        self.assertEqual(config.num_hidden_layers, 5)
+        self.assertEqual(config.layers_block_type[1], "mlp")
+        self.assertEqual(config.layers_block_type[4], "mlp")
+
+        # Config with mlp layers via legacy hybrid_override_pattern (the '-' character)
+        config2 = NemotronHConfig(vocab_size=100, hidden_size=32, hybrid_override_pattern="M-M*-")
+        self.assertEqual(config2.layers_block_type, ["mamba", "mlp", "mamba", "attention", "mlp"])
+        self.assertEqual(config2.hybrid_override_pattern, "M-M*-")
+
+    @require_torch
+    def test_mlp_layer_type_forward(self):
+        """Test that a tiny NemotronH model with MLP layers can run a forward pass (regression test)."""
+        config = NemotronHConfig(
+            vocab_size=99,
+            hidden_size=32,
+            layers_block_type=["mamba", "mlp", "mamba", "attention", "mlp"],
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=32,
+            intermediate_size=40,
+            use_mamba_kernels=False,
+            ssm_state_size=16,
+            mamba_num_heads=8,
+            mamba_n_groups=8,
+            mamba_head_dim=16,
+            mamba_d_conv=4,
+            mamba_expand=2,
+            mamba_chunk_size=64,
+        )
+
+        model = NemotronHModel(config=config)
+        model.to(torch_device)
+        model.eval()
+
+        input_ids = ids_tensor([2, 7], config.vocab_size).to(torch_device)
+        with torch.no_grad():
+            result = model(input_ids)
+        self.assertEqual(result.last_hidden_state.shape, (2, 7, 32))
+
+    @require_torch
+    def test_mlp_layer_type_causal_lm(self):
+        """Test that NemotronHForCausalLM with MLP layers can generate tokens (regression test)."""
+        config = NemotronHConfig(
+            vocab_size=99,
+            hidden_size=32,
+            layers_block_type=["mamba", "mlp", "mamba", "attention", "mlp"],
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=32,
+            intermediate_size=40,
+            use_mamba_kernels=False,
+            ssm_state_size=16,
+            mamba_num_heads=8,
+            mamba_n_groups=8,
+            mamba_head_dim=16,
+            mamba_d_conv=4,
+            mamba_expand=2,
+            mamba_chunk_size=64,
+        )
+
+        model = NemotronHForCausalLM(config=config)
+        model.to(torch_device)
+        model.eval()
+
+        input_ids = ids_tensor([1, 5], config.vocab_size).to(torch_device)
+        with torch.no_grad():
+            output = model.generate(input_ids, max_new_tokens=3, do_sample=False, use_cache=True)
+        # Should have generated 3 new tokens
+        self.assertEqual(output.shape[1], 5 + 3)
+
+    @require_torch
+    def test_mlp_layer_type_nemotron_h_pattern(self):
+        """Test with a pattern resembling real Nemotron-H models (e.g. Nano-4B: M-M-M-MM-M-M*-...)."""
+        # Use a shortened version of the real Nano-4B pattern
+        config = NemotronHConfig(
+            vocab_size=99,
+            hidden_size=32,
+            hybrid_override_pattern="M-M-*M-M",
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=32,
+            intermediate_size=40,
+            use_mamba_kernels=False,
+            ssm_state_size=16,
+            mamba_num_heads=8,
+            mamba_n_groups=8,
+            mamba_head_dim=16,
+            mamba_d_conv=4,
+            mamba_expand=2,
+            mamba_chunk_size=64,
+        )
+
+        self.assertEqual(
+            config.layers_block_type,
+            ["mamba", "mlp", "mamba", "mlp", "attention", "mamba", "mlp", "mamba"],
+        )
+
+        model = NemotronHForCausalLM(config=config)
+        model.to(torch_device)
+        model.eval()
+
+        input_ids = ids_tensor([1, 5], config.vocab_size).to(torch_device)
+        with torch.no_grad():
+            result = model(input_ids)
+        self.assertEqual(result.logits.shape, (1, 5, 99))
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

Nemotron-H models use standalone MLP layers in their `hybrid_override_pattern` (the `-` character), but the config parser, validators, and modeling code only know about `mamba`/`attention`/`moe`. This means every Nemotron-H model on the hub (`nvidia/Nemotron-H-8B-Base-8K`, `nvidia/Nemotron-H-56B-Base-8K`, and all Nemotron-3-Nano variants) crashes on load:

```
KeyError: '-'
```

in `_pattern_to_list()`.

NVIDIA's own hub modeling code (the `trust_remote_code=True` path) handles `-` as `"mlp"` and dispatches to `NemotronHMLP` in its mixer, but the native transformers integration missed it. The `NemotronHMLP` class already exists in the codebase, it just wasn't wired up.

The fix is small, 4 files, all one-liners:

- `configuration_nemotron_h.py`: add `"-": "mlp"` to `_pattern_to_list` mapping, add `"mlp"` to `valid_types` in `validate_layers_block_type`
- `modeling_nemotron_h.py`: add `"mlp": NemotronHMLP` to `MIXER_TYPES`, add `"mlp": None` to `block_type_to_mask`, accept `**kwargs` in `NemotronHMLP.__init__` (because `NemotronHBlock` passes `layer_idx=`)
- `configuration_utils.py`: add `"mlp"` to `ALLOWED_LAYER_TYPES`

Tested locally: loaded `nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16` (pattern `M-M-M-MM-M-M*-M-M*-M-M-M*-M-M-MM*-MMM-M-M-`), ran `model.generate()` with a chat prompt, got coherent output. Before the fix it crashes on config parsing. Also ran `make fix-repo` checks (ruff, auto_mappings, copies, dummies) -- all pass.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @Cyrilvallez