### PR TITLE
[CB] Refactor any model-related code in a separate class

### DIFF
--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1739,12 +1739,6 @@ class ContinuousBatchingConfig:
     # are kept but warnings are logged for unsupported/unknown ones.
     drop_unsupported_processors: bool = True
 
-    @property
-    def fallback_max_blocks_per_request(self) -> int:
-        """Returns the fallback max blocks per request. If no user-hint is given and decode path is available, this is
-        the default max blocks per request. With default block size of 256, this means a max sequence length of 8192
-        tokens for the fast decode path."""
-        return 32
 
     def account_for_cb_deprecated_arguments(
         self,
@@ -1785,54 +1779,6 @@ class ContinuousBatchingConfig:
                 "through the continuous_batching_config: " + ", ".join(kwargs_to_warn)
             )
 
-    def decide_use_cuda_graphs(self, compile_config: CompileConfig | None, is_attn_mask_needed: bool) -> None:
-        """Decides whether or not to use cuda graphs for continuous batching. If the user specified this in the config
-        or if they specified a parameter related to cuda graphs, they are turned on. Otherwise, we use a heuristic
-        based on the attention implementation: we turn on cuda graphs if and only if no attention mask is needed.
-
-        This function modifies the `use_cuda_graph` attribute of the config in place, to a tuple of booleans.
-        """
-        # If cuda is not available, we cannot use cuda graphs
-        import torch
-
-        if not torch.cuda.is_available():
-            intended_use_cuda_graph = any(self.get_cuda_graph_booleans())
-            if intended_use_cuda_graph:  # throw a warning only if the user intended to use cuda graphs
-                logger.warning(f"{self.use_cuda_graph = } but {torch.cuda.is_available() = }: turning off cuda graphs")
-            self.use_cuda_graph = (False, False)
-
-        # Else if use_cuda_graph is specified, we follow the user's choice and make sure it is a tuple of booleans
-        elif self.use_cuda_graph is not None:
-            if isinstance(self.use_cuda_graph, bool):
-                self.use_cuda_graph = (self.use_cuda_graph, self.use_cuda_graph)
-
-        # Else if the user specified a parameter related to cuda graphs, we activate cuda graphs
-        elif self.q_padding_interval_size or self.kv_padding_interval_size or self.max_cached_graphs:
-            self.use_cuda_graph = (True, True)
-
-        # Else if a compile config was found, turn off cuda graphs if the compile config already uses them
-        elif compile_config is not None:
-            options = torch._inductor.list_mode_options().get(compile_config.mode, compile_config.options)
-            compile_uses_cudagraphs = options.get("triton.cudagraphs", False)
-            if compile_uses_cudagraphs:
-                logger.warning(
-                    f"Compile config {compile_config.mode = } uses cudagraphs, which usually does not work well with "
-                    "continuous batching. We recommend using mode 'default' or 'max-autotune-no-cudagraphs' instead."
-                )
-            use_cuda_graph = not compile_uses_cudagraphs  # TODO: should this also match the dynamic shapes?
-            self.use_cuda_graph = (use_cuda_graph, use_cuda_graph)
-
-        # Otherwise we have a default heuristic based on the attention implementation:
-        # attention implementations where an attention mask is needed suffer a lot more from the padding associated
-        # with cuda graphs, so default is to turn cuda graphs off for those implementations
-        else:
-            use_cuda_graph = not is_attn_mask_needed
-            self.use_cuda_graph = (use_cuda_graph, use_cuda_graph)
-            logger.warning(
-                f"No behavior specified for use_cuda_graph, defaulting to {self.use_cuda_graph = } because "
-                f"{is_attn_mask_needed = }. If you want to save memory, turn off cuda graphs, but they tend to improve "
-                "performances by a lot."
-            )
 
     def get_cuda_graph_booleans(self) -> tuple[bool, bool]:
         """Returns the cuda graph booleans for the varlen and decode paths."""
@@ -1842,87 +1788,8 @@ class ContinuousBatchingConfig:
             return self.use_cuda_graph, self.use_cuda_graph
         return self.use_cuda_graph
 
-    def decide_use_async_batching(self, is_attn_mask_needed: bool) -> bool:
-        """Returns whether or not to use asynchronous batching for continuous batching. If the user specified this in
-        the config, we follow their choice. Otherwise, we turn on asynchronous batching if and only if CUDA graphs are
-        turned on and no attention mask is needed.
 
-        This function modifies the `use_async_batching` attribute of the config in place.
-        """
-        # If the user specifies to use async or not, no need to decide ourselves
-        if self.use_async_batching is None:
-            use_cuda_graphs = any(self.get_cuda_graph_booleans())
-            self.use_async_batching = use_cuda_graphs and not is_attn_mask_needed
-            logger.info(
-                f"No behavior specified for use_async_batching, choosing {self.use_async_batching = } because "
-                f"{use_cuda_graphs = } and {not is_attn_mask_needed = }. If you want to save memory, you can "
-                "disable asynchronous batching but it will degrade performance."
-            )
-        return self.use_async_batching
-
-    def resolve_max_memory_percent(self, has_logit_processors: bool) -> None:
-        """Resolves `max_memory_percent` when unset: 0.9 without logit processors, 0.8 with them. Active processors
-        materialize `[N, V]` intermediates (e.g. top-p sort, softmax) that get captured into the CUDA graph pool, so
-        the cache has to cede some budget to that pool."""
-        if self.max_memory_percent is None:
-            self.max_memory_percent = 0.8 if has_logit_processors else 0.9
-
-    def resolve_sentinel_values(self) -> None:
-        """For some parameters (padding intervals and max cached graphs), the default is a sentinel value of 0: that
-        way, if the user specifies a value for those parameters, we know they want it used, ie. we turn on cuda graphs.
-        But in the case the user does not specify those values, we still need them to resolve to a non-zero value.
-        This function takes care of that."""
-        # Interval sizes are in tokens for both Q and KV
-        if self.q_padding_interval_size == 0:
-            self.q_padding_interval_size = 64
-        if self.kv_padding_interval_size == 0:
-            self.kv_padding_interval_size = 64 * 256  # 64 blocks of 256 tokens ie. 16384 tokens
-        if self.max_cached_graphs == 0:
-            self.max_cached_graphs = 32
-
-    def resolve_compile_configs(
-        self, fallback_compile_config: CompileConfig | None, is_flash_attn: bool, decode_fast_path_available: bool
-    ) -> None:
-        """Resolve if the compile configs for varlen and decode paths, modifying these attributes in place if needed.
-        Default config use full compile over regional compile, because the throughput is significantly higher (~15%)"""
-        logger_ = logging.get_logger("ContinuousBatchingLogger")
-
-        # For each config, priority is: explicit config, default config, fallback config, None
-        if self.varlen_compile_config is None:
-            if self.use_default_compile_configs:
-                # We don't use compile with flash varlen, because max_seqlen_k is volatile and introduces recompilations
-                if is_flash_attn:
-                    varlen_config = None
-                else:
-                    varlen_config = CompileConfig(mode="max-autotune-no-cudagraphs", fullgraph=True, dynamic=True)
-            elif fallback_compile_config is not None:
-                varlen_config = fallback_compile_config
-            else:
-                varlen_config = None
-        else:
-            varlen_config = self.varlen_compile_config
-
-        if self.decode_compile_config is None:
-            if self.use_default_compile_configs:
-                # Paged attention is wrapped in @torch.compiler.disable so we can't use fullgraph
-                decode_config = CompileConfig(mode="max-autotune-no-cudagraphs", fullgraph=False, dynamic=False)
-            elif fallback_compile_config is not None:
-                decode_config = fallback_compile_config
-            else:
-                decode_config = None
-        else:
-            decode_config = self.decode_compile_config
-
-        # For decode, we throw a warning if the fast decode path is not available and a compile config was found
-        if not decode_fast_path_available and self.decode_compile_config is not None:
-            decode_config = None
-            logger_.warning("A decode_compile_config was set but fast decode path is not available. Ignoring it.")
-
-        # Log what will be compiled
-        if varlen_config is not None:
-            logger_.info(f"Varlen path will be compiled with {varlen_config.to_dict()}")
-        if decode_config is not None:
-            logger_.info(f"Decode path will be compiled with {decode_config.to_dict()}")
-        # Modify in place
-        self.varlen_compile_config = varlen_config
-        self.decode_compile_config = decode_config
+    @property
+    def fallback_max_blocks_per_request(self) -> int:
+        """Returns the max blocks per request."""
+        return 32

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1739,7 +1739,6 @@ class ContinuousBatchingConfig:
     # are kept but warnings are logged for unsupported/unknown ones.
     drop_unsupported_processors: bool = True
 
-
     def account_for_cb_deprecated_arguments(
         self,
         max_queue_size: int = 0,
@@ -1779,7 +1778,6 @@ class ContinuousBatchingConfig:
                 "through the continuous_batching_config: " + ", ".join(kwargs_to_warn)
             )
 
-
     def get_cuda_graph_booleans(self) -> tuple[bool, bool]:
         """Returns the cuda graph booleans for the varlen and decode paths."""
         if self.use_cuda_graph is None:
@@ -1787,7 +1785,6 @@ class ContinuousBatchingConfig:
         if isinstance(self.use_cuda_graph, bool):
             return self.use_cuda_graph, self.use_cuda_graph
         return self.use_cuda_graph
-
 
     @property
     def fallback_max_blocks_per_request(self) -> int:

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1741,7 +1741,9 @@ class ContinuousBatchingConfig:
 
     @property
     def fallback_max_blocks_per_request(self) -> int:
-        """A good default for the size of the block table for the decode path"""
+        """Returns the fallback max blocks per request. If no user-hint is given and decode path is available, this is
+        the default max blocks per request. With default block size of 256, this means a max sequence length of 8192
+        tokens for the fast decode path."""
         return 32
 
     def account_for_cb_deprecated_arguments(

--- a/src/transformers/generation/configuration_utils.py
+++ b/src/transformers/generation/configuration_utils.py
@@ -1778,8 +1778,9 @@ class ContinuousBatchingConfig:
                 "through the continuous_batching_config: " + ", ".join(kwargs_to_warn)
             )
 
-    def get_cuda_graph_booleans(self) -> tuple[bool, bool]:
-        """Returns the cuda graph booleans for the varlen and decode paths."""
+    @property
+    def cuda_graph_booleans(self) -> tuple[bool, bool]:
+        """The cuda graph booleans for the varlen and decode paths."""
         if self.use_cuda_graph is None:
             return False, False
         if isinstance(self.use_cuda_graph, bool):

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -222,15 +222,10 @@ class PagedAttentionCache:
             f"{self.max_batch_tokens = } {num_attention_masks = }"
         )
 
-        # If max_blocks_per_request is not set, the default value is 16 max blocks. With default block size of 256, this
-        # means a max sequence length of 4096 tokens for the fast decode path.
+        # If max_blocks_per_request is not set, initialize it to the non-zero fallback value
         max_blocks_per_request = continuous_batching_config.max_blocks_per_request
         if max_blocks_per_request is None:
-            max_blocks_per_request = 0
-            # logger.info( TODO: uncomment when we have good defaults
-            #     f"max_blocks_per_request was not set, using {max_blocks_per_request}. This means max sequence "
-            #     f"length for the decode fast path is {max_blocks_per_request * self.block_size}."
-            # )
+            max_blocks_per_request = continuous_batching_config._fallback_max_blocks_per_request
         self.max_blocks_per_request = max_blocks_per_request
 
         # Initialize the cache

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -225,7 +225,7 @@ class PagedAttentionCache:
         # If max_blocks_per_request is not set, initialize it to the non-zero fallback value
         max_blocks_per_request = continuous_batching_config.max_blocks_per_request
         if max_blocks_per_request is None:
-            max_blocks_per_request = continuous_batching_config._fallback_max_blocks_per_request
+            max_blocks_per_request = continuous_batching_config.fallback_max_blocks_per_request
         self.max_blocks_per_request = max_blocks_per_request
 
         # Initialize the cache

--- a/src/transformers/generation/continuous_batching/cache.py
+++ b/src/transformers/generation/continuous_batching/cache.py
@@ -22,6 +22,7 @@ from ...generation.configuration_utils import ContinuousBatchingConfig
 from ...utils.generic import is_flash_attention_requested
 from ...utils.metrics import attach_tracer, traced
 from .cache_manager import BlockManager, CacheAllocator, FullAttentionCacheAllocator, SlidingAttentionCacheAllocator
