### PR TITLE
Fix `NameError: PeftConfigLike` triggered by `PreTrainedModel.__init_subclass__`

### DIFF
--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 
 from safetensors import safe_open
 
+from .._typing import PeftConfigLike
 from ..conversion_mapping import (
     _MODEL_TO_CONVERSION_PATTERN,
     get_checkpoint_conversion_mapping,
@@ -61,8 +62,6 @@ MIN_PEFT_VERSION = "0.18.2"
 
 
 logger = logging.get_logger(__name__)
-
-from .._typing import PeftConfigLike
 
 
 if TYPE_CHECKING:

--- a/src/transformers/integrations/peft.py
+++ b/src/transformers/integrations/peft.py
@@ -62,8 +62,10 @@ MIN_PEFT_VERSION = "0.18.2"
 
 logger = logging.get_logger(__name__)
 
+from .._typing import PeftConfigLike
+
+
 if TYPE_CHECKING:
-    from .._typing import PeftConfigLike
     from ..modeling_utils import LoadStateDictConfig, LoadStateDictInfo
 
 
@@ -425,7 +427,7 @@ class PeftAdapterMixin:
 
     _hf_peft_config_loaded = False
     _prepare_peft_hotswap_kwargs: dict | None = None
-    peft_config: dict[str, "PeftConfigLike"]
+    peft_config: dict[str, PeftConfigLike]
 
     def load_adapter(
         self,


### PR DESCRIPTION
https://github.com/huggingface/transformers/pull/45425 added a class-level `peft_config` annotation in `integrations/peft.py`:

https://github.com/huggingface/transformers/blob/63378d94998c540997fcf818078c79437b04888d/src/transformers/integrations/peft.py#L407-L428

`PeftConfigLike` is imported only under `TYPE_CHECKING`, so it does not exist in the module's runtime namespace.

`PreTrainedModel` inherits from `PeftAdapterMixin`, and `modeling_utils.py:1296` runs `get_type_hints(cls)` inside `__init_subclass__`.

https://github.com/huggingface/transformers/blob/63378d94998c540997fcf818078c79437b04888d/src/transformers/modeling_utils.py#L1285-L1297

 `get_type_hints` walks the MRO and eagerly evaluates every forward reference in each base's module globals, so the unresolved `"PeftConfigLike"` raises `NameError` the moment any `PreTrainedModel` subclass is defined.

It's an import-time failure. It fires while `transformers.modeling_utils` itself is being imported (first triggered by `PreTrainedAudioTokenizerBase`), so any downstream library that imports a model (e.g. `trl`'s `SFTTrainer`) fails at collection

### Fix

Move `PeftConfigLike` out of the `TYPE_CHECKING` block so it's available at runtime, and drop the now-unneeded forward-reference quotes on the annotation.
