### PR TITLE
fix(utils): Resolve backbone utils test regressions

### DIFF
--- a/tests/models/timm_backbone/test_modeling_timm_backbone.py
+++ b/tests/models/timm_backbone/test_modeling_timm_backbone.py
@@ -16,7 +16,8 @@ import copy
 import inspect
 import unittest
 
-from transformers import AutoBackbone
+from transformers import AutoBackbone, MaskFormerConfig
+from transformers.backbone_utils import load_backbone
 from transformers.testing_utils import is_flaky, require_timm, require_torch, torch_device
 from transformers.utils.import_utils import is_torch_available
 
@@ -259,3 +260,26 @@ class TimmBackboneModelTest(ModelTesterMixin, BackboneTesterMixin, PipelineTeste
 
             self.assertEqual(len(result.feature_maps), 1)
             self.assertEqual(len(model.channels), 1)
+
+
+@require_torch
+@require_timm
+class TimmBackboneIntegrationTest(unittest.TestCase):
+    def test_load_timm_backbone_from_config(self):
+        config = MaskFormerConfig(backbone_config=TimmBackboneConfig(backbone="resnet18", out_indices=[0, 2]))
+        backbone = load_backbone(config)
+        self.assertEqual(backbone.out_indices, [0, 2])
+        self.assertIsInstance(backbone, TimmBackbone)
+
+    def test_load_timm_backbone_from_checkpoint(self):
+        config = MaskFormerConfig(backbone="resnet18", use_timm_backbone=True)
+        backbone = load_backbone(config)
+        self.assertEqual(backbone.out_indices, [-1])
+        self.assertEqual(backbone.out_features, ["layer4"])
+        self.assertIsInstance(backbone, TimmBackbone)
+
+    def test_load_timm_backbone_with_kwargs(self):
+        config = MaskFormerConfig(backbone="resnet18", use_timm_backbone=True, backbone_kwargs={"out_indices": (0, 1)})
+        backbone = load_backbone(config)
+        self.assertEqual(backbone.out_indices, [0, 1])
+        self.assertIsInstance(backbone, TimmBackbone)

--- a/tests/utils/test_backbone_utils.py
+++ b/tests/utils/test_backbone_utils.py
@@ -16,20 +16,17 @@ import unittest
 
 import pytest
 
-from transformers import MaskFormerConfig, PreTrainedConfig, ResNetBackbone, ResNetConfig, TimmBackbone
+from transformers import PreTrainedConfig
 from transformers.backbone_utils import (
     BackboneConfigMixin,
     BackboneMixin,
-    load_backbone,
 )
-from transformers.testing_utils import require_torch, slow
+from transformers.testing_utils import require_torch
 from transformers.utils.import_utils import is_torch_available
 
 
 if is_torch_available():
-    import torch
-
-    from transformers import BertPreTrainedModel, PreTrainedModel
+    from transformers import PreTrainedModel
 
 
 class AnyBackboneConfig(BackboneConfigMixin, PreTrainedConfig):
@@ -152,110 +149,3 @@ class BackboneUtilsTester(unittest.TestCase):
         backbone.out_indices = [-3, -1]
         self.assertEqual(backbone.out_features, ["a", "c"])
         self.assertEqual(backbone.out_indices, [-3, -1])
-
-    @slow
-    @require_torch
-    def test_load_backbone_from_config(self):
-        """
-        Test that load_backbone correctly loads a backbone from a backbone config.
-        """
-        config = MaskFormerConfig(backbone_config=ResNetConfig(out_indices=(0, 2)))
-        backbone = load_backbone(config)
-        self.assertEqual(backbone.out_features, ["stem", "stage2"])
-        self.assertEqual(backbone.out_indices, [0, 2])
-        self.assertIsInstance(backbone, ResNetBackbone)
-
-    @slow
-    @require_torch
-    def test_load_backbone_from_checkpoint(self):
-        """
-        Test that load_backbone correctly loads a backbone from a checkpoint.
-        """
-        config = MaskFormerConfig(backbone="microsoft/resnet-18", backbone_config=None)
-        backbone = load_backbone(config)
-        self.assertEqual(backbone.out_indices, [4])
-        self.assertEqual(backbone.out_features, ["stage4"])
-        self.assertIsInstance(backbone, ResNetBackbone)
-
-        config = MaskFormerConfig(
-            backbone="resnet18",
-            use_timm_backbone=True,
-        )
-        backbone = load_backbone(config)
-        # We can't know ahead of time the exact output features and indices, or the layer names before
-        # creating the timm model, so it defaults to the last layer (-1,) and has a different layer name
-        self.assertEqual(backbone.out_indices, (-1,))
-        self.assertEqual(backbone.out_features, ["layer4"])
-        self.assertIsInstance(backbone, TimmBackbone)
-
-    @slow
-    @require_torch
-    def test_load_backbone_backbone_kwargs(self):
-        """
-        Test that load_backbone correctly configures the loaded backbone with the provided kwargs.
-        """
-        config = MaskFormerConfig(backbone="resnet18", use_timm_backbone=True, backbone_kwargs={"out_indices": (0, 1)})
-        backbone = load_backbone(config)
-        self.assertEqual(backbone.out_indices, (0, 1))
-        self.assertIsInstance(backbone, TimmBackbone)
-
-        config = MaskFormerConfig(backbone="microsoft/resnet-18", backbone_kwargs={"out_indices": (0, 2)})
-        backbone = load_backbone(config)
-        self.assertEqual(backbone.out_indices, (0, 2))
-        self.assertIsInstance(backbone, ResNetBackbone)
-
-        # Check can't be passed with a backone config
-        with pytest.raises(ValueError):
-            config = MaskFormerConfig(
-                backbone="microsoft/resnet-18",
-                backbone_config=ResNetConfig(out_indices=(0, 2)),
-                backbone_kwargs={"out_indices": (0, 1)},
-            )
-
-    @slow
-    @require_torch
-    def test_load_backbone_in_new_model(self):
-        """
-        Tests that new model can be created, with its weights instantiated and pretrained backbone weights loaded.
-        """
-
-        # Inherit from PreTrainedModel to ensure that the weights are initialized
-        class NewModel(BertPreTrainedModel):
-            def __init__(self, config):
-                super().__init__(config)
-                self.backbone = load_backbone(config)
-                self.layer_0 = torch.nn.Linear(config.hidden_size, config.hidden_size)
-                self.layer_1 = torch.nn.Linear(config.hidden_size, config.hidden_size)
-
-        def get_equal_not_equal_weights(model_0, model_1):
-            equal_weights = []
-            not_equal_weights = []
-            for (k0, v0), (k1, v1) in zip(model_0.named_parameters(), model_1.named_parameters()):
-                self.assertEqual(k0, k1)
-                weights_are_equal = torch.allclose(v0, v1)
-                if weights_are_equal:
-                    equal_weights.append(k0)
-                else:
-                    not_equal_weights.append(k0)
-            return equal_weights, not_equal_weights
-
-        config = MaskFormerConfig(backbone="microsoft/resnet-18")
-        model_0 = NewModel(config)
-        model_1 = NewModel(config)
-        equal_weights, not_equal_weights = get_equal_not_equal_weights(model_0, model_1)
-
-        # Norm layers are always initialized with the same weights
-        equal_weights = [w for w in equal_weights if "normalization" not in w]
-        self.assertEqual(len(equal_weights), 0)
-        self.assertEqual(len(not_equal_weights), 24)
-
-        # Setting use_pretrained_backbone has no effect on load_backbone
-        config.use_pretrained_backbone = True
-        model_0 = NewModel(config)
-        model_1 = NewModel(config)
-        equal_weights, not_equal_weights = get_equal_not_equal_weights(model_0, model_1)
-
-        # Norm layers are always initialized with the same weights
-        equal_weights = [w for w in equal_weights if "normalization" not in w]
-        self.assertEqual(len(equal_weights), 0)
-        self.assertEqual(len(not_equal_weights), 24)

--- a/tests/utils/test_backbone_utils.py
+++ b/tests/utils/test_backbone_utils.py
@@ -16,7 +16,7 @@ import unittest
 
 import pytest
 
-from transformers import DetrConfig, MaskFormerConfig, PreTrainedConfig, ResNetBackbone, ResNetConfig, TimmBackbone
+from transformers import MaskFormerConfig, PreTrainedConfig, ResNetBackbone, ResNetConfig, TimmBackbone
 from transformers.backbone_utils import (
     BackboneConfigMixin,
     BackboneMixin,
@@ -162,7 +162,7 @@ class BackboneUtilsTester(unittest.TestCase):
         config = MaskFormerConfig(backbone_config=ResNetConfig(out_indices=(0, 2)))
         backbone = load_backbone(config)
         self.assertEqual(backbone.out_features, ["stem", "stage2"])
-        self.assertEqual(backbone.out_indices, (0, 2))
+        self.assertEqual(backbone.out_indices, [0, 2])
         self.assertIsInstance(backbone, ResNetBackbone)
 
     @slow
@@ -239,7 +239,7 @@ class BackboneUtilsTester(unittest.TestCase):
                     not_equal_weights.append(k0)
             return equal_weights, not_equal_weights
 
-        config = MaskFormerConfig(use_pretrained_backbone=False, backbone="microsoft/resnet-18")
+        config = MaskFormerConfig(backbone="microsoft/resnet-18")
         model_0 = NewModel(config)
         model_1 = NewModel(config)
         equal_weights, not_equal_weights = get_equal_not_equal_weights(model_0, model_1)
@@ -249,7 +249,7 @@ class BackboneUtilsTester(unittest.TestCase):
         self.assertEqual(len(equal_weights), 0)
         self.assertEqual(len(not_equal_weights), 24)
 
-        # Now we create a new model with backbone weights that are pretrained
+        # Setting use_pretrained_backbone has no effect on load_backbone
         config.use_pretrained_backbone = True
         model_0 = NewModel(config)
         model_1 = NewModel(config)
@@ -257,29 +257,5 @@ class BackboneUtilsTester(unittest.TestCase):
 
         # Norm layers are always initialized with the same weights
         equal_weights = [w for w in equal_weights if "normalization" not in w]
-        self.assertEqual(len(equal_weights), 20)
-        # Linear layers are still initialized randomly
-        self.assertEqual(len(not_equal_weights), 4)
-
-        # Check loading in timm backbone
-        config = DetrConfig(use_pretrained_backbone=False, backbone="resnet18", use_timm_backbone=True)
-        model_0 = NewModel(config)
-        model_1 = NewModel(config)
-        equal_weights, not_equal_weights = get_equal_not_equal_weights(model_0, model_1)
-
-        # Norm layers are always initialized with the same weights
-        equal_weights = [w for w in equal_weights if "bn" not in w and "downsample.1" not in w]
         self.assertEqual(len(equal_weights), 0)
         self.assertEqual(len(not_equal_weights), 24)
-
-        # Now we create a new model with backbone weights that are pretrained
-        config.use_pretrained_backbone = True
-        model_0 = NewModel(config)
-        model_1 = NewModel(config)
-        equal_weights, not_equal_weights = get_equal_not_equal_weights(model_0, model_1)
-
-        # Norm layers are always initialized with the same weights
-        equal_weights = [w for w in equal_weights if "bn" not in w and "downsample.1" not in w]
-        self.assertEqual(len(equal_weights), 20)
-        # Linear layers are still initialized randomly
-        self.assertEqual(len(not_equal_weights), 4)


### PR DESCRIPTION
### What does this PR do?

The following regressions were identified and fixed in this PR:

→ [0c4fe5c ("Delete duplicate code in backbone utils")](https://github.com/huggingface/transformers/pull/43323) removed `use_pretrained_backbone` from `load_backbone`; pretrained weights are now loaded via `from_pretrained` on the parent. The tests in [test_backbone_utils.py#L217](https://github.com/huggingface/transformers/blob/main/tests/utils/test_backbone_utils.py#L217) weren't updated likely because `tests/utils/` wasn't in the `run-slow` scope of that PR. Updated the test to match the new design (`load_backbone` always initializes with random weights).
→ [dff54ad ("out_indices always a list")](https://github.com/huggingface/transformers/pull/30941) made `out_indices` always return a list via [backbone_utils.py#L57](https://github.com/huggingface/transformers/blob/main/src/transformers/backbone_utils.py#L57). The assertion at [test_backbone_utils.py#L165](https://github.com/huggingface/transformers/blob/main/tests/utils/test_backbone_utils.py#L165) was written before that change in [#28784](https://github.com/huggingface/transformers/pull/28784) and still expected a tuple. Updated the assertion to expect a list.

cc: @zucchini-nlp @Rocketknight1

**CI coverage fixed by this PR** (checked in [the latest CI run](https://github.com/huggingface/transformers/actions/runs/24758510131/job/72437302961)):

```
tests/generation/test_utils.py::GenerationIntegrationTests::test_green_red_watermark_generation, tests/utils/test_backbone_utils.py::BackboneUtilsTester::test_load_backbone_from_config, tests/utils/test_backbone_utils.py::BackboneUtilsTester::test_load_backbone_in_new_model
```

**Current output:**

<img alt="6" src="https://github.com/user-attachments/assets/738c67de-8891-4286-a423-af628b35d076" /><br>

**Output after fix:**

<img alt="5" src="https://github.com/user-attachments/assets/710cb48c-db22-497f-bf6d-c3d3a347df38" />

### Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

### Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
    [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
    [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you fix any necessary existing tests?