### PR TITLE
fix(processing): guard message content access in apply_chat_template

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1804,7 +1804,10 @@ class ProcessorMixin(PushToHubMixin):
             for conversation in conversations:
                 images, videos = [], []
                 for message in conversation:
-                    visuals = [content for content in (message.get("content") or []) if content["type"] in ["image", "video"]]
+                    visuals = [
+                        content for content in (message.get("content") or [])
+                        if content["type"] in ["image", "video"]
+                    ]
                     audio_fnames = [
                         content[key]
                         for content in (message.get("content") or [])

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1805,7 +1805,8 @@ class ProcessorMixin(PushToHubMixin):
                 images, videos = [], []
                 for message in conversation:
                     visuals = [
-                        content for content in (message.get("content") or [])
+                        content
+                        for content in (message.get("content") or [])
                         if content["type"] in ["image", "video"]
                     ]
                     audio_fnames = [

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -1804,10 +1804,10 @@ class ProcessorMixin(PushToHubMixin):
             for conversation in conversations:
                 images, videos = [], []
                 for message in conversation:
-                    visuals = [content for content in message["content"] if content["type"] in ["image", "video"]]
+                    visuals = [content for content in (message.get("content") or []) if content["type"] in ["image", "video"]]
                     audio_fnames = [
                         content[key]
-                        for content in message["content"]
+                        for content in (message.get("content") or [])
                         for key in ["audio", "url", "path"]
                         if key in content and content["type"] == "audio"
                     ]


### PR DESCRIPTION
## Description

Fixes #45290.

`apply_chat_template(tokenize=True)` raises `KeyError: 'content'` when a conversation contains an assistant message that has `tool_calls` but no `content` key:

```python
processor.apply_chat_template(
    [[
        {"role": "user", "content": [{"type": "text", "text": "dummy"}]},
        {"role": "assistant", "tool_calls": [{"type": "function", "function": {"name": "foo", "arguments": {}}}]},
    ]],
    tokenize=True,
)
# KeyError: 'content'
```

The crash happens at the two `message["content"]` subscripts in the `tokenize=True` branch of `ProcessorMixin.apply_chat_template` (lines 1807 and 1810 in `processing_utils.py`). The `content` field is optional for assistant messages with `tool_calls` — confirmed as intentional by @zucchini-nlp and @Rocketknight1.

## Fix

Replace the bare `message["content"]` subscripts with `message.get("content") or []` so that messages without a `content` key produce an empty visual/audio list and processing continues normally. The `message["content"].append(...)` at line 1837 is not affected: it is only reached when `video_fnames` is non-empty, which requires `visuals` to contain video items — impossible when `content` is absent.

## Testing

Verified locally that the reproduction case from the issue no longer raises `KeyError`. Existing test suite for `apply_chat_template` passes unchanged.