### PR TITLE
fix(generation): remove stale warning for num_return_sequences in paged generate

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2305,10 +2305,10 @@ class GenerationMixin(ContinuousMixin):
                 logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
             num_return_sequences = kwargs.get("num_return_sequences", 1)
             num_beams = kwargs.get("num_beams", 1)
-            if num_return_sequences > 1 or num_beams > 1:  # FIXME: remove this once CB supports it (which is planned)
+            if num_beams > 1:  # FIXME: remove this once CB supports it (which is planned)
                 logger.warning(
-                    f"num_return_sequences and num_beams are not supported for continuous batching yet. "
-                    f"Got {num_return_sequences = } and {num_beams = }. "
+                    f"num_beams is not supported for continuous batching yet. "
+                    f"Got {num_beams = }. "
                 )
 
             # switch to CB


### PR DESCRIPTION
Fixes #45563.

generate(..., cache_implementation=paged) incorrectly warned that num_return_sequences is unsupported for continuous batching. This warning is stale: generate_batch() already uses generation_config.num_return_sequences to expand the number of requests.

Changes: Split the guard in src/transformers/generation/utils.py — keep warning only for num_beams > 1 (beam search is genuinely unsupported), remove the warning for num_return_sequences.

Test plan:
- generate(..., cache_implementation=paged, num_return_sequences=2) no longer emits warning
- generate(..., cache_implementation=paged, num_beams=2) still emits warning

Reference: https://github.com/oleksii-tumanov/transformers/commit/f7a939d95239d26f94195cd6b820e4c720976507