### PR TITLE
Fix check_auto.py wiping auto_mappings.py due to missing flush

### DIFF
--- a/utils/check_auto.py
+++ b/utils/check_auto.py
@@ -261,6 +261,7 @@ def main(overwrite: bool):
     # Dirty hack to sort and apply ruff to the file content, for easier matching
     with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as tmpfile:
         tmpfile.write(new_content)
+        tmpfile.flush()
         tmpfile_path = tmpfile.name
 
         run_ruff_and_sort(tmpfile_path)


### PR DESCRIPTION
# What does this PR do?

`utils/check_auto.py` uses a `NamedTemporaryFile` to generate and format the new `auto_mappings.py` content before comparing it to the existing file. However, `tmpfile.write(new_content)` was never followed by `tmpfile.flush()`, so the write stayed in Python's I/O buffer and the file on disk remained empty. `sort_auto_mapping` then read 0 bytes, overwrote the temp file with nothing, and that empty string was written to `auto_mappings.py`, wiping it completely.

Fix: adding `tmpfile.flush()` after the write, before handing the path to `run_ruff_and_sort`.

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?


## Who can review?

@ydshieh 