### PR TITLE
Fix shared config mutation issue in flash_attn_from_config

### DIFF
--- a/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
+++ b/tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import unittest
 
 import pytest
@@ -110,8 +111,8 @@ class Phi4MultimodalModelTester:
         self.eos_token_id = eos_token_id
         self.image_token_id = image_token_id
         self.audio_token_id = audio_token_id
-        self.audio_config = audio_config
-        self.vision_config = vision_config
+        self.audio_config = copy.deepcopy(audio_config)
+        self.vision_config = copy.deepcopy(vision_config)
 
         self.is_training = is_training
         self.batch_size = batch_size

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3994,9 +3994,8 @@ class ModelTesterMixin:
                 self.skipTest(reason=f"At least some parts of this model do not support {attn_implementation}")
 
             # TODO: to change it in the future with other relevant auto classes
-            # deepcopy to avoid mutating the shared config (e.g. _from_config sets dtype on sub-configs)
             fa_model = model_class._from_config(
-                copy.deepcopy(config), attn_implementation=attn_implementation, dtype=torch.bfloat16
+                config, attn_implementation=attn_implementation, dtype=torch.bfloat16
             ).to(torch_device)
 
             # By default, we perform the forward pass in train mode, because it's more sctrict than eval mode. If the

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -3994,8 +3994,9 @@ class ModelTesterMixin:
                 self.skipTest(reason=f"At least some parts of this model do not support {attn_implementation}")
 
             # TODO: to change it in the future with other relevant auto classes
+            # deepcopy to avoid mutating the shared config (e.g. _from_config sets dtype on sub-configs)
             fa_model = model_class._from_config(
-                config, attn_implementation=attn_implementation, dtype=torch.bfloat16
+                copy.deepcopy(config), attn_implementation=attn_implementation, dtype=torch.bfloat16
             ).to(torch_device)
 
             # By default, we perform the forward pass in train mode, because it's more sctrict than eval mode. If the


### PR DESCRIPTION
# What does this PR do?
Fixes a test isolation bug where test_from_pretrained_no_checkpoint and test_load_save_without_tied_weights fail when run after `test_flash_attn_2_from_config` in the same session (with RUN_SLOW=1).

# Root cause
`_from_config()` mutates sub-configs in-place when setting dtype:


`for sub_config_key in config.sub_configs:    sub_config.dtype = dtype`
Some model testers (e.g. `Phi4MultimodalModelTester`) use mutable default arguments for sub-configs like `vision_config=Phi4MultimodalVisionConfig(...)`. These objects are created once at class definition time and shared across all calls to` prepare_config_and_inputs_for_common()`.

When `flash_attn_from_config` calls `_from_config(config, dtype=torch.bfloat16)`, it permanently sets `vision_config.dtype = torch.bfloat16` on the shared sub-config object. All subsequent tests then create models with bfloat16 vision weights instead of float32, causing weight mismatches.

# Fix
deepcopy the config before passing it to _from_config in flash_attn_from_config, preventing the mutation from leaking across tests. This is a general fix that protects all models.

# Tests
```
RUN_SLOW=1 pytest tests/models/phi4_multimodal/test_modeling_phi4_multimodal.py -k "not deepspeed"
# Before: 2 failed (test_from_pretrained_no_checkpoint, test_load_save_without_tied_weights)
# After: all pass
```
@ydshieh pls help review, thx!