### PR TITLE
Fix: modular image processors

### DIFF
--- a/src/transformers/models/llava_onevision/image_processing_pil_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/image_processing_pil_llava_onevision.py
@@ -36,6 +36,7 @@ from ...processing_utils import ImagesKwargs, Unpack
 from ...utils import TensorType, auto_docstring
 
 
+# Adapted from transformers.models.llava_onevision.image_processing_llava_onevision.LlavaOnevisionImageProcessorKwargs
 class LlavaOnevisionImageProcessorKwargs(ImagesKwargs, total=False):
     r"""
     image_grid_pinpoints (`list[list[int]]`, *optional*):

--- a/src/transformers/models/llava_onevision/modular_llava_onevision.py
+++ b/src/transformers/models/llava_onevision/modular_llava_onevision.py
@@ -34,7 +34,7 @@ from ...image_utils import (
 )
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPooling
-from ...processing_utils import ImagesKwargs, Unpack
+from ...processing_utils import Unpack
 from ...utils import TensorType, auto_docstring, logging
 from ...utils.generic import can_return_tuple, merge_with_config_defaults
 from ..llava_next.image_processing_llava_next import LlavaNextImageProcessor, LlavaNextImageProcessorKwargs
@@ -215,17 +215,6 @@ class LlavaOnevisionImageProcessor(LlavaNextImageProcessor):
             data={"pixel_values": processed_images, "image_sizes": image_sizes, "batch_num_images": batch_num_images},
             tensor_type=return_tensors,
         )
-
-
-class LlavaOnevisionImageProcessorKwargs(ImagesKwargs, total=False):
-    r"""
-    image_grid_pinpoints (`list[list[int]]`, *optional*):
-        A list of possible resolutions to use for processing high resolution images. The best resolution is selected
-        based on the original size of the image. Can be overridden by `image_grid_pinpoints` in the `preprocess`
-        method.
-    """
-
-    image_grid_pinpoints: list[list[int]]
 
 
 class LlavaOnevisionImageProcessorPil(LlavaNextImageProcessorPil):

--- a/utils/modular_model_converter.py
+++ b/utils/modular_model_converter.py
@@ -1766,13 +1766,7 @@ def get_class_node_and_dependencies(
 
         relative_dependency_order = mapper.compute_relative_order(all_dependencies_to_add)
         nodes_to_add = {
-            dep: (
-                relative_dependency_order[dep],
-                # If this dependency is explicitly defined in the modular, prefer the modular's version.
-                # This prevents a renamed parent class from overriding a modular-defined class of the same name.
-                modular_mapper.global_nodes[dep] if dep in modular_mapper.classes else mapper.global_nodes[dep],
-            )
-            for dep in all_dependencies_to_add
+            dep: (relative_dependency_order[dep], mapper.global_nodes[dep]) for dep in all_dependencies_to_add
         }
 
     # No transformers (modeling file) super class, just check functions and assignments dependencies


### PR DESCRIPTION
# What does this PR do?

Discovered in https://github.com/huggingface/transformers/pull/45075

This was added in the recent image processing refactor, but was not reverted after fixing pkg requirements. We should not be defining the same class with identical name two times in modular, defining it once should copy in both files and resolve deps