### PR TITLE
Speedup Qwen2VLImageProcessor

### DIFF
--- a/src/transformers/models/ernie4_5_vl_moe/image_processing_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/image_processing_ernie4_5_vl_moe.py
@@ -169,17 +169,12 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
             patches = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            if patches.ndim == 4:
-                # add a temporal dimension if we have images
-                patches = patches.unsqueeze(1)
 
-            # Main difference to Qwen2 VL - no temporal patches
-            batch_size, grid_t, channel = patches.shape[:3]
+            batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
 
             patches = patches.view(
                 batch_size,
-                grid_t,
                 channel,
                 grid_h // merge_size,
                 merge_size,
@@ -189,17 +184,17 @@ class Ernie4_5_VLMoeImageProcessor(TorchvisionBackend):
                 patch_size,
             )
             # Reorder dimensions to group grid and patch information for subsequent flattening.
-            # [batch, grid_t, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
-            patches = patches.permute(0, 1, 3, 6, 4, 7, 2, 5, 8)
+            # [batch, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
 
             flatten_patches = patches.reshape(
                 batch_size,
-                grid_t * grid_h * grid_w,
+                grid_h * grid_w,
                 channel * patch_size * patch_size,
             )
 
             processed_images_grouped[shape] = flatten_patches
-            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+            processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/ernie4_5_vl_moe/modular_ernie4_5_vl_moe.py
+++ b/src/transformers/models/ernie4_5_vl_moe/modular_ernie4_5_vl_moe.py
@@ -1406,17 +1406,12 @@ class Ernie4_5_VLMoeImageProcessor(Glm4vImageProcessor):
             patches = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            if patches.ndim == 4:
-                # add a temporal dimension if we have images
-                patches = patches.unsqueeze(1)
 
-            # Main difference to Qwen2 VL - no temporal patches
-            batch_size, grid_t, channel = patches.shape[:3]
+            batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
 
             patches = patches.view(
                 batch_size,
-                grid_t,
                 channel,
                 grid_h // merge_size,
                 merge_size,
@@ -1426,17 +1421,17 @@ class Ernie4_5_VLMoeImageProcessor(Glm4vImageProcessor):
                 patch_size,
             )
             # Reorder dimensions to group grid and patch information for subsequent flattening.
-            # [batch, grid_t, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
-            patches = patches.permute(0, 1, 3, 6, 4, 7, 2, 5, 8)
+            # [batch, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
 
             flatten_patches = patches.reshape(
                 batch_size,
-                grid_t * grid_h * grid_w,
+                grid_h * grid_w,
                 channel * patch_size * patch_size,
             )
 
             processed_images_grouped[shape] = flatten_patches
-            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+            processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glm_image/image_processing_glm_image.py
+++ b/src/transformers/models/glm_image/image_processing_glm_image.py
@@ -197,55 +197,34 @@ class GlmImageImageProcessor(TorchvisionBackend):
             patches = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            if patches.ndim == 4:
-                patches = patches.unsqueeze(1)
-            batch_size, frames, channel = patches.shape[:3]
+            batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+            patches = patches.reshape(
+                batch_size,
+                channel,
+                grid_h // merge_size,
+                merge_size,
+                patch_size,
+                grid_w // merge_size,
+                merge_size,
+                patch_size,
+            )
+            # Reorder dimensions to group grid and patch information for subsequent flattening.
+            # [batch, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
 
