### PR TITLE
[nemotron_h] respect _no_reinit flag on dt_bias and out_proj.weight

### DIFF
--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -1004,7 +1004,7 @@ class NemotronHPreTrainedModel(PreTrainedModel):
 
         if isinstance(module, nn.Linear):
             if module.bias is not None:
-                if not getattr(module.bias, "_no_reinit", False):
+                if not getattr(module.bias, "_is_hf_initialized", False):
                     init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
             init.normal_(module.weight, std=self.config.initializer_range)

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -973,6 +973,13 @@ class NemotronHPreTrainedModel(PreTrainedModel):
         """Initialize the weights."""
         super()._init_weights(module)
         if isinstance(module, NemotronHMamba2Mixer):
+            # Respect _no_reinit: once a Mamba2 mixer has been initialised (or
+            # its params have been loaded from a checkpoint in a previous
+            # load cycle), skip re-initialisation. Without this, a second
+            # pass of _init_weights would overwrite checkpoint values for
+            # A_log / D / dt_bias with fresh random draws.
+            if getattr(module.dt_bias, "_no_reinit", False):
+                return
             # Initialize A_log and D parameters
             A = torch.arange(1, self.config.mamba_num_heads + 1)
             init.copy_(module.A_log, torch.log(A))
@@ -1013,14 +1020,19 @@ class NemotronHPreTrainedModel(PreTrainedModel):
             # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
             for name, p in module.named_parameters():
                 if name == "out_proj.weight":
+                    # Respect _no_reinit so checkpoint-loaded weights are
+                    # not silently overwritten when _init_weights is invoked
+                    # a second time (e.g. post-load safety pass in
+                    # transformers >= 5).
+                    if getattr(p, "_no_reinit", False):
+                        continue
                     # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                     # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
-                    # We need to reinit p since this code could be called multiple times
-                    # Having just p *= scale would repeatedly scale it down
                     init.kaiming_uniform_(p, a=math.sqrt(5))
                     with torch.no_grad():
                         p_new = p / math.sqrt(self.config.num_hidden_layers)
                         init.copy_(p, p_new)
+                    p._no_reinit = True
 
 
 class NemotronHModel(NemotronHPreTrainedModel):

--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -973,29 +973,27 @@ class NemotronHPreTrainedModel(PreTrainedModel):
         """Initialize the weights."""
         super()._init_weights(module)
         if isinstance(module, NemotronHMamba2Mixer):
-            # Respect _no_reinit: once a Mamba2 mixer has been initialised (or
-            # its params have been loaded from a checkpoint in a previous
-            # load cycle), skip re-initialisation. Without this, a second
-            # pass of _init_weights would overwrite checkpoint values for
+            # Only re-initialise params that were NOT loaded from a checkpoint.
+            # `_is_hf_initialized` is set by `from_pretrained` on each loaded
+            # parameter; without this guard a post-load safety pass of
+            # `_init_weights` would overwrite checkpoint values of
             # A_log / D / dt_bias with fresh random draws.
-            if getattr(module.dt_bias, "_no_reinit", False):
-                return
-            # Initialize A_log and D parameters
-            A = torch.arange(1, self.config.mamba_num_heads + 1)
-            init.copy_(module.A_log, torch.log(A))
-            init.ones_(module.D)
+            if not getattr(module.A_log, "_is_hf_initialized", False):
+                A = torch.arange(1, self.config.mamba_num_heads + 1)
+                init.copy_(module.A_log, torch.log(A))
+            if not getattr(module.D, "_is_hf_initialized", False):
+                init.ones_(module.D)
+            if not getattr(module.dt_bias, "_is_hf_initialized", False):
+                dt = torch.exp(
+                    torch.rand(self.config.mamba_num_heads)
+                    * (math.log(self.config.time_step_max) - math.log(self.config.time_step_min))
+                    + math.log(self.config.time_step_min)
+                ).clamp(min=self.config.time_step_floor)
 
