### PR TITLE
Fix memory leak in T5 by adding opt-out for apex FusedRMSNorm

### DIFF
--- a/src/transformers/models/t5/modeling_t5.py
+++ b/src/transformers/models/t5/modeling_t5.py
@@ -15,6 +15,7 @@
 
 import copy
 import math
+import os
 
 import torch
 from torch import nn
@@ -68,17 +69,16 @@ class T5LayerNorm(nn.Module):
         return self.weight * hidden_states
 
 
-try:
-    from apex.normalization import FusedRMSNorm
+if os.environ.get("TRANSFORMERS_NO_APEX", "0") == "0":
+    try:
+        from apex.normalization import FusedRMSNorm
 
-    T5LayerNorm = FusedRMSNorm
-
-    logger.info("Discovered apex.normalization.FusedRMSNorm - will use it instead of T5LayerNorm")
-except ImportError:
-    # using the normal T5LayerNorm
-    pass
-except Exception:
-    logger.warning("discovered apex but it failed to load, falling back to T5LayerNorm")
+        T5LayerNorm = FusedRMSNorm  # noqa
+        logger.info("Discovered apex.normalization.FusedRMSNorm - will use it instead of T5LayerNorm")
+    except ImportError:
+        pass
+    except Exception:
+        logger.warning("discovered apex but it failed to load, falling back to T5LayerNorm")
 
 
 class T5DenseActDense(nn.Module):


### PR DESCRIPTION
# What does this PR do?

This PR addresses a known memory leak in `apex.normalization.FusedRMSNorm` when used within `torch.no_grad()` (documented in NVIDIA/apex#1999). Currently, T5 silently forces the use of the `apex` implementation if it is installed in the environment, causing OOM errors in long-running inference pipelines (like FLUX encoding).

To fix this without breaking backward compatibility for users relying on Apex's speed, I have introduced an opt-out environment variable: `TRANSFORMERS_NO_APEX`. 

Setting `TRANSFORMERS_NO_APEX=1` bypasses the `apex` import attempt and forces T5 to safely fall back to the native PyTorch `T5LayerNorm`. Default behavior remains unchanged.

### Who can review?
@ArthurZucker @Cyrilvallez

Fixes #45704 (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [yes] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [yes] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [yes] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. (https://github.com/huggingface/transformers/issues/45704)
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?