### PR TITLE
Fix padding calculation in new_conv_state assignment

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -469,7 +469,7 @@ class Qwen3_5GatedDeltaNet(nn.Module):
                 # at the end of this branch.
                 mixed_qkv = torch.cat([conv_state, mixed_qkv], dim=-1)
             if cache_params is not None:
-                new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1], 0))
+                new_conv_state = F.pad(mixed_qkv, (self.conv_kernel_size - mixed_qkv.shape[-1] -1, 0))
                 cache_params.update_conv_state(new_conv_state, self.layer_idx)
             if self.causal_conv1d_fn is not None:
                 mixed_qkv = self.causal_conv1d_fn(


### PR DESCRIPTION
In torch_causal_conv1d_update, we concat state_cache(len 4) and current state(len 1) to get len 5 input for conv1d. The conv kernel is 4 so we get output of len 2. Then we get last seq_len of output which is len 1. This will result in one unnecessary conv operation. If input len is 4, we just conv once is enough.
