### PR TITLE
docs: fix 5 docstring errors in Gemma3nTextConfig (typos, grammar, formatting)

### DIFF
--- a/src/transformers/models/gemma3n/configuration_gemma3n.py
+++ b/src/transformers/models/gemma3n/configuration_gemma3n.py
@@ -41,23 +41,23 @@ class Gemma3nTextConfig(PreTrainedConfig):
     vocab_size_per_layer_input (`int`, *optional*, defaults to 262144):
         Vocabulary size of the per-layer text embeddings that augment the standard embeddings.
     hidden_size_per_layer_input (`int`, *optional*, defaults to 256):
-        Dimension of the hidden representations for per-layer emebeddings.
+        Dimension of the hidden representations for per-layer embeddings.
     altup_active_idx (`int`, *optional*, defaults to 0):
-        The index of the prediction from which AltUp will compute additional predictions or correct
+        The index of the prediction from which AltUp will compute additional predictions or correct the active prediction.
     altup_coef_clip (`float`, *optional*, defaults to 120.0):
         The maximum amplitude of an AltUp prediction or correction coefficient weight.
     altup_correct_scale (`bool`, *optional*, defaults to `True`):
         If True, apply the `AltUp.correct_output_scale` to the corrected prediction at `altup_active_idx`.
     altup_num_inputs (`int`, *optional*, defaults to 4):
-        The number of predictions that AltUp should be make given the input sequence.
+        The number of predictions that AltUp should make given the input sequence.
     num_kv_shared_layers (`int`, *optional*, defaults to 15):
-        The number of layer that share KV cache values. During the forward pass, the last `num_kv_shared_layers`
+        The number of layers that share KV cache values. During the forward pass, the last `num_kv_shared_layers`
         layers in the model "share" the KV values in that each local and global layer in this range uses the KV
         cache values computed for the last local or global layer, respectively, before entering this range. The
         value should be a multiple of the attention pattern size (see `layer_types` parameter).
-    laurel_rank (int, *optional*, defaults to 64):
+    laurel_rank (`int`, *optional*, defaults to 64):
         The intermediate size for the linear projections in the Learned Augmented Residual Layer.
-    activation_sparsity_pattern (Sequence[float], *optional*):
+    activation_sparsity_pattern (`Sequence[float]`, *optional*):
         The sparsity factor used to extract the top-k activations for a given layer. The provided Sequence must
         explicitly provide a sparsity value for each layer in the model. By default, the first 10 layers are
         sparse with a sparsity factor of 0.95 and the rest are dense.

--- a/src/transformers/models/gemma3n/modular_gemma3n.py
+++ b/src/transformers/models/gemma3n/modular_gemma3n.py
@@ -69,23 +69,23 @@ class Gemma3nTextConfig(Gemma3TextConfig):
     vocab_size_per_layer_input (`int`, *optional*, defaults to 262144):
         Vocabulary size of the per-layer text embeddings that augment the standard embeddings.
     hidden_size_per_layer_input (`int`, *optional*, defaults to 256):
-        Dimension of the hidden representations for per-layer emebeddings.
+        Dimension of the hidden representations for per-layer embeddings.
     altup_active_idx (`int`, *optional*, defaults to 0):
-        The index of the prediction from which AltUp will compute additional predictions or correct
+        The index of the prediction from which AltUp will compute additional predictions or correct the active prediction.
     altup_coef_clip (`float`, *optional*, defaults to 120.0):
         The maximum amplitude of an AltUp prediction or correction coefficient weight.
     altup_correct_scale (`bool`, *optional*, defaults to `True`):
         If True, apply the `AltUp.correct_output_scale` to the corrected prediction at `altup_active_idx`.
     altup_num_inputs (`int`, *optional*, defaults to 4):
-        The number of predictions that AltUp should be make given the input sequence.
+        The number of predictions that AltUp should make given the input sequence.
     num_kv_shared_layers (`int`, *optional*, defaults to 15):
-        The number of layer that share KV cache values. During the forward pass, the last `num_kv_shared_layers`
+        The number of layers that share KV cache values. During the forward pass, the last `num_kv_shared_layers`
         layers in the model "share" the KV values in that each local and global layer in this range uses the KV
         cache values computed for the last local or global layer, respectively, before entering this range. The
         value should be a multiple of the attention pattern size (see `layer_types` parameter).
-    laurel_rank (int, *optional*, defaults to 64):
+    laurel_rank (`int`, *optional*, defaults to 64):
         The intermediate size for the linear projections in the Learned Augmented Residual Layer.
-    activation_sparsity_pattern (Sequence[float], *optional*):
+    activation_sparsity_pattern (`Sequence[float]`, *optional*):
         The sparsity factor used to extract the top-k activations for a given layer. The provided Sequence must
         explicitly provide a sparsity value for each layer in the model. By default, the first 10 layers are
         sparse with a sparsity factor of 0.95 and the rest are dense.


### PR DESCRIPTION
# What does this PR do?

Fixes five documentation errors in the `Gemma3nTextConfig` docstring in `modular_gemma3n.py` (and the generated `configuration_gemma3n.py`):

1. **Typo**: `"emebeddings"` → `"embeddings"` in `hidden_size_per_layer_input`
2. **Incomplete sentence**: `altup_active_idx` description was cut off at `"or correct"` — completed to `"or correct the active prediction."`
3. **Grammar**: `"should be make"` → `"should make"` in `altup_num_inputs`
4. **Grammar**: `"number of layer"` → `"number of layers"` in `num_kv_shared_layers`
5. **Formatting**: Added missing backticks around type annotations for `laurel_rank` and `activation_sparsity_pattern` to match HF docstring conventions used consistently throughout the file

Both the modular source file (`modular_gemma3n.py`) and the generated configuration file (`configuration_gemma3n.py`) are updated in sync.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the "Test" section below).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

**Note to maintainers:** These are purely documentation corrections — no logic changes. The modular file is the source of truth; the generated file was updated by hand to match (identical diff in both files). Running `make fix-repo` will confirm the generated file is in sync.

## AI disclosure

- [x] AI-assisted contribution (Claude Code used to identify and draft fixes; all changes reviewed and validated by Rudrendu Paul)
- [x] I confirm this is NOT a pure code agent PR — the human submitter (Rudrendu Paul) has reviewed every changed line

## Who can review?

@stevhliu @zucchini-nlp