### PR TITLE
Remove dead beam-search dummies from dummy_pt_objects.py

### DIFF
--- a/src/transformers/utils/dummy_pt_objects.py
+++ b/src/transformers/utils/dummy_pt_objects.py
@@ -86,42 +86,7 @@ class BayesianDetectorModel(metaclass=DummyObject):
         requires_backends(self, ["torch"])
 
 
-class BeamScorer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
 class ClassifierFreeGuidanceLogitsProcessor(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class ConstrainedBeamSearchScorer(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class Constraint(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class ConstraintListState(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class DisjunctiveConstraint(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):
@@ -262,13 +227,6 @@ class NoBadWordsLogitsProcessor(metaclass=DummyObject):
 
 
 class NoRepeatNGramLogitsProcessor(metaclass=DummyObject):
-    _backends = ["torch"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["torch"])
-
-
-class PhrasalConstraint(metaclass=DummyObject):
     _backends = ["torch"]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Fixes #45712

# What does this PR do?

Removes six dead dummy classes from `dummy_pt_objects.py`:
`BeamScorer`, `ConstrainedBeamSearchScorer`, `Constraint`, `ConstraintListState`, `DisjunctiveConstraint`, `PhrasalConstraint`.

The real implementations were removed in v5 (#41223) but the dummies stayed. None of the six is referenced anywhere under `src/`, `tests/`, `docs/`, or in `MIGRATION_GUIDE_V5.md`. Without torch they leak into `dir(transformers)` and `utils/check_repo.py` fails the public-init-vs-docs invariant.

After removal, `from transformers import BeamScorer` raises `ImportError` in a no-torch env (matching the with-torch behavior) instead of returning the dummy and producing a misleading `requires backend torch` error on use.

`DEPRECATED_OBJECTS` in `check_repo.py` would be the alternative, but that list is for objects that still exist as aliases or shims (e.g. `PretrainedConfig` → `PreTrainedConfig`). These six don't.

**Tests run** (no-torch venv):

```bash
$ python utils/check_repo.py
# was: "Exception: ... in the public init, but not in the docs"
# now: docs step passes (later steps fail only on torch import, unrelated to this change)

$ python utils/check_dummies.py     # exit 0
$ python utils/check_inits.py       # exit 0
$ python utils/checkers.py copies,modular_conversion   # all pass
```

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

AI assistance (Claude) was used during investigation and patch preparation. All changes were reviewed and tested by me.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. (Six leftover dummy classes in dummy_pt_objects.py fail check_repo.py and leak into dir(transformers) without torch #45712, approved by @Rocketknight1)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
