### PR TITLE
docs(pipeline): fix num_workers docstring default from 8 to 0

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -676,7 +676,7 @@ def build_pipeline_init_args(
     docstring += r"""
         task (`str`, defaults to `""`):
             A task-identifier for the pipeline.
-        num_workers (`int`, *optional*, defaults to 8):
+        num_workers (`int`, *optional*, defaults to 0):
             When the pipeline will use *DataLoader* (when passing a dataset, on GPU for a Pytorch model), the number of
             workers to be used.
         batch_size (`int`, *optional*, defaults to 1):


### PR DESCRIPTION
## What does this PR do?

Fixes #45557.

The docstring for `num_workers` in `build_pipeline_init_args()` states `defaults to 8`, but the actual runtime fallback in `Pipeline.__call__()` is `0`:

```python
# Line 1210 in base.py
if self._num_workers is None:
    num_workers = 0  # actual default
```

This PR updates the docstring to accurately reflect the runtime behavior (`defaults to 0`), preventing confusion for users relying on the docs for performance tuning.

## Before submitting
- [x] This PR fixes a typo or improves the docs (and does not need the community review, just direct merge by the author)
- [x] Did you read the contributor guideline?

Fixes: #45557