### PR TITLE
Fix mps device check for moe histogram routing

### DIFF
--- a/src/transformers/integrations/finegrained_fp8.py
+++ b/src/transformers/integrations/finegrained_fp8.py
@@ -396,7 +396,7 @@ def fp8_grouped_mm_experts_forward(
     # Compute offsets for grouped processing.
     # histc instead of bincount avoids cuda-graph issues;
     # CPU requires float input, CUDA requires int input (deterministic mode).
-    histc_input = expert_ids_g.float() if device.type == "cpu" else expert_ids_g.int()
+    histc_input = expert_ids_g.float() if device.type in ("cpu", "mps") else expert_ids_g.int()
     tokens_per_expert = torch.histc(histc_input, bins=self.num_experts, min=0, max=self.num_experts - 1)
     offsets = torch.cumsum(tokens_per_expert, dim=0, dtype=torch.int32)
 

--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -401,7 +401,7 @@ def grouped_mm_experts_forward(
     # Compute offsets for grouped_mm
     # using histc instead of bincount to avoid cuda graph issues
     # With deterministic algorithms, CPU only supports float input, CUDA only supports int input.
-    histc_input = expert_ids_g.float() if device.type == "cpu" else expert_ids_g.int()
+    histc_input = expert_ids_g.float() if device.type in ("cpu", "mps") else expert_ids_g.int()
     tokens_per_expert = torch.histc(histc_input, bins=self.num_experts, min=0, max=self.num_experts - 1)
     offsets = torch.cumsum(tokens_per_expert, dim=0, dtype=torch.int32)
 


### PR DESCRIPTION
# What does this PR do?

Fixes #45685

This PR updates the device check during the histogram calculation in the MoE routing logic (`moe.py` and `finegrained_fp8.py`). 

Apple Silicon (`mps`) does not support `histc` for integer types, so it must be cast to a float before the operation, aligning it with the CPU behavior.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the contributor guideline, Pull Request section?
- [x] Was this discussed/approved via a Github issue or the forum? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? 
- [ ] Did you write any new necessary tests?

## Who can review?

cc @amyeroberts (as discussed in the issue)