### PR TITLE
fix(testing): check torch.cuda.is_available() before get_device_capability

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3204,9 +3204,7 @@ def get_device_properties() -> DeviceProperties:
     """
     Get environment device properties.
     """
-    if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
-        import torch
-
+    if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
         major, minor = torch.cuda.get_device_capability()
         if IS_ROCM_SYSTEM:
             return ("rocm", major, minor)


### PR DESCRIPTION
## Summary

Fixes #45341

`get_device_properties()` crashes with an error on machines that have CUDA installed (`torch.version.cuda is not None`) but no physical GPU available. This happens on cloud instances like Lightning AI Studio where CUDA runtime is present but no GPU is attached.

## Bug

```python
# Line 3207-3210
if IS_CUDA_SYSTEM or IS_ROCM_SYSTEM:
    import torch
    major, minor = torch.cuda.get_device_capability()  # Crashes if no GPU!
```

`IS_CUDA_SYSTEM` is set to `True` when `torch.version.cuda is not None`, but this only means CUDA runtime is available, not that a GPU is actually present.

## Fix

- Add `torch.cuda.is_available()` check to the condition on line 3207
- Remove the redundant `import torch` (torch is already imported at module level for `IS_CUDA_SYSTEM`/`IS_ROCM_SYSTEM` checks)

```python
if (IS_CUDA_SYSTEM or IS_ROCM_SYSTEM) and torch.cuda.is_available():
    major, minor = torch.cuda.get_device_capability()
```

This gracefully falls through to the `else` branch when no GPU is available, returning `(torch_device, None, None)` instead of crashing.