### PR TITLE
fix: raise clear error when tokenizer config uses v5 list format on older versions

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1412,6 +1412,11 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         Args:
             special_tokens: Dictionary of {token_name: token_value}
         """
+        if isinstance(special_tokens, list):
+            raise ValueError(
+                "This model's tokenizer config uses the list-based `extra_special_tokens` format "
+                "introduced in transformers v5. Please upgrade: pip install 'transformers>=5.0.0'"
+            )
         self.SPECIAL_TOKENS_ATTRIBUTES = self.SPECIAL_TOKENS_ATTRIBUTES + list(special_tokens.keys())
         for key, value in special_tokens.items():
             if isinstance(value, (str, AddedToken)):


### PR DESCRIPTION
## Summary

When loading a model whose `tokenizer_config.json` uses the v5-style list-based `extra_special_tokens` format on transformers < 5.0, `_set_model_specific_special_tokens()` crashes with a misleading:

```
AttributeError: 'list' object has no attribute 'keys'
```

This sends users down the wrong debugging path (patching config files, reinstalling packages) when the real issue is a version mismatch.

## Fix

Add an `isinstance(special_tokens, list)` guard at the top of `_set_model_specific_special_tokens()` that raises a clear `ValueError` telling users to upgrade to transformers >= 5.0.0.

Fixes #45376