### PR TITLE
[`fix`] Make Qwen2_5OmniProcessor warning a lot less noisy via warning_once

### DIFF
--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -107,7 +107,13 @@ class Qwen2_5OmniProcessorKwargs(ProcessingKwargs, total=False):
 @auto_docstring
 class Qwen2_5OmniProcessor(ProcessorMixin):
     def __init__(
-        self, image_processor=None, video_processor=None, feature_extractor=None, tokenizer=None, chat_template=None
+        self,
+        image_processor=None,
+        video_processor=None,
+        feature_extractor=None,
+        tokenizer=None,
+        chat_template=None,
+        check_audio_system_prompt: bool = True,
     ):
         super().__init__(image_processor, video_processor, feature_extractor, tokenizer, chat_template=chat_template)
         self.image_token = self.tokenizer.image_token
@@ -117,6 +123,7 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         self.vision_eos_token = self.tokenizer.vision_eos_token
         self.audio_bos_token = self.tokenizer.audio_bos_token
         self.audio_eos_token = self.tokenizer.audio_eos_token
+        self.check_audio_system_prompt = check_audio_system_prompt
 
     @auto_docstring
     def __call__(
@@ -309,16 +316,17 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
             conversations = [conversations]
             is_batched = True
 
-        for conversation in conversations:
-            if (
-                conversation[0]["role"] != "system"
-                or conversation[0]["content"][0]["text"]
-                != "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."
-            ):
-                logger.warning_once(
-                    "System prompt modified, audio output may not work as expected. "
-                    + "Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'"
-                )
+        if self.check_audio_system_prompt:
+            for conversation in conversations:
+                if (
+                    conversation[0]["role"] != "system"
+                    or conversation[0]["content"][0]["text"]
+                    != "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."
+                ):
+                    logger.warning_once(
+                        "System prompt modified, audio output may not work as expected. "
+                        + "Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'"
+                    )
         if is_batched:
             conversations = conversations[0]
 

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -16,7 +16,6 @@
 Processor class for Qwen2.5Omni.
 """
 
-import logging
 import re
 
 import numpy as np

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -16,7 +16,6 @@
 Processor class for Qwen2.5Omni.
 """
 
-import logging
 import re
 
 import numpy as np
@@ -25,8 +24,11 @@ from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack, VideosKwargs
 from ...tokenization_utils_base import AudioInput, PreTokenizedInput, TextInput
-from ...utils import auto_docstring
+from ...utils import auto_docstring, logging
 from ...video_utils import VideoInput
+
+
+logger = logging.get_logger(__name__)
 
 
 # Redefine kwargs for videos because Qwen-Omni uses some kwargs for processing omni
@@ -313,7 +315,7 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
                 or conversation[0]["content"][0]["text"]
                 != "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."
             ):
