### PR TITLE
fix(tokenization): re-raise ImportError to allow RuntimeError/OSError fallback (#45459)

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1930,11 +1930,11 @@ class PreTrainedTokenizerBase(PushToHubMixin):
 
         try:
             tokenizer = cls(*init_inputs, **init_kwargs)
-        except import_protobuf_decode_error():
-            raise RuntimeError(
-                "Unable to load tokenizer model from SPM, loading from TikToken will be attempted instead."
-                "(Google protobuf error: Tried to load SPM model with non-SPM vocab file).",
-            )
+        except ImportError as e:
+            # Re-raise so that subsequent RuntimeError/OSError handlers can execute.
+            # When protobuf is not installed, import_protobuf_decode_error() raises ImportError
+            # instead of matching the original exception, preventing fallback handlers.
+            raise e
         except RuntimeError as e:
             if "sentencepiece_processor.cc" in str(e):
                 raise RuntimeError(


### PR DESCRIPTION
## Summary

When protobuf is not installed,  is a function call used as an  expression. Because it is evaluated lazily when the try block raises, the resulting  from the function itself bypasses the RuntimeError and OSError handlers below it, silently swallowing the original exception.

## Changes

- Replaced  with 
- This allows the original exception (RuntimeError or OSError) to propagate to the appropriate fallback handler below
- When protobuf is not installed, the user now gets the correct error message instead of an opaque protobuf ImportError

## Testing



Fixes #45459