### PR TITLE
Add `step3_vl` to `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -373,6 +373,7 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "phi3_v",
     "phimoe",
     "step3p5",
+    "step3_vl",
     "vipllava",
     "cohere_asr",
 }


### PR DESCRIPTION
This model also has the wrong tokenizer class in its config