### PR TITLE
Fix auto mapping script

### DIFF
--- a/utils/check_auto.py
+++ b/utils/check_auto.py
@@ -259,12 +259,13 @@ def main(overwrite: bool):
 
     # 3. If the new auto-generate content is different, overwrite it
     # Dirty hack to sort and apply ruff to the file content, for easier matching
-    with tempfile.NamedTemporaryFile(mode="w", suffix=".py") as tmpfile:
-        tmpfile.write(new_content)
-        tmpfile_path = tmpfile.name
+    with tempfile.TemporaryDirectory() as temp_folder:
+        temp_filename = os.path.join(temp_folder, "temp.py")
+        with open(temp_filename, "w") as temp_file:
+            temp_file.write(new_content)
 
-        run_ruff_and_sort(tmpfile_path)
-        new_content = open(tmpfile_path, "r").read()
+        run_ruff_and_sort(temp_filename)
+        new_content = open(temp_filename, "r").read()
 
     if old_content != new_content:
         if not overwrite:


### PR DESCRIPTION
# What does this PR do?

As per the title. The current script fully truncates the file instead, so running `make fix-repo` results in a lot of errors and corrupted library.
It's not really possible to both write and read the same file with the same `open`, without messing with `.seek()`.

I have no idea how it was not caught on the CI. cc @tarekziade @ydshieh @zucchini-nlp can you please make sure the script is run/checked on the CI?? The fact that it was not caught before makes me think we are not checking that the mappings are up-to-date and not corrupted!