+from .initialization import resolve_max_memory_percent
 from .requests import RequestState, RequestStatus, get_device_and_memory_breakdown, logger
 
 
@@ -204,7 +205,7 @@ class PagedAttentionCache:
 
         # If somehow the max memory percent is not yet resolved, resolve it conservatively
         if continuous_batching_config.max_memory_percent is None:
-            continuous_batching_config.resolve_max_memory_percent(has_logit_processors=True)
+            resolve_max_memory_percent(cb_config=continuous_batching_config, has_logit_processors=True)
 
         num_blocks, max_batch_tokens = memory_handler.infer_num_blocks_and_max_batch_tokens(
             num_blocks=continuous_batching_config.num_blocks,

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -498,6 +498,13 @@ class ContinuousBatchProcessor:
         # mode.
         self.inputs_and_outputs.retrieve_device_outputs()
 
+    @torch.inference_mode()
+    def warmup(self, model: nn.Module) -> None:
+        """Pre-capture CUDA graphs (or trigger compile warmup) for varlen and decode paths. In async mode, both IO
+        pairs are warmed up since each has its own graph buffer and static tensors. The varlen path is warmed up at
+        the largest possible `(q, kv)` sizes so subsequent captures fit inside it without growing the pool."""
+        self.model_runner.warmup(model)
+
 
 # Manager Class (User Interface)
 @attach_tracer()

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -30,19 +30,18 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from ...configuration_utils import PretrainedConfig
 from ...generation.configuration_utils import ContinuousBatchingConfig, GenerationConfig
-from ...modeling_flash_attention_utils import lazy_import_paged_flash_attention
-from ...utils.generic import is_flash_attention_requested
 from ...utils.logging import logging
 from ...utils.metrics import ContinuousBatchProcessorMetrics, attach_tracer, traced
 from ..logits_process import LogitsProcessorList
 from .cache import PagedAttentionCache
 from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
+from .initialization import resolve_continuous_batching_config
 from .input_outputs import ContinuousBatchingAsyncIOs, ContinuousBatchingIOs
 from .model_runner import ModelRunner
 from .offloading_manager import OffloadingManager
 from .requests import GenerationOutput, RequestState, RequestStatus, logger
 from .scheduler import SCHEDULER_MAPPING, FIFOScheduler, Scheduler
-from .utils import WorkloadHints, attn_mask_is_needed, create_warmup_future_states, pad_to_interval
+from .utils import WorkloadHints
 
 
 """
@@ -188,15 +187,7 @@ class ContinuousBatchProcessor:
         self.max_batch_tokens = cache.max_batch_tokens
         self.metrics = ContinuousBatchProcessorMetrics(cache.max_batch_tokens)
 
-        # If the user turned on the decode fast path (ie. using a block table), check if it is available
-        self._ensure_decode_fast_path_is_available()  # this needs to happen before self.inputs_and_outputs is created
-
         # Resolve compile behavior
-        self.cb_config.resolve_compile_configs(
-            fallback_compile_config=getattr(generation_config, "compile_config", None),
-            is_flash_attn=is_flash_attention_requested(config=config),
-            decode_fast_path_available=self.cache.max_blocks_per_request > 0,
-        )
         use_compile = self.cb_config.varlen_compile_config is not None
         use_compile |= self.cb_config.decode_compile_config is not None
 
@@ -255,39 +246,6 @@ class ContinuousBatchProcessor:
         gc.collect()
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-
-    def _ensure_decode_fast_path_is_available(self) -> None:
-        """Ensures the decode fast path is available. If it is not, set the max blocks per request to 0. If it is
-        available, and no user-provided max blocks per request, set it to the fallback default."""
-        # First, set max blocks per request to 32 if it needs to be auto-inferred
-        user_requested = self.cb_config.max_blocks_per_request is not None
-        if not user_requested:
-            self.cache.max_blocks_per_request = self.cb_config.fallback_max_blocks_per_request
-
-        # Then, if the decode fast path is not turned off, check if it is available
-        if self.cache.max_blocks_per_request != 0:
-            # NOTE: block table should be available with FA2 and FA3, but there seems to be an issue with FA2 atm
-            if is_flash_attention_requested(self.config, version=3):
-                flash_attn_with_kvcache = lazy_import_paged_flash_attention(self.config._attn_implementation)[1]
-                conditions = [
-                    self.cache.num_sliding_attention_groups == 0,  # TODO: add support for sliding window layers
-                    torch.cuda.is_available(),  # Block table is only supported on CUDA
-                    flash_attn_with_kvcache is not None,  # The `flash_attn_with_kvcache` fn is needed
-                ]
-                # Throw a warning only if the decode fast path was requested by the user
-                if not all(conditions):
-                    logger_warning(
-                        f"Although {self.cache.max_blocks_per_request = }, the decode fast path is not available "
-                        f"because at least one condition is not met: {conditions}."
-                    )
-                    self.cache.max_blocks_per_request = 0
-            # Specific warning for attn implementation other than FA3
-            else:
-                logger_warning(
-                    f"Although {self.cache.max_blocks_per_request = }, the decode fast path is not available "
-                    f"because the attention implementation is not FA3. Got {self.config._attn_implementation = }."
-                )
-                self.cache.max_blocks_per_request = 0
 
     def reset(self) -> None:
         """Reset the batch processor for a new generation loop."""
@@ -522,6 +480,7 @@ class ContinuousBatchingManager:
         model: ProtoPretrainedModel,
         generation_config: GenerationConfig,
         continuous_batching_config: ContinuousBatchingConfig,
+        workload_hints: WorkloadHints | None = None,
     ) -> None:
         """Initialize the continuous batching manager.
 
@@ -529,6 +488,7 @@ class ContinuousBatchingManager:
             model: The language model for generation
             generation_config: Configuration for generation parameters
             continuous_batching_config: Configuration for continuous batching parameters
+            workload_hints: Workload hints for the continuous batching initialization (optional)
         """
         # Reload paged version of the attention implementation if necessary
         if "paged|" not in model.config._attn_implementation:
@@ -539,6 +499,7 @@ class ContinuousBatchingManager:
         self.generation_config = generation_config
         self.continuous_batching_config = continuous_batching_config
         self.warmed_up = False  # Set to True after warmup is completed. Useful for persistent managers.
+        self.workload_hints = workload_hints
         # This is an approximation until the cache is created: it will infer the correct value in cache.__init__
         self._use_prefix_sharing = self.continuous_batching_config.allow_block_sharing
 
@@ -560,22 +521,6 @@ class ContinuousBatchingManager:
             per_request_processors=self.continuous_batching_config.per_request_processors,
             drop_unsupported_processors=self.continuous_batching_config.drop_unsupported_processors,
         )
-
-        # Cuda graph behavior is determined below using either user-specified arguments or heuristics
-        is_attn_mask_needed = attn_mask_is_needed(self.model.config)
-        self.continuous_batching_config.decide_use_cuda_graphs(
-            compile_config=getattr(generation_config, "compile_config", None),
-            is_attn_mask_needed=is_attn_mask_needed,
-        )
-        # Same for asynchronous batching behavior
-        self.use_async_batching = self.continuous_batching_config.decide_use_async_batching(is_attn_mask_needed)
-
-        # Resolve default parameters for Q and KV interval sizes, and max cached graphs. If one of those parameters is
-        # not specified (set to 0) then we use the default value and change its value in the config.
-        self.continuous_batching_config.resolve_sentinel_values()
-        self.q_padding_interval_size = self.continuous_batching_config.q_padding_interval_size
-        self.kv_padding_interval_size = self.continuous_batching_config.kv_padding_interval_size
-        self.max_cached_graphs = self.continuous_batching_config.max_cached_graphs
 
     @traced
     def start(self) -> None:
@@ -820,8 +765,15 @@ class ContinuousBatchingManager:
         self.batch_processor._generation_step(self.model)
 
     def _create_batch_processor(self) -> ContinuousBatchProcessor:
-        # Resolve max_memory_percent now that we know whether any logit processors are active.
-        self.continuous_batching_config.resolve_max_memory_percent(self.logit_processor.do_processing)
+        # Resolve all missing attributes of the continuous batching config
+        self.continuous_batching_config = resolve_continuous_batching_config(
+            config=self.model.config,
+            _og_cb_config=self.continuous_batching_config,
+            workload_hints=self.workload_hints,
+            has_logit_processors=self.logit_processor.do_processing,
+        )
+        self.workload_hints = None  # does not make sense to keep them after initialization
+
         # Create the PagedAttentionCache
         paged_attention_cache = PagedAttentionCache(
             self.model.config,
@@ -988,12 +940,13 @@ class ContinuousMixin:
             else:
                 continuous_batching_config = ContinuousBatchingConfig()
         continuous_batching_config.account_for_cb_deprecated_arguments(**deprecated_kwargs)
-        if workload_hints is not None:
-            workload_hints.resolve_using_hints(continuous_batching_config)
 
         # Create and return the manager
         return ContinuousBatchingManager(
-            model=self, generation_config=gen_config, continuous_batching_config=continuous_batching_config
+            model=self,
+            generation_config=gen_config,
+            continuous_batching_config=continuous_batching_config,
+            workload_hints=workload_hints,
         )
 
     def destroy_cached_continuous_batching_manager(self) -> None:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -180,22 +180,13 @@ class ContinuousBatchProcessor:
 
         # Retrieve the size of the sliding window if there is one
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
-        # Cuda graphs for the generation step
-        self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.get_cuda_graph_booleans()
 
         # Set up metrics collector
         self.max_batch_tokens = cache.max_batch_tokens
         self.metrics = ContinuousBatchProcessorMetrics(cache.max_batch_tokens)
 
-        # Resolve compile behavior
-        use_compile = self.cb_config.varlen_compile_config is not None
-        use_compile |= self.cb_config.decode_compile_config is not None
-
-        # Padding is turned on when either cuda graphs or compile is used
-        use_cuda_graphs = self.use_cuda_graph_varlen or self.use_cuda_graph_decode
-        self._pad_inputs = use_cuda_graphs or use_compile
-
         # Setup inputs and outputs
+        use_cuda_graph_varlen, _ = self.cb_config.get_cuda_graph_booleans()
         io_kwargs = {
             "cache": cache,
             "config": config,
@@ -203,7 +194,7 @@ class ContinuousBatchProcessor:
             "model_dtype": model_dtype,
             "return_logprobs": self.return_logprobs,
             "logit_processor": self.logit_processor,
-            "use_cuda_graph_varlen": self.use_cuda_graph_varlen,
+            "use_cuda_graph_varlen": use_cuda_graph_varlen,
         }
         self.use_async_batching = self.cb_config.use_async_batching
 
@@ -446,7 +437,7 @@ class ContinuousBatchProcessor:
         """Perform a single generation step."""
         # Retrieve the model kwargs with or without padding. After this function returns, everything happens on the
         # device. Hence, to make the limit clear, this is left out of the model runner scope.
-        batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=self._pad_inputs)
+        batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=self.model_runner.pad_inputs)
 
         # This takes care of the forward pass, logits processing, and sampling. After this returns, the compute is
         # scheduled on the device's compute stream, but may not have finished yet.
@@ -497,13 +488,9 @@ class ContinuousBatchingManager:
         # Internal arguments
         self.model = model.eval()
         self.generation_config = generation_config
-        self.continuous_batching_config = continuous_batching_config
         self.warmed_up = False  # Set to True after warmup is completed. Useful for persistent managers.
-        self.workload_hints = workload_hints
-        # This is an approximation until the cache is created: it will infer the correct value in cache.__init__
-        self._use_prefix_sharing = self.continuous_batching_config.allow_block_sharing
 
-        self.input_queue = queue.Queue(maxsize=self.continuous_batching_config.max_queue_size)
+        self.input_queue = queue.Queue(maxsize=continuous_batching_config.max_queue_size)
         self._has_new_requests = threading.Event()
         self.output_router = OutputRouter()
         self.stop_event = threading.Event()
@@ -518,9 +505,19 @@ class ContinuousBatchingManager:
 
         self.logit_processor = ContinuousBatchingLogitsProcessorList(
             logits_processor=self.model._get_logits_processor(generation_config),
-            per_request_processors=self.continuous_batching_config.per_request_processors,
-            drop_unsupported_processors=self.continuous_batching_config.drop_unsupported_processors,
+            per_request_processors=continuous_batching_config.per_request_processors,
+            drop_unsupported_processors=continuous_batching_config.drop_unsupported_processors,
         )
+
+        # Fully resolve the continuous batching config now that we have the model, the config and the logit processor.
+        self.continuous_batching_config = resolve_continuous_batching_config(
+            config=self.model.config,
+            cb_config=continuous_batching_config,
+            workload_hints=workload_hints,
+            has_logit_processors=self.logit_processor.do_processing,
+        )
+        # This is an approximation until the cache is created: it will infer the correct value in cache.__init__
+        self._use_prefix_sharing = self.continuous_batching_config.allow_block_sharing
 
     @traced
     def start(self) -> None:
@@ -765,15 +762,6 @@ class ContinuousBatchingManager:
         self.batch_processor._generation_step(self.model)
 
     def _create_batch_processor(self) -> ContinuousBatchProcessor:
-        # Resolve all missing attributes of the continuous batching config
-        self.continuous_batching_config = resolve_continuous_batching_config(
-            config=self.model.config,
-            _og_cb_config=self.continuous_batching_config,
-            workload_hints=self.workload_hints,
-            has_logit_processors=self.logit_processor.do_processing,
-        )
-        self.workload_hints = None  # does not make sense to keep them after initialization
-
         # Create the PagedAttentionCache
         paged_attention_cache = PagedAttentionCache(
             self.model.config,

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -784,6 +784,10 @@ class ContinuousBatchingManager:
         )
         self._use_prefix_sharing = paged_attention_cache.use_prefix_sharing  # update the approximation
 
+        # Disable the decode path if the model has sliding window attention (TODO)
+        if paged_attention_cache.num_sliding_attention_groups > 0:
+            self.continuous_batching_config.max_blocks_per_request = 0
+
         # Create the scheduler
         scheduler_type = self.continuous_batching_config.scheduler_type
         scheduler = SCHEDULER_MAPPING.get(scheduler_type, None)

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -186,7 +186,7 @@ class ContinuousBatchProcessor:
         self.metrics = ContinuousBatchProcessorMetrics(cache.max_batch_tokens)
 
         # Setup inputs and outputs
-        use_cuda_graph_varlen, _ = self.cb_config.get_cuda_graph_booleans()
+        use_cuda_graph_varlen, _ = self.cb_config.cuda_graph_booleans
         io_kwargs = {
             "cache": cache,
             "config": config,

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -38,10 +38,11 @@ from ..logits_process import LogitsProcessorList
 from .cache import PagedAttentionCache
 from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
 from .input_outputs import ContinuousBatchingAsyncIOs, ContinuousBatchingIOs
+from .model_runner import ModelRunner
 from .offloading_manager import OffloadingManager
 from .requests import GenerationOutput, RequestState, RequestStatus, logger
 from .scheduler import SCHEDULER_MAPPING, FIFOScheduler, Scheduler
-from .utils import WorkloadHints, attn_mask_is_needed, create_warmup_future_states, pad_to_interval, pad_to_pow2
+from .utils import WorkloadHints, attn_mask_is_needed, create_warmup_future_states, pad_to_interval
 
 
 """
@@ -181,8 +182,6 @@ class ContinuousBatchProcessor:
         # Retrieve the size of the sliding window if there is one
         self.sliding_window = 1 if getattr(config, "sliding_window", None) is None else config.sliding_window
         # Cuda graphs for the generation step
-        self.q_padding_interval_size = self.cb_config.q_padding_interval_size
-        self.kv_padding_interval_size = self.cb_config.kv_padding_interval_size
         self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.get_cuda_graph_booleans()
 
         # Set up metrics collector
@@ -198,23 +197,12 @@ class ContinuousBatchProcessor:
             is_flash_attn=is_flash_attention_requested(config=config),
             decode_fast_path_available=self.cache.max_blocks_per_request > 0,
         )
