### PR TITLE
fix: align attention_mask padding with appended eos token in clvp

### DIFF
--- a/src/transformers/models/clvp/modeling_clvp.py
+++ b/src/transformers/models/clvp/modeling_clvp.py
@@ -141,7 +141,7 @@ def _pad_extra_bos_eos_tokens(
                 # if there are no pad tokens present, then add eos to the end
                 modified_input_ids[i] = torch.nn.functional.pad(each_input_id, (0, 1), value=eos_token_id)
         attention_mask = (
-            torch.nn.functional.pad(attention_mask, (1, 0), value=1) if attention_mask is not None else attention_mask
+            torch.nn.functional.pad(attention_mask, (0, 1), value=1) if attention_mask is not None else attention_mask
         )
 
     return modified_input_ids, attention_mask


### PR DESCRIPTION
## Summary
In `_pad_extra_bos_eos_tokens` at `src/transformers/models/clvp/modeling_clvp.py:144`, when `add_eos_token=True` the eos token is appended to the right of `input_ids` but `attention_mask` was padded on the left. The mask no longer lines up with the tokens, so the appended eos position gets the wrong mask value and a real token at position 0 is masked out.

## Fix
Pad `attention_mask` on the right `(0, 1)` instead of the left `(1, 0)` so the new mask entry corresponds to the appended eos token.
