### PR TITLE
[serve] cb error 

### DIFF
--- a/src/transformers/cli/serve.py
+++ b/src/transformers/cli/serve.py
@@ -150,6 +150,7 @@ class Serve:
             completion_handler=self._completion_handler,
             response_handler=self._response_handler,
             transcription_handler=self._transcription_handler,
+            generation_state=self._generation_state,
             enable_cors=enable_cors,
         )
 

--- a/src/transformers/cli/serving/server.py
+++ b/src/transformers/cli/serving/server.py
@@ -32,7 +32,7 @@ from .completion import CompletionHandler
 from .model_manager import ModelManager
 from .response import ResponseHandler
 from .transcription import TranscriptionHandler
-from .utils import X_REQUEST_ID
+from .utils import X_REQUEST_ID, CBWorkerDeadError, GenerationState
 
 
 logger = logging.get_logger(__name__)
@@ -44,6 +44,7 @@ def build_server(
     completion_handler: CompletionHandler,
     response_handler: ResponseHandler,
     transcription_handler: TranscriptionHandler,
+    generation_state: GenerationState,
     enable_cors: bool = False,
 ) -> FastAPI:
     """Build and return a configured FastAPI application.
@@ -52,6 +53,7 @@ def build_server(
         model_manager: Handles model loading, caching, and cleanup.
         chat_handler: Handles `/v1/chat/completions` requests.
         response_handler: Handles `/v1/responses` requests.
+        generation_state: Shared generation state, used by `/health` to report CB liveness.
         enable_cors: If `True`, adds permissive CORS middleware (allow all origins).
 
     Returns:
@@ -64,6 +66,12 @@ def build_server(
         model_manager.shutdown()
 
     app = FastAPI(lifespan=lifespan)
+
+    @app.exception_handler(CBWorkerDeadError)
+    async def _cb_dead_handler(_request: Request, exc: CBWorkerDeadError):
+        # CB worker died (e.g. CUDA illegal memory access); reject new requests with 503
+        # carrying the cause, instead of letting them hang in the input queue forever.
+        return JSONResponse({"error": str(exc)}, status_code=503)
 
     if enable_cors:
         app.add_middleware(
@@ -128,6 +136,8 @@ def build_server(
 
     @app.get("/health")
     def health():
+        if not generation_state.is_cb_alive():
+            return JSONResponse({"status": "unhealthy", "reason": "cb_worker_dead"}, status_code=503)
         return JSONResponse({"status": "ok"})
 
     return app

--- a/src/transformers/cli/serving/server.py
+++ b/src/transformers/cli/serving/server.py
@@ -53,7 +53,9 @@ def build_server(
         model_manager: Handles model loading, caching, and cleanup.
         chat_handler: Handles `/v1/chat/completions` requests.
         response_handler: Handles `/v1/responses` requests.
-        generation_state: Shared generation state, used by `/health` to report CB liveness.
+        generation_state: Owns the per-model generation managers (regular and CB). Passed
+            in here so `/health` can check whether the CB worker has died and respond with
+            503 instead of a misleading 200.
         enable_cors: If `True`, adds permissive CORS middleware (allow all origins).
 
     Returns:
@@ -69,8 +71,7 @@ def build_server(
 
     @app.exception_handler(CBWorkerDeadError)
     async def _cb_dead_handler(_request: Request, exc: CBWorkerDeadError):
-        # CB worker died (e.g. CUDA illegal memory access); reject new requests with 503
-        # carrying the cause, instead of letting them hang in the input queue forever.
+        # Map CBWorkerDeadError to 503; otherwise it'd fall through to Starlette's default 500.
         return JSONResponse({"error": str(exc)}, status_code=503)
 
     if enable_cors:

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -73,6 +73,14 @@ class _GenerationCancelled(Exception):
     """Raised inside ``DirectStreamer.put()`` to abort ``model.generate()``."""
 
 
+class CBWorkerDeadError(RuntimeError):
+    """Raised when a request is submitted to a CB worker that has died.
+
+    Surfaced as 503 by the FastAPI exception handler. Carries the original error message
+    that killed the worker so the client knows why the server is in this state.
+    """
+
+
 # Fallback tool call configs for models that don't declare stc_token/etc_token/response_schema
 # on their tokenizer.
 # Keys are matched via substring against model_type (e.g. "qwen" matches "qwen2", "qwen3_vl", etc.).
@@ -635,6 +643,21 @@ class CBGenerateManager(BaseGenerateManager):
         )
         self._cb.start()
 
+    def is_alive(self) -> bool:
+        """Whether the CB worker is healthy and able to serve new requests."""
+        return self._cb is not None and self._cb.fatal_error is None
+
+    def _check_alive(self, request_id: str) -> None:
+        """Raise :class:`CBWorkerDeadError` if the CB worker has died.
+
+        Called at request entry to fail fast — submitting to a dead worker would otherwise
+        enqueue the request into a void where it never gets processed.
+        """
+        if self._cb is not None and self._cb.fatal_error is not None:
+            raise CBWorkerDeadError(
+                f"CB worker is dead and cannot accept request {request_id}: {self._cb.fatal_error}"
+            )
+
     def generate_streaming(
         self,
         model: "PreTrainedModel",
@@ -648,6 +671,7 @@ class CBGenerateManager(BaseGenerateManager):
         cb = self._cb
         if cb is None:
             raise RuntimeError("CB manager not initialized. Call `init_cb()` first.")
+        self._check_alive(request_id)
 
         loop = asyncio.get_running_loop()
         text_queue: asyncio.Queue = asyncio.Queue()
@@ -669,7 +693,13 @@ class CBGenerateManager(BaseGenerateManager):
         def _on_output(output):
             try:
                 streamer.put(output)
-                if output.is_finished():
+                # ``error`` is set together with ``status = FAILED`` in CB's _handle_request_error.
+                # Surface it as an end-of-stream error so the SSE handler can emit it and close,
+                # instead of leaving the client hanging on a stream that will never end.
+                if output.error is not None:
+                    text_queue.put_nowait(_StreamError(output.error))
+                    streamer.end()
+                elif output.is_finished():
                     streamer.end()
             except Exception as e:
                 text_queue.put_nowait(_StreamError(str(e)))
@@ -689,6 +719,7 @@ class CBGenerateManager(BaseGenerateManager):
         cb = self._cb
         if cb is None:
             raise RuntimeError("CB manager not initialized. Call `init_cb()` first.")
+        self._check_alive(request_id)
 
         input_ids = inputs["input_ids"]
         input_len = len(input_ids)
@@ -711,8 +742,16 @@ class CBGenerateManager(BaseGenerateManager):
             eos_token_id=gen_config.eos_token_id,
         )
         result = await future
-        if result is None:
-            raise RuntimeError(f"CB manager stopped before producing a result for {request_id}")
+        # CB signals a failed request by setting ``error`` (and ``status = FAILED``) on the
+        # delivered GenerationOutput, often with empty ``generated_tokens``. Surface it instead
+        # of returning an empty success that downstream parsing/decoding would silently mask.
+        # If the worker itself died, route to CBWorkerDeadError so the client gets the same 503
+        # as requests submitted post-crash; otherwise it's a per-request failure (e.g. unsupported
+        # logit-processor kwarg) and a plain RuntimeError -> 500 is appropriate.
+        if result.error is not None:
+            if self._cb.fatal_error is not None:
+                raise CBWorkerDeadError(f"CB worker died during request {request_id}: {result.error}")
+            raise RuntimeError(f"CB generation failed for {request_id}: {result.error}")
         generated_ids = result.generated_tokens
         text = processor.decode(generated_ids, skip_special_tokens=True)
         return text, input_len, generated_ids
@@ -804,6 +843,12 @@ class GenerationState:
         if self._cb_manager is not None:
             self._cb_manager.stop()
             self._cb_manager = None
+
+    def is_cb_alive(self) -> bool:
+        """Whether the CB worker is healthy. ``True`` if CB is disabled or not yet initialized."""
+        if self._cb_manager is None:
+            return True
+        return self._cb_manager.is_alive()
 
 
 class BaseHandler:

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -749,7 +749,7 @@ class CBGenerateManager(BaseGenerateManager):
         # as requests submitted post-crash; otherwise it's a per-request failure (e.g. unsupported
         # logit-processor kwarg) and a plain RuntimeError -> 500 is appropriate.
         if result.error is not None:
-            if self._cb.fatal_error is not None:
+            if cb.fatal_error is not None:
                 raise CBWorkerDeadError(f"CB worker died during request {request_id}: {result.error}")
             raise RuntimeError(f"CB generation failed for {request_id}: {result.error}")
         generated_ids = result.generated_tokens

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -644,8 +644,8 @@ class CBGenerateManager(BaseGenerateManager):
         self._cb.start()
 
     def is_alive(self) -> bool:
-        """Whether the CB worker is healthy and able to serve new requests."""
-        return self._cb is not None and self._cb.fatal_error is None
+        """Whether the CB worker is healthy. ``True`` before ``init_cb()`` is called."""
+        return self._cb is None or self._cb.fatal_error is None
 
     def _check_alive(self, request_id: str) -> None:
         """Raise :class:`CBWorkerDeadError` if the CB worker has died.
