### PR TITLE
fix: return correct forward output in AriaTextForCausalLM

### DIFF
--- a/src/transformers/models/aria/modular_aria.py
+++ b/src/transformers/models/aria/modular_aria.py
@@ -870,7 +870,7 @@ class AriaTextForCausalLM(AriaTextPreTrainedModel, LlamaForCausalLM):
 
     @auto_docstring
     def forward(self, **super_kwargs):
-        super().forward(self, **super_kwargs)
+        return super().forward(**super_kwargs)
 
 
 class AriaCausalLMOutputWithPast(LlavaCausalLMOutputWithPast):


### PR DESCRIPTION
## Summary
`AriaTextForCausalLM.forward` in `src/transformers/models/aria/modular_aria.py:873` called `super().forward(self, **super_kwargs)` and discarded the result, so the model passed self twice and returned `None` instead of the LM output.

## Fix
Drop the spurious self argument and return the parent forward result.

## Tests
Verified locally that `AriaTextForCausalLM` now returns a `CausalLMOutputWithPast` instead of `None` on a forward pass. The relevant Aria tests selected via `utils/tests_fetcher.py` pass.
