### PR TITLE
refector: renamed file glob to cache to make it clearer

### DIFF
--- a/tests/repo_utils/test_checkers.py
+++ b/tests/repo_utils/test_checkers.py
@@ -37,7 +37,7 @@ def patch_checkers_paths(repo_root: Path):
         stack.enter_context(patch.object(checkers, "REPO_ROOT", repo_root))
         stack.enter_context(patch.object(checkers, "CACHE_PATH", cache_path))
         stack.enter_context(patch.object(checkers, "CHECKERS", {"demo": ("Demo checker", "fake_checker.py", [], [])}))
-        stack.enter_context(patch.object(checkers, "CHECKER_FILE_GLOBS", {"demo": ["tracked/**/*.txt"]}))
+        stack.enter_context(patch.object(checkers, "CHECKER_CACHE_GLOBS", {"demo": ["tracked/**/*.txt"]}))
         yield cache_path
 
 

--- a/utils/add_dates.py
+++ b/utils/add_dates.py
@@ -16,7 +16,7 @@ CHECKER_CONFIG = {
     "label": "Model dates",
     # Approximate: also reads docs/source/en/model_doc/*.md and uses git log + network
     # calls to GitHub/HuggingFace for commit dates and paper metadata.
-    "file_globs": ["src/transformers/models/**/__init__.py", "docs/source/en/model_doc/**/*.md"],
+    "cache_globs": ["src/transformers/models/**/__init__.py", "docs/source/en/model_doc/**/*.md"],
     "check_args": ["--check-only"],
     "fix_args": [],
 }

