### PR TITLE
End-to-end test of Gemma 3 + FA2 construction

### DIFF
--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -165,16 +165,15 @@ class Gemma3TextModelTest(CausalLMModelTest, unittest.TestCase):
     @require_torch_gpu
     @require_flash_attn
     @pytest.mark.flash_attn_test
-    def test_flash_attention_2_forward_on_sinkless_model(self):
-        """Regression for #45588. Before #45589, ``flash_attention_forward`` called
-        ``s_aux.to(query.dtype)`` unconditionally, which raised ``AttributeError``
-        on models that do not use attention sinks. This runs a forward pass
-        through the real dispatcher on a sinkless tiny checkpoint, so any future
-        refactor that re-introduces the unguarded ``.to()`` will fail here.
+    def test_flash_attention_2_forward_on_sinkless_model(self) -> None:
+        """End-to-end integration test of model construction and forward pass with ``flash_attention_2``.
+
+        Loads a tiny Gemma3 checkpoint through the ``from_pretrained`` dispatcher
+        and runs a forward pass (through the flash-attention backend).
         """
         model = AutoModelForCausalLM.from_pretrained(
             "hf-internal-testing/tiny-random-Gemma3ForCausalLM",
-            dtype=torch.bfloat16,
+            dtype=torch.bfloat16,  # FA2 only supports half precision
             attn_implementation="flash_attention_2",
         ).to(torch_device)
         input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], device=torch_device)

--- a/tests/models/gemma3/test_modeling_gemma3.py
+++ b/tests/models/gemma3/test_modeling_gemma3.py
@@ -161,6 +161,26 @@ class Gemma3TextModelTest(CausalLMModelTest, unittest.TestCase):
         EXPECTED_OUTPUT = torch.tensor([[90109, 90109, 90109, 83191, 83191], [246901, 69832, 69832, 69832, 62288]])
         torch.testing.assert_close(generated_sequences, EXPECTED_OUTPUT)
 
+    @slow
+    @require_torch_gpu
+    @require_flash_attn
+    @pytest.mark.flash_attn_test
+    def test_flash_attention_2_forward_on_sinkless_model(self):
+        """Regression for #45588. Before #45589, ``flash_attention_forward`` called
+        ``s_aux.to(query.dtype)`` unconditionally, which raised ``AttributeError``
+        on models that do not use attention sinks. This runs a forward pass
+        through the real dispatcher on a sinkless tiny checkpoint, so any future
+        refactor that re-introduces the unguarded ``.to()`` will fail here.
+        """
+        model = AutoModelForCausalLM.from_pretrained(
+            "hf-internal-testing/tiny-random-Gemma3ForCausalLM",
+            dtype=torch.bfloat16,
+            attn_implementation="flash_attention_2",
+        ).to(torch_device)
+        input_ids = torch.tensor([[1, 2, 3, 4, 5, 6, 7, 8]], device=torch_device)
+        with torch.no_grad():
+            _ = model(input_ids=input_ids)
+
     @parameterized.expand([("linear",), ("dynamic",), ("yarn",)])
     @unittest.skip("TODO (joao): check why this is failing")
     def test_model_rope_scaling_from_config(self):


### PR DESCRIPTION
This small PR adds an end-to-end regression test for the fix in https://github.com/huggingface/transformers/pull/45589 for https://github.com/huggingface/transformers/issues/45588:
1. Builds a sinkless tiny Gemma3 with FA2
2. Runs a forward pass.

Cherry-picked from @truffle-dev's fork; verified on compute cluster with H100.

This PR adds test coverage for the fix in https://github.com/huggingface/transformers/pull/45589 for https://github.com/huggingface/transformers/issues/45588.

@ArthurZucker @Cyrilvallez