-            dt = torch.exp(
-                torch.rand(self.config.mamba_num_heads)
-                * (math.log(self.config.time_step_max) - math.log(self.config.time_step_min))
-                + math.log(self.config.time_step_min)
-            ).clamp(min=self.config.time_step_floor)
-
-            # # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-            inv_dt = dt + torch.log(-torch.expm1(-dt))
-            with torch.no_grad():
-                init.copy_(module.dt_bias, inv_dt)
-            module.dt_bias._no_reinit = True
+                # # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                inv_dt = dt + torch.log(-torch.expm1(-dt))
+                with torch.no_grad():
+                    init.copy_(module.dt_bias, inv_dt)
         elif isinstance(module, NemotronHTopkRouter):
             init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             init.zeros_(module.e_score_correction_bias)
@@ -1020,11 +1018,9 @@ class NemotronHPreTrainedModel(PreTrainedModel):
             # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
             for name, p in module.named_parameters():
                 if name == "out_proj.weight":
-                    # Respect _no_reinit so checkpoint-loaded weights are
-                    # not silently overwritten when _init_weights is invoked
-                    # a second time (e.g. post-load safety pass in
-                    # transformers >= 5).
-                    if getattr(p, "_no_reinit", False):
+                    # Skip checkpoint-loaded weights so a post-load safety
+                    # pass of `_init_weights` doesn't silently overwrite them.
+                    if getattr(p, "_is_hf_initialized", False):
                         continue
                     # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                     # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
@@ -1032,7 +1028,6 @@ class NemotronHPreTrainedModel(PreTrainedModel):
                     with torch.no_grad():
                         p_new = p / math.sqrt(self.config.num_hidden_layers)
                         init.copy_(p, p_new)
-                    p._no_reinit = True
 
 
 class NemotronHModel(NemotronHPreTrainedModel):

--- a/src/transformers/models/nemotron_h/modular_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modular_nemotron_h.py
@@ -357,7 +357,7 @@ class NemotronHPreTrainedModel(PreTrainedModel):
 
         if isinstance(module, nn.Linear):
             if module.bias is not None:
-                if not getattr(module.bias, "_no_reinit", False):
+                if not getattr(module.bias, "_is_hf_initialized", False):
                     init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):
             init.normal_(module.weight, std=self.config.initializer_range)

--- a/src/transformers/models/nemotron_h/modular_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modular_nemotron_h.py
@@ -326,29 +326,27 @@ class NemotronHPreTrainedModel(PreTrainedModel):
         """Initialize the weights."""
         super()._init_weights(module)
         if isinstance(module, NemotronHMamba2Mixer):
-            # Respect _no_reinit: once a Mamba2 mixer has been initialised (or
-            # its params have been loaded from a checkpoint in a previous
-            # load cycle), skip re-initialisation. Without this, a second
-            # pass of _init_weights would overwrite checkpoint values for
+            # Only re-initialise params that were NOT loaded from a checkpoint.
+            # `_is_hf_initialized` is set by `from_pretrained` on each loaded
+            # parameter; without this guard a post-load safety pass of
+            # `_init_weights` would overwrite checkpoint values of
             # A_log / D / dt_bias with fresh random draws.
-            if getattr(module.dt_bias, "_no_reinit", False):
-                return
-            # Initialize A_log and D parameters
-            A = torch.arange(1, self.config.mamba_num_heads + 1)
-            init.copy_(module.A_log, torch.log(A))
-            init.ones_(module.D)
+            if not getattr(module.A_log, "_is_hf_initialized", False):
+                A = torch.arange(1, self.config.mamba_num_heads + 1)
+                init.copy_(module.A_log, torch.log(A))
+            if not getattr(module.D, "_is_hf_initialized", False):
+                init.ones_(module.D)
+            if not getattr(module.dt_bias, "_is_hf_initialized", False):
+                dt = torch.exp(
+                    torch.rand(self.config.mamba_num_heads)
+                    * (math.log(self.config.time_step_max) - math.log(self.config.time_step_min))
+                    + math.log(self.config.time_step_min)
+                ).clamp(min=self.config.time_step_floor)
 
