### PR TITLE
fix: check CUDA availability before calling get_device_capability

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3198,9 +3198,9 @@ def get_device_properties() -> DeviceProperties:
     """
     Get environment device properties.
     """
-    if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
-        import torch
-
+    import torch
+    
+    if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
         major, minor = torch.cuda.get_device_capability()
         if IS_ROCM_SYSTEM:
             return ("rocm", major, minor)


### PR DESCRIPTION
Fixes #45341

When CUDA is installed but no GPU is available, `get_device_properties()` calls `torch.cuda.get_device_capability()` which fails because there is no CUDA device.

The fix moves `import torch` to the top of the function and adds a `torch.cuda.is_available()` check to the condition, so the function gracefully falls through to the else branch when no GPU is present.