### PR TITLE
Fix EP + FSDP2: experts silently overwritten by rank-0 broadcast

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1108,6 +1108,8 @@ def set_param_for_module(
         if ref is not None and param_value.shape != expected_shape and hf_quantizer is None:
             loading_info.mismatched_keys.add((target_name, param_value.shape, expected_shape))
         else:
+            if distributed_operation is not None:
+                param_value = distributed_operation.post_shard_wrap(param_value)
             # super important otherwise _init_weight will re-init the param
             param_value._is_hf_initialized = True
             setattr(module_obj, param_name, param_value)

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -434,10 +434,10 @@ def grouped_mm_experts_forward(
     # NOTE: The grouped_mm kernel only targets the active experts / tokens via the offsets
     if self.has_gate:
         selected_weights = _local(self.gate_up_proj)
-        selected_biases = self.gate_up_proj_bias[expert_ids_g] if self.has_bias else None
+        selected_biases = _local(self.gate_up_proj_bias)[expert_ids_g] if self.has_bias else None
     else:
         selected_weights = _local(self.up_proj)
-        selected_biases = self.up_proj_bias[expert_ids_g] if self.has_bias else None
+        selected_biases = _local(self.up_proj_bias)[expert_ids_g] if self.has_bias else None
 
     # Pre-mask (bwd path).
     selected_hidden_states_g.masked_fill_(sentinel_mask, 0.0)
@@ -457,7 +457,7 @@ def grouped_mm_experts_forward(
 
     # Select down projection weights and biases
     selected_weights = _local(self.down_proj)
-    selected_biases = self.down_proj_bias[expert_ids_g] if self.has_bias else None
+    selected_biases = _local(self.down_proj_bias)[expert_ids_g] if self.has_bias else None
 
     # --- Down projection per expert (grouped) ---
     proj_out = _grouped_linear(

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import wraps
 
+from torch.distributed.tensor import DTensor
+
 from ..utils import logging
 from ..utils.generic import GeneralInterface
 from ..utils.import_utils import (
@@ -421,6 +423,9 @@ def grouped_mm_experts_forward(
     sentinel_mask = (expert_ids_g >= self.num_experts).unsqueeze(-1)
     expert_ids_g.clamp_(max=self.num_experts - 1)
 
+    def _local(p):
+        return p.to_local() if isinstance(p, DTensor) else p
+
     # Select expert weights and biases
     # NOTE: We keep all experts here and rely on offsets to target the active ones.
     # I have already implemented a version that only passes the active experts, but
@@ -428,10 +433,10 @@ def grouped_mm_experts_forward(
     # Also there were no speedup gains from it in my experiments, even in eager mode.
     # NOTE: The grouped_mm kernel only targets the active experts / tokens via the offsets
     if self.has_gate:
-        selected_weights = self.gate_up_proj
+        selected_weights = _local(self.gate_up_proj)
         selected_biases = self.gate_up_proj_bias[expert_ids_g] if self.has_bias else None
     else:
-        selected_weights = self.up_proj
+        selected_weights = _local(self.up_proj)
         selected_biases = self.up_proj_bias[expert_ids_g] if self.has_bias else None
 
     # Pre-mask (bwd path).
@@ -451,7 +456,7 @@ def grouped_mm_experts_forward(
         proj_out = self.act_fn(proj_out)  # (S, intermediate_dim)
 
     # Select down projection weights and biases
-    selected_weights = self.down_proj
+    selected_weights = _local(self.down_proj)
     selected_biases = self.down_proj_bias[expert_ids_g] if self.has_bias else None
 
     # --- Down projection per expert (grouped) ---

--- a/src/transformers/integrations/tensor_parallel.py
+++ b/src/transformers/integrations/tensor_parallel.py
@@ -29,6 +29,7 @@ if is_torch_available():
     import torch
     import torch.distributed as dist
     from torch import nn
+    from torch.distributed.tensor import DTensor, Shard
 
     # Cache this result has it's a C FFI call which can be pretty time-consuming
     _torch_distributed_available = torch.distributed.is_available()
@@ -135,6 +136,17 @@ def _get_parameter_tp_plan(parameter_name: str, tp_plan: dict[str, str], is_weig
     elif is_weight and "." in generic_param_name and (module_name := generic_param_name.rsplit(".", 1)[0]) in tp_plan:
         return tp_plan[module_name]
     return None
+
+
+def get_ep_sharded_param_names(model) -> list[str]:
+    """FQNs of parameters whose data is per-rank unique under EP sharding."""
+    if not getattr(model, "has_ep", False):
+        return []
+    return [
+        name
+        for name, _ in model.named_parameters()
+        if _get_parameter_tp_plan(parameter_name=name, tp_plan=model.tp_plan, is_weight=True) == "grouped_gemm"
+    ]
 
 
 # =============================================================================
@@ -692,6 +704,14 @@ class TensorParallelLayer:
         """
         pass
 
+    def post_shard_wrap(self, param: nn.Parameter) -> nn.Parameter:
+        """
+        Optional final wrap applied to a parameter after `shard_tensor` and before it is
+        attached to the module. Default is identity. Subclasses can override to e.g. wrap
+        the local shard as a DTensor.
+        """
+        return param
+
 
 class ColwiseParallel(TensorParallelLayer):
     """
@@ -1084,6 +1104,15 @@ class GroupedGemmParallel(TensorParallelLayer):
     def update_module_attributes(self, module: nn.Module):
         if hasattr(module, "num_experts"):
             module.num_experts = self.get_expected_sharded_shape((self.empty_param.shape[0],))[0]
+
+    def post_shard_wrap(self, param: nn.Parameter) -> nn.Parameter:
+        """
+        Wrap the EP-sharded local tensor as a DTensor on the TP/EP mesh. Without this, the
+        optimizer's foreach ops error with "mixed Tensor and DTensor" against the
+        FSDP-wrapped DTensor params on the rest of the model.
+        """
+        dt = DTensor.from_local(param.data, self.device_mesh, [Shard(0)], run_check=False)
+        return nn.Parameter(dt, requires_grad=param.requires_grad)
 
 
 class RouterParallel(TensorParallelLayer):
@@ -1495,6 +1524,8 @@ def shard_and_distribute_module(
     # otherwise loading is crazy slow
     if not isinstance(param, torch.nn.Parameter):
         param = torch.nn.Parameter(param, requires_grad=empty_param.is_floating_point())
+    if current_shard_plan is not None:
+        param = tp_layer.post_shard_wrap(param)
     setattr(module_to_tp, param_type, param)
     if tp_layer is not None:
         tp_layer.update_module_attributes(module_to_tp)

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -1425,11 +1425,31 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         self._backward_compatibility_gradient_checkpointing()
 
     @property
+    def has_ep(self) -> bool:
+        """Whether expert parallelism is enabled for this model."""
+        distributed_config = getattr(getattr(self, "config", None), "distributed_config", None)
+        return distributed_config is not None and getattr(distributed_config, "enable_expert_parallel", False)
+
+    @property
+    def ep_sharded_param_names(self) -> list[str]:
+        """FQNs of parameters whose data is per-rank unique under EP sharding."""
+        from .integrations.tensor_parallel import _get_parameter_tp_plan
+
+        if not self.has_ep:
+            return []
+        plan = self.tp_plan
+        return [
+            name
+            for name, _ in self.named_parameters()
+            if _get_parameter_tp_plan(parameter_name=name, tp_plan=plan, is_weight=True) == "grouped_gemm"
+        ]
+
+    @property
     def tp_plan(self) -> dict[str, str]:
         """
         The full tp plan for the model's modules
         """
-        if hasattr(self.config, "distributed_config") and self.config.distributed_config.enable_expert_parallel:
+        if self.has_ep:
             return self._ep_plan
         return self._tp_plan
 
@@ -4276,6 +4296,8 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         model.eval()  # Set model in evaluation mode to deactivate Dropout modules by default
         model.set_use_kernels(use_kernels, kernel_config)
 
+        cls._wrap_ep_params_as_dtensor(model, device_mesh)
+
         # If it is a model with generation capabilities, attempt to load generation files (generation config,
         # custom generate function)
         if model.can_generate() and hasattr(model, "adjust_generation_fn") and not gguf_file:
@@ -4414,6 +4436,26 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 k.__exit__(None, None, None)
 
         return loading_info, disk_offload_index
+
+    @staticmethod
+    def _wrap_ep_params_as_dtensor(model, device_mesh) -> None:
+        """Wrap EP-sharded params (`grouped_gemm` style) as DTensors in-place.
+
+        Without this, the optimizer's foreach ops error with "mixed Tensor and DTensor"
+        against the FSDP-wrapped DTensor params on the rest of the model.
+        """
+        from .integrations.tensor_parallel import _get_parameter_tp_plan
+        from torch.distributed.tensor import DTensor, Shard
+
+        if not model.has_ep:
+            return
+        plan = model.tp_plan
+        for name, p in list(model.named_parameters()):
+            if _get_parameter_tp_plan(parameter_name=name, tp_plan=plan, is_weight=True) != "grouped_gemm":
+                continue
+            parent, attr = get_module_from_name(model, name)
+            dt = DTensor.from_local(p.data, device_mesh, [Shard(0)], run_check=False)
+            setattr(parent, attr, nn.Parameter(dt, requires_grad=p.requires_grad))
 
     @staticmethod
     def _finalize_model_loading(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -32,14 +32,15 @@ from threading import Thread
 from typing import TYPE_CHECKING, Any, TypeVar, get_type_hints, overload
 from zipfile import is_zipfile
 
-import torch
 from huggingface_hub import create_repo, is_offline_mode, split_torch_state_dict_into_shards
 from packaging import version
 from safetensors import safe_open
 from safetensors.torch import load as _safe_load_bytes
 from safetensors.torch import save_file as safe_save_file
+import torch
 from torch import Tensor, nn
 from torch.distributions import constraints
+from torch.distributed.tensor import DTensor, Shard
 from torch.utils.checkpoint import checkpoint
 
 from . import initialization as init
@@ -1433,8 +1434,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
     @property
     def ep_sharded_param_names(self) -> list[str]:
         """FQNs of parameters whose data is per-rank unique under EP sharding."""
-        from .integrations.tensor_parallel import _get_parameter_tp_plan
-
         if not self.has_ep:
             return []
         plan = self.tp_plan
@@ -4444,8 +4443,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         Without this, the optimizer's foreach ops error with "mixed Tensor and DTensor"
         against the FSDP-wrapped DTensor params on the rest of the model.
         """
-        from .integrations.tensor_parallel import _get_parameter_tp_plan
-        from torch.distributed.tensor import DTensor, Shard
 
         if not model.has_ep:
             return

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -39,7 +39,6 @@ from safetensors import safe_open
 from safetensors.torch import load as _safe_load_bytes
 from safetensors.torch import save_file as safe_save_file
 from torch import Tensor, nn
-from torch.distributed.tensor import DTensor, Shard
 from torch.distributions import constraints
 from torch.utils.checkpoint import checkpoint
 
@@ -1430,18 +1429,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         """Whether expert parallelism is enabled for this model."""
         distributed_config = getattr(getattr(self, "config", None), "distributed_config", None)
         return distributed_config is not None and getattr(distributed_config, "enable_expert_parallel", False)
-
-    @property
-    def ep_sharded_param_names(self) -> list[str]:
-        """FQNs of parameters whose data is per-rank unique under EP sharding."""
-        if not self.has_ep:
-            return []
-        plan = self.tp_plan
-        return [
-            name
-            for name, _ in self.named_parameters()
-            if _get_parameter_tp_plan(parameter_name=name, tp_plan=plan, is_weight=True) == "grouped_gemm"
-        ]
 
     @property
     def tp_plan(self) -> dict[str, str]:
@@ -4295,8 +4282,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         model.eval()  # Set model in evaluation mode to deactivate Dropout modules by default
         model.set_use_kernels(use_kernels, kernel_config)
 
-        cls._wrap_ep_params_as_dtensor(model, device_mesh)
-
         # If it is a model with generation capabilities, attempt to load generation files (generation config,
         # custom generate function)
         if model.can_generate() and hasattr(model, "adjust_generation_fn") and not gguf_file:
@@ -4435,24 +4420,6 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
                 k.__exit__(None, None, None)
 
         return loading_info, disk_offload_index
-
-    @staticmethod
-    def _wrap_ep_params_as_dtensor(model, device_mesh) -> None:
-        """Wrap EP-sharded params (`grouped_gemm` style) as DTensors in-place.
-
-        Without this, the optimizer's foreach ops error with "mixed Tensor and DTensor"
-        against the FSDP-wrapped DTensor params on the rest of the model.
-        """
-
-        if not model.has_ep:
-            return
-        plan = model.tp_plan
-        for name, p in list(model.named_parameters()):
-            if _get_parameter_tp_plan(parameter_name=name, tp_plan=plan, is_weight=True) != "grouped_gemm":
-                continue
-            parent, attr = get_module_from_name(model, name)
-            dt = DTensor.from_local(p.data, device_mesh, [Shard(0)], run_check=False)
-            setattr(parent, attr, nn.Parameter(dt, requires_grad=p.requires_grad))
 
     @staticmethod
     def _finalize_model_loading(

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -32,15 +32,15 @@ from threading import Thread
 from typing import TYPE_CHECKING, Any, TypeVar, get_type_hints, overload
 from zipfile import is_zipfile
 
+import torch
 from huggingface_hub import create_repo, is_offline_mode, split_torch_state_dict_into_shards
 from packaging import version
 from safetensors import safe_open
 from safetensors.torch import load as _safe_load_bytes
 from safetensors.torch import save_file as safe_save_file
-import torch
 from torch import Tensor, nn
-from torch.distributions import constraints
 from torch.distributed.tensor import DTensor, Shard
+from torch.distributions import constraints
 from torch.utils.checkpoint import checkpoint
 
 from . import initialization as init

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -70,6 +70,7 @@ from .integrations.fsdp import get_fsdp_ckpt_kwargs, update_fsdp_plugin_peft
 from .integrations.liger import apply_liger_kernel
 from .integrations.neftune import activate_neftune, deactivate_neftune
 from .integrations.peft import MIN_PEFT_VERSION
+from .integrations.tensor_parallel import get_ep_sharded_param_names
 from .integrations.tpu import save_tpu_checkpoint, tpu_spmd_dataloader, wrap_model_xla_fsdp
 from .modelcard import TrainingSummary
 from .modeling_utils import PreTrainedModel, unwrap_model
@@ -828,9 +829,8 @@ class Trainer:
         # post accelerator creation setup
         if self.is_fsdp_enabled:
             fsdp_plugin = self.accelerator.state.fsdp_plugin
-            # EP-sharded experts must not be re-sharded by FSDP — their params are
-            # already DTensors on the EP mesh.
-            ep_param_names = getattr(self.model, "ep_sharded_param_names", []) or []
+            # EP-sharded experts must not be re-sharded by FSDP,  their params are DTensors on the EP mesh.
+            ep_param_names = get_ep_sharded_param_names(self.model)
             if ep_param_names:
                 module_names = list({n.rsplit(".", 1)[0] for n in ep_param_names})
                 fsdp_plugin.ignored_modules = [self.model.get_submodule(n) for n in module_names]

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -726,7 +726,12 @@ class Trainer:
                 )
             args["parallelism_config"] = self.args.parallelism_config
 
-        if getattr(self.model, "tp_size", None) is not None and self.model.tp_size > 1:
+        # EP-sharded params are already DTensors on the EP mesh, not on a TP mesh.
+        if (
+            getattr(self.model, "tp_size", None) is not None
+            and self.model.tp_size > 1
+            and not getattr(self.model, "has_ep", False)
+        ):
             if self.args.parallelism_config is None:
                 if is_accelerate_available("1.12.0"):
                     if self.args.parallelism_config is None:
@@ -823,6 +828,12 @@ class Trainer:
         # post accelerator creation setup
         if self.is_fsdp_enabled:
             fsdp_plugin = self.accelerator.state.fsdp_plugin
+            # EP-sharded experts must not be re-sharded by FSDP — their params are
+            # already DTensors on the EP mesh.
+            ep_param_names = getattr(self.model, "ep_sharded_param_names", []) or []
+            if ep_param_names:
+                module_names = list({n.rsplit(".", 1)[0] for n in ep_param_names})
+                fsdp_plugin.ignored_modules = [self.model.get_submodule(n) for n in module_names]
             for param in ["limit_all_gathers", "activation_checkpointing"]:
                 setattr(fsdp_plugin, param, self.args.fsdp_config.get(param, getattr(fsdp_plugin, param)))
             if fsdp_plugin.activation_checkpointing and self.args.gradient_checkpointing:


### PR DESCRIPTION
# What does this PR do?

Loading a MoE model with Expert Parallelism (`distributed_config=DistributedConfig(enable_expert_parallel=True)`) and then calling `accelerator.prepare` with FSDP2 silently loads wrong of the experts on ranks. The model trains, but on broken weights. 

Tested on `Qwen3-30B-A3B` with 128 experts and EP=8. The `from_pretrained` correctly EP-shards experts: rank 0 holds experts 0–15, rank 1 holds 16–31, … Then in `accelerate.utils.fsdp_utils.fsdp2_prepare_model` (with `cpu_ram_efficient_loading=True`):

1. Snapshot `original_sd = model.state_dict()`: captures per-rank-unique data.
2. `model.to("meta")` : drops values.
3. `fully_shard(model)`: wraps params as DTensors on the FSDP mesh, **assuming all ranks started with the same data**.
4. `fsdp2_load_full_state_dict` rank 0 calls `dist.broadcast(full_param, src=0)` for each param. **For an EP-sharded param, rank 0's local tensor contains only experts 0–15.** Every rank receives that data. After `distribute_tensor`, each rank holds a slice of *rank 0's 16 experts*.

The router still picks among 128, but all wrong weights.

## Minimal repro

```python
# repro_ep_fsdp.py — torchrun --nproc_per_node=8 repro_ep_fsdp.py
import os, torch, torch.distributed as dist
from transformers import AutoModelForCausalLM
from transformers.distributed import DistributedConfig
from accelerate import Accelerator
from accelerate.utils import FullyShardedDataParallelPlugin

rank = int(os.environ["RANK"])
model = AutoModelForCausalLM.from_pretrained(
    "Qwen/Qwen3-30B-A3B",
    dtype=torch.bfloat16,
    distributed_config=DistributedConfig(enable_expert_parallel=True),
)
dist.barrier()

# Per-rank-unique values: each rank holds 16 of the original 128 experts.
gu = model.model.layers[0].mlp.experts.gate_up_proj
local = gu.to_local() if hasattr(gu, "to_local") else gu
before = (local[0, 0, 0].item(), local[15, 0, 0].item())
print(f"[rank {rank}] BEFORE  expert0={before[0]:+.4e}  expert15={before[1]:+.4e}", flush=True)
dist.barrier()

# Wrap with FSDP2 the same way the Trainer does
plugin = FullyShardedDataParallelPlugin(
    fsdp_version=2, auto_wrap_policy="transformer_based_wrap",
    cpu_ram_efficient_loading=False,  # True triggers the destructive broadcast path
)
acc = Accelerator(fsdp_plugin=plugin)
optim = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=0.0)
model, optim = acc.prepare(model, optim)

gu = model.model.layers[0].mlp.experts.gate_up_proj
local = gu.to_local() if hasattr(gu, "to_local") else gu
after = (local[0, 0, 0].item(), local[15, 0, 0].item())
print(f"[rank {rank}] AFTER   expert0={after[0]:+.4e}  expert15={after[1]:+.4e}", flush=True)
dist.destroy_process_group()
```

Run on 1node, 8xH100s:

```bash
torchrun --nproc_per_node=8 repro_ep_fsdp.py
```

- **Without this PR**: each rank's AFTER values match rank 0's BEFORE values (rank 0's 16 experts broadcast to everyone; ranks 1–7's data is lost).
- **With this PR**: each rank's BEFORE/AFTER values match per rank all 8 unique slices preserved (128/128 experts retained).

## The fix
- Tell FSDP to skip the EP-sharded experts modules : `fully_shard()` doesn't auto-skip DTensors on a non-FSDP mesh. Also gate the existing `ParallelismConfig(tp_size=...)` auto-build on `not has_ep

- Wrap EP-sharded params as DTensors (`PreTrainedModel._wrap_ep_params_as_dtensor`). Without this, after `fully_shard()` the rest of the model is DTensors but EP params stay plain `nn.Parameter`, optimizer crashes. we then  use `.to_local()` in `grouped_mm_experts_forward` to get the local tensor, applied at the three weights (`gate_up_proj`, `up_proj`, `down_proj`).

> Follow-up: `batched_mm_experts_forward` and `sonicmoe_experts_forward` need the same one-liner before they're EP-compatible. Kept out of scope here.

## Verification

End-to-end SFT on Qwen3-30B-A3B, EP=8, single 8-GPU node, real `trl/scripts/sft.py` via `accelerate launch --use_fsdp --fsdp_cpu_ram_efficient_loading false`:

| | step 0 | step 4 |
|---|---|---|
| Before this PR | loss=62, grad=nan | loss=0, grad=nan |
| After this PR  | loss=8.88, grad=2.3 | loss=8.80, grad=2.8 |


## Who can review?

@ArthurZucker @IlyasMoutawwakil @3outeille 