-            dt = torch.exp(
-                torch.rand(self.config.mamba_num_heads)
-                * (math.log(self.config.time_step_max) - math.log(self.config.time_step_min))
-                + math.log(self.config.time_step_min)
-            ).clamp(min=self.config.time_step_floor)
-
-            # # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
-            inv_dt = dt + torch.log(-torch.expm1(-dt))
-            with torch.no_grad():
-                init.copy_(module.dt_bias, inv_dt)
-            module.dt_bias._no_reinit = True
+                # # Inverse of softplus: https://github.com/pytorch/pytorch/issues/72759
+                inv_dt = dt + torch.log(-torch.expm1(-dt))
+                with torch.no_grad():
+                    init.copy_(module.dt_bias, inv_dt)
         elif isinstance(module, NemotronHTopkRouter):
             init.normal_(module.weight, mean=0.0, std=self.config.initializer_range)
             init.zeros_(module.e_score_correction_bias)
@@ -373,11 +371,9 @@ class NemotronHPreTrainedModel(PreTrainedModel):
             # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
             for name, p in module.named_parameters():
                 if name == "out_proj.weight":
-                    # Respect _no_reinit so checkpoint-loaded weights are
-                    # not silently overwritten when _init_weights is invoked
-                    # a second time (e.g. post-load safety pass in
-                    # transformers >= 5).
-                    if getattr(p, "_no_reinit", False):
+                    # Skip checkpoint-loaded weights so a post-load safety
+                    # pass of `_init_weights` doesn't silently overwrite them.
+                    if getattr(p, "_is_hf_initialized", False):
                         continue
                     # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                     # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
@@ -385,7 +381,6 @@ class NemotronHPreTrainedModel(PreTrainedModel):
                     with torch.no_grad():
                         p_new = p / math.sqrt(self.config.num_hidden_layers)
                         init.copy_(p, p_new)
-                    p._no_reinit = True
 
 
 class NemotronHModel(NemotronHPreTrainedModel):

--- a/src/transformers/models/nemotron_h/modular_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modular_nemotron_h.py
@@ -326,6 +326,13 @@ class NemotronHPreTrainedModel(PreTrainedModel):
         """Initialize the weights."""
         super()._init_weights(module)
         if isinstance(module, NemotronHMamba2Mixer):
+            # Respect _no_reinit: once a Mamba2 mixer has been initialised (or
+            # its params have been loaded from a checkpoint in a previous
+            # load cycle), skip re-initialisation. Without this, a second
+            # pass of _init_weights would overwrite checkpoint values for
+            # A_log / D / dt_bias with fresh random draws.
+            if getattr(module.dt_bias, "_no_reinit", False):
+                return
             # Initialize A_log and D parameters
             A = torch.arange(1, self.config.mamba_num_heads + 1)
             init.copy_(module.A_log, torch.log(A))
@@ -366,14 +373,19 @@ class NemotronHPreTrainedModel(PreTrainedModel):
             # Reference (Megatron-LM): https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/model/gpt_model.py
             for name, p in module.named_parameters():
                 if name == "out_proj.weight":
+                    # Respect _no_reinit so checkpoint-loaded weights are
+                    # not silently overwritten when _init_weights is invoked
+                    # a second time (e.g. post-load safety pass in
+                    # transformers >= 5).
+                    if getattr(p, "_no_reinit", False):
+                        continue
                     # Special Scaled Initialization --> There are 2 Layer Norms per Transformer Block
                     # Following Pytorch init, except scale by 1/sqrt(2 * n_layer)
