### PR TITLE
Update Torch version check for flex attention

### DIFF
--- a/src/transformers/integrations/flex_attention.py
+++ b/src/transformers/integrations/flex_attention.py
@@ -40,7 +40,7 @@ from ..utils.import_utils import (
 )
 
 
-_TORCH_FLEX_USE_AUX = is_torch_greater_or_equal("2.9.0")
+_TORCH_FLEX_USE_AUX = is_torch_greater_or_equal("2.9.1")
 
 
 if is_torch_flex_attn_available():


### PR DESCRIPTION
This commit corrects the PyTorch version check for importing `AuxRequest` from `torch.nn.attention.flex_attention`(line51). The `AuxRequest` class was actually introduced in PyTorch 2.9.1, not 2.9.0. The current code attempts to import it for any version >= 2.9.0, which causes an `ImportError` in PyTorch 2.9.0 environments.
You can view the introduced version of AuxRequest at https://docs.pytorch.org/docs/2.9/nn.attention.flex_attention.html.
Fixes #45446 