### PR TITLE
Add Multi-Token Prediction (MTP) inference support

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -72,6 +72,7 @@ class GenerationMode(ExplicitEnum):
     GREEDY_SEARCH = "greedy_search"
     SAMPLE = "sample"
     ASSISTED_GENERATION = "assisted_generation"
+    MTP_DECODING = "mtp_decoding"
     DOLA_GENERATION = "dola_generation"
     # Beam methods
     BEAM_SEARCH = "beam_search"
@@ -326,6 +327,10 @@ class GenerationConfig(PushToHubMixin):
             If set to a positive integer, the re-encodeing process will additionally consider the last `target_lookbehind` target tokens
             to correctly align tokens. Can only be used with different tokenizers in speculative decoding.
             See this [blog](https://huggingface.co/blog/universal_assisted_generation) for more details.
+        use_mtp(`bool`, *optional*, defaults to `False`):
+            If `True`, speculate with the model's Multi-Token Prediction (MTP) modules (DeepSeek-V3 / GLM-4 MoE style).
+            The base model drafts `config.num_nextn_predict_layers` extra tokens per step via the MTP heads, then
+            verifies them in a single forward pass — standard speculative decoding, shared weights + KV cache.
 
         > Parameters related to performances and compilation
 
@@ -424,6 +429,7 @@ class GenerationConfig(PushToHubMixin):
         self.assistant_early_exit = kwargs.pop("assistant_early_exit", None)
         self.assistant_lookbehind = kwargs.pop("assistant_lookbehind", None)
         self.target_lookbehind = kwargs.pop("target_lookbehind", None)
+        self.use_mtp = kwargs.pop("use_mtp", False)
 
         # Performance
         self.compile_config = kwargs.pop("compile_config", None)
@@ -532,6 +538,16 @@ class GenerationConfig(PushToHubMixin):
                     "You've set `assistant_model`, which triggers assisted generate. Currently, assisted generate "
                     "is only supported with Greedy Search and Sample. However, the base decoding mode (based on "
                     f"current flags) is {generation_mode} -- some of the set flags will be ignored."
+                )
+
+        # Multi-Token Prediction decoding uses the model's own MTP modules as the draft
+        if self.use_mtp:
+            if generation_mode in (GenerationMode.GREEDY_SEARCH, GenerationMode.SAMPLE):
+                generation_mode = GenerationMode.MTP_DECODING
+            else:
+                logger.warning(
+                    f"`use_mtp=True` is only supported with Greedy Search and Sample; the current mode is "
+                    f"{generation_mode}. Ignoring `use_mtp`."
                 )
 
         # DoLa generation may extend some generation modes

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -742,6 +742,17 @@ class ContinuousBatchingManager:
             generation_config: Configuration for generation parameters
             continuous_batching_config: Configuration for continuous batching parameters
         """
+        # MTP speculative decoding in continuous batching needs paged-cache slot reservation
+        # (K + 1 tokens per request per step) plus per-request accept/reject in the sampler.
+        # That work is tracked separately; until it lands, refuse the combination rather than
+        # silently downgrade to plain decoding.
+        if getattr(generation_config, "use_mtp", False):
+            raise NotImplementedError(
+                "`use_mtp=True` with `generate_batch` / continuous batching is not supported yet. "
+                "Use `model.generate(..., use_mtp=True)` for single-sequence MTP decoding, or set "
+                "`use_mtp=False` for batched generation."
+            )
+
         # Reload paged version of the attention implementation if necessary
         if "paged|" not in model.config._attn_implementation:
             model.set_attn_implementation(f"paged|{model.config._attn_implementation}")

--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -136,6 +136,7 @@ GENERATION_MODES_MAPPING = {
     GenerationMode.BEAM_SEARCH: "_beam_search",
     GenerationMode.BEAM_SAMPLE: "_beam_search",
     GenerationMode.ASSISTED_GENERATION: "_assisted_decoding",
+    GenerationMode.MTP_DECODING: "_mtp_decoding",
     # Deprecated methods
     GenerationMode.DOLA_GENERATION: "transformers-community/dola",
     GenerationMode.CONTRASTIVE_SEARCH: "transformers-community/contrastive-search",
@@ -1477,6 +1478,18 @@ class GenerationMixin(ContinuousMixin):
                     f"assisted generation is not supported with stateful models, such as {self.__class__.__name__}"
                 )
 
+        if generation_mode == GenerationMode.MTP_DECODING:
+            if generation_config.num_return_sequences > 1:
+                raise ValueError(
+                    "num_return_sequences must be 1 when `use_mtp=True` "
+                    f"(got {generation_config.num_return_sequences})."
+                )
+            if getattr(self.config, "num_nextn_predict_layers", 0) <= 0:
+                raise ValueError(
+                    "`use_mtp=True` was passed but the model config has no MTP modules "
+                    "(`num_nextn_predict_layers <= 0`)."
+                )
+
         if (assistant_model := generation_mode_kwargs.get("assistant_model")) is not None:
             if self.config.is_encoder_decoder and not assistant_model.config.is_encoder_decoder:
                 attributes_to_check = ["encoder_attention_heads", "encoder_ffn_dim", "encoder_layers"]
@@ -1848,7 +1861,11 @@ class GenerationMixin(ContinuousMixin):
         # Assisted decoding and contrastive search require cache rollback, which is incompatible with sliding layers.
         # To handle this, we skip passing the model config to DynamicCache (forcing a full-layer cache).
         # The "dynamic_full" option is a shortcut for generate() users to avoid sliding layers on their own.
-        if generation_mode in (GenerationMode.ASSISTED_GENERATION, GenerationMode.CONTRASTIVE_SEARCH):
+        if generation_mode in (
+            GenerationMode.ASSISTED_GENERATION,
+            GenerationMode.CONTRASTIVE_SEARCH,
+            GenerationMode.MTP_DECODING,
+        ):
             if generation_config.cache_implementation is not None:
                 logger.warning_once(
                     "An assistant model is provided, using a dynamic cache instead of a cache of type="
@@ -3719,6 +3736,207 @@ class GenerationMixin(ContinuousMixin):
                 )
         else:
             return input_ids
+
+    def _mtp_decoding(
+        self: "GenerativePreTrainedModel",
+        input_ids: torch.LongTensor,
+        logits_processor: LogitsProcessorList,
+        stopping_criteria: StoppingCriteriaList,
+        generation_config: GenerationConfig,
+        synced_gpus: bool = False,
+        streamer: Optional["BaseStreamer"] = None,
+        **model_kwargs,
+    ) -> GenerateNonBeamOutput | torch.LongTensor:
+        r"""
+        Multi-Token Prediction (MTP) speculative decoding. The model's own MTP modules — declared via
+        `config.num_nextn_predict_layers` and exposed through `model.forward_mtp` — act as the draft. Each step
+        samples one token from the base model, drafts K = `num_nextn_predict_layers` additional tokens by chaining
+        the MTP heads, then verifies all K + 1 candidates with a single extra forward on the base model and
+        accepts via standard speculative sampling.
+
+        Only supports `batch_size = 1`.
+        """
+        if not model_kwargs.get("use_cache"):
+            raise ValueError("`use_mtp` generate requires `use_cache=True`.")
+        num_mtp = getattr(self.config, "num_nextn_predict_layers", 0)
+        if num_mtp <= 0:
+            raise ValueError("`use_mtp=True` requires `config.num_nextn_predict_layers > 0` and loaded MTP weights.")
+        if not hasattr(self.model, "forward_mtp"):
+            raise ValueError(
+                f"{type(self.model).__name__} does not implement `forward_mtp`; MTP decoding is not supported."
+            )
+
+        do_sample = generation_config.do_sample
+        output_scores = generation_config.output_scores
+        output_logits = generation_config.output_logits
+        return_dict_in_generate = generation_config.return_dict_in_generate
+        scores = () if (return_dict_in_generate and output_scores) else None
+        raw_logits = () if (return_dict_in_generate and output_logits) else None
+
+        batch_size = input_ids.shape[0]
+        if batch_size > 1:
+            raise ValueError("MTP decoding currently only supports batch_size = 1.")
+        unfinished_sequences = torch.ones(batch_size, dtype=torch.long, device=input_ids.device)
+        this_peer_finished = False
+        is_first_iteration = True
+
+        while self._has_unfinished_sequences(this_peer_finished, synced_gpus, device=input_ids.device):
+            cur_len = input_ids.shape[1]
+
+            # 1. Base-model forward on either the full prompt (first iter) or the not-yet-cached tail.
+            next_sequence_length = None if is_first_iteration else 1 if model_kwargs["use_cache"] else None
+            model_inputs = self.prepare_inputs_for_generation(
+                input_ids,
+                next_sequence_length=next_sequence_length,
+                is_first_iteration=is_first_iteration,
+                **model_kwargs,
+            )
+            model_inputs["output_hidden_states"] = True
+            outputs = self(**model_inputs, return_dict=True)
+            main_cache = outputs.past_key_values
+            h_last = outputs.hidden_states[-1][:, -1:, :]
+
+            # 2. Sample x_{t+1} from the base model's prediction at the last prompt position.
+            base_logits = outputs.logits[:, -1, :].to(dtype=torch.float32, device=input_ids.device)
+            base_scores = logits_processor(input_ids, base_logits)
+            if do_sample:
+                x_next = torch.multinomial(nn.functional.softmax(base_scores, dim=-1), num_samples=1)
+            else:
+                x_next = torch.argmax(base_scores, dim=-1, keepdim=True)
+
+            # 3. Chain the MTP heads to draft K further tokens. Each head consumes the previous (hidden, token)
+            #    and produces (next_hidden, next_logits).
+            draft_tokens = [x_next]
+            draft_logits: list[torch.Tensor] = []
+            prev_hidden = h_last
+            for depth in range(num_mtp):
+                pos_id = torch.tensor([[cur_len + depth]], device=input_ids.device, dtype=torch.long)
+                prev_hidden, mtp_step_logits = self.model.forward_mtp(
+                    input_ids=draft_tokens[depth],
+                    previous_hidden_state=prev_hidden,
+                    past_key_values=main_cache,
+                    position_ids=pos_id,
+                    mtp_depth=depth,
+                )
+                mtp_vec = mtp_step_logits[:, 0, :].to(dtype=torch.float32)
+                mtp_vec = logits_processor(torch.cat([input_ids] + draft_tokens, dim=1), mtp_vec)
+                draft_logits.append(mtp_vec)
+                if do_sample:
+                    drafted = torch.multinomial(nn.functional.softmax(mtp_vec, dim=-1), num_samples=1)
+                else:
+                    drafted = torch.argmax(mtp_vec, dim=-1, keepdim=True)
+                draft_tokens.append(drafted)
+
+            # 4. Verify: feed all K+1 candidates through the base model at positions cur_len..cur_len+K.
+            candidate_tokens = torch.cat(draft_tokens, dim=1)  # (1, K+1)
+            is_done_candidate = stopping_criteria(torch.cat([input_ids, candidate_tokens], dim=1), None)
+            verify_kwargs = copy.copy(model_kwargs)
+            verify_kwargs["past_key_values"] = main_cache
+            verify_kwargs = _prepare_attention_mask(
+                verify_kwargs, cur_len + num_mtp + 1, self.config.is_encoder_decoder
+            )
+            if verify_kwargs.get("position_ids") is not None:
+                verify_kwargs = _prepare_position_ids(
+                    verify_kwargs, cur_len + num_mtp + 1, self.config.is_encoder_decoder
+                )
+            verify_inputs = self.prepare_inputs_for_generation(
+                torch.cat([input_ids, candidate_tokens], dim=1),
+                next_sequence_length=num_mtp + 1,
+                is_first_iteration=False,
+                **verify_kwargs,
+            )
+            if "logits_to_keep" in verify_inputs:
+                verify_inputs["logits_to_keep"] = num_mtp + 1
+            verify_outputs = self(**verify_inputs, return_dict=True)
+            verify_logits = verify_outputs.logits[:, -(num_mtp + 1) :, :].to(
+                dtype=torch.float32, device=input_ids.device
+            )
+            for i in range(num_mtp + 1):
+                verify_logits[:, i, :] = logits_processor(
+                    torch.cat([input_ids, candidate_tokens[:, :i]], dim=1), verify_logits[:, i, :]
+                )
+
+            # 5. Accept/reject. We compare the base model's predictions at positions cur_len..cur_len+K-1
+            #    (logits for x_{t+2}..x_{t+K+1}) against the drafts x_{t+2}..x_{t+K+1} = candidate_tokens[:, 1:].
+            #    x_{t+1} itself came from the base model, so it is unconditionally kept.
+            if num_mtp > 0:
+                draft_stack = torch.stack(draft_logits, dim=1)  # (1, K, V)
+                drafts_for_check = candidate_tokens[:, 1:]  # (1, K)
+                verify_for_drafts = verify_logits[:, :num_mtp, :]  # (1, K, V)
+                if do_sample:
+                    _candidate_input_ids = torch.cat([input_ids, drafts_for_check], dim=1)
+                    accepted_drafts, n_matches = _speculative_sampling(
+                        _candidate_input_ids,
+                        draft_stack,
+                        num_mtp,
+                        verify_for_drafts,
+                        is_done_candidate,
+                    )
+                    # `_speculative_sampling` returns `n_matches + 1` tokens (matched drafts + the resample).
+                    accepted_after_xnext = accepted_drafts
+                else:
+                    verify_argmax = verify_logits.argmax(dim=-1)  # (1, K+1)
+                    draft_match = verify_argmax[:, :num_mtp] == drafts_for_check
+                    n_matches = int(((~draft_match).cumsum(dim=-1) < 1).sum().item())
+                    if is_done_candidate and n_matches == num_mtp:
+                        n_matches -= 1
+                    bonus = verify_argmax[:, n_matches : n_matches + 1]
+                    accepted_after_xnext = torch.cat([drafts_for_check[:, :n_matches], bonus], dim=1)
+            else:
+                accepted_after_xnext = candidate_tokens[:, :0]
+                n_matches = 0
+
+            accepted = torch.cat([x_next, accepted_after_xnext], dim=1)
+
+            # 6. Commit. Extend input_ids, crop the base-model cache, and update model_kwargs.
+            input_ids = torch.cat([input_ids, accepted], dim=1)
+            if streamer is not None:
+                streamer.put(accepted.cpu())
+            new_cur_len = input_ids.shape[1]
+            main_cache.crop(new_cur_len - 1)
+            model_kwargs["past_key_values"] = main_cache
+            model_kwargs = self._update_model_kwargs_for_generation(
+                outputs,
+                model_kwargs,
+                is_encoder_decoder=self.config.is_encoder_decoder,
+                num_new_tokens=accepted.shape[1],
+            )
+            # `_update_model_kwargs_for_generation` only extended attention_mask by 1; add the rest.
+            if model_kwargs.get("attention_mask") is not None:
+                extra = accepted.shape[1] - 1
+                if extra > 0:
+                    mask = model_kwargs["attention_mask"]
+                    model_kwargs["attention_mask"] = torch.cat([mask, mask.new_ones((mask.shape[0], extra))], dim=-1)
+
+            if return_dict_in_generate:
+                newly_added = accepted.shape[1]
+                if output_scores:
+                    scores += tuple(verify_logits[:, i, :] for i in range(newly_added))
+                if output_logits:
+                    raw_logits += tuple(verify_logits[:, i, :] for i in range(newly_added))
+
+            is_first_iteration = False
+            unfinished_sequences = unfinished_sequences & ~stopping_criteria(input_ids, scores)
+            this_peer_finished = unfinished_sequences.max() == 0
+            del outputs
+
+        if streamer is not None:
+            streamer.end()
+
+        if return_dict_in_generate:
+            cache = None
+            if any(cache_key in model_kwargs for cache_key in ALL_CACHE_NAMES):
+                cache_key = next(cache_key for cache_key in ALL_CACHE_NAMES if cache_key in model_kwargs)
+                cache = model_kwargs[cache_key]
+            return GenerateDecoderOnlyOutput(
+                sequences=input_ids,
+                scores=scores,
+                logits=raw_logits,
+                attentions=None,
+                hidden_states=None,
+                past_key_values=cache,
+            )
+        return input_ids
 
     # TODO: v5.1: make public once API stabilized
     def _prefill(

--- a/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/configuration_deepseek_v3.py
@@ -31,6 +31,11 @@ class DeepseekV3Config(PreTrainedConfig):
     first_k_dense_replace (`int`, *optional*, defaults to 3):
         Number of dense layers in shallow layers(embed->dense->dense->...->dense->moe->moe...->lm_head).
                                                         \--k dense layers--/
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
     rope_interleave (`bool`, *optional*, defaults to `True`):
         Whether to interleave the rotary position embeddings.
 
@@ -88,6 +93,7 @@ class DeepseekV3Config(PreTrainedConfig):
     num_experts_per_tok: int | None = 8
     first_k_dense_replace: int | None = 3
     norm_topk_prob: bool | None = True
+    num_nextn_predict_layers: int = 0
     hidden_act: str = "silu"
     max_position_embeddings: int = 4096
     initializer_range: float = 0.02

--- a/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modeling_deepseek_v3.py
@@ -14,7 +14,7 @@ from torch import nn
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache
+from ...cache_utils import Cache, DynamicCache, DynamicLayer
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation, use_kernel_forward_from_hub, use_kernel_func_from_hub
 from ...masking_utils import create_causal_mask
@@ -526,6 +526,61 @@ class DeepseekV3DecoderLayer(GradientCheckpointingLayer):
         return hidden_states
 
 
+class DeepseekV3MTPSharedHead(nn.Module):
+    def __init__(self, config: DeepseekV3Config):
+        super().__init__()
+        self.norm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class DeepseekV3MTPLayer(nn.Module):
+    """One Multi-Token Prediction module (DeepSeek-V3 spec).
+
+    Given the hidden state `h_{t+k}` produced at position t+k by the base model
+    (or the previous MTP depth) and the embedding of the token sampled at t+k+1,
+    runs a single transformer block and produces logits for position t+k+2. Each
+    MTP layer owns its transformer block (sharing the base model's KV cache at
+    `layer_idx = num_hidden_layers + k`) and its own `shared_head` that projects
+    back to vocab space.
+    """
+
+    def __init__(self, config: DeepseekV3Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = DeepseekV3DecoderLayer(config, layer_idx)
+        self.shared_head = DeepseekV3MTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 @auto_docstring
 class DeepseekV3PreTrainedModel(PreTrainedModel):
     config: DeepseekV3Config
@@ -544,6 +599,9 @@ class DeepseekV3PreTrainedModel(PreTrainedModel):
         "attentions": DeepseekV3Attention,
     }
     _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
+    # MTP layers live at `model.layers.{num_hidden_layers + k}`. When
+    # `num_nextn_predict_layers == 0` these entries aren't in the model, so we
+    # ignore them if a user loads a checkpoint that still carries MTP weights.
     _keys_to_ignore_on_load_unexpected = [r"model\.layers\.61.*"]
 
     @torch.no_grad()
@@ -571,6 +629,8 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
         self.norm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = DeepseekV3RotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(DeepseekV3MTPLayer(config, config.num_hidden_layers + k))
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -628,6 +688,49 @@ class DeepseekV3Model(DeepseekV3PreTrainedModel):
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
+        )
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        # Caches constructed from the base config only allocate `num_hidden_layers`
+        # slots. MTP layers share the same cache but live at higher indices, so
+        # extend with empty layers on the first MTP call.
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(self.config.num_hidden_layers + mtp_depth)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
+++ b/src/transformers/models/deepseek_v3/modular_deepseek_v3.py
@@ -6,7 +6,8 @@ import torch.nn.functional as F
 from torch import nn
 
 from ... import initialization as init
-from ...cache_utils import Cache
+from ...cache_utils import Cache, DynamicLayer
+from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_layers import GenericForSequenceClassification, GenericForTokenClassification
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
@@ -300,8 +301,66 @@ class DeepseekV3DecoderLayer(LlamaDecoderLayer):
         self.post_attention_layernorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
 
+class DeepseekV3MTPSharedHead(nn.Module):
+    def __init__(self, config: DeepseekV3Config):
+        super().__init__()
+        self.norm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class DeepseekV3MTPLayer(nn.Module):
+    """One Multi-Token Prediction module (DeepSeek-V3 spec).
+
+    Given the hidden state `h_{t+k}` produced at position t+k by the base model
+    (or the previous MTP depth) and the embedding of the token sampled at t+k+1,
+    runs a single transformer block and produces logits for position t+k+2. Each
+    MTP layer owns its transformer block (sharing the base model's KV cache at
+    `layer_idx = num_hidden_layers + k`) and its own `shared_head` that projects
+    back to vocab space.
+    """
+
+    def __init__(self, config: DeepseekV3Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = DeepseekV3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = DeepseekV3DecoderLayer(config, layer_idx)
+        self.shared_head = DeepseekV3MTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 class DeepseekV3PreTrainedModel(LlamaPreTrainedModel):
     _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
+    # MTP layers live at `model.layers.{num_hidden_layers + k}`. When
+    # `num_nextn_predict_layers == 0` these entries aren't in the model, so we
+    # ignore them if a user loads a checkpoint that still carries MTP weights.
     _keys_to_ignore_on_load_unexpected = [r"model\.layers\.61.*"]
 
     @torch.no_grad()
@@ -316,7 +375,54 @@ class DeepseekV3PreTrainedModel(LlamaPreTrainedModel):
 
 
 class DeepseekV3Model(LlamaModel):
-    pass
+    def __init__(self, config: DeepseekV3Config):
+        super().__init__(config)
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(DeepseekV3MTPLayer(config, config.num_hidden_layers + k))
+        self.post_init()
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        # Caches constructed from the base config only allocate `num_hidden_layers`
+        # slots. MTP layers share the same cache but live at higher indices, so
+        # extend with empty layers on the first MTP call.
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(self.config.num_hidden_layers + mtp_depth)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
+        )
 
 
 class DeepseekV3ForCausalLM(LlamaForCausalLM):

--- a/src/transformers/models/glm4_moe/configuration_glm4_moe.py
+++ b/src/transformers/models/glm4_moe/configuration_glm4_moe.py
@@ -33,6 +33,11 @@ class Glm4MoeConfig(PreTrainedConfig):
     first_k_dense_replace (`int`, *optional*, defaults to 1):
         Number of dense layers in shallow layers(embed->dense->dense->...->dense->moe->moe...->lm_head).
                                                         \--k dense layers--/
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
 
     Example:
 
@@ -101,6 +106,7 @@ class Glm4MoeConfig(PreTrainedConfig):
     topk_group: int = 1
     first_k_dense_replace: int = 1
     norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 0
     use_qk_norm: bool = False
     bos_token_id: int | None = None
     eos_token_id: int | list[int] | None = None

--- a/src/transformers/models/glm4_moe/modeling_glm4_moe.py
+++ b/src/transformers/models/glm4_moe/modeling_glm4_moe.py
@@ -27,7 +27,7 @@ from torch import nn
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache
+from ...cache_utils import Cache, DynamicCache, DynamicLayer
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation, use_kernel_forward_from_hub, use_kernelized_func
 from ...masking_utils import create_causal_mask
@@ -469,6 +469,51 @@ class Glm4MoeDecoderLayer(GradientCheckpointingLayer):
         return hidden_states
 
 
+class Glm4MoeMTPSharedHead(nn.Module):
+    def __init__(self, config: Glm4MoeConfig):
+        super().__init__()
+        self.norm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class Glm4MoeMTPLayer(nn.Module):
+    def __init__(self, config: Glm4MoeConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = Glm4MoeDecoderLayer(config, layer_idx)
+        self.shared_head = Glm4MoeMTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 @auto_docstring
 class Glm4MoePreTrainedModel(PreTrainedModel):
     config: Glm4MoeConfig
@@ -487,6 +532,9 @@ class Glm4MoePreTrainedModel(PreTrainedModel):
         "attentions": Glm4MoeAttention,
     }
     _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
+    # GLM-4 MoE ships MTP weights at layer index `num_hidden_layers` — 46 for
+    # GLM-4.5-Air, 92 for the larger GLM-4.5 variant. Both are ignored when
+    # `num_nextn_predict_layers == 0` (the default).
     _keys_to_ignore_on_load_unexpected = [r"model\.layers\.92.*", r"model\.layers\.46.*"]
 
     @torch.no_grad()
@@ -514,6 +562,8 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         self.norm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Glm4MoeRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(Glm4MoeMTPLayer(config, config.num_hidden_layers + k))
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -571,6 +621,46 @@ class Glm4MoeModel(Glm4MoePreTrainedModel):
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
+        )
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(layer_idx)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/glm4_moe/modular_glm4_moe.py
+++ b/src/transformers/models/glm4_moe/modular_glm4_moe.py
@@ -17,7 +17,9 @@ import torch
 from huggingface_hub.dataclasses import strict
 from torch import nn
 
+from ...cache_utils import Cache, DynamicLayer
 from ...configuration_utils import PreTrainedConfig
+from ...masking_utils import create_causal_mask
 from ...modeling_rope_utils import RopeParameters
 from ...utils import auto_docstring, logging
 from ..cohere.modeling_cohere import CohereAttention
@@ -46,6 +48,11 @@ class Glm4MoeConfig(PreTrainedConfig):
     first_k_dense_replace (`int`, *optional*, defaults to 1):
         Number of dense layers in shallow layers(embed->dense->dense->...->dense->moe->moe...->lm_head).
                                                         \--k dense layers--/
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
 
     Example:
 
@@ -114,6 +121,7 @@ class Glm4MoeConfig(PreTrainedConfig):
     topk_group: int = 1
     first_k_dense_replace: int = 1
     norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 0
     use_qk_norm: bool = False
     bos_token_id: int | None = None
     eos_token_id: int | list[int] | None = None
@@ -183,12 +191,104 @@ class Glm4MoeDecoderLayer(DeepseekV3DecoderLayer):
     pass
 
 
+class Glm4MoeMTPSharedHead(nn.Module):
+    def __init__(self, config: Glm4MoeConfig):
+        super().__init__()
+        self.norm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class Glm4MoeMTPLayer(nn.Module):
+    def __init__(self, config: Glm4MoeConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = Glm4MoeRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = Glm4MoeDecoderLayer(config, layer_idx)
+        self.shared_head = Glm4MoeMTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 class Glm4MoePreTrainedModel(DeepseekV3PreTrainedModel):
+    # GLM-4 MoE ships MTP weights at layer index `num_hidden_layers` — 46 for
+    # GLM-4.5-Air, 92 for the larger GLM-4.5 variant. Both are ignored when
+    # `num_nextn_predict_layers == 0` (the default).
     _keys_to_ignore_on_load_unexpected = [r"model\.layers\.92.*", r"model\.layers\.46.*"]
 
 
 class Glm4MoeModel(DeepseekV3Model):
-    pass
+    def __init__(self, config: Glm4MoeConfig):
+        super().__init__(config)
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(Glm4MoeMTPLayer(config, config.num_hidden_layers + k))
+        self.post_init()
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(layer_idx)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
+        )
 
 
 class Glm4MoeForCausalLM(DeepseekV3ForCausalLM):

--- a/src/transformers/models/glm4_moe_lite/modeling_glm4_moe_lite.py
+++ b/src/transformers/models/glm4_moe_lite/modeling_glm4_moe_lite.py
@@ -29,7 +29,7 @@ import torch.nn.functional as F
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache
+from ...cache_utils import Cache, DynamicCache, DynamicLayer
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation, use_kernel_forward_from_hub, use_kernel_func_from_hub
 from ...masking_utils import create_causal_mask
@@ -574,6 +574,51 @@ class Glm4MoeLitePreTrainedModel(PreTrainedModel):
             init.normal_(module.down_proj, mean=0.0, std=self.config.initializer_range)
 
 
+class Glm4MoeLiteMTPSharedHead(nn.Module):
+    def __init__(self, config: Glm4MoeLiteConfig):
+        super().__init__()
+        self.norm = Glm4MoeLiteRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class Glm4MoeLiteMTPLayer(nn.Module):
+    def __init__(self, config: Glm4MoeLiteConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = Glm4MoeLiteRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = Glm4MoeLiteRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = Glm4MoeLiteDecoderLayer(config, layer_idx)
+        self.shared_head = Glm4MoeLiteMTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 @auto_docstring
 class Glm4MoeLiteModel(Glm4MoeLitePreTrainedModel):
     def __init__(self, config: Glm4MoeLiteConfig):
@@ -588,6 +633,8 @@ class Glm4MoeLiteModel(Glm4MoeLitePreTrainedModel):
         self.norm = Glm4MoeLiteRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Glm4MoeLiteRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(Glm4MoeLiteMTPLayer(config, config.num_hidden_layers + k))
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -645,6 +692,46 @@ class Glm4MoeLiteModel(Glm4MoeLitePreTrainedModel):
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
+        )
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(layer_idx)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/glm4v_moe/configuration_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/configuration_glm4v_moe.py
@@ -33,6 +33,11 @@ class Glm4vMoeTextConfig(PreTrainedConfig):
     first_k_dense_replace (`int`, *optional*, defaults to 1):
         Number of dense layers in shallow layers(embed->dense->dense->...->dense->moe->moe...->lm_head).
                                                                 \--k dense layers--/
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
 
     Example:
 
@@ -94,6 +99,7 @@ class Glm4vMoeTextConfig(PreTrainedConfig):
     topk_group: int = 1
     first_k_dense_replace: int = 1
     norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 0
     bos_token_id: int | None = None
     eos_token_id: int | list[int] | None = None
     pad_token_id: int | None = None

--- a/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modeling_glm4v_moe.py
@@ -411,6 +411,9 @@ class Glm4vMoePreTrainedModel(PreTrainedModel):
     _supports_attention_backend = True
     _can_record_outputs = {}
     _keep_in_fp32_modules_strict = ["e_score_correction_bias"]
+    # GLM-4 MoE ships MTP weights at layer index `num_hidden_layers` — 46 for
+    # GLM-4.5-Air, 92 for the larger GLM-4.5 variant. Both are ignored when
+    # `num_nextn_predict_layers == 0` (the default).
     _keys_to_ignore_on_load_unexpected = [r"model\.layers\.92.*", r"model\.layers\.46.*"]
     input_modalities = ("text", "image", "video")
 

--- a/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
+++ b/src/transformers/models/glm4v_moe/modular_glm4v_moe.py
@@ -64,6 +64,11 @@ class Glm4vMoeTextConfig(Glm4MoeConfig):
     first_k_dense_replace (`int`, *optional*, defaults to 1):
         Number of dense layers in shallow layers(embed->dense->dense->...->dense->moe->moe...->lm_head).
                                                                 \--k dense layers--/
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
 
     Example:
 

--- a/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
+++ b/src/transformers/models/glm_moe_dsa/modeling_glm_moe_dsa.py
@@ -27,7 +27,7 @@ import torch.nn.functional as F
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache
+from ...cache_utils import Cache, DynamicCache, DynamicLayer
 from ...generation import GenerationMixin
 from ...integrations import use_experts_implementation, use_kernel_forward_from_hub
 from ...masking_utils import create_causal_mask
@@ -742,6 +742,51 @@ class GlmMoeDsaRotaryEmbedding(nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
+class GlmMoeDsaMTPSharedHead(nn.Module):
+    def __init__(self, config: GlmMoeDsaConfig):
+        super().__init__()
+        self.norm = GlmMoeDsaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class GlmMoeDsaMTPLayer(nn.Module):
+    def __init__(self, config: GlmMoeDsaConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = GlmMoeDsaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = GlmMoeDsaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = GlmMoeDsaDecoderLayer(config, layer_idx)
+        self.shared_head = GlmMoeDsaMTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 @auto_docstring
 class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
     def __init__(self, config: GlmMoeDsaConfig):
@@ -756,6 +801,8 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         self.norm = GlmMoeDsaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = GlmMoeDsaRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(GlmMoeDsaMTPLayer(config, config.num_hidden_layers + k))
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -815,6 +862,46 @@ class GlmMoeDsaModel(GlmMoeDsaPreTrainedModel):
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
+        )
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(layer_idx)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/longcat_flash/modeling_longcat_flash.py
+++ b/src/transformers/models/longcat_flash/modeling_longcat_flash.py
@@ -28,7 +28,7 @@ from torch import nn
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache
+from ...cache_utils import Cache, DynamicCache, DynamicLayer
 from ...generation import GenerationMixin
 from ...integrations import use_kernel_forward_from_hub
 from ...masking_utils import create_causal_mask
@@ -568,6 +568,61 @@ class LongcatFlashPreTrainedModel(PreTrainedModel):
                 init.normal_(module.down_proj, mean=0.0, std=self.config.initializer_range)
 
 
+class LongcatFlashMTPSharedHead(nn.Module):
+    def __init__(self, config: LongcatFlashConfig):
+        super().__init__()
+        self.norm = LongcatFlashRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class LongcatFlashMTPLayer(nn.Module):
+    """One Multi-Token Prediction module (DeepSeek-V3 spec).
+
+    Given the hidden state `h_{t+k}` produced at position t+k by the base model
+    (or the previous MTP depth) and the embedding of the token sampled at t+k+1,
+    runs a single transformer block and produces logits for position t+k+2. Each
+    MTP layer owns its transformer block (sharing the base model's KV cache at
+    `layer_idx = num_hidden_layers + k`) and its own `shared_head` that projects
+    back to vocab space.
+    """
+
+    def __init__(self, config: LongcatFlashConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = LongcatFlashRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = LongcatFlashRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = LongcatFlashDecoderLayer(config, layer_idx)
+        self.shared_head = LongcatFlashMTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 @auto_docstring
 class LongcatFlashModel(LongcatFlashPreTrainedModel):
     def __init__(self, config):
@@ -582,6 +637,8 @@ class LongcatFlashModel(LongcatFlashPreTrainedModel):
         self.norm = LongcatFlashRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = LongcatFlashRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(LongcatFlashMTPLayer(config, config.num_hidden_layers + k))
         # Each layer above has 2 sublayers, config hack to have a correct cache (to avoid a checkpoint change)
         self.head_dim = config.head_dim  # For CI happiness (we didn't convert so head_dim is not directly used)
 
@@ -644,6 +701,49 @@ class LongcatFlashModel(LongcatFlashPreTrainedModel):
             past_key_values=past_key_values,
             hidden_states=None,
             attentions=None,
+        )
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        # Caches constructed from the base config only allocate `num_hidden_layers`
+        # slots. MTP layers share the same cache but live at higher indices, so
+        # extend with empty layers on the first MTP call.
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(self.config.num_hidden_layers + mtp_depth)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/solar_open/configuration_solar_open.py
+++ b/src/transformers/models/solar_open/configuration_solar_open.py
@@ -31,6 +31,11 @@ class SolarOpenConfig(PreTrainedConfig):
     r"""
     n_group (`int`, *optional*, defaults to 1):
         Number of groups for routed experts.
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
     """
 
     model_type = "solar_open"
@@ -77,6 +82,7 @@ class SolarOpenConfig(PreTrainedConfig):
     n_group: int = 1
     topk_group: int = 1
     norm_topk_prob: bool = True
+    num_nextn_predict_layers: int = 0
     bos_token_id: int | None = None
     eos_token_id: int | list[int] | None = None
     pad_token_id: int | None = None

--- a/src/transformers/models/solar_open/modeling_solar_open.py
+++ b/src/transformers/models/solar_open/modeling_solar_open.py
@@ -26,7 +26,7 @@ from torch import nn
 
 from ... import initialization as init
 from ...activations import ACT2FN
-from ...cache_utils import Cache, DynamicCache
+from ...cache_utils import Cache, DynamicCache, DynamicLayer
 from ...generation import GenerationMixin
 from ...integrations import (
     use_experts_implementation,
@@ -475,6 +475,51 @@ class SolarOpenRotaryEmbedding(nn.Module):
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
 
+class SolarOpenMTPSharedHead(nn.Module):
+    def __init__(self, config: SolarOpenConfig):
+        super().__init__()
+        self.norm = SolarOpenRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.head(self.norm(hidden_states))
+
+
+class SolarOpenMTPLayer(nn.Module):
+    def __init__(self, config: SolarOpenConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.enorm = SolarOpenRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hnorm = SolarOpenRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.eh_proj = nn.Linear(config.hidden_size * 2, config.hidden_size, bias=False)
+        self.mtp_block = SolarOpenDecoderLayer(config, layer_idx)
+        self.shared_head = SolarOpenMTPSharedHead(config)
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        previous_hidden_state: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        position_ids: torch.Tensor | None,
+        past_key_values: Cache | None,
+        use_cache: bool | None = None,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        hidden_states = self.eh_proj(torch.cat([self.enorm(inputs_embeds), self.hnorm(previous_hidden_state)], dim=-1))
+        hidden_states = self.mtp_block(
+            hidden_states,
+            attention_mask=attention_mask,
+            position_embeddings=position_embeddings,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        logits = self.shared_head(hidden_states)
+        return hidden_states, logits
+
+
 @auto_docstring
 class SolarOpenModel(SolarOpenPreTrainedModel):
     def __init__(self, config: SolarOpenConfig):
@@ -489,6 +534,8 @@ class SolarOpenModel(SolarOpenPreTrainedModel):
         self.norm = SolarOpenRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = SolarOpenRotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        for k in range(getattr(config, "num_nextn_predict_layers", 0)):
+            self.layers.append(SolarOpenMTPLayer(config, config.num_hidden_layers + k))
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -546,6 +593,46 @@ class SolarOpenModel(SolarOpenPreTrainedModel):
         return BaseModelOutputWithPast(
             last_hidden_state=hidden_states,
             past_key_values=past_key_values,
+        )
+
+    def forward_mtp(
+        self,
+        input_ids: torch.LongTensor,
+        previous_hidden_state: torch.Tensor,
+        past_key_values: Cache,
+        position_ids: torch.LongTensor | None = None,
+        mtp_depth: int = 0,
+        **kwargs,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run one MTP depth. Returns `(hidden_state, logits)` for position t+depth+2."""
+        layer_idx = self.config.num_hidden_layers + mtp_depth
+        mtp_layer = self.layers[layer_idx]
+        if hasattr(past_key_values, "layers"):
+            while len(past_key_values.layers) <= layer_idx:
+                past_key_values.layers.append(DynamicLayer())
+        inputs_embeds = self.embed_tokens(input_ids)
+        if position_ids is None:
+            past_seen_tokens = past_key_values.get_seq_length(layer_idx)
+            position_ids = (
+                torch.arange(inputs_embeds.shape[1], device=inputs_embeds.device) + past_seen_tokens
+            ).unsqueeze(0)
+        position_embeddings = self.rotary_emb(inputs_embeds, position_ids=position_ids)
+        causal_mask = create_causal_mask(
+            config=self.config,
+            inputs_embeds=inputs_embeds,
+            attention_mask=None,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+        )
+        return mtp_layer(
+            inputs_embeds=inputs_embeds,
+            previous_hidden_state=previous_hidden_state,
+            position_embeddings=position_embeddings,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            use_cache=True,
+            **kwargs,
         )
 
 

