### PR TITLE
[GGUF] Add support for Qwen3.5 MoE (qwen35moe arch)

### DIFF
--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -144,6 +144,25 @@ GGUF_CONFIG_MAPPING = {
         "expert_count": "num_experts",
         "expert_used_count": "num_experts_per_tok",
     },
+    "qwen3_5_moe_text": {
+        "context_length": "max_position_embeddings",
+        "block_count": "num_hidden_layers",
+        # Non-MoE layers in the hybrid stack still use a regular MLP whose
+        # size comes from feed_forward_length.
+        "feed_forward_length": "intermediate_size",
+        "embedding_length": "hidden_size",
+        "rope.dimension_count": None,
+        "rope.freq_base": "rope_theta",
+        "attention.key_length": "head_dim",
+        "attention.head_count": "num_attention_heads",
+        "attention.head_count_kv": "num_key_value_heads",
+        "attention.layer_norm_rms_epsilon": "rms_norm_eps",
+        "vocab_size": "vocab_size",
+        "expert_count": "num_experts",
+        "expert_used_count": "num_experts_per_tok",
+        "expert_feed_forward_length": "moe_intermediate_size",
+        "expert_shared_feed_forward_length": "shared_expert_intermediate_size",
+    },
     "falcon": {
         "context_length": "max_position_embeddings",
         "block_count": "num_hidden_layers",
@@ -351,6 +370,11 @@ GGUF_CONFIG_DEFAULTS_MAPPING = {
         # NOTE: Qwen3MoeConfig defaults to false but llama.cpp needs this to be true.
         # See: https://github.com/ggml-org/llama.cpp/blob/17f7f4baad8b3a716ee139da7bb56ae984e8c0fa/src/models/qwen3moe.cpp#L85-L96
         #      (the parameter right after LLM_FFN_SILU corresponds to norm_topk_prob)
+        "norm_topk_prob": True,
+    },
+    "qwen3_5_moe_text": {
+        # Same as qwen3_moe — llama.cpp's qwen35moe.cpp normalizes routed
+        # expert weights, so override the HF default to match.
         "norm_topk_prob": True,
     },
     "minimax_m2": {
@@ -791,6 +815,7 @@ GGUF_TO_FAST_CONVERTERS = {
     "qwen2_moe": GGUFQwen2Converter,
     "qwen3": GGUFQwen2Converter,
     "qwen3_moe": GGUFQwen2Converter,
+    "qwen3_5_moe_text": GGUFQwen2Converter,
     "phi3": GGUFPhi3Converter,
     "bloom": GGUFGPTConverter,
     "falcon": GGUFGPTConverter,

--- a/src/transformers/integrations/ggml.py
+++ b/src/transformers/integrations/ggml.py
@@ -162,6 +162,23 @@ GGUF_CONFIG_MAPPING = {
         "expert_used_count": "num_experts_per_tok",
         "expert_feed_forward_length": "moe_intermediate_size",
         "expert_shared_feed_forward_length": "shared_expert_intermediate_size",
+        # Hybrid layer pattern: convert_hf_to_gguf emits full_attention_interval;
+        # Qwen3_5MoeTextConfig.__post_init__ pops this kwarg to build layer_types.
+        "full_attention_interval": "full_attention_interval",
+        # GatedDeltaNet (linear-attention) shape parameters. The writer reuses
+        # the SSM key namespace; the mapping is:
+        #   ssm.conv_kernel    -> linear_conv_kernel_dim
+        #   ssm.state_size     -> linear_key_head_dim
+        #   ssm.group_count    -> linear_num_key_heads
+        #   ssm.time_step_rank -> linear_num_value_heads
+        # ssm.inner_size is derived (linear_value_head_dim * linear_num_value_heads)
+        # and has no direct config field; ignored here so linear_value_head_dim
+        # falls back to its config default.
+        "ssm.conv_kernel": "linear_conv_kernel_dim",
+        "ssm.state_size": "linear_key_head_dim",
+        "ssm.group_count": "linear_num_key_heads",
+        "ssm.time_step_rank": "linear_num_value_heads",
+        "ssm.inner_size": None,
     },
     "falcon": {
         "context_length": "max_position_embeddings",

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -725,6 +725,21 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
             i for i, num_kv_heads in enumerate(gguf_num_key_value_heads) if num_kv_heads > 0
         ]
 
+    if updated_architecture == "qwen3_5_moe_text":
+        # GatedDeltaNet's value head dim isn't emitted as its own GGUF key —
+        # the writer only emits ssm.inner_size (= linear_value_head_dim *
+        # linear_num_value_heads). Recover it here so the config matches the
+        # checkpoint instead of silently falling back to the class default.
+        ssm_inner_key = f"{architecture}.ssm.inner_size"
+        n_v_heads = parsed_parameters["config"].get("linear_num_value_heads")
+        if ssm_inner_key in reader.fields and n_v_heads:
+            ssm_inner = _gguf_parse_value(
+                reader.fields[ssm_inner_key].parts[reader.fields[ssm_inner_key].data[0]],
+                reader.fields[ssm_inner_key].types,
+            )
+            if ssm_inner % n_v_heads == 0:
+                parsed_parameters["config"]["linear_value_head_dim"] = ssm_inner // n_v_heads
+
     if updated_architecture == "gpt_oss":
         # Helper to read keys with the correct prefix
         def read_gpt_key(reader, suffix, default=None):

--- a/src/transformers/modeling_gguf_pytorch_utils.py
+++ b/src/transformers/modeling_gguf_pytorch_utils.py
@@ -458,6 +458,8 @@ TENSOR_PROCESSORS = {
     "qwen2moe": Qwen2MoeTensorProcessor,
     "gpt_oss": GptOssTensorProcessor,
     "qwen3moe": Qwen2MoeTensorProcessor,
+    # Qwen3.5 MoE reuses the qwen2/qwen3 fused 3-D ffn_*_exps layout.
+    "qwen35moe": Qwen2MoeTensorProcessor,
     "bloom": BloomTensorProcessor,
     "t5": T5TensorProcessor,
     "t5encoder": T5TensorProcessor,
@@ -512,6 +514,8 @@ def get_gguf_hf_weights_map(
         model_type = "qwen2moe"
     elif model_type == "qwen3_moe":
         model_type = "qwen3moe"
+    elif model_type == "qwen3_5_moe_text":
+        model_type = "qwen35moe"
     elif model_type == "gemma3_text":
         model_type = "gemma3"
     elif model_type == "umt5":
@@ -630,6 +634,12 @@ def load_gguf_checkpoint(gguf_checkpoint_path, return_tensors=False, model_to_lo
         updated_architecture = "gpt_oss"
     elif "qwen3moe" in architecture:
         updated_architecture = "qwen3_moe"
+    elif "qwen35moe" in architecture:
+        # GGUF identifies Qwen3.5 MoE as "qwen35moe". Route to the
+        # text-only qwen3_5_moe_text config rather than the multimodal
+        # qwen3_5_moe wrapper so Qwen3_5MoeForCausalLM gets the matching
+        # Qwen3_5MoeTextConfig.
+        updated_architecture = "qwen3_5_moe_text"
     elif "minimax-m2" in architecture:
         updated_architecture = "minimax_m2"
 

--- a/tests/quantization/ggml/test_ggml.py
+++ b/tests/quantization/ggml/test_ggml.py
@@ -309,6 +309,7 @@ class GgufModelTests(unittest.TestCase):
     gemma3_vision_model_id = "unsloth/gemma-3-4b-it-GGUF"
     qwen3_model_id = "Qwen/Qwen3-0.6B-GGUF"
     qwen3moe_model_id = "Qwen/Qwen3-30B-A3B-GGUF"
+    qwen35moe_model_id = "unsloth/Qwen3.6-35B-A3B-GGUF"
     umt5_encoder_model_id = "city96/umt5-xxl-encoder-gguf"
     lfm2_model_id = "LiquidAI/LFM2-1.2B-GGUF"
 
@@ -349,6 +350,7 @@ class GgufModelTests(unittest.TestCase):
     fp16_deci_model_id = "decilm-7b-uniform-gqa-f16.gguf"
     q8_0_qwen3_model_id = "Qwen3-0.6B-Q8_0.gguf"
     q4_k_m_qwen3moe_model_id = "Qwen3-30B-A3B-Q4_K_M.gguf"
+    iq3_s_qwen35moe_model_id = "Qwen3.6-35B-A3B-UD-IQ3_S.gguf"
     q8_0_umt5_encoder_model_id = "umt5-xxl-encoder-Q8_0.gguf"
     q4_k_m_lfm2_model_id = "LFM2-1.2B-Q4_K_M.gguf"
     gpt_oss_model_id = "unsloth/gpt-oss-20b-GGUF"
@@ -1094,6 +1096,22 @@ class GgufModelTests(unittest.TestCase):
 
         EXPECTED_TEXT = "Hello, I am a 20 year old male"
         self.assertEqual(tokenizer.decode(out[0], skip_special_tokens=True), EXPECTED_TEXT)
+
+    @unittest.skip("Heavyweight: ~12.7 GB GGUF download. Run manually.")
+    def test_qwen35moe_iq3_s(self):
+        # Smoke test for Qwen3.5/3.6 MoE GGUF support: tokenizer + model
+        # both load without error and the model produces non-empty output.
+        # A smaller fixture would be preferable; none was available at the
+        # time this test was added.
+        tokenizer = AutoTokenizer.from_pretrained(self.qwen35moe_model_id, gguf_file=self.iq3_s_qwen35moe_model_id)
+        model = AutoModelForCausalLM.from_pretrained(
+            self.qwen35moe_model_id,
+            gguf_file=self.iq3_s_qwen35moe_model_id,
+            dtype=torch.float16,
+        )
+        text = tokenizer(self.example_text, return_tensors="pt")
+        out = model.generate(**text, max_new_tokens=4)
+        self.assertGreater(len(tokenizer.decode(out[0], skip_special_tokens=True)), 0)
 
     def test_umt5_encoder_q8_0(self):
         """


### PR DESCRIPTION
# What does this PR do?

Currently, GGUF versions of Qwen3.5 MoE models raise
`GGUF model with architecture qwen35moe is not supported yet`.
This PR resolves that.

The arch is the one llama.cpp's `convert_hf_to_gguf.py` writes for
`Qwen3_5MoeForCausalLM` / `Qwen3_5MoeForConditionalGeneration` (see
`MODEL_ARCH.QWEN35MOE` in `gguf-py>=0.18.0`). Loading routes to the
text-only `Qwen3_5MoeTextConfig` so `Qwen3_5MoeForCausalLM` gets the
matching config; vision weights, when present, ride in a co-located
`mmproj-*.gguf`.

### Changes

**`src/transformers/integrations/ggml.py`**
- `GGUF_CONFIG_MAPPING["qwen3_5_moe_text"]` covering the qwen35moe
  metadata block: standard transformer fields, the MoE-specific
  `expert_*_length` keys, the hybrid-pattern `full_attention_interval`,
  and the SSM block (`ssm.conv_kernel`, `ssm.state_size`,
  `ssm.group_count`, `ssm.time_step_rank`) for the GatedDeltaNet
  linear-attention layers. `ssm.inner_size` is mapped to `None`
  (it's a derived value; recovered via post-processing — see below).
- `GGUF_CONFIG_DEFAULTS_MAPPING["qwen3_5_moe_text"]` with
  `norm_topk_prob: True` — same trap as `qwen3_moe`. llama.cpp
  normalizes routed expert weights by default while transformers
  defaults to `False`, so the override is needed to keep routing math
  consistent (see #42770 for the qwen3_moe precedent).
- `GGUF_TO_FAST_CONVERTERS["qwen3_5_moe_text"] = GGUFQwen2Converter`
  (Qwen3.5 reuses the qwen2/qwen3 BPE tokenizer convention).

**`src/transformers/modeling_gguf_pytorch_utils.py`**
- Architecture detection: `qwen35moe` → `qwen3_5_moe_text`.
- `TENSOR_PROCESSORS["qwen35moe"] = Qwen2MoeTensorProcessor` plus the
  matching alias in `get_gguf_hf_weights_map`. Without this, the
  fused 3-D `ffn_{gate,up,down}_exps` tensors silently fall through
  to the default processor and aren't sliced into per-expert
  `{gate,up,down}_proj`.
- Per-arch post-process to recover `linear_value_head_dim` from
  `ssm.inner_size / linear_num_value_heads`. The writer doesn't
  emit `linear_value_head_dim` directly (it only emits the product
  via `ssm.inner_size`), so without recovery it would silently
  default to 128. Mirrors the per-arch hooks already used for
  `lfm2`, `gpt_oss`, `minimax_m2`, and `gemma3`.

### Testing

A smoke test is added in `tests/quantization/ggml/test_ggml.py`
under `test_qwen35moe_iq3_s`, but marked `@unittest.skip` because
the only public Qwen3.5 MoE GGUF (`unsloth/Qwen3.6-35B-A3B-GGUF`,
~12.7 GB for the IQ3_S quant) is too large for routine CI. Same
approach used for other large MoE models like Qwen3-30B-A3B in
#42854 and MiniMax-M2.1 in #44526. Maintainers with a smaller
fixture in hand can drop the skip.

Verified end-to-end locally by loading the IQ3_S quant of the
35B-A3B model via `AutoModelForCausalLM.from_pretrained(...,
gguf_file=...)` and confirming generation produces sensible output.

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc @MekkCyber @CyrilVallez