### PR TITLE
qa: bumped mlinter and allow local override

### DIFF
--- a/docs/source/en/modeling_rules.md
+++ b/docs/source/en/modeling_rules.md
@@ -13,22 +13,22 @@ specific language governing permissions and limitations under the License.
 
 # Model structure rules
 
-Transformers enforces a set of static rules on every `modeling_*.py`, `modular_*.py`, and `configuration_*.py` file. The [mlinter](https://github.com/huggingface/transformers-mlinter) tool checks them as part of `make typing` and errors out if violations are found.
+Transformers enforces a set of static rules on every `modeling_*.py`, `modular_*.py`, and `configuration_*.py` file. The [mlinter](https://github.com/huggingface/transformers-mlinter) package provides the checker engine, and the repository keeps its active rule set in `utils/rules.toml`. That local TOML lets us enable, disable, or tweak rules quickly without waiting for a new `transformers-mlinter` release.
 
 These are the expected model conventions for adding or changing modeling code. They keep the codebase consistent and ensure compatibility with features like pipeline parallelism, device maps, and weight tying.
 
 ## Running the checker
 
-`make typing` runs `mlinter` alongside the `ty` type checker. Run `mlinter` on its own with the following commands.
+`make typing` runs `mlinter` alongside the `ty` type checker through the repo wrapper, so it picks up `utils/rules.toml`. Run the same wrapper directly with the following commands.
 
 ```bash
-mlinter                  # check all modeling files
-mlinter --changed-only   # check only files changed vs origin/main
-mlinter --list-rules     # list all rules and their enabled status
-mlinter --rule TRF001    # show built-in docs for a specific rule
+python utils/check_modeling_structure.py                 # check all modeling files
+python utils/check_modeling_structure.py --changed-only  # check only files changed vs origin/main
+python utils/check_modeling_structure.py --list-rules    # list all rules and their enabled status
+python utils/check_modeling_structure.py --rule TRF001   # show built-in docs for a specific rule
 ```
 
-The `--changed-only` flag is the fastest option during development. It only checks the files you've modified relative to the main branch.
+The `--changed-only` flag is the fastest option during development. It only checks the files you've modified relative to the main branch. If you invoke `mlinter` directly instead of the wrapper, pass `--rules-toml utils/rules.toml` so local overrides are applied.
 
 ## Fixing a violation
 
@@ -52,7 +52,7 @@ Use the rule ID to look up the fix in the [rules reference](#rules-reference). T
 
 ## Rules reference
 
-Each rule below lists what it enforces and a diff showing the fix. Run `mlinter --rule TRF001` to see the built-in docs for any rule.
+Each rule below lists what it enforces and a diff showing the fix. Run `python utils/check_modeling_structure.py --rule TRF001` to see the built-in docs for any rule with the repo's current rule set.
 
 <!-- BEGIN RULES REFERENCE -->
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,9 @@ _deps = [
     "rjieba",
     "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff==0.14.10",
-    "transformers-mlinter==0.1.0",
+    # When bumping `transformers-mlinter`, sync repo-local rule overrides from
+    # `utils/rules.toml` back into the released package.
+    "transformers-mlinter==0.1.1",
     "ty==0.0.20",
     # `sacrebleu` not used in `transformers`. However, it is needed in several tests, when a test calls
     # `evaluate.load("sacrebleu")`. This metric is used in the examples that we use to test the `Trainer` with, in the

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -56,7 +56,7 @@ deps = {
     "rjieba": "rjieba",
     "rouge-score": "rouge-score!=0.0.7,!=0.0.8,!=0.1,!=0.1.1",
     "ruff": "ruff==0.14.10",
-    "transformers-mlinter": "transformers-mlinter==0.1.0",
+    "transformers-mlinter": "transformers-mlinter==0.1.1",
     "ty": "ty==0.0.20",
     "sacrebleu": "sacrebleu>=1.4.12,<2.0.0",
     "sacremoses": "sacremoses",

--- a/utils/check_modeling_rules_doc.py
+++ b/utils/check_modeling_rules_doc.py
@@ -46,7 +46,7 @@ CHECKER_CONFIG = {
 
 ROOT = Path(__file__).resolve().parent.parent
 DOC_PATH = ROOT / "docs" / "source" / "en" / "modeling_rules.md"
-RULES_TOML_PATH = Path(__file__).resolve().with_name("rules.toml")
+RULES_TOML_PATH = ROOT / "utils" / "rules.toml"
 
 BEGIN_MARKER = "<!-- BEGIN RULES REFERENCE -->"
 END_MARKER = "<!-- END RULES REFERENCE -->"

--- a/utils/check_modeling_rules_doc.py
+++ b/utils/check_modeling_rules_doc.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 """
 Keep `## Rules reference` section of docs/source/en/modeling_rules.md in sync
-with the rules defined in the mlinter package.
+with the rules defined in utils/rules.toml via the installed mlinter package.
 
 Usage (from the root of the repo):
 
@@ -31,21 +31,22 @@ python utils/check_modeling_rules_doc.py --fix_and_overwrite
 """
 
 import argparse
-import os
+from pathlib import Path
 
 
 CHECKER_CONFIG = {
     "name": "modeling_rules_doc",
     "label": "Modeling rules documentation",
-    # Depends on the installed `mlinter` package output, which cannot be expressed
-    # as repo file globs for the checker cache.
+    # Depends on utils/rules.toml plus the installed `mlinter` package output,
+    # which cannot be fully expressed as repo file globs for the checker cache.
     "file_globs": None,
-    "check_args": [],
-    "fix_args": ["--fix_and_overwrite"],
+    "check_args": ["--rules-toml", "utils/rules.toml"],
+    "fix_args": ["--rules-toml", "utils/rules.toml", "--fix_and_overwrite"],
 }
 
-ROOT = os.path.dirname(os.path.dirname(__file__))
-DOC_PATH = os.path.join(ROOT, "docs", "source", "en", "modeling_rules.md")
+ROOT = Path(__file__).resolve().parent.parent
+DOC_PATH = ROOT / "docs" / "source" / "en" / "modeling_rules.md"
+RULES_TOML_PATH = Path(__file__).resolve().with_name("rules.toml")
 
 BEGIN_MARKER = "<!-- BEGIN RULES REFERENCE -->"
 END_MARKER = "<!-- END RULES REFERENCE -->"
@@ -54,21 +55,29 @@ END_MARKER = "<!-- END RULES REFERENCE -->"
 def _require_mlinter():
     try:
         import mlinter
+        from mlinter import mlinter as mlinter_impl
     except ModuleNotFoundError as error:
         raise ModuleNotFoundError(
             "This script requires the standalone `transformers-mlinter` package. "
             'Install the repo quality dependencies with `pip install -e ".[quality]"` and retry.'
         ) from error
 
-    return mlinter
+    return mlinter, mlinter_impl
 
 
-def generate_rules_reference() -> str:
-    return _require_mlinter().render_rules_reference()
+def _resolve_path(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT / path
 
 
-def check_modeling_rules_doc(overwrite: bool = False):
-    with open(DOC_PATH, encoding="utf-8") as f:
+def generate_rules_reference(rule_specs_path: Path = RULES_TOML_PATH) -> str:
+    mlinter, mlinter_impl = _require_mlinter()
+    # Reuse mlinter's registry-switching helper so docs rendering reflects the repo-local rule file.
+    with mlinter_impl._using_rule_specs(_resolve_path(rule_specs_path)):
+        return mlinter.render_rules_reference()
+
+
+def check_modeling_rules_doc(overwrite: bool = False, rule_specs_path: Path = RULES_TOML_PATH):
+    with DOC_PATH.open(encoding="utf-8") as f:
         content = f.read()
 
     begin_idx = content.find(BEGIN_MARKER)
@@ -80,7 +89,7 @@ def check_modeling_rules_doc(overwrite: bool = False):
         )
 
     after_begin = begin_idx + len(BEGIN_MARKER)
-    expected = "\n\n" + generate_rules_reference() + "\n"
+    expected = "\n\n" + generate_rules_reference(rule_specs_path) + "\n"
     current = content[after_begin:end_idx]
 
     if current == expected:
@@ -88,22 +97,28 @@ def check_modeling_rules_doc(overwrite: bool = False):
 
     if overwrite:
         new_content = content[:after_begin] + expected + content[end_idx:]
-        with open(DOC_PATH, "w", encoding="utf-8") as f:
+        with DOC_PATH.open("w", encoding="utf-8") as f:
             f.write(new_content)
         print(f"Updated rules reference in {DOC_PATH}")
     else:
         raise ValueError(
             "The rules reference section in docs/source/en/modeling_rules.md is out of sync "
-            "with the mlinter package's rules. Run `make fix-repo` to regenerate it."
+            "with utils/rules.toml. Run `make fix-repo` to regenerate it."
         )
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--rules-toml",
+        type=Path,
+        default=RULES_TOML_PATH,
+        help="Path to a rules TOML file. Defaults to utils/rules.toml.",
+    )
     parser.add_argument("--fix_and_overwrite", action="store_true", help="Whether to fix inconsistencies.")
     args = parser.parse_args()
 
     try:
-        check_modeling_rules_doc(args.fix_and_overwrite)
+        check_modeling_rules_doc(args.fix_and_overwrite, args.rules_toml)
     except ModuleNotFoundError as error:
         raise SystemExit(str(error)) from error

--- a/utils/check_modeling_structure.py
+++ b/utils/check_modeling_structure.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 """Thin local entrypoint for the external mlinter package."""
 
+import sys
+from pathlib import Path
+
+
 CHECKER_CONFIG = {
     "name": "modeling_structure",
     "label": "Modeling file structure",
@@ -9,9 +13,11 @@ CHECKER_CONFIG = {
         "src/transformers/models/**/modular_*.py",
         "src/transformers/models/**/configuration_*.py",
     ],
-    "check_args": [],
+    "check_args": ["--rules-toml", "utils/rules.toml"],
     "fix_args": None,
 }
+
+RULES_TOML_PATH = Path(__file__).resolve().with_name("rules.toml")
 
 
 def _require_mlinter():
@@ -26,8 +32,16 @@ def _require_mlinter():
     return mlinter
 
 
+def _add_default_rules_toml(argv: list[str]) -> list[str]:
+    if any(arg == "--rules-toml" or arg.startswith("--rules-toml=") for arg in argv[1:]):
+        return argv
+
+    return [argv[0], "--rules-toml", str(RULES_TOML_PATH), *argv[1:]]
+
+
 if __name__ == "__main__":
     try:
+        sys.argv = _add_default_rules_toml(sys.argv)
         raise SystemExit(_require_mlinter().main())
     except ModuleNotFoundError as error:
         raise SystemExit(str(error)) from error

--- a/utils/check_modeling_structure.py
+++ b/utils/check_modeling_structure.py
@@ -1,4 +1,17 @@
 #!/usr/bin/env python
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Thin local entrypoint for the external mlinter package."""
 
 import sys

--- a/utils/rules.toml
+++ b/utils/rules.toml
@@ -1,0 +1,237 @@
+# This file can carry repo-local rule overrides for faster iteration between
+# `transformers-mlinter` releases.
+# Keep it synced with the upstream package's rules.toml when possible so local
+# behavior does not drift from the published checker longer than necessary.
+
+version = 1
+
+[rules.TRF001]
+description = "Class-level config_class on <Model>PreTrainedModel should match <Model>Config naming."
+default_enabled = true
+allowlist_models = ["qwen3_omni_moe"]
+
+[rules.TRF001.explanation]
+what_it_does = "Checks naming consistency between <Model>PreTrainedModel and config_class."
+why_bad = "Mismatched config_class can break loading, auto classes, and developer expectations."
+diff = '''
+ class AcmePreTrainedModel(PreTrainedModel):
+-    config_class = WileConfig
++    config_class = AcmeConfig
+'''
+
+[rules.TRF002]
+description = "base_model_prefix should be a non-empty canonical string when defined on PreTrainedModel classes."
+default_enabled = true
+allowlist_models = ["lighton_ocr"]
+
+[rules.TRF002.explanation]
+what_it_does = "Checks that base_model_prefix, when set, is a non-empty, whitespace-free string literal."
+why_bad = "Invalid prefixes can break weight loading key mapping and base model access patterns."
+diff = '''
+ class AcmePreTrainedModel(PreTrainedModel):
+-    base_model_prefix = ""
++    base_model_prefix = "model"
+'''
+
+[rules.TRF003]
+description = "forward() should use capture_output/can_return_tuple decorators instead of manual return_dict branching."
+default_enabled = false
+allowlist_models = []
+
+[rules.TRF003.explanation]
+what_it_does = "Detects forward methods that use the old 'if not return_dict: return (x,)' pattern."
+why_bad = "The old return_dict branching pattern is error-prone and verbose. Use the capture_output or can_return_tuple decorators instead."
+diff = '''
+-def forward(self, x, return_dict=None):
+-    if not return_dict:
+-        return (x,)
+-    return AcmeModelOutput(last_hidden_state=x)
++@can_return_tuple
++def forward(self, x):
++    return AcmeModelOutput(last_hidden_state=x)
+'''
+
+[rules.TRF004]
+description = "Models must never override tie_weights. Use _tied_weights_keys instead."
+default_enabled = true
+allowlist_models = ["data2vec", "hubert", "sew", "sew_d", "unispeech", "unispeech_sat", "wav2vec2", "wav2vec2_conformer", "wavlm"]
+
+[rules.TRF004.explanation]
+what_it_does = "Checks that no model class defines a tie_weights method."
+why_bad = "Overriding tie_weights leads to bad consequences for loading, device_map computation, and saving. Use _tied_weights_keys class attribute to declare tied weights instead."
+diff = '''
+-def tie_weights(self):
+-    self.lm_head.weight = self.emb.weight
++class AcmeForCausalLM(AcmePreTrainedModel):
++    _tied_weights_keys = ["lm_head.weight"]
+'''
+
+[rules.TRF005]
+description = "_no_split_modules, when defined, should be a list/tuple of non-empty strings."
+default_enabled = true
+allowlist_models = ["d_fine", "deformable_detr", "glm46v", "lw_detr", "pp_doclayout_v3", "rt_detr", "rt_detr_v2", "voxtral", "voxtral_realtime"]
+
+[rules.TRF005.explanation]
+what_it_does = "Checks the shape of _no_split_modules when present."
+why_bad = "Malformed values can break device-map partitioning and sharding behavior."
+diff = '''
+-_no_split_modules = [SomeLayerClass, ""]
++_no_split_modules = ["AcmeDecoderLayer", "AcmeAttention"]
+'''
+
+[rules.TRF006]
+description = "forward with cache arguments should reference cache control/state variables consistently."
+default_enabled = true
+allowlist_models = ["chinese_clip", "evolla", "idefics2", "llama4"]
+
+[rules.TRF006.explanation]
+what_it_does = "Checks forward signatures that expose cache arguments for usage of those arguments in method body."
+why_bad = "Unused cache arguments can indicate incomplete caching support and inconsistent API behavior."
+diff = '''
+ def forward(self, x, past_key_values=None, use_cache=False):
++    if use_cache:
++        ...
+     return x
+'''
+
+[rules.TRF007]
+description = "self.post_init() in __init__ should remain at the end of initialization for PreTrainedModel classes."
+default_enabled = true
+allowlist_models = ["distilbert", "lxmert", "mt5", "pix2struct", "pop2piano", "switch_transformers", "t5"]
+
+[rules.TRF007.explanation]
+what_it_does = "Checks for self attribute assignments after self.post_init() in __init__."
+why_bad = "Mutating model structure after post_init can bypass intended initialization/finalization logic."
+diff = '''
+ def __init__(self, config):
+     ...
+-    self.post_init()
+-    self.proj = nn.Linear(...)
++    self.proj = nn.Linear(...)
++    self.post_init()
+'''
+
+[rules.TRF008]
+description = "Doc decorators on PreTrainedModel classes should avoid empty add_start_docstrings usage."
+default_enabled = true
+
+[rules.TRF008.explanation]
+what_it_does = "Checks add_start_docstrings usage on model classes for non-empty docstring arguments."
+why_bad = "Empty decorator usage produces unclear docs and weakens generated API documentation quality."
+diff = '''
+-@add_start_docstrings("")
++@add_start_docstrings("The Acme model.")
+ class AcmeModel(AcmePreTrainedModel):
+     ...
+'''
+
+[rules.TRF009]
+description = "modeling_<name>.py should avoid importing implementation code from another model package."
+default_enabled = true
+allowlist_models = ["dpr", "maskformer", "sam3_video", "vision_text_dual_encoder"]
+
+[rules.TRF009.explanation]
+what_it_does = "Checks modeling files for cross-model imports such as transformers.models.other_model.* or from ..other_model.* imports."
+why_bad = "Cross-model implementation imports violate the single-file policy and make model behavior harder to inspect and maintain."
+diff = '''
+-from transformers.models.llama.modeling_llama import LlamaAttention
++# Keep implementation local to this file.
++# If reusing code, copy it with a # Copied from comment.
+'''
+
+[rules.TRF010]
+description = "Direct config definitions must use @strict(accept_kwargs=True)."
+default_enabled = true
+allowlist_models = ["nemotron_h", "vibevoice_asr"]
+
+[rules.TRF010.explanation]
+what_it_does = "Checks direct PreTrainedConfig/PretrainedConfig subclasses in configuration_*.py and modular_*.py for an explicit @strict(accept_kwargs=True) decorator."
+why_bad = "Without strict, new config classes miss the repo's runtime type-validation contract and drift from the dataclass-based config standard."
+diff = '''
++@strict(accept_kwargs=True)
+ class AcmeConfig(PreTrainedConfig):
+     ...
+'''
+
+[rules.TRF011]
+description = "forward() must not access non-nn.Module attributes on submodules (breaks pipeline parallelism with Identity replacement)."
+default_enabled = true
+allowlist_models = []
+
+[rules.TRF011.explanation]
+what_it_does = "In forward() methods of PreTrainedModel subclasses, checks for attribute accesses on submodules that would not exist on torch.nn.Identity. This includes attribute accesses on loop variables iterating over self.layers, and self.<submodule>.<attr> chains where <attr> is not a standard nn.Module attribute."
+why_bad = "Pipeline parallelism may replace any submodule with torch.nn.Identity. Accessing custom attributes (e.g. decoder_layer.attention_type) on a replaced module raises AttributeError at runtime. Per-layer metadata should be read from self.config instead."
+diff = '''
+ def forward(self, ...):
+-    for decoder_layer in self.layers:
++    for i, decoder_layer in enumerate(self.layers):
+         hidden_states = decoder_layer(
+             hidden_states,
+-            attention_mask=causal_mask_mapping[decoder_layer.attention_type],
++            attention_mask=causal_mask_mapping[self.config.layer_types[i]],
+         )
+'''
+
+[rules.TRF012]
+description = "_init_weights must use init primitives, not in-place operations on module weights."
+default_enabled = true
+allowlist_models = []
+
+[rules.TRF012.explanation]
+what_it_does = "Checks that _init_weights(self, module) does not use in-place operations (e.g. .normal_(), .zero_()) directly on module weights."
+why_bad = "We rely on internal flags set on parameters to track whether they need re-initialization. In-place ops bypass this mechanism. Use the `init` primitives instead."
+diff = '''
++from transformers import initialization as init
++
+ def _init_weights(self, module):
+-    module.weight.normal_(mean=0.0, std=0.02)
++    init.normal_(module.weight, mean=0.0, std=0.02)
+'''
+
+[rules.TRF013]
+description = "PreTrainedModel __init__ must call self.post_init()."
+default_enabled = true
+allowlist_models = []
+
+[rules.TRF013.explanation]
+what_it_does = "Checks that every PreTrainedModel subclass with an __init__ method calls self.post_init(). In modular files, calling super().__init__() is also accepted since it propagates post_init from the parent."
+why_bad = "post_init performs essential finalization (weight initialization, gradient checkpointing setup, etc.). Omitting it causes subtle runtime bugs."
+diff = '''
+ class AcmeModel(AcmePreTrainedModel):
+     def __init__(self, config):
+         super().__init__(config)
+         self.layers = nn.ModuleList(...)
++        self.post_init()
+'''
+
+[rules.TRF014]
+description = "`trust_remote_code` should never be used in native model integrations."
+default_enabled = true
+allowlist_models = []
+
+[rules.TRF014.explanation]
+what_it_does = "Checks whether `trust_remote_code` is passed or used in code (e.g. as kwarg) within native model integration files."
+why_bad = "`trust_remote_code` allows arbitrary loading, including binaries, which should only be a power feature for users, not a standard use-case. Native integrations must not depend on it, as remote code cannot be reviewed or maintained within transformers."
+diff = '''
+ class AcmeModel(AcmePreTrainedModel):
+     def __init__(self, config):
+         super().__init__(config)
+-        self.model = AutoModel.from_pretrained(..., trust_remote_code=True)
++        self.model = AutoModel.from_pretrained(...)
+'''
+
+[rules.TRF015]
+description = "Models with non-empty _tied_weights_keys must have tie_word_embeddings in their Config."
+default_enabled = true
+allowlist_models = []
+
+[rules.TRF015.explanation]
+what_it_does = "When a PreTrainedModel subclass defines _tied_weights_keys as a non-empty collection, checks that the corresponding configuration file declares a tie_word_embeddings field."
+why_bad = "Without tie_word_embeddings in the config, users cannot control weight tying behavior. The model ties weights unconditionally, breaking serialization round-trips and preventing fine-tuning with untied heads."
+diff = '''
+ # configuration_foo.py
+ @strict(accept_kwargs=True)
+ class FooConfig(PreTrainedConfig):
+     hidden_size: int = 768
++    tie_word_embeddings: bool = True
+'''

--- a/utils/rules.toml
+++ b/utils/rules.toml
@@ -1,3 +1,17 @@
+# Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This file can carry repo-local rule overrides for faster iteration between
 # `transformers-mlinter` releases.
 # Keep it synced with the upstream package's rules.toml when possible so local


### PR DESCRIPTION
# What does this PR do?

- bumps mlinter to 0.1.1
- add a local config that can be used to quickly override the linter rules 