### PR TITLE
fix(testing_utils): guard get_device_capability() with torch.cuda.is_available()

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3198,7 +3198,7 @@ def get_device_properties() -> DeviceProperties:
     """
     Get environment device properties.
     """
-    if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
+    if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
         import torch
 
         major, minor = torch.cuda.get_device_capability()


### PR DESCRIPTION
## What does this PR do?

Fixes #45341.

`get_device_properties()` in `testing_utils.py` calls `torch.cuda.get_device_capability()` whenever `IS_CUDA_SYSTEM or IS_ROCM_SYSTEM` is `True`. This raises a `RuntimeError` on environments where CUDA drivers are installed (so `torch.version.cuda is not None`) but no physical GPU is attached (e.g., Lightning AI Studio CPU-only instances, CI runners with CUDA drivers but no GPU).

**Root cause:** `IS_CUDA_SYSTEM` reflects whether the CUDA *toolkit* is present, not whether a CUDA-capable device is available at runtime. `torch.cuda.get_device_capability()` requires an actual device.

**Fix:** Add `and torch.cuda.is_available()` to the condition so that `get_device_capability()` is only called when a CUDA/ROCm device is actually present. When CUDA is installed but no device is available, the function falls through to the generic `else` branch and returns `(torch_device, None, None)`.

```diff
-    if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
+    if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
```

## Before submitting
- [ ] This PR fixes a bug (non-breaking change that fixes an issue)
- [ ] This PR is a new feature (non-breaking change that adds functionality)
- [ ] This PR is a breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This PR adds tests that prove my fix is effective or that my feature works: *N/A — the crash only occurs on systems with CUDA installed but no GPU, which is not a typical CI environment; the fix is a one-line guard matching existing patterns elsewhere in the file (e.g. line 995).*