### PR TITLE
[`fix`] Always early return for non-Mistral models in _patch_mistral_regex

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1324,21 +1324,15 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 # Detect if we can skip the mistral fix by
                 #   a) having a non-mistral tokenizer
                 #   b) fixed version of transformers
-                if transformers_version and version.parse(transformers_version) <= version.parse("4.57.2"):
-                    if (
-                        is_local
-                        and transformers_model_type is not None
-                        and transformers_model_type
-                        not in [
-                            "mistral",
-                            "mistral3",
-                            "voxtral",
-                            "ministral",
-                            "pixtral",
-                        ]
-                    ):
-                        return tokenizer
-                elif transformers_version and version.parse(transformers_version) > version.parse("4.57.3"):
+                if is_local and transformers_model_type not in [
+                    "mistral",
+                    "mistral3",
+                    "voxtral",
+                    "ministral",
+                    "pixtral",
+                ]:
+                    return tokenizer
+                if transformers_version and version.parse(transformers_version) > version.parse("4.57.3"):
                     return tokenizer
 
                 mistral_config_detected = True

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1324,7 +1324,7 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 # Detect if we can skip the mistral fix by
                 #   a) having a non-mistral tokenizer
                 #   b) fixed version of transformers
-                if transformers_version and version.parse(transformers_version) <= version.parse("5.0.0"):
+                if transformers_version and version.parse(transformers_version) < version.parse("5.0.0"):
                     if (
                         is_local
                         and transformers_model_type is not None

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -1324,15 +1324,21 @@ class TokenizersBackend(PreTrainedTokenizerBase):
                 # Detect if we can skip the mistral fix by
                 #   a) having a non-mistral tokenizer
                 #   b) fixed version of transformers
-                if is_local and transformers_model_type not in [
-                    "mistral",
-                    "mistral3",
-                    "voxtral",
-                    "ministral",
-                    "pixtral",
-                ]:
-                    return tokenizer
-                if transformers_version and version.parse(transformers_version) > version.parse("4.57.3"):
+                if transformers_version and version.parse(transformers_version) <= version.parse("5.0.0"):
+                    if (
+                        is_local
+                        and transformers_model_type is not None
+                        and transformers_model_type
+                        not in [
+                            "mistral",
+                            "mistral3",
+                            "voxtral",
+                            "ministral",
+                            "pixtral",
+                        ]
+                    ):
+                        return tokenizer
+                elif transformers_version and version.parse(transformers_version) >= version.parse("5.0.0"):
                     return tokenizer
 
                 mistral_config_detected = True

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -267,7 +267,7 @@ class AutoTokenizerTest(unittest.TestCase):
         self.assertEqual(tokenizer2.vocab_size, 12)
 
     def test_auto_tokenizer_from_local_folder_mistral_detection(self):
-        """See #42374 for reference, ensuring proper mistral detection on local tokenizers"""
+        """See #42374 and #45444 for reference, ensuring proper mistral detection on local tokenizers"""
         tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen3-235B-A22B-Thinking-2507")
         config = Qwen3MoeConfig.from_pretrained("Qwen/Qwen3-235B-A22B-Thinking-2507")
         self.assertIsInstance(tokenizer, (Qwen2Tokenizer, Qwen2TokenizerFast))

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -281,25 +281,26 @@ class AutoTokenizerTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             tokenizer.save_pretrained(tmp_dir)
+            config_path = os.path.join(tmp_dir, "config.json")
 
-            # Case 1: Tokenizer with no config associated
+            def _write_config(**overrides):
+                config_dict = config.to_diff_dict()
+                for key, value in overrides.items():
+                    if value is None:
+                        config_dict.pop(key, None)
+                    else:
+                        config_dict[key] = value
+                with open(config_path, "w", encoding="utf-8") as f:
+                    json.dump(config_dict, f, indent=2, sort_keys=True)
+
+            # Case 1: Tokenizer with no config associated must not warn
             with CaptureLogger(logger) as cl:
                 AutoTokenizer.from_pretrained(tmp_dir)
             self.assertNotIn(mistral_warning, cl.out)
 
-            # Case 2: Non-mistral tokenizer with a config.json present must not trigger the warning,
-            # regardless of the `transformers_version` recorded in the config
-            config_path = os.path.join(tmp_dir, "config.json")
-            for saved_version in ("4.57.2", "4.57.3", "4.57.6", None):
-                config_dict = config.to_diff_dict()
-                if saved_version is None:
-                    config_dict.pop("transformers_version", None)
-                else:
-                    config_dict["transformers_version"] = saved_version
-
-                with open(config_path, "w", encoding="utf-8") as f:
-                    json.dump(config_dict, f, indent=2, sort_keys=True)
-
+            # Case 2: Non-mistral local config must not warn for any `transformers_version`
+            for saved_version in ("4.57.2", "4.57.3", "4.57.6", "5.0.1"):
+                _write_config(transformers_version=saved_version)
                 with CaptureLogger(logger) as cl:
                     tokenizer2 = AutoTokenizer.from_pretrained(tmp_dir)
                 self.assertNotIn(
@@ -307,6 +308,24 @@ class AutoTokenizerTest(unittest.TestCase):
                     cl.out,
                     msg=f"Unexpected mistral regex warning for non-mistral config (transformers_version={saved_version!r})",
                 )
+
+            # Case 3: Mistral-family local config saved by an affected transformers release
+            # must still warn, even up to 4.57.6
+            for saved_version in ("4.57.3", "4.57.6"):
+                _write_config(model_type="mistral", transformers_version=saved_version)
+                with CaptureLogger(logger) as cl:
+                    AutoTokenizer.from_pretrained(tmp_dir)
+                self.assertIn(
+                    mistral_warning,
+                    cl.out,
+                    msg=f"Missing mistral regex warning for mistral config (transformers_version={saved_version!r})",
+                )
+
+            # Case 4: Mistral-family local config saved by a fixed transformers release must not warn
+            _write_config(model_type="mistral", transformers_version="5.0.1")
+            with CaptureLogger(logger) as cl:
+                AutoTokenizer.from_pretrained(tmp_dir)
+            self.assertNotIn(mistral_warning, cl.out)
 
         self.assertIsInstance(tokenizer2, tokenizer.__class__)
         self.assertTrue(tokenizer2.vocab_size > 100_000)

--- a/tests/models/auto/test_tokenization_auto.py
+++ b/tests/models/auto/test_tokenization_auto.py
@@ -272,30 +272,41 @@ class AutoTokenizerTest(unittest.TestCase):
         config = Qwen3MoeConfig.from_pretrained("Qwen/Qwen3-235B-A22B-Thinking-2507")
         self.assertIsInstance(tokenizer, (Qwen2Tokenizer, Qwen2TokenizerFast))
 
+        mistral_warning = (
+            "with an incorrect regex pattern: "
+            "https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84"
+            "#69121093e8b480e709447d5e"
+        )
+        logger = logging.get_logger("transformers.tokenization_utils_tokenizers")
+
         with tempfile.TemporaryDirectory() as tmp_dir:
             tokenizer.save_pretrained(tmp_dir)
 
             # Case 1: Tokenizer with no config associated
-            logger = logging.get_logger("transformers.tokenization_utils_base")
             with CaptureLogger(logger) as cl:
                 AutoTokenizer.from_pretrained(tmp_dir)
-            self.assertNotIn(
-                "with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e",
-                cl.out,
-            )
+            self.assertNotIn(mistral_warning, cl.out)
 
-            # Case 2: Tokenizer with config associated
-            # Needed to be saved along the tokenizer to detect (non)mistral
-            # for a version where the regex bug occurs
-            config_dict = config.to_diff_dict()
-            config_dict["transformers_version"] = "4.57.2"
-
-            # Manually saving to avoid versioning clashes
+            # Case 2: Non-mistral tokenizer with a config.json present must not trigger the warning,
+            # regardless of the `transformers_version` recorded in the config
             config_path = os.path.join(tmp_dir, "config.json")
-            with open(config_path, "w", encoding="utf-8") as f:
-                json.dump(config_dict, f, indent=2, sort_keys=True)
+            for saved_version in ("4.57.2", "4.57.3", "4.57.6", None):
+                config_dict = config.to_diff_dict()
+                if saved_version is None:
+                    config_dict.pop("transformers_version", None)
+                else:
+                    config_dict["transformers_version"] = saved_version
 
-            tokenizer2 = AutoTokenizer.from_pretrained(tmp_dir)
+                with open(config_path, "w", encoding="utf-8") as f:
+                    json.dump(config_dict, f, indent=2, sort_keys=True)
+
+                with CaptureLogger(logger) as cl:
+                    tokenizer2 = AutoTokenizer.from_pretrained(tmp_dir)
+                self.assertNotIn(
+                    mistral_warning,
+                    cl.out,
+                    msg=f"Unexpected mistral regex warning for non-mistral config (transformers_version={saved_version!r})",
+                )
 
         self.assertIsInstance(tokenizer2, tokenizer.__class__)
         self.assertTrue(tokenizer2.vocab_size > 100_000)


### PR DESCRIPTION
# What does this PR do?

Resolves https://github.com/huggingface/sentence-transformers/issues/3724

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Details
The non-mistral `model_type` early exit in `_patch_mistral_regex` was nested inside `if transformers_version <= "4.57.2"`. If the case, `mistral_config_detected` is set to `True` and the warning fired for any local large-vocab non-mistral tokenizer (Qwen3, Gemma3, etc.). Reproducer:

```python
import json, tempfile
from transformers import AutoTokenizer

with tempfile.TemporaryDirectory() as tmp_dir:
    AutoTokenizer.from_pretrained("Qwen/Qwen3-0.6B").save_pretrained(tmp_dir)
    with open(f"{tmp_dir}/config.json", "w") as f:
        json.dump({"model_type": "qwen3", "transformers_version": "4.57.2"}, f)
    tokenizer = AutoTokenizer.from_pretrained(tmp_dir)
    print(type(tokenizer))
```
```
[transformers] The tokenizer you are loading from 'C:\Users\tom\AppData\Local\Temp\tmp_orxp87p' with an incorrect regex pattern: https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503/discussions/84#69121093e8b480e709447d5e. This will lead to incorrect tokenization. You should set the `fix_mistral_regex=True` flag when loading this tokenizer to fix this issue.
```

This warning is obviously nonsensical: this isn't even a mistral model. It's fixed very simply by separating the `model_type` check from the version check, so it runs regardless of `transformers_version`. There's no warning anymore from the reproducer now.

P.s. I know I can merge the two consecutive `if ...` as they both just return `tokenizer`, but I don't love massive `if`-branches.

## Who can review?

cc @vasqu @zucchini-nlp 

- Tom Aarsen