### PR TITLE
fix(testing_utils): guard get_device_capability with torch.cuda.is_available()

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3207,6 +3207,8 @@ def get_device_properties() -> DeviceProperties:
     if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
         import torch
 
+        if not torch.cuda.is_available():
+            return (torch_device, None, None)
         major, minor = torch.cuda.get_device_capability()
         if IS_ROCM_SYSTEM:
             return ("rocm", major, minor)


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in `get_device_properties()` in `testing_utils.py` when CUDA is installed on the system but no GPU device is present (e.g., a CPU-only cloud studio with CUDA libraries installed).

The function called `torch.cuda.get_device_capability()` immediately after checking `IS_CUDA_SYSTEM` (which is `True` whenever `torch.version.cuda is not None`), without first verifying that an actual GPU is available. On CUDA-installed but GPU-less systems, `get_device_capability()` raises an error.

Fixes #45341

## Changes

- `src/transformers/testing_utils.py`: Add `if not torch.cuda.is_available(): return (torch_device, None, None)` guard inside the `IS_CUDA_SYSTEM or IS_ROCM_SYSTEM` branch of `get_device_properties()`, before the `get_device_capability()` call.

## Tests

This is a fix to the test infrastructure itself (`testing_utils.py`). The change prevents a crash that occurs in environments where `IS_CUDA_SYSTEM=True` but no physical GPU is present.

## Notes

- AI-assisted contribution (Kevin Malana)
- Coordinated with issue #45341 which reports the bug
- No duplicate open PRs found addressing this fix