### PR TITLE
Add unified Cache-layer management for GLM-5 DSA Indexer keys

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -31,6 +31,7 @@ class CacheLayerMixin(ABC):
     def __init__(self):
         self.keys: torch.Tensor | None = None
         self.values: torch.Tensor | None = None
+        self.indexer_keys: torch.Tensor | None = None
         self.is_initialized = False
 
     def __repr__(self):
@@ -52,6 +53,9 @@ class CacheLayerMixin(ABC):
 
     @abstractmethod
     def get_max_cache_shape(self) -> int: ...
+    
+    @abstractmethod
+    def update_cached_keys(self, cached_keys: torch.Tensor) -> torch.Tensor: ...
 
     def offload(self):
         """Offload this layer's data to CPU device."""
@@ -77,12 +81,16 @@ class CacheLayerMixin(ABC):
                 self.cumulative_length = 0
             else:
                 self.cumulative_length.zero_()
+        if hasattr(self, "indexer_keys"):
+            self.indexer_keys = None
 
     def reorder_cache(self, beam_idx: torch.LongTensor) -> None:
         """Reorders this layer's cache for beam search."""
         if self.get_seq_length() > 0:
             self.keys = self.keys.index_select(0, beam_idx.to(self.keys.device))
             self.values = self.values.index_select(0, beam_idx.to(self.values.device))
+        if getattr(self, "indexer_keys", None) is not None and self.indexer_keys.numel() > 0:
+            self.indexer_keys = self.indexer_keys.index_select(0, beam_idx.to(self.indexer_keys.device))
 
 
 class DynamicLayer(CacheLayerMixin):
@@ -120,6 +128,16 @@ class DynamicLayer(CacheLayerMixin):
         self.values = torch.cat([self.values, value_states], dim=-2)
         return self.keys, self.values
 
+    def update_cached_keys(self, cached_keys: torch.Tensor) -> torch.Tensor:
+        """
+        Update the indexer's key caches.
+        """
+        if self.indexer_keys is not None:
+            self.indexer_keys = torch.cat([self.indexer_keys, cached_keys], dim=1)
+        else:
+            self.indexer_keys = cached_keys
+        return self.indexer_keys
+
     def get_mask_sizes(self, query_length: int) -> tuple[int, int]:
         """Return the length and offset of the cache, used to generate the mask"""
         kv_offset = 0
@@ -149,18 +167,24 @@ class DynamicLayer(CacheLayerMixin):
 
         self.keys = self.keys[..., :max_length, :]
         self.values = self.values[..., :max_length, :]
+        if self.indexer_keys is not None and self.indexer_keys.numel() > 0:
+            self.indexer_keys = self.indexer_keys[:, :max_length, :]
 
     def batch_repeat_interleave(self, repeats: int) -> None:
         """Repeat the cache `repeats` times in the batch dimension."""
         if self.get_seq_length() > 0:
             self.keys = self.keys.repeat_interleave(repeats, dim=0)
             self.values = self.values.repeat_interleave(repeats, dim=0)
+        if self.indexer_keys is not None and self.indexer_keys.numel() > 0:
+            self.indexer_keys = self.indexer_keys.repeat_interleave(repeats, dim=0)
 
     def batch_select_indices(self, indices: torch.Tensor) -> None:
         """Only keep the `indices` in the batch dimension of the cache."""
         if self.get_seq_length() > 0:
             self.keys = self.keys[indices, ...]
             self.values = self.values[indices, ...]
+        if self.indexer_keys is not None and self.indexer_keys.numel() > 0:
+            self.indexer_keys = self.indexer_keys[indices, ...]
 
 
 class DynamicSlidingWindowLayer(DynamicLayer):
@@ -352,6 +376,9 @@ class StaticLayer(CacheLayerMixin):
     def get_max_cache_shape(self) -> int:
         """Return the maximum cache shape of the cache"""
         return self.max_cache_len
+
+    def update_cached_keys(self, cached_keys: torch.Tensor) -> torch.Tensor:
+        return cached_keys
 
 
 class StaticSlidingWindowLayer(StaticLayer):
@@ -980,6 +1007,31 @@ class Cache:
             raise ValueError("Cannot call `update_conv_state` on a non-LinearAttention layer!")
         recurrent_states = self.layers[layer_idx].update_recurrent_state(recurrent_states, **kwargs)
         return recurrent_states
