### PR TITLE
fix(generation): handle CUDA multinomial limit in beam search sampling

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2973,9 +2973,16 @@ class GenerationMixin(ContinuousMixin):
 
         # Gather the top K scores from _all_ beams.
         if do_sample:
-            topk_indices = torch.multinomial(
-                nn.functional.softmax(accumulated_log_probs, dim=-1), num_samples=beams_to_keep
-            )
+            probs = nn.functional.softmax(accumulated_log_probs, dim=-1)
+            # torch.multinomial on CUDA requires the last dimension to be <= 2**24.
+            # When num_beams * vocab_size exceeds this, pre-filter to the top candidates.
+            _MULTINOMIAL_MAX = 2**24
+            if probs.shape[-1] > _MULTINOMIAL_MAX:
+                top_values, top_indices = torch.topk(probs, k=_MULTINOMIAL_MAX, dim=-1)
+                sampled = torch.multinomial(top_values, num_samples=beams_to_keep)
+                topk_indices = torch.gather(top_indices, dim=1, index=sampled)
+            else:
+                topk_indices = torch.multinomial(probs, num_samples=beams_to_keep)
             topk_log_probs = torch.gather(input=accumulated_log_probs, dim=1, index=topk_indices)
         else:
             topk_log_probs, topk_indices = torch.topk(accumulated_log_probs, k=beams_to_keep)


### PR DESCRIPTION
## Summary

Fixes #45245 — `torch.multinomial` crashes with `RuntimeError: number of categories cannot exceed 2^24` when `num_beams * vocab_size > 16,777,216` during beam search with `do_sample=True`.

**Root cause:** In `_get_top_k_continuations()`, the accumulated log-probs are flattened to shape `(batch_size, num_beams * vocab_size)` and passed directly to `torch.multinomial`. With large beam counts (e.g. 128) and large vocabularies (e.g. 164K), this exceeds PyTorch's CUDA limit of `2^24` categories.

**Fix:** When the flattened dimension exceeds `2^24`, pre-filter to the top `2^24` candidates using `torch.topk` (which has no such limit), then sample from the filtered set. The candidate indices are mapped back to the original space. This preserves the sampling distribution — with 16.7M out of ~21M candidates retained, virtually all probability mass is covered.

The fix is 7 net new lines. No new files, no new dependencies, no behavioral change for users within the limit.

## Coordination

- Issue discussion: https://github.com/huggingface/transformers/issues/45245#issuecomment-4227935471
- Previous PR #45251 was closed for being over-engineered (91 additions). This fix is minimal.
- No other open PRs for this issue.
- AI assistance (Claude Code) was used. All changes reviewed and validated by the submitting human.

## Test plan

- [ ] Verify `model.generate(num_beams=128, do_sample=True)` no longer crashes with large-vocab models
- [ ] Verify normal beam search (`num_beams < 2^24/vocab_size`) is unaffected (takes the else branch)
- [ ] `ruff check src/transformers/generation/utils.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)