### PR TITLE
perf(qwen3_vl): replace Conv3d with F.linear in patch embed forward

### DIFF
--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -82,10 +82,15 @@ class Qwen3VLVisionPatchEmbed(nn.Module):
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         target_dtype = self.proj.weight.dtype
-        hidden_states = hidden_states.view(
-            -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size
+        hidden_states = hidden_states.to(dtype=target_dtype).view(
+            -1, self.in_channels * self.temporal_patch_size * self.patch_size * self.patch_size
         )
-        hidden_states = self.proj(hidden_states.to(dtype=target_dtype)).view(-1, self.embed_dim)
+        # Use F.linear instead of Conv3d. When stride == kernel_size, Conv3d
+        # just extracts non-overlapping patches and applies a linear projection.
+        # F.linear avoids cuDNN overhead that causes ~50,000x slowdown on
+        # some GPU/dtype combinations (see #45750).
+        weight = self.proj.weight.view(self.embed_dim, -1)
+        hidden_states = torch.nn.functional.linear(hidden_states, weight, self.proj.bias)
         return hidden_states
 
 


### PR DESCRIPTION
## What does this PR do?

Replaces the Conv3d forward pass in `Qwen3VLVisionPatchEmbed` with `F.linear` on the reshaped weight. When `stride == kernel_size`, Conv3d is mathematically equivalent to extracting non-overlapping patches and applying a linear projection. The Conv3d codepath triggers an extremely slow cuDNN kernel on some GPU/dtype combinations (~50,000x slower on Blackwell + bf16, ~62x on other configs per the issue benchmarks).

The fix reshapes the input to `(batch, in_channels * t * h * w)` and uses `F.linear(input, weight.view(embed_dim, -1), bias)`. Same weight tensor, just reshaped at forward time, so existing checkpoints load without changes.

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] This PR fixes a bug (issue #45750)
- [x] Backward compatible (same weights, same outputs, just faster)

Fixes #45750.