### PR TITLE
Fix ByteLevel-BPE tokenizers silently breaking in `LlamaTokenizer`

### DIFF
--- a/src/transformers/models/llama/tokenization_llama.py
+++ b/src/transformers/models/llama/tokenization_llama.py
@@ -113,24 +113,35 @@ class LlamaTokenizer(TokenizersBackend):
             }
 
         self._merges = merges or []
+        # Detect whether the merges use ByteLevel encoding (Ġ markers) or
+        # SentencePiece (▁ markers). ByteLevel-BPE tokenizers need the
+        # pre_tokenizer/decoder from tokenizer.json, not the Metaspace defaults.
+        is_byte_level = any("Ġ" in "".join(m) for m in self._merges[:20])
+        file_pre_tokenizer = kwargs.pop("pre_tokenizer", None)
+        file_decoder = kwargs.pop("decoder", None)
         self._tokenizer = Tokenizer(
             BPE(vocab=self._vocab, merges=self._merges, fuse_unk=True, byte_fallback=True, dropout=None)
         )
         self._tokenizer.normalizer = None
-        self._tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
-            replacement="▁", prepend_scheme=_get_prepend_scheme(self.add_prefix_space, self), split=False
-        )
+        if is_byte_level and file_pre_tokenizer is not None:
+            self._tokenizer.pre_tokenizer = file_pre_tokenizer
+            if file_decoder is not None:
+                self._tokenizer.decoder = file_decoder
+        else:
+            self._tokenizer.pre_tokenizer = pre_tokenizers.Metaspace(
+                replacement="▁", prepend_scheme=_get_prepend_scheme(self.add_prefix_space, self), split=False
+            )
 
-        sequence = [
-            decoders.Replace("▁", " "),
-            decoders.ByteFallback(),
-            decoders.Fuse(),
-        ]
+            sequence = [
+                decoders.Replace("▁", " "),
+                decoders.ByteFallback(),
+                decoders.Fuse(),
+            ]
 
-        if self.add_prefix_space:
-            sequence += [decoders.Strip(content=" ", left=1)]
+            if self.add_prefix_space:
+                sequence += [decoders.Strip(content=" ", left=1)]
 
-        self._tokenizer.decoder = decoders.Sequence(sequence)
+            self._tokenizer.decoder = decoders.Sequence(sequence)
         self.use_default_system_prompt = use_default_system_prompt
         super().__init__(
             clean_up_tokenization_spaces=clean_up_tokenization_spaces,

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -145,6 +145,8 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 tok_from_file = TokenizerFast.from_file(fast_tokenizer_file)
 
             local_kwargs["post_processor"] = tok_from_file.post_processor
+            local_kwargs["pre_tokenizer"] = tok_from_file.pre_tokenizer
+            local_kwargs["decoder"] = tok_from_file.decoder
             local_kwargs["tokenizer_padding"] = tok_from_file.padding
             local_kwargs["tokenizer_truncation"] = tok_from_file.truncation
             # Preserve truncation and padding baked into tokenizer.json so that classes
@@ -337,6 +339,9 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         tokenizer_object = kwargs.pop("tokenizer_object", None)
         gguf_file = kwargs.pop("gguf_file", None)
         fast_tokenizer_file = kwargs.pop("tokenizer_file", None)
+        # Pop Rust tokenizer objects before super().__init__ deepcopies kwargs.
+        kwargs.pop("pre_tokenizer", None)
+        kwargs.pop("decoder", None)
         # Note: added_tokens_decoder is NOT popped - it's passed to super().__init__() for processing
         added_tokens_decoder = kwargs.get("added_tokens_decoder", {})
         # Store add_prefix_space before super().__init__() to ensure it's not overridden


### PR DESCRIPTION
The `transformers` V5 "rm slow tokenizers" refactor (\#40936) aliased   
`LlamaTokenizerFast` to `LlamaTokenizer`, whose `__init__`              
unconditionally installs a SentencePiece Metaspace pre-tokenizer. This  
is correct for classic Llama/Llama-2 models but silently breaks newer   
models that use ByteLevel BPE under the same                            
`tokenizer_class="LlamaTokenizerFast"` label.    

## Reproduction

### `transformers` V4 (correct behavior)
```
~/modular $ python3
Python 3.10.12 (main, Mar  3 2026, 11:56:32) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import transformers
>>> print(transformers.__version__)
4.57.3
>>> from transformers import AutoTokenizer
>>> tok = AutoTokenizer.from_pretrained("black-forest-labs/FLUX.2-dev", subfolder="tokenizer")
>>> print(tok.encode("a cat in a garden", add_special_tokens=False))
[1097, 7990, 1294, 1261, 26428]
>>> print(tok.decode(tok.encode("a cat in a garden", add_special_tokens=False)))
a cat in a garden
>>> 
```
### `transformers` V5 (incorrect behavior)
```
(venv) ~/modular $ python3
Python 3.13.11 (main, Dec  9 2025, 19:04:10) [Clang 21.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import transformers
>>> print(transformers.__version__)
5.2.0
>>> from transformers import AutoTokenizer
>>> tok = AutoTokenizer.from_pretrained("black-forest-labs/FLUX.2-dev", subfolder="tokenizer")
>>> print(tok.encode("a cat in a garden", add_special_tokens=False))
[1413, 8002, 1393, 38083]
>>> print(tok.decode(tok.encode("a cat in a garden", add_special_tokens=False)))
acatinagarden
>>> 
```
### `transformers` V5 with bugfix (correct behavior)
```
(venv) ~/transformers $ python3
Python 3.13.11 (main, Dec  9 2025, 19:04:10) [Clang 21.1.4 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import transformers
>>> print(transformers.__version__)
5.6.0.dev0
>>> from transformers import AutoTokenizer
>>> tok = AutoTokenizer.from_pretrained("black-forest-labs/FLUX.2-dev", subfolder="tokenizer")
>>> print(tok.encode("a cat in a garden", add_special_tokens=False))
[1097, 7990, 1294, 1261, 26428]
>>> print(tok.decode(tok.encode("a cat in a garden", add_special_tokens=False)))
a cat in a garden
>>> 
```

## Validation
- [X] I confirm that this is not a pure code agent PR.
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. 
_No, it was not discussed. I ran into this bug at work, and the fix was clear to me, so I made the change without bothering to file an issue._
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
_No, I didn't feel like any documentation changes were relevant, since this is just a small bugfix._
- [X] Did you write any new necessary tests?
_Yes, although tests were not necessary in this case._