+
+    def update_cached_keys(self, cached_keys: torch.Tensor, layer_idx: int) -> torch.Tensor:
+        """
+        Updates the indexer's key cache for the layer `layer_idx`.
+
+        Parameters:
+            cached_keys (`torch.Tensor`):
+                The new indexer key states to cache, shape `[batch_size, seq_len, head_dim]`.
+            layer_idx (`int`):
+                The index of the layer to cache the states for.
+
+        Return:
+            `torch.Tensor`: The updated cached keys.
+        """
+        if self.layer_class_to_replicate is not None:
+            while len(self.layers) <= layer_idx:
+                self.layers.append(self.layer_class_to_replicate())
+        return self.layers[layer_idx].update_cached_keys(cached_keys)
+
+    def reset_cached_keys(self, layer_idx: int) -> None:
+        """Reset the indexer's cached keys for the given layer (e.g. on prefill)."""
+        if layer_idx < len(self.layers):
+            layer = self.layers[layer_idx]
+            if hasattr(layer, "indexer_keys"):
+                layer.indexer_keys = None
 
     def early_initialization(
         self,

--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -109,11 +109,6 @@ class GlmMoeDsaIndexer(nn.Module):
     The Indexer has its own lightweight projections (wq_b, wk) separate from the
     main MLA attention. It uses non-interleaved (NeoX/Llama) RoPE, unlike the main attention
     which uses interleaved RoPE.
-
-    **Cache strategy**: The Indexer manages its own key cache (`_cached_keys`) separately
-    from the DynamicCache used by MLA attention, since DynamicCache is sized for exactly
-    `num_hidden_layers` attention layers. Keys are concatenated along the sequence dimension
-    during autoregressive decode.
     """
 
     def __init__(self, config: "GlmMoeDsaConfig", layer_idx: int):
@@ -138,9 +133,6 @@ class GlmMoeDsaIndexer(nn.Module):
         self.weights_proj = nn.Linear(self.hidden_size, self.n_heads, bias=False)
         self.softmax_scale = self.head_dim**-0.5
 
-        # Indexer maintains its own key cache (not in DynamicCache, which is sized for attention layers only)
-        self.register_buffer("_cached_keys", None, persistent=False)
-
     @torch.no_grad()
     def forward(
         self,
@@ -148,7 +140,7 @@ class GlmMoeDsaIndexer(nn.Module):
         q_resid: torch.Tensor,  # [B, S, q_lora_rank]
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
-        use_cache: bool = False,
+        past_key_values: Cache | None = None,
     ) -> torch.LongTensor:
         """
         Computes top-k token indices for sparse attention (DSA).
@@ -166,7 +158,7 @@ class GlmMoeDsaIndexer(nn.Module):
             q_resid: Query residual from `q_a_layernorm(q_a_proj(x))`, shape `[B, S, q_lora_rank]`.
             position_embeddings: `(cos, sin)` from RotaryEmbedding.
             attention_mask: Causal mask, broadcastable to `[B, S, T]`.
-            use_cache: Whether to store/update the indexer's own key cache for autoregressive decode.
+            past_key_values: Cache containing past key states for autoregressive decode.
 
         Returns:
             `torch.LongTensor`: Top-k token indices of shape `[B, S, topk]`.
@@ -187,17 +179,13 @@ class GlmMoeDsaIndexer(nn.Module):
         k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)  # [B, S, rope_D]
         k = torch.cat([k_pe, k_nope], dim=-1)  # [B, S, D]
 
-        # === Key cache (managed by the indexer, not DynamicCache) ===
+        # === Key cache (managed by the DynamicCache) ===
         # Reset cache on prefill (new prompt) to avoid stale keys / batch-size mismatch
-        if seq_len > 1:
-            self._cached_keys = None
+        if seq_len > 1 and past_key_values is not None:
+            past_key_values.reset_cached_keys(self.layer_idx)
 
-        if use_cache:
-            if self._cached_keys is not None:
-                k_cached = torch.cat([self._cached_keys, k], dim=1)  # [B, T, D]
-            else:
-                k_cached = k
-            self._cached_keys = k_cached
+        if past_key_values is not None:
+            k_cached = past_key_values.update_cached_keys(k, self.layer_idx)
         else:
             k_cached = k
 
