### PR TITLE
Fix ZeRO-3 from_pretrained: load registered buffers in _load_state_dict_into_zero3_model

### DIFF
--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -474,7 +474,7 @@ def _load_state_dict_into_zero3_model(model_to_load, state_dict, load_config=Non
 
     # PyTorch's `_load_from_state_dict` does not copy parameters in a module's descendants
     # so we need to apply the function recursively.
-    def load(module: nn.Module, state_dict, prefix="", assign_to_params_buffers=False):
+def load(module: nn.Module, state_dict, prefix="", assign_to_params_buffers=False):
         local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
         local_metadata["assign_to_params_buffers"] = assign_to_params_buffers
 
@@ -504,13 +504,22 @@ def _load_state_dict_into_zero3_model(model_to_load, state_dict, load_config=Non
                     if torch.distributed.get_rank() == 0:
                         module._load_from_state_dict(*args)
 
+            # Buffers are not partitioned by ZeRO-3, load them directly
+            named_buffers = dict(module.named_buffers(prefix=prefix[:-1], recurse=False))
+            for k, buf in named_buffers.items():
+                if k in state_dict and buf is not None:
+                    missing_keys.discard(k)
+                    if torch.distributed.get_rank() == 0:
+                        with torch.no_grad():
+                            buf.copy_(state_dict[k])
+
         for name, child in module._modules.items():
             if child is not None:
                 load(child, state_dict, prefix + name + ".", assign_to_params_buffers)
 
-    load(model_to_load, state_dict, assign_to_params_buffers=False)
+        load(model_to_load, state_dict, assign_to_params_buffers=False)
 
-    return error_msgs, missing_keys
+        return error_msgs, missing_keys
 
 
 def deepspeed_optim_sched(trainer, hf_deepspeed_config, args, num_training_steps, model_parameters):

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -509,9 +509,9 @@ def _load_state_dict_into_zero3_model(model_to_load, state_dict, load_config=Non
             for k, buf in named_buffers.items():
                 if k in state_dict and buf is not None:
                     missing_keys.discard(k)
-                    if torch.distributed.get_rank() == 0:
-                        with torch.no_grad():
-                            buf.copy_(state_dict[k])
+                    with torch.no_grad():
+                        buf.copy_(state_dict[k])
+                    buf._is_hf_initialized = True
 
         for name, child in module._modules.items():
             if child is not None:

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -474,7 +474,7 @@ def _load_state_dict_into_zero3_model(model_to_load, state_dict, load_config=Non
 
     # PyTorch's `_load_from_state_dict` does not copy parameters in a module's descendants
     # so we need to apply the function recursively.
-def load(module: nn.Module, state_dict, prefix="", assign_to_params_buffers=False):
+    def load(module: nn.Module, state_dict, prefix="", assign_to_params_buffers=False):
         local_metadata = {} if metadata is None else metadata.get(prefix[:-1], {})
         local_metadata["assign_to_params_buffers"] = assign_to_params_buffers
 
@@ -491,7 +491,7 @@ def load(module: nn.Module, state_dict, prefix="", assign_to_params_buffers=Fals
             for k in named_parameters:
                 if k in state_dict:
                     param = named_parameters[k]
-                    # crutial to not init the weight again
+                    # crucial to not init the weight again
                     param._is_hf_initialized = True
                     params_to_gather.append(param)
                     missing_keys.discard(k)
@@ -517,9 +517,9 @@ def load(module: nn.Module, state_dict, prefix="", assign_to_params_buffers=Fals
             if child is not None:
                 load(child, state_dict, prefix + name + ".", assign_to_params_buffers)
 
-        load(model_to_load, state_dict, assign_to_params_buffers=False)
+    load(model_to_load, state_dict, assign_to_params_buffers=False)
 
-        return error_msgs, missing_keys
+    return error_msgs, missing_keys
 
 
 def deepspeed_optim_sched(trainer, hf_deepspeed_config, args, num_training_steps, model_parameters):

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1876,7 +1876,7 @@ class Gemma4AudioModel(Gemma4PreTrainedModel):
 
     config: Gemma4AudioConfig
     main_input_name = "input_features"
-    base_model_prefix = "model.audio_tower"  # prefix for Gemma4ForConditionalGeneration saved checkpoints, required for Gemma4AudioModel.from_pretrained()
+    base_model_prefix = "audio_tower"
     _can_record_outputs = {
         "hidden_states": Gemma4AudioLayer,
         "attentions": Gemma4AudioAttention,
@@ -1959,6 +1959,7 @@ class Gemma4AudioModel(Gemma4PreTrainedModel):
 class Gemma4VisionModel(Gemma4PreTrainedModel):
     """The Gemma 4 Vision Encoder."""
 
+    base_model_prefix = "vision_tower"
     config = Gemma4VisionConfig
     _can_record_outputs = {
         "hidden_states": Gemma4VisionEncoderLayer,

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1876,7 +1876,7 @@ class Gemma4AudioModel(Gemma4PreTrainedModel):
 
     config: Gemma4AudioConfig
     main_input_name = "input_features"
-    base_model_prefix = "audio_tower"
+    base_model_prefix = "model.audio_tower"  # prefix for Gemma4ForConditionalGeneration saved checkpoints, required for Gemma4AudioModel.from_pretrained()
     _can_record_outputs = {
         "hidden_states": Gemma4AudioLayer,
         "attentions": Gemma4AudioAttention,

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1959,7 +1959,6 @@ class Gemma4AudioModel(Gemma4PreTrainedModel):
 class Gemma4VisionModel(Gemma4PreTrainedModel):
     """The Gemma 4 Vision Encoder."""
 
-    base_model_prefix = "vision_tower"
     config = Gemma4VisionConfig
     _can_record_outputs = {
         "hidden_states": Gemma4VisionEncoderLayer,

--- a/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
+++ b/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
@@ -1537,10 +1537,17 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
         from transformers.models.gemma4.modeling_gemma4 import Gemma4ForConditionalGeneration
 
         text_config = Gemma4TextConfig(
-            hidden_size=128, num_hidden_layers=2, num_attention_heads=2,
-            intermediate_size=256, vocab_size=32000, num_key_value_heads=2, pad_token_id=None,
+            hidden_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=2,
+            intermediate_size=256,
+            vocab_size=32000,
+            num_key_value_heads=2,
+            pad_token_id=None,
         )
-        vision_config = Gemma4VisionConfig(hidden_size=64, num_hidden_layers=2, num_attention_heads=2, intermediate_size=128)
+        vision_config = Gemma4VisionConfig(
+            hidden_size=64, num_hidden_layers=2, num_attention_heads=2, intermediate_size=128
+        )
         audio_config = Gemma4AudioConfig()
         config = Gemma4Config(text_config=text_config, vision_config=vision_config, audio_config=audio_config)
 
@@ -1557,10 +1564,7 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
             model2 = Gemma4ForConditionalGeneration.from_pretrained(save_path, torch_dtype=torch.bfloat16)
 
         # verify no registered buffers are MISSING
-        missing = [
-            name for name, buf in model2.named_buffers()
-            if buf is None
-        ]
+        missing = [name for name, buf in model2.named_buffers() if buf is None]
         self.assertEqual(missing, [], f"Registered buffers missing after ZeRO-3 load: {missing}")
 
 

--- a/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
+++ b/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
@@ -1525,6 +1525,40 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
         embedding = model.get_input_embeddings()
         with deepspeed.zero.GatheredParameters([embedding.weight]):
             self.assertEqual(embedding.weight.shape[0], new_size)
+            
+    def test_zero3_load_registered_buffers(self):
+        """Test that registered buffers are loaded correctly under ZeRO-3 from_pretrained."""
+        from transformers.models.gemma4.configuration_gemma4 import (
+            Gemma4AudioConfig, Gemma4Config, Gemma4TextConfig, Gemma4VisionConfig,
+        )
+        from transformers.models.gemma4.modeling_gemma4 import Gemma4ForConditionalGeneration
+
+        text_config = Gemma4TextConfig(
+            hidden_size=128, num_hidden_layers=2, num_attention_heads=2,
+            intermediate_size=256, vocab_size=32000, num_key_value_heads=2, pad_token_id=None,
+        )
+        vision_config = Gemma4VisionConfig(hidden_size=64, num_hidden_layers=2, num_attention_heads=2, intermediate_size=128)
+        audio_config = Gemma4AudioConfig()
+        config = Gemma4Config(text_config=text_config, vision_config=vision_config, audio_config=audio_config)
+
+        # save without ZeRO-3
+        save_path = self.get_auto_remove_tmp_dir()
+        model = Gemma4ForConditionalGeneration(config)
+        model.save_pretrained(save_path)
+        del model
+
+        # load with ZeRO-3
+        ds_config = self._get_zero3_ds_config(bf16={"enabled": True}, train_micro_batch_size_per_gpu=1)
+        with mockenv_context(**self.dist_env_1_gpu):
+            dschf = HfDeepSpeedConfig(ds_config)
+            model2 = Gemma4ForConditionalGeneration.from_pretrained(save_path, torch_dtype=torch.bfloat16)
+
+        # verify no registered buffers are MISSING
+        missing = [
+            name for name, buf in model2.named_buffers()
+            if buf is None
+        ]
+        self.assertEqual(missing, [], f"Registered buffers missing after ZeRO-3 load: {missing}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
+++ b/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
@@ -1527,7 +1527,7 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
             self.assertEqual(embedding.weight.shape[0], new_size)
 
     def test_zero3_load_registered_buffers(self):
-        """Test that registered buffers are loaded correctly under ZeRO-3 from_pretrained."""
+        """Test that registered buffers are loaded with correct values under ZeRO-3 from_pretrained."""
         from transformers.models.gemma4.configuration_gemma4 import (
             Gemma4AudioConfig,
             Gemma4Config,
@@ -1543,7 +1543,7 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
             intermediate_size=256,
             vocab_size=32000,
             num_key_value_heads=2,
-            pad_token_id=None,
+            pad_token_id=0,
         )
         vision_config = Gemma4VisionConfig(
             hidden_size=64, num_hidden_layers=2, num_attention_heads=2, intermediate_size=128
@@ -1551,21 +1551,34 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
         audio_config = Gemma4AudioConfig()
         config = Gemma4Config(text_config=text_config, vision_config=vision_config, audio_config=audio_config)
 
-        # save without ZeRO-3
+        # Save without ZeRO-3, with non-default buffer values
         save_path = self.get_auto_remove_tmp_dir()
         model = Gemma4ForConditionalGeneration(config)
+        for name, buf in model.named_buffers():
+            if "input_max" in name:
+                buf.fill_(42.0)
+            elif "output_min" in name:
+                buf.fill_(-42.0)
+            elif "layer_scalar" in name:
+                buf.fill_(0.5)
         model.save_pretrained(save_path)
         del model
 
-        # load with ZeRO-3
-        ds_config = self._get_zero3_ds_config(bf16={"enabled": True}, train_micro_batch_size_per_gpu=1)
+        # Load with ZeRO-3
+        ds_config = self._get_zero3_ds_config(bf16={"enabled": True})
+        dschf = HfDeepSpeedConfig(ds_config)
+        self.assertTrue(dschf.is_zero3())
         with mockenv_context(**self.dist_env_1_gpu):
-            HfDeepSpeedConfig(ds_config)
             model2 = Gemma4ForConditionalGeneration.from_pretrained(save_path, torch_dtype=torch.bfloat16)
 
-        # verify no registered buffers are MISSING
-        missing = [name for name, buf in model2.named_buffers() if buf is None]
-        self.assertEqual(missing, [], f"Registered buffers missing after ZeRO-3 load: {missing}")
+        # Verify buffer VALUES were loaded from checkpoint, not re-initialized
+        for name, buf in model2.named_buffers():
+            if "input_max" in name:
+                self.assertEqual(buf.item(), 42.0, f"{name} was not loaded from checkpoint")
+            elif "output_min" in name:
+                self.assertEqual(buf.item(), -42.0, f"{name} was not loaded from checkpoint")
+            elif "layer_scalar" in name:
+                self.assertEqual(buf.item(), 0.5, f"{name} was not loaded from checkpoint")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
+++ b/tests/trainer/distributed/test_trainer_distributed_deepspeed.py
@@ -1525,11 +1525,14 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
         embedding = model.get_input_embeddings()
         with deepspeed.zero.GatheredParameters([embedding.weight]):
             self.assertEqual(embedding.weight.shape[0], new_size)
-            
+
     def test_zero3_load_registered_buffers(self):
         """Test that registered buffers are loaded correctly under ZeRO-3 from_pretrained."""
         from transformers.models.gemma4.configuration_gemma4 import (
-            Gemma4AudioConfig, Gemma4Config, Gemma4TextConfig, Gemma4VisionConfig,
+            Gemma4AudioConfig,
+            Gemma4Config,
+            Gemma4TextConfig,
+            Gemma4VisionConfig,
         )
         from transformers.models.gemma4.modeling_gemma4 import Gemma4ForConditionalGeneration
 
@@ -1550,7 +1553,7 @@ class TestNonTrainerIntegrationDeepSpeed(TestCasePlus):
         # load with ZeRO-3
         ds_config = self._get_zero3_ds_config(bf16={"enabled": True}, train_micro_batch_size_per_gpu=1)
         with mockenv_context(**self.dist_env_1_gpu):
-            dschf = HfDeepSpeedConfig(ds_config)
+            HfDeepSpeedConfig(ds_config)
             model2 = Gemma4ForConditionalGeneration.from_pretrained(save_path, torch_dtype=torch.bfloat16)
 
         # verify no registered buffers are MISSING


### PR DESCRIPTION
Fixes #45397

## What does this PR do?

Fixes #45397

**Root cause:** `_load_state_dict_into_zero3_model` in 
`src/transformers/integrations/deepspeed.py` only iterates over 
`named_parameters` — never `named_buffers`. Buffers registered via 
`register_buffer()` are completely skipped during ZeRO-3 loading,
causing them to always appear as MISSING.

**Fix:** After gathering and loading parameters, explicitly load 
buffers directly. Buffers don't need `GatheredParameters` since 
ZeRO-3 doesn't shard them.

**Impact:** Affects ANY model with registered buffers under ZeRO-3,
not just Gemma-4. Gemma-4's `Gemma4ClippableLinear` uses buffers
for clipping values (`input_max`, `output_min`, `output_max`).

**Tested:** Reproduced bug and verified fix on 2xRTX40 GPUs.