### PR TITLE
Fix IndexError with DeepSpeed ZeRO-3 when kernels rotary is active

### DIFF
--- a/docs/source/en/model_doc/pp_chart2table.md
+++ b/docs/source/en/model_doc/pp_chart2table.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on 2025-05-20 and added to Hugging Face Transformers on 2026-03-18.*
+*This model was released on 2025-05-20 and added to Hugging Face Transformers on 2026-03-20.*
 
 # PP-Chart2Table
 

--- a/docs/source/en/model_doc/slanext.md
+++ b/docs/source/en/model_doc/slanext.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on 2025-03-07 and added to Hugging Face Transformers on 2026-03-19.*
+*This model was released on 2025-03-07 and added to Hugging Face Transformers on 2026-03-21.*
 
 # SLANeXt
 

--- a/docs/source/en/model_doc/uvdoc.md
+++ b/docs/source/en/model_doc/uvdoc.md
@@ -13,7 +13,7 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on 2023-02-06 and added to Hugging Face Transformers on 2026-03-19.*
+*This model was released on 2023-02-06 and added to Hugging Face Transformers on 2026-03-21.*
 
 # UVDoc
 

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -452,6 +452,15 @@ def use_kernelized_func(module_names: list[Callable] | Callable):
 
         def new_init(self, *args, **kwargs):
             orig_init(self, *args, **kwargs)
+            # Skip attaching the kernelized submodule under DeepSpeed ZeRO-3: the coordinator traces
+            # the module graph at init time, and a child `nn.Module` that is not actually invoked
+            # during forward (e.g. when the model keeps calling the plain Python `apply_rotary_pos_emb`)
+            # breaks the parameter fetch trace and raises `IndexError: pop from an empty deque`.
+            # See https://github.com/huggingface/transformers/issues/45137
+            from .deepspeed import is_deepspeed_zero3_enabled
+
+            if is_deepspeed_zero3_enabled():
+                return
             for fn in module_names:
                 # we hardcode the name of the function to "rotary_fn" for now
                 setattr(self, "rotary_fn", fn)


### PR DESCRIPTION
## Summary

Fixes #45137. Re-opened from #45395 on a same-repo branch so CI can run.

Since #41147, attention layers are decorated with `@use_kernelized_func(apply_rotary_pos_emb)` which attaches a `rotary_fn` child `nn.Module` at init when the `kernels` library is available. DeepSpeed ZeRO-3's parameter coordinator traces the module graph at init and expects every registered submodule to fire during forward. The attention forward still calls the plain Python `apply_rotary_pos_emb`, so `rotary_fn` is never invoked and the parameter-fetch trace desynchronizes, raising:

```
IndexError: pop from an empty deque
  at deepspeed/runtime/zero/partitioned_param_coordinator.py
```

on the second forward (reproducible via TRL's RLOO/GRPO trainers under ZeRO-3, see huggingface/trl#4899).

## Fix

Skip attaching the kernelized submodule when `is_deepspeed_zero3_enabled()` is true. Under ZeRO-3 the Python `apply_rotary_pos_emb` path is used (same behavior as before #41147). Non-ZeRO-3 users are unaffected.

The second commit refreshes dates on three model cards (`pp_chart2table`, `slanext`, `uvdoc`) that were missing them on `main` — required for `check-repository-consistency` to pass.

## Test plan

- [ ] Reproducer from huggingface/trl#4899 no longer raises `IndexError: pop from an empty deque`
- [ ] Qwen3 forward + `kernelize` still replaces `rotary_fn` when not under ZeRO-3
- [ ] `make style` + `check-repository-consistency` pass