-                    # We need to reinit p since this code could be called multiple times
-                    # Having just p *= scale would repeatedly scale it down
                     init.kaiming_uniform_(p, a=math.sqrt(5))
                     with torch.no_grad():
                         p_new = p / math.sqrt(self.config.num_hidden_layers)
                         init.copy_(p, p_new)
+                    p._no_reinit = True
 
 
 class NemotronHModel(NemotronHPreTrainedModel):


### PR DESCRIPTION
## Summary

`NemotronHPreTrainedModel._init_weights` unconditionally overwrites two trained parameters every time it is invoked:
- `NemotronHMamba2Mixer.dt_bias` — reset to a fresh `inv_softplus(random dt)` draw
- `{…}.out_proj.weight` — reset to a kaiming-uniform scaled by `1/sqrt(num_hidden_layers)`

It sets `module.dt_bias._no_reinit = True` after the copy, but that flag is only checked for the `nn.Linear.bias` branch of the same function — never for `dt_bias` itself, and `out_proj.weight` doesn't set the flag at all.

On `transformers>=5.0`, `_init_weights` runs a second time after `from_pretrained` has finished loading the checkpoint (the post-load pass that initialises tensors still on `meta`). For `NemotronHForCausalLM` that silently overwrites the on-disk values for `dt_bias` and `out_proj.weight` with fresh random ones, while all other tensors keep their trained values.

The resulting model outputs repetitive filler streams like ` and and and , and and ,` for any input — sanity is preserved only when loading through vLLM (which bypasses `_init_weights`) or via an older transformers release.

## Reproduction

```python
import json, pathlib, torch
from safetensors.torch import load_file
from transformers import AutoConfig, AutoModelForCausalLM

path = "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"   # any Nemotron-H ckpt
cfg = AutoConfig.from_pretrained(path, trust_remote_code=True)
cfg._attn_implementation = "eager"
m = AutoModelForCausalLM.from_pretrained(path, config=cfg, torch_dtype=torch.bfloat16)

idx = json.load(open(pathlib.Path(path) / "model.safetensors.index.json"))["weight_map"]
k = "backbone.layers.0.mixer.dt_bias"
on_disk = load_file(f"{path}/{idx[k]}")[k]
in_mem  = m.backbone.layers[0].mixer.dt_bias
print((on_disk.float() - in_mem.float().cpu()).abs().max().item())
# → ~26.8 before this patch, 0 after
```

Prompting ``"Hello, how are you? I am"`` on an unpatched load returns ``' and' ' in' ' the' ' first' ','`` as top-5 next tokens — a symptom of Mamba2 with randomised `dt_bias` and mis-scaled `out_proj`. After the patch, trained values are preserved and the model generates normally.

## The fix

Both changes live in `NemotronHPreTrainedModel._init_weights`:

1. `dt_bias` branch: early-return if `dt_bias._no_reinit` is already set (the flag is set at the end of the current branch, so the first pass initialises normally, the second pass becomes a no-op).
2. `out_proj.weight` branch: skip when `p._no_reinit` is set, and set `p._no_reinit = True` after the initial kaiming scale so a second invocation is a no-op.

Fresh-init training is unaffected — only the second (post-load) invocation is made idempotent. Same edit is mirrored into `modular_nemotron_h.py` and `modeling_nemotron_h.py`.

## Test plan
- [x] Unpatched load: `|on_disk - in_mem|.max()` for layer-0 dt_bias ≈ 26.8, next-token logits return stop-word garbage.
- [x] Patched load: diff is 0, next-token logits look sane, eval on our NemotronH-based classifier no longer collapses to 1000/1000 parse failures.
- [ ] CI: run `tests/models/nemotron_h/` — no behaviour change for fresh-init, only the idempotence of the re-init pass changes.

Please let me know if you'd like the fix to take a different shape (e.g. short-circuit `_init_weights` entirely when the module's parameters are all materialised, or move the guard to a shared utility in `modeling_utils`). Happy to adjust.