### PR TITLE
Make patched testing debug logs xdist-safe

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3611,9 +3611,9 @@ def _prepare_debugging_info(test_info, info):
     """Combine the information about the test and the call information to a patched function/method within it."""
 
     info = f"{test_info}\n\n{info}"
-    p = os.path.join(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""), "captured_info.txt")
-    # TODO (ydshieh): This is not safe when we use pytest-xdist with more than 1 worker.
-    with open(p, "a") as fp:
+    output_path = _get_patched_testing_methods_output_file()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("a") as fp:
         fp.write(f"{info}\n\n{'=' * 120}\n\n")
 
     return info
@@ -3836,6 +3836,28 @@ def _parse_call_info(func, args, kwargs, call_argument_expressions, target_args)
     return info
 
 
+def _get_patched_testing_methods_output_file() -> Path:
+    """Return the output file used by patched assertion methods.
+
+    Under `pytest-xdist`, workers run in separate processes but can share the same output directory. Using a worker-
+    specific file avoids concurrent writes and resets clobbering each other's captured debugging information.
+    """
+
+    output_dir = Path(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""))
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    filename = f"captured_info_{worker_id}.txt" if worker_id else "captured_info.txt"
+    return output_dir / filename
+
+
+def _reset_patched_testing_methods_output_file() -> Path:
+    """Clear the output file used by patched assertion methods and return its path."""
+
+    output_path = _get_patched_testing_methods_output_file()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.unlink(missing_ok=True)
+    return output_path
+
+
 def patch_testing_methods_to_collect_info():
     """
     Patch some methods (`torch.testing.assert_close`, `unittest.case.TestCase.assertEqual`, etc).
@@ -3843,8 +3865,7 @@ def patch_testing_methods_to_collect_info():
     This will allow us to collect the call information, e.g. the argument names and values, also the literal expressions
     passed as the arguments.
     """
-    p = os.path.join(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""), "captured_info.txt")
-    Path(p).unlink(missing_ok=True)
+    _reset_patched_testing_methods_output_file()
 
     if is_torch_available():
         import torch

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3612,7 +3612,6 @@ def _prepare_debugging_info(test_info, info):
 
     info = f"{test_info}\n\n{info}"
     output_path = _get_patched_testing_methods_output_file()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("a") as fp:
         fp.write(f"{info}\n\n{'=' * 120}\n\n")
 
@@ -3853,7 +3852,6 @@ def _reset_patched_testing_methods_output_file() -> Path:
     """Clear the output file used by patched assertion methods and return its path."""
 
     output_path = _get_patched_testing_methods_output_file()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.unlink(missing_ok=True)
     return output_path
 

--- a/tests/utils/test_testing_utils.py
+++ b/tests/utils/test_testing_utils.py
@@ -1,0 +1,86 @@
+# Copyright 2020 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from transformers import testing_utils
+
+
+class PatchedTestingMethodsOutputFileTest(unittest.TestCase):
+    def test_get_output_file_without_xdist_worker(self):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch.dict(os.environ, {"_PATCHED_TESTING_METHODS_OUTPUT_DIR": tmpdir}, clear=True),
+        ):
+            output_path = testing_utils._get_patched_testing_methods_output_file()
+
+        self.assertEqual(output_path, Path(tmpdir) / "captured_info.txt")
+
+    def test_get_output_file_with_xdist_worker(self):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch.dict(
+                os.environ,
+                {
+                    "_PATCHED_TESTING_METHODS_OUTPUT_DIR": tmpdir,
+                    "PYTEST_XDIST_WORKER": "gw2",
+                },
+                clear=True,
+            ),
+        ):
+            output_path = testing_utils._get_patched_testing_methods_output_file()
+
+        self.assertEqual(output_path, Path(tmpdir) / "captured_info_gw2.txt")
+
+    def test_prepare_debugging_info_writes_worker_specific_file(self):
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            mock.patch.dict(
+                os.environ,
+                {
+                    "_PATCHED_TESTING_METHODS_OUTPUT_DIR": tmpdir,
+                    "PYTEST_XDIST_WORKER": "gw1",
+                },
+                clear=True,
+            ),
+        ):
+            output_path = Path(tmpdir) / "captured_info_gw1.txt"
+            rendered_info = testing_utils._prepare_debugging_info("test-info", "payload")
+            self.assertEqual(rendered_info, "test-info\n\npayload")
+            self.assertTrue(output_path.exists())
+            self.assertIn("test-info\n\npayload", output_path.read_text())
+
+    def test_reset_only_clears_current_worker_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            current_worker_path = Path(tmpdir) / "captured_info_gw0.txt"
+            other_worker_path = Path(tmpdir) / "captured_info_gw1.txt"
+            current_worker_path.write_text("current worker")
+            other_worker_path.write_text("other worker")
+
+            with mock.patch.dict(
+                os.environ,
+                {
+                    "_PATCHED_TESTING_METHODS_OUTPUT_DIR": tmpdir,
+                    "PYTEST_XDIST_WORKER": "gw0",
+                },
+                clear=True,
+            ):
+                output_path = testing_utils._reset_patched_testing_methods_output_file()
+                self.assertEqual(output_path, current_worker_path)
+                self.assertFalse(current_worker_path.exists())
+                self.assertTrue(other_worker_path.exists())

