### PR TITLE
fix(serving): resolve rust tokenizer from ProcessorMixin in streaming generation

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -562,7 +562,9 @@ class GenerateManager(BaseGenerateManager):
         """Start streaming generation via ``model.generate()`` on the inference thread."""
         loop = asyncio.get_running_loop()
         queue: asyncio.Queue = asyncio.Queue()
-        streamer = DirectStreamer(processor._tokenizer, loop, queue, skip_special_tokens=True)
+        # ProcessorMixin exposes the fast tokenizer as .tokenizer; PreTrainedTokenizerFast is already one.
+        rust_tokenizer = getattr(processor, "tokenizer", processor)._tokenizer
+        streamer = DirectStreamer(rust_tokenizer, loop, queue, skip_special_tokens=True)
         gen_kwargs = {**inputs, "streamer": streamer, "generation_config": gen_config, "tokenizer": processor}
 
         def _run() -> None:
@@ -661,7 +663,9 @@ class CBGenerateManager(BaseGenerateManager):
             max_new_tokens=gen_config.max_new_tokens,
             eos_token_id=gen_config.eos_token_id,
         )
-        streamer = CBStreamer(self._cb, request_id, processor._tokenizer, loop, text_queue)
+        # ProcessorMixin exposes the fast tokenizer as .tokenizer; PreTrainedTokenizerFast is already one.
+        rust_tokenizer = getattr(processor, "tokenizer", processor)._tokenizer
+        streamer = CBStreamer(self._cb, request_id, rust_tokenizer, loop, text_queue)
 
         # Register a direct callback: the dispatcher calls this on the event loop with each GenerationOutput.
         # This decodes tokens and pushes text straight to the SSE text_queue


### PR DESCRIPTION
## Summary

Fixes #45362 — `transformers chat` crashes with `AttributeError: 'Qwen3VLProcessor' object has no attribute '_tokenizer'` when streaming responses from Qwen models.

**Root cause:** `GenerateManager.generate_streaming()` and `CBGenerateManager.generate_streaming()` access `processor._tokenizer` to get the Rust tokenizer backend. This works for `PreTrainedTokenizerFast` (which stores the Rust backend at `._tokenizer`), but `ProcessorMixin` subclasses like `Qwen3VLProcessor` expose the fast tokenizer at the public `.tokenizer` attribute instead.

**Fix:** Use `getattr(processor, "tokenizer", processor)._tokenizer` to first resolve the fast tokenizer (which is `processor.tokenizer` for ProcessorMixin, or `processor` itself for PreTrainedTokenizerFast), then access `._tokenizer` for the Rust backend.

Two locations updated:
- `GenerateManager.generate_streaming()` (line 565)
- `CBGenerateManager.generate_streaming()` (line 664)

## Coordination

- Issue discussion: https://github.com/huggingface/transformers/issues/45362#issuecomment-4227898143
- No existing open PRs for this issue.
- AI assistance (Claude Code) was used. All changes reviewed and validated by the submitting human.

## Test plan

- [ ] Verify `transformers chat Qwen/Qwen3.5-35B-A3B` no longer crashes on first prompt
- [ ] Verify streaming works correctly with non-processor models (e.g. text-only models)
- [ ] `ruff check src/transformers/cli/serving/utils.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)