### PR TITLE
fix(mistral): guard ReasoningEffort import for older mistral_common versions

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -39,7 +39,11 @@ from transformers.utils.import_utils import is_mistral_common_available, is_torc
 
 
 if is_mistral_common_available():
-    from mistral_common.protocol.instruct.request import ChatCompletionRequest, ReasoningEffort
+    from mistral_common.protocol.instruct.request import ChatCompletionRequest
+    try:
+        from mistral_common.protocol.instruct.request import ReasoningEffort
+    except ImportError:
+        from typing import Any as ReasoningEffort  # type: ignore[assignment]
     from mistral_common.protocol.instruct.validator import ValidationMode
     from mistral_common.tokens.tokenizers.base import SpecialTokenPolicy, SpecialTokens
     from mistral_common.tokens.tokenizers.mistral import MistralTokenizer


### PR DESCRIPTION
## Fix: Guard ReasoningEffort import for older mistral_common versions

Fixes #45372

### Problem
`ReasoningEffort` was added in `mistral-common>=1.10.0`, but the import in `tokenization_mistral_common.py` was unconditional within the `is_mistral_common_available()` guard. Users with `mistral-common<1.10.0` would get an `ImportError` that prevented loading **any** processor — including non-Mistral models like Gemma 4 and Qwen.

Additionally, even stubbing `ReasoningEffort = None` was insufficient because line 1042 uses `ReasoningEffort | None` in a type annotation, causing `TypeError: unsupported operand type(s) for |` since `NoneType` does not support the `|` operator.

### Fix
Wrap the `ReasoningEffort` import in a `try/except ImportError`, falling back to `typing.Any`. This ensures:
1. The module loads regardless of `mistral-common` version
2. The `ReasoningEffort | None` type annotation resolves correctly (`Any | None` is valid)
3. Non-Mistral models work without requiring the latest `mistral-common`
4. Mistral models with `reasoning_effort` support work correctly when `mistral-common>=1.10.0` is installed

### Changes
- `src/transformers/tokenization_mistral_common.py`: Split the combined import of `ChatCompletionRequest` and `ReasoningEffort` into separate imports with a `try/except` guard

### Testing
- Syntax validation passes
- Type annotation `Any | None` resolves correctly at runtime
- No changes to runtime behavior for users with `mistral-common>=1.10.0`