### PR TITLE
Fix CUDA availability check in get_device_properties()

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3204,9 +3204,7 @@ def get_device_properties() -> DeviceProperties:
     """
     Get environment device properties.
     """
-    if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
-        import torch
-
+    if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
         major, minor = torch.cuda.get_device_capability()
         if IS_ROCM_SYSTEM:
             return ("rocm", major, minor)


### PR DESCRIPTION
Good day

## Summary

This PR fixes a bug in `src/transformers/testing_utils.py` where `get_device_properties()` calls `torch.cuda.get_device_capability()` without first checking if a GPU is actually available.

## Bug Description

When CUDA is installed on a system (e.g., `torch.version.cuda` is not `None`) but no GPU is present, calling `torch.cuda.get_device_capability()` raises a `RuntimeError`.

## Fix

Changed the condition from:

```python
if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
    import torch
    major, minor = torch.cuda.get_device_capability()
```

to:

```python
if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
    major, minor = torch.cuda.get_device_capability()
```

This ensures the GPU capability call only happens when a GPU is actually present, and also removes the redundant `import torch` statement that was inside the conditional block (the import is already at the top of the file).

## Reference

Fixes #45341

---

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof