### PR TITLE
generation/stopping_criteria: short-circuit StoppingCriteriaList when all sequences are done

### DIFF
--- a/src/transformers/generation/stopping_criteria.py
+++ b/src/transformers/generation/stopping_criteria.py
@@ -498,6 +498,8 @@ class StoppingCriteriaList(list):
         is_done = torch.full((input_ids.shape[0],), False, device=input_ids.device, dtype=torch.bool)
         for criteria in self:
             is_done = is_done | criteria(input_ids, scores, **kwargs)
+            if is_done.all():
+                break
         return is_done
 
     @property

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -63,6 +63,29 @@ class StoppingCriteriaTestCase(unittest.TestCase):
         input_ids, scores = self._get_tensors(10)
         self.assertTrue(all(criteria(input_ids, scores)))
 
+    def test_list_criteria_short_circuits_when_all_done(self):
+        """Verify that StoppingCriteriaList stops evaluating remaining criteria once all
+        sequences are already marked done, avoiding unnecessary computation."""
+        call_count = 0
+
+        class CountingCriteria(StoppingCriteria):
+            def __call__(self, input_ids, scores, **kwargs):
+                nonlocal call_count
+                call_count += 1
+                return torch.zeros(input_ids.shape[0], dtype=torch.bool, device=input_ids.device)
+
+        # MaxLengthCriteria fires immediately (length == max_length), so CountingCriteria should be skipped
+        input_ids, scores = self._get_tensors(10)
+        criteria = StoppingCriteriaList(
+            [
+                MaxLengthCriteria(max_length=10),
+                CountingCriteria(),
+            ]
+        )
+        result = criteria(input_ids, scores)
+        self.assertTrue(all(result))
+        self.assertEqual(call_count, 0, "CountingCriteria should not be called when first criterion marks all done")
+
     def test_max_length_criteria(self):
         criteria = MaxLengthCriteria(max_length=10)
 

--- a/tests/generation/test_stopping_criteria.py
+++ b/tests/generation/test_stopping_criteria.py
@@ -25,14 +25,15 @@ if is_torch_available():
     import torch
 
     from transformers.generation import (
-        ConfidenceCriteria,
-        EosTokenCriteria,
-        MaxLengthCriteria,
-        MaxTimeCriteria,
-        StoppingCriteriaList,
-        StopStringCriteria,
-        validate_stopping_criteria,
-    )
+    ConfidenceCriteria,
+    EosTokenCriteria,
+    MaxLengthCriteria,
+    MaxTimeCriteria,
+    StoppingCriteria,
+    StoppingCriteriaList,
+    StopStringCriteria,
+    validate_stopping_criteria,
+)
 
 
 @require_torch


### PR DESCRIPTION
# What does this PR do?

`StoppingCriteriaList.__call__` previously evaluated every registered criterion
unconditionally on every generation step, even after `is_done` was already `True`
for all sequences in the batch. This adds a single `if is_done.all(): break` guard
inside the loop to skip remaining criteria once the entire batch is finished.

This is semantically safe because OR-ing any further `True` values into an
all-`True` tensor cannot change the result. The saving scales with
`(number_of_criteria − 1) × remaining_steps_after_completion`, and is most
impactful when `StopStringCriteria` (which runs a full vocab embedding lookup via
`F.embedding` each call) appears after a cheaper criterion like `MaxLengthCriteria`.

A new test `test_list_criteria_short_circuits_when_all_done` is added to verify
the behaviour using a `CountingCriteria` sentinel.

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?