-            if frames == 1:
-                grid_t = 1
-                patches = patches.reshape(
+            flatten_patches = (
+                patches.unsqueeze(6)
+                .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
+                .reshape(
                     batch_size,
-                    channel,
-                    grid_h // merge_size,
-                    merge_size,
-                    patch_size,
-                    grid_w // merge_size,
-                    merge_size,
-                    patch_size,
-                )
-                patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
-                flatten_patches = (
-                    patches.unsqueeze(6)
-                    .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
-                    .reshape(batch_size, grid_h * grid_w, channel * temporal_patch_size * patch_size * patch_size)
-                )
-            else:
-                if patches.shape[1] % temporal_patch_size != 0:
-                    repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                    patches = torch.cat([patches, repeats], dim=1)
-                grid_t = patches.shape[1] // temporal_patch_size
-                patches = patches.view(
-                    batch_size,
-                    grid_t,
-                    temporal_patch_size,
-                    channel,
-                    grid_h // merge_size,
-                    merge_size,
-                    patch_size,
-                    grid_w // merge_size,
-                    merge_size,
-                    patch_size,
-                )
-                patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
-                flatten_patches = patches.reshape(
-                    batch_size,
-                    grid_t * grid_h * grid_w,
+                    grid_h * grid_w,
                     channel * temporal_patch_size * patch_size * patch_size,
                 )
+            )
 
             processed_images_grouped[shape] = flatten_patches
-            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+            processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/glm_image/image_processing_glm_image.py
+++ b/src/transformers/models/glm_image/image_processing_glm_image.py
@@ -199,31 +199,50 @@ class GlmImageImageProcessor(TorchvisionBackend):
             )
             if patches.ndim == 4:
                 patches = patches.unsqueeze(1)
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
-            batch_size, grid_t, channel = patches.shape[:3]
-            grid_t = grid_t // temporal_patch_size
+            batch_size, frames, channel = patches.shape[:3]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
 
-            patches = patches.view(
-                batch_size,
-                grid_t,
-                temporal_patch_size,
-                channel,
-                grid_h // merge_size,
-                merge_size,
-                patch_size,
-                grid_w // merge_size,
-                merge_size,
-                patch_size,
-            )
-            patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
-            flatten_patches = patches.reshape(
-                batch_size,
-                grid_t * grid_h * grid_w,
-                channel * temporal_patch_size * patch_size * patch_size,
-            )
+            if frames == 1:
+                grid_t = 1
+                patches = patches.reshape(
+                    batch_size,
+                    channel,
+                    grid_h // merge_size,
+                    merge_size,
+                    patch_size,
+                    grid_w // merge_size,
+                    merge_size,
+                    patch_size,
+                )
+                patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+                flatten_patches = (
+                    patches.unsqueeze(6)
+                    .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
+                    .reshape(batch_size, grid_h * grid_w, channel * temporal_patch_size * patch_size * patch_size)
+                )
+            else:
+                if patches.shape[1] % temporal_patch_size != 0:
+                    repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
+                    patches = torch.cat([patches, repeats], dim=1)
+                grid_t = patches.shape[1] // temporal_patch_size
+                patches = patches.view(
+                    batch_size,
+                    grid_t,
+                    temporal_patch_size,
+                    channel,
+                    grid_h // merge_size,
+                    merge_size,
+                    patch_size,
+                    grid_w // merge_size,
+                    merge_size,
+                    patch_size,
+                )
+                patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+                flatten_patches = patches.reshape(
+                    batch_size,
+                    grid_t * grid_h * grid_w,
+                    channel * temporal_patch_size * patch_size * patch_size,
+                )
 
             processed_images_grouped[shape] = flatten_patches
             processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -191,55 +191,34 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
             patches = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            if patches.ndim == 4:
-                patches = patches.unsqueeze(1)
-            batch_size, frames, channel = patches.shape[:3]
+            batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+            patches = patches.reshape(
+                batch_size,
+                channel,
+                grid_h // merge_size,
+                merge_size,
+                patch_size,
+                grid_w // merge_size,
+                merge_size,
+                patch_size,
+            )
+            # Reorder dimensions to group grid and patch information for subsequent flattening.
+            # [batch, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
 
-            if frames == 1:
-                grid_t = 1
-                patches = patches.reshape(
+            flatten_patches = (
+                patches.unsqueeze(6)
+                .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
+                .reshape(
                     batch_size,
-                    channel,
-                    grid_h // merge_size,
-                    merge_size,
-                    patch_size,
-                    grid_w // merge_size,
-                    merge_size,
-                    patch_size,
-                )
-                patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
-                flatten_patches = (
-                    patches.unsqueeze(6)
-                    .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
-                    .reshape(batch_size, grid_h * grid_w, channel * temporal_patch_size * patch_size * patch_size)
-                )
-            else:
-                if patches.shape[1] % temporal_patch_size != 0:
-                    repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                    patches = torch.cat([patches, repeats], dim=1)
-                grid_t = patches.shape[1] // temporal_patch_size
-                patches = patches.view(
-                    batch_size,
-                    grid_t,
-                    temporal_patch_size,
-                    channel,
-                    grid_h // merge_size,
-                    merge_size,
-                    patch_size,
-                    grid_w // merge_size,
-                    merge_size,
-                    patch_size,
-                )
-                patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
-                flatten_patches = patches.reshape(
-                    batch_size,
-                    grid_t * grid_h * grid_w,
+                    grid_h * grid_w,
                     channel * temporal_patch_size * patch_size * patch_size,
                 )
+            )
 
             processed_images_grouped[shape] = flatten_patches
-            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+            processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
+++ b/src/transformers/models/qwen2_vl/image_processing_qwen2_vl.py
@@ -193,31 +193,50 @@ class Qwen2VLImageProcessor(TorchvisionBackend):
             )
             if patches.ndim == 4:
                 patches = patches.unsqueeze(1)
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
-            batch_size, grid_t, channel = patches.shape[:3]
-            grid_t = grid_t // temporal_patch_size
+            batch_size, frames, channel = patches.shape[:3]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
 