@@ -407,7 +395,7 @@ class GlmMoeDsaAttention(nn.Module):
                 q_resid,
                 position_embeddings,
                 indexer_mask,
-                use_cache=past_key_values is not None,
+                past_key_values=past_key_values,
             )  # [B, S, topk]
         else:
             topk_indices = prev_topk_indices  # [B, S, topk]

--- a/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modular_glm_moe_dsa.py
@@ -175,11 +175,6 @@ class GlmMoeDsaIndexer(nn.Module):
     The Indexer has its own lightweight projections (wq_b, wk) separate from the
     main MLA attention. It uses non-interleaved (NeoX/Llama) RoPE, unlike the main attention
     which uses interleaved RoPE.
-
-    **Cache strategy**: The Indexer manages its own key cache (`_cached_keys`) separately
-    from the DynamicCache used by MLA attention, since DynamicCache is sized for exactly
-    `num_hidden_layers` attention layers. Keys are concatenated along the sequence dimension
-    during autoregressive decode.
     """
 
     def __init__(self, config: "GlmMoeDsaConfig", layer_idx: int):
@@ -204,9 +199,6 @@ class GlmMoeDsaIndexer(nn.Module):
         self.weights_proj = nn.Linear(self.hidden_size, self.n_heads, bias=False)
         self.softmax_scale = self.head_dim**-0.5
 
-        # Indexer maintains its own key cache (not in DynamicCache, which is sized for attention layers only)
-        self.register_buffer("_cached_keys", None, persistent=False)
-
     @torch.no_grad()
     def forward(
         self,
@@ -214,7 +206,7 @@ class GlmMoeDsaIndexer(nn.Module):
         q_resid: torch.Tensor,  # [B, S, q_lora_rank]
         position_embeddings: tuple[torch.Tensor, torch.Tensor],
         attention_mask: torch.Tensor | None,
-        use_cache: bool = False,
+        past_key_values: Cache | None = None,
     ) -> torch.LongTensor:
         """
         Computes top-k token indices for sparse attention (DSA).
@@ -232,7 +224,7 @@ class GlmMoeDsaIndexer(nn.Module):
             q_resid: Query residual from `q_a_layernorm(q_a_proj(x))`, shape `[B, S, q_lora_rank]`.
             position_embeddings: `(cos, sin)` from RotaryEmbedding.
             attention_mask: Causal mask, broadcastable to `[B, S, T]`.
-            use_cache: Whether to store/update the indexer's own key cache for autoregressive decode.
+            past_key_values: Cache containing past key states for autoregressive decode.
 
         Returns:
             `torch.LongTensor`: Top-k token indices of shape `[B, S, topk]`.
@@ -253,17 +245,13 @@ class GlmMoeDsaIndexer(nn.Module):
         k_pe = apply_rotary_pos_emb(k_pe.unsqueeze(2), cos, sin, unsqueeze_dim=2).squeeze(2)  # [B, S, rope_D]
         k = torch.cat([k_pe, k_nope], dim=-1)  # [B, S, D]
 
-        # === Key cache (managed by the indexer, not DynamicCache) ===
+        # === Key cache (managed by the DynamicCache) ===
         # Reset cache on prefill (new prompt) to avoid stale keys / batch-size mismatch
-        if seq_len > 1:
-            self._cached_keys = None
+        if seq_len > 1 and past_key_values is not None:
+            past_key_values.reset_cached_keys(self.layer_idx)
 
-        if use_cache:
-            if self._cached_keys is not None:
-                k_cached = torch.cat([self._cached_keys, k], dim=1)  # [B, T, D]
-            else:
-                k_cached = k
-            self._cached_keys = k_cached
+        if past_key_values is not None:
+            k_cached = past_key_values.update_cached_keys(k, self.layer_idx)
         else:
             k_cached = k
 
@@ -436,7 +424,7 @@ class GlmMoeDsaAttention(nn.Module):
                 q_resid,
                 position_embeddings,
                 indexer_mask,
-                use_cache=past_key_values is not None,
+                past_key_values=past_key_values,
             )  # [B, S, topk]
         else:
             topk_indices = prev_topk_indices  # [B, S, topk]


### PR DESCRIPTION
## What does this PR do?

