### PR TITLE
Exclude audio modules from conversion process

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -162,9 +162,6 @@ _deps = [
     "libcst",
     "rich",
     "ray[tune]>=2.7.0",
-    "opentelemetry-api",
-    "opentelemetry-exporter-otlp",
-    "opentelemetry-sdk",
 ]
 
 # This is a lookup table with items like: {"tokenizers": "tokenizers==0.9.4", "packaging": "packaging"}, i.e.
@@ -211,8 +208,6 @@ extras["benchmark"] = deps_list("optimum-benchmark")
 extras["ja"] = deps_list("fugashi", "ipadic", "unidic_lite", "unidic", "rhoknp")
 if PYTHON_MINOR_VERSION < 14:
     extras["ja"] += deps_list("sudachipy", "sudachidict_core")
-# OpenTelemetry dependencies for metrics collection in continuous batching
-extras["open-telemetry"] = deps_list("opentelemetry-api", "opentelemetry-exporter-otlp", "opentelemetry-sdk")
 
 extras["testing"] = (
     deps_list(
@@ -330,7 +325,7 @@ if __name__ == "__main__":
 
     setup(
         name="transformers",
-        version="5.7.0.dev0",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
+        version="5.10.0.dev0",  # expected format is one of x.y.z.dev0, or x.y.z.rc1 or x.y.z (no to dashes, yes to dots)
         author="The Hugging Face team (past and future) with the help of all our contributors (https://github.com/huggingface/transformers/graphs/contributors)",
         author_email="transformers@huggingface.co",
         description="Transformers: the model-definition framework for state-of-the-art machine learning models in text, vision, audio, and multimodal models, for both inference and training.",

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -89,7 +89,4 @@ deps = {
     "libcst": "libcst",
     "rich": "rich",
     "ray[tune]": "ray[tune]>=2.7.0",
-    "opentelemetry-api": "opentelemetry-api",
-    "opentelemetry-exporter-otlp": "opentelemetry-exporter-otlp",
-    "opentelemetry-sdk": "opentelemetry-sdk",
 }

--- a/src/transformers/models/zamba2/configuration_zamba2.py
+++ b/src/transformers/models/zamba2/configuration_zamba2.py
@@ -29,12 +29,12 @@ class Zamba2Config(PreTrainedConfig):
         Number of groups for the evolution matrices of mamba 2.
     n_mamba_heads (`int`, *optional*, defaults to 8):
         Number of heads for the evolution matrices of mamba 2.
+    use_mamba_kernels (`bool`, *optional*, defaults to `True`):
+        Flag indicating whether or not to use the fast mamba kernels.
     use_conv_bias (`bool`, *optional*, defaults to `True`):
         Whether or not to use bias in the convolution layer of the mixer block.
     chunk_size (`int`, *optional*, defaults to 256):
         Size of the chunks that will comprise the sequence.
-    use_mamba_kernels (`bool`, *optional*, defaults to `True`):
-        Flag indicating whether or not to use the fast mamba kernels.
     use_mem_eff_path (`bool`, *optional*, defaults to `False`):
         Whether or not to use the fused conv1d and scan in mamba2 layers.
     add_bias_linear (`bool`, *optional*, defaults to `False`):

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -57,6 +57,12 @@ def get_keys_to_not_convert(model) -> list:
     }
     modules_to_not_convert = tied_keys | last_module_key | output_emb_keys
 
+    # remove audio modules for multimodal models to prevent uint8 crash
+    for name, _ in model.named_modules():
+        if "audio_tower" in name or "embed_audio" in name:
+            modules_to_not_convert.add(name)
+
+    
     modules_to_not_convert = list({k.removesuffix(".weight") for k in modules_to_not_convert})
 
     return list(modules_to_not_convert)

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -59,9 +59,11 @@ def get_keys_to_not_convert(model) -> list:
 
     # Audio modules in multimodal models are typically small and not worth quantizing.
     # Skipping them also prevents uint8 dtype crashes during inference.
-    for name, _ in model.named_children():
-        if name in ("audio_tower", "embed_audio"):
+    # Use named_modules() to find audio modules regardless of nesting depth.
+    for name, _ in model.named_modules():
+        if name.endswith(("audio_tower", "embed_audio")):
             modules_to_not_convert.add(name)
+
 
     
     modules_to_not_convert = list({k.removesuffix(".weight") for k in modules_to_not_convert})

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -64,8 +64,6 @@ def get_keys_to_not_convert(model) -> list:
         if name.endswith(("audio_tower", "embed_audio")):
             modules_to_not_convert.add(name)
 
-
-    
     modules_to_not_convert = list({k.removesuffix(".weight") for k in modules_to_not_convert})
 
     return list(modules_to_not_convert)

--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -57,9 +57,10 @@ def get_keys_to_not_convert(model) -> list:
     }
     modules_to_not_convert = tied_keys | last_module_key | output_emb_keys
 
-    # remove audio modules for multimodal models to prevent uint8 crash
-    for name, _ in model.named_modules():
-        if "audio_tower" in name or "embed_audio" in name:
+    # Audio modules in multimodal models are typically small and not worth quantizing.
+    # Skipping them also prevents uint8 dtype crashes during inference.
+    for name, _ in model.named_children():
+        if name in ("audio_tower", "embed_audio"):
             modules_to_not_convert.add(name)
 
     

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -874,16 +874,22 @@ class Bnb4bitCompile(unittest.TestCase):
         from transformers.quantizers.base import get_keys_to_not_convert
         import torch.nn as nn
 
-        class DummyMultimodalModel(nn.Module):
+        class DummyInnerModel(nn.Module):
             def __init__(self):
                 super().__init__()
                 self.audio_tower = nn.Sequential(nn.Linear(10, 10), nn.Linear(10, 10))
                 self.embed_audio = nn.Linear(10, 10)
                 self.language_model = nn.Linear(10, 10)
 
+        class DummyMultimodalModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.model = DummyInnerModel()
+
         model = DummyMultimodalModel()
         keys = get_keys_to_not_convert(model)
 
-        self.assertIn("audio_tower", keys)
-        self.assertIn("embed_audio", keys)
-        self.assertNotIn("audio_tower.0", keys)
+        self.assertIn("model.audio_tower", keys)
+        self.assertIn("model.embed_audio", keys)
+        self.assertNotIn("model.audio_tower.0", keys)
+

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -871,8 +871,9 @@ class Bnb4bitCompile(unittest.TestCase):
 
     def test_get_keys_to_not_convert_excludes_audio_modules(self):
         """Audio modules should be excluded from quantization by default."""
-        from transformers.quantizers.base import get_keys_to_not_convert
         import torch.nn as nn
+
+        from transformers.quantizers.base import get_keys_to_not_convert
 
         class DummyInnerModel(nn.Module):
             def __init__(self):
@@ -892,4 +893,3 @@ class Bnb4bitCompile(unittest.TestCase):
         self.assertIn("model.audio_tower", keys)
         self.assertIn("model.embed_audio", keys)
         self.assertNotIn("model.audio_tower.0", keys)
-

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -868,3 +868,22 @@ class Bnb4bitCompile(unittest.TestCase):
                 max_new_tokens=10,
                 cache_implementation="static",
             )
