### PR TITLE
Fix Kimi-K2.5 tokenizer regression and _patch_mistral_regex AttributeError

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -358,7 +358,6 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "internvl_chat",
     "jamba",
     "janus",
-    "kimi_k25",
     "llava",
     "llava_next",
     "minicpmv",

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1360,11 +1360,11 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                         ),
                         behavior="isolated",
                     )
-                    current_pretokenizer = tokenizer.backend_tokenizer.pre_tokenizer
+                    current_pretokenizer = tokenizer.pre_tokenizer
                     # Check if it's already a Sequence
                     if isinstance(current_pretokenizer, tokenizers.pre_tokenizers.Sequence):
                         # Replace the first element (the Split pattern)
-                        tokenizer.backend_tokenizer.pre_tokenizer[0] = split_pretokenizer
+                        tokenizer.pre_tokenizer[0] = split_pretokenizer
                     else:
                         # Replace Metaspace with ByteLevel when adding Split, as Metaspace(split=False) doesn't
                         # work correctly with the Split pre-tokenizer and causes spaces to be lost during encoding
@@ -1374,7 +1374,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                             )
 
                         # Not a Sequence, so create one with Split + current pretokenizer
-                        tokenizer.backend_tokenizer.pre_tokenizer = tokenizers.pre_tokenizers.Sequence(
+                        tokenizer.pre_tokenizer = tokenizers.pre_tokenizers.Sequence(
                             [
                                 split_pretokenizer,
                                 current_pretokenizer,


### PR DESCRIPTION
Fixes #45356

## Summary

- Remove `kimi_k25` from `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`: its remote `TikTokenTokenizer` is the only correct backend — the model has no `tokenizer.json`, and its `added_tokens_decoder` has non-sequential IDs (gaps + `[UNK]`/`[PAD]` at 163838/163839) that `TokenizersBackend.add_tokens()` can't reproduce, causing every token after ID 163588 to be assigned wrong IDs.
- Fix `_patch_mistral_regex`: use `tokenizer.pre_tokenizer` instead of `tokenizer.backend_tokenizer.pre_tokenizer` — the method receives the raw `tokenizers.Tokenizer`, which doesn't have `.backend_tokenizer`.

## Test plan

- [x] `AutoTokenizer.from_pretrained("moonshotai/Kimi-K2.5", trust_remote_code=True).decode([163607])` returns `'</think>'`
- [x] Roundtrip encode/decode of `<think>hello</think>` works
