### PR TITLE
generate: drop stale num_return_sequences warning on continuous batching path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -328,7 +328,7 @@ if __name__ == "__main__":
 
     setup(
         name="transformers",
-        version="5.6.0.dev0",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+        version="5.7.0.dev0",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
         author="The Hugging Face team (past and future) with the help of all our contributors (https://github.com/huggingface/transformers/graphs/contributors)",
         author_email="transformers@huggingface.co",
         description="Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.",

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2305,9 +2305,7 @@ class GenerationMixin(ContinuousMixin):
                 logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
             num_beams = kwargs.get("num_beams", 1)
             if num_beams > 1:  # FIXME: remove this once CB supports num_beams (which is planned)
-                logger.warning(
-                    f"num_beams is not supported for continuous batching yet. Got {num_beams = }. "
-                )
+                logger.warning(f"num_beams is not supported for continuous batching yet. Got {num_beams = }. ")
 
             # switch to CB
             outputs = self.generate_batch(

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2303,12 +2303,10 @@ class GenerationMixin(ContinuousMixin):
             # others are ignored
             if synced_gpus is not None:
                 logger.warning(f"synced_gpus is not ignored for continuous batching. Got {synced_gpus = }")
-            num_return_sequences = kwargs.get("num_return_sequences", 1)
             num_beams = kwargs.get("num_beams", 1)
-            if num_return_sequences > 1 or num_beams > 1:  # FIXME: remove this once CB supports it (which is planned)
+            if num_beams > 1:  # FIXME: remove this once CB supports num_beams (which is planned)
                 logger.warning(
-                    f"num_return_sequences and num_beams are not supported for continuous batching yet. "
-                    f"Got {num_return_sequences = } and {num_beams = }. "
+                    f"num_beams is not supported for continuous batching yet. Got {num_beams = }. "
                 )
 
             # switch to CB


### PR DESCRIPTION
The continuous-batching branch in `generate` warned that `num_return_sequences` was unsupported alongside `num_beams`, but `generate_batch()` already honors `generation_config.num_return_sequences` when expanding requests. The warning fires for any run that explicitly sets `num_return_sequences` even though the feature works, cluttering logs and misleading users.

Drop the `num_return_sequences` half of the warning; keep the `num_beams` guard since beam search is still unsupported on the CB path.

Fixes #45563