### PR TITLE
Fix IndexError in sdpa_mask and flex_attention_mask for 0D tensors during ONNX export

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -477,6 +477,8 @@ def sdpa_mask(
     ```
 
     """
+    if cache_position.ndim == 0:
+        cache_position = cache_position.unsqueeze(0)
     q_length = cache_position.shape[0]
 
     # Potentially pad the 2D mask
@@ -660,6 +662,8 @@ def flex_attention_mask(
         attention_mask (`torch.Tensor`, optional):
             The 2D attention mask corresponding to padded tokens of shape (batch_size, number_of_seen_tokens+q_length)
     """
+    if cache_position.ndim == 0:
+        cache_position = cache_position.unsqueeze(0)
     q_length, q_offset = cache_position.shape[0], cache_position[0]
 
     # Potentially add the padding 2D mask


### PR DESCRIPTION
## Fix for Issue #45735

### Problem
When calling `torch.onnx.export` with ModernBERT models, an `IndexError: tuple index out of range` occurs in `sdpa_mask` and `flex_attention_mask` functions. This happens because during ONNX export, `cache_position` can be passed as a 0-dimensional tensor (scalar), causing failures when accessing `cache_position.shape[0]` or `cache_position[0]`.

### Solution
Add a check at the start of both functions to handle 0D tensors by unsqueezing them to 1D before extracting shape information.

### Changes
- `src/transformers/masking_utils.py`: Added 0D tensor handling in both `sdpa_mask` and `flex_attention_mask`

### Reproduction
```python
import torch
from transformers import AutoModel, AutoTokenizer

path = "answerdotai/ModernBERT-base"
model = AutoModel.from_pretrained(path)
tokenizer = AutoTokenizer.from_pretrained(path)
dummy = dict(tokenizer(["test inputs"], return_tensors="pt"))
torch.onnx.export(model, (dummy,), dynamo=False)
```

Fixes #45735