This PR migrates the GLM-5 DSA **IndexCache** key cache from a self-managed `register_buffer` (as introduced in #45424) into the standard `past_key_values` (`Cache`) per-layer infrastructure. Indexer keys now share the same lifecycle as attention KV caches, enabling transparent support for beam-search reordering, cache cropping, batch selection/repetition, and offloading.

## Background & Motivation

GLM-5 integrates the DeepSeek Sparse Attention (DSA) Indexer. In #45424, we added support for the **IndexCache** mechanism (THUDM/IndexCache, arXiv:2603.12201) to accelerate inference by caching indexer keys and allowing Shared (S) layers to reuse indices from Full (F) layers.

However, the implementation in #45424 managed these cached keys inside `GlmMoeDsaIndexer` via `self.register_buffer("_cached_keys", None, persistent=False)`. While this works for basic generation, it creates architectural friction when building **downstream models on top of GLM-5**:

- **Lifecycle drift**: `Cache.reset`, `reorder_cache`, `crop`, `batch_repeat_interleave`, and `batch_select_indices` do not propagate to the Indexer's isolated buffer.
- **Offloading blind spot**: The indexer keys are invisible to the Cache offloading / prefetching system.
- **Duplicated logic**: Prefill-vs-decode concatenation is manually implemented inside the Indexer, duplicating what `DynamicCache` already does.

To simplify our own downstream model code and benefit the broader GLM-5 ecosystem, we are upstreaming this unification first.

## Changes

### `src/transformers/cache_utils.py`

- **`CacheLayerMixin`**: Added `indexer_keys` attribute and abstract method `update_cached_keys()`.
- **`DynamicLayer`**: Implemented `update_cached_keys()` by concatenating along the sequence dimension (`dim=1`); synchronized `crop`, `batch_repeat_interleave`, `batch_select_indices`, `reset`, and `reorder_cache` to also operate on `indexer_keys`.
- **`StaticLayer`**: Added passthrough `update_cached_keys()` returning the input as-is.
- **`Cache`**: Added `update_cached_keys(cached_keys, layer_idx)` and `reset_cached_keys(layer_idx)` to dispatch per layer, mirroring the existing `update()` / `reset()` API.

### `src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py`

- **`GlmMoeDsaIndexer`**:
  - Removed `self.register_buffer("_cached_keys", None, persistent=False)`.
  - `forward()` now accepts `past_key_values: Cache | None` instead of `use_cache: bool`.
  - Prefill (`seq_len &gt; 1`) triggers `past_key_values.reset_cached_keys(layer_idx)` before computing scores.
  - Decode (`seq_len == 1`) appends keys via `past_key_values.update_cached_keys(k, layer_idx)`.
- **`GlmMoeDsaAttention`**: Updated `self.indexer(...)` call to pass `past_key_values=past_key_values` directly.

## Behavior equivalence

| #45424 (self-managed IndexCache) | This PR (unified Cache layer) |
|---|---|
| `if seq_len &gt; 1: self._cached_keys = None` | `if seq_len &gt; 1: past_key_values.reset_cached_keys(layer_idx)` |
| `if use_cache: cat([self._cached_keys, k])` | `if past_key_values is not None: past_key_values.update_cached_keys(k, layer_idx)` |
| `else: k_cached = k` | `else: k_cached = k` |

## Local verification

Verified locally with a tiny `hidden_size=256` config:
- Prefill + decode cache growth
- Multi-layer isolation
- Beam-search `reorder_cache`
- `batch_select_indices` / `batch_repeat_interleave`
- `crop` truncation
- Shared indexer (`skip_topk`) reuse path
- No-cache fallback (`past_key_values=None`)
- `Cache.reset()` clears `indexer_keys`
- End-to-end multi-turn chat: `indexer_keys` accumulate correctly across turns

## Backward compatibility

- No public API changes; `generate()` behavior is unchanged.
- The removed `_cached_keys` buffer was never part of saved state (`persistent=False`), so existing checkpoints remain fully compatible.

## Follow-up context

We are actively building a new LLM architecture on top of the GLM-5 backbone, leveraging the DSA Indexer and IndexCache design. Unifying the Indexer cache into the standard `Cache` layer is prerequisite infrastructure work for open-sourcing that model. We will share more details once training converges. Stay tuned!

&lt;!-- Remove if not applicable --&gt;

Fixes # (N/A)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez

Library:

- attention: @vasqu @ArthurZucker @CyrilVallez
- generate: @gante