### PR TITLE
Raise clear error for `problem_type="single_label_classification"` with `num_labels=1`

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -267,7 +267,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
 
         if self.problem_type == "single_label_classification" and self.num_labels == 1:
             raise ValueError(
-                '`problem_type="single_label_classification"` requires `num_labels > 1`. For binary "
+                '`problem_type="single_label_classification"` requires `num_labels > 1`. For binary '
                 'classification use `num_labels=2`, or use `problem_type="regression"` for a '
                 "single-output regression head."
             )

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -265,6 +265,19 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
             # Keys are always strings in JSON so convert ids to int
             self.id2label = {int(key): value for key, value in self.id2label.items()}
 
+        # `problem_type="single_label_classification"` with `num_labels=1` is degenerate: applying
+        # cross-entropy to a single logit yields a constant zero loss. Reject this combination with a
+        # clear message pointing users to the intended setup (use `num_labels=2` for binary
+        # classification, or `problem_type="regression"` for a single-output regression head).
+        # See https://github.com/huggingface/transformers/issues/45479.
+        if self.problem_type == "single_label_classification" and self.num_labels == 1:
+            raise ValueError(
+                '`problem_type="single_label_classification"` requires `num_labels > 1`. With '
+                "`num_labels=1` the cross-entropy loss is degenerate and always zero. For binary "
+                'classification use `num_labels=2`, or use `problem_type="regression"` for a '
+                "single-output regression head."
+            )
+
         # BC for rotary embeddings. We will pop out legacy keys from kwargs and rename to new format
         if hasattr(self, "rope_parameters"):
             kwargs = self.convert_rope_params_to_dict(**kwargs)

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -265,15 +265,9 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
             # Keys are always strings in JSON so convert ids to int
             self.id2label = {int(key): value for key, value in self.id2label.items()}
 
-        # `problem_type="single_label_classification"` with `num_labels=1` is degenerate: applying
-        # cross-entropy to a single logit yields a constant zero loss. Reject this combination with a
-        # clear message pointing users to the intended setup (use `num_labels=2` for binary
-        # classification, or `problem_type="regression"` for a single-output regression head).
-        # See https://github.com/huggingface/transformers/issues/45479.
         if self.problem_type == "single_label_classification" and self.num_labels == 1:
             raise ValueError(
-                '`problem_type="single_label_classification"` requires `num_labels > 1`. With '
-                "`num_labels=1` the cross-entropy loss is degenerate and always zero. For binary "
+                '`problem_type="single_label_classification"` requires `num_labels > 1`. For binary "
                 'classification use `num_labels=2`, or use `problem_type="regression"` for a '
                 "single-output regression head."
             )

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -261,20 +261,6 @@ class ConfigTestUtils(unittest.TestCase):
             warnings.simplefilter("error")
             PreTrainedConfig.from_pretrained("bert-base-uncased")
 
-    def test_single_label_classification_requires_more_than_one_label(self):
-        """Regression test for https://github.com/huggingface/transformers/issues/45479.
-
-        `problem_type="single_label_classification"` with `num_labels=1` used to silently produce a
-        degenerate zero cross-entropy loss. It must now raise a clear error at config construction.
-        """
-        with self.assertRaises(ValueError):
-            BertConfig(num_labels=1, problem_type="single_label_classification")
-
-        # Valid combinations must still work.
-        BertConfig(num_labels=2, problem_type="single_label_classification")
-        BertConfig(num_labels=1, problem_type="regression")
-        BertConfig(num_labels=1)  # problem_type left unset is fine; it is inferred at forward time.
-
     def test_get_text_config(self):
         """Tests the `get_text_config` method."""
         # 1. model with only text input -> returns the original config instance

--- a/tests/utils/test_configuration_utils.py
+++ b/tests/utils/test_configuration_utils.py
@@ -261,6 +261,20 @@ class ConfigTestUtils(unittest.TestCase):
             warnings.simplefilter("error")
             PreTrainedConfig.from_pretrained("bert-base-uncased")
 
