### PR TITLE
Fix custom-module copies inheriting read-only permissions

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -420,7 +420,7 @@ def get_cached_module_file(
             resolved_module_file, str(submodule_path / module_file)
         ):
             (submodule_path / module_file).parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(resolved_module_file, submodule_path / module_file)
+            shutil.copyfile(resolved_module_file, submodule_path / module_file)
             importlib.invalidate_caches()
         for module_needed in modules_needed:
             module_needed = Path(module_file).parent / f"{module_needed}.py"
@@ -428,7 +428,7 @@ def get_cached_module_file(
             if not (submodule_path / module_needed).exists() or not filecmp.cmp(
                 module_needed_file, str(submodule_path / module_needed)
             ):
-                shutil.copy(module_needed_file, submodule_path / module_needed)
+                shutil.copyfile(module_needed_file, submodule_path / module_needed)
                 importlib.invalidate_caches()
     else:
         # Get the commit hash
@@ -442,7 +442,7 @@ def get_cached_module_file(
         create_dynamic_module(Path(full_submodule_module_file_path).parent)
 
         if not (submodule_path / module_file).exists():
-            shutil.copy(resolved_module_file, submodule_path / module_file)
+            shutil.copyfile(resolved_module_file, submodule_path / module_file)
             importlib.invalidate_caches()
         # Make sure we also have every file with relative
         for module_needed in modules_needed:
@@ -647,13 +647,13 @@ def custom_object_save(obj: Any, folder: str | os.PathLike, config: dict | None 
     # Copy module file to the output folder.
     object_file = sys.modules[obj.__module__].__file__
     dest_file = Path(folder) / (Path(object_file).name)
-    shutil.copy(object_file, dest_file)
+    shutil.copyfile(object_file, dest_file)
     result.append(dest_file)
 
     # Gather all relative imports recursively and make sure they are copied as well.
     for needed_file in get_relative_import_files(object_file):
         dest_file = Path(folder) / (Path(needed_file).name)
-        shutil.copy(needed_file, dest_file)
+        shutil.copyfile(needed_file, dest_file)
         result.append(dest_file)
 
     return result


### PR DESCRIPTION
# What does this PR do?

Fixes #45684.

`shutil.copy` is `copyfile` + `copymode`, so when source files are read-only (common with version-control systems like Perforce that check files out as `r--r--r--` until edit), the destination inherits those permissions. This breaks post-save tooling that wants to rewrite the saved module file, and leaves users with read-only files in their saved-model directories.

The fix swaps `shutil.copy` for `shutil.copyfile` at all five call sites in `dynamic_module_utils.py` (one in `custom_object_save`, four in `get_cached_module_file`). `copyfile` copies file contents only; the destination, when newly created, gets standard umask-based permissions, which is what callers of `save_pretrained` expect.

A regression test is added to `tests/utils/test_dynamic_module_utils.py`: it makes a source module read-only, calls `custom_object_save`, and asserts the destination is writable. The test fails on `main` and passes with this fix.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.
    * AI was used for making the change, but I hand-edited, reviewed and added tests myself.
  
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section? (I read and tried `make style` but it changes many files I did not touch and exits with errors)
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
    * not discussed yet but issue is here: https://github.com/huggingface/transformers/issues/45684
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
    * I don't think this warrants a docs change
- [x] Did you write any new necessary tests?
    * yes!

## Who can review?

@Cyrilvallez (model loading)