### PR TITLE
Fix UnboundLocalError for `is_updated` in encoder-decoder cross-attention

### DIFF
--- a/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
+++ b/src/transformers/models/audioflamingo3/modeling_audioflamingo3.py
@@ -141,6 +141,7 @@ class AudioFlamingo3Attention(nn.Module):
         query_states = (self.q_proj(hidden_states) * self.scaling).view(hidden_shape).transpose(1, 2).contiguous()
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
+        is_updated = False
         if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/src/transformers/models/moonshine/modeling_moonshine.py
+++ b/src/transformers/models/moonshine/modeling_moonshine.py
@@ -297,6 +297,7 @@ class MoonshineAttention(nn.Module):
         )
 
         is_cross_attention = key_value_states is not None
+        is_updated = False
         if past_key_values is not None:
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/src/transformers/models/moonshine/modular_moonshine.py
+++ b/src/transformers/models/moonshine/modular_moonshine.py
@@ -218,6 +218,7 @@ class MoonshineAttention(GlmAttention):
         )
 
         is_cross_attention = key_value_states is not None
+        is_updated = False
         if past_key_values is not None:
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
+++ b/src/transformers/models/moonshine_streaming/modeling_moonshine_streaming.py
@@ -626,6 +626,7 @@ class MoonshineStreamingAttention(nn.Module):
         )
 
         is_cross_attention = key_value_states is not None
+        is_updated = False
         if past_key_values is not None:
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/src/transformers/models/pix2struct/modeling_pix2struct.py
+++ b/src/transformers/models/pix2struct/modeling_pix2struct.py
@@ -697,6 +697,7 @@ class Pix2StructTextAttention(nn.Module):
         query_states = query_states.view(batch_size, -1, self.n_heads, self.key_value_proj_dim).transpose(1, 2)
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
+        is_updated = False
         if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -743,8 +743,6 @@ class WhisperDecoder(WhisperPreTrainedModel):
                 if encoder_hidden_states is not None or self.config.is_encoder_decoder
                 else DynamicCache(config=self.config)
             )
-        elif use_cache and encoder_hidden_states is not None and not isinstance(past_key_values, EncoderDecoderCache):
-            past_key_values = EncoderDecoderCache(past_key_values, DynamicCache(config=self.config))
 
         past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -743,6 +743,8 @@ class WhisperDecoder(WhisperPreTrainedModel):
                 if encoder_hidden_states is not None or self.config.is_encoder_decoder
                 else DynamicCache(config=self.config)
             )
+        elif use_cache and encoder_hidden_states is not None and not isinstance(past_key_values, EncoderDecoderCache):
+            past_key_values = EncoderDecoderCache(past_key_values, DynamicCache(config=self.config))
 
         past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -309,6 +309,7 @@ class WhisperAttention(nn.Module):
         query_states = (self.q_proj(hidden_states) * self.scaling).view(hidden_shape).transpose(1, 2).contiguous()
 
         # Check is encoder-decoder model is being used. Otherwise we'll get `DynamicCache`
+        is_updated = False
         if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
             is_updated = past_key_values.is_updated.get(self.layer_idx)
             if is_cross_attention:

--- a/tests/models/pix2struct/test_modeling_pix2struct.py
+++ b/tests/models/pix2struct/test_modeling_pix2struct.py
@@ -646,6 +646,37 @@ class Pix2StructModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTeste
     def test_model_base_model_prefix(self):
         pass
 
+    def test_attention_no_unbound_is_updated_without_encoder_decoder_cache(self):
+        """Regression test for #45773: `UnboundLocalError` on non-EncoderDecoderCache caches.
+        This can happen e.g. when using assistant models for speculative decoding.
+        """
+        from transformers.cache_utils import DynamicCache, EncoderDecoderCache
+        from transformers.models.pix2struct.modeling_pix2struct import Pix2StructTextAttention
+
+        text_config = self.model_tester.text_model_tester.get_config()
+        hidden_size = text_config.hidden_size
+
+        attn = Pix2StructTextAttention(
+            config=text_config,
+            has_relative_attention_bias=False,
+            layer_idx=0,
+        ).to(torch_device)
+
+        batch_size = 2
+        seq_len = 4
+        encoder_seq_len = 8
+
+        hidden_states = torch.randn(batch_size, seq_len, hidden_size, device=torch_device)
+        key_value_states = torch.randn(batch_size, encoder_seq_len, hidden_size, device=torch_device)
+
+        cache = EncoderDecoderCache(DynamicCache(), DynamicCache())
+        output = attn(
+            hidden_states=hidden_states,
+            key_value_states=key_value_states,
+            past_key_values=cache,
+        )
+        self.assertEqual(output[0].shape, (batch_size, seq_len, hidden_size))
+
 
 # We will verify our results on an image of a stop sign
 def prepare_img():

--- a/tests/models/whisper/test_modeling_whisper.py
+++ b/tests/models/whisper/test_modeling_whisper.py
@@ -1220,6 +1220,46 @@ class WhisperModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMi
     def test_generate_compilation_all_outputs(self):
         pass
 
