### PR TITLE
Remove attribute_map from GptOssConfig

### DIFF
--- a/src/transformers/models/gpt_oss/configuration_gpt_oss.py
+++ b/src/transformers/models/gpt_oss/configuration_gpt_oss.py
@@ -23,9 +23,6 @@ from ...utils import auto_docstring
 @strict
 class GptOssConfig(PreTrainedConfig):
     model_type = "gpt_oss"
-    attribute_map = {
-        "num_experts": "num_local_experts",
-    }
     default_theta = 150000.0
     base_model_pp_plan = {
         "embed_tokens": (["input_ids"], ["inputs_embeds"]),


### PR DESCRIPTION

Added in #45473,  it clobbers num_local_experts when checkpoints carry both keys (breaks tiny-GptOssForCausalLM loading in PEFT/TRL CI) : https://github.com/huggingface/transformers/pull/45473/changes/BASE..20c2a54ea0f7669d1c5af1fa512ca91379e48df6#r3116765952

Was added for API parity with Mixtral/MiniMax `{"num_experts": "num_local_experts"}`.  Looked like a natural consistency change to land alongside the EP fixes.

Transformers CI didn't fail. The bug only fires when a `config.json` carries both `num_experts` and `num_local_experts`. GPT-OSS-20 has only the latter, so the transformers tests pass. TRL/PEFT CI pin on `trl-internal-testing/tiny-GptOssForCausalLM`, whose config has both [(num_experts: 4, num_local_experts: 128](https://huggingface.co/trl-internal-testing/tiny-GptOssForCausalLM/commit/ffe015e42676a3b43e8ff4534b67d3f3eeb0f25a)). With the attribute_map, the num_experts=4 kwarg silently rewrites num_local_experts to 4, so the built model has 4 experts while the
checkpoint holds 128, that's why we got the shape MISMATCH.

Although I saw @albertvillanova fixing the `num_local_experts` 👀  in   https://huggingface.co/trl-internal-testing/tiny-GptOssForCausalLM/commit/ffe015e42676a3b43e8ff4534b67d3f3eeb0f25a

# What does this PR do?
- Removes config attr_map for num_experts and num_local_experts 
 
## Who can review?
 @ArthurZucker @BenjaminBossan  @qgallouedec  @albertvillanova 