### PR TITLE
fix(quantizers): make user-supplied skip_modules additive with auto-detected defaults

### DIFF
--- a/src/transformers/quantizers/base.py
+++ b/src/transformers/quantizers/base.py
@@ -237,10 +237,10 @@ class HfQuantizer(ABC):
         keep_in_fp32_modules: list[str] | None = None,
         add_default_skips: bool = False,
     ):
-        if skip_modules is None or add_default_skips:
-            modules_to_not_convert = get_keys_to_not_convert(model)
-        else:
-            modules_to_not_convert = []
+        # Always include auto-detected keys (lm_head, tied embeddings) so that skip_modules is
+        # additive. Previously this branch was gated on add_default_skips, causing lm_head to be
+        # quantized and bitsandbytes to raise AssertionError when any skip_modules were supplied.
+        modules_to_not_convert = get_keys_to_not_convert(model)
 
         if skip_modules is not None:
             modules_to_not_convert.extend(skip_modules)

--- a/tests/quantization/bnb/test_4bit.py
+++ b/tests/quantization/bnb/test_4bit.py
@@ -14,6 +14,7 @@
 import gc
 import tempfile
 import unittest
+from unittest.mock import patch
 
 import pytest
 
@@ -868,3 +869,51 @@ class Bnb4bitCompile(unittest.TestCase):
                 max_new_tokens=10,
                 cache_implementation="static",
             )
+
+
+class GetModulesToNotConvertTest(unittest.TestCase):
+    """Unit tests for HfQuantizer.get_modules_to_not_convert (no GPU / no pretrained weights required)."""
+
+    def _make_mock_model(self):
+        """Return a MagicMock that satisfies get_keys_to_not_convert's interface."""
+        from unittest.mock import MagicMock
+
+        mock_model = MagicMock()
+        mock_model.all_tied_weights_keys = {}
+        mock_model.named_parameters.return_value = [("lm_head.weight", None)]
+        mock_model.get_output_embeddings.return_value = None
+        mock_model.named_modules.return_value = []
+        return mock_model
+
+    @patch("transformers.quantizers.base.get_keys_to_not_convert", return_value=["lm_head"])
+    def test_skip_modules_is_additive(self, _mock):
+        """Providing skip_modules must not clear the auto-detected defaults (e.g. lm_head)."""
+        from transformers.quantizers.base import HfQuantizer
+
+        mock_model = self._make_mock_model()
+
+        result = HfQuantizer.get_modules_to_not_convert(mock_model, skip_modules=["model.audio_tower"])
+        self.assertIn("lm_head", result, "lm_head should always be excluded even when skip_modules is provided")
+        self.assertIn("model.audio_tower", result, "user-provided skip module should be included")
+
+    @patch("transformers.quantizers.base.get_keys_to_not_convert", return_value=["lm_head"])
+    def test_skip_modules_none_includes_defaults(self, _mock):
+        """Without skip_modules the auto-detected defaults are still returned."""
+        from transformers.quantizers.base import HfQuantizer
+
+        mock_model = self._make_mock_model()
+        result = HfQuantizer.get_modules_to_not_convert(mock_model, skip_modules=None)
+        self.assertIn("lm_head", result)
+
+    @patch("transformers.quantizers.base.get_keys_to_not_convert", return_value=["lm_head"])
+    def test_keep_in_fp32_modules_combined(self, _mock):
+        """keep_in_fp32_modules should also be merged with defaults."""
+        from transformers.quantizers.base import HfQuantizer
+
+        mock_model = self._make_mock_model()
+        result = HfQuantizer.get_modules_to_not_convert(
+            mock_model, skip_modules=["audio_tower"], keep_in_fp32_modules=["vision_tower"]
+        )
+        self.assertIn("lm_head", result)
+        self.assertIn("audio_tower", result)
+        self.assertIn("vision_tower", result)


### PR DESCRIPTION
## Summary

When a user passes `llm_int8_skip_modules` (or `modules_to_not_convert`) to any bitsandbytes quantizer, `get_modules_to_not_convert` previously replaced the auto-detected safe list (from `get_keys_to_not_convert`, which finds `lm_head`, tied embedding weights, etc.) with an empty list and then only included the user-provided modules. This silently caused `lm_head` to be quantized, which triggers an `AssertionError` in bitsandbytes (`fix_4bit_weight_quant_state_from_module` asserts `module.weight.shape[1] == 1`).

The fix unconditionally starts from `get_keys_to_not_convert(model)` and extends it with any caller-supplied modules, making `skip_modules` additive rather than replacing. This matches the behavior that the AWQ quantizer already opted into explicitly via `add_default_skips=True`. The `add_default_skips` parameter is kept for backwards API compatibility but is now a no-op.

The issue is particularly impactful for multimodal models (e.g. Gemma 4 E2B-IT) where users need to add modality-specific towers to `llm_int8_skip_modules` without realising that doing so removes the critical `lm_head` exclusion.

## Issue

Fixes #45674

## Local verification

```bash
# Ruff lint
ruff check src/transformers/quantizers/base.py tests/quantization/bnb/test_4bit.py
# → All checks passed!

# Unit tests (no GPU, no pretrained weights required)
python -c "
from unittest.mock import patch, MagicMock

with patch('transformers.quantizers.base.get_keys_to_not_convert', return_value=['lm_head']):
    from transformers.quantizers.base import HfQuantizer

    mock_model = MagicMock()
    mock_model.all_tied_weights_keys = {}
    mock_model.named_parameters.return_value = [('lm_head.weight', None)]
    mock_model.get_output_embeddings.return_value = None
    mock_model.named_modules.return_value = []

    result = HfQuantizer.get_modules_to_not_convert(mock_model, skip_modules=['model.audio_tower'])
    assert 'lm_head' in result, f'lm_head missing: {result}'
    assert 'model.audio_tower' in result
    print('Test 1 passed: skip_modules is additive')

    result = HfQuantizer.get_modules_to_not_convert(mock_model, skip_modules=None)
    assert 'lm_head' in result
    print('Test 2 passed: skip_modules=None still includes defaults')

    result = HfQuantizer.get_modules_to_not_convert(
        mock_model, skip_modules=['audio_tower'], keep_in_fp32_modules=['vision_tower']
    )
    assert 'lm_head' in result and 'audio_tower' in result and 'vision_tower' in result
    print('Test 3 passed: keep_in_fp32_modules combined')
"
```

```
Test 1 passed: skip_modules is additive
Test 2 passed: skip_modules=None still includes defaults
Test 3 passed: keep_in_fp32_modules combined
=== LOCAL_TEST_PASSED ===
```

## Risk

**Low.** The change only adds modules to the exclusion list; it never removes any. Callers that previously provided a complete `skip_modules` list (including `lm_head` manually) will now see `lm_head` deduplicated via `set()`, which is harmless. Callers that relied on `skip_modules` clearing all defaults (i.e. using it as a strict override) would need to audit their usage, but such usage was undocumented and almost certainly unintentional given the `AssertionError` it produces in bitsandbytes.