### PR TITLE
Fix SDPA inference tolerances for MPS backend

### DIFF
--- a/tests/models/video_llama_3/test_modeling_video_llama_3.py
+++ b/tests/models/video_llama_3/test_modeling_video_llama_3.py
@@ -236,7 +236,7 @@ def _test_encoder_eager_matches_sdpa_inference(
             elif torch_device == "hpu":
                 atol = atols["cuda", enable_kernels, dtype]
                 rtol = rtols["cuda", enable_kernels, dtype]
-            elif torch_device == "xpu":
+            elif torch_device in ("xpu", "mps"):
                 # As of PyTorch 2.5 XPU backend supports only torch.nn.attention.SDPBackend.MATH
                 # which is implemented on PyTorch level using aten operators and is
                 # device agnostic with respect to implementation of each aten operator.

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -465,7 +465,7 @@ def _test_eager_matches_sdpa_inference(
             elif torch_device in ["hpu", "npu"]:
                 atol = atols["cuda", enable_kernels, dtype]
                 rtol = rtols["cuda", enable_kernels, dtype]
-            elif torch_device == "xpu":
+            elif torch_device in ("xpu", "mps"):
                 # As of PyTorch 2.5 XPU backend supports only torch.nn.attention.SDPBackend.MATH
                 # which is implemented on PyTorch level using aten operators and is
                 # device agnostic with respect to implementation of each aten operator.


### PR DESCRIPTION
Fixes #45644

This PR adjusts `test_eager_matches_sdpa_inference` on the MPS backend by routing `"mps"` through the same tolerance branch as `"xpu"` in:

- `tests/test_modeling_common.py`
- `tests/models/video_llama_3/test_modeling_video_llama_3.py`

The previous default tolerances were too strict for fp16 on MPS and caused spurious test failures.