+    def test_single_label_classification_requires_more_than_one_label(self):
+        """Regression test for https://github.com/huggingface/transformers/issues/45479.
+
+        `problem_type="single_label_classification"` with `num_labels=1` used to silently produce a
+        degenerate zero cross-entropy loss. It must now raise a clear error at config construction.
+        """
+        with self.assertRaises(ValueError):
+            BertConfig(num_labels=1, problem_type="single_label_classification")
+
+        # Valid combinations must still work.
+        BertConfig(num_labels=2, problem_type="single_label_classification")
+        BertConfig(num_labels=1, problem_type="regression")
+        BertConfig(num_labels=1)  # problem_type left unset is fine; it is inferred at forward time.
+
     def test_get_text_config(self):
         """Tests the `get_text_config` method."""
         # 1. model with only text input -> returns the original config instance


### PR DESCRIPTION
## What

Adds validation in `PreTrainedConfig.__post_init__` that rejects the combination `problem_type="single_label_classification"` + `num_labels=1` with a clear `ValueError` pointing users to the correct setup.

Closes #45479

## Why

Before this change, constructing a sequence-classification model with this combination silently produced a degenerate zero cross-entropy loss (softmax over a single logit is always `1`, so `CrossEntropyLoss` always returns `0`). Training appeared to run but accomplished nothing.

Reproducer (confirmed on `main`, both on shared-loss models like BERT and inlined-loss models like ModernBERT):

```python
import torch
from transformers import BertConfig, BertForSequenceClassification
config = BertConfig(vocab_size=100, hidden_size=32, num_hidden_layers=2,
                    num_attention_heads=2, intermediate_size=64,
                    num_labels=1, problem_type="single_label_classification")
model = BertForSequenceClassification(config)
model.eval()
out = model(input_ids=torch.tensor([[1, 2, 3, 4]]), labels=torch.tensor([0]))
print(out.loss)  # tensor(0.)
```

## Fix

`PreTrainedConfig.__post_init__` now raises `ValueError` on this combination after `num_labels` is resolved from `id2label`. Error message redirects the user to `num_labels=2` (binary classification) or `problem_type="regression"` (single-output regression).

The check sits at the config layer so it covers every sequence-classification model uniformly — both models that delegate to `ForSequenceClassificationLoss` in `src/transformers/loss/loss_utils.py` and models that inline the loss selection (e.g. ModernBERT, ~40 others).

## Coordination / approach

This matches the maintainer direction in [this comment on #45479](https://github.com/huggingface/transformers/issues/45479#issuecomment-4267713872):

> "maybe we could raise a clearer error if users set `num_labels=1` and `problem_type="single_label_classification"` to tell them not to do that?"

## Tests

New regression test `tests/utils/test_configuration_utils.py::ConfigTestUtils::test_single_label_classification_requires_more_than_one_label` asserts the degenerate combination raises, and verifies the three valid shapes (`num_labels=2 + single_label`, `num_labels=1 + regression`, `num_labels=1` with no explicit `problem_type`) still construct.

Verified that the test FAILS on `main` without the fix and PASSES with it.

Ran locally:

```
pytest tests/utils/test_configuration_utils.py
pytest tests/models/bert/test_modeling_bert.py -k "for_sequence or problem_type"
pytest tests/models/modernbert/test_modeling_modernbert.py -k "problem_type or sequence_classification"
pytest tests/models/roberta/test_modeling_roberta.py::RobertaModelTest::test_problem_types
pytest tests/models/albert/test_modeling_albert.py::AlbertModelTest::test_problem_types
```

All pass. `ruff check` and `ruff format --check` clean on the two touched files.

The existing common `test_problem_types` continues to pass: it assigns `problem_type` and `num_labels` as attributes on an already-constructed config, which bypasses `__post_init__` by design, and the test only asserts `loss.backward()` doesn't error.

## Compatibility

- Valid configurations are unaffected.
- Save/load round-trip of valid configs verified.
- A saved Hub config containing this exact bad combination will now fail to load with a clear error. Any such checkpoint can never have been trained successfully (loss was always 0), so no working workflow regresses.

## AI disclosure

AI-assisted: the fix was drafted with Claude, then human-reviewed end-to-end including the reproducer, diff, and test outputs listed above. Disclosed per `CONTRIBUTING.md` "AI-assisted and agentic contributions".
