### PR TITLE
refactor: display test duration

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -114,6 +114,12 @@ def pytest_addoption(parser):
     pytest_addoption_shared(parser)
 
 
+def pytest_runtest_logreport(report):
+    if report.when == "call":
+        outcome = "PASSED" if report.passed else "FAILED" if report.failed else "SKIPPED"
+        print(f"{report.nodeid} [{outcome}] {report.duration:.2f}s")
+
+
 def pytest_terminal_summary(terminalreporter):
     from transformers.testing_utils import pytest_terminal_summary_main
 


### PR DESCRIPTION
# What does this PR do?

Simple hook to display test duration.

This will append inline duration per test during the run, example:

```
tests/utils/test_configuration_utils.py::ConfigPushToHubTester::test_push_to_hub
[gw1] [ 90%] PASSED tests/utils/test_configuration_utils.py::ConfigPushToHubTester::test_push_to_hub tests/utils/test_configuration_utils.py::ConfigPushToHubTester::test_push_to_hub [PASSED] 28.678s
```
unlike the `--duration` option that generates a report at the end of the run.