+
+    def test_get_keys_to_not_convert_excludes_audio_modules(self):
+        """Audio modules should be excluded from quantization by default."""
+        from transformers.quantizers.base import get_keys_to_not_convert
+        import torch.nn as nn
+
+        class DummyMultimodalModel(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.audio_tower = nn.Sequential(nn.Linear(10, 10), nn.Linear(10, 10))
+                self.embed_audio = nn.Linear(10, 10)
+                self.language_model = nn.Linear(10, 10)
+
+        model = DummyMultimodalModel()
+        keys = get_keys_to_not_convert(model)
+
+        self.assertIn("audio_tower", keys)
+        self.assertIn("embed_audio", keys)
+        self.assertNotIn("audio_tower.0", keys)

--- a/utils/add_dates.py
+++ b/utils/add_dates.py
@@ -16,7 +16,7 @@ CHECKER_CONFIG = {
     "label": "Model dates",
     # Approximate: also reads docs/source/en/model_doc/*.md and uses git log + network
     # calls to GitHub/HuggingFace for commit dates and paper metadata.
-    "file_globs": ["src/transformers/models/**/__init__.py", "docs/source/en/model_doc/**/*.md"],
+    "cache_globs": ["src/transformers/models/**/__init__.py", "docs/source/en/model_doc/**/*.md"],
     "check_args": ["--check-only"],
     "fix_args": [],
 }

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -49,7 +49,7 @@ CHECKER_CONFIG = {
     "name": "copies",
     "label": "Copied code consistency",
     # Actual scope: all of src/transformers/**/*.py and tests/models/**/*.py via glob.glob().
-    "file_globs": ["src/transformers/**/*.py", "tests/models/**/*.py"],
+    "cache_globs": ["src/transformers/**/*.py", "tests/models/**/*.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_doc_toc.py
+++ b/utils/check_doc_toc.py
@@ -41,7 +41,7 @@ CHECKER_CONFIG = {
     "name": "doc_toc",
     "label": "Documentation table of contents",
     # Also reads docs/source/en/_toctree.yml; the .md glob catches new/renamed doc files.
-    "file_globs": ["docs/**/*.md", "docs/source/en/_toctree.yml"],
+    "cache_globs": ["docs/**/*.md", "docs/source/en/_toctree.yml"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -67,7 +67,7 @@ CHECKER_CONFIG = {
     "label": "Docstring formatting",
     # Approximate: at runtime the checker also introspects the live transformers module for
     # @auto_docstring-decorated objects. These globs cover the files it reads via glob.glob().
-    "file_globs": [
+    "cache_globs": [
         "src/transformers/models/**/modeling_*.py",
         "src/transformers/models/**/modular_*.py",
         "src/transformers/models/**/configuration_*.py",

--- a/utils/check_doctest_list.py
+++ b/utils/check_doctest_list.py
@@ -39,7 +39,7 @@ CHECKER_CONFIG = {
     "label": "Doctest list",
     # Over-approximation: the checker validates that paths in .txt list files exist and are
     # sorted. The broad globs ensure cache invalidation when source files are added/removed.
-    "file_globs": [
+    "cache_globs": [
         "utils/not_doctested.txt",
         "utils/slow_documentation_tests.txt",
         "src/transformers/**/*.py",

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -43,7 +43,7 @@ CHECKER_CONFIG = {
     "label": "Dummy objects",
     # Over-approximation: only reads __init__.py and utils/dummy_*_objects.py, but any
     # new public object added anywhere could require a dummy update.
-    "file_globs": ["src/transformers/**/*.py"],
+    "cache_globs": ["src/transformers/**/*.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -20,7 +20,7 @@ CHECKER_CONFIG = {
     "name": "modular_conversion",
     "label": "Modular file conversions",
     # Globs the modular sources; also reads generated modeling_*.py at runtime for diffing.
-    "file_globs": ["src/transformers/models/**/modular_*.py", "src/transformers/models/**/modeling_*.py"],
+    "cache_globs": ["src/transformers/models/**/modular_*.py", "src/transformers/models/**/modeling_*.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_pipeline_typing.py
+++ b/utils/check_pipeline_typing.py
@@ -6,7 +6,7 @@ from transformers.pipelines import SUPPORTED_TASKS, Pipeline
 CHECKER_CONFIG = {
     "name": "pipeline_typing",
     "label": "Pipeline type hints",
-    "file_globs": ["src/transformers/pipelines/__init__.py"],
+    "cache_globs": ["src/transformers/pipelines/__init__.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/custom_init_isort.py
+++ b/utils/custom_init_isort.py
@@ -44,7 +44,7 @@ from typing import Any
 CHECKER_CONFIG = {
     "name": "init_isort",
     "label": "Import ordering",
-    "file_globs": ["src/transformers/**/__init__.py"],
+    "cache_globs": ["src/transformers/**/__init__.py"],
     "check_args": ["--check_only"],
     "fix_args": [],
 }

--- a/utils/sort_auto_mappings.py
+++ b/utils/sort_auto_mappings.py
@@ -37,7 +37,7 @@ import re
 CHECKER_CONFIG = {
     "name": "sort_auto_mappings",
     "label": "Sort auto mappings",
-    "file_globs": ["src/transformers/models/auto/*.py"],
+    "cache_globs": ["src/transformers/models/auto/*.py"],
     "check_args": ["--check_only"],
     "fix_args": [],
 }


### PR DESCRIPTION
Add logic to exclude audio modules from conversion to prevent uint8 crash in multimodal models.

As discussed in the issue, this prevents the torch.finfo() TypeError on uint8 weights during 4-bit inference for multimodal models like Gemma 4, and preserves audio encoder fidelity.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #45672, Fixes #45674

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
