### PR TITLE
Add missing requests dependency to transformers[serving]

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -165,6 +165,7 @@ _deps = [
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",
     "opentelemetry-sdk",
+    "requests",
 ]
 
 # This is a lookup table with items like: {"tokenizers": "tokenizers==0.9.4", "packaging": "packaging"}, i.e.
@@ -205,7 +206,7 @@ if PYTHON_MINOR_VERSION < 14:
     extras["ray"] = deps_list("ray[tune]")
     extras["integrations"] += extras["ray"]
 extras["codecarbon"] = deps_list("codecarbon")
-extras["serving"] = deps_list("openai", "pydantic", "uvicorn", "fastapi", "starlette", "rich") + extras["torch"]
+extras["serving"] = deps_list("openai", "pydantic", "uvicorn", "fastapi", "starlette", "rich", "requests") + extras["torch"]
 extras["num2words"] = deps_list("num2words")
 extras["benchmark"] = deps_list("optimum-benchmark")
 extras["ja"] = deps_list("fugashi", "ipadic", "unidic_lite", "unidic", "rhoknp")


### PR DESCRIPTION
Adds missing requests dependency. Otherwise installing just pip install transformers[serving] cannot launch transformers serve due to lack of requests