### PR TITLE
add kwargs to all methods in the CallbackHandler class

### DIFF
--- a/src/transformers/trainer_callback.py
+++ b/src/transformers/trainer_callback.py
@@ -484,58 +484,58 @@ class CallbackHandler(TrainerCallback):
     def callback_list(self):
         return "\n".join(cb.__class__.__name__ for cb in self.callbacks)
 
-    def on_init_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_init_end", args, state, control)
+    def on_init_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_init_end", args, state, control, **kwargs)
 
-    def on_train_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
+    def on_train_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         control.should_training_stop = False
-        return self.call_event("on_train_begin", args, state, control)
+        return self.call_event("on_train_begin", args, state, control, **kwargs)
 
-    def on_train_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_train_end", args, state, control)
+    def on_train_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_train_end", args, state, control, **kwargs)
 
-    def on_epoch_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
+    def on_epoch_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         control.should_epoch_stop = False
-        return self.call_event("on_epoch_begin", args, state, control)
+        return self.call_event("on_epoch_begin", args, state, control, **kwargs)
 
-    def on_epoch_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_epoch_end", args, state, control)
+    def on_epoch_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_epoch_end", args, state, control, **kwargs)
 
-    def on_step_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
+    def on_step_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         control.should_log = False
         control.should_evaluate = False
         control.should_save = False
-        return self.call_event("on_step_begin", args, state, control)
+        return self.call_event("on_step_begin", args, state, control, **kwargs)
 
-    def on_pre_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_pre_optimizer_step", args, state, control)
+    def on_pre_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_pre_optimizer_step", args, state, control, **kwargs)
 
-    def on_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_optimizer_step", args, state, control)
+    def on_optimizer_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_optimizer_step", args, state, control, **kwargs)
 
-    def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_substep_end", args, state, control)
+    def on_substep_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_substep_end", args, state, control, **kwargs)
 
-    def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_step_end", args, state, control)
+    def on_step_end(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_step_end", args, state, control, **kwargs)
 
-    def on_evaluate(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, metrics):
+    def on_evaluate(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, metrics, **kwargs):
         control.should_evaluate = False
-        return self.call_event("on_evaluate", args, state, control, metrics=metrics)
+        return self.call_event("on_evaluate", args, state, control, metrics=metrics, **kwargs)
 
-    def on_predict(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, metrics):
-        return self.call_event("on_predict", args, state, control, metrics=metrics)
+    def on_predict(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, metrics, **kwargs):
+        return self.call_event("on_predict", args, state, control, metrics=metrics, **kwargs)
 
-    def on_save(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
+    def on_save(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         control.should_save = False
-        return self.call_event("on_save", args, state, control)
+        return self.call_event("on_save", args, state, control, **kwargs)
 
-    def on_log(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, logs):
+    def on_log(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, logs, **kwargs):
         control.should_log = False
-        return self.call_event("on_log", args, state, control, logs=logs)
+        return self.call_event("on_log", args, state, control, logs=logs, **kwargs)
 
-    def on_prediction_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl):
-        return self.call_event("on_prediction_step", args, state, control)
+    def on_prediction_step(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
+        return self.call_event("on_prediction_step", args, state, control, **kwargs)
 
     def on_push_begin(self, args: TrainingArguments, state: TrainerState, control: TrainerControl, **kwargs):
         return self.call_event("on_push_begin", args, state, control, **kwargs)


### PR DESCRIPTION
# What does this PR do?
Add `**kwargs` to all methods in the `CallbackHandler` class. Previously, only the `CallbackHandler.on_push_begin()` method accepted `**kwargs`, while all other methods did not. This forces users who want to customize the Trainer class for their own use cases to modify methods in the CallbackHandler class, which is inconvenient. Adding `**kwargs` allows them to pass whatever they want to the CallbackHandler method calls and access those values in their own callback classes. Additionally, this makes the methods consistent with the template methods in `TrainerCallback`.

Fixes # (issue)

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@SunMarc

