### PR TITLE
Ignore CLIP position_ids in unexpected key loading report

### DIFF
--- a/src/transformers/models/clip/modeling_clip.py
+++ b/src/transformers/models/clip/modeling_clip.py
@@ -401,6 +401,10 @@ class CLIPPreTrainedModel(PreTrainedModel):
         "hidden_states": CLIPEncoderLayer,
         "attentions": CLIPAttention,
     }
+    _keys_to_ignore_on_load_unexpected = [
+        r".*text_model\.embeddings\.position_ids",
+        r".*vision_model\.embeddings\.position_ids",
+    ]
 
     @torch.no_grad()
     def _init_weights(self, module):

--- a/tests/models/clip/test_modeling_clip.py
+++ b/tests/models/clip/test_modeling_clip.py
@@ -570,6 +570,17 @@ class CLIPModelTest(CLIPModelTesterMixin, PipelineTesterMixin, unittest.TestCase
         model = CLIPModel.from_pretrained(model_name)
         self.assertIsNotNone(model)
 
+    @slow
+    def test_model_from_pretrained_ignores_position_ids_unexpected_keys(self):
+        _, loading_info = CLIPModel.from_pretrained(
+            "openai/clip-vit-base-patch32",
+            output_loading_info=True,
+        )
+
+        unexpected_keys = loading_info["unexpected_keys"]
+        self.assertNotIn("text_model.embeddings.position_ids", unexpected_keys)
+        self.assertNotIn("vision_model.embeddings.position_ids", unexpected_keys)
+
     @parameterized.expand(TEST_EAGER_MATCHES_SDPA_INFERENCE_PARAMETERIZATION)
     @slow
     @is_flaky()


### PR DESCRIPTION
## What does this PR do?

Loading `openai/clip-vit-base-patch32` currently reports the following keys as unexpected:

- `text_model.embeddings.position_ids`
- `vision_model.embeddings.position_ids`

In the current CLIP implementation, these buffers are registered with `persistent=False`, so they are not part of the current serialization contract and are not expected to be restored from checkpoints.

Older CLIP checkpoints may still contain these keys, but they are harmless historical buffers. This PR adds them to `_keys_to_ignore_on_load_unexpected` in `CLIPPreTrainedModel` so they no longer appear as misleading unexpected keys during loading.

This follows the same approach as #44508 for OwlViT.

Related to #44493.

I reproduced the issue locally, verified that the two keys disappear from `unexpected_keys` after the change, and added a targeted regression test.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue or the forum? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Test plan

- Reproduced the issue locally with:
  - `CLIPModel.from_pretrained("openai/clip-vit-base-patch32", output_loading_info=True)`
- Added a slow test covering the loading report
- Ran:
  - `RUN_SLOW=1 python -m pytest tests/models/clip/test_modeling_clip.py -k position_ids -sv -rs`

## Who can review?
@CyrilVallez