### PR TITLE
Update latest revision for Phi-4-multimodal test

### DIFF
--- a/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
+++ b/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
@@ -276,13 +276,13 @@ class Phi4MultimodalModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.
 @slow
 class Phi4MultimodalIntegrationTest(unittest.TestCase):
     checkpoint_path = "microsoft/Phi-4-multimodal-instruct"
-    revision = "refs/pr/70"
+    revision = "refs/pr/94"
     image_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/australia.jpg"
     audio_url = "https://huggingface.co/datasets/raushan-testing-hf/audio-test/resolve/main/f2641_0_throatclearing.wav"
 
     def setUp(self):
         # Currently, the Phi-4 checkpoint on the hub is not working with the latest Phi-4 code, so the slow integration tests
-        # won't pass without using the correct revision (refs/pr/70)
+        # won't pass without using the correct revision (refs/pr/94)
         self.processor = AutoProcessor.from_pretrained(self.checkpoint_path, revision=self.revision)
         self.generation_config = GenerationConfig(max_new_tokens=20, do_sample=False)
         self.user_token = "<|user|>"

--- a/tests/models/phi4_multimodal/test_processing_phi4_multimodal.py
+++ b/tests/models/phi4_multimodal/test_processing_phi4_multimodal.py
@@ -32,7 +32,7 @@ if is_vision_available():
 class Phi4MultimodalProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     processor_class = Phi4MultimodalProcessor
     checkpoint_path = "microsoft/Phi-4-multimodal-instruct"
-    revision = "refs/pr/70"
+    revision = "refs/pr/94"
     text_input_name = "input_ids"
     images_input_name = "image_pixel_values"
     audio_input_name = "audio_input_features"


### PR DESCRIPTION
This PR tries to fix a failed test case: `tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py::Phi4MultimodalIntegrationTest::test_audio_text_generation`.I submit a PR https://huggingface.co/microsoft/Phi-4-multimodal-instruct/discussions/94 based on https://huggingface.co/microsoft/Phi-4-multimodal-instruct/discussions/70 to avoid using `trust_remote_code` and fix the bug `CommonKwargs` cannot be found in latest transformers. Hence we need to use 94 revision in the test case. More detailed background pls refer to discussion in https://github.com/huggingface/transformers/issues/44964. @Cyrilvallez @ydshieh pls help review, thx!