--- a/tests/utils/test_testing_utils.py
+++ b/tests/utils/test_testing_utils.py
@@ -12,13 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib.util
 import os
+import sys
 import tempfile
+import types
 import unittest
 from pathlib import Path
 from unittest import mock
 
 from transformers import testing_utils
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_notification_service_module():
+    module_path = REPO_ROOT / "utils" / "notification_service.py"
+    spec = importlib.util.spec_from_file_location("notification_service_for_tests", module_path)
+    module = importlib.util.module_from_spec(spec)
+    stub_modules = {
+        "compare_test_runs": types.SimpleNamespace(compare_job_sets=lambda *args, **kwargs: None),
+        "get_ci_error_statistics": types.SimpleNamespace(get_jobs=lambda *args, **kwargs: []),
+        "get_previous_daily_ci": types.SimpleNamespace(
+            get_last_daily_ci_reports=lambda *args, **kwargs: None,
+            get_last_daily_ci_run=lambda *args, **kwargs: None,
+            get_last_daily_ci_workflow_run_id=lambda *args, **kwargs: None,
+        ),
+        "huggingface_hub": types.SimpleNamespace(HfApi=object),
+        "slack_sdk": types.SimpleNamespace(WebClient=object),
+    }
+    with mock.patch.dict(sys.modules, stub_modules):
+        spec.loader.exec_module(module)
+    return module
 
 
 class PatchedTestingMethodsOutputFileTest(unittest.TestCase):
@@ -84,3 +110,35 @@ class PatchedTestingMethodsOutputFileTest(unittest.TestCase):
                 self.assertEqual(output_path, current_worker_path)
                 self.assertFalse(current_worker_path.exists())
                 self.assertTrue(other_worker_path.exists())
+
+
+class RetrieveArtifactCapturedInfoTest(unittest.TestCase):
+    def test_retrieve_artifact_preserves_legacy_captured_info_file(self):
+        notification_service = _load_notification_service_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_dir = Path(tmpdir)
+            (artifact_dir / "captured_info.txt").write_text("legacy info")
+
+            artifact = notification_service.retrieve_artifact(str(artifact_dir), gpu=None)
+
+        self.assertEqual(artifact["captured_info"], "legacy info")
+
+    def test_retrieve_artifact_merges_worker_specific_captured_info_files(self):
+        notification_service = _load_notification_service_module()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            artifact_dir = Path(tmpdir)
+            (artifact_dir / "captured_info_gw1.txt").write_text("gw1 info")
+            (artifact_dir / "captured_info_gw0.txt").write_text("gw0 info")
+            (artifact_dir / "summary_short.txt").write_text("FAILED test_example\n")
+
+            artifact = notification_service.retrieve_artifact(str(artifact_dir), gpu="multi")
+
+        self.assertEqual(artifact["summary_short"], "FAILED test_example\n")
+        self.assertIn("captured_info_gw0.txt", artifact["captured_info"])
+        self.assertIn("gw0 info", artifact["captured_info"])
+        self.assertIn("captured_info_gw1.txt", artifact["captured_info"])
+        self.assertIn("gw1 info", artifact["captured_info"])
+        self.assertNotIn("captured_info_gw0", artifact)
+        self.assertNotIn("captured_info_gw1", artifact)

--- a/utils/notification_service.py
+++ b/utils/notification_service.py
@@ -935,15 +935,32 @@ def retrieve_artifact(artifact_path: str, gpu: str | None):
         raise ValueError(f"Invalid GPU for artifact. Passed GPU: `{gpu}`.")
 
     _artifact = {}
+    captured_info = []
 
     if os.path.exists(artifact_path):
-        files = os.listdir(artifact_path)
+        files = sorted(os.listdir(artifact_path))
         for file in files:
             try:
                 with open(os.path.join(artifact_path, file)) as f:
-                    _artifact[file.split(".")[0]] = f.read()
+                    content = f.read()
             except UnicodeDecodeError as e:
                 raise ValueError(f"Could not open {os.path.join(artifact_path, file)}.") from e
+
+            artifact_name = file.split(".")[0]
+            if artifact_name == "captured_info" or artifact_name.startswith("captured_info_"):
+                captured_info.append((file, content))
+                continue
+
+            _artifact[artifact_name] = content
+
+    if captured_info:
+        if len(captured_info) == 1 and captured_info[0][0] == "captured_info.txt":
+            _artifact["captured_info"] = captured_info[0][1]
+        else:
+            separator = f"\n\n{'=' * 120}\n\n"
+            _artifact["captured_info"] = separator.join(
+                f"{file}\n{'-' * len(file)}\n{content}" for file, content in captured_info
+            )
 
     return _artifact
 


### PR DESCRIPTION
Fixes #45561

Patched testing debug logs. Instead of having all workers write to the same `captured_info.txt` file, each `pytest-xdist` worker now writes to its own `captured_info_<worker>.txt` file, while non-`xdist` runs keep the existing `captured_info.txt` behavior. Resetting the logs now clears only the current worker's file.

The reporting path was updated as well so worker-specific `captured_info*.txt` files are aggregated back into the existing `captured_info` reporting field.

I did not find an existing PR covering this narrower fix.

Tests:
- `python -m pytest tests/utils/test_testing_utils.py -q`
- `python -m ruff check tests/utils/test_testing_utils.py utils/notification_service.py`
- `python -m ruff format --check tests/utils/test_testing_utils.py utils/notification_service.py`
