### PR TITLE
fix Qwen3_5MoeVisionConfig deepstack_visual_indexes silently dropped by @strict (Issue: https://github.com/huggingface/transformers/issues/45375)

### DIFF
--- a/src/transformers/models/qwen3_5/configuration_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/configuration_qwen3_5.py
@@ -121,6 +121,8 @@ class Qwen3_5VisionConfig(PreTrainedConfig):
         The output hidden size of the vision model.
     num_position_embeddings (`int`, *optional*, defaults to 2304):
         The maximum sequence length that this model might ever be used with
+    deepstack_visual_indexes (`list[int]`, *optional*, defaults to `[]`):
+        Indexed of layers for deepstack embeddings. Defaults to empty for Qwen3.5.
     """
 
     model_type = "qwen3_5"
@@ -137,6 +139,8 @@ class Qwen3_5VisionConfig(PreTrainedConfig):
     temporal_patch_size: int | list[int] | tuple[int, int] = 2
     out_hidden_size: int = 3584
     num_position_embeddings: int = 2304
+
+    deepstack_visual_indexes: list[int] | tuple[int, ...] = ()
     initializer_range: float = 0.02
 
 

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -129,9 +129,11 @@ class Qwen3_5VisionConfig(Qwen3VLVisionConfig):
         The output hidden size of the vision model.
     num_position_embeddings (`int`, *optional*, defaults to 2304):
         The maximum sequence length that this model might ever be used with
+    deepstack_visual_indexes (`list[int]`, *optional*, defaults to `[]`):
+        Indexed of layers for deepstack embeddings. Defaults to empty for Qwen3.5.
     """
 
-    deepstack_visual_indexes = AttributeError()
+    deepstack_visual_indexes: list[int] | tuple[int, ...] = ()
 
 
 @auto_docstring(checkpoint="Qwen/Qwen3.5-27B")

--- a/src/transformers/models/qwen3_5_moe/configuration_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/configuration_qwen3_5_moe.py
@@ -129,6 +129,8 @@ class Qwen3_5MoeVisionConfig(PreTrainedConfig):
         The output hidden size of the vision model.
     num_position_embeddings (`int`, *optional*, defaults to 2304):
         The maximum sequence length that this model might ever be used with
+    deepstack_visual_indexes (`list[int]`, *optional*, defaults to `[]`):
+        Indexed of layers for deepstack embeddings. Defaults to empty for Qwen3.5.
     """
 
     model_type = "qwen3_5_moe"
@@ -145,6 +147,8 @@ class Qwen3_5MoeVisionConfig(PreTrainedConfig):
     temporal_patch_size: int | list[int] | tuple[int, int] = 2
     out_hidden_size: int = 3584
     num_position_embeddings: int = 2304
+
+    deepstack_visual_indexes: list[int] | tuple[int, ...] = ()
     initializer_range: float = 0.02
 
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #45375 ([issue](https://github.com/huggingface/transformers/issues/45375))

## Root Cause
In `modular_qwen3_5.py`, `Qwen3_5VisionConfig` was marked `@strict` but also had `deepstack_visual_indexes = AttributeError()`. That meant the field was effectively undeclared for strict loading, so when a real checkpoint config included `"deepstack_visual_indexes": []`, Transformers silently dropped it during config construction. Since `Qwen3_5MoeVisionConfig` inherits that shared Qwen3.5 vision config shape, the bug affected both plain Qwen3.5 and Qwen3.5-MoE configs.

## Fix
I restored `deepstack_visual_indexes` as a real config attribute in `modular_qwen3_5.py`, with an empty default so Qwen3.5 keeps deepstack disabled by default.

## Tests
```Python
from transformers import Qwen3_5Config, Qwen3_5MoeConfig

for cls in [Qwen3_5Config, Qwen3_5MoeConfig]:
    config = cls(vision_config={"deepstack_visual_indexes": [1, 2]})
    print(
        cls.__name__,
        type(config.vision_config.deepstack_visual_indexes).__name__,
        config.vision_config.deepstack_visual_indexes,
    )
```
Output:
```
Qwen3_5MoeConfig list [1, 2]
```