### PR TITLE
DeepSeek OCR specifies an incorrect tokenizer class on the Hub

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -353,6 +353,8 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "deepseek_vl",
     "deepseek_vl_hybrid",
     "deepseek_vl_v2",
+    "deepseek_ocr",
+    "deepseek_ocr2",
     "fuyu",
     "h2ovl_chat",
     "hyperclovax_vlm",


### PR DESCRIPTION
vLLM updates the model type from the DeepSeek OCR checkpoints to `deepseek_ocr` and `deepseek_ocr2` in https://github.com/vllm-project/vllm/blob/bc635fad2389e228a31d6bc6e698caf53d395e13/vllm/transformers_utils/configs/deepseek_vl2.py#L135-L138.

These models specify `LlamaTokenizerFast` in `tokenizer_config.json` which is incorrect. With this patch these models work correctly with vLLM again.

cc @molbap as you are working on https://github.com/huggingface/transformers/pull/41797