### PR TITLE
Fix get_device_properties crash when CUDA is installed but no GPU

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3204,7 +3204,7 @@ def get_device_properties() -> DeviceProperties:
     """
     Get environment device properties.
     """
-    if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
+    if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
         import torch
 
         major, minor = torch.cuda.get_device_capability()


### PR DESCRIPTION
Good day

## Problem
In `src/transformers/testing_utils.py`, the `get_device_properties()` function checks `IS_CUDA_SYSTEM` to determine whether to call `torch.cuda.get_device_capability()`. However, `IS_CUDA_SYSTEM` is set to `True` when `torch.version.cuda` is not `None`, regardless of whether a GPU is actually available.

When CUDA is installed (e.g., CUDA toolkit on a headless cloud instance with no GPU), but no GPU device is present, `torch.cuda.get_device_capability()` raises a `RuntimeError`, causing the function to crash.

## Solution
Added a guard check for `torch.cuda.is_available()` before calling `torch.cuda.get_device_capability()`:

```python
# Before
if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:

# After
if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
```

When CUDA is installed but no GPU is available, the function will now fall through to the `else` branch and return `(torch_device, None, None)` instead of crashing.

## Testing
- The fix is a minimal, targeted change — only one line modified.
- The reproduction is straightforward: run `get_device_properties()` on a CUDA-installed but GPU-less environment (e.g., cloud CPU-only instance with CUDA toolkit).
- The existing test `test_get_device_properties` should continue to pass on GPU-enabled machines.

Fixes https://github.com/huggingface/transformers/issues/45341

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof