### PR TITLE
[MistralCommonBackend] Soften validation mode and apply_chat_template arguments check

### DIFF
--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1180,7 +1180,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
                 tools=tools,
                 continue_final_message=continue_final_message,
                 reasoning_effort=reasoning_effort,
-                **kwargs
+                **kwargs,
             )
 
             tokenized_request = self.tokenizer.encode_chat_completion(chat_request)
@@ -1590,9 +1590,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
     @staticmethod
     def _get_validation_mode(mode: str | ValidationMode) -> ValidationMode:
         """Get the validation mode from a string or a ValidationMode."""
-        _invalid_mode_msg = (
-            f"Invalid `mistral-common` tokenizer mode: {mode}. Possible values are {', '.join([vm.value for vm in list(ValidationMode)])}."
-        )
+        _invalid_mode_msg = f"Invalid `mistral-common` tokenizer mode: {mode}. Possible values are {', '.join([vm.value for vm in list(ValidationMode)])}."
         if isinstance(mode, str):
             try:
                 mode = ValidationMode[mode]

--- a/src/transformers/tokenization_mistral_common.py
+++ b/src/transformers/tokenization_mistral_common.py
@@ -1090,16 +1090,11 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
                 If not specified, the default reasoning effort will be used.
 
             kwargs (additional keyword arguments, *optional*):
-                Not supported by `MistralCommonBackend.apply_chat_template`.
-                Will raise an error if used.
+                Additional arguments passed to the mistral-common `ChatCompletionRequest.from_openai` method.
 
         Returns:
             `Union[str, list[int], list[str], list[list[int]], BatchEncoding]`: The tokenized chat so far, including control tokens. This output is ready to pass to the model, either directly or via methods like `generate()`.
         """
-        if kwargs:
-            raise ValueError(
-                f"Kwargs {list(kwargs.keys())} are not supported by `MistralCommonBackend.apply_chat_template`."
-            )
         if not isinstance(truncation, bool):
             raise TypeError("`truncation` must be a boolean for `apply_chat_template` method.")
 
@@ -1185,6 +1180,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
                 tools=tools,
                 continue_final_message=continue_final_message,
                 reasoning_effort=reasoning_effort,
+                **kwargs
             )
 
             tokenized_request = self.tokenizer.encode_chat_completion(chat_request)
@@ -1595,7 +1591,7 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
     def _get_validation_mode(mode: str | ValidationMode) -> ValidationMode:
         """Get the validation mode from a string or a ValidationMode."""
         _invalid_mode_msg = (
-            f"Invalid `mistral-common` tokenizer mode: {mode}. Possible values are 'finetuning' or 'test'."
+            f"Invalid `mistral-common` tokenizer mode: {mode}. Possible values are {', '.join([vm.value for vm in list(ValidationMode)])}."
         )
         if isinstance(mode, str):
             try:
@@ -1605,8 +1601,6 @@ class MistralCommonBackend(PreTrainedTokenizerBase):
         elif not isinstance(mode, (str, ValidationMode)):
             raise ValueError(_invalid_mode_msg)
 
-        if mode not in [ValidationMode.finetuning, ValidationMode.test]:
-            raise ValueError(_invalid_mode_msg)
         return mode
 
     def __repr__(self) -> str:

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -902,9 +902,6 @@ class TestMistralCommonBackend(unittest.TestCase):
             expected_tokenized.tokens,
         )
 
-        with self.assertRaises(ValueError, msg="Invalid parameters passed to `ChatCompletionRequest.from_openai`"):
-            self.tokenizer.apply_chat_template(conversation, tokenize=True, unk_args="")
-
     def test_apply_chat_template_continue_final_message(self):
         conversation = [
             {"role": "system", "content": "You are a helpful assistant."},
@@ -1265,12 +1262,6 @@ class TestMistralCommonBackend(unittest.TestCase):
         for text, token, expected in zip(text_outputs, token_outputs, expected_tokenized):
             self.assertEqual(text, expected.text)
             self.assertEqual(token, expected.tokens)
-
-        with self.assertRaises(
-            ValueError,
-            msg="Invalid parameters passed to `ChatCompletionRequest.from_openai`",
-        ):
-            self.tokenizer.apply_chat_template(conversations, tools=tools, tokenize=True, unk_args="")
 
     def test_batch_apply_chat_template_images(self):
         conversations = [

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -903,7 +903,7 @@ class TestMistralCommonBackend(unittest.TestCase):
         )
 
         with self.assertRaises(
-            ValueError, msg="Kwargs [unk_args] are not supported by `MistralCommonBackend.apply_chat_template`."
+            ValueError, msg="Invalid parameters passed to `ChatCompletionRequest.from_openai`"
         ):
             self.tokenizer.apply_chat_template(conversation, tokenize=True, unk_args="")
 
@@ -1270,7 +1270,7 @@ class TestMistralCommonBackend(unittest.TestCase):
 
         with self.assertRaises(
             ValueError,
-            msg="Kwargs [unk_args] are not supported by `MistralCommonBackend.batch_apply_chat_template`.",
+            msg="Invalid parameters passed to `ChatCompletionRequest.from_openai`",
         ):
             self.tokenizer.apply_chat_template(conversations, tools=tools, tokenize=True, unk_args="")
 
@@ -2140,10 +2140,12 @@ class TestMistralCommonBackend(unittest.TestCase):
             (ValidationMode.test, ValidationMode.test),
             ("finetuning", ValidationMode.finetuning),
             (ValidationMode.finetuning, ValidationMode.finetuning),
+            ("serving", ValidationMode.serving),
+            (ValidationMode.serving, ValidationMode.serving),
         ]:
             self.assertEqual(MistralCommonBackend._get_validation_mode(mode), expected)
 
-        for invalid_mode in [("serving", ValidationMode.serving, "invalid", 1)]:
+        for invalid_mode in ["invalid", 1]:
             with self.assertRaises(ValueError):
                 MistralCommonBackend._get_validation_mode(invalid_mode)
 

--- a/tests/test_tokenization_mistral_common.py
+++ b/tests/test_tokenization_mistral_common.py
@@ -902,9 +902,7 @@ class TestMistralCommonBackend(unittest.TestCase):
             expected_tokenized.tokens,
         )
 
-        with self.assertRaises(
-            ValueError, msg="Invalid parameters passed to `ChatCompletionRequest.from_openai`"
-        ):
+        with self.assertRaises(ValueError, msg="Invalid parameters passed to `ChatCompletionRequest.from_openai`"):
             self.tokenizer.apply_chat_template(conversation, tokenize=True, unk_args="")
 
     def test_apply_chat_template_continue_final_message(self):


### PR DESCRIPTION
# What does this PR do?

This PR soften validation and apply_chat_template arguments check. This is to avoid upon new Mistral model releases the need to patch this backend and force users to install main.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

@ArthurZucker and @itazap

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
