### PR TITLE
[Doc] Fix 'tokenized' -> 'tokenizer' typo in streamer docstrings

### DIFF
--- a/src/transformers/generation/streamers.py
+++ b/src/transformers/generation/streamers.py
@@ -50,7 +50,7 @@ class TextStreamer(BaseStreamer):
 
     Parameters:
         tokenizer (`AutoTokenizer`):
-            The tokenized used to decode the tokens.
+            The tokenizer used to decode the tokens.
         skip_prompt (`bool`, *optional*, defaults to `False`):
             Whether to skip the prompt to `.generate()` or not. Useful e.g. for chatbots.
         decode_kwargs (`dict`, *optional*):
@@ -173,7 +173,7 @@ class TextIteratorStreamer(TextStreamer):
 
     Parameters:
         tokenizer (`AutoTokenizer`):
-            The tokenized used to decode the tokens.
+            The tokenizer used to decode the tokens.
         skip_prompt (`bool`, *optional*, defaults to `False`):
             Whether to skip the prompt to `.generate()` or not. Useful e.g. for chatbots.
         timeout (`float`, *optional*):
@@ -248,7 +248,7 @@ class AsyncTextIteratorStreamer(TextStreamer):
 
     Parameters:
         tokenizer (`AutoTokenizer`):
-            The tokenized used to decode the tokens.
+            The tokenizer used to decode the tokens.
         skip_prompt (`bool`, *optional*, defaults to `False`):
             Whether to skip the prompt to `.generate()` or not. Useful e.g. for chatbots.
         timeout (`float`, *optional*):


### PR DESCRIPTION
## Summary

Fixes a systematic docstring typo in all three streamer classes in `src/transformers/generation/streamers.py`:

- `TextStreamer`
- `TextIteratorStreamer`
- `AsyncTextIteratorStreamer`

Each had `"The tokenized used to decode the tokens."` in the `tokenizer` parameter description. This should be `"The tokenizer used to decode the tokens."` — the parameter accepts a tokenizer object, not a tokenized output.

## Why this is not a duplicate

No existing PR addresses this specific documentation error across all three streamer classes.

## AI assistance disclosure

This PR was prepared with AI assistance. The submitting human has reviewed every changed line and confirms the fix is correct.

Co-authored-by: opencode