--- a/utils/check_auto.py
+++ b/utils/check_auto.py
@@ -31,7 +31,7 @@ from transformers.models.auto.video_processing_auto import MISSING_VIDEO_PROCESS
 CHECKER_CONFIG = {
     "name": "auto_mappings",
     "label": "Generate auto mappings",
-    "file_globs": [],
+    "cache_globs": [],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_config_attributes.py
+++ b/utils/check_config_attributes.py
@@ -25,7 +25,7 @@ CHECKER_CONFIG = {
     "label": "Config attributes",
     # Approximate: iterates CONFIG_MAPPING at runtime and also reads modeling_*.py files
     # in each config's directory via os.listdir(). Deprecated models are skipped.
-    "file_globs": ["src/transformers/models/**/configuration_*.py", "src/transformers/models/**/modeling_*.py"],
+    "cache_globs": ["src/transformers/models/**/configuration_*.py", "src/transformers/models/**/modeling_*.py"],
     "check_args": [],
     "fix_args": None,
 }

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -21,9 +21,9 @@ from transformers.utils import direct_transformers_import
 CHECKER_CONFIG = {
     "name": "config_docstrings",
     "label": "Config docstrings",
-    # Approximate: iterates CONFIG_MAPPING at runtime via inspect.getsource(), not file globs.
+    # Approximate: iterates CONFIG_MAPPING at runtime via inspect.getsource(), not cache globs.
     # Only configs registered in CONFIG_MAPPING are checked; deprecated models are skipped.
-    "file_globs": ["src/transformers/models/**/configuration_*.py"],
+    "cache_globs": ["src/transformers/models/**/configuration_*.py"],
     "check_args": [],
     "fix_args": None,
 }

--- a/utils/check_copies.py
+++ b/utils/check_copies.py
@@ -49,7 +49,7 @@ CHECKER_CONFIG = {
     "name": "copies",
     "label": "Copied code consistency",
     # Actual scope: all of src/transformers/**/*.py and tests/models/**/*.py via glob.glob().
-    "file_globs": ["src/transformers/**/*.py", "tests/models/**/*.py"],
+    "cache_globs": ["src/transformers/**/*.py", "tests/models/**/*.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_doc_toc.py
+++ b/utils/check_doc_toc.py
@@ -41,7 +41,7 @@ CHECKER_CONFIG = {
     "name": "doc_toc",
     "label": "Documentation table of contents",
     # Also reads docs/source/en/_toctree.yml; the .md glob catches new/renamed doc files.
-    "file_globs": ["docs/**/*.md", "docs/source/en/_toctree.yml"],
+    "cache_globs": ["docs/**/*.md", "docs/source/en/_toctree.yml"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -67,7 +67,7 @@ CHECKER_CONFIG = {
     "label": "Docstring formatting",
     # Approximate: at runtime the checker also introspects the live transformers module for
     # @auto_docstring-decorated objects. These globs cover the files it reads via glob.glob().
-    "file_globs": [
+    "cache_globs": [
         "src/transformers/models/**/modeling_*.py",
         "src/transformers/models/**/modular_*.py",
         "src/transformers/models/**/configuration_*.py",

--- a/utils/check_doctest_list.py
+++ b/utils/check_doctest_list.py
@@ -39,7 +39,7 @@ CHECKER_CONFIG = {
     "label": "Doctest list",
     # Over-approximation: the checker validates that paths in .txt list files exist and are
     # sorted. The broad globs ensure cache invalidation when source files are added/removed.
-    "file_globs": [
+    "cache_globs": [
         "utils/not_doctested.txt",
         "utils/slow_documentation_tests.txt",
         "src/transformers/**/*.py",

--- a/utils/check_dummies.py
+++ b/utils/check_dummies.py
@@ -43,7 +43,7 @@ CHECKER_CONFIG = {
     "label": "Dummy objects",
     # Over-approximation: only reads __init__.py and utils/dummy_*_objects.py, but any
     # new public object added anywhere could require a dummy update.
-    "file_globs": ["src/transformers/**/*.py"],
+    "cache_globs": ["src/transformers/**/*.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_inits.py
+++ b/utils/check_inits.py
@@ -43,7 +43,7 @@ from pathlib import Path
 CHECKER_CONFIG = {
     "name": "inits",
     "label": "Init files",
-    "file_globs": ["src/transformers/**/__init__.py"],
+    "cache_globs": ["src/transformers/**/__init__.py"],
     "check_args": [],
     "fix_args": None,
 }

--- a/utils/check_modeling_rules_doc.py
+++ b/utils/check_modeling_rules_doc.py
@@ -38,8 +38,8 @@ CHECKER_CONFIG = {
     "name": "modeling_rules_doc",
     "label": "Modeling rules documentation",
     # Depends on utils/rules.toml plus the installed `mlinter` package output,
-    # which cannot be fully expressed as repo file globs for the checker cache.
-    "file_globs": None,
+    # which cannot be fully expressed as repo cache globs for the checker cache.
+    "cache_globs": None,
     "check_args": ["--rules-toml", "utils/rules.toml"],
     "fix_args": ["--rules-toml", "utils/rules.toml", "--fix_and_overwrite"],
 }

--- a/utils/check_modeling_structure.py
+++ b/utils/check_modeling_structure.py
@@ -21,7 +21,7 @@ from pathlib import Path
 CHECKER_CONFIG = {
     "name": "modeling_structure",
     "label": "Modeling file structure",
-    "file_globs": [
+    "cache_globs": [
         "src/transformers/models/**/modeling_*.py",
         "src/transformers/models/**/modular_*.py",
         "src/transformers/models/**/configuration_*.py",

--- a/utils/check_modular_conversion.py
+++ b/utils/check_modular_conversion.py
@@ -20,7 +20,7 @@ CHECKER_CONFIG = {
     "name": "modular_conversion",
     "label": "Modular file conversions",
     # Globs the modular sources; also reads generated modeling_*.py at runtime for diffing.
-    "file_globs": ["src/transformers/models/**/modular_*.py", "src/transformers/models/**/modeling_*.py"],
+    "cache_globs": ["src/transformers/models/**/modular_*.py", "src/transformers/models/**/modeling_*.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_pipeline_typing.py
+++ b/utils/check_pipeline_typing.py
@@ -6,7 +6,7 @@ from transformers.pipelines import SUPPORTED_TASKS, Pipeline
 CHECKER_CONFIG = {
     "name": "pipeline_typing",
     "label": "Pipeline type hints",
-    "file_globs": ["src/transformers/pipelines/__init__.py"],
+    "cache_globs": ["src/transformers/pipelines/__init__.py"],
     "check_args": [],
     "fix_args": ["--fix_and_overwrite"],
 }

--- a/utils/check_repo.py
+++ b/utils/check_repo.py
@@ -56,7 +56,7 @@ CHECKER_CONFIG = {
     "label": "Repository structure",
     # Approximate: the checker also introspects the live transformers module at runtime
     # (e.g. dir(transformers.models), CONFIG_MAPPING_NAMES) and walks tests/ broadly.
-    "file_globs": [
+    "cache_globs": [
         "src/transformers/models/**/*.py",
         "src/transformers/models/auto/*.py",
         "src/transformers/**/__init__.py",

--- a/utils/check_types.py
+++ b/utils/check_types.py
@@ -11,9 +11,13 @@ import sys
 CHECKER_CONFIG = {
     "name": "types",
     "label": "Type annotations",
+    # For contributors:
+    # - `check_args` below are the exact roots passed to `ty check`.
+    # - `cache_globs` here are only used by `utils/checkers.py` to decide when a
+    #   previously clean `types` run can be reused from cache.
     # Approximate: ty follows imports beyond the listed directories; these globs cover
     # the explicitly targeted paths but not transitive dependencies.
-    "file_globs": [
+    "cache_globs": [
         "src/transformers/_typing.py",
         "src/transformers/cli/**/*.py",
         "src/transformers/modeling_utils.py",

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -27,9 +27,9 @@ Each checker module declares a ``CHECKER_CONFIG`` dict (extracted via ``ast.lite
 no import needed — this keeps discovery fast and avoids executing checker code at scan time).
 See any ``check_*.py`` file for the schema.
 
-Cache semantics of ``file_globs``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``file_globs`` lists the file patterns whose content is hashed to decide whether a checker
+Cache semantics of ``cache_globs``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``cache_globs`` lists the file patterns whose content is hashed to decide whether a checker
 can be skipped. **Not all globs are exact reflections of the checker's runtime behaviour.**
 
 * Some checkers introspect the live ``transformers`` module (``check_repo``,
@@ -39,10 +39,12 @@ can be skipped. **Not all globs are exact reflections of the checker's runtime b
   inside the broad glob forces a re-run even if the checker wouldn't look at that file.
   This is safe—just less cache-efficient.
 * Some checkers rely on external state (network, git history, installed packages) that
-  cannot be captured by file globs at all (``add_dates``, ``imports``).
+  cannot be captured by cache globs at all (``add_dates``, ``imports``).
 
 Each ``CHECKER_CONFIG`` that is an approximation has an inline comment explaining the
-gap. When in doubt, use ``--no-cache`` to force a full run.
+gap. For contributors: ``check_args`` control what a checker runs on, while
+``cache_globs`` only control when the cache is invalidated. When in doubt, use
+``--no-cache`` to force a full run.
 """
 
 import argparse
@@ -66,20 +68,20 @@ REPO_ROOT = UTILS_DIR.parent
 CACHE_PATH = UTILS_DIR / ".checkers_cache.json"
 
 # Required keys in each module's CHECKER_CONFIG dict.
-_CHECKER_CONFIG_KEYS = {"name", "label", "file_globs", "check_args", "fix_args"}
+_CHECKER_CONFIG_KEYS = {"name", "label", "cache_globs", "check_args", "fix_args"}
 
 
 def _discover_checkers() -> tuple[dict, dict]:
     """Scan utils/*.py for CHECKER_CONFIG dicts using AST (no imports).
 
     Each checker module may define a top-level ``CHECKER_CONFIG`` dict with
-    keys: name, label, file_globs, check_args, fix_args.
+    keys: name, label, cache_globs, check_args, fix_args.
 
-    Returns (checkers_dict, file_globs_dict) matching the shapes of
-    the old CHECKERS and CHECKER_FILE_GLOBS registries.
+    Returns (checkers_dict, cache_globs_dict) matching the shapes of
+    the old CHECKERS and CHECKER_CACHE_GLOBS registries.
     """
     checkers = {}
-    file_globs = {}
+    cache_globs = {}
 
     for py_file in sorted(UTILS_DIR.glob("*.py")):
         if py_file.name == Path(__file__).name:
@@ -128,10 +130,10 @@ def _discover_checkers() -> tuple[dict, dict]:
             config["check_args"],
             config["fix_args"],
         )
-        if config["file_globs"] is not None:
-            file_globs[name] = config["file_globs"]
+        if config["cache_globs"] is not None:
+            cache_globs[name] = config["cache_globs"]
 
-    return checkers, file_globs
+    return checkers, cache_globs
 
 
 # Inline checkers have no separate script file; they use custom runner functions below.
@@ -143,7 +145,7 @@ _INLINE_CHECKERS = {
     "ruff_format": ("Ruff formatting", None, None, None),
 }
 
-_INLINE_FILE_GLOBS = {
+_INLINE_CACHE_GLOBS = {
     # Also generates/checks src/transformers/dependency_versions_table.py.
     "deps_table": ["setup.py", "pyproject.toml", "src/transformers/dependency_versions_table.py"],
     # Approximate: runs `from transformers import *` at runtime; depends on the full
@@ -177,15 +179,15 @@ _INLINE_FILE_GLOBS = {
 }
 
 # Build the registries: discovered modules + inline custom runners.
-_discovered_checkers, _discovered_globs = _discover_checkers()
+_discovered_checkers, _discovered_cache_globs = _discover_checkers()
 
 CHECKERS = {**_discovered_checkers, **_INLINE_CHECKERS}
-CHECKER_FILE_GLOBS = {**_discovered_globs, **_INLINE_FILE_GLOBS}
+CHECKER_CACHE_GLOBS = {**_discovered_cache_globs, **_INLINE_CACHE_GLOBS}
 
 
 def get_checker_cache_globs(checker_name: str) -> list[str] | None:
     """Return the cache inputs for a checker, including its implementation files."""
-    globs = CHECKER_FILE_GLOBS.get(checker_name)
+    globs = CHECKER_CACHE_GLOBS.get(checker_name)
     if globs is None:
         return None
 
@@ -199,7 +201,7 @@ def get_checker_cache_globs(checker_name: str) -> list[str] | None:
 class CheckerCache:
     """Disk-backed cache that tracks file content hashes per checker.
 
-    For each checker that declares file globs in CHECKER_FILE_GLOBS, we compute
+    For each checker that declares cache globs in CHECKER_CACHE_GLOBS, we compute
     a single digest over all matching files.  If the digest matches the stored
     value from the last clean (rc == 0) run, the checker can be skipped.
     """

--- a/utils/custom_init_isort.py
+++ b/utils/custom_init_isort.py
@@ -44,7 +44,7 @@ from typing import Any
 CHECKER_CONFIG = {
     "name": "init_isort",
     "label": "Import ordering",
-    "file_globs": ["src/transformers/**/__init__.py"],
+    "cache_globs": ["src/transformers/**/__init__.py"],
     "check_args": ["--check_only"],
     "fix_args": [],
 }

--- a/utils/sort_auto_mappings.py
+++ b/utils/sort_auto_mappings.py
@@ -37,7 +37,7 @@ import re
 CHECKER_CONFIG = {
     "name": "sort_auto_mappings",
     "label": "Sort auto mappings",
-    "file_globs": ["src/transformers/models/auto/*.py"],
+    "cache_globs": ["src/transformers/models/auto/*.py"],
     "check_args": ["--check_only"],
     "fix_args": [],
 }

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -46,7 +46,7 @@ CHECKER_CONFIG = {
     "label": "Model metadata",
     # Approximate: imports the transformers module and inspects pipeline/auto mappings
     # at runtime. Does not iterate over files matching these globs directly.
-    "file_globs": ["src/transformers/models/**/*.py", "docs/**/*.md"],
+    "cache_globs": ["src/transformers/models/**/*.py", "docs/**/*.md"],
     "check_args": ["--check-only"],
     "fix_args": [],
 }


### PR DESCRIPTION
# What does this PR do?

Renamed `file_globs` to `cache_globs` so its intent is clearer