-        varlen_config, decode_config = self.cb_config.varlen_compile_config, self.cb_config.decode_compile_config
-
-        # Compile the varlen path if config provided
-        self._compiled_varlen = None
-        if varlen_config is not None:
-            self._compiled_varlen = torch.compile(self._forward_process_and_sample, **varlen_config.to_dict())
-
-        # Compile the decode path if config provided
-        self._compiled_decode = None
-        if decode_config is not None:
-            self._compiled_decode = torch.compile(self._forward_process_and_sample, **decode_config.to_dict())
+        use_compile = self.cb_config.varlen_compile_config is not None
+        use_compile |= self.cb_config.decode_compile_config is not None
 
         # Padding is turned on when either cuda graphs or compile is used
         use_cuda_graphs = self.use_cuda_graph_varlen or self.use_cuda_graph_decode
-        self._pad_inputs = use_cuda_graphs or (varlen_config is not None or decode_config is not None)
-        # Set up the graph pool. This allows all graphs to share the same memory pool, greatly saving memory.
-        self.graph_pool = torch.cuda.graph_pool_handle() if use_cuda_graphs else None
+        self._pad_inputs = use_cuda_graphs or use_compile
 
         # Setup inputs and outputs
         io_kwargs = {
@@ -245,6 +233,16 @@ class ContinuousBatchProcessor:
             compute_stream=self.inputs_and_outputs.compute_stream,
         )
 
