### PR TITLE
refactor(qa): extend extras so ty can run on server modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
         parallelism: 1
         steps:
             - checkout
-            - run: uv pip install -e ".[quality]"
+            - run: uv pip install -e ".[quality,serving]"
             - run:
                 name: Show installed libraries and their versions
                 command: pip freeze | tee installed.txt

--- a/docker/quality.dockerfile
+++ b/docker/quality.dockerfile
@@ -5,5 +5,5 @@ USER root
 RUN apt-get update && apt-get install -y time git make
 ENV UV_PYTHON=/usr/local/bin/python
 RUN pip install uv
-RUN uv pip install --no-cache-dir -U pip setuptools GitPython "git+https://github.com/huggingface/transformers.git@${REF}#egg=transformers[quality]" urllib3
+RUN uv pip install --no-cache-dir -U pip setuptools GitPython "git+https://github.com/huggingface/transformers.git@${REF}#egg=transformers[quality,serving]" urllib3
 RUN apt-get install -y jq curl && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
# What does this PR do?

we're extending `ty` to more modules and we need stubs from more libs like openai. 