### PR TITLE
Fix vlm weight mappings

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -62,21 +62,18 @@ _MODEL_TO_CONVERSION_PATTERN = {
     "pp_doclayout_v3": "rt_detr",
     "paligemma": "llava",
     "aya_vision": "llava",
-    "fuyu": "llava",
     "got_ocr2": "llava",
     "shieldgemma2": "llava",
     "gemma3": "llava",
     "internvl": "llava",
-    "llava_next": "llava",
-    "llava_next_video": "llava",
-    "llava_onevision": "llava",
+    "llava_next_video": "llava_next",
+    "llava_onevision": "llava_next",
     "vipllava": "llava",
-    "video_llava": "llava",
     "mistral3": "llava",
-    "mllama": "llava",
     "qwen2_5_vl": "qwen2_vl",
     "sam3_tracker_video": "sam3_tracker",
     "pp_chart2table": "llava",
+    "gemma3n_text": "qwen3_5_text",
     "qwen3_5_moe_text": "qwen3_5_text",
 }
 
@@ -87,15 +84,44 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming(source_patterns=r"layer\.", target_patterns="layers."),
         ],
         "llava": [
-            WeightRenaming(source_patterns=r"language_model.model", target_patterns="language_model"),
-            WeightRenaming(source_patterns=r"language_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^language_model.model", target_patterns="model.language_model"),
+            WeightRenaming(source_patterns=r"^language_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^vision_tower", target_patterns="model.vision_tower"),
+            WeightRenaming(source_patterns=r"^multi_modal_projector", target_patterns="model.multi_modal_projector"),
+        ],
+        "llava_next": [
+            WeightRenaming(source_patterns=r"^language_model.model", target_patterns="model.language_model"),
+            WeightRenaming(source_patterns=r"^language_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^vision_tower", target_patterns="model.vision_tower"),
+            WeightRenaming(source_patterns=r"^multi_modal_projector", target_patterns="model.multi_modal_projector"),
+            WeightRenaming(source_patterns=r"^image_newline", target_patterns="model.image_newline"),
+        ],
+        "video_llava": [
+            WeightRenaming(source_patterns=r"^language_model.model", target_patterns="model.language_model"),
+            WeightRenaming(source_patterns=r"^language_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^image_tower", target_patterns="model.image_tower"),
+            WeightRenaming(source_patterns=r"^video_tower", target_patterns="model.video_tower"),
+            WeightRenaming(source_patterns=r"^multi_modal_projector", target_patterns="model.multi_modal_projector"),
+        ],
+        "fuyu": [
+            WeightRenaming(source_patterns=r"^language_model.model", target_patterns="model.language_model"),
+            WeightRenaming(source_patterns=r"^language_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^vision_embed_tokens", target_patterns="model.vision_embed_tokens"),
+        ],
+        "mllama": [
+            WeightRenaming(source_patterns=r"^language_model.model", target_patterns="model.language_model"),
+            WeightRenaming(source_patterns=r"^language_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^vision_model", target_patterns="model.vision_model"),
+            WeightRenaming(source_patterns=r"^multi_modal_projector", target_patterns="model.multi_modal_projector"),
         ],
         "emu3": [
-            WeightRenaming(source_patterns=r"text_model.model", target_patterns="text_model"),
-            WeightRenaming(source_patterns=r"text_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^text_model.model", target_patterns="model.text_model"),
+            WeightRenaming(source_patterns=r"^text_model.lm_head", target_patterns="lm_head"),
+            WeightRenaming(source_patterns=r"^vqmodel", target_patterns="model.vqmodel"),
         ],
         "paddleocr_vl": [
-            WeightRenaming(source_patterns=r"mlp_AR", target_patterns="model.projector"),
+            WeightRenaming(source_patterns=r"^mlp_AR", target_patterns="model.projector"),
+            WeightRenaming(source_patterns=r"^visual", target_patterns="model.visual"),
             WeightRenaming(
                 source_patterns=r"^model(?!(\.visual|\.projector|\.language_model))",
                 target_patterns="model.language_model",
@@ -105,6 +131,7 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming(
                 source_patterns=r"(?<!_)model(?!\.(language_model|visual))", target_patterns="model.language_model"
             ),
+            WeightRenaming(source_patterns=r"^visual", target_patterns="model.visual"),
         ],
         "colqwen2": [
             WeightRenaming(source_patterns=r"vlm.model", target_patterns="vlm"),
@@ -158,9 +185,8 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming("feedforward_layer_norm", "post_attention_layernorm"),
         ],
         "qwen3_5_text": [
-            # Note: the lookbehind on the target is to avoid replacing the `model` part when saving with the
-            # ForConditionalGeneration (main) model - this is supposed to replace only when the ForCausalLM (submodel)
-            # is used, with keys coming from the ForConditionalGeneration model
+            # Note: the lookbehind on the target is to avoid replacing bigger matches when the model is a submodel of
+            # the ForConditionalGeneration model
             WeightRenaming(
                 source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"
             ),
@@ -170,6 +196,8 @@ def _build_checkpoint_conversion_mapping():
                 source_patterns=r"detector_model.vision_encoder.backbone.", target_patterns="vision_encoder.backbone."
             ),
             WeightRenaming(source_patterns=r"tracker_neck.", target_patterns="vision_encoder.neck."),
+            # the regex allows to remove the prefix, and add it back in revert mode
+            WeightRenaming(source_patterns=r"tracker_model.(.+)", target_patterns=r"\1"),
         ],
         "t5gemma2_encoder": [
             WeightRenaming(r"(?<!decoder\.)(?<!text_model\.)embed_tokens\.", "text_model.embed_tokens."),

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -77,7 +77,6 @@ _MODEL_TO_CONVERSION_PATTERN = {
     "qwen2_5_vl": "qwen2_vl",
     "sam3_tracker_video": "sam3_tracker",
     "pp_chart2table": "llava",
-    "gemma3n_text": "qwen3_5_text",
     "qwen3_5_moe_text": "qwen3_5_text",
 }
 

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -159,8 +159,8 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming("feedforward_layer_norm", "post_attention_layernorm"),
         ],
         "qwen3_5_text": [
-            # Note: the lookbehind on the target is to avoid replacing bigger matches when the model is a submodel of
-            # the ForConditionalGeneration model
+            # Note: the lookbehind on the target is to avoid replacing bigger matches during saving when the model is
+            # a submodel of the ForConditionalGeneration model
             WeightRenaming(
                 source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"
             ),

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -161,7 +161,7 @@ def _build_checkpoint_conversion_mapping():
         "qwen3_5_text": [
             # Note: the lookbehind on the target is to avoid replacing bigger matches when the model is a submodel of
             # the ForConditionalGeneration model
-            WeightRenaming(source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!language_model.)"),
+            WeightRenaming(source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"),
         ],
         "sam3_tracker": [
             WeightRenaming(

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -159,8 +159,9 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming("feedforward_layer_norm", "post_attention_layernorm"),
         ],
         "qwen3_5_text": [
-            # Note: the lookbehind on the target is to avoid replacing bigger matches during saving when the model is
-            # a submodel of the ForConditionalGeneration model
+            # Note: the lookbehind on the target is to avoid replacing the `model` part when saving with the
+            # ForConditionalGeneration (main) model - this is supposed to replace only when the ForCausalLM (submodel)
+            # is used, with keys coming from the ForConditionalGeneration model
             WeightRenaming(
                 source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"
             ),

--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -161,7 +161,9 @@ def _build_checkpoint_conversion_mapping():
         "qwen3_5_text": [
             # Note: the lookbehind on the target is to avoid replacing bigger matches when the model is a submodel of
             # the ForConditionalGeneration model
-            WeightRenaming(source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"),
+            WeightRenaming(
+                source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"
+            ),
         ],
         "sam3_tracker": [
             WeightRenaming(

--- a/tests/models/aya_vision/test_modeling_aya_vision.py
+++ b/tests/models/aya_vision/test_modeling_aya_vision.py
@@ -206,6 +206,9 @@ class AyaVisionModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_batching_equivalence(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class AyaVisionIntegrationTest(unittest.TestCase):

--- a/tests/models/cohere_asr/test_modeling_cohere_asr.py
+++ b/tests/models/cohere_asr/test_modeling_cohere_asr.py
@@ -175,15 +175,9 @@ class CohereAsrModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
     def test_config(self):
         self.config_tester.run_common_tests()
 
-    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
+    def test_reverse_loading_mapping(self):
         # proj_out conversion only applies to ForConditionalGeneration, not the base model
-        try:
-            self.all_model_classes = (CohereAsrForConditionalGeneration,) if is_torch_available() else ()
-            super().test_reverse_loading_mapping(check_keys_were_modified)
-        finally:
-            self.all_model_classes = (
-                (CohereAsrModel, CohereAsrForConditionalGeneration) if is_torch_available() else ()
-            )
+        super().test_reverse_loading_mapping(skip_base_model=True)
 
     # Copied from tests.models.moonshine_streaming.test_modeling_moonshine_streaming.MoonshineStreamingModelTest.test_resize_tokens_embeddings
     def test_resize_tokens_embeddings(self):

--- a/tests/models/colpali/test_modeling_colpali.py
+++ b/tests/models/colpali/test_modeling_colpali.py
@@ -226,8 +226,9 @@ class ColPaliForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
     def test_sdpa_can_compile_dynamic(self):
         pass
 
+    @unittest.skip(reason="Some weight mappings from paligemma are unreachable here as they use a `^` pattern")
     def test_reverse_loading_mapping(self):
-        super().test_reverse_loading_mapping(skip_base_model=True)
+        pass
 
 
 @require_torch

--- a/tests/models/colpali/test_modeling_colpali.py
+++ b/tests/models/colpali/test_modeling_colpali.py
@@ -226,6 +226,9 @@ class ColPaliForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
     def test_sdpa_can_compile_dynamic(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class ColPaliModelIntegrationTest(unittest.TestCase):

--- a/tests/models/colqwen2/test_modeling_colqwen2.py
+++ b/tests/models/colqwen2/test_modeling_colqwen2.py
@@ -284,6 +284,9 @@ class ColQwen2ForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
     def test_load_save_without_tied_weights(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class ColQwen2ModelIntegrationTest(unittest.TestCase):

--- a/tests/models/colqwen2/test_modeling_colqwen2.py
+++ b/tests/models/colqwen2/test_modeling_colqwen2.py
@@ -284,8 +284,9 @@ class ColQwen2ForRetrievalModelTest(ModelTesterMixin, unittest.TestCase):
     def test_load_save_without_tied_weights(self):
         pass
 
+    @unittest.skip(reason="One weight renaming from qwen2 is unreachable here as it uses a `^` pattern")
     def test_reverse_loading_mapping(self):
-        super().test_reverse_loading_mapping(skip_base_model=True)
+        pass
 
 
 @require_torch

--- a/tests/models/emu3/test_modeling_emu3.py
+++ b/tests/models/emu3/test_modeling_emu3.py
@@ -340,6 +340,9 @@ class Emu3Vision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, Pipeline
         up_down_blocks = len(model_tester.vq_channel_multiplier) * model_tester.vq_num_res_blocks
         return up_down_blocks + 2 + model_tester.vq_num_res_blocks + 1
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class Emu3IntegrationTest(unittest.TestCase):

--- a/tests/models/fuyu/test_modeling_fuyu.py
+++ b/tests/models/fuyu/test_modeling_fuyu.py
@@ -264,6 +264,9 @@ class FuyuModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMixin
     def test_get_image_features_attentions(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @slow
 @require_torch_accelerator

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -409,6 +409,9 @@ class Gemma3Vision2TextModelTest(VLMModelTest, unittest.TestCase):
     def test_flash_attn_4_from_config(self):
         self.flash_attn_from_config(attn_implementation="flash_attention_4", test_fwd_in_train=False)
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @slow
 @require_torch_accelerator

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -410,6 +410,10 @@ class Gemma3nTextModelTest(CausalLMModelTest, unittest.TestCase):
             rtols=rtols,
         )
 
+    @unittest.skip("Intentionally not reversable (no changes) as only load time within a VLM depends on this")
+    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
+        pass
+
     @pytest.mark.generate
     @unittest.skip("Gemma3n does not support QuantizedCache as it performs cache manipulation in the forward pass")
     def test_generate_with_quant_cache(self):
@@ -853,6 +857,12 @@ class Gemma3nVision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
     @pytest.mark.generate
     @unittest.skip("Gemma3n does not support QuantizedCache as it performs cache manipulation in the forward pass")
     def test_generate_with_quant_cache(self):
+        pass
+
+    @unittest.skip(
+        "Conversion only for the `CausalLM` loading from saved `ConditionalLM`, doesn't apply to simple VLM"
+    )
+    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 
     def _check_hidden_states_for_generate(

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -410,10 +410,6 @@ class Gemma3nTextModelTest(CausalLMModelTest, unittest.TestCase):
             rtols=rtols,
         )
 
-    @unittest.skip("Intentionally not reversable (no changes) as only load time within a VLM depends on this")
-    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
-        pass
-
     @pytest.mark.generate
     @unittest.skip("Gemma3n does not support QuantizedCache as it performs cache manipulation in the forward pass")
     def test_generate_with_quant_cache(self):
@@ -857,12 +853,6 @@ class Gemma3nVision2TextModelTest(ModelTesterMixin, GenerationTesterMixin, unitt
     @pytest.mark.generate
     @unittest.skip("Gemma3n does not support QuantizedCache as it performs cache manipulation in the forward pass")
     def test_generate_with_quant_cache(self):
-        pass
-
-    @unittest.skip(
-        "Conversion only for the `CausalLM` loading from saved `ConditionalLM`, doesn't apply to simple VLM"
-    )
-    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 
     def _check_hidden_states_for_generate(

--- a/tests/models/got_ocr2/test_modeling_got_ocr2.py
+++ b/tests/models/got_ocr2/test_modeling_got_ocr2.py
@@ -161,6 +161,9 @@ class GotOcr2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     def test_config(self):
         self.config_tester.run_common_tests()
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class GotOcr2IntegrationTest(unittest.TestCase):

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -134,7 +134,7 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
         return super().test_generate_compile_model_forward_fullgraph()
 
     def test_reverse_loading_mapping(self, check_keys_were_modified=False):
-        super().test_reverse_loading_mapping(check_keys_were_modified)
+        super().test_reverse_loading_mapping(check_keys_were_modified=False)
 
 
 RESULTS_PATH = Path(__file__).parent.parent.parent / "fixtures/gpt_oss/integration_tests.json"

--- a/tests/models/internvl/test_modeling_internvl.py
+++ b/tests/models/internvl/test_modeling_internvl.py
@@ -214,6 +214,9 @@ class InternVLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     def test_flash_attn_2_fp32_ln(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @slow
 @require_torch_accelerator

--- a/tests/models/llava/test_modeling_llava.py
+++ b/tests/models/llava/test_modeling_llava.py
@@ -282,6 +282,9 @@ class LlavaForConditionalGenerationModelTest(
     def test_flash_attention_2_padding_matches_padding_free_with_position_ids(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 @slow

--- a/tests/models/llava_next/test_modeling_llava_next.py
+++ b/tests/models/llava_next/test_modeling_llava_next.py
@@ -125,6 +125,9 @@ class LlavaNextForConditionalGenerationModelTest(VLMModelTest, unittest.TestCase
     def test_flash_attention_2_padding_matches_padding_free_with_position_ids(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class LlavaNextForConditionalGenerationIntegrationTest(unittest.TestCase):

--- a/tests/models/llava_next_video/test_modeling_llava_next_video.py
+++ b/tests/models/llava_next_video/test_modeling_llava_next_video.py
@@ -340,6 +340,9 @@ class LlavaNextVideoForConditionalGenerationModelTest(ModelTesterMixin, Generati
         inputs_dict = {"pixel_values": inputs_dict["pixel_values_videos"]}
         return config, inputs_dict
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class LlavaNextVideoForConditionalGenerationIntegrationTest(unittest.TestCase):

--- a/tests/models/llava_onevision/test_modeling_llava_onevision.py
+++ b/tests/models/llava_onevision/test_modeling_llava_onevision.py
@@ -312,6 +312,9 @@ class LlavaOnevisionForConditionalGenerationModelTest(ModelTesterMixin, Generati
         inputs_dict = {"pixel_values": pixel_values_videos}
         return config, inputs_dict
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class LlavaOnevisionForConditionalGenerationIntegrationTest(unittest.TestCase):

--- a/tests/models/mistral3/test_modeling_mistral3.py
+++ b/tests/models/mistral3/test_modeling_mistral3.py
@@ -230,6 +230,9 @@ class Mistral3ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterM
     def test_flex_attention_with_grads(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @slow
 @require_torch_accelerator

--- a/tests/models/mllama/test_modeling_mllama.py
+++ b/tests/models/mllama/test_modeling_mllama.py
@@ -452,6 +452,9 @@ class MllamaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTester
             unpadded_custom_inputs=unpadded_custom_inputs, padded_custom_inputs=padded_custom_inputs
         )
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class MllamaForConditionalGenerationIntegrationTest(unittest.TestCase):

--- a/tests/models/nemotron_h/test_modeling_nemotron_h.py
+++ b/tests/models/nemotron_h/test_modeling_nemotron_h.py
@@ -438,10 +438,7 @@ class NemotronHModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         pass
 
     def test_reverse_loading_mapping(self):
-        original_all_model_classes = self.all_model_classes
-        self.all_model_classes = (NemotronHForCausalLM,) if is_torch_available() else ()
-        super().test_reverse_loading_mapping()
-        self.all_model_classes = original_all_model_classes
+        super().test_reverse_loading_mapping(skip_base_model=True)
 
     # TODO(liding):
     # in test_configuration_common.py, three tests failed

--- a/tests/models/paligemma/test_modeling_paligemma.py
+++ b/tests/models/paligemma/test_modeling_paligemma.py
@@ -327,6 +327,9 @@ class PaliGemmaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTes
                                     f"Found non-zero attention weights for padding token at batch {batch_idx}, sequence position {seq_idx}",
                                 )
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @slow
 @require_torch

--- a/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
+++ b/tests/models/qwen2_5_vl/test_modeling_qwen2_5_vl.py
@@ -397,15 +397,8 @@ class Qwen2_5_VLModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
                 tol = torch.finfo(torch.bfloat16).eps
                 torch.testing.assert_close(logits_padded, logits_padfree, rtol=tol, atol=tol)
 
-    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
-        # Conversion happens only for the `ConditionalGeneration` model, not the base model
-        try:
-            self.all_model_classes = (Qwen2_5_VLForConditionalGeneration,) if is_torch_available() else ()
-            super().test_reverse_loading_mapping(check_keys_were_modified)
-        finally:
-            self.all_model_classes = (
-                (Qwen2_5_VLModel, Qwen2_5_VLForConditionalGeneration) if is_torch_available() else ()
-            )
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
 
     @unittest.skip(reason="Feedforward chunking is not yet supported")
     def test_feed_forward_chunking(self):

--- a/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
+++ b/tests/models/qwen2_vl/test_modeling_qwen2_vl.py
@@ -359,13 +359,8 @@ class Qwen2VLModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
                 tol = torch.finfo(torch.bfloat16).eps
                 torch.testing.assert_close(logits_padded, logits_padfree, rtol=tol, atol=tol)
 
-    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
-        # Conversion happens only for the `ConditionalGeneration` model, not the base model
-        try:
-            self.all_model_classes = (Qwen2VLForConditionalGeneration,) if is_torch_available() else ()
-            super().test_reverse_loading_mapping(check_keys_were_modified)
-        finally:
-            self.all_model_classes = (Qwen2VLModel, Qwen2VLForConditionalGeneration) if is_torch_available() else ()
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
 
     @unittest.skip(reason="Feedforward chunking is not yet supported")
     def test_feed_forward_chunking(self):

--- a/tests/models/video_llava/test_modeling_video_llava.py
+++ b/tests/models/video_llava/test_modeling_video_llava.py
@@ -397,6 +397,9 @@ class VideoLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTe
             assert base_model.multi_modal_projector.linear_1.in_features == expected_features
             model(**input_dict)
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class VideoLlavaForConditionalGenerationIntegrationTest(unittest.TestCase):

--- a/tests/models/vipllava/test_modeling_vipllava.py
+++ b/tests/models/vipllava/test_modeling_vipllava.py
@@ -274,6 +274,9 @@ class VipLlavaForConditionalGenerationModelTest(ModelTesterMixin, GenerationTest
     def test_flash_attention_2_padding_matches_padding_free_with_position_ids(self):
         pass
 
+    def test_reverse_loading_mapping(self):
+        super().test_reverse_loading_mapping(skip_base_model=True)
+
 
 @require_torch
 class VipLlavaForConditionalGenerationIntegrationTest(unittest.TestCase):

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -434,10 +434,6 @@ def _test_eager_matches_sdpa_inference(
                 outputs_eager = outputs_eager["language_model_outputs"]
                 outputs_sdpa = outputs_sdpa["language_model_outputs"]
                 key = "hidden_states" if "hidden_states" in outputs_eager else "decoder_hidden_states"
-            elif "decoder_output" in outputs_eager and "clipseg" in model_class.__name__.lower():
-                outputs_eager = outputs_eager["decoder_output"]
-                outputs_sdpa = outputs_sdpa["decoder_output"]
-                key = "hidden_states" if "hidden_states" in outputs_eager else "decoder_hidden_states"
             else:
                 key = "hidden_states"
 
@@ -1754,10 +1750,7 @@ class ModelTesterMixin:
         """Helper function to recursively set a config attr to a given value"""
         for k in config.sub_configs:
             if (
-                self._is_composite
-                and attribute_name == "output_attentions"
-                and k == "vision_config"
-                and "Timm" in getattr(config, k).__class__.__name__
+                self._is_composite and attribute_name == "output_attentions" and k == "vision_config"
             ):  # skip because it's not needed and causes errors e.g with Timm
                 continue
             if getattr(config, k) is not None:
@@ -4743,7 +4736,7 @@ class ModelTesterMixin:
                 len(unused_entries) == 0, f"The following entries of the TP-plan are not valid: {unused_entries}"
             )
 
-    def test_reverse_loading_mapping(self, check_keys_were_modified=True):
+    def test_reverse_loading_mapping(self, check_keys_were_modified=True, skip_base_model=False):
         """Make sure we can load and save correctly the models having any weight renaming mapping or weight conversion
         mapping.
         Note that this test would be better if we could start from the serialized keys, and check that the model
@@ -4757,6 +4750,11 @@ class ModelTesterMixin:
             check_keys_were_modified (`bool`, *optional*, defaults to `True`):
                 Whether to expect keys being modified or not. In some cases, models do not change keys but
                 their weights, e.g. via transpose, memory alignment, etc.
+            skip_base_model (`bool`, *optional*, defaults to `False`):
+                Sometimes, mappings are only visible when applied to the model with head, and not visible on the
+                base model. This allows to skip the check on the base model. See e.g. `llava` mapping where this
+                is the case. In practice, the mappings are still coherent and a base model can still be loaded from
+                the head model, thanks to the `base_model_prefix` which will remove the prefix automatically.
         """
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()
 
@@ -4769,8 +4767,11 @@ class ModelTesterMixin:
         config_to_set.num_dense_layers = 1  # lfm2_moe
 
         for model_class in self.all_model_classes:
+            if skip_base_model and "For" not in model_class.__name__:
+                continue
             # Each individual model is a subtest
             with self.subTest(model_class.__name__):
+                print(f"STARTING WITH {model_class.__name__}")
                 model = model_class(copy.deepcopy(config))
                 # Skip if no conversions
                 conversions = get_model_conversion_mapping(model, add_legacy=False)

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -434,6 +434,10 @@ def _test_eager_matches_sdpa_inference(
                 outputs_eager = outputs_eager["language_model_outputs"]
                 outputs_sdpa = outputs_sdpa["language_model_outputs"]
                 key = "hidden_states" if "hidden_states" in outputs_eager else "decoder_hidden_states"
+            elif "decoder_output" in outputs_eager and "clipseg" in model_class.__name__.lower():
+                outputs_eager = outputs_eager["decoder_output"]
+                outputs_sdpa = outputs_sdpa["decoder_output"]
+                key = "hidden_states" if "hidden_states" in outputs_eager else "decoder_hidden_states"
             else:
                 key = "hidden_states"
 
@@ -1750,7 +1754,10 @@ class ModelTesterMixin:
         """Helper function to recursively set a config attr to a given value"""
         for k in config.sub_configs:
             if (
-                self._is_composite and attribute_name == "output_attentions" and k == "vision_config"
+                self._is_composite
+                and attribute_name == "output_attentions"
+                and k == "vision_config"
+                and "Timm" in getattr(config, k).__class__.__name__
             ):  # skip because it's not needed and causes errors e.g with Timm
                 continue
             if getattr(config, k) is not None:
@@ -4771,7 +4778,6 @@ class ModelTesterMixin:
                 continue
             # Each individual model is a subtest
             with self.subTest(model_class.__name__):
-                print(f"STARTING WITH {model_class.__name__}")
                 model = model_class(copy.deepcopy(config))
                 # Skip if no conversions
                 conversions = get_model_conversion_mapping(model, add_legacy=False)


### PR DESCRIPTION
# What does this PR do?

Fix https://github.com/huggingface/transformers/issues/45357 finally. This was not catched in the previous fix, as the model can be reloaded correctly by `from_pretrained`, but keys are still wrongly serialized!

After deeper look, I noticed @zucchini-nlp did not correctly copy the mappings in https://github.com/huggingface/transformers/pull/44627... It is EXTREMELY IMPORTANT and can very easily silently break loading and/or saving @zucchini-nlp - we cannot touch the mappings without being 100% sure of the change. You missed a lot before
In this case, most would load correctly, but would not resave the same format

For ref, I'm using this small snippet to check formats:

```python
import transformers
from transformers import LlavaForConditionalGeneration, LlavaNextForConditionalGeneration
from safetensors.torch import load_file
from transformers.utils.hub import cached_file, cached_files
import json

# model_id = "llava-hf/llava-1.5-7b-hf"
model_id = "llava-hf/llava-v1.6-mistral-7b-hf"
# model_id = "adept/fuyu-8b"
model_class = transformers.LlavaNextForConditionalGeneration

target_folder = "/raid/cyril/test_model"

with open(cached_file(model_id, "model.safetensors.index.json")) as f:
    index = json.load(f)
model_files = set(index["weight_map"].values())
model_files = cached_files(model_id, model_files)

original_state_dict = {}
for file in model_files:
    original_state_dict.update(load_file(file))

model = model_class.from_pretrained(model_id)
model.save_pretrained(target_folder)

saved_weights = load_file(f"{target_folder}/model.safetensors")

not_in_saved = []
for k, v in original_state_dict.items():
    if k not in saved_weights:
        not_in_saved.append(k)
    else:
        assert (v == saved_weights[k]).all()

not_in_original = []
for k, v in saved_weights.items():
    if k not in original_state_dict:
        not_in_original.append(k)
    else:
        assert (v == original_state_dict[k]).all()

print(f"The following are in original but not in saved: {not_in_saved}")
print(f"The following are saved but not in original: {not_in_original}")

model = model_class.from_pretrained(target_folder)
```