### PR TITLE
docs(README_zh-hans): clarify conditions for not using Transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ pipeline(
     <img alt="Hugging Face Enterprise Hub" src="https://github.com/user-attachments/assets/247fb16d-d251-4583-96c4-d3d76dda4925">
 </a><br>
 
-## Why shouldn't I use Transformers?
+## When shouldn't I use Transformers?
 
 - This library is not a modular toolbox of building blocks for neural nets. The code in the model files is not refactored with additional abstractions on purpose, so that researchers can quickly iterate on each of the models without diving into additional abstractions/files.
 - The training API is optimized to work with PyTorch models provided by Transformers. For generic machine learning loops, you should use another library like [Accelerate](https://huggingface.co/docs/accelerate).

--- a/i18n/README_zh-hans.md
+++ b/i18n/README_zh-hans.md
@@ -258,7 +258,7 @@ pipeline(
     <img alt="Hugging Face Enterprise Hub" src="https://github.com/user-attachments/assets/247fb16d-d251-4583-96c4-d3d76dda4925">
 </a><br>
 
-## 为什么我不该用 Transformers？
+## 什么情况下我不该用 Transformers？
 
 - 该库不是一个可自由拼搭的神经网络模块化工具箱。模型文件中的代码刻意减少额外抽象，以便研究者能快速在各个模型上迭代，而无需深入更多抽象或文件跳转。
 - 训练 API 优化用于 Transformers 提供的 PyTorch 模型。若需要通用的机器学习训练循环，请使用其它库，如 [Accelerate](https://huggingface.co/docs/accelerate)。


### PR DESCRIPTION
Rephrase section title for clarity regarding the use of Transformers.

# What does this PR do?

This PR updates the Chinese README (`i18n/README_zh-hans.md`) to rephrase a section title for better clarity:

- **Before**: `## 为什么我不该用 Transformers？`
- **After**: `## 什么情况下我不该用 Transformers？`

The new title more accurately conveys that the section discusses **appropriate use cases and limitations**, rather than sounding like a general discouragement. This helps readers better understand when Transformers might not be the right tool for their specific needs (e.g., if they need low-level control or a generic training loop).

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline]...
- [x] Was this discussed/approved via a Github issue or the [forum]... *(optional, can leave unchecked for trivial docs fixes)*
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests? *(N/A for docs-only change)*

## Who can review?

@stevhliu