-                logging.warning(
+                logger.warning_once(
                     "System prompt modified, audio output may not work as expected. "
                     + "Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'"
                 )

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -16,6 +16,7 @@
 Processor class for Qwen2.5Omni.
 """
 
+import logging
 import re
 
 import numpy as np
@@ -24,11 +25,8 @@ from ...feature_extraction_utils import BatchFeature
 from ...image_utils import ImageInput
 from ...processing_utils import ProcessingKwargs, ProcessorMixin, Unpack, VideosKwargs
 from ...tokenization_utils_base import AudioInput, PreTokenizedInput, TextInput
-from ...utils import auto_docstring, logging
+from ...utils import auto_docstring
 from ...video_utils import VideoInput
-
-
-logger = logging.get_logger(__name__)
 
 
 # Redefine kwargs for videos because Qwen-Omni uses some kwargs for processing omni
@@ -107,13 +105,7 @@ class Qwen2_5OmniProcessorKwargs(ProcessingKwargs, total=False):
 @auto_docstring
 class Qwen2_5OmniProcessor(ProcessorMixin):
     def __init__(
-        self,
-        image_processor=None,
-        video_processor=None,
-        feature_extractor=None,
-        tokenizer=None,
-        chat_template=None,
-        check_audio_system_prompt: bool = True,
+        self, image_processor=None, video_processor=None, feature_extractor=None, tokenizer=None, chat_template=None
     ):
         super().__init__(image_processor, video_processor, feature_extractor, tokenizer, chat_template=chat_template)
         self.image_token = self.tokenizer.image_token
@@ -123,7 +115,6 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         self.vision_eos_token = self.tokenizer.vision_eos_token
         self.audio_bos_token = self.tokenizer.audio_bos_token
         self.audio_eos_token = self.tokenizer.audio_eos_token
-        self.check_audio_system_prompt = check_audio_system_prompt
 
     @auto_docstring
     def __call__(
@@ -316,17 +307,16 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
             conversations = [conversations]
             is_batched = True
 
-        if self.check_audio_system_prompt:
-            for conversation in conversations:
-                if (
-                    conversation[0]["role"] != "system"
-                    or conversation[0]["content"][0]["text"]
-                    != "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."
-                ):
-                    logger.warning_once(
-                        "System prompt modified, audio output may not work as expected. "
-                        + "Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'"
-                    )
+        for conversation in conversations:
+            if (
+                conversation[0]["role"] != "system"
+                or conversation[0]["content"][0]["text"]
+                != "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."
+            ):
+                logging.warning(
+                    "System prompt modified, audio output may not work as expected. "
+                    + "Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'"
+                )
         if is_batched:
             conversations = conversations[0]
 

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -300,16 +300,6 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
 
         return list(_iter())
 
-    def apply_chat_template(self, conversations, chat_template=None, **kwargs):
-        is_batched = False
-        if isinstance(conversations[0], dict):
-            conversations = [conversations]
-            is_batched = True
-        if is_batched:
-            conversations = conversations[0]
-
-        return super().apply_chat_template(conversations, chat_template, **kwargs)
-
     def post_process_image_text_to_text(self, generated_outputs, skip_special_tokens=True, **kwargs):
         """
         Post-process the output of a vlm to decode the text.

--- a/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
+++ b/src/transformers/models/qwen2_5_omni/processing_qwen2_5_omni.py
@@ -306,17 +306,6 @@ class Qwen2_5OmniProcessor(ProcessorMixin):
         if isinstance(conversations[0], dict):
             conversations = [conversations]
             is_batched = True
-
-        for conversation in conversations:
-            if (
-                conversation[0]["role"] != "system"
-                or conversation[0]["content"][0]["text"]
-                != "You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech."
-            ):
-                logging.warning(
-                    "System prompt modified, audio output may not work as expected. "
-                    + "Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'"
-                )
         if is_batched:
             conversations = conversations[0]
 

--- a/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/processing_qwen3_omni_moe.py
@@ -318,9 +318,6 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
 
         return list(_iter())
 
-    def apply_chat_template(self, conversations, chat_template=None, **kwargs):
-        return super().apply_chat_template(conversations, chat_template, **kwargs)
-
     def post_process_image_text_to_text(self, generated_outputs, skip_special_tokens=True, **kwargs):
         """
         Post-process the output of a vlm to decode the text.
@@ -391,6 +388,9 @@ class Qwen3OmniMoeProcessor(ProcessorMixin):
                 + ["video_second_per_grid"]
             )
         )
+
+    def apply_chat_template(self, conversations, chat_template=None, **kwargs):
+        return super().apply_chat_template(conversations, chat_template, **kwargs)
 
 
 __all__ = ["Qwen3OmniMoeProcessor"]

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
+import json
+import os
+import tempfile
 import unittest
 
 import numpy as np
@@ -353,3 +356,29 @@ class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Qwen pixel values are flattened, verify length matches video_grid_thw
         expected_video_tokens = sum(thw[0] * thw[1] * thw[2] for thw in out_dict["video_grid_thw"])
         self.assertEqual(len(out_dict[self.videos_input_name]), expected_video_tokens)  # 1 video in the conversation
+
+    def test_check_audio_system_prompt_round_trip(self):
+        processor = self.get_processor()
+        self.assertTrue(processor.check_audio_system_prompt)
+
+        processor.check_audio_system_prompt = False
+        with tempfile.TemporaryDirectory() as tmpdir:
+            processor.save_pretrained(tmpdir)
+
+            with open(os.path.join(tmpdir, "processor_config.json")) as f:
+                saved_config = json.load(f)
+            self.assertFalse(saved_config["check_audio_system_prompt"])
+
+            reloaded = self.processor_class.from_pretrained(tmpdir)
+        self.assertFalse(reloaded.check_audio_system_prompt)
+
+        # With the flag disabled, a non-default system prompt must not produce a warning.
+        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        with self.assertNoLogs("transformers.models.qwen2_5_omni.processing_qwen2_5_omni", level="WARNING"):
+            reloaded.apply_chat_template(messages, tokenize=False)
+
+        # While with the flag enabled, we'll get a warning
+        reloaded.check_audio_system_prompt = True
+        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
+        with self.assertLogs("transformers.models.qwen2_5_omni.processing_qwen2_5_omni", level="WARNING"):
+            reloaded.apply_chat_template(messages, tokenize=False)

--- a/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
+++ b/tests/models/qwen2_5_omni/test_processing_qwen2_5_omni.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
-import json
-import os
-import tempfile
 import unittest
 
 import numpy as np
@@ -356,29 +353,3 @@ class Qwen2_5OmniProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         # Qwen pixel values are flattened, verify length matches video_grid_thw
         expected_video_tokens = sum(thw[0] * thw[1] * thw[2] for thw in out_dict["video_grid_thw"])
         self.assertEqual(len(out_dict[self.videos_input_name]), expected_video_tokens)  # 1 video in the conversation
-
-    def test_check_audio_system_prompt_round_trip(self):
-        processor = self.get_processor()
-        self.assertTrue(processor.check_audio_system_prompt)
-
-        processor.check_audio_system_prompt = False
-        with tempfile.TemporaryDirectory() as tmpdir:
-            processor.save_pretrained(tmpdir)
-
-            with open(os.path.join(tmpdir, "processor_config.json")) as f:
-                saved_config = json.load(f)
-            self.assertFalse(saved_config["check_audio_system_prompt"])
-
-            reloaded = self.processor_class.from_pretrained(tmpdir)
-        self.assertFalse(reloaded.check_audio_system_prompt)
-
-        # With the flag disabled, a non-default system prompt must not produce a warning.
-        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
-        with self.assertNoLogs("transformers.models.qwen2_5_omni.processing_qwen2_5_omni", level="WARNING"):
-            reloaded.apply_chat_template(messages, tokenize=False)
-
-        # While with the flag enabled, we'll get a warning
-        reloaded.check_audio_system_prompt = True
-        messages = [{"role": "user", "content": [{"type": "text", "text": "hi"}]}]
-        with self.assertLogs("transformers.models.qwen2_5_omni.processing_qwen2_5_omni", level="WARNING"):
-            reloaded.apply_chat_template(messages, tokenize=False)


### PR DESCRIPTION
# What does this PR do?

There's 2 changes, one is a definite fix and one is a preference. Some background: there are a lot of models that have finetuned `qwen2_5_omni`, e.g. https://huggingface.co/LCO-Embedding/LCO-Embedding-Omni-3B, and in the case of this model, finetuned with a whole new chat template/system prompt/no system prompt.

This is totally fine, except every single input processing results in a spam of 
```
WARNING:root:System prompt modified, audio output may not work as expected. Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
WARNING:root:System prompt modified, audio output may not work as expected. Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
WARNING:root:System prompt modified, audio output may not work as expected. Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
WARNING:root:System prompt modified, audio output may not work as expected. Audio output mode only works when using default system prompt 'You are Qwen, a virtual human developed by the Qwen Team, Alibaba Group, capable of perceiving auditory and visual inputs, as well as generating text and speech.'
...
```

So I've made 2 changes:
1. Use `warning_once` instead of warning every single time
2. (My preference) being able to disable the warning altogether by setting `check_audio_system_prompt` or `check_system_prompt` in the processor config. That way I should be able to remove the warning altogether in these cases where it's a totally incorrect warning.

If change 2 goes too far, I can revert that commit and we can go for just option 1.

An alternative solution would be to just remove the warning: we don't often get involved with the chat template/system prompt choices of the architectures, right?

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

This one was written manually, except the test, which was half generated

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

@zucchini-nlp

- Tom Aarsen