### PR TITLE
fix: remove stale num_return_sequences warning in paged generate

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2300,21 +2300,19 @@ class GenerationMixin(ContinuousMixin):
                     f"negative_prompt_attention_mask is not supported for continuous batching. Got {negative_prompt_attention_mask = }"
                 )
 
+            cb_generation_config = self._prepare_generation_config(generation_config, **kwargs)[0]
+
             # others are ignored
             if synced_gpus is not None:
                 logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
-            num_return_sequences = kwargs.get("num_return_sequences", 1)
-            num_beams = kwargs.get("num_beams", 1)
-            if num_return_sequences > 1 or num_beams > 1:  # FIXME: remove this once CB supports it (which is planned)
-                logger.warning(
-                    f"num_return_sequences and num_beams are not supported for continuous batching yet. "
-                    f"Got {num_return_sequences = } and {num_beams = }. "
-                )
+            num_beams = cb_generation_config.num_beams if cb_generation_config.num_beams is not None else 1
+            if num_beams > 1:  # FIXME: remove this once CB supports it (which is planned)
+                logger.warning(f"num_beams is not supported for continuous batching yet. Got {num_beams = }.")
 
             # switch to CB
             outputs = self.generate_batch(
                 inputs=inputs,
-                generation_config=self._prepare_generation_config(generation_config, **kwargs)[0],
+                generation_config=cb_generation_config,
                 **kwargs,
             )
             sequences = [


### PR DESCRIPTION
## Summary

The `generate(..., cache_implementation="paged")` path emits a misleading warning that `num_return_sequences` is not supported for continuous batching. This is stale — `generate_batch()` already handles `num_return_sequences` by expanding the number of requests internally.

## Changes

- Remove the `num_return_sequences > 1` condition from the warning check
- Keep the warning for `num_beams > 1` (still not supported)
- Read `num_beams` from the prepared generation config instead of raw kwargs (more accurate)
- Cache the prepared generation config to avoid calling `_prepare_generation_config()` twice

## Before

```
num_return_sequences and num_beams are not supported for continuous batching yet. Got num_return_sequences=2 and num_beams=1.
```

## After (when num_beams=1)

No warning emitted.

## After (when num_beams > 1)

```
num_beams is not supported for continuous batching yet. Got num_beams=3.
```

Fixes #45563