### PR TITLE
Raise 400 on model mismatch when `transformers serve` is pinned

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -872,10 +872,7 @@ class BaseHandler:
             if requested is not None and requested != self.model_manager.force_model:
                 raise HTTPException(
                     status_code=400,
-                    detail=(
-                        f"Server is pinned to '{self.model_manager.force_model}'; "
-                        f"requested '{requested}'."
-                    ),
+                    detail=(f"Server is pinned to '{self.model_manager.force_model}'; requested '{requested}'."),
                 )
             body["model"] = self.model_manager.force_model
 

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -865,7 +865,18 @@ class BaseHandler:
 
         Returns ``(model_id, model, processor)``.
         """
+        from fastapi import HTTPException
+
         if self.model_manager.force_model is not None:
+            requested = body.get("model")
+            if requested is not None and requested != self.model_manager.force_model:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Server is pinned to '{self.model_manager.force_model}'; "
+                        f"requested '{requested}'."
+                    ),
+                )
             body["model"] = self.model_manager.force_model
 
         model_id = self.model_manager.process_model_name(body["model"])

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -323,6 +323,36 @@ class TestValidation(unittest.TestCase):
         self.assertTrue(any("audio" in msg for msg in cm.output))
 
 
+class TestResolveModel(unittest.TestCase):
+    def _make_handler(self, force_model=None):
+        mm = MagicMock()
+        mm.force_model = force_model
+        mm.process_model_name.side_effect = ModelManager.process_model_name
+        mm.load_model_and_processor.return_value = (MagicMock(), MagicMock())
+        return ChatCompletionHandler(model_manager=mm, generation_state=GenerationState())
+
+    def test_force_model_overrides_when_model_omitted(self):
+        handler = self._make_handler(force_model="org/pinned")
+        body = {}
+        model_id, _, _ = handler._resolve_model(body)
+        self.assertEqual(model_id, "org/pinned@main")
+        self.assertEqual(body["model"], "org/pinned")
+
+    def test_force_model_allows_matching_request(self):
+        handler = self._make_handler(force_model="org/pinned")
+        body = {"model": "org/pinned"}
+        model_id, _, _ = handler._resolve_model(body)
+        self.assertEqual(model_id, "org/pinned@main")
+
+    def test_force_model_rejects_mismatched_request(self):
+        handler = self._make_handler(force_model="org/pinned")
+        with self.assertRaises(HTTPException) as ctx:
+            handler._resolve_model({"model": "other/model"})
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertIn("org/pinned", ctx.exception.detail)
+        self.assertIn("other/model", ctx.exception.detail)
+
+
 class TestModelManager(unittest.TestCase):
     def test_process_model_name_adds_main(self):
         self.assertEqual(ModelManager.process_model_name("org/model"), "org/model@main")


### PR DESCRIPTION
When `transformers serve` is launched with a positional model argument, the server silently overwrites the `"model"` field in every incoming request with the pinned model id. This is surprising: a client that asks for model B receives a response generated by model A, with no indication that the requested model was ignored.

This PR changes `_resolve_model` in `src/transformers/cli/serving/utils.py` to return `400 Bad Request` when the client-supplied `model` disagrees with the pinned one. Requests that omit `model` or send an empty value still fall back to the pinned model, so existing well-behaved clients are unaffected.

## Reproducer

Start the server pinned to model A:

```bash
transformers serve meta-llama/Llama-3.2-1B-Instruct
```

Then query with a different model, either via `curl`:

```bash
curl http://localhost:8000/v1/chat/completions \
  -H "Authorization: Bearer x" \
  -H "Content-Type: application/json" \
  -d '{
    "model": "Qwen/Qwen2.5-0.5B-Instruct",
    "messages": [{"role": "user", "content": "Hi!"}]
  }'
```

or via the OpenAI Python client:

```python
# repro.py
from openai import OpenAI

client = OpenAI(base_url="http://localhost:8000/v1", api_key="x")

print(client.chat.completions.create(
    model="Qwen/Qwen2.5-0.5B-Instruct",
    messages=[{"role": "user", "content": "Hi!"}],
))
```

**Before:**

```
ChatCompletion(id='5b793e5a-189b-49ac-a022-7f74d60c563a', choices=[Choice(finish_reason='stop', index=0, logprobs=None, message=ChatCompletionMessage(content='How can I assist you today?', refusal=None, role='assistant', annotations=None, audio=None, function_call=None, tool_calls=None))], created=1776194005, model='meta-llama/Llama-3.2-1B-Instruct@main', object='chat.completion', service_tier=None, system_fingerprint=None, usage=CompletionUsage(completion_tokens=8, prompt_tokens=37, total_tokens=45, completion_tokens_details=None, prompt_tokens_details=None))
```

**After:**

```
Traceback (most recent call last):
  File "/fsx/qgallouedec/transformers/repro.py", line 5, in <module>
    resp = client.chat.completions.create(
        model="Qwen/Qwen2.5-0.5B-Instruct",
        messages=[{"role": "user", "content": "Hi!"}],
    )
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.13/site-packages/openai/_utils/_utils.py", line 286, in wrapper
    return func(*args, **kwargs)
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.13/site-packages/openai/resources/chat/completions/completions.py", line 1204, in create
    return self._post(
           ~~~~~~~~~~^
        "/chat/completions",
        ^^^^^^^^^^^^^^^^^^^^
    ...<47 lines>...
        stream_cls=Stream[ChatCompletionChunk],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.13/site-packages/openai/_base_client.py", line 1297, in post
    return cast(ResponseT, self.request(cast_to, opts, stream=stream, stream_cls=stream_cls))
                           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/fsx/qgallouedec/miniconda3/envs/trl/lib/python3.13/site-packages/openai/_base_client.py", line 1070, in request
    raise self._make_status_error_from_response(err.response) from None
openai.BadRequestError: Error code: 400 - {'detail': "Server is pinned to 'meta-llama/Llama-3.2-1B-Instruct'; requested 'Qwen/Qwen2.5-0.5B-Instruct'."}
```

## Notes

- AI assistance was used to draft this change