-            patches = patches.view(
-                batch_size,
-                grid_t,
-                temporal_patch_size,
-                channel,
-                grid_h // merge_size,
-                merge_size,
-                patch_size,
-                grid_w // merge_size,
-                merge_size,
-                patch_size,
-            )
-            patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
-            flatten_patches = patches.reshape(
-                batch_size,
-                grid_t * grid_h * grid_w,
-                channel * temporal_patch_size * patch_size * patch_size,
-            )
+            if frames == 1:
+                grid_t = 1
+                patches = patches.reshape(
+                    batch_size,
+                    channel,
+                    grid_h // merge_size,
+                    merge_size,
+                    patch_size,
+                    grid_w // merge_size,
+                    merge_size,
+                    patch_size,
+                )
+                patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+                flatten_patches = (
+                    patches.unsqueeze(6)
+                    .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
+                    .reshape(batch_size, grid_h * grid_w, channel * temporal_patch_size * patch_size * patch_size)
+                )
+            else:
+                if patches.shape[1] % temporal_patch_size != 0:
+                    repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
+                    patches = torch.cat([patches, repeats], dim=1)
+                grid_t = patches.shape[1] // temporal_patch_size
+                patches = patches.view(
+                    batch_size,
+                    grid_t,
+                    temporal_patch_size,
+                    channel,
+                    grid_h // merge_size,
+                    merge_size,
+                    patch_size,
+                    grid_w // merge_size,
+                    merge_size,
+                    patch_size,
+                )
+                patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+                flatten_patches = patches.reshape(
+                    batch_size,
+                    grid_t * grid_h * grid_w,
+                    channel * temporal_patch_size * patch_size * patch_size,
+                )
 
             processed_images_grouped[shape] = flatten_patches
             processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size

--- a/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
@@ -187,18 +187,11 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
             patches = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            if patches.ndim == 4:
-                patches = patches.unsqueeze(1)
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
-            batch_size, grid_t, channel = patches.shape[:3]
-            grid_t = grid_t // temporal_patch_size
+            batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
 
             patches = patches.view(
                 batch_size,
-                grid_t,
                 temporal_patch_size,
                 channel,
                 grid_h // merge_size,
@@ -208,15 +201,15 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
                 merge_size,
                 patch_size,
             )
-            patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+            patches = patches.permute(0, 3, 6, 4, 7, 2, 1, 5, 8)
             flatten_patches = patches.reshape(
                 batch_size,
-                grid_t * grid_h * grid_w,
+                grid_h * grid_w,
                 channel * temporal_patch_size * patch_size * patch_size,
             )
 
             processed_images_grouped[shape] = flatten_patches
-            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+            processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/image_processing_video_llama_3.py
@@ -189,10 +189,8 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
             )
             batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