--- a/src/transformers/models/solar_open/modular_solar_open.py
+++ b/src/transformers/models/solar_open/modular_solar_open.py
@@ -37,6 +37,11 @@ class SolarOpenConfig(Glm4MoeConfig):
     r"""
     n_group (`int`, *optional*, defaults to 1):
         Number of groups for routed experts.
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
     """
 
     model_type = "solar_open"

--- a/src/transformers/models/youtu/configuration_youtu.py
+++ b/src/transformers/models/youtu/configuration_youtu.py
@@ -35,6 +35,11 @@ from ...utils import auto_docstring
 @strict
 class YoutuConfig(PreTrainedConfig):
     r"""
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
     rope_interleave (`bool`, *optional*, defaults to `True`):
         Whether to interleave the rotary position embeddings.
     embedding_initializer_range (`float`, *optional*):
@@ -73,6 +78,7 @@ class YoutuConfig(PreTrainedConfig):
     qk_rope_head_dim: int = 64
     v_head_dim: int | None = 128
     qk_nope_head_dim: int = 128
+    num_nextn_predict_layers: int = 0
     hidden_act: str = "silu"
     max_position_embeddings: int = 131072
     initializer_range: float | None = None

--- a/src/transformers/models/youtu/modular_youtu.py
+++ b/src/transformers/models/youtu/modular_youtu.py
@@ -45,6 +45,11 @@ logger = logging.get_logger(__name__)
 @strict
 class YoutuConfig(DeepseekV3Config):
     r"""
