### PR TITLE
Fix: propagate quantization_config to text sub-config for composite models in AutoModelForCausalLM

### DIFF
--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -383,7 +383,12 @@ class _BaseAutoModelClass:
         elif has_local_code:
             model_class = _get_model_class(config, cls._model_mapping)
             if model_class.config_class == config.sub_configs.get("text_config", None):
+                parent_config = config
                 config = config.get_text_config()
+                # Propagate quantization_config from the composite parent config so that
+                # `get_hf_quantizer` can correctly detect the model as pre-quantized.
+                if hasattr(parent_config, "quantization_config") and not hasattr(config, "quantization_config"):
+                    config.quantization_config = parent_config.quantization_config
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs
             )

--- a/src/transformers/models/auto/auto_factory.py
+++ b/src/transformers/models/auto/auto_factory.py
@@ -383,11 +383,13 @@ class _BaseAutoModelClass:
         elif has_local_code:
             model_class = _get_model_class(config, cls._model_mapping)
             if model_class.config_class == config.sub_configs.get("text_config", None):
+                # TODO: Validate that copying the parent quantization config to the text sub-config preserves
+                # modules_to_not_convert and skip-module matching when composite-model module prefixes differ.
                 parent_config = config
                 config = config.get_text_config()
                 # Propagate quantization_config from the composite parent config so that
                 # `get_hf_quantizer` can correctly detect the model as pre-quantized.
-                if hasattr(parent_config, "quantization_config") and not hasattr(config, "quantization_config"):
+                if hasattr(parent_config, "quantization_config"):
                     config.quantization_config = parent_config.quantization_config
             return model_class.from_pretrained(
                 pretrained_model_name_or_path, *model_args, config=config, **hub_kwargs, **kwargs


### PR DESCRIPTION
# What does this PR do?

Fixes loading of quantized composite models (e.g. Qwen3.5-35B-A3B with AutoRound quantization) via AutoModelForCausalLM.from_pretrained.

Problem:
For composite models whose model_class.config_class maps to text_config, the from_pretrained method in auto_factory.py swaps the full composite config with the text sub-config:
```
if model_class.config_class == config.sub_configs.get("text_config", None):
    config = config.get_text_config()
```

The quantization_config is stored on the top-level composite config (from config.json), but not on the text sub-config. When modeling_utils.py later calls get_hf_quantizer, it checks hasattr(config, "quantization_config") to determine pre_quantized. Since the text sub-config lacks this attribute, pre_quantized is set to False, which causes a ValueError for quantization methods that require pre-quantized weights (e.g. AutoRound, GPTQ, AWQ).

> ValueError: The quantization method QuantizationMethod.AUTOROUND does require the model to be pre-quantized.
> You explicitly passed `pre_quantized=False` meaning your model weights are not quantized.

How to reproduce the issue:
```
qconfig = transformers.AutoRoundConfig()
model = transformers.AutoModelForCausalLM.from_pretrained(model_name_or_path="Intel/Qwen3.5-35B-A3B-int4-AutoRound", trust_remote_code=True, device_map="cuda", quantization_config=qconfig)
```

Fixes # (issue)

After swapping to the text sub-config, propagate quantization_config from the parent composite config if it exists and the text sub-config does not already have one.
