### PR TITLE
Replace deprecated `huggingface-cli` references with `hf`

### DIFF
--- a/src/transformers/models/audioflamingo3/convert_audioflamingo3_to_hf.py
+++ b/src/transformers/models/audioflamingo3/convert_audioflamingo3_to_hf.py
@@ -233,7 +233,7 @@ python src/transformers/models/audioflamingo3/convert_audioflamingo3_to_hf.py \
   --dst_dir audio-flamingo-3-hf
 ```
 
-3) Convert and push directly to the Hub (requires `huggingface-cli login` or `HF_TOKEN`):
+3) Convert and push directly to the Hub (requires `hf auth login` or `HF_TOKEN`):
 
 ```
 python src/transformers/models/audioflamingo3/convert_audioflamingo3_to_hf.py \

--- a/src/transformers/models/musicflamingo/convert_musicflamingo_to_hf.py
+++ b/src/transformers/models/musicflamingo/convert_musicflamingo_to_hf.py
@@ -256,7 +256,7 @@ python src/transformers/models/musicflamingo/convert_musicflamingo_to_hf.py \
   --dst_dir music-flamingo-2601-hf
 ```
 
-3) Convert and push directly to the Hub (requires `huggingface-cli login` or `HF_TOKEN`):
+3) Convert and push directly to the Hub (requires `hf auth login` or `HF_TOKEN`):
 
 ```
 python src/transformers/models/musicflamingo/convert_musicflamingo_to_hf.py \

--- a/src/transformers/models/vibevoice_asr/convert_vibevoice_asr_to_hf.py
+++ b/src/transformers/models/vibevoice_asr/convert_vibevoice_asr_to_hf.py
@@ -328,7 +328,7 @@ Usage:
 
 1) Download the original VibeVoice ASR model checkpoint:
 ```bash
-huggingface-cli download microsoft/VibeVoice-ASR --local-dir /path/to/vibevoice-asr
+hf download microsoft/VibeVoice-ASR --local-dir /path/to/vibevoice-asr
 ```
 
 2) Run conversion script (with optional `push_to_hub` argument):


### PR DESCRIPTION
# What does this PR do?
`huggingface-cli` is deprecated and no longer maintained. This PR updates the remaining references with `hf`


