### PR TITLE
Require input_ids for repetition penalty

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2437,6 +2437,20 @@ class GenerationMixin(ContinuousMixin):
         if not kwargs_has_position_ids and accepts_position_ids and not self.config.is_encoder_decoder:
             model_kwargs["position_ids"] = self._prepare_position_ids_for_generation(inputs_tensor, model_kwargs)
 
+        if (
+            not self.config.is_encoder_decoder
+            and model_input_name == "inputs_embeds"
+            and generation_config.repetition_penalty is not None
+            and generation_config.repetition_penalty != 1.0
+        ):
+            prompt_input_ids = model_kwargs.get("input_ids")
+            has_prompt_ids = isinstance(prompt_input_ids, torch.Tensor) and prompt_input_ids.numel() > 0
+            if not has_prompt_ids:
+                raise ValueError(
+                    "`repetition_penalty` requires the prompt token ids to be available. "
+                    "Pass in `input_ids` too or disable the penalty."
+                )
+
         if self.config.is_encoder_decoder and "encoder_outputs" not in model_kwargs:
             # if model is encoder decoder encoder_outputs are created and added to `model_kwargs`
             model_kwargs = self._prepare_encoder_decoder_kwargs_for_generation(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1086,9 +1086,31 @@ class GenerationMixin(ContinuousMixin):
                     UserWarning,
                 )
         if generation_config.repetition_penalty is not None and generation_config.repetition_penalty != 1.0:
-            processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
+            if self.config.is_encoder_decoder:
+                processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
+            else:
+                inputs_embeds = model_kwargs.get("inputs_embeds") if model_kwargs is not None else None
+                if inputs_embeds is not None and (input_ids_seq_length is None or input_ids_seq_length == 0):
+                    warnings.warn(
+                        "Passing `repetition_penalty` requires some form of `input_ids` to be passed to "
+                        "`generate`, ignoring the argument.",
+                        UserWarning,
+                    )
+                else:
+                    processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
         if generation_config.no_repeat_ngram_size is not None and generation_config.no_repeat_ngram_size > 0:
