### PR TITLE
fix attribute access in PermuteForRope._apply

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -384,7 +384,7 @@ class PermuteForRope(ConversionOps):
 
     def _apply(self, tensor: torch.Tensor) -> torch.Tensor:
         dim1, dim2 = tensor.shape
-        n_heads = self.config.getattr("num_attention_heads", 1)
+        n_heads = getattr(self.config, "num_attention_heads", 1)
 
         tensor = tensor.view(n_heads, dim1 // n_heads // 2, 2, dim2)
         tensor = tensor.transpose(1, 2).reshape(dim1, dim2)


### PR DESCRIPTION
## Summary
`PermuteForRope._apply` in src/transformers/core_model_loading.py:387 calls `self.config.getattr("num_attention_heads", 1)`, but config objects have no `getattr` method, so this raises `AttributeError` every time the op runs.

## Fix
Use the builtin `getattr(self.config, "num_attention_heads", 1)` to read the attribute with a default fallback, matching the original intent.

## Tests
Loading a model that exercises `PermuteForRope` no longer raises `AttributeError` on the config lookup.
