### PR TITLE
fix(config): add deepstack_visual_indexes to Qwen3_5MoeVisionConfig

### DIFF
--- a/src/transformers/models/qwen3_5_moe/configuration_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/configuration_qwen3_5_moe.py
@@ -129,6 +129,8 @@ class Qwen3_5MoeVisionConfig(PreTrainedConfig):
         The output hidden size of the vision model.
     num_position_embeddings (`int`, *optional*, defaults to 2304):
         The maximum sequence length that this model might ever be used with
+    deepstack_visual_indexes (`list[int]`, *optional*, defaults to `[]`):
+        Indexes of layers for deepstack embeddings.
     """
 
     model_type = "qwen3_5_moe"
@@ -145,6 +147,7 @@ class Qwen3_5MoeVisionConfig(PreTrainedConfig):
     temporal_patch_size: int | list[int] | tuple[int, int] = 2
     out_hidden_size: int = 3584
     num_position_embeddings: int = 2304
+    deepstack_visual_indexes: list[int] | tuple[int, ...] = ()
     initializer_range: float = 0.02
 
 

--- a/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modular_qwen3_5_moe.py
@@ -119,7 +119,12 @@ class Qwen3_5MoeTextConfig(Qwen3NextConfig):
 @auto_docstring(checkpoint="Qwen/Qwen3.5-35B-A3B")
 @strict
 class Qwen3_5MoeVisionConfig(Qwen3_5VisionConfig):
-    pass
+    r"""
+    deepstack_visual_indexes (`list[int]`, *optional*, defaults to `[]`):
+        Indexes of layers for deepstack embeddings.
+    """
+
+    deepstack_visual_indexes: list[int] | tuple[int, ...] = ()
 
 
 @auto_docstring(checkpoint="Qwen/Qwen3.5-35B-A3B")


### PR DESCRIPTION
## Problem

The `@strict` decorator on `Qwen3_5MoeVisionConfig` silently drops the `deepstack_visual_indexes` field during config loading because it is not declared as a class attribute. Every Qwen3.5 MoE model on HuggingFace ships with this field in its config.json (e.g. `Qwen/Qwen3.5-35B-A3B-Base`).

## Root Cause

`Qwen3_5MoeVisionConfig` inherits from `Qwen3_5VisionConfig`, which overrides `deepstack_visual_indexes` with an `AttributeError()` sentinel (inherited from the parent chain). The generated `configuration_qwen3_5_moe.py` does not include the field at all, so `@strict` rejects it when deserializing from config.json.

## Fix

Override `deepstack_visual_indexes` as a properly typed class attribute on `Qwen3_5MoeVisionConfig` with default `()`, matching the type annotation used in `Qwen3VLVisionConfig`. This ensures:

- The field is accepted when loading model configs
- `config.vision_config.deepstack_visual_indexes` returns the value from config.json
- No silent data loss during deserialization

## Verification

```python
from transformers import AutoConfig
config = AutoConfig.from_pretrained("Qwen/Qwen3.5-35B-A3B-Base", trust_remote_code=True)
print(config.vision_config.deepstack_visual_indexes)  # [] — no longer raises AttributeError
```

Fixes #45375

## Changes

- `modular_qwen3_5_moe.py`: Add `deepstack_visual_indexes` field override with docstring
- `configuration_qwen3_5_moe.py`: Add `deepstack_visual_indexes` field with docstring (generated)