+    def test_attention_no_unbound_is_updated_without_encoder_decoder_cache(self):
+        """Regression test for #45773: `UnboundLocalError` on non-EncoderDecoderCache caches.
+        This can happen e.g. when using assistant models for speculative decoding.
+        """
+        from transformers.cache_utils import DynamicCache
+        from transformers.models.whisper.modeling_whisper import WhisperAttention
+
+        config = self.model_tester.get_config()
+        embed_dim = config.d_model
+        num_heads = config.decoder_attention_heads
+
+        attn = WhisperAttention(
+            embed_dim=embed_dim,
+            num_heads=num_heads,
+            is_decoder=True,
+            layer_idx=0,
+            config=config,
+        ).to(torch_device)
+
+        batch_size = 2
+        seq_len = 4
+        encoder_seq_len = 8
+
+        hidden_states = torch.randn(batch_size, seq_len, embed_dim, device=torch_device)
+        key_value_states = torch.randn(batch_size, encoder_seq_len, embed_dim, device=torch_device)
+
+        cache = DynamicCache()
+        cache.update(
+            torch.randn(batch_size, num_heads, seq_len, embed_dim // num_heads, device=torch_device),
+            torch.randn(batch_size, num_heads, seq_len, embed_dim // num_heads, device=torch_device),
+            layer_idx=0,
+        )
+
+        output, _ = attn(
+            hidden_states=hidden_states,
+            key_value_states=key_value_states,
+            past_key_values=cache,
+        )
+        self.assertEqual(output.shape, (batch_size, seq_len, embed_dim))
+
 
 @require_torch
 @require_torchaudio


### PR DESCRIPTION
## What does this PR do?

Fixes an `UnboundLocalError` in the cross-attention forward pass of several encoder-decoder models. The variable `is_updated` is only assigned inside a conditional block that checks for `EncoderDecoderCache`, but is referenced unconditionally afterward. When `past_key_values` is `None` or a non-`EncoderDecoderCache` type (e.g., `DynamicCache` during speculative decoding), the variable is never bound.

**Error:**
```
File ".../transformers/models/whisper/modeling_whisper.py", line 323, in forward
    if is_cross_attention and past_key_values and is_updated:
                                                  ^^^^^^^^^^
UnboundLocalError: cannot access local variable 'is_updated' where it is not associated with a value
```

## Affected models

- `whisper` (`modeling_whisper.py`)
- `moonshine` (`modeling_moonshine.py`, `modular_moonshine.py`)
- `moonshine_streaming` (`modeling_moonshine_streaming.py`)
- `pix2struct` (`modeling_pix2struct.py`)
- `audioflamingo3` (`modeling_audioflamingo3.py`)

## Root cause

The buggy pattern:
```python
# is_updated only assigned inside this block
if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
    is_updated = past_key_values.is_updated.get(self.layer_idx)
    ...

# Unconditional reference — UnboundLocalError if the block above was skipped
if is_cross_attention and past_key_values and is_updated:
    ...
```

## Fix

Add `is_updated = False` initialization before the conditional block. This is consistent with the pattern already used in T5, BART, xglm, BioGPT, Informer, and other encoder-decoder models:

```python
is_updated = False
if past_key_values is not None and isinstance(past_key_values, EncoderDecoderCache):
    is_updated = past_key_values.is_updated.get(self.layer_idx)
    ...
```

## How to reproduce

```python
from transformers import AutoProcessor, AutoModelForSpeechSeq2Seq, AutoModelForCausalLM, AutoTokenizer
import torch

main_model = AutoModelForSpeechSeq2Seq.from_pretrained("openai/whisper-small", torch_dtype=torch.float16).to("cuda")
assistant = AutoModelForCausalLM.from_pretrained("distil-whisper/distil-small.en", torch_dtype=torch.float16).to("cuda")
processor = AutoProcessor.from_pretrained("openai/whisper-small")
tokenizer = AutoTokenizer.from_pretrained("openai/whisper-small")
asst_tokenizer = AutoTokenizer.from_pretrained("distil-whisper/distil-small.en")

# Any audio input
import numpy as np
audio = np.zeros(16000, dtype=np.float32)  # 1 second silence
inputs = processor(audio, return_tensors="pt", sampling_rate=16000)
features = inputs.input_features.to("cuda", dtype=torch.float16)

# This raises UnboundLocalError
main_model.generate(
    input_features=features,
    assistant_model=assistant,
    tokenizer=tokenizer,
    assistant_tokenizer=asst_tokenizer,
)
```

## Reference

Correct implementations for comparison:
- [`models/t5/modeling_t5.py`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/t5/modeling_t5.py) — initializes `is_updated = False` before conditional
- [`models/xglm/modeling_xglm.py`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/xglm/modeling_xglm.py) — same pattern
- [`models/biogpt/modeling_biogpt.py`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/biogpt/modeling_biogpt.py) — same pattern