### PR TITLE
Move some conversion mappings to PrefixChange

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -151,19 +151,10 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming(source_patterns=r"^visual", target_patterns="model.visual"),
         ],
         "colqwen2": [
-            WeightRenaming(source_patterns=r"vlm.model", target_patterns="vlm"),
+            PrefixChange(prefix_to_remove="model", model_prefix="vlm"),
             WeightRenaming(source_patterns=r"vlm(?!\.(language_model|visual))", target_patterns="vlm.language_model"),
         ],
-        "timm_wrapper": [
-            # Simply add the prefix `timm_model`. Similar to `base_model_prefix` but also removes prefix
-            # when saving. TODO: Would be probably much cleaner with a `add_prefix` argument in WeightRenaming
-            # Note: we don't add `timm_model` when it is part of a bigger VLM, because they already have `timm_model`
-            # saved in state dict keys. Thus the look behind check. Should be fixed by proper `add_prefix`!
-            WeightRenaming(
-                source_patterns=r"^(?!(?:model\.|backbone\.|tower\.))(.+)$",
-                target_patterns=r"timm_model.\1",
-            )
-        ],
+        "timm_wrapper": [PrefixChange(prefix_to_add="timm_model")],
         "pi0": [
             WeightRenaming(source_patterns=r"state_proj", target_patterns="embed_action_time.state_proj"),
             WeightRenaming(source_patterns=r"action_in_proj", target_patterns="embed_action_time.action_in_proj"),
@@ -201,13 +192,7 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming("attention_layer_norm", "input_layernorm"),
             WeightRenaming("feedforward_layer_norm", "post_attention_layernorm"),
         ],
-        "qwen3_5_text": [
-            # Note: the lookbehind on the target is to avoid replacing bigger matches when the model is a submodel of
-            # the ForConditionalGeneration model
-            WeightRenaming(
-                source_patterns=r"^model.language_model.", target_patterns=r"^model.(?!(?:language_model.|visual.))"
-            ),
-        ],
+        "qwen3_5_text": [PrefixChange(prefix_to_remove="language_model", model_prefix="model")],
         "sam3_tracker": [
             WeightRenaming(
                 source_patterns=r"detector_model.vision_encoder.backbone.", target_patterns="vision_encoder.backbone."


### PR DESCRIPTION
# What does this PR do?

As per the title.
cc @vasqu @zucchini-nlp 

Confirmed with the following script that it works correctly:

```python
import transformers
from safetensors.torch import load_file
from transformers.utils.hub import cached_file, cached_files
import json
import torch

# model_id = "Qwen/Qwen3.5-0.8B"
# model_id = "google/gemma-3n-E4B"
model_id = "vidore/colqwen2-v1.0-hf"
model_class = transformers.ColQwen2ForRetrieval

target_folder = "/raid/cyril/test_model"

try:
    with open(cached_file(model_id, "model.safetensors.index.json")) as f:
        index = json.load(f)
    model_files = set(index["weight_map"].values())
    model_files = cached_files(model_id, model_files)
except OSError:
    model_files = cached_files(model_id, ["model.safetensors"])

original_state_dict = {}
for file in model_files:
    original_state_dict.update(load_file(file))
original_state_dict = {k: v.to(torch.bfloat16) for k,v in original_state_dict.items()}

model = model_class.from_pretrained(model_id, dtype=torch.bfloat16)
model.save_pretrained(target_folder)

saved_weights = load_file(f"{target_folder}/model.safetensors")

not_in_saved = []
for k, v in original_state_dict.items():
    if k not in saved_weights:
        not_in_saved.append(k)
    else:
        assert (v == saved_weights[k]).all()

not_in_original = []
for k, v in saved_weights.items():
    if k not in original_state_dict:
        not_in_original.append(k)
    else:
        assert (v == original_state_dict[k]).all()

print(f"The following are in original but not in saved: {not_in_saved}")
print(f"The following are saved but not in original: {not_in_original}")

model = model_class.from_pretrained(target_folder)
```