### PR TITLE
Make Gemma4ClippableLinear inherit from nn.Linear for PEFT/LoRA compatibility

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -592,6 +592,10 @@ def _build_checkpoint_conversion_mapping():
         WeightRenaming(r"log_softmax\.mlp\.layer0", r"proj_out"),
     ]
 
+    mapping["gemma4"] = [
+        WeightRenaming(r"\.linear\.weight", ".weight"),
+    ]
+
     for model_type, base_pattern in _MODEL_TO_CONVERSION_PATTERN.items():
         if model_type in mapping:
             continue

--- a/src/transformers/models/gemma4/convert_gemma4_weights.py
+++ b/src/transformers/models/gemma4/convert_gemma4_weights.py
@@ -371,10 +371,10 @@ def convert_audio_encoder_weights(
                     converted_paths.append(f"{base}.ffw_layer_2.{param.removeprefix('clip_')}")
                     converted_weights.append(matrix)
                 elif path.endswith("ffn_layer1"):
-                    converted_paths.append(f"{base}.ffw_layer_1.linear.weight")
+                    converted_paths.append(f"{base}.ffw_layer_1.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("ffn_layer2"):
-                    converted_paths.append(f"{base}.ffw_layer_2.linear.weight")
+                    converted_paths.append(f"{base}.ffw_layer_2.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("post_layer_norm"):
                     converted_paths.append(f"{base}.post_layer_norm.weight")
@@ -392,10 +392,10 @@ def convert_audio_encoder_weights(
                     converted_paths.append(f"{base}.ffw_layer_2.{param.removeprefix('clip_')}")
                     converted_weights.append(matrix)
                 elif path.endswith("ffn_layer1"):
-                    converted_paths.append(f"{base}.ffw_layer_1.linear.weight")
+                    converted_paths.append(f"{base}.ffw_layer_1.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("ffn_layer2"):
-                    converted_paths.append(f"{base}.ffw_layer_2.linear.weight")
+                    converted_paths.append(f"{base}.ffw_layer_2.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("post_layer_norm"):
                     converted_paths.append(f"{base}.post_layer_norm.weight")
@@ -422,10 +422,10 @@ def convert_audio_encoder_weights(
                     converted_paths.append(f"{base}.depthwise_conv1d.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("linear_end"):
-                    converted_paths.append(f"{base}.linear_end.linear.weight")
+                    converted_paths.append(f"{base}.linear_end.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("linear_start"):
-                    converted_paths.append(f"{base}.linear_start.linear.weight")
+                    converted_paths.append(f"{base}.linear_start.weight")
                     converted_weights.append(matrix.transpose())
                 elif path.endswith("ln"):
                     converted_paths.append(f"{base}.pre_layer_norm.weight")
@@ -451,9 +451,9 @@ def convert_audio_encoder_weights(
                 if path.endswith("query_key_value_projection"):
                     converted_paths.extend(
                         [
-                            f"{base}.self_attn.q_proj.linear.weight",
-                            f"{base}.self_attn.k_proj.linear.weight",
-                            f"{base}.self_attn.v_proj.linear.weight",
+                            f"{base}.self_attn.q_proj.weight",
+                            f"{base}.self_attn.k_proj.weight",
+                            f"{base}.self_attn.v_proj.weight",
                         ]
                     )
                     converted_weights.extend(
@@ -466,7 +466,7 @@ def convert_audio_encoder_weights(
                     converted_paths.append(f"{base}.self_attn.relative_k_proj.weight")
                     converted_weights.append(matrix.reshape(config.hidden_size, config.hidden_size).transpose())
                 elif path.endswith("post"):
-                    converted_paths.append(f"{base}.self_attn.post.linear.weight")
+                    converted_paths.append(f"{base}.self_attn.post.weight")
                     converted_weights.append(matrix.transpose(2, 0, 1).reshape(config.hidden_size, config.hidden_size))
                 elif path.endswith("post_norm"):
                     converted_paths.append(f"{base}.norm_post_attn.weight")
@@ -620,7 +620,7 @@ def convert_vision_encoder_weights(
 
             if path.endswith("attn/attn_vec_einsum"):
                 # Shape: (12, 64, 768) -> reshape to (768, 768) for o_proj
-                converted_paths.append(f"{base_path}.self_attn.o_proj.linear.weight")
+                converted_paths.append(f"{base_path}.self_attn.o_proj.weight")
                 converted_weights.append(
                     matrix.transpose(2, 0, 1).reshape(config.hidden_size, config.num_attention_heads * config.head_dim)
                 )
@@ -628,8 +628,8 @@ def convert_vision_encoder_weights(
                 # Shape: (2, 12, 768, 64) -> split into k_proj and v_proj
                 converted_paths.extend(
                     [
-                        f"{base_path}.self_attn.k_proj.linear.weight",
-                        f"{base_path}.self_attn.v_proj.linear.weight",
+                        f"{base_path}.self_attn.k_proj.weight",
+                        f"{base_path}.self_attn.v_proj.weight",
                     ]
                 )
                 k_proj_weights, v_proj_weights = matrix.transpose(0, 2, 1, 3)
@@ -642,7 +642,7 @@ def convert_vision_encoder_weights(
                 )
             elif path.endswith("attn/q_einsum"):
                 # Shape: (12, 768, 64) -> reshape to (768, 768) for q_proj
-                converted_paths.append(f"{base_path}.self_attn.q_proj.linear.weight")
+                converted_paths.append(f"{base_path}.self_attn.q_proj.weight")
                 converted_weights.append(
                     matrix.transpose(1, 0, 2)
                     .reshape(config.hidden_size, config.num_attention_heads * config.head_dim)
@@ -652,15 +652,15 @@ def convert_vision_encoder_weights(
                 # Shape: (2, 3072, 768) -> split into gate_proj and up_proj
                 converted_paths.extend(
                     [
-                        f"{base_path}.mlp.gate_proj.linear.weight",
-                        f"{base_path}.mlp.up_proj.linear.weight",
+                        f"{base_path}.mlp.gate_proj.weight",
+                        f"{base_path}.mlp.up_proj.weight",
                     ]
                 )
                 gate_proj_weight, up_proj_weight = matrix
                 converted_weights.extend([gate_proj_weight, up_proj_weight])
             elif path.endswith("mlp/linear"):
                 # Shape: (3072, 768) -> transpose for down_proj
-                converted_paths.append(f"{base_path}.mlp.down_proj.linear.weight")
+                converted_paths.append(f"{base_path}.mlp.down_proj.weight")
                 converted_weights.append(matrix.transpose())
             elif path.endswith("post_attention_norm"):
                 converted_paths.append(f"{base_path}.post_attention_layernorm.weight")

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -128,9 +128,8 @@ class Gemma4AudioModelOutput(BaseModelOutputWithPooling):
 class Gemma4ClippableLinear(nn.Linear):
     """Linear layer with optional input/output clamping.
 
-    Inherits from ``nn.Linear`` so that parameter-efficient fine-tuning
-    libraries (PEFT/LoRA) can discover and target these layers via the standard
-    ``isinstance(module, nn.Linear)`` check.
+    Inherits from ``nn.Linear`` directly so that PEFT/LoRA can target these
+    layers via ``isinstance(module, nn.Linear)``.
     """
 
     def __init__(
@@ -147,17 +146,6 @@ class Gemma4ClippableLinear(nn.Linear):
             self.register_buffer("input_max", torch.tensor(float("inf")))
             self.register_buffer("output_min", torch.tensor(-float("inf")))
             self.register_buffer("output_max", torch.tensor(float("inf")))
-
-        # Backward compat: older checkpoints store the weight under "linear.weight"
-        # (the previous implementation wrapped an nn.Linear as self.linear).
-        self._register_load_state_dict_pre_hook(self._remap_legacy_keys)
-
-    @staticmethod
-    def _remap_legacy_keys(state_dict, prefix, *args, **kwargs):
-        old_key = prefix + "linear.weight"
-        new_key = prefix + "weight"
-        if old_key in state_dict:
-            state_dict[new_key] = state_dict.pop(old_key)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         if self.use_clipped_linears:

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -125,16 +125,22 @@ class Gemma4AudioModelOutput(BaseModelOutputWithPooling):
     attention_mask: torch.BoolTensor | None = None
 
 
-class Gemma4ClippableLinear(nn.Module):
+class Gemma4ClippableLinear(nn.Linear):
+    """Linear layer with optional input/output clamping.
+
+    Inherits from ``nn.Linear`` so that parameter-efficient fine-tuning
+    libraries (PEFT/LoRA) can discover and target these layers via the standard
+    ``isinstance(module, nn.Linear)`` check.
+    """
+
     def __init__(
         self,
         config: Gemma4VisionConfig | Gemma4AudioConfig,
         in_features: int,
         out_features: int,
     ) -> None:
-        super().__init__()
+        super().__init__(in_features, out_features, bias=False)
         self.use_clipped_linears = config.use_clipped_linears
-        self.linear = nn.Linear(in_features, out_features, bias=False)
 
         if self.use_clipped_linears:
             self.register_buffer("input_min", torch.tensor(-float("inf")))
@@ -142,11 +148,22 @@ class Gemma4ClippableLinear(nn.Module):
             self.register_buffer("output_min", torch.tensor(-float("inf")))
             self.register_buffer("output_max", torch.tensor(float("inf")))
 
+        # Backward compat: older checkpoints store the weight under "linear.weight"
+        # (the previous implementation wrapped an nn.Linear as self.linear).
+        self._register_load_state_dict_pre_hook(self._remap_legacy_keys)
+
+    @staticmethod
+    def _remap_legacy_keys(state_dict, prefix, *args, **kwargs):
+        old_key = prefix + "linear.weight"
+        new_key = prefix + "weight"
+        if old_key in state_dict:
+            state_dict[new_key] = state_dict.pop(old_key)
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         if self.use_clipped_linears:
             hidden_states = torch.clamp(hidden_states, self.input_min, self.input_max)
 
-        hidden_states = self.linear(hidden_states)
+        hidden_states = nn.Linear.forward(self, hidden_states)
 
         if self.use_clipped_linears:
             hidden_states = torch.clamp(hidden_states, self.output_min, self.output_max)
@@ -309,7 +326,7 @@ class Gemma4AudioAttention(nn.Module):
         attn_output = attn_weights @ value_states.permute(0, 3, 1, 2, 4)
         attn_output = attn_output.permute(0, 2, 3, 1, 4).reshape(batch_size, num_blocks * self.chunk_size, -1)
         attn_output = attn_output[:, :seq_length].contiguous()
-        attn_output = self.post(attn_output.to(dtype=self.post.linear.weight.dtype))
+        attn_output = self.post(attn_output.to(dtype=self.post.weight.dtype))
 
         return attn_output, attn_weights
 
@@ -389,7 +406,7 @@ class Gemma4AudioFeedForward(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # This is needed to avoid any underflow/overflow issues when clipping
-        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.ffw_layer_1.linear.weight.dtype).max)
+        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.ffw_layer_1.weight.dtype).max)
 
         residual = hidden_states
         hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
@@ -472,7 +489,7 @@ class Gemma4AudioLightConv1d(nn.Module):
         hidden_states = self.depthwise_conv1d(hidden_states.transpose(1, 2)).transpose(1, 2)
 
         # This is needed to avoid any underflow/overflow issues when clipping
-        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.linear_start.linear.weight.dtype).max)
+        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.linear_start.weight.dtype).max)
         hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
         hidden_states = self.conv_norm(hidden_states)
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -97,9 +97,8 @@ class Gemma4AudioModelOutput(BaseModelOutputWithPooling):
 class Gemma4ClippableLinear(nn.Linear):
     """Linear layer with optional input/output clamping.
 
-    Inherits from ``nn.Linear`` so that parameter-efficient fine-tuning
-    libraries (PEFT/LoRA) can discover and target these layers via the standard
-    ``isinstance(module, nn.Linear)`` check.
+    Inherits from ``nn.Linear`` directly so that PEFT/LoRA can target these
+    layers via ``isinstance(module, nn.Linear)``.
     """
 
     def __init__(
@@ -116,17 +115,6 @@ class Gemma4ClippableLinear(nn.Linear):
             self.register_buffer("input_max", torch.tensor(float("inf")))
             self.register_buffer("output_min", torch.tensor(-float("inf")))
             self.register_buffer("output_max", torch.tensor(float("inf")))
-
-        # Backward compat: older checkpoints store the weight under "linear.weight"
-        # (the previous implementation wrapped an nn.Linear as self.linear).
-        self._register_load_state_dict_pre_hook(self._remap_legacy_keys)
-
-    @staticmethod
-    def _remap_legacy_keys(state_dict, prefix, *args, **kwargs):
-        old_key = prefix + "linear.weight"
-        new_key = prefix + "weight"
-        if old_key in state_dict:
-            state_dict[new_key] = state_dict.pop(old_key)
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         if self.use_clipped_linears:

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -94,16 +94,22 @@ class Gemma4AudioModelOutput(BaseModelOutputWithPooling):
     attention_mask: torch.BoolTensor | None = None
 
 
-class Gemma4ClippableLinear(nn.Module):
+class Gemma4ClippableLinear(nn.Linear):
+    """Linear layer with optional input/output clamping.
+
+    Inherits from ``nn.Linear`` so that parameter-efficient fine-tuning
+    libraries (PEFT/LoRA) can discover and target these layers via the standard
+    ``isinstance(module, nn.Linear)`` check.
+    """
+
     def __init__(
         self,
         config: Gemma4VisionConfig | Gemma4AudioConfig,
         in_features: int,
         out_features: int,
     ) -> None:
-        super().__init__()
+        super().__init__(in_features, out_features, bias=False)
         self.use_clipped_linears = config.use_clipped_linears
-        self.linear = nn.Linear(in_features, out_features, bias=False)
 
         if self.use_clipped_linears:
             self.register_buffer("input_min", torch.tensor(-float("inf")))
@@ -111,11 +117,22 @@ class Gemma4ClippableLinear(nn.Module):
             self.register_buffer("output_min", torch.tensor(-float("inf")))
             self.register_buffer("output_max", torch.tensor(float("inf")))
 
+        # Backward compat: older checkpoints store the weight under "linear.weight"
+        # (the previous implementation wrapped an nn.Linear as self.linear).
+        self._register_load_state_dict_pre_hook(self._remap_legacy_keys)
+
+    @staticmethod
+    def _remap_legacy_keys(state_dict, prefix, *args, **kwargs):
+        old_key = prefix + "linear.weight"
+        new_key = prefix + "weight"
+        if old_key in state_dict:
+            state_dict[new_key] = state_dict.pop(old_key)
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         if self.use_clipped_linears:
             hidden_states = torch.clamp(hidden_states, self.input_min, self.input_max)
 
-        hidden_states = self.linear(hidden_states)
+        hidden_states = nn.Linear.forward(self, hidden_states)
 
         if self.use_clipped_linears:
             hidden_states = torch.clamp(hidden_states, self.output_min, self.output_max)
@@ -261,7 +278,7 @@ class Gemma4AudioAttention(nn.Module):
         attn_output = attn_weights @ value_states.permute(0, 3, 1, 2, 4)
         attn_output = attn_output.permute(0, 2, 3, 1, 4).reshape(batch_size, num_blocks * self.chunk_size, -1)
         attn_output = attn_output[:, :seq_length].contiguous()
-        attn_output = self.post(attn_output.to(dtype=self.post.linear.weight.dtype))
+        attn_output = self.post(attn_output.to(dtype=self.post.weight.dtype))
 
         return attn_output, attn_weights
 
@@ -341,7 +358,7 @@ class Gemma4AudioFeedForward(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         # This is needed to avoid any underflow/overflow issues when clipping
-        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.ffw_layer_1.linear.weight.dtype).max)
+        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.ffw_layer_1.weight.dtype).max)
 
         residual = hidden_states
         hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
@@ -424,7 +441,7 @@ class Gemma4AudioLightConv1d(nn.Module):
         hidden_states = self.depthwise_conv1d(hidden_states.transpose(1, 2)).transpose(1, 2)
 
         # This is needed to avoid any underflow/overflow issues when clipping
-        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.linear_start.linear.weight.dtype).max)
+        gradient_clipping = min(self.gradient_clipping, torch.finfo(self.linear_start.weight.dtype).max)
         hidden_states = torch.clamp(hidden_states, -gradient_clipping, gradient_clipping)
         hidden_states = self.conv_norm(hidden_states)
 


### PR DESCRIPTION
# What does this PR do?

Makes `Gemma4ClippableLinear` inherit from `nn.Linear` instead of wrapping one via composition, enabling PEFT/LoRA to discover and target vision/audio encoder layers.

**Problem:** PEFT's LoRA module discovery uses `isinstance(module, nn.Linear)` to find targetable layers. The current `Gemma4ClippableLinear` subclasses `nn.Module` and stores an internal `self.linear = nn.Linear(...)`, so PEFT skips all vision and audio encoder projections (q_proj, k_proj, v_proj, o_proj, ffw layers). Users cannot fine-tune the Gemma4 vision tower with LoRA.

**Fix:**
- Change `Gemma4ClippableLinear` to inherit from `nn.Linear` directly
- Weight lives as `self.weight` (standard `nn.Linear`) instead of `self.linear.weight`
- Clipping behavior is fully preserved
- Add `_remap_legacy_keys` state dict pre-hook for backward compatibility with existing checkpoints that store weight under `"linear.weight"`
- Update weight converter to use new key names
- Fix three `.linear.weight` references in forward methods

**Backward compatibility:** Existing checkpoints with `linear.weight` keys load correctly via the pre-hook remap. Verified with `strict=True`:
```python
# Old checkpoint format
old_sd = {"linear.weight": ..., "input_min": ..., ...}

# Loads into new class without errors
new_module.load_state_dict(old_sd, strict=True)  # works
```

## Files changed

- `src/transformers/models/gemma4/modular_gemma4.py` — source of truth
- `src/transformers/models/gemma4/modeling_gemma4.py` — generated, matching changes
- `src/transformers/models/gemma4/convert_gemma4_weights.py` — updated key names

## How to reproduce the bug

```python
from transformers import Gemma4ForConditionalGeneration
import torch.nn as nn

model = Gemma4ForConditionalGeneration.from_pretrained("google/gemma-4-12b-it")

# These are all False — PEFT can't target them
for name, mod in model.named_modules():
    if "vision_tower" in name and hasattr(mod, "linear"):
        print(f"{name}: isinstance(nn.Linear) = {isinstance(mod, nn.Linear)}")
        # Prints: False for every ClippableLinear module
```

After this PR, all `Gemma4ClippableLinear` modules pass `isinstance(mod, nn.Linear)`.