### PR TITLE
Fix GraniteMoeHybrid _update_mamba_mask crash on attention-only models

### DIFF
--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -1180,7 +1180,8 @@ class GraniteMoeHybridModel(GraniteMoeHybridPreTrainedModel):
             attention_mask=attention_mask,
             past_key_values=past_key_values,
         )
-        mamba_mask = self._update_mamba_mask(attention_mask, past_key_values)
+        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
+        mamba_mask = self._update_mamba_mask(attention_mask, past_key_values) if has_mamba_layers else None
 
         # embed positions
         hidden_states = inputs_embeds
@@ -1214,9 +1215,6 @@ class GraniteMoeHybridModel(GraniteMoeHybridPreTrainedModel):
             2. Attending to all inputs
         """
         mamba_mask = attention_mask
-        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
-        if not has_mamba_layers:
-            return mamba_mask
         if (past_key_values is not None and past_key_values.has_previous_state()) or (
             attention_mask is not None and torch.all(attention_mask == 1)
         ):

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -1214,6 +1214,9 @@ class GraniteMoeHybridModel(GraniteMoeHybridPreTrainedModel):
             2. Attending to all inputs
         """
         mamba_mask = attention_mask
+        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
+        if not has_mamba_layers:
+            return mamba_mask
         if (past_key_values is not None and past_key_values.has_previous_state()) or (
             attention_mask is not None and torch.all(attention_mask == 1)
         ):

