### PR TITLE
fix(security): prevent untrusted users from triggering TRL CI dispatch

### DIFF
--- a/.github/workflows/trl-ci-bot.yml
+++ b/.github/workflows/trl-ci-bot.yml
@@ -30,13 +30,14 @@ jobs:
             *) echo "trusted=false" >> $GITHUB_OUTPUT ;;
           esac
 
-      - name: Ignore untrusted commenter
+      - name: Reject untrusted commenter
         if: steps.trust.outputs.trusted != 'true'
         run: |
-          echo "Untrusted commenter; ignoring."
-          exit 0
+          echo "::error::Untrusted commenter (${{ github.event.comment.author_association }}); aborting."
+          exit 1
 
       - name: Fetch PR head SHA + number
+        if: steps.trust.outputs.trusted == 'true'
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
@@ -48,6 +49,7 @@ jobs:
           echo "number=$number" >> $GITHUB_OUTPUT
 
       - name: Dispatch TRL workflow
+        if: steps.trust.outputs.trusted == 'true'
         id: dispatch
         env:
           GH_TOKEN: ${{ secrets.TRL_CI_DISPATCH_TOKEN }}
@@ -57,6 +59,7 @@ jobs:
             -f transformers_ref=${{ steps.pr.outputs.sha }}
 
       - name: Find TRL workflow run URL
+        if: steps.trust.outputs.trusted == 'true'
         id: find_run
         env:
           GH_TOKEN: ${{ secrets.TRL_CI_DISPATCH_TOKEN }}
@@ -82,6 +85,7 @@ jobs:
           done
 
       - name: Comment back on PR with link
+        if: steps.trust.outputs.trusted == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Security Fix

Fixes a trust check bypass in `trl-ci-bot.yml` that allowed any GitHub user to trigger TRL CI on self-hosted GPU runners by commenting `/trl-ci` on any PR.

### The bug

The "Ignore untrusted commenter" step used `exit 0`, which only exits the shell step with success. GitHub Actions interprets this as "step passed" and continues to the next steps — dispatching the TRL workflow, which runs attacker-controlled code on self-hosted runners with access to secrets.

### The fix

1. Changed `exit 0` to `exit 1` — now fails the step and halts the job
2. Added `if: steps.trust.outputs.trusted == 'true'` on every subsequent step as defense in depth

### Impact

- The workflow has been disabled as an immediate mitigation
- HF_TOKEN exposed in the incident has been revoked
- All affected secrets are being rotated

Reported via HackerOne. Please merge promptly and re-enable the workflow after merge.