-
-            patches = patches.view(
+            patches = patches.reshape(
                 batch_size,
-                temporal_patch_size,
                 channel,
                 grid_h // merge_size,
                 merge_size,
@@ -201,11 +199,18 @@ class VideoLlama3ImageProcessor(TorchvisionBackend):
                 merge_size,
                 patch_size,
             )
-            patches = patches.permute(0, 3, 6, 4, 7, 2, 1, 5, 8)
-            flatten_patches = patches.reshape(
-                batch_size,
-                grid_h * grid_w,
-                channel * temporal_patch_size * patch_size * patch_size,
+            # Reorder dimensions to group grid and patch information for subsequent flattening.
+            # [batch, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+
+            flatten_patches = (
+                patches.unsqueeze(6)
+                .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
+                .reshape(
+                    batch_size,
+                    grid_h * grid_w,
+                    channel * temporal_patch_size * patch_size * patch_size,
+                )
             )
 
             processed_images_grouped[shape] = flatten_patches

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1277,18 +1277,11 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
             patches = self.rescale_and_normalize(
                 stacked_images, do_rescale, rescale_factor, do_normalize, image_mean, image_std
             )
-            if patches.ndim == 4:
-                patches = patches.unsqueeze(1)
-            if patches.shape[1] % temporal_patch_size != 0:
-                repeats = patches[:, -1:].repeat(1, temporal_patch_size - 1, 1, 1, 1)
-                patches = torch.cat([patches, repeats], dim=1)
-            batch_size, grid_t, channel = patches.shape[:3]
-            grid_t = grid_t // temporal_patch_size
+            batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
 
             patches = patches.view(
                 batch_size,
-                grid_t,
                 temporal_patch_size,
                 channel,
                 grid_h // merge_size,
@@ -1298,15 +1291,15 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
                 merge_size,
                 patch_size,
             )
-            patches = patches.permute(0, 1, 4, 7, 5, 8, 3, 2, 6, 9)
+            patches = patches.permute(0, 3, 6, 4, 7, 2, 1, 5, 8)
             flatten_patches = patches.reshape(
                 batch_size,
-                grid_t * grid_h * grid_w,
+                grid_h * grid_w,
                 channel * temporal_patch_size * patch_size * patch_size,
             )
 
             processed_images_grouped[shape] = flatten_patches
-            processed_grids[shape] = [[grid_t, grid_h, grid_w]] * batch_size
+            processed_grids[shape] = [[1, grid_h, grid_w]] * batch_size
 
         processed_images = reorder_images(processed_images_grouped, grouped_images_index)
         processed_grids_ordered = reorder_images(processed_grids, grouped_images_index)

--- a/src/transformers/models/video_llama_3/modular_video_llama_3.py
+++ b/src/transformers/models/video_llama_3/modular_video_llama_3.py
@@ -1279,10 +1279,8 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
             )
             batch_size, channel = patches.shape[:2]
             grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
-
-            patches = patches.view(
+            patches = patches.reshape(
                 batch_size,
-                temporal_patch_size,
                 channel,
                 grid_h // merge_size,
                 merge_size,
@@ -1291,11 +1289,18 @@ class VideoLlama3ImageProcessor(Qwen2VLImageProcessor):
                 merge_size,
                 patch_size,
             )
-            patches = patches.permute(0, 3, 6, 4, 7, 2, 1, 5, 8)
-            flatten_patches = patches.reshape(
-                batch_size,
-                grid_h * grid_w,
-                channel * temporal_patch_size * patch_size * patch_size,
+            # Reorder dimensions to group grid and patch information for subsequent flattening.
+            # [batch, grid_h/merge, grid_w/merge, merge, merge, channel, patch, patch]
+            patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+
+            flatten_patches = (
+                patches.unsqueeze(6)
+                .expand(-1, -1, -1, -1, -1, -1, temporal_patch_size, -1, -1)
+                .reshape(
+                    batch_size,
+                    grid_h * grid_w,
+                    channel * temporal_patch_size * patch_size * patch_size,
+                )
             )
 
             processed_images_grouped[shape] = flatten_patches


### PR DESCRIPTION
# What does this PR do?

`Qwen2VLImageProcessor` currently spends a significant amount copying data during preprocessing:
<img width="2123" height="139" alt="Screenshot 2026-04-30 at 11 16 28" src="https://github.com/user-attachments/assets/9ca995c2-6291-47fb-8644-7fd9ca3a917c" />

For images the amount of data copies can be reduced which speedsup preprocessing by **22% end2end**:
```python
import numpy as np
from PIL import Image
from transformers import Qwen2VLImageProcessor

rng = np.random.default_rng(0)
processor = Qwen2VLImageProcessor()
images = [Image.fromarray(rng.integers(0, 255, (1024, 1024, 3), dtype=np.uint8)) for _ in range(8)]

%timeit processor(images)
```
```
main:    33 ms ± 399 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
this PR: 25.7 ms ± 498 μs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

/cc @zucchini-nlp

Best to review the diff with hidden whitespace 