+        # Setup the model runner
+        self.model_runner = ModelRunner(
+            logit_processor=self.logit_processor,
+            cb_config=self.cb_config,
+            cache=self.cache,
+            inputs_and_outputs=self.inputs_and_outputs,
+            do_sample=self.do_sample,
+            return_logprobs=self.return_logprobs,
+        )
+
     def __repr__(self) -> str:
         return (
             f"ContinuousBatchProcessor(input_queue={self.input_queue}, "
@@ -265,9 +263,6 @@ class ContinuousBatchProcessor:
         user_requested = self.cb_config.max_blocks_per_request is not None
         if not user_requested:
             self.cache.max_blocks_per_request = self.cb_config.fallback_max_blocks_per_request
-            logger_warning = lambda x: x  # silences warning for user_requested=False  # noqa: E731
-        else:
-            logger_warning = logger.warning
 
         # Then, if the decode fast path is not turned off, check if it is available
         if self.cache.max_blocks_per_request != 0:
@@ -283,7 +278,7 @@ class ContinuousBatchProcessor:
                 if not all(conditions):
                     logger_warning(
                         f"Although {self.cache.max_blocks_per_request = }, the decode fast path is not available "
-                        f"because the one condition is not met: {conditions}."
+                        f"because at least one condition is not met: {conditions}."
                     )
                     self.cache.max_blocks_per_request = 0
             # Specific warning for attn implementation other than FA3
@@ -336,19 +331,6 @@ class ContinuousBatchProcessor:
         self.metrics.record_request_completion(state.created_time, state.request_id)
         self.output_router.deliver(state.to_generation_output())
 
-    def maybe_pad_inputs(self, num_q_tokens: int, max_kv_read: int, use_decode_fast_path: bool) -> tuple[int, int]:
-        """Pads the inputs sizes for the next batch if it is needed. Often it is, for max performance."""
-        if self._pad_inputs:
-            # For varlen batches, we pad using interval sizes
-            if not use_decode_fast_path:
-                num_q_tokens = pad_to_interval(num_q_tokens, self.q_padding_interval_size, self.max_batch_tokens)
-                max_kv_read = pad_to_interval(max_kv_read, self.kv_padding_interval_size, self.cache.num_pages)
-            # For decode fast path batches, we pad using powers of 2 and use no KV
-            else:
-                num_q_tokens = pad_to_pow2(num_q_tokens, self.max_batch_tokens)
-                max_kv_read = 0
-        return num_q_tokens, max_kv_read
-
     @traced
     def prepare_next_batch(self) -> bool:
         """Prepare tensors and metadata for the next model forward pass. Returns True if there are requests to process,
@@ -391,7 +373,7 @@ class ContinuousBatchProcessor:
         )
 
         # If inputs are static sized, eg. for compile, we find the padded sizes of the queries and keys/values
-        num_q_tokens, max_kv_read = self.maybe_pad_inputs(num_q_tokens, max_kv_read, use_decode_fast_path)
+        num_q_tokens, max_kv_read = self.model_runner.maybe_pad_inputs(num_q_tokens, max_kv_read, use_decode_fast_path)
 
         self.inputs_and_outputs.prepare_batch_tensors(
             requests_in_batch, self.logit_processor, use_decode_fast_path, num_q_tokens, max_kv_read
@@ -504,224 +486,17 @@ class ContinuousBatchProcessor:
     @torch.no_grad()
     def _generation_step(self, model: nn.Module) -> None:
         """Perform a single generation step."""
-
-        # Retrieve the model kwargs with or without padding
+        # Retrieve the model kwargs with or without padding. After this function returns, everything happens on the
+        # device. Hence, to make the limit clear, this is left out of the model runner scope.
         batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=self._pad_inputs)
-        carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
-        compute_stream = self.inputs_and_outputs.compute_stream
 
-        # Get the appropriate forward function (compiled or not, based on current path)
-        if self.inputs_and_outputs.use_block_table:
-            forward_fn = self._forward_process_and_sample if self._compiled_decode is None else self._compiled_decode
-            use_cuda_graph = self.use_cuda_graph_decode
-        else:
-            forward_fn = self._forward_process_and_sample if self._compiled_varlen is None else self._compiled_varlen
-            use_cuda_graph = self.use_cuda_graph_varlen
+        # This takes care of the forward pass, logits processing, and sampling. After this returns, the compute is
+        # scheduled on the device's compute stream, but may not have finished yet.
+        self.model_runner.compute_batch(model, batch_data)
 
-        # If we are not using cuda graphs, we perform the generation step and return
-        if not use_cuda_graph:
-            maybe_stream = torch.cuda.stream(compute_stream) if compute_stream is not None else nullcontext()
-            with maybe_stream:
-                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids)
-
-        # Otherwise, we use create or replay the graph (cuda is available in this path)
-        else:
-            graph = self.inputs_and_outputs.get_graph()
-            # Case: the graph already exists, so we replay it
-            if graph is not None:
-                with torch.cuda.stream(compute_stream):
-                    graph.replay()
-            # Otherwise, the graph does not exist, so we create it
-            else:
-                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
-                self.capture_graph(forward_fn, compute_stream, *args)
-
-        # In any case, we transfer the outputs to the host
+        # This initiates the transfer of the outputs to the host. It is blocking in sync mode and non-blocking in async
+        # mode.
         self.inputs_and_outputs.retrieve_device_outputs()
-
-    def capture_graph(self, forward_fn: Any, compute_stream: torch.cuda.Stream, *args) -> None:
-        # Warmup (ensures the right result is computed before capturing the graph)
-        with torch.cuda.stream(compute_stream):
-            forward_fn(*args)
-        # Capture
-        graph = torch.cuda.CUDAGraph()
-        # Continuous batching can run multiple manager threads concurrently in one process, but PyTorch's
-        # default capture mode ("global") errors on CUDA actions from other threads. This means capture can be
-        # invalidated even when each manager uses a different device. To avoid this, we use "thread_local" mode.
-        with torch.cuda.graph(graph, stream=compute_stream, pool=self.graph_pool, capture_error_mode="thread_local"):
-            forward_fn(*args)
-        # Store
-        self.inputs_and_outputs.set_graph(graph)
-
-    @traced
-    def _forward_process_and_sample(
-        self,
-        model: nn.Module,
-        batch_data: dict,
-        carry_over_ids: torch.Tensor,
-        prev_output_ids: torch.Tensor,
-        output_ids: torch.Tensor,
-    ) -> None:
-        """This function performs the forward pass, logits processing, and sampling; which are broken down into smaller
-        function to be easier to trace with OpenTelemetry."""
-        self.inputs_and_outputs.carry_over_tokens(batch_data["input_ids"], carry_over_ids, prev_output_ids)
-        logits = self._model_forward(model, batch_data).float()  # convert to fp32 to match generate
-        scores = self._process_logit(batch_data, logits) if self.logit_processor.do_processing else logits
-        self._sample(scores, batch_data["logits_indices"], output_ids)
-
-    @traced(span_name="model_forward")
-    def _model_forward(self, model: nn.Module, batch_data: dict) -> torch.Tensor:
-        return model(**batch_data).logits
-
-    @traced(span_name="logit_processing")
-    def _process_logit(self, batch_data: dict, logits: torch.Tensor) -> torch.Tensor:
-        # Handle shape compatibility: logit processors expect 2D tensors [batch_size, vocab_size]
-        # but continuous batching always produces 3D tensors [batch_size, seq_len, vocab_size]
-        batch_size, seq_len, vocab_size = logits.shape
-        logits_2d = logits.view(batch_size * seq_len, vocab_size)
-        input_ids_2d = batch_data["input_ids"].view(batch_size * seq_len)
-        # Process with 2D tensors
-        processed_logits_2d = self.logit_processor(input_ids_2d, logits_2d, batch_data["logits_processor_args"])
-        # Reshape back to 3D
-        return processed_logits_2d.view(batch_size, seq_len, vocab_size)
-
-    @traced(span_name="sampling")
-    def _sample(self, scores: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
-        # Apply softmax if we are sampling or if we are generating log probabilities
-        if self.do_sample or self.return_logprobs:
-            probs = nn.functional.softmax(scores[0], dim=-1)  # shape [seq_len, vocab_size]
-        # Otherwise just remove the batch size dimension, which is always 1
-        else:
-            probs = scores.squeeze(0)  # shape [seq_len, vocab_size]
-
-        # Retrieve next tokens through sampling or argmax
-        if self.do_sample:
-            next_tokens = torch.multinomial(probs, num_samples=1)  # shape [seq_len, 1]
-        else:
-            next_tokens = torch.argmax(probs, dim=-1, keepdim=True)  # shape [seq_len, 1]
-
-        # Maybe retrieve log probabilities
-        if self.return_logprobs:
-            per_token_probs = probs.gather(dim=1, index=next_tokens).squeeze(-1)
-            logprobs = per_token_probs.log()  # shape [seq_len]
-        # And always remove the extra dimension for the gather
-        next_tokens = next_tokens.squeeze(-1)  # shape [seq_len]
-
-        # Get seq_len dimension to slice the logits indices
-        tokens = next_tokens.size(0)
-        # Shuffle the next tokens to match the order of the batch's requests
-        indices = logits_indices[:tokens]
-        next_tokens = next_tokens[indices]
-        # Copy the next tokens and maybe their logprobs to the static output tensor
-        output_ids[0, :tokens].copy_(next_tokens)
-        if self.return_logprobs:
-            # Shuffle the logprobs the same way as the next tokens
-            logprobs = logprobs[indices]
-            # In order to match the dtype of output_ids, we cast the fp32 logprobs as int32 without changing the
-            # underlying data. It's just a trick to use the same storage for both tensors.
-            output_ids[1, :tokens].copy_(logprobs.view(dtype=torch.int32))
-
-    @torch.inference_mode()
-    def warmup(self, model: nn.Module) -> None:
-        """Pre-capture CUDA graphs (or trigger compile warmup) for varlen and decode paths. In async mode, both IO
-        pairs are warmed up since each has its own graph buffer and static tensors. The varlen path is warmed up at
-        the largest possible `(q, kv)` sizes so subsequent captures fit inside it without growing the pool."""
-
-        if not self._pad_inputs:
-            logger.info("CUDA graphs and compile are disabled, skipping warmup.")
-            return None
-
-        num_query_tokens = self.max_batch_tokens
-        num_pages = self.cache.num_blocks * self.cache.block_size
-        num_cache_tokens = num_pages - num_query_tokens
-        compute_stream = self.inputs_and_outputs.compute_stream
-
-        # In async mode, each IO pair has its own graph buffer and static tensors, so we warm up both
-        num_io_pairs = 2 if self.use_async_batching else 1
-
-        for pair_idx in range(num_io_pairs):
-            if self.use_async_batching:
-                self.inputs_and_outputs.current_pair = pair_idx
-                logger.info(f"Warming up IO pair {pair_idx + 1}/2...")
-
-            # --- Varlen path ---
-            padded_q, padded_kv = self.maybe_pad_inputs(
-                num_q_tokens=num_query_tokens,
-                max_kv_read=num_cache_tokens + num_query_tokens,
-                use_decode_fast_path=False,
-            )
-            logger.info(f"Warming up varlen path ({padded_q} Q tokens, {padded_kv} KV tokens)...")
-
-            future_states = create_warmup_future_states(
-                1, RequestStatus.PREFILLING, num_query_tokens, num_cache_tokens, self.cache
-            )
-            try:
-                start = perf_counter()
-                self.inputs_and_outputs.prepare_batch_tensors(
-                    future_states, self.logit_processor, False, padded_q, padded_kv - padded_q
-                )
-                batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=True)
-                carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
-                forward_fn = self._compiled_varlen or self._forward_process_and_sample
-                forward_fn_args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
-                if self.use_cuda_graph_varlen:
-                    self.capture_graph(forward_fn, compute_stream, *forward_fn_args)
-                else:
-                    with torch.cuda.stream(compute_stream):
-                        forward_fn(*forward_fn_args)
-                logger.info(f"Varlen warmup completed in {perf_counter() - start:.2f}s")
-            except Exception as e:
-                logger.warning(f"Failed to warm up varlen path: {e}. Graph pool may fragment and OOM under load.")
-            finally:
-                for fs in future_states:
-                    self.cache.free_blocks(fs.state.request_id)
-
-            # Exit here if the decode fast path is not available
-            if self.cache.max_blocks_per_request == 0:
-                continue
-
-            # --- Decode fast path ---
-            logger.info("Warming up decode fast path...")
-            decode_graphs = 0
-            start = perf_counter()
-
-            num_requests = 1
-            while True:
-                future_states = create_warmup_future_states(
-                    num_requests, RequestStatus.DECODING, 1, self.cache.block_size, self.cache
-                )
-                if not future_states:
-                    break
-                try:
-                    padded_q, _ = self.maybe_pad_inputs(
-                        num_q_tokens=num_requests, max_kv_read=0, use_decode_fast_path=True
-                    )
-                    self.inputs_and_outputs.prepare_batch_tensors(
-                        future_states, self.logit_processor, True, padded_q, 0
-                    )
-                    batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=True)
-                    carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
-                    forward_fn = self._compiled_decode or self._forward_process_and_sample
-                    forward_fn_args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
-                    if self.use_cuda_graph_decode:
-                        self.capture_graph(forward_fn, compute_stream, *forward_fn_args)
-                    else:
-                        with torch.cuda.stream(compute_stream):
-                            forward_fn(*forward_fn_args)
-                    decode_graphs += 1
-                except Exception as e:
-                    logger.warning(f"Failed to warm up decode path for {num_requests} requests: {e}")
-                finally:
-                    for fs in future_states:
-                        self.cache.free_blocks(fs.state.request_id)
-                if num_requests >= self.max_batch_tokens:
-                    break
-                num_requests = min(2 * num_requests, self.max_batch_tokens)
-            logger.info(f"Decode warmup completed ({decode_graphs} graphs) in {perf_counter() - start:.2f}s.")
-
-        # If using async batching, reset to pair 0 for the generation loop
-        if self.use_async_batching:
-            self.inputs_and_outputs.current_pair = 0
 
 
 # Manager Class (User Interface)

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -1,3 +1,19 @@
+# Copyright 2026 The HuggingFace Inc. team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Resolves a `ContinuousBatchingConfig` into a fully-specified config ready for cache and runner creation. Each
+helper mutates the config in place; `resolve_continuous_batching_config` orchestrates them in the required order."""
+
 from copy import deepcopy
 from math import ceil
 
@@ -13,24 +29,28 @@ from .utils import WorkloadHints
 
 def resolve_continuous_batching_config(
     config: PretrainedConfig,
-    _og_cb_config: ContinuousBatchingConfig,
+    cb_config: ContinuousBatchingConfig,
     workload_hints: WorkloadHints | None,
     has_logit_processors: bool,
 ) -> ContinuousBatchingConfig:
-    # Copy the continuous batching config to not alter the original config
-    cb_config = deepcopy(_og_cb_config)
+    """Returns a deep-copied and fully-resolved `ContinuousBatchingConfig`. The original `cb_config` is not mutated."""
+    cb_config = deepcopy(cb_config)
 
-    # Resolve missing attributes or which we have hints. Must happen before no-hints resolve.
-    decode_path_requested = resolve_using_hints(cb_config, workload_hints)
-
-    # Resolve missing attributes without hints. Must happen before decode fast path is checked.
+    # Look at whether the user explicitly asked for the decode fast path before we assign a default value
+    user_requested_decode_path = cb_config.max_blocks_per_request is not None
+    # Same for cuda graphs, if the user signals they want CUDA graphs via any padding/cached-graph parameter
     cuda_graph_requested = any(
         [cb_config.q_padding_interval_size, cb_config.kv_padding_interval_size, cb_config.max_cached_graphs]
     )
+
+    # Resolve missing attributes for which we have hints. Must happen before no-hints resolve.
+    resolve_using_hints(cb_config, workload_hints)
+
+    # Resolve remaining missing attributes. Must happen before decode fast path is checked.
     resolve_without_hints(cb_config)
 
-    # Check if the decode fast path is available. Must happen before the compile config
-    ensure_decode_fast_path_is_available(config, cb_config, decode_path_requested)
+    # Check if the decode fast path is available. Must happen before the compile config.
+    ensure_decode_fast_path_is_available(config, cb_config, user_requested_decode_path)
 
     # Decide if compile should be used. Must happen before CUDA graphs are decided.
     resolve_compile_configs(
@@ -54,31 +74,26 @@ def resolve_continuous_batching_config(
     return cb_config
 
 
-def resolve_using_hints(new_cb_config: ContinuousBatchingConfig, workload_hints: WorkloadHints | None) -> bool:
-    """Resolves the config using the given hints."""
-    # The max number of block per request is an even number large enough to hold the max request length
-    decode_path_requested = new_cb_config.max_blocks_per_request is not None
-    if not decode_path_requested and workload_hints is not None:
+def resolve_using_hints(cb_config: ContinuousBatchingConfig, workload_hints: WorkloadHints | None) -> None:
+    """Fills `max_blocks_per_request` from the workload hints, when the user did not set it explicitly."""
+    # The max number of blocks per request is an even number large enough to hold the max request length
+    if cb_config.max_blocks_per_request is None and workload_hints is not None:
         max_sequence_length = workload_hints.max_prompt_length + workload_hints.max_generated_length
         if max_sequence_length > 0:
-            blocks_per_request = int(ceil(max_sequence_length / new_cb_config.block_size)) + 1
-            new_cb_config.max_blocks_per_request = blocks_per_request + (blocks_per_request % 2)
-    return decode_path_requested
+            blocks_per_request = int(ceil(max_sequence_length / cb_config.block_size)) + 1
+            cb_config.max_blocks_per_request = blocks_per_request + (blocks_per_request % 2)
 
 
-def resolve_without_hints(new_cb_config: ContinuousBatchingConfig) -> None:
-    """Resolves the config without hints."""
-    # Max blocks per request
-    if new_cb_config.max_blocks_per_request is None:
-        new_cb_config.max_blocks_per_request = 32
-    # Q and KV padding intervals
-    if new_cb_config.q_padding_interval_size == 0:
-        new_cb_config.q_padding_interval_size = 64
-    if new_cb_config.kv_padding_interval_size == 0:
-        new_cb_config.kv_padding_interval_size = 64 * 256  # 64 blocks of 256 tokens ie. 16384 tokens
-    # Max cached graphs
-    if new_cb_config.max_cached_graphs == 0:
-        new_cb_config.max_cached_graphs = 32
+def resolve_without_hints(cb_config: ContinuousBatchingConfig) -> None:
+    """Fills any remaining unset/sentinel attribute with a fallback default."""
+    if cb_config.max_blocks_per_request is None:
+        cb_config.max_blocks_per_request = 32
+    if cb_config.q_padding_interval_size == 0:
+        cb_config.q_padding_interval_size = 64
+    if cb_config.kv_padding_interval_size == 0:
+        cb_config.kv_padding_interval_size = 64 * 256  # 64 blocks of 256 tokens ie. 16384 tokens
+    if cb_config.max_cached_graphs == 0:
+        cb_config.max_cached_graphs = 32
 
 
 def ensure_decode_fast_path_is_available(

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -1,0 +1,234 @@
+from copy import deepcopy
+from math import ceil
+
+import torch
+
+from ...configuration_utils import PretrainedConfig
+from ...generation.configuration_utils import CompileConfig, ContinuousBatchingConfig
+from ...modeling_flash_attention_utils import lazy_import_paged_flash_attention
+from ...utils.generic import is_flash_attention_requested
+from .requests import logger
+from .utils import WorkloadHints
+
+
+def resolve_continuous_batching_config(
+    config: PretrainedConfig,
+    _og_cb_config: ContinuousBatchingConfig,
+    workload_hints: WorkloadHints | None,
+    has_logit_processors: bool,
+) -> ContinuousBatchingConfig:
+    # Copy the continuous batching config to not alter the original config
+    cb_config = deepcopy(_og_cb_config)
+
+    # Resolve missing attributes or which we have hints. Must happen before no-hints resolve.
+    decode_path_requested = resolve_using_hints(cb_config, workload_hints)
+
+    # Resolve missing attributes without hints. Must happen before decode fast path is checked.
+    cuda_graph_requested = any(
+        [cb_config.q_padding_interval_size, cb_config.kv_padding_interval_size, cb_config.max_cached_graphs]
+    )
+    resolve_without_hints(cb_config)
+
+    # Check if the decode fast path is available. Must happen before the compile config
+    ensure_decode_fast_path_is_available(config, cb_config, decode_path_requested)
+
+    # Decide if compile should be used. Must happen before CUDA graphs are decided.
+    resolve_compile_configs(
+        cb_config=cb_config,
+        fallback_compile_config=getattr(config, "compile_config", None),
+        is_flash_attn=is_flash_attention_requested(config),
+        decode_fast_path_available=cb_config.max_blocks_per_request > 0,
+    )
+
+    # Decide if CUDA graphs should be used. Should happen after compile configs are decided.
+    is_attn_mask_needed = not is_flash_attention_requested(config)
+    decide_use_cuda_graphs(
+        cb_config=cb_config, is_attn_mask_needed=is_attn_mask_needed, cuda_graph_requested=cuda_graph_requested
+    )
+
+    # Decide if asynchronous batching should be used. Should happen after CUDA graphs are decided.
+    decide_use_async_batching(cb_config=cb_config, is_attn_mask_needed=is_attn_mask_needed)
+
+    # Resolve the max memory percent. This can happen anytime before cache creation.
+    resolve_max_memory_percent(cb_config=cb_config, has_logit_processors=has_logit_processors)
+    return cb_config
+
+
+def resolve_using_hints(new_cb_config: ContinuousBatchingConfig, workload_hints: WorkloadHints | None) -> bool:
+    """Resolves the config using the given hints."""
+    # The max number of block per request is an even number large enough to hold the max request length
+    decode_path_requested = new_cb_config.max_blocks_per_request is not None
+    if not decode_path_requested and workload_hints is not None:
+        max_sequence_length = workload_hints.max_prompt_length + workload_hints.max_generated_length
+        if max_sequence_length > 0:
+            blocks_per_request = int(ceil(max_sequence_length / new_cb_config.block_size)) + 1
+            new_cb_config.max_blocks_per_request = blocks_per_request + (blocks_per_request % 2)
+    return decode_path_requested
+
+
+def resolve_without_hints(new_cb_config: ContinuousBatchingConfig) -> None:
+    """Resolves the config without hints."""
+    # Max blocks per request
+    if new_cb_config.max_blocks_per_request is None:
+        new_cb_config.max_blocks_per_request = 32
+    # Q and KV padding intervals
+    if new_cb_config.q_padding_interval_size == 0:
+        new_cb_config.q_padding_interval_size = 64
+    if new_cb_config.kv_padding_interval_size == 0:
+        new_cb_config.kv_padding_interval_size = 64 * 256  # 64 blocks of 256 tokens ie. 16384 tokens
+    # Max cached graphs
+    if new_cb_config.max_cached_graphs == 0:
+        new_cb_config.max_cached_graphs = 32
+
+
+def ensure_decode_fast_path_is_available(
+    config: PretrainedConfig, cb_config: ContinuousBatchingConfig, user_requested: bool
+) -> None:
+    """Ensures the decode fast path is available. If it is not, set the max blocks per request to 0. If it is
+    available, and no user-provided max blocks per request, set it to the fallback default."""
+    # Then, if the decode fast path is not turned off, check if it is available
+    if cb_config.max_blocks_per_request != 0:
+        # NOTE: block table should be available with FA2 and FA3, but there seems to be an issue with FA2 atm
+        if is_flash_attention_requested(config, version=3):
+            flash_attn_with_kvcache = lazy_import_paged_flash_attention(config._attn_implementation)[1]
+            conditions = [
+                torch.cuda.is_available(),  # Block table is only supported on CUDA
+                flash_attn_with_kvcache is not None,  # The `flash_attn_with_kvcache` fn is needed
+            ]
+            # Throw a warning only if the decode fast path was requested by the user
+            if not all(conditions):
+                if user_requested:
+                    logger.warning(
+                        f"Although {cb_config.max_blocks_per_request = }, the decode fast path is not available "
+                        f"because at least one condition is not met: {conditions}."
+                    )
+                cb_config.max_blocks_per_request = 0
+        # Specific warning for attn implementation other than FA3
+        else:
+            if user_requested:
+                logger.warning(
+                    f"Although {cb_config.max_blocks_per_request = }, the decode fast path is not available "
+                    f"because the attention implementation is not FA3. Got {config._attn_implementation = }."
+                )
+            cb_config.max_blocks_per_request = 0
+
+
+def resolve_compile_configs(
+    cb_config: ContinuousBatchingConfig,
+    fallback_compile_config: CompileConfig | None,
+    is_flash_attn: bool,
+    decode_fast_path_available: bool,
+) -> None:
+    """Resolve if the compile configs for varlen and decode paths, modifying these attributes in place if needed.
+    Default config use full compile over regional compile, because the throughput is significantly higher (~15%)"""
+    # For each config, priority is: explicit config, default config, fallback config, None
+    if cb_config.varlen_compile_config is None:
+        if cb_config.use_default_compile_configs:
+            # We don't use compile with flash varlen, because max_seqlen_k is volatile and introduces recompilations
+            if is_flash_attn:
+                varlen_config = None
+            else:
+                varlen_config = CompileConfig(mode="max-autotune-no-cudagraphs", fullgraph=True, dynamic=True)
+        elif fallback_compile_config is not None:
+            varlen_config = fallback_compile_config
+        else:
+            varlen_config = None
+    else:
+        varlen_config = cb_config.varlen_compile_config
+
+    if cb_config.decode_compile_config is None:
+        if cb_config.use_default_compile_configs:
+            # Paged attention is wrapped in @torch.compiler.disable so we can't use fullgraph
+            decode_config = CompileConfig(mode="max-autotune-no-cudagraphs", fullgraph=False, dynamic=False)
+        elif fallback_compile_config is not None:
+            decode_config = fallback_compile_config
+        else:
+            decode_config = None
+    else:
+        decode_config = cb_config.decode_compile_config
+
+    # For decode, we throw a warning if the fast decode path is not available and a compile config was found
+    if not decode_fast_path_available and cb_config.decode_compile_config is not None:
+        decode_config = None
+        logger.warning("A decode_compile_config was set but fast decode path is not available. Ignoring it.")
+
+    # Log what will be compiled
+    if varlen_config is not None:
+        logger.info(f"Varlen path will be compiled with {varlen_config.to_dict()}")
+    if decode_config is not None:
+        logger.info(f"Decode path will be compiled with {decode_config.to_dict()}")
+    # Modify in place
+    cb_config.varlen_compile_config = varlen_config
+    cb_config.decode_compile_config = decode_config
+
+
+def decide_use_cuda_graphs(
+    cb_config: ContinuousBatchingConfig, is_attn_mask_needed: bool, cuda_graph_requested: bool
+) -> None:
+    """Decides whether or not to use cuda graphs for continuous batching. If the user specified this in the config
+    or if they specified a parameter related to cuda graphs, they are turned on. Otherwise, we use a heuristic
+    based on the attention implementation: we turn on cuda graphs if and only if no attention mask is needed.
+
+    This function modifies the `use_cuda_graph` attribute of the config in place, to a tuple of booleans.
+    """
+    # If cuda is not available, we cannot use cuda graphs
+    if not torch.cuda.is_available():
+        intended_use_cuda_graph = any(cb_config.get_cuda_graph_booleans())
+        if intended_use_cuda_graph:  # throw a warning only if the user intended to use cuda graphs
+            logger.warning(f"{cb_config.use_cuda_graph = } but {torch.cuda.is_available() = }: turning off cuda graphs")
+        cb_config.use_cuda_graph = (False, False)
+
+    # Else if use_cuda_graph is specified, we follow the user's choice and make sure it is a tuple of booleans
+    elif cb_config.use_cuda_graph is not None:
+        if isinstance(cb_config.use_cuda_graph, bool):
+            cb_config.use_cuda_graph = (cb_config.use_cuda_graph, cb_config.use_cuda_graph)
+
+    # Else if the user specified a parameter related to cuda graphs, we activate cuda graphs
+    elif cuda_graph_requested:
+        cb_config.use_cuda_graph = (True, True)
+
+    # Otherwise we have a default heuristic based on the attention implementation:
+    # attention implementations where an attention mask is needed suffer a lot more from the padding associated
+    # with cuda graphs, so default is to turn cuda graphs off for those implementations
+    else:
+        use_cuda_graph = []
+        for compile_config in [cb_config.varlen_compile_config, cb_config.decode_compile_config]:
+            # No compile config means we decide on attention
+            if compile_config is None:
+                use_cuda_graph.append(not is_attn_mask_needed)
+                continue
+            # Otherwise we disable cuda graphs if the compile config uses them
+            options = torch._inductor.list_mode_options().get(compile_config.mode, compile_config.options)
+            compile_uses_cudagraphs = options.get("triton.cudagraphs", False)
+            if compile_uses_cudagraphs:
+                logger.warning(
+                    f"Compile config {compile_config.mode = } uses cudagraphs, which usually does not work well with "
+                    "continuous batching. We recommend using mode 'default' or 'max-autotune-no-cudagraphs' instead."
+                )
+            use_cuda_graph.append(not compile_uses_cudagraphs and not is_attn_mask_needed)
+        cb_config.use_cuda_graph = tuple(use_cuda_graph)
+
+    logger.info(f"Using cuda graphs for (varlen, decode) paths: {cb_config.use_cuda_graph}")
+
+
+def decide_use_async_batching(cb_config: ContinuousBatchingConfig, is_attn_mask_needed: bool) -> None:
+    """Returns whether or not to use asynchronous batching for continuous batching. If the user specified this in
+    the config, we follow their choice. Otherwise, we turn on asynchronous batching if and only if CUDA graphs are
+    turned on and no attention mask is needed.
+
+    This function modifies the `use_async_batching` attribute of the config in place.
+    """
+    # If the user specifies to use async or not, no need to decide ourselves
+    if cb_config.use_async_batching is None:
+        use_cuda_graphs = any(cb_config.get_cuda_graph_booleans())
+        cb_config.use_async_batching = use_cuda_graphs and not is_attn_mask_needed
+        logger.info(
+            f"No behavior specified for use_async_batching, choosing {cb_config.use_async_batching = } because "
+            f"{use_cuda_graphs = } and {is_attn_mask_needed = }. If you want to save memory, you can "
+            "disable asynchronous batching but it will degrade performance."
+        )
+
+
+def resolve_max_memory_percent(cb_config: ContinuousBatchingConfig, has_logit_processors: bool) -> None:
+    if cb_config.max_memory_percent is None:
+        cb_config.max_memory_percent = 0.8 if has_logit_processors else 0.9

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -175,7 +175,9 @@ def decide_use_cuda_graphs(
     if not torch.cuda.is_available():
         intended_use_cuda_graph = any(cb_config.get_cuda_graph_booleans())
         if intended_use_cuda_graph:  # throw a warning only if the user intended to use cuda graphs
-            logger.warning(f"{cb_config.use_cuda_graph = } but {torch.cuda.is_available() = }: turning off cuda graphs")
+            logger.warning(
+                f"{cb_config.use_cuda_graph = } but {torch.cuda.is_available() = }: turning off cuda graphs"
+            )
         cb_config.use_cuda_graph = (False, False)
 
     # Else if use_cuda_graph is specified, we follow the user's choice and make sure it is a tuple of booleans

--- a/src/transformers/generation/continuous_batching/initialization.py
+++ b/src/transformers/generation/continuous_batching/initialization.py
@@ -188,7 +188,7 @@ def decide_use_cuda_graphs(
     """
     # If cuda is not available, we cannot use cuda graphs
     if not torch.cuda.is_available():
-        intended_use_cuda_graph = any(cb_config.get_cuda_graph_booleans())
+        intended_use_cuda_graph = any(cb_config.cuda_graph_booleans)
         if intended_use_cuda_graph:  # throw a warning only if the user intended to use cuda graphs
             logger.warning(
                 f"{cb_config.use_cuda_graph = } but {torch.cuda.is_available() = }: turning off cuda graphs"
@@ -237,7 +237,7 @@ def decide_use_async_batching(cb_config: ContinuousBatchingConfig, is_attn_mask_
     """
     # If the user specifies to use async or not, no need to decide ourselves
     if cb_config.use_async_batching is None:
-        use_cuda_graphs = any(cb_config.get_cuda_graph_booleans())
+        use_cuda_graphs = any(cb_config.cuda_graph_booleans)
         cb_config.use_async_batching = use_cuda_graphs and not is_attn_mask_needed
         logger.info(
             f"No behavior specified for use_async_batching, choosing {cb_config.use_async_batching = } because "

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -194,8 +194,9 @@ class ContinuousBatchingIOs:
         # Last output token is never changed and set to 0 for async carry on purpose
         self.output_ids.zero_()
         self.total_seqlen_q = 0
+        self.total_seqlen_k: dict[str, int] = dict.fromkeys(self.cumulative_seqlens_k.keys(), 0)
         self.max_seqlen_q = 0
-        self.max_seqlen_k = dict.fromkeys(self.cumulative_seqlens_k.keys(), 0)
+        self.max_seqlen_k: dict[str, int] = dict.fromkeys(self.cumulative_seqlens_k.keys(), 0)
 
         # If the attention mask is needed, it is allocated separately
         if attn_mask_is_needed(self.config):
@@ -240,8 +241,9 @@ class ContinuousBatchingIOs:
         other.use_block_table = self.use_block_table
         # Transfer scalar attributes
         other.total_seqlen_q = self.total_seqlen_q
+        other.total_seqlen_k = dict(self.total_seqlen_k)
         other.max_seqlen_q = self.max_seqlen_q
-        other.max_seqlen_k = dict(self.max_seqlen_k.items())
+        other.max_seqlen_k = dict(self.max_seqlen_k)
         # Transfer static tensors
         maybe_stream = torch.cuda.stream(stream) if stream is not None else nullcontext()
         with maybe_stream:
@@ -283,6 +285,7 @@ class ContinuousBatchingIOs:
         # Reset the attributes that are either tensors or dict of tensors
         for layer_type in self.cumulative_seqlens_k:
             self.max_seqlen_k[layer_type] = 0
+            self.total_seqlen_k[layer_type] = 0
             if self.attention_mask is not None:
                 self.attention_mask[layer_type][:, :, :q_len, : q_len + kv_len].fill_(
                     torch.finfo(self.model_dtype).min
@@ -441,6 +444,7 @@ class ContinuousBatchingIOs:
         # Those kwargs are either dict of tensors or tensors, so we need to handle both cases
         for layer_type, layer_type_seqlens_k in cumulative_seqlens_k.items():
             self.cumulative_seqlens_k[layer_type][: len(layer_type_seqlens_k)] = to_tensor(layer_type_seqlens_k)
+            self.total_seqlen_k[layer_type] = layer_type_seqlens_k[-1]
             if self.attention_mask is not None:
                 build_attention_mask(
                     attention_mask=self.attention_mask[layer_type],
@@ -516,10 +520,10 @@ class ContinuousBatchingIOs:
         for layer_type, seqlens_k in self.cumulative_seqlens_k.items():
             kwargs.cu_seq_lens_k[layer_type] = seqlens_k[: batch_size + 1]
             if use_padding:
-                kwargs.cu_seq_lens_k[layer_type][self.true_batch_size + 1 :] = seqlens_k[self.true_batch_size]
+                kwargs.cu_seq_lens_k[layer_type][self.true_batch_size + 1 :] = self.total_seqlen_k[layer_type]
             kwargs.max_seqlen_k[layer_type] = 1 if self.use_block_table else self.max_seqlen_k[layer_type]
             if self.attention_mask is not None:
-                k_len = kv_size if use_padding else seqlens_k[batch_size]
+                k_len = kv_size if use_padding else self.total_seqlen_k[layer_type]
                 kwargs.attention_mask[layer_type] = self.attention_mask[layer_type][..., :q_size, :k_len]
 
         # If there is only one layer type, we remove the dicts around some attributes to avoid unnecessary overhead

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -802,7 +802,10 @@ class ContinuousBatchingAsyncIOs:
         # Transfer the outputs to the host
         io_pair.transfer_outputs_d2h(self.d2h_stream)
         self.d2h_stream.record_event(io_pair.d2h_over)
-        # Switch IO pair
+        # Swap IO pair
+        self.swap_io_pairs()
+
+    def swap_io_pairs(self) -> None:
         self.current_pair = 1 - self.current_pair
 
     # This method is called after the switch and not during the first batch

--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -806,6 +806,7 @@ class ContinuousBatchingAsyncIOs:
         self.swap_io_pairs()
 
     def swap_io_pairs(self) -> None:
+        """Switch to the other IO pair so the next batch reads from / writes into a fresh set of static buffers."""
         self.current_pair = 1 - self.current_pair
 
     # This method is called after the switch and not during the first batch

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -1,0 +1,301 @@
+# Copyright 2026 The HuggingFace Inc. team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import time
+from collections.abc import Callable
+from contextlib import nullcontext
+
+import torch
+from torch import nn
+
+from ...generation.configuration_utils import ContinuousBatchingConfig
+from .cache import PagedAttentionCache
+from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
+from .input_outputs import ContinuousBatchingAsyncIOs, ContinuousBatchingIOs
+from .requests import RequestStatus, logger
+from .utils import create_warmup_future_states, pad_to_interval, pad_to_pow2
+
+
+class ModelRunner:
+    """This class is the continuous batching entry point for running the model. As a rule of thumb, anything running on
+    the device should happen from this class."""
+
+    def __init__(
+        self,
+        logit_processor: ContinuousBatchingLogitsProcessorList,
+        cb_config: ContinuousBatchingConfig,
+        inputs_and_outputs: ContinuousBatchingIOs | ContinuousBatchingAsyncIOs,
+        cache: PagedAttentionCache,
+        do_sample: bool,
+        return_logprobs: bool,
+    ) -> None:
+        # Main attributes
+        self.logit_processor = logit_processor
+        self.cb_config = cb_config
+        self.inputs_and_outputs = inputs_and_outputs
+        # Helper attributes
+        self.do_sample = do_sample
+        self.return_logprobs = return_logprobs
+        self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.get_cuda_graph_booleans()
+        self.cache = cache
+
+        # Set up the graph pool. This allows all graphs to share the same memory pool, greatly saving memory.
+        if self.use_cuda_graph_varlen or self.use_cuda_graph_decode:
+            self.graph_pool = torch.cuda.graph_pool_handle()
+        else:
+            self.graph_pool = None
+
+        # Set up compiled version of the forward pass for the varlen path
+        self._compiled_varlen = None
+        if self.cb_config.varlen_compile_config is not None:
+            self._compiled_varlen = torch.compile(
+                self._forward_process_and_sample, **self.cb_config.varlen_compile_config.to_dict()
+            )
+
+        # Set up compiled version of the forward pass for the decode path
+        self._compiled_decode = None
+        if self.cb_config.decode_compile_config is not None:
+            self._compiled_decode = torch.compile(
+                self._forward_process_and_sample, **self.cb_config.decode_compile_config.to_dict()
+            )
+
+    def maybe_pad_inputs(self, num_q_tokens: int, max_kv_read: int, use_decode_fast_path: bool) -> tuple[int, int]:
+        """Pads the input sizes for the next batch if it is needed. Often it is, for max performance."""
+        max_batch_tokens = self.cache.max_batch_tokens
+        # For varlen batches, we pad using interval sizes
+        if not use_decode_fast_path:
+            num_q_tokens = pad_to_interval(num_q_tokens, self.cb_config.q_padding_interval_size, max_batch_tokens)
+            max_kv_read = pad_to_interval(max_kv_read, self.cb_config.kv_padding_interval_size, self.cache.num_pages)
+        # For decode fast path batches, we pad using powers of 2 and use no KV
+        else:
+            num_q_tokens = pad_to_pow2(num_q_tokens, max_batch_tokens)
+            max_kv_read = 0
+        return num_q_tokens, max_kv_read
+
+    def compute_batch(self, model: nn.Module, batch_data: dict) -> None:
+        """Runs the forward pass, processes the logits and samples the next tokens. It also handles which version of
+        the forward pass to use (varlen or decode), whether to use CUDA graphs (with the eventual capture of the graph)
+        and torch compile."""
+        # These tensors are device-resident, this is just pointer retrieval
+        carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
+        # This is the stream on which the compute happens
+        compute_stream = self.inputs_and_outputs.compute_stream
+
+        # Get the appropriate forward function (compiled or not, based on current path)
+        forward_fn, use_cuda_graph = self._get_forward_fn(use_block_table=self.inputs_and_outputs.use_block_table)
+
+        # If we are not using CUDA graphs, we perform the generation step and return
+        if not use_cuda_graph:
+            maybe_stream = torch.cuda.stream(compute_stream) if compute_stream is not None else nullcontext()
+            with maybe_stream:
+                forward_fn(model, batch_data, carry_over_ids, prev_output_ids, output_ids)
+
+        # Otherwise, we either create or replay the graph (CUDA is available in this path)
+        else:
+            graph = self.inputs_and_outputs.get_graph()
+            # Case: the graph already exists, so we replay it
+            if graph is not None:
+                with torch.cuda.stream(compute_stream):
+                    graph.replay()
+            # Otherwise, the graph does not exist, so we create it
+            else:
+                args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
+                self._capture_graph(forward_fn, compute_stream, *args)
+
+    def _get_forward_fn(self, use_block_table: bool) -> tuple[Callable, bool]:
+        """Helper function to get the appropriate forward function based on the block table and compile behavior."""
+        if use_block_table:
+            forward_fn = self._forward_process_and_sample if self._compiled_decode is None else self._compiled_decode
+            use_cuda_graph = self.use_cuda_graph_decode
+        else:
+            forward_fn = self._forward_process_and_sample if self._compiled_varlen is None else self._compiled_varlen
+            use_cuda_graph = self.use_cuda_graph_varlen
+        return forward_fn, use_cuda_graph
+
+    def _capture_graph(self, forward_fn: Callable, compute_stream: torch.cuda.Stream, *args) -> None:
+        """Helper function to capture and store a graph for a given forward function."""
+        # Warmup (ensures the right result is computed before capturing the graph)
+        with torch.cuda.stream(compute_stream):
+            forward_fn(*args)
+        # Capture using a thread-local capture mode to avoid capturing GPU operations from outside the model forward
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph, stream=compute_stream, pool=self.graph_pool, capture_error_mode="thread_local"):
+            forward_fn(*args)
+        # Store
+        self.inputs_and_outputs.set_graph(graph)
+
+    def _forward_process_and_sample(
+        self,
+        model: nn.Module,
+        batch_data: dict,
+        carry_over_ids: torch.Tensor,
+        prev_output_ids: torch.Tensor,
+        output_ids: torch.Tensor,
+    ) -> None:
+        """This function performs the forward pass, logits processing, and sampling. This is what is either captured
+        and/or compiled."""
+        # Perform carry-over (no-op for synchronous batching)
+        self.inputs_and_outputs.carry_over_tokens(batch_data["input_ids"], carry_over_ids, prev_output_ids)
+
+        # Run model forward pass and convert to fp32 to match generate
+        logits = model(**batch_data).logits.float()
+
+        # Process logits if there are any logit processors
+        if self.logit_processor.do_processing:
+            # Handle shape inconsistency between generate and continuous batching (dummy_dim is always 1)
+            dummy_dim, num_tokens, vocab_size = logits.shape
+            logits_2d = logits.view(dummy_dim * num_tokens, vocab_size)
+            input_ids_2d = batch_data["input_ids"].view(dummy_dim * num_tokens)
+            # Process with 2D tensors
+            logits_2d = self.logit_processor(input_ids_2d, logits_2d, batch_data["logits_processor_args"])
+            # Reshape back to 3D
+            scores = logits_2d.view(dummy_dim, num_tokens, vocab_size)
+        else:
+            scores = logits
+
+        # Sample next tokens
+        self._sample(scores, batch_data["logits_indices"], output_ids)
+
+    def _sample(self, scores: torch.Tensor, logits_indices: torch.Tensor, output_ids: torch.Tensor) -> None:
+        """Private method to sample next tokens from the scores."""
+        # Apply softmax if we are sampling or if we are generating log probabilities
+        if self.do_sample or self.return_logprobs:
+            probs = nn.functional.softmax(scores[0], dim=-1)  # shape [seq_len, vocab_size]
+        else:
+            probs = scores.squeeze(0)  # shape [seq_len, vocab_size]
+
+        # Retrieve next tokens through sampling or argmax
+        if self.do_sample:
+            next_tokens = torch.multinomial(probs, num_samples=1)  # shape [seq_len, 1]
+        else:
+            next_tokens = torch.argmax(probs, dim=-1, keepdim=True)  # shape [seq_len, 1]
+
+        # Maybe retrieve log probabilities
+        if self.return_logprobs:
+            per_token_probs = probs.gather(dim=1, index=next_tokens).squeeze(-1)
+            logprobs = per_token_probs.log()  # shape [seq_len]
+
+        # Always remove the extra dimension for the gather
+        next_tokens = next_tokens.squeeze(-1)  # shape [seq_len]
+
+        # Get seq_len dimension to slice the logits indices
+        tokens = next_tokens.size(0)
+        # Shuffle the next tokens to match the order of the batch's requests
+        indices = logits_indices[:tokens]
+        next_tokens = next_tokens[indices]
+        # Copy the next tokens and maybe their logprobs to the static output tensor
+        output_ids[0, :tokens].copy_(next_tokens)
+        if self.return_logprobs:
+            # Shuffle the logprobs the same way as the next tokens
+            logprobs = logprobs[indices]
+            # In order to match the dtype of output_ids, we cast the fp32 logprobs as int32 without changing the
+            # underlying data. It's just a trick to use the same storage for both tensors.
+            output_ids[1, :tokens].copy_(logprobs.view(dtype=torch.int32))
+
+    @torch.inference_mode()
+    def warmup(self, model: nn.Module) -> None:
+        """Pre-capture CUDA graphs and/or trigger compile warmup for varlen and decode paths (if available). Unless the
+        force_warmup flag is set, the warmup is only performed if the CUDA graphs or compile are enabled."""
+        # Early return if the warmup is not needed
+        cuda_graph_off = not (self.use_cuda_graph_varlen or self.use_cuda_graph_decode)
+        compile_off = self.cb_config.varlen_compile_config is None or self.cb_config.decode_compile_config is None
+        if cuda_graph_off and compile_off:
+            return None
+
+        # In async mode, each IO pair has its own graph buffer and static tensors, so we warm up both
+        total_duration = 0
+        iterations = 2 if isinstance(self.inputs_and_outputs, ContinuousBatchingAsyncIOs) else 1
+        for _ in range(iterations):
+            # Warm up the varlen path, with the largest possible dimensions to get the biggest pool and avoid fragmentation
+            num_q_tokens = self.cache.max_batch_tokens
+            max_kv_read = self.cache.num_blocks * self.cache.block_size
+            max_kv_read -= num_q_tokens  # make room for the new tokens
+            total_duration += self.run_one_warmup(model=model, num_q_tokens=num_q_tokens, max_kv_read=max_kv_read)
+
+            # Exit here if the decode fast path is not available
+            if self.cache.max_blocks_per_request == 0:
+                continue
+
+            # Warm up the decode path
+            num_requests = 1
+            while True:
+                total_duration += self.run_one_warmup(model=model, num_q_tokens=num_requests, max_kv_read=None)
+                if num_requests >= self.cache.max_batch_tokens:
+                    break
+                num_requests = min(2 * num_requests, self.cache.max_batch_tokens)
+
+            # Switch to the other IO pair if this is async
+            if isinstance(self.inputs_and_outputs, ContinuousBatchingAsyncIOs):
+                self.inputs_and_outputs.swap_io_pairs()
+        logger.info(f"Warmup completed in {total_duration:.2f}s")
+
+    def run_one_warmup(self, model: nn.Module, num_q_tokens: int, max_kv_read: int | None) -> float:
+        """Warms up the decode fast path (if max_kv_read is None) or varlen path (if max_kv_read is an int) for a
+        specific number of query and cache-resident tokens. `max_kv_read` is the number of tokens already in cache,
+        matching the terminology used by `prepare_batch_tensors` and the scheduler."""
+        # Make up fake request states according to the chosen path
+        use_decode_fast_path = max_kv_read is None
+        if use_decode_fast_path:
+            num_requests = num_q_tokens
+            status = RequestStatus.DECODING
+            num_q_tokens = 1
+            max_kv_read = self.cache.block_size
+            logger.debug(f"Warming up decode fast path for {num_requests =}.")
+        else:
+            num_requests = 1
+            status = RequestStatus.PREFILLING
+            logger.debug(f"Warming up varlen path for {num_q_tokens =}, {max_kv_read =}.")
+        future_states = create_warmup_future_states(num_requests, status, num_q_tokens, max_kv_read, self.cache)
+        if not future_states:
+            logger.warning(
+                f"Failed to warm up: no blocks allocated for {num_requests =}, {num_q_tokens =}, {max_kv_read =}."
+            )
+            return 0.0
+
+        # Pad the inputs to the appropriate size
+        padded_q, padded_kv = self.maybe_pad_inputs(
+            num_q_tokens=num_q_tokens * num_requests,
+            max_kv_read=max_kv_read,
+            use_decode_fast_path=use_decode_fast_path,
+        )
+
+        # Actual warmup, which happens in a try-finally block to ensure the blocks are freed even if the warmup fails
+        start = time.perf_counter()
+        try:
+            self.inputs_and_outputs.prepare_batch_tensors(
+                future_states, self.logit_processor, use_decode_fast_path, padded_q, padded_kv
+            )
+            batch_data = self.inputs_and_outputs.get_model_kwargs(use_padding=True)
+            carry_over_ids, prev_output_ids, output_ids = self.inputs_and_outputs.get_cb_kwargs()
+            forward_fn, use_cuda_graph = self._get_forward_fn(use_block_table=self.inputs_and_outputs.use_block_table)
+            forward_fn_args = (model, batch_data, carry_over_ids, prev_output_ids, output_ids)
+            if use_cuda_graph:
+                self._capture_graph(forward_fn, self.inputs_and_outputs.compute_stream, *forward_fn_args)
+            else:
+                with torch.cuda.stream(self.inputs_and_outputs.compute_stream):
+                    forward_fn(*forward_fn_args)
+            duration = time.perf_counter() - start
+            logger.debug(f"Warmup completed in {duration:.2f}s")
+
+        # Exception handling
+        except Exception as e:
+            duration = 0.0
+            logger.warning(f"Failed to warm up: {e}.\nGraph pool may fragment and OOM under load.")
+
+        # In any case, free the blocks allocated for the fake warmup requests
+        finally:
+            for fs in future_states:
+                self.cache.free_blocks(fs.state.request_id)
+        return duration

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -48,7 +48,7 @@ class ModelRunner:
         # Helper attributes
         self.do_sample = do_sample
         self.return_logprobs = return_logprobs
-        self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.get_cuda_graph_booleans()
+        self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.cuda_graph_booleans
         self.cache = cache
 
         # Padding only happen when CUDA graphs or compile is used
@@ -257,15 +257,15 @@ class ModelRunner:
             status = RequestStatus.DECODING
             num_q_tokens = 1
             max_kv_read = self.cache.block_size
-            logger.debug(f"Warming up decode fast path for {num_requests =}.")
+            logger.debug(f"Warming up decode fast path for {num_requests = }.")
         else:
             num_requests = 1
             status = RequestStatus.PREFILLING
-            logger.debug(f"Warming up varlen path for {num_q_tokens =}, {max_kv_read =}.")
+            logger.debug(f"Warming up varlen path for {num_q_tokens = }, {max_kv_read = }.")
         future_states = create_warmup_future_states(num_requests, status, num_q_tokens, max_kv_read, self.cache)
         if not future_states:
             logger.warning(
-                f"Failed to warm up: no blocks allocated for {num_requests =}, {num_q_tokens =}, {max_kv_read =}."
+                f"Failed to warm up: no blocks allocated for {num_requests = }, {num_q_tokens = }, {max_kv_read = }."
             )
             return 0.0
 

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -51,6 +51,11 @@ class ModelRunner:
         self.use_cuda_graph_varlen, self.use_cuda_graph_decode = self.cb_config.get_cuda_graph_booleans()
         self.cache = cache
 
+        # Padding only happen when CUDA graphs or compile is used
+        cuda_graph = self.use_cuda_graph_varlen or self.use_cuda_graph_decode
+        compile = self.cb_config.varlen_compile_config is not None or self.cb_config.decode_compile_config is not None
+        self.pad_inputs = cuda_graph or compile
+
         # Set up the graph pool. This allows all graphs to share the same memory pool, greatly saving memory.
         if self.use_cuda_graph_varlen or self.use_cuda_graph_decode:
             self.graph_pool = torch.cuda.graph_pool_handle()
@@ -73,6 +78,8 @@ class ModelRunner:
 
     def maybe_pad_inputs(self, num_q_tokens: int, max_kv_read: int, use_decode_fast_path: bool) -> tuple[int, int]:
         """Pads the input sizes for the next batch if it is needed. Often it is, for max performance."""
+        if not self.pad_inputs:
+            return num_q_tokens, max_kv_read
         max_batch_tokens = self.cache.max_batch_tokens
         # For varlen batches, we pad using interval sizes
         if not use_decode_fast_path:
@@ -209,9 +216,7 @@ class ModelRunner:
         """Pre-capture CUDA graphs and/or trigger compile warmup for varlen and decode paths (if available). Unless the
         force_warmup flag is set, the warmup is only performed if the CUDA graphs or compile are enabled."""
         # Early return if the warmup is not needed
-        cuda_graph_off = not (self.use_cuda_graph_varlen or self.use_cuda_graph_decode)
-        compile_off = self.cb_config.varlen_compile_config is None or self.cb_config.decode_compile_config is None
-        if cuda_graph_off and compile_off:
+        if not self.pad_inputs:
             return None
 
         # In async mode, each IO pair has its own graph buffer and static tensors, so we warm up both

--- a/src/transformers/generation/continuous_batching/offloading_manager.py
+++ b/src/transformers/generation/continuous_batching/offloading_manager.py
@@ -88,9 +88,10 @@ class OffloadingManager:
         # FIFO order favors contiguity when blocks are returned in bulk
         self._free_cpu_blocks = deque(range(self._num_cpu_blocks))
 
-        # Reusable int32 scratch for cpu_ids / gpu_ids (bounded by _num_cpu_blocks on both paths)
-        self._cpu_ids_scratch = torch.empty(self._num_cpu_blocks, dtype=torch.int32, pin_memory=True)
-        self._gpu_ids_scratch = torch.empty(self._num_cpu_blocks, dtype=torch.int32, device=cache.device)
+        # Reusable int64 scratch for cpu_ids / gpu_ids (bounded by _num_cpu_blocks on both paths).
+        # int64 is required by index_copy_ / index_select.
+        self._cpu_ids_scratch = torch.empty(self._num_cpu_blocks, dtype=torch.long, pin_memory=True)
+        self._gpu_ids_scratch = torch.empty(self._num_cpu_blocks, dtype=torch.long, device=cache.device)
 
         # Log the size of the CPU swap pool
         cache_tensor = self._cpu_key_cache[0]
@@ -229,15 +230,18 @@ class OffloadingManager:
             return None
 
         # Single batched copy for all requests (still, one copy per layer)
-        cpu_ids = self._cpu_ids_scratch[: len(all_cpu_indices)]
-        gpu_ids = self._gpu_ids_scratch[: len(all_cpu_indices)]
-        cpu_ids.copy_(torch.as_tensor(all_cpu_indices, dtype=torch.int32))  # cpu op, not in the stream
+        n = len(all_cpu_indices)
+        cpu_ids = self._cpu_ids_scratch[:n]
+        gpu_ids = self._gpu_ids_scratch[:n]
+        cpu_ids.copy_(torch.as_tensor(all_cpu_indices, dtype=torch.long))  # cpu op, not in the stream
         with self._stream_ctx():
-            gpu_ids.copy_(torch.as_tensor(all_gpu_indices, dtype=torch.int32))
+            gpu_ids.copy_(torch.as_tensor(all_gpu_indices, dtype=torch.long))
             for cpu_k, gpu_k in zip(self._cpu_key_cache, self._gpu_key_views):
-                gpu_k[gpu_ids].copy_(cpu_k[cpu_ids])
+                device_side_cpu_blocks = cpu_k.index_select(0, cpu_ids).to(gpu_k.device)
+                gpu_k.index_copy_(0, gpu_ids, device_side_cpu_blocks)
             for cpu_v, gpu_v in zip(self._cpu_value_cache, self._gpu_value_views):
-                gpu_v[gpu_ids].copy_(cpu_v[cpu_ids])
+                device_side_cpu_blocks = cpu_v.index_select(0, cpu_ids).to(gpu_v.device)
+                gpu_v.index_copy_(0, gpu_ids, device_side_cpu_blocks)
         self._free_cpu_blocks.extend(all_cpu_indices)
 
     def free_request_cpu_cache(self, state: RequestState) -> None:
@@ -281,17 +285,17 @@ class OffloadingManager:
         # Offload using the compute stream so it does not interfere with current generation
         cpu_ids = self._cpu_ids_scratch[:total_gpu_blocks]
         gpu_ids = self._gpu_ids_scratch[:total_gpu_blocks]
-        cpu_ids.copy_(torch.as_tensor(cpu_indices, dtype=torch.int32))  # cpu op, not in the stream
+        cpu_ids.copy_(torch.as_tensor(cpu_indices, dtype=torch.long))  # cpu op, not in the stream
         with self._stream_ctx():
-            gpu_ids.copy_(torch.as_tensor(gpu_indices, dtype=torch.int32))
-            # Keys
+            gpu_ids.copy_(torch.as_tensor(gpu_indices, dtype=torch.long))
             for cpu_key_cache, gpu_key_view in zip(self._cpu_key_cache, self._gpu_key_views):
-                cpu_key_cache[cpu_ids].copy_(gpu_key_view[gpu_ids])
-            # Values
+                host_side_gpu_blocks = gpu_key_view.index_select(0, gpu_ids).to(cpu_key_cache.device)
+                cpu_key_cache.index_copy_(0, cpu_ids, host_side_gpu_blocks)
             for cpu_value_cache, gpu_value_view in zip(self._cpu_value_cache, self._gpu_value_views):
-                cpu_value_cache[cpu_ids].copy_(gpu_value_view[gpu_ids])
-            # TODO: add asynchronous version of this
-            # TODO: can we get rid of this for loop? eg. by consolidating the cache.
+                host_side_gpu_blocks = gpu_value_view.index_select(0, gpu_ids).to(cpu_value_cache.device)
+                cpu_value_cache.index_copy_(0, cpu_ids, host_side_gpu_blocks)
+            # TODO: async path with a preallocated pinned scratch + non_blocking=True; current .to() materializes
+            # an unpinned intermediate per layer, so _stream_ctx() does not actually overlap.
 
         # No explicit sync needed: finish_request is logical, and the next forward pass serializes on the same stream.
         self._request_id_to_cpu_blocks[request_id] = cpu_indices

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -19,7 +19,6 @@ from typing import Any
 import torch
 
 from transformers.configuration_utils import PretrainedConfig
-from transformers.generation.configuration_utils import ContinuousBatchingConfig
 
 from .requests import FutureRequestState, RequestState, RequestStatus, logger
 
@@ -64,16 +63,6 @@ class WorkloadHints:
 
     max_prompt_length: int = 0
     max_generated_length: int = 0
-
-    # TODO: can this be fused with other resolve methods?
-    def resolve_using_hints(self, cb_config: "ContinuousBatchingConfig") -> None:
-        """Resolves the config using the given hints."""
-        # The max number of block per request is an even number large enough to hold the max request length
-        if self.max_prompt_length and self.max_generated_length:
-            if cb_config.max_blocks_per_request is None:
-                max_sequence_length = self.max_prompt_length + self.max_generated_length
-                blocks_per_request = int(ceil(max_sequence_length / cb_config.block_size)) + 1
-                cb_config.max_blocks_per_request = blocks_per_request + (blocks_per_request % 2)
 
 
 def attn_mask_is_needed(config: PretrainedConfig) -> bool:

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -191,27 +191,27 @@ def build_attention_mask(
 def create_warmup_future_states(
     num: int,
     status: RequestStatus,
-    num_query_tokens: int,
-    num_cache_tokens: int,
+    num_q_tokens: int,
+    max_kv_read: int,
     cache: Any,  # not annotated to avoid circular import
 ) -> list[FutureRequestState]:
-    """An utility function to create a list of FutureRequestStates for the warmup of CB."""
+    """A utility function to create a list of FutureRequestStates for the warmup of CB."""
     # Setup
     request_ids = [f"__warmup_{status.name}_{i}__" for i in range(num)]
-    total_tokens = num_query_tokens + num_cache_tokens
+    total_tokens = num_q_tokens + max_kv_read
     blocks_needed = ceil(total_tokens / cache.block_size)
     # Main loop
     future_states = []
     for req_id in request_ids:
         state = RequestState(request_id=req_id, initial_tokens=[0] * total_tokens, max_new_tokens=1)
         state._status = status  # bypass the property setter to avoid the lifecycle side effects
-        state.tokens_to_process = [0] * num_query_tokens
-        state.position_offset = num_cache_tokens
+        state.tokens_to_process = [0] * num_q_tokens
+        state.position_offset = max_kv_read
         # Stop if allocation fails for any request
         allocated = cache.allocate_blocks(blocks_needed, state.request_id, 0)
         if allocated is None:
             return future_states
         future_states.append(
-            FutureRequestState(state, has_new_token=True, complete_blocks=0, query_length=num_query_tokens)
+            FutureRequestState(state, has_new_token=True, complete_blocks=0, query_length=num_q_tokens)
         )
     return future_states

--- a/tests/generation/test_continuous_batching.py
+++ b/tests/generation/test_continuous_batching.py
@@ -746,67 +746,6 @@ class ContinuousBatchingWithAcceleratorTest(unittest.TestCase):
                 error_msg = f"logprob mismatch at position {j} for request {i}: CB={cb_lp}, expected={exp_lp}"
                 self.assertAlmostEqual(cb_lp, exp_lp, delta=delta, msg=error_msg)
 
-    def test_continuous_batching_with_default_compile_configs(self) -> None:
-        """Test continuous batching with use_default_compile_configs=True in ContinuousBatchingConfig.
-
-        This test verifies that:
-        1. Default compile configs are created for appropriate paths
-        2. Generation completes successfully with compiled functions
-        3. Output matches expectations
-        """
-        # Skip if Flash Attention 2 is not available
-        if not (is_flash_attn_2_available() or is_kernels_available()):
-            self.skipTest("Flash Attention 2 is not available and neither is the kernels library. Skipping test.")
-        # Skip if not on CUDA (compile works best on CUDA)
-        if torch_device != "cuda":
-            self.skipTest("This test is designed for CUDA devices. Skipping test.")
-
-        model_id = "TinyLlama/TinyLlama-1.1B-Chat-v1.0"
-
-        try:
-            # Prepare inputs
-            tokenizer, model = get_tokenizer_and_model(model_id, "flash_attention_2", torch_device)
-            user_messages = ["What is 2+2?", "What is the capital of France?"]
-            input_ids = get_generation_inputs(user_messages, tokenizer, for_continuous_batching=True)
-
-            # Create ContinuousBatchingConfig with use_default_compile_configs=True
-            cb_config = ContinuousBatchingConfig(use_default_compile_configs=True)
-
-            # Verify the config will create default compile configs
-            cb_config.resolve_compile_configs(
-                fallback_compile_config=None, is_flash_attn=True, decode_fast_path_available=False
-            )
-            self.assertIsNone(
-                cb_config.varlen_compile_config,
-                "Varlen compile config should not be created with use_default_compile_configs=True",
-            )
-            self.assertIsNotNone(
-                cb_config.decode_compile_config,
-                "Decode compile config should be created with use_default_compile_configs=True",
-            )
-
-            # Create GenerationConfig
-            gen_config = GenerationConfig(max_new_tokens=20, do_sample=False)
-
-            # Test that generation works with default compile configs
-            outputs = model.generate_batch(
-                inputs=input_ids, generation_config=gen_config, continuous_batching_config=cb_config
-            )
-
-            # Verify we got outputs for all requests
-            self.assertEqual(len(outputs), len(user_messages), "Should have outputs for all input requests")
-
-            # Verify outputs are valid
-            for req_id, output in outputs.items():
-                self.assertIsNotNone(output.generated_tokens, f"Output for {req_id} should have generated_tokens")
-                self.assertGreater(
-                    len(output.generated_tokens), 0, f"Output for {req_id} should have at least one token"
-                )
-                self.assertEqual(output.status.name, "FINISHED", f"Output for {req_id} should be FINISHED")
-
-        finally:
-            flush_memory(flush_compile=True)
-
     def test_continuous_batching_few_blocks(self) -> None:
         """This test verifies that generation works with a very small number of blocks, ie. small enough that we need to
         offload a request at some point. To add more complexity, we repeat the same prompt 4 times and enable prefix


### PR DESCRIPTION
# Summary

This PR simplifies the continuous batching code by refactoring away any model-related code in the `ModelRunner` class. This is because the `ContinuousBatchingProcessor` class is starting to get too big and this will help keep things organized.
Draft until https://github.com/huggingface/transformers/pull/45653 is merged.

## Performance

| label                |   samples |   avg_in |   max_new |   time (s) |   tokens |    tok/s |   mem (GB) |
|----------------------|-----------|----------|-----------|------------|----------|----------|------------|
| gsm8k_default        |      1319 |       94 |       256 |      27.36 |   337664 | 12341    |      72.57 |
| gsm8k_sampling       |      1319 |       94 |       256 |      28.32 |   337664 | 11922.8  |      71.95 |
| gsm8k_compile        |      1319 |       94 |       256 |      27.07 |   337664 | 12472.6  |      72.01 |
| gsm8k_no_fast_decode |      1319 |       94 |       256 |      30.65 |   337664 | 11015.3  |      71.95 |
| rollouts_1024        |        32 |      256 |      1024 |       9.97 |    32768 |  3286.04 |      72.01 |
| rollouts_2048        |        32 |      256 |      2048 |      20.95 |    65536 |  3128.95 |      71.98 |
| rollouts_4096        |        32 |      256 |      4096 |      46.97 |   131072 |  2790.29 |      72.01 |
| rollouts_8192        |        32 |      256 |      8192 |     115.66 |   262144 |  2266.54 |      71.97 |
| rollouts_16384       |        32 |      256 |     16384 |     351.32 |   524288 |  1492.34 |      72    |
| few_blocks           |        20 |      256 |       256 |       7.29 |     5120 |   702.41 |      16.88 |
| multi_return_seq     |        50 |      256 |       256 |       8.37 |    12800 |  1528.67 |      72    |

Perf is on par with main, which is to be expected.

## Tests

All good