+    num_nextn_predict_layers (`int`, *optional*, defaults to 0):
+        Number of Multi-Token Prediction (MTP) modules appended after the base
+        transformer. When `0`, the model behaves as a standard decoder. When `>0`,
+        each extra module predicts one additional future token at inference time
+        (speculative decoding via `generate(..., use_mtp=True)`).
     rope_interleave (`bool`, *optional*, defaults to `True`):
         Whether to interleave the rotary position embeddings.
     embedding_initializer_range (`float`, *optional*):

--- a/tests/generation/test_mtp.py
+++ b/tests/generation/test_mtp.py
@@ -1,0 +1,169 @@
+import unittest
+
+import torch
+
+from transformers import DeepseekV3Config, DeepseekV3ForCausalLM, Glm4MoeConfig, Glm4MoeForCausalLM
+from transformers.generation.configuration_utils import GenerationMode
+from transformers.testing_utils import require_torch
+
+
+DEEPSEEK_V3_TINY_KW = {
+    "hidden_size": 64,
+    "intermediate_size": 64,
+    "moe_intermediate_size": 32,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "vocab_size": 100,
+    "kv_lora_rank": 16,
+    "q_lora_rank": 16,
+    "qk_rope_head_dim": 8,
+    "v_head_dim": 16,
+    "qk_nope_head_dim": 16,
+    "n_routed_experts": 4,
+    "first_k_dense_replace": 1,
+    "num_experts_per_tok": 2,
+    "n_group": 1,
+    "topk_group": 1,
+    "max_position_embeddings": 64,
+    "rope_parameters": {"rope_theta": 10000.0},
+}
+
+GLM4_MOE_TINY_KW = {
+    "hidden_size": 64,
+    "intermediate_size": 64,
+    "moe_intermediate_size": 32,
+    "num_hidden_layers": 2,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "vocab_size": 100,
+    "n_routed_experts": 4,
+    "first_k_dense_replace": 1,
+    "num_experts_per_tok": 2,
+    "n_group": 1,
+    "topk_group": 1,
+    "max_position_embeddings": 64,
+    "rope_parameters": {"rope_theta": 10000.0},
+}
+
+
+@require_torch
+class MTPGenerationModeTest(unittest.TestCase):
+    def test_use_mtp_routes_to_mtp_mode(self):
+        cfg = DeepseekV3Config(num_nextn_predict_layers=1, **DEEPSEEK_V3_TINY_KW)
+        model = DeepseekV3ForCausalLM(cfg)
+        gc = model.generation_config
+        gc.use_mtp = True
+        gc.do_sample = False
+        self.assertEqual(gc.get_generation_mode(), GenerationMode.MTP_DECODING)
+
+    def test_use_mtp_on_greedy_matches_plain_greedy(self):
+        """With random-init weights, rejection rate is high; MTP should fall back to bonus tokens from the base
+        model and reproduce plain greedy decoding token-for-token."""
+        for K in (1, 2, 3):
+            torch.manual_seed(0)
+            cfg = DeepseekV3Config(num_nextn_predict_layers=K, **DEEPSEEK_V3_TINY_KW)
+            model = DeepseekV3ForCausalLM(cfg).eval()
+            ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.long)
+            torch.manual_seed(0)
+            baseline = model.generate(ids, max_new_tokens=10, do_sample=False)
+            torch.manual_seed(0)
+            with_mtp = model.generate(ids, max_new_tokens=10, do_sample=False, use_mtp=True)
+            self.assertTrue(torch.equal(baseline, with_mtp), f"mismatch for K={K}: {baseline} vs {with_mtp}")
+
+    def test_use_mtp_without_mtp_layers_raises(self):
+        cfg = DeepseekV3Config(num_nextn_predict_layers=0, **DEEPSEEK_V3_TINY_KW)
+        model = DeepseekV3ForCausalLM(cfg).eval()
+        ids = torch.tensor([[1, 2, 3]], dtype=torch.long)
+        with self.assertRaisesRegex(ValueError, "num_nextn_predict_layers"):
+            model.generate(ids, max_new_tokens=3, do_sample=False, use_mtp=True)
+
+    def test_glm4_moe_greedy_match(self):
+        torch.manual_seed(0)
+        cfg = Glm4MoeConfig(num_nextn_predict_layers=2, **GLM4_MOE_TINY_KW)
+        model = Glm4MoeForCausalLM(cfg).eval()
+        ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.long)
+        torch.manual_seed(0)
+        baseline = model.generate(ids, max_new_tokens=8, do_sample=False)
+        torch.manual_seed(0)
+        with_mtp = model.generate(ids, max_new_tokens=8, do_sample=False, use_mtp=True)
+        self.assertTrue(torch.equal(baseline, with_mtp))
+
+
+@require_torch
+class MTPModelLoadingTest(unittest.TestCase):
+    def test_deepseek_v3_extends_layers(self):
+        cfg = DeepseekV3Config(num_nextn_predict_layers=2, **DEEPSEEK_V3_TINY_KW)
+        model = DeepseekV3ForCausalLM(cfg)
+        total = cfg.num_hidden_layers + cfg.num_nextn_predict_layers
+        self.assertEqual(len(model.model.layers), total)
+        self.assertEqual(type(model.model.layers[-1]).__name__, "DeepseekV3MTPLayer")
+        self.assertEqual(type(model.model.layers[cfg.num_hidden_layers - 1]).__name__, "DeepseekV3DecoderLayer")
+
+    def test_glm4_moe_extends_layers(self):
+        cfg = Glm4MoeConfig(num_nextn_predict_layers=1, **GLM4_MOE_TINY_KW)
+        model = Glm4MoeForCausalLM(cfg)
+        total = cfg.num_hidden_layers + cfg.num_nextn_predict_layers
+        self.assertEqual(len(model.model.layers), total)
+        self.assertEqual(type(model.model.layers[-1]).__name__, "Glm4MoeMTPLayer")
+
+    def test_base_forward_ignores_mtp_layers(self):
+        """Extending self.layers with MTP modules must not change the base forward output."""
+        torch.manual_seed(0)
+        cfg_no_mtp = DeepseekV3Config(num_nextn_predict_layers=0, **DEEPSEEK_V3_TINY_KW)
+        model_no_mtp = DeepseekV3ForCausalLM(cfg_no_mtp).eval()
+        base_state = model_no_mtp.state_dict()
+
+        torch.manual_seed(0)
+        cfg_mtp = DeepseekV3Config(num_nextn_predict_layers=1, **DEEPSEEK_V3_TINY_KW)
+        model_mtp = DeepseekV3ForCausalLM(cfg_mtp).eval()
+        # Copy the shared parameters so base-forward paths compare like-for-like.
+        mtp_state = model_mtp.state_dict()
+        for k, v in base_state.items():
+            if k in mtp_state:
+                mtp_state[k].copy_(v)
+
+        ids = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.long)
+        with torch.no_grad():
+            out_a = model_no_mtp(ids).logits
+            out_b = model_mtp(ids).logits
+        torch.testing.assert_close(out_a, out_b, atol=1e-5, rtol=1e-5)
+
+    def test_forward_mtp_shapes(self):
+        cfg = DeepseekV3Config(num_nextn_predict_layers=2, **DEEPSEEK_V3_TINY_KW)
+        model = DeepseekV3ForCausalLM(cfg).eval()
+        ids = torch.tensor([[1, 2, 3, 4]], dtype=torch.long)
+        with torch.no_grad():
+            base_out = model.model(ids, use_cache=True)
+            h = base_out.last_hidden_state[:, -1:, :]
+            cache = base_out.past_key_values
+            for depth in range(cfg.num_nextn_predict_layers):
+                tok = torch.tensor([[5 + depth]], dtype=torch.long)
+                pos = torch.tensor([[ids.shape[1] + depth]], dtype=torch.long)
+                h, logits = model.model.forward_mtp(
+                    input_ids=tok,
+                    previous_hidden_state=h,
+                    past_key_values=cache,
+                    position_ids=pos,
+                    mtp_depth=depth,
+                )
+                self.assertEqual(h.shape, (1, 1, cfg.hidden_size))
+                self.assertEqual(logits.shape, (1, 1, cfg.vocab_size))
+
+
+@require_torch
+class MTPContinuousBatchingTest(unittest.TestCase):
+    def test_generate_batch_with_use_mtp_raises_not_implemented(self):
+        from transformers import GenerationConfig
+        from transformers.generation.configuration_utils import ContinuousBatchingConfig
+        from transformers.generation.continuous_batching import ContinuousBatchingManager
+
+        cfg = DeepseekV3Config(num_nextn_predict_layers=1, **DEEPSEEK_V3_TINY_KW)
+        model = DeepseekV3ForCausalLM(cfg).eval()
+        gc = GenerationConfig(use_mtp=True, max_new_tokens=4)
+        with self.assertRaisesRegex(NotImplementedError, "use_mtp=True"):
+            ContinuousBatchingManager(model, gc, ContinuousBatchingConfig())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Wires MTP speculative decoding into `generate()` for DeepSeek-V3 and GLM-4 MoE, loading the MTP modules that ship in the original checkpoints (previously ignored via `_keys_to_ignore_on_load_unexpected`).
- New `GenerationConfig.use_mtp=True` opt-in (default `False`; no behavior change when off). Routes to a new `GenerationMode.MTP_DECODING` / `_mtp_decoding` that uses the model's own MTP heads as the draft, verifies in a single forward, reuses the existing `_speculative_sampling` helper.
- Adds a tiny `MTPLayer` (RMSNorm + concat-and-project + decoder block + `shared_head`) mirroring vLLM's `deepseek_mtp.py`. Base `forward` keeps iterating only `self.layers[:num_hidden_layers]`; MTP is reached via a new `model.forward_mtp(...)` helper.
- `_assisted_decoding` / `candidate_generator.py` are untouched.

