### PR TITLE
qa: re-run modular converter when the script itself is modified

### DIFF
--- a/tests/repo_utils/test_check_modular_conversion.py
+++ b/tests/repo_utils/test_check_modular_conversion.py
@@ -1,0 +1,74 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+
+git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+utils_path = os.path.join(git_repo_path, "utils")
+if utils_path not in sys.path:
+    sys.path.append(utils_path)
+
+import check_modular_conversion  # noqa: E402
+
+
+class ConverterChangedInDiffTest(unittest.TestCase):
+    """Regression guard for PR #45492: changes to the converter alone must force a full check."""
+
+    def _patch_modified(self, files):
+        return patch.object(check_modular_conversion, "_get_modified_files", return_value=files)
+
+    def test_returns_true_when_modular_model_converter_changed(self):
+        with self._patch_modified(
+            [
+                "utils/modular_model_converter.py",
+                "src/transformers/models/llava_onevision/modular_llava_onevision.py",
+            ]
+        ):
+            self.assertTrue(check_modular_conversion.converter_changed_in_diff())
+
+    def test_returns_true_when_create_dependency_mapping_changed(self):
+        with self._patch_modified(["utils/create_dependency_mapping.py"]):
+            self.assertTrue(check_modular_conversion.converter_changed_in_diff())
+
+    def test_returns_false_for_model_only_diff(self):
+        with self._patch_modified(
+            [
+                "src/transformers/models/llama/modular_llama.py",
+                "src/transformers/models/llama/modeling_llama.py",
+            ]
+        ):
+            self.assertFalse(check_modular_conversion.converter_changed_in_diff())
+
+    def test_returns_false_for_unrelated_utils_change(self):
+        with self._patch_modified(["utils/check_modular_conversion.py", "utils/check_copies.py"]):
+            self.assertFalse(check_modular_conversion.converter_changed_in_diff())
+
+    def test_converter_files_set_includes_expected_entries(self):
+        # Keep the allow-list grounded: if either file is renamed/removed, this test fails loudly
+        # so the detection logic is updated alongside the rename.
+        self.assertIn("utils/modular_model_converter.py", check_modular_conversion.CONVERTER_FILES)
+        self.assertIn("utils/create_dependency_mapping.py", check_modular_conversion.CONVERTER_FILES)
+        for rel_path in check_modular_conversion.CONVERTER_FILES:
+            self.assertTrue(
+                os.path.exists(os.path.join(git_repo_path, rel_path)),
+                f"{rel_path} listed in CONVERTER_FILES but does not exist on disk",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -106,6 +106,23 @@ def compare_files(modular_file_path, show_diff=True):
     return diff
 
 
+# Changes to any of these files can alter the generated output for every modular model,
+# so touching them must force a full re-check (see `converter_changed_in_diff`).
+CONVERTER_FILES = {
+    "utils/modular_model_converter.py",
+    "utils/create_dependency_mapping.py",
+}
+
+
+def _get_modified_files():
+    fork_point_sha = subprocess.check_output("git merge-base main HEAD".split()).decode("utf-8")
+    return (
+        subprocess.check_output(f"git diff --diff-filter=d --name-only {fork_point_sha}".split())
+        .decode("utf-8")
+        .split()
+    )
+
+
 def get_models_in_diff():
     """
     Finds all models that have been modified in the diff.
@@ -113,12 +130,7 @@ def get_models_in_diff():
     Returns:
         A set containing the names of the models that have been modified (e.g. {'llama', 'whisper'}).
     """
-    fork_point_sha = subprocess.check_output("git merge-base main HEAD".split()).decode("utf-8")
-    modified_files = (
-        subprocess.check_output(f"git diff --diff-filter=d --name-only {fork_point_sha}".split())
-        .decode("utf-8")
-        .split()
-    )
+    modified_files = _get_modified_files()
 
     # Matches both modelling files and tests
     relevant_modified_files = [x for x in modified_files if "/models/" in x and x.endswith(".py")]
@@ -127,6 +139,11 @@ def get_models_in_diff():
         model_name = file_path.split("/")[-2]
         model_names.add(model_name)
     return model_names
+
+
+def converter_changed_in_diff():
+    """Whether the diff touches a file that can change conversion output for every model."""
+    return any(f in CONVERTER_FILES for f in _get_modified_files())
 
 
 def guaranteed_no_diff(modular_file_path, dependencies, models_in_diff):
@@ -186,6 +203,12 @@ if __name__ == "__main__":
         console.print(
             "[bold red]You are developing on the main branch. We cannot identify the list of changed files and will have to check all files. This may take a while.[/bold red]"
         )
+        models_in_diff = {file_path.split("/")[-2] for file_path in args.files}
+    elif converter_changed_in_diff():
+        # The converter (or its dependency-mapping helper) is in the diff: its output can shift
+        # for any model, so restrict-by-diff would miss regressions. Force a full check.
+        console.print("[bold yellow]Converter change detected in diff; checking all modular files.[/bold yellow]")
+        args.check_all = True
         models_in_diff = {file_path.split("/")[-2] for file_path in args.files}
     else:
         models_in_diff = get_models_in_diff()


### PR DESCRIPTION
# What does this PR do?

- When changing the checker itself, we want to ignore the `guaranteed_no_diff` shortcut since changing the checker might impact models not in the PR
