### PR TITLE
fix(musicgen_melody): use DynamicCache instead of EncoderDecoderCache

### DIFF
--- a/src/transformers/models/musicgen_melody/modeling_musicgen_melody.py
+++ b/src/transformers/models/musicgen_melody/modeling_musicgen_melody.py
@@ -491,7 +491,7 @@ class MusicgenMelodyDecoder(MusicgenMelodyPreTrainedModel):
             raise ValueError("You have to specify either decoder_input_ids or decoder_inputs_embeds")
 
         if use_cache and past_key_values is None:
-            past_key_values = EncoderDecoderCache(DynamicCache(config=self.config), DynamicCache(config=self.config))
+            past_key_values = DynamicCache(config=self.config)
 
         past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0
         if inputs_embeds is None:


### PR DESCRIPTION
## What does this PR do?

Fixes #45647

MusicgenMelody fuses `encoder_hidden_states` directly into `inputs_embeds` 
and uses pure self-attention — it does not use cross-attention. Using 
`EncoderDecoderCache` caused audio conditioning to be silently ignored 
during generation, producing byte-identical output regardless of the audio input.

## Root cause

Identified via `git bisect` — the regression was introduced in #38635, which 
refactored the cache system. The decoder was incorrectly initialized with 
`EncoderDecoderCache` when it only needs a plain `DynamicCache`.

## Fix

One line change in `MusicgenMelodyDecoder.forward()`:

```python
# Before
past_key_values = EncoderDecoderCache(DynamicCache(config=self.config), DynamicCache(config=self.config))

# After  
past_key_values = DynamicCache(config=self.config)
```

## Testing

Existing test suite passes (133 passed, 62 skipped). 
Regression test for this specific bug is in #45737.