## Scope

- `generate(..., use_mtp=True)` is supported for DeepSeek-V3 / GLM-4 MoE at `batch_size=1` with dynamic cache.
- `generate_batch` with `use_mtp=True` raises `NotImplementedError` for now — continuous batching needs paged-cache slot reservation (K+1 per MTP request) plus per-request accept/reject in `_forward_process_and_sample`. That will come as a follow-up PR so it gets a clean review on its own.
- Training-time MTP loss is explicitly out of scope.

## Design decisions

| | |
|---|---|
| Draft | Model's own MTP heads (shared weights + shared KV cache). |
| Path | Dedicated `_mtp_decoding`, not routed through `_assisted_decoding`. |
| Activation | Explicit `use_mtp=True`; depth = `config.num_nextn_predict_layers`. |
| Layout | Tail of `self.layers` holds MTP modules (matches the checkpoint key scheme `model.layers.{num_base + k}.*`). |

## Files

- **Generation:** `generation/configuration_utils.py` (new `use_mtp` flag + mode), `generation/utils.py` (new `_mtp_decoding`, mode registration, validation), `generation/continuous_batching/continuous_api.py` (explicit refusal for now).
- **Models:** `deepseek_v3/` and `glm4_moe/` modular/config/modeling. Downstream variants (`glm4_moe_lite`, `glm4v_moe`, `glm_moe_dsa`, `longcat_flash`, `solar_open`, `youtu`) got regenerated with the new field propagated through the modular chain.
- **Tests:** new `tests/generation/test_mtp.py`.

