### PR TITLE
[Gemma4] Fix SharedKVCache identity loss under FSDP2 cast_forward_inputs

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -135,6 +135,21 @@ class Gemma4CausalLMOutputWithPast(ModelOutput):
     shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] | None = None
 
 
+class SharedKVCache:
+    """Opaque wrapper around the shared-KV dict so FSDP2's _apply_to_tensors
+    does not recurse into it and rebuild a fresh dict on every layer call,
+    which would silently discard writes made by earlier layers."""
+
+    def __init__(self):
+        self._data: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+
 @dataclass
 class Gemma4TextModelOutputWithPast(BaseModelOutputWithPast):
     """
@@ -1214,7 +1229,7 @@ class Gemma4TextAttention(nn.Module):
         hidden_states: torch.Tensor,
         position_embeddings: torch.Tensor,
         attention_mask: torch.Tensor | None,
-        shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]],
+        shared_kv_states: SharedKVCache,
         past_key_values: Cache | None = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -1382,7 +1397,7 @@ class Gemma4TextDecoderLayer(GradientCheckpointingLayer):
         self,
         hidden_states: torch.Tensor,
         per_layer_input: torch.Tensor = None,
-        shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] | None = None,
+        shared_kv_states: SharedKVCache | None = None,
         position_embeddings: torch.Tensor = None,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
@@ -1681,8 +1696,8 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         for layer_type in self.unique_layer_types:
             position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
 
-        # Initialize as empty dict - it will be filled in the right layers, or use passed ones
-        shared_kv_states = kwargs.pop("shared_kv_states", {})
+        # Initialize as SharedKVCache (opaque to FSDP2's _apply_to_tensors), or use passed ones
+        shared_kv_states = kwargs.pop("shared_kv_states", None) or SharedKVCache()
 
         # decoder layers
         for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -126,6 +126,21 @@ class Gemma4CausalLMOutputWithPast(Gemma3nCausalLMOutputWithPast):
     shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] | None = None
 
 
+class SharedKVCache:
+    """Opaque wrapper around the shared-KV dict so FSDP2's _apply_to_tensors
+    does not recurse into it and rebuild a fresh dict on every layer call,
+    which would silently discard writes made by earlier layers."""
+
+    def __init__(self):
+        self._data: dict[str, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def __getitem__(self, key):
+        return self._data[key]
+
+    def __setitem__(self, key, value):
+        self._data[key] = value
+
+
 @dataclass
 class Gemma4TextModelOutputWithPast(BaseModelOutputWithPast):
     """
@@ -1009,7 +1024,7 @@ class Gemma4TextAttention(nn.Module):
         hidden_states: torch.Tensor,
         position_embeddings: torch.Tensor,
         attention_mask: torch.Tensor | None,
-        shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]],
+        shared_kv_states: SharedKVCache,
         past_key_values: Cache | None = None,
         **kwargs: Unpack[FlashAttentionKwargs],
     ) -> tuple[torch.Tensor, torch.Tensor | None]:
@@ -1138,7 +1153,7 @@ class Gemma4TextDecoderLayer(Gemma3DecoderLayer):
         self,
         hidden_states: torch.Tensor,
         per_layer_input: torch.Tensor = None,
-        shared_kv_states: dict[str, tuple[torch.Tensor, torch.Tensor]] | None = None,
+        shared_kv_states: SharedKVCache | None = None,
         position_embeddings: torch.Tensor = None,
         attention_mask: torch.Tensor | None = None,
         position_ids: torch.LongTensor | None = None,
@@ -1447,8 +1462,8 @@ class Gemma4TextModel(Gemma3TextModel):
         for layer_type in self.unique_layer_types:
             position_embeddings[layer_type] = self.rotary_emb(hidden_states, position_ids, layer_type)
 
-        # Initialize as empty dict - it will be filled in the right layers, or use passed ones
-        shared_kv_states = kwargs.pop("shared_kv_states", {})
+        # Initialize as SharedKVCache (opaque to FSDP2's _apply_to_tensors), or use passed ones
+        shared_kv_states = kwargs.pop("shared_kv_states", None) or SharedKVCache()
 
         # decoder layers
         for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -141,6 +141,17 @@ class Gemma4TextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_torch_compile_for_training(self):
         pass
 
+    def test_shared_kv_cache_identity_preserved_by_apply_to_tensors(self):
+        from torch.distributed.utils import _apply_to_tensors
+
+        from transformers.models.gemma4.modeling_gemma4 import SharedKVCache
+
+        cache = SharedKVCache()
+        cache[0] = (torch.zeros(1), torch.zeros(1))
+
+        result = _apply_to_tensors(lambda t: t, {"shared_kv_states": cache})
+        self.assertIs(result["shared_kv_states"], cache)  # Same object, not a rebuilt
+
 
 class Gemma4Audio2TextModelTester:
     def __init__(


### PR DESCRIPTION
# What does this PR do?

Fixes #45663 

Fixes a `KeyError` that occurs when running `Gemma4TextModel` under FSDP2 with `MixedPrecisionPolicy(cast_forward_inputs=True)`.

### Root cause

`Gemma4TextModel.forward` creates a single `shared_kv_states = {}` dict and passes it as a kwarg to every decoder layer so that "source" layers can write their KV states and "sharing" layers can read them. Under FSDP2, `_FSDPState._pre_forward` calls `_apply_to_tensors(cast_fn, kwargs)` on every wrapped module's inputs. `_apply_to_tensors` rebuilds every `dict` it traverses via a dict comprehension (even when no tensor inside needs casting), so each decoder layer receives a fresh `shared_kv_states` dict. The write from the source layer lands in an orphan dict, the sharing layer reads from a different empty dict so it raises `KeyError`.

Note: `Gemma4TextModel` already declares `_skip_keys_device_placement = ["shared_kv_states"]`, but FSDP2 has no equivalent skip-key mechanism in `_apply_to_tensors`.

### Fix

Introduce a thin `SharedKVCache` wrapper class. Since `_apply_to_tensors` only recurses into `dict`, `list`, and `tuple`, a custom class is passed through opaquely, thus dict identity is preserved across all layer calls.

The change is minimal: one new class, one updated type annotation, and one changed instantiation line.

### Testing

Added `test_shared_kv_cache_identity_preserved_by_apply_to_tensors` to `Gemma4TextModelTest`, which directly asserts that passing a `SharedKVCache` through `_apply_to_tensors` returns the same object and preserves written entries.


## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker @3outeille @Cyrilvallez 