### PR TITLE
Optimize Qwen3 RoPE: precompute cos/sin cache for static rope_type

### DIFF
--- a/src/transformers/models/qwen3/modeling_qwen3.py
+++ b/src/transformers/models/qwen3/modeling_qwen3.py
@@ -101,6 +101,18 @@ class Qwen3RotaryEmbedding(nn.Module):
 
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
+        if self.rope_type == "default":
+            cos_cached, sin_cached = self._build_cos_sin_cache(inv_freq)
+            self.register_buffer("cos_cached", cos_cached, persistent=False)
+            self.register_buffer("sin_cached", sin_cached, persistent=False)
+
+    def _build_cos_sin_cache(self, inv_freq: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        positions = torch.arange(self.max_seq_len_cached, device=inv_freq.device, dtype=torch.float32)
+        freqs = torch.outer(positions, inv_freq.float())
+        emb = torch.cat((freqs, freqs), dim=-1)
+        cos = emb.cos() * self.attention_scaling
+        sin = emb.sin() * self.attention_scaling
+        return cos, sin
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -135,6 +147,20 @@ class Qwen3RotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        if (
+            self.rope_type == "default"
+            and hasattr(self, "cos_cached")
+            and hasattr(self, "sin_cached")
+            and position_ids.shape[-1] <= self.cos_cached.shape[0]
+        ):
+            cache_device = self.cos_cached.device
+            if position_ids.device != cache_device:
+                position_ids = position_ids.to(cache_device)
+            flat_positions = position_ids.reshape(-1)
+            cos = self.cos_cached.index_select(0, flat_positions).view(*position_ids.shape, -1)
+            sin = self.sin_cached.index_select(0, flat_positions).view(*position_ids.shape, -1)
+            return cos.to(device=x.device, dtype=x.dtype), sin.to(device=x.device, dtype=x.dtype)
+
         inv_freq_expanded = self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, None, :].float()
 
@@ -351,6 +377,18 @@ class Qwen3PreTrainedModel(PreTrainedModel):
         "hidden_states": Qwen3DecoderLayer,
         "attentions": Qwen3Attention,
     }
+
+    def _init_weights(self, module):
+        super()._init_weights(module)
+        if (
+            isinstance(module, Qwen3RotaryEmbedding)
+            and module.rope_type == "default"
+            and hasattr(module, "cos_cached")
+            and hasattr(module, "sin_cached")
+        ):
+            cos_cached, sin_cached = module._build_cos_sin_cache(module.inv_freq)
+            module.register_buffer("cos_cached", cos_cached, persistent=False)
+            module.register_buffer("sin_cached", sin_cached, persistent=False)
 
 
 @auto_docstring

--- a/tests/models/qwen3/test_modeling_qwen3.py
+++ b/tests/models/qwen3/test_modeling_qwen3.py
@@ -35,9 +35,11 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        Qwen3Config,
         Qwen3ForCausalLM,
         Qwen3Model,
     )
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3RotaryEmbedding
 
 from ...causal_lm_tester import CausalLMModelTest, CausalLMModelTester
 
@@ -70,6 +72,36 @@ class Qwen3ModelTest(CausalLMModelTest, unittest.TestCase):
         processor_name,
     ):
         return True
+
+    def test_rope_precomputed_cache_matches_legacy_path(self):
+        config = Qwen3Config(
+            hidden_size=16,
+            intermediate_size=32,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=8,
+            max_position_embeddings=32,
+            rope_parameters={"rope_type": "default", "rope_theta": 10000.0},
+        )
+        cached_rope = Qwen3RotaryEmbedding(config)
+        legacy_rope = Qwen3RotaryEmbedding(config)
+        del legacy_rope.cos_cached
+        del legacy_rope.sin_cached
+
+        x = torch.empty(2, 4, config.head_dim, device="cpu", dtype=torch.float32)
+        position_vectors = [
+            torch.tensor([[0, 1, 2, 3]], device="cpu"),
+            torch.tensor([[3, 7, 11], [2, 5, 13]], device="cpu"),
+            torch.tensor([[0, 4, 8, 16, 31]], device="cpu"),
+        ]
+
+        for position_ids in position_vectors:
+            cos_cached, sin_cached = cached_rope(x, position_ids)
+            cos_legacy, sin_legacy = legacy_rope(x, position_ids)
+
+            torch.testing.assert_close(cos_cached, cos_legacy, rtol=0, atol=0)
+            torch.testing.assert_close(sin_cached, sin_legacy, rtol=0, atol=0)
 
 
 @require_torch


### PR DESCRIPTION
## Summary

Precompute the RoPE cos/sin tables for `rope_type == "default"` at module init and `index_select` in `forward`, replacing the per-call `inv_freq @ position_ids` BMM. Dynamic rope types (NTK-aware scaling, etc.) continue to use the existing per-call path via `@dynamic_rope_update`.

## Motivation

1. **Performance**: eliminates a small per-call cuBLAS BMM and an FP32 autocast block on every forward. Most useful at decode where each step pays the latency.
2. **Robustness**: the BMM hits a cuBLAS deterministic-mode edge case with bf16 + `:4096:8` workspace config that produces NaN. Precompute side-steps it. (Underlying issue is arguably PyTorch/cuBLAS, but precompute is a useful workaround that also helps perf.)
3. **Standard pattern**: older RoPE implementations always cached; the dynamic recompute was added specifically to support changing `inv_freq` for long-context scaling.

## What changed

- `src/transformers/models/qwen3/modeling_qwen3.py`:
  - `Qwen3RotaryEmbedding.__init__` now precomputes `cos_cached`/`sin_cached` for `max_position_embeddings` x `head_dim` when `rope_type == "default"`, using `torch.outer` instead of BMM.
  - `Qwen3RotaryEmbedding.forward` indexes into the cache when available and the requested positions fit the static cache; it falls back to the existing BMM path for dynamic rope types and long-position extrapolation.
  - `@dynamic_rope_update` decorator preserved so NTK paths get their inv_freq updates.
  - The cache buffers are non-persistent derived buffers, matching existing rotary buffer practice and avoiding checkpoint bloat. They are rebuilt in `_init_weights` so meta/from_pretrained loading initializes them after `inv_freq` is restored.

## Math equivalence

Verified bit-identical to the existing forward via `torch.testing.assert_close(rtol=0, atol=0)` on representative position vectors. See new test `test_rope_precomputed_cache_matches_legacy_path`.

## Memory

Adds two FP32 buffers of shape `(max_position_embeddings, head_dim)` per Qwen3RotaryEmbedding instance. For Qwen3 with max_position=128k and head_dim=128, that's about 128 MB per RoPE module. There's typically one shared rotary instance per model, so the overhead is modest relative to model weights.

## Status

DRAFT - opened for early feedback on the approach before broader test/benchmark work and before considering whether to mirror this change to other model families (Llama, Mistral, DeepSeek-V3, Gemma 3, etc., which all use a similar dynamic-RoPE forward pattern).

## Test

- New unit test verifies cached and legacy paths produce bit-identical cos/sin.
- Existing Qwen3 tests pass: `pytest tests/models/qwen3/`.