## Test plan

- [x] `pytest tests/generation/test_mtp.py` — 9/9 passing:
  - `use_mtp=True` routes to `GenerationMode.MTP_DECODING`.
  - Greedy output matches plain `_sample` token-for-token for K=1/2/3 on DeepSeek-V3 and GLM-4 MoE (random-init, so drafts usually miss → verified bonus-token fallback path).
  - `use_mtp=True` with `num_nextn_predict_layers == 0` raises a clear `ValueError`.
  - Base forward output is unchanged when MTP layers are added (shared-weight copy + compare).
  - `model.forward_mtp` produces `(hidden, logits)` of the expected shapes.
  - `ContinuousBatchingManager(..., GenerationConfig(use_mtp=True))` raises `NotImplementedError`.
- [x] `pytest tests/generation/test_candidate_generator.py tests/generation/test_configuration_utils.py` — unchanged / green (regression check).
- [x] Import smoke-test on every modular-regenerated downstream model (`glm4_moe_lite`, `glm4v_moe`, `glm_moe_dsa`, `longcat_flash`, `solar_open`, `youtu`).
- [x] `make style` clean.
- [x] `make fix-repo` clean apart from a pre-existing `mlinter._using_rule_specs` / `check_modeling_structure.py --rules-toml` toolchain mismatch that also fails on an unmodified checkout — unrelated to this PR.

## Follow-ups

- `generate_batch` + MTP (paged-cache reservation, per-request accept/reject).
- Prefill through the MTP layers during the initial forward, to seed their KV caches for better draft quality (currently each step's MTP self-attn only sees the current query token; degraded acceptance vs vLLM but correct).
- Real-weight end-to-end test on `deepseek-ai/DeepSeek-V3` once GPU capacity is available.