### PR TITLE
docs: document known limitations of _can_set_attn/experts_implementation source inspection

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1946,8 +1946,25 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
     @classmethod
     def _can_set_attn_implementation(cls) -> bool:
-        """Detect whether the class supports setting its attention implementation dynamically. It is an ugly check based on
-        opening the file, but avoids maintaining yet another property flag.
+        """Detect whether the class supports setting its attention implementation dynamically.
+
+        This is a heuristic based on reading the module's source file as text and searching for
+        specific string patterns. It avoids maintaining a separate property flag on every model class,
+        but has the following known limitations:
+
+        - **False positives from comments or string literals**: The searched patterns
+          (``eager_attention_forward``, ``ALL_ATTENTION_FUNCTIONS.get_interface(``) may appear
+          inside docstrings, comments, or string constants rather than actual control-flow code,
+          causing this method to return ``True`` even when the model does not properly implement
+          the dynamic-attention interface.
+        - **Compiled modules**: If the model class is defined in a compiled extension (``.so`` /
+          ``.pyd``), the source file is not readable as text. This case is already handled: the
+          ``__file__`` guard returns ``False`` before attempting to open the file.
+        - **Non-standard import environments**: Environments such as PyInstaller bundles,
+          ``zipimport``, or custom module loaders may not expose a readable ``__file__`` path.
+          These also fall through the ``__file__`` guard and return ``False`` safely.
+        - **Jupyter notebooks and REPLs**: Models defined interactively have no associated source
+          file. This is also caught by the ``__file__`` guard.
         """
         class_module = sys.modules[cls.__module__]
         # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then
@@ -1965,8 +1982,24 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
     @classmethod
     def _can_set_experts_implementation(cls) -> bool:
-        """Detect whether the class supports setting its experts implementation dynamically. It is an ugly check based on
-        opening the file, but avoids maintaining yet another property flag.
+        """Detect whether the class supports setting its experts implementation dynamically.
+
+        This is a heuristic based on reading the module's source file as text and searching for
+        the ``@use_experts_implementation`` decorator string. It avoids maintaining a separate
+        property flag on every model class, but has the following known limitations:
+
+        - **False positives from comments or string literals**: The searched pattern
+          (``@use_experts_implementation``) may appear inside docstrings, comments, or string
+          constants rather than actual decorator usage, causing this method to return ``True``
+          even when the decorator is not applied to any function.
+        - **Compiled modules**: If the model class is defined in a compiled extension (``.so`` /
+          ``.pyd``), the source file is not readable as text. This case is already handled: the
+          ``__file__`` guard returns ``False`` before attempting to open the file.
+        - **Non-standard import environments**: Environments such as PyInstaller bundles,
+          ``zipimport``, or custom module loaders may not expose a readable ``__file__`` path.
+          These also fall through the ``__file__`` guard and return ``False`` safely.
+        - **Jupyter notebooks and REPLs**: Models defined interactively have no associated source
+          file. This is also caught by the ``__file__`` guard.
         """
         class_module = sys.modules[cls.__module__]
         # This can happen for a custom model in a jupyter notebook or repl for example - simply do not allow to set it then


### PR DESCRIPTION
Closes #45162

## What this PR does

Expands the docstrings of `_can_set_attn_implementation` and `_can_set_experts_implementation` in `modeling_utils.py` to explicitly document the known limitations of their source-inspection heuristic.

**Coordination:** I posted on the issue before opening this PR. The maintainer comment (#45162 (comment)) confirmed the approach is "definitely hacky" and that the team is "open to ideas" — this PR addresses the immediate documentation gap as a first step.

## Limitations now documented

Both methods now document four known edge cases:

1. **False positives from comments/strings** — the searched patterns (`eager_attention_forward`, `ALL_ATTENTION_FUNCTIONS.get_interface(`, `@use_experts_implementation`) may appear inside docstrings, comments, or string constants rather than actual code, causing a spurious `True`.
2. **Compiled modules** (`.so` / `.pyd`) — no readable source file. Already handled safely by the `__file__` guard (returns `False`), but this was not documented.
3. **Non-standard import environments** (PyInstaller, `zipimport`, custom loaders) — `__file__` may be absent or non-filesystem. Also caught by the guard, but undocumented.
4. **Interactive environments** (Jupyter, REPL) — no `__file__`. Caught by the guard.

## No behaviour change

This is a documentation-only PR. No logic was modified.

## Testing

No tests changed. `make style` was run to verify formatting.

> **Note:** Claude Code was used to assist in drafting the expanded docstrings. All changes were reviewed by the submitter.