--- a/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modeling_granitemoehybrid.py
@@ -1174,14 +1174,17 @@ class GraniteMoeHybridModel(GraniteMoeHybridPreTrainedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             position_ids = position_ids.unsqueeze(0)
 
-        causal_mask = create_causal_mask(
-            config=self.config,
-            inputs_embeds=inputs_embeds,
-            attention_mask=attention_mask,
-            past_key_values=past_key_values,
-        )
-        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
-        mamba_mask = self._update_mamba_mask(attention_mask, past_key_values) if has_mamba_layers else None
+        causal_mask_mapping = {}
+        for layer_type in set(self.config.layers_block_type):
+            if "mamba" in layer_type:
+                causal_mask_mapping[layer_type] = self._update_mamba_mask(attention_mask, past_key_values)
+            else:
+                causal_mask_mapping[layer_type] = create_causal_mask(
+                    config=self.config,
+                    inputs_embeds=inputs_embeds,
+                    attention_mask=attention_mask,
+                    past_key_values=past_key_values,
+                )
 
         # embed positions
         hidden_states = inputs_embeds
@@ -1190,12 +1193,9 @@ class GraniteMoeHybridModel(GraniteMoeHybridPreTrainedModel):
             position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
         for i, decoder_layer in enumerate(self.layers):
-            # Depending on the layer type we opt for 2D base attention mask (Mamba) or 4D causal mask (Attention)
-            layer_mask = mamba_mask if self.config.layers_block_type[i] == "mamba" else causal_mask
-
             hidden_states = decoder_layer(
                 hidden_states,
-                attention_mask=layer_mask,
+                attention_mask=causal_mask_mapping[self.config.layers_block_type[i]],
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,

--- a/src/transformers/models/granitemoehybrid/modular_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modular_granitemoehybrid.py
@@ -274,6 +274,9 @@ class GraniteMoeHybridModel(GraniteMoeSharedModel):
             2. Attending to all inputs
         """
         mamba_mask = attention_mask
+        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
+        if not has_mamba_layers:
+            return mamba_mask
         if (past_key_values is not None and past_key_values.has_previous_state()) or (
             attention_mask is not None and torch.all(attention_mask == 1)
         ):

--- a/src/transformers/models/granitemoehybrid/modular_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modular_granitemoehybrid.py
@@ -234,14 +234,17 @@ class GraniteMoeHybridModel(GraniteMoeSharedModel):
             position_ids = torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
             position_ids = position_ids.unsqueeze(0)
 
-        causal_mask = create_causal_mask(
-            config=self.config,
-            inputs_embeds=inputs_embeds,
-            attention_mask=attention_mask,
-            past_key_values=past_key_values,
-        )
-        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
-        mamba_mask = self._update_mamba_mask(attention_mask, past_key_values) if has_mamba_layers else None
+        causal_mask_mapping = {}
+        for layer_type in set(self.config.layers_block_type):
+            if "mamba" in layer_type:
+                causal_mask_mapping[layer_type] = self._update_mamba_mask(attention_mask, past_key_values)
+            else:
+                causal_mask_mapping[layer_type] = create_causal_mask(
+                    config=self.config,
+                    inputs_embeds=inputs_embeds,
+                    attention_mask=attention_mask,
+                    past_key_values=past_key_values,
+                )
 
         # embed positions
         hidden_states = inputs_embeds
@@ -250,12 +253,9 @@ class GraniteMoeHybridModel(GraniteMoeSharedModel):
             position_embeddings = self.rotary_emb(hidden_states, position_ids)
 
         for i, decoder_layer in enumerate(self.layers):
-            # Depending on the layer type we opt for 2D base attention mask (Mamba) or 4D causal mask (Attention)
-            layer_mask = mamba_mask if self.config.layers_block_type[i] == "mamba" else causal_mask
-
             hidden_states = decoder_layer(
                 hidden_states,
-                attention_mask=layer_mask,
+                attention_mask=causal_mask_mapping[self.config.layers_block_type[i]],
                 past_key_values=past_key_values,
                 use_cache=use_cache,
                 position_embeddings=position_embeddings,

--- a/src/transformers/models/granitemoehybrid/modular_granitemoehybrid.py
+++ b/src/transformers/models/granitemoehybrid/modular_granitemoehybrid.py
@@ -240,7 +240,8 @@ class GraniteMoeHybridModel(GraniteMoeSharedModel):
             attention_mask=attention_mask,
             past_key_values=past_key_values,
         )
-        mamba_mask = self._update_mamba_mask(attention_mask, past_key_values)
+        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
+        mamba_mask = self._update_mamba_mask(attention_mask, past_key_values) if has_mamba_layers else None
 
         # embed positions
         hidden_states = inputs_embeds
@@ -274,9 +275,6 @@ class GraniteMoeHybridModel(GraniteMoeSharedModel):
             2. Attending to all inputs
         """
         mamba_mask = attention_mask
-        has_mamba_layers = any(t == "mamba" for t in self.config.layers_block_type)
-        if not has_mamba_layers:
-            return mamba_mask
         if (past_key_values is not None and past_key_values.has_previous_state()) or (
             attention_mask is not None and torch.all(attention_mask == 1)
         ):

--- a/tests/models/granitemoehybrid/test_modeling_granitemoehybrid.py
+++ b/tests/models/granitemoehybrid/test_modeling_granitemoehybrid.py
@@ -313,6 +313,20 @@ class GraniteMoeHybridModelTest(ModelTesterMixin, GenerationTesterMixin, Pipelin
     def _get_recurrent_state_shape(self, batch_size: int, config):
         return (batch_size, config.mamba_n_heads, config.mamba_d_head, config.mamba_d_state)
 
+    def test_attention_only_forward(self):
+        """Ensure forward pass works when all layers are attention (no mamba layers). Regression test for #45507."""
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        config = config_and_inputs[0]
+        config.layers_block_type = ["attention"] * config.num_hidden_layers
+
+        for model_class in self.all_model_classes:
+            model = model_class._from_config(config)
+            model.to(torch_device)
+            model.eval()
+            input_ids = config_and_inputs[1]
+            with torch.no_grad():
+                model(input_ids)
+
     def test_config_requires_mamba_or_attention_layers(self):
         """Ensure we can't create a config with disallowed layers."""
         with pytest.raises(StrictDataclassClassValidationError):


### PR DESCRIPTION
Fixes #45507

## Summary

`GraniteMoeHybridModel._update_mamba_mask` calls `past_key_values.has_previous_state()` without checking whether the model actually has mamba layers. When all layers are attention-only (no mamba layers in `config.layers_block_type`), `has_previous_state()` fails to find a `LinearAttentionCacheLayerMixin` layer and raises `ValueError`.

## Fix

Check `config.layers_block_type` for mamba layers before calling `has_previous_state()`. If no mamba layers exist, return the attention mask as-is since the mamba mask optimization is irrelevant.

Applied to both `modeling_granitemoehybrid.py` and `modular_granitemoehybrid.py`.