### PR TITLE
Fix colmodernvbert tests

### DIFF
--- a/tests/models/colmodernvbert/test_modeling_colmodernvbert.py
+++ b/tests/models/colmodernvbert/test_modeling_colmodernvbert.py
@@ -67,7 +67,6 @@ class ColModernVBertForRetrievalModelTester:
                 "intermediate_size": 64,
                 "hidden_activation": "gelu",
                 "mlp_dropout": 0.1,
-                "attention_dropout": 0.1,
                 "embedding_dropout": 0.1,
                 "classifier_dropout": 0.1,
                 "max_position_embeddings": 512,

--- a/tests/models/colmodernvbert/test_modeling_colmodernvbert.py
+++ b/tests/models/colmodernvbert/test_modeling_colmodernvbert.py
@@ -63,7 +63,7 @@ class ColModernVBertForRetrievalModelTester:
                 "pad_token_id": 0,
                 "hidden_size": 32,
                 "num_hidden_layers": 2,
-                "num_attention_heads": 4,
+                "num_attention_heads": 2,
                 "intermediate_size": 64,
                 "hidden_activation": "gelu",
                 "mlp_dropout": 0.1,


### PR DESCRIPTION
# What does this PR do?

Now that modernbert uses the right way to get the attention since https://github.com/huggingface/transformers/pull/45598, it supports `_can_set_attn_implementation` and in turn flex attention. Flex attention does not support dropout, nor head_dim<16.