@@ -846,9 +846,7 @@ class GenerationState:
 
     def is_cb_alive(self) -> bool:
         """Whether the CB worker is healthy. ``True`` if CB is disabled or not yet initialized."""
-        if self._cb_manager is None:
-            return True
-        return self._cb_manager.is_alive()
+        return self._cb_manager is None or self._cb_manager.is_alive()
 
 
 class BaseHandler:

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -556,6 +556,7 @@ class TestAppRoutes(unittest.TestCase):
             cls.completion_handler,
             cls.response_handler,
             cls.transcription_handler,
+            generation_state=GenerationState(),
         )
         cls.transport = httpx.ASGITransport(app=cls.app)
 
@@ -1821,6 +1822,67 @@ class TestToolCallUnit(unittest.TestCase):
         processor.parse_response = lambda t, s: recursive_parse(t, s)
         calls = parse_tool_calls(processor, text, _TOOL_CALL_FALLBACKS["qwen"]["schema"])
         self.assertEqual(len(calls), 2)
+
+
+class TestCBWorkerDeadServerIntegration(unittest.TestCase):
+    """End-to-end FastAPI behavior when the CB worker has died.
+
+    Asserts the wiring from a ``CBWorkerDeadError`` raised in a request handler
+    (or a dead CB worker observed by ``/health``) to a 503 response carrying the cause —
+    the contract orchestrators rely on to recycle the pod.
+    """
+
+    def _build_app(self, generation_state, chat_handler=None):
+        from transformers.cli.serving.server import build_server
+
+        return build_server(
+            model_manager=MagicMock(),
+            chat_handler=chat_handler or MagicMock(),
+            completion_handler=MagicMock(),
+            response_handler=MagicMock(),
+            transcription_handler=MagicMock(),
+            generation_state=generation_state,
+        )
+
+    def test_health_returns_503_when_cb_dead(self):
+        from fastapi.testclient import TestClient
+
+        from transformers.cli.serving.utils import CBGenerateManager
+
+        state = GenerationState(continuous_batching=True)
+        # Manager whose underlying CB has a fatal_error set -> is_alive() returns False.
+        mgr = CBGenerateManager()
+        mgr._cb = MagicMock()
+        mgr._cb.fatal_error = RuntimeError("CUDA illegal memory access")
+        state._cb_manager = mgr
+
+        resp = TestClient(self._build_app(state)).get("/health")
+
+        self.assertEqual(resp.status_code, 503)
+        self.assertEqual(resp.json(), {"status": "unhealthy", "reason": "cb_worker_dead"})
+
+    def test_chat_endpoint_returns_503_with_cause(self):
+        """A CBWorkerDeadError raised from the chat route maps to 503 with the cause in the body."""
+        from fastapi.testclient import TestClient
+
+        from transformers.cli.serving.utils import CBWorkerDeadError
+
+        chat_handler = MagicMock()
+
+        async def handle_request(_body, _request_id):
+            raise CBWorkerDeadError("CB worker is dead and cannot accept request: CUDA illegal memory access")
+
+        chat_handler.handle_request = handle_request
+
+        client = TestClient(self._build_app(GenerationState(continuous_batching=True), chat_handler=chat_handler))
+        resp = client.post(
+            "/v1/chat/completions",
+            json={"model": "x", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+        self.assertEqual(resp.status_code, 503)
+        # Body carries the original cause so the client knows why the server is broken.
+        self.assertIn("CUDA illegal memory access", resp.json()["error"])
 
 
 class _TestToolCallBase:


### PR DESCRIPTION
# What does this PR do?

This PR adds better support for CB when the CB worker thread dies due to unexpected errors. We display clearly to the user that they need to restart the server. 

cc @qgallouedec 