-            processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
+            if self.config.is_encoder_decoder:
+                processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
+            else:
+                inputs_embeds = model_kwargs.get("inputs_embeds") if model_kwargs is not None else None
+                if inputs_embeds is not None and (input_ids_seq_length is None or input_ids_seq_length == 0):
+                    warnings.warn(
+                        "Passing `no_repeat_ngram_size` requires some form of `input_ids` to be passed to "
+                        "`generate`, ignoring the argument.",
+                        UserWarning,
+                    )
+                else:
+                    processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
         if (
             generation_config.encoder_no_repeat_ngram_size is not None
             and generation_config.encoder_no_repeat_ngram_size > 0
@@ -2436,20 +2458,6 @@ class GenerationMixin(ContinuousMixin):
         accepts_position_ids = "position_ids" in set(inspect.signature(self.forward).parameters.keys())
         if not kwargs_has_position_ids and accepts_position_ids and not self.config.is_encoder_decoder:
             model_kwargs["position_ids"] = self._prepare_position_ids_for_generation(inputs_tensor, model_kwargs)
-
-        if (
-            not self.config.is_encoder_decoder
-            and model_input_name == "inputs_embeds"
-            and generation_config.repetition_penalty is not None
-            and generation_config.repetition_penalty != 1.0
-        ):
-            prompt_input_ids = model_kwargs.get("input_ids")
-            has_prompt_ids = isinstance(prompt_input_ids, torch.Tensor) and prompt_input_ids.numel() > 0
-            if not has_prompt_ids:
-                raise ValueError(
-                    "`repetition_penalty` requires the prompt token ids to be available. "
-                    "Pass in `input_ids` too or disable the penalty."
-                )
 
         if self.config.is_encoder_decoder and "encoder_outputs" not in model_kwargs:
             # if model is encoder decoder encoder_outputs are created and added to `model_kwargs`

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1092,12 +1092,11 @@ class GenerationMixin(ContinuousMixin):
                 inputs_embeds = model_kwargs.get("inputs_embeds") if model_kwargs is not None else None
                 if inputs_embeds is not None and (input_ids_seq_length is None or input_ids_seq_length == 0):
                     warnings.warn(
-                        "Passing `repetition_penalty` requires some form of `input_ids` to be passed to "
-                        "`generate`, ignoring the argument.",
+                        "Passing `repetition_penalty` with `inputs_embeds` and without `input_ids` to `generate` will "
+                        "apply the penalty only to newly generated tokens, not to the prompt.",
                         UserWarning,
                     )
-                else:
-                    processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
+                processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
         if generation_config.no_repeat_ngram_size is not None and generation_config.no_repeat_ngram_size > 0:
             if self.config.is_encoder_decoder:
                 processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
@@ -1105,12 +1104,11 @@ class GenerationMixin(ContinuousMixin):
                 inputs_embeds = model_kwargs.get("inputs_embeds") if model_kwargs is not None else None
                 if inputs_embeds is not None and (input_ids_seq_length is None or input_ids_seq_length == 0):
                     warnings.warn(
-                        "Passing `no_repeat_ngram_size` requires some form of `input_ids` to be passed to "
-                        "`generate`, ignoring the argument.",
+                        "Passing `no_repeat_ngram_size` with `inputs_embeds` and without `input_ids` to `generate` will "
+                        "apply n-gram constraints only to newly generated tokens, not to the prompt.",
                         UserWarning,
                     )
-                else:
-                    processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
+                processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
         if (
             generation_config.encoder_no_repeat_ngram_size is not None
             and generation_config.encoder_no_repeat_ngram_size > 0

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -1086,29 +1086,21 @@ class GenerationMixin(ContinuousMixin):
                     UserWarning,
                 )
         if generation_config.repetition_penalty is not None and generation_config.repetition_penalty != 1.0:
-            if self.config.is_encoder_decoder:
-                processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
-            else:
-                inputs_embeds = model_kwargs.get("inputs_embeds") if model_kwargs is not None else None
-                if inputs_embeds is not None and (input_ids_seq_length is None or input_ids_seq_length == 0):
-                    warnings.warn(
-                        "Passing `repetition_penalty` with `inputs_embeds` and without `input_ids` to `generate` will "
-                        "apply the penalty only to newly generated tokens, not to the prompt.",
-                        UserWarning,
-                    )
-                processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
+            processors.append(RepetitionPenaltyLogitsProcessor(penalty=generation_config.repetition_penalty))
+            if not self.config.is_encoder_decoder and (input_ids_seq_length is None or input_ids_seq_length == 0):
+                warnings.warn(
+                    "Passing `repetition_penalty` with `inputs_embeds` and without `input_ids` to `generate` will "
+                    "apply the penalty only to newly generated tokens, not to the prompt.",
+                    UserWarning,
+                )
         if generation_config.no_repeat_ngram_size is not None and generation_config.no_repeat_ngram_size > 0:
-            if self.config.is_encoder_decoder:
-                processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
-            else:
-                inputs_embeds = model_kwargs.get("inputs_embeds") if model_kwargs is not None else None
-                if inputs_embeds is not None and (input_ids_seq_length is None or input_ids_seq_length == 0):
-                    warnings.warn(
-                        "Passing `no_repeat_ngram_size` with `inputs_embeds` and without `input_ids` to `generate` will "
-                        "apply n-gram constraints only to newly generated tokens, not to the prompt.",
-                        UserWarning,
-                    )
-                processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
+            processors.append(NoRepeatNGramLogitsProcessor(generation_config.no_repeat_ngram_size))
+            if not self.config.is_encoder_decoder and (input_ids_seq_length is None or input_ids_seq_length == 0):
+                warnings.warn(
+                    "Passing `no_repeat_ngram_size` with `inputs_embeds` and without `input_ids` to `generate` will "
+                    "apply n-gram constraints only to newly generated tokens, not to the prompt.",
+                    UserWarning,
+                )
         if (
             generation_config.encoder_no_repeat_ngram_size is not None
             and generation_config.encoder_no_repeat_ngram_size > 0

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2441,6 +2441,20 @@ class GenerationMixin(ContinuousMixin):
         if not kwargs_has_position_ids and accepts_position_ids and not self.config.is_encoder_decoder:
             model_kwargs["position_ids"] = self._prepare_position_ids_for_generation(inputs_tensor, model_kwargs)
 
+        if (
+            not self.config.is_encoder_decoder
+            and model_input_name == "inputs_embeds"
+            and generation_config.repetition_penalty is not None
+            and generation_config.repetition_penalty != 1.0
+        ):
+            prompt_input_ids = model_kwargs.get("input_ids")
+            has_prompt_ids = isinstance(prompt_input_ids, torch.Tensor) and prompt_input_ids.numel() > 0
+            if not has_prompt_ids:
+                raise ValueError(
+                    "`repetition_penalty` requires the prompt token ids to be available. "
+                    "Pass in `input_ids` too or disable the penalty."
+                )
+
         if self.config.is_encoder_decoder and "encoder_outputs" not in model_kwargs:
             # if model is encoder decoder encoder_outputs are created and added to `model_kwargs`
             model_kwargs = self._prepare_encoder_decoder_kwargs_for_generation(

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2902,15 +2902,31 @@ class GenerationIntegrationTests(unittest.TestCase):
         outputs_without_penalty = model.generate(inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.0)
         self.assertEqual(outputs_without_penalty.shape[0], inputs["input_ids"].shape[0])
 
-        with self.assertWarnsRegex(UserWarning, "repetition_penalty"):
-            outputs_with_ignored_penalty = model.generate(
+        with self.assertWarnsRegex(UserWarning, "apply the penalty only to newly generated tokens, not to the prompt"):
+            outputs_with_repetition_warning = model.generate(
                 inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1
             )
-        self.assertEqual(outputs_with_ignored_penalty.shape[0], inputs["input_ids"].shape[0])
+        self.assertEqual(outputs_with_repetition_warning.shape[0], inputs["input_ids"].shape[0])
 
-        with self.assertWarnsRegex(UserWarning, "no_repeat_ngram_size"):
-            outputs_with_ignored_ngram = model.generate(inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
-        self.assertEqual(outputs_with_ignored_ngram.shape[0], inputs["input_ids"].shape[0])
+        with self.assertWarnsRegex(UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"):
+            outputs_with_ngram_warning = model.generate(inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
+        self.assertEqual(outputs_with_ngram_warning.shape[0], inputs["input_ids"].shape[0])
+
+        with self.assertWarnsRegex(UserWarning, "apply the penalty only to newly generated tokens, not to the prompt"):
+            processors = model._get_logits_processor(
+                generation_config=GenerationConfig(repetition_penalty=1.1),
+                input_ids_seq_length=0,
+                model_kwargs={"inputs_embeds": embeds},
+            )
+        self.assertIn("RepetitionPenaltyLogitsProcessor", [processor.__class__.__name__ for processor in processors])
+
+        with self.assertWarnsRegex(UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"):
+            processors = model._get_logits_processor(
+                generation_config=GenerationConfig(no_repeat_ngram_size=2),
+                input_ids_seq_length=0,
+                model_kwargs={"inputs_embeds": embeds},
+            )
+        self.assertIn("NoRepeatNGramLogitsProcessor", [processor.__class__.__name__ for processor in processors])
 
         outputs = model.generate(
             input_ids=inputs["input_ids"],

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2893,14 +2893,24 @@ class GenerationIntegrationTests(unittest.TestCase):
         finally:
             logger.removeHandler(warningHandler)
 
-    def test_inputs_embeds_require_ids_for_repetition_penalty(self):
+    def test_inputs_embeds_warn_without_ids_for_token_based_processors(self):
         model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device).eval()
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         inputs = tokenizer("Hello world", return_tensors="pt").to(torch_device)
         embeds = model.get_input_embeddings()(inputs["input_ids"])
 
-        with self.assertRaisesRegex(ValueError, "repetition_penalty"):
-            model.generate(inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1)
+        outputs_without_penalty = model.generate(inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.0)
+        self.assertEqual(outputs_without_penalty.shape[0], inputs["input_ids"].shape[0])
+
+        with self.assertWarnsRegex(UserWarning, "repetition_penalty"):
+            outputs_with_ignored_penalty = model.generate(
+                inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1
+            )
+        self.assertEqual(outputs_with_ignored_penalty.shape[0], inputs["input_ids"].shape[0])
+
+        with self.assertWarnsRegex(UserWarning, "no_repeat_ngram_size"):
+            outputs_with_ignored_ngram = model.generate(inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
+        self.assertEqual(outputs_with_ignored_ngram.shape[0], inputs["input_ids"].shape[0])
 
         outputs = model.generate(
             input_ids=inputs["input_ids"],
@@ -2908,6 +2918,7 @@ class GenerationIntegrationTests(unittest.TestCase):
             attention_mask=inputs.get("attention_mask"),
             max_new_tokens=5,
             repetition_penalty=1.1,
+            no_repeat_ngram_size=2,
         )
         self.assertEqual(outputs.shape[0], inputs["input_ids"].shape[0])
 

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2893,6 +2893,24 @@ class GenerationIntegrationTests(unittest.TestCase):
         finally:
             logger.removeHandler(warningHandler)
 
+    def test_inputs_embeds_require_ids_for_repetition_penalty(self):
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device).eval()
+        tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
+        inputs = tokenizer("Hello world", return_tensors="pt").to(torch_device)
+        embeds = model.get_input_embeddings()(inputs["input_ids"])
+
+        with self.assertRaisesRegex(ValueError, "repetition_penalty"):
+            model.generate(inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1)
+
+        outputs = model.generate(
+            input_ids=inputs["input_ids"],
+            inputs_embeds=embeds,
+            attention_mask=inputs.get("attention_mask"),
+            max_new_tokens=5,
+            repetition_penalty=1.1,
+        )
+        self.assertEqual(outputs.shape[0], inputs["input_ids"].shape[0])
+
     @slow
     def test_beam_search_early_stop_heuristic(self):
         """Regression test for #38778 (early stopping needs to be tracked at a batch level)"""

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2893,54 +2893,44 @@ class GenerationIntegrationTests(unittest.TestCase):
         finally:
             logger.removeHandler(warningHandler)
 
-    def test_inputs_embeds_warn_without_ids_for_token_based_processors(self):
-        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2").to(torch_device).eval()
+    def test_inputs_embeds_warn_without_ids_for_token_based_logit_processors(self):
+        model = AutoModelForCausalLM.from_pretrained("hf-internal-testing/tiny-random-gpt2", device_map=torch_device)
         tokenizer = AutoTokenizer.from_pretrained("hf-internal-testing/tiny-random-gpt2")
         inputs = tokenizer("Hello world", return_tensors="pt").to(torch_device)
-        embeds = model.get_input_embeddings()(inputs["input_ids"])
+        ids = inputs["input_ids"]
+        embeds = model.get_input_embeddings()(ids)
 
-        outputs_without_penalty = model.generate(inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.0)
-        self.assertEqual(outputs_without_penalty.shape[0], inputs["input_ids"].shape[0])
-
+        # Check that it raises with only embeds
         with self.assertWarnsRegex(UserWarning, "apply the penalty only to newly generated tokens, not to the prompt"):
-            outputs_with_repetition_warning = model.generate(
-                inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1
-            )
-        self.assertEqual(outputs_with_repetition_warning.shape[0], inputs["input_ids"].shape[0])
+            _ = model.generate(inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1)
 
+        # Check that it does NOT raise with both ids and embeds
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = model.generate(input_ids=ids, inputs_embeds=embeds, max_new_tokens=5, repetition_penalty=1.1)
+            self.assertFalse(
+                any(
+                    "apply the penalty only to newly generated tokens, not to the prompt" in str(warn.message)
+                    for warn in w
+                )
+            )
+
+        # Check that it raises with only embeds
         with self.assertWarnsRegex(
             UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"
         ):
-            outputs_with_ngram_warning = model.generate(inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
-        self.assertEqual(outputs_with_ngram_warning.shape[0], inputs["input_ids"].shape[0])
+            _ = model.generate(inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
 
-        with self.assertWarnsRegex(UserWarning, "apply the penalty only to newly generated tokens, not to the prompt"):
-            processors = model._get_logits_processor(
-                generation_config=GenerationConfig(repetition_penalty=1.1),
-                input_ids_seq_length=0,
-                model_kwargs={"inputs_embeds": embeds},
+        # Check that it does NOT raise with both ids and embeds
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _ = model.generate(input_ids=ids, inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
+            self.assertFalse(
+                any(
+                    "n-gram constraints only to newly generated tokens, not to the prompt" in str(warn.message)
+                    for warn in w
+                )
             )
-        self.assertIn("RepetitionPenaltyLogitsProcessor", [processor.__class__.__name__ for processor in processors])
-
-        with self.assertWarnsRegex(
-            UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"
-        ):
-            processors = model._get_logits_processor(
-                generation_config=GenerationConfig(no_repeat_ngram_size=2),
-                input_ids_seq_length=0,
-                model_kwargs={"inputs_embeds": embeds},
-            )
-        self.assertIn("NoRepeatNGramLogitsProcessor", [processor.__class__.__name__ for processor in processors])
-
-        outputs = model.generate(
-            input_ids=inputs["input_ids"],
-            inputs_embeds=embeds,
-            attention_mask=inputs.get("attention_mask"),
-            max_new_tokens=5,
-            repetition_penalty=1.1,
-            no_repeat_ngram_size=2,
-        )
-        self.assertEqual(outputs.shape[0], inputs["input_ids"].shape[0])
 
     @slow
     def test_beam_search_early_stop_heuristic(self):

--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -2908,7 +2908,9 @@ class GenerationIntegrationTests(unittest.TestCase):
             )
         self.assertEqual(outputs_with_repetition_warning.shape[0], inputs["input_ids"].shape[0])
 
-        with self.assertWarnsRegex(UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"):
+        with self.assertWarnsRegex(
+            UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"
+        ):
             outputs_with_ngram_warning = model.generate(inputs_embeds=embeds, max_new_tokens=5, no_repeat_ngram_size=2)
         self.assertEqual(outputs_with_ngram_warning.shape[0], inputs["input_ids"].shape[0])
 
@@ -2920,7 +2922,9 @@ class GenerationIntegrationTests(unittest.TestCase):
             )
         self.assertIn("RepetitionPenaltyLogitsProcessor", [processor.__class__.__name__ for processor in processors])
 
-        with self.assertWarnsRegex(UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"):
+        with self.assertWarnsRegex(
+            UserWarning, "n-gram constraints only to newly generated tokens, not to the prompt"
+        ):
             processors = model._get_logits_processor(
                 generation_config=GenerationConfig(no_repeat_ngram_size=2),
                 input_ids_seq_length=0,


### PR DESCRIPTION
# What does this PR do?
This PR warns when using repetition penalty or ngram repetition penalty in decoder models on input_embed without input_ids args.

Previously, users were able to call repetition penalty on generate calls with input_embeds args. Since they don't actually have tokens, the repetition penalty was not applied to the input args, but only to the generated tokens.
An equivalent call (ie tokens corresponding to those embeddings) would behave differently by applying the repetition penalty to the input tokens.
This change makes it so that the repetition penalty is not applied and a warning is shown.

## Testing
pytest tests/generation -vv -k 'not test_text_streamer_decode_kwargs'
test_text_streamer_decode_kwargs was giving an unrelated failure

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?
@gante 
