### PR TITLE
Fix CSM `TextToAudioPipeline` missing `<bos>` token

### DIFF
--- a/src/transformers/pipelines/text_to_audio.py
+++ b/src/transformers/pipelines/text_to_audio.py
@@ -179,6 +179,7 @@ class TextToAudioPipeline(Pipeline):
             # Add speaker ID if needed and user didn't insert at start of text
             if self.model.config.model_type == "csm":
                 text = [f"[0]{t}" if not t.startswith("[") else t for t in text]
+                kwargs.setdefault("add_special_tokens", True)
             if self.model.config.model_type == "dia":
                 text = [f"[S1] {t}" if not t.startswith("[") else t for t in text]
             output = preprocessor(text, **kwargs, return_tensors="pt")


### PR DESCRIPTION
## What does this PR do?

`CsmProcessor` defaults `add_special_tokens=False` (designed for `apply_chat_template`, which includes `<bos>` in the Jinja template). When the pipeline calls `preprocessor(text)` directly for raw text input, `<bos>` (128000) and `<eos>` (128001) are missing from the tokenized sequence. Without these tokens the model receives malformed input it was never trained on, making generation unstable — certain seed/sampling parameter combinations cause the model to emit all-zero codebook frames, which are treated as EOS (`codebook_eos_token_id=0`), resulting in an empty audio tensor that crashes Mimi's Conv1d decoder.

Fix: set `add_special_tokens=True` for CSM in pipeline `preprocess`.

## Reproduction

```python
from transformers import pipeline, set_seed

pipe = pipeline("text-to-speech", model="sesame/csm-1b")
set_seed(777)
output = pipe("Hello, my dog is cooler than you!", forward_params={"do_sample": True, "temperature": 0.7, "top_k": 50, "top_p": 0.95})
# RuntimeError: Calculated padded input size per channel: (0). Kernel size: (1).
# Kernel size can't be greater than actual input size
```

error:
```
......
  File "/home/jiqing/transformers/src/transformers/models/csm/generation_csm.py", line 478, in generate
    codec_decode_output = self.codec_model.decode(audio_codes_batch.transpose(0, 1).unsqueeze(0))                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                      File "/home/jiqing/transformers/src/transformers/models/mimi/modeling_mimi.py", line 1666, in decode
    audio_values, decoder_past_key_values = self._decode_frame(                                                                                                                  ^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/models/mimi/modeling_mimi.py", line 1619, in _decode_frame
    embeddings = self.quantizer.decode(codes)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/models/mimi/modeling_mimi.py", line 1344, in decode
    quantized_out = self.semantic_residual_vector_quantizer.decode(codes[:, : self.num_semantic_quantizers])
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/jiqing/transformers/src/transformers/models/mimi/modeling_mimi.py", line 1292, in decode
    quantized_out = self.output_proj(quantized_out)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1778, in _wrapped_call_impl
    return self._call_impl(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1789, in _call_impl
    return forward_call(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 385, in forward
    return self._conv_forward(input, self.weight, self.bias)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/conv.py", line 380, in _conv_forward
    return F.conv1d(
           ^^^^^^^^^
RuntimeError: Calculated padded input size per channel: (0). Kernel size: (1). Kernel size can't be greater than actual input size
```

Hi @Rocketknight1 . Would you please review this PR? Thanks!