### PR TITLE
make sure we call check_auto in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,101 +4,72 @@ export PYTHONPATH = src
 .PHONY: style typing check-code-quality check-repository-consistency check-repo fix-repo test test-examples benchmark codex claude clean-ai
 
 
+# Checker lists. The two CI jobs (CircleCI runs `make check-code-quality` and
+# `make check-repository-consistency` in parallel) own the canonical sets below.
+# Local convenience targets `check-repo` and `fix-repo` are *derived* from them,
+# so they can never drift out of sync (e.g. silently dropping `auto_mappings`
+# from CI, as happened in #45018 → fixed in #45774).
+
+STYLE_CHECKERS := ruff_check ruff_format init_isort sort_auto_mappings
+TYPING_CHECKERS := types modeling_structure
+CODE_QUALITY_CHECKERS := $(TYPING_CHECKERS) $(STYLE_CHECKERS)
+
+REPO_CONSISTENCY_CHECKERS := \
+	auto_mappings \
+	imports \
+	import_complexity \
+	copies \
+	modular_conversion \
+	doc_toc \
+	modeling_rules_doc \
+	docstrings \
+	dummies \
+	repo \
+	inits \
+	pipeline_typing \
+	config_docstrings \
+	config_attributes \
+	doctest_list \
+	update_metadata \
+	add_dates \
+	deps_table
+
+ALL_CHECKERS := $(CODE_QUALITY_CHECKERS) $(REPO_CONSISTENCY_CHECKERS)
+
+# `update_metadata` in --fix mode pushes to the `huggingface/transformers-metadata`
+# Hub dataset (requires an auth token); exclude it from the local fix workflow.
+FIX_CHECKERS := $(filter-out update_metadata,$(ALL_CHECKERS))
+
+# Convert a space-separated checker list to the comma-separated form `checkers.py` expects.
+empty :=
+space := $(empty) $(empty)
+comma := ,
+csv = $(subst $(space),$(comma),$(strip $1))
+
+
 # Runs all linting/formatting scripts, most notably ruff
 style:
-	@python utils/checkers.py \
-		ruff_check,\
-		ruff_format,\
-		init_isort,\
-		sort_auto_mappings \
-		--fix
+	@python utils/checkers.py $(call csv,$(STYLE_CHECKERS)) --fix
 
 # Runs ty type checker and model structure rules
 typing:
-	@python utils/checkers.py \
-		types,\
-		modeling_structure
+	@python utils/checkers.py $(call csv,$(TYPING_CHECKERS))
 
 # Runs typing, ruff linting/formatting, import-order checks and auto-mappings
 check-code-quality:
-	@python utils/checkers.py \
-		types,\
-		modeling_structure,\
-		ruff_check,\
-		ruff_format,\
-		init_isort,\
-		sort_auto_mappings
+	@python utils/checkers.py $(call csv,$(CODE_QUALITY_CHECKERS))
 
 # Runs a full repository consistency check.
 check-repository-consistency:
-	@python utils/checkers.py \
-		auto_mappings,\
-		imports,\
-		import_complexity,\
-		copies,\
-		modular_conversion,\
-		doc_toc,\
-		modeling_rules_doc,\
-		docstrings,\
-		dummies,\
-		repo,\
-		inits,\
-		pipeline_typing,\
-		config_docstrings,\
-		config_attributes,\
-		doctest_list,\
-		update_metadata,\
-		add_dates,\
-		deps_table
+	@python utils/checkers.py $(call csv,$(REPO_CONSISTENCY_CHECKERS))
 
 # Runs typing and formatting checks + repository consistency check (ignores errors)
 check-repo:
-	@python utils/checkers.py \
-		ruff_check,\
-		ruff_format,\
-		types,\
-		modeling_structure,\
-		init_isort,\
-		auto_mappings,\
-		sort_auto_mappings,\
-		imports,\
-		import_complexity,\
-		copies,\
-		modular_conversion,\
-		doc_toc,\
-		modeling_rules_doc,\
-		docstrings,\
-		dummies,\
-		repo,\
-		inits,\
-		pipeline_typing,\
-		config_docstrings,\
-		config_attributes,\
-		doctest_list,\
-		update_metadata,\
-		add_dates,\
-		deps_table \
-		--keep-going
+	@python utils/checkers.py $(call csv,$(ALL_CHECKERS)) --keep-going
 
 # Run all repo checks for which there is an automatic fix, most notably modular conversions
 fix-repo:
-	@python utils/checkers.py \
-		ruff_check,\
-		ruff_format,\
-		init_isort,\
-		auto_mappings,\
-		sort_auto_mappings,\
-		doc_toc,\
-		modeling_rules_doc,\
-		copies,\
-		modular_conversion,\
-		dummies,\
-		pipeline_typing,\
-		doctest_list,\
-		docstrings,\
-		add_dates,\
-		deps_table \
-		--fix --keep-going
+	@python utils/checkers.py $(call csv,$(FIX_CHECKERS)) --fix --keep-going
 
 # Run tests for the library, requires pytest-random-order
 test:

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ check-code-quality:
 # Runs a full repository consistency check.
 check-repository-consistency:
 	@python utils/checkers.py \
+		auto_mappings,\
 		imports,\
 		import_complexity,\
 		copies,\

--- a/Makefile
+++ b/Makefile
@@ -10,66 +10,61 @@ export PYTHONPATH = src
 # so they can never drift out of sync (e.g. silently dropping `auto_mappings`
 # from CI, as happened in #45018 → fixed in #45774).
 
-STYLE_CHECKERS := ruff_check ruff_format init_isort sort_auto_mappings
-TYPING_CHECKERS := types modeling_structure
-CODE_QUALITY_CHECKERS := $(TYPING_CHECKERS) $(STYLE_CHECKERS)
+STYLE_CHECKERS := ruff_check, ruff_format, init_isort, sort_auto_mappings
+TYPING_CHECKERS := types, modeling_structure
+CODE_QUALITY_CHECKERS := $(TYPING_CHECKERS), $(STYLE_CHECKERS)
 
 REPO_CONSISTENCY_CHECKERS := \
-	auto_mappings \
-	imports \
-	import_complexity \
-	copies \
-	modular_conversion \
-	doc_toc \
-	modeling_rules_doc \
-	docstrings \
-	dummies \
-	repo \
-	inits \
-	pipeline_typing \
-	config_docstrings \
-	config_attributes \
-	doctest_list \
-	update_metadata \
-	add_dates \
+	auto_mappings, \
+	imports, \
+	import_complexity, \
+	copies, \
+	modular_conversion, \
+	doc_toc, \
+	modeling_rules_doc, \
+	docstrings, \
+	dummies, \
+	repo, \
+	inits, \
+	pipeline_typing, \
+	config_docstrings, \
+	config_attributes, \
+	doctest_list, \
+	update_metadata, \
+	add_dates, \
 	deps_table
 
-ALL_CHECKERS := $(CODE_QUALITY_CHECKERS) $(REPO_CONSISTENCY_CHECKERS)
+ALL_CHECKERS := $(CODE_QUALITY_CHECKERS), $(REPO_CONSISTENCY_CHECKERS)
 
 # `update_metadata` in --fix mode pushes to the `huggingface/transformers-metadata`
-# Hub dataset (requires an auth token); exclude it from the local fix workflow.
-FIX_CHECKERS := $(filter-out update_metadata,$(ALL_CHECKERS))
-
-# Convert a space-separated checker list to the comma-separated form `checkers.py` expects.
-empty :=
-space := $(empty) $(empty)
-comma := ,
-csv = $(subst $(space),$(comma),$(strip $1))
+# Hub dataset (requires an auth token); strip it from the local fix workflow.
+# `checkers.py` ignores the empty entry left behind.
+FIX_CHECKERS := $(subst update_metadata,,$(ALL_CHECKERS))
 
 
 # Runs all linting/formatting scripts, most notably ruff
 style:
-	@python utils/checkers.py $(call csv,$(STYLE_CHECKERS)) --fix
+	@python utils/checkers.py $(STYLE_CHECKERS) --fix
 
 # Runs ty type checker and model structure rules
 typing:
-	@python utils/checkers.py $(call csv,$(TYPING_CHECKERS))
+	@python utils/checkers.py $(TYPING_CHECKERS)
 
 # Runs typing, ruff linting/formatting, import-order checks and auto-mappings
 check-code-quality:
-	@python utils/checkers.py $(call csv,$(CODE_QUALITY_CHECKERS))
+	@python utils/checkers.py $(CODE_QUALITY_CHECKERS)
 
 # Runs a full repository consistency check.
 check-repository-consistency:
-	@python utils/checkers.py $(call csv,$(REPO_CONSISTENCY_CHECKERS))
+	@python utils/checkers.py $(REPO_CONSISTENCY_CHECKERS)
 
 # Runs typing and formatting checks + repository consistency check (ignores errors)
 check-repo:
-	@python utils/checkers.py $(call csv,$(ALL_CHECKERS)) --keep-going
+	@python utils/checkers.py $(ALL_CHECKERS) --keep-going
 
 # Run all repo checks for which there is an automatic fix, most notably modular conversions
 fix-repo:
-	@python utils/checkers.py $(call csv,$(FIX_CHECKERS)) --fix --keep-going
+	@python utils/checkers.py $(FIX_CHECKERS) --fix --keep-going
 
 # Run tests for the library, requires pytest-random-order
 test:

--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,6 @@ REPO_CONSISTENCY_CHECKERS := \
 
 ALL_CHECKERS := $(CODE_QUALITY_CHECKERS), $(REPO_CONSISTENCY_CHECKERS)
 
-# `update_metadata` in --fix mode pushes to the `huggingface/transformers-metadata`
-# Hub dataset (requires an auth token); strip it from the local fix workflow.
-# `checkers.py` ignores the empty entry left behind.
-FIX_CHECKERS := $(subst update_metadata,,$(ALL_CHECKERS))
-
 
 # Runs all linting/formatting scripts, most notably ruff
 style:
@@ -64,7 +59,7 @@ check-repo:
 
 # Run all repo checks for which there is an automatic fix, most notably modular conversions
 fix-repo:
-	@python utils/checkers.py $(FIX_CHECKERS) --fix --keep-going
+	@python utils/checkers.py $(ALL_CHECKERS) --fix --keep-going
 
 # Run tests for the library, requires pytest-random-order
 test:

--- a/src/transformers/models/auto/auto_mappings.py
+++ b/src/transformers/models/auto/auto_mappings.py
@@ -680,7 +680,6 @@ SPECIAL_MODEL_TYPE_TO_MODULE_NAME = OrderedDict(
         ("data2vec-text", "data2vec"),
         ("data2vec-vision", "data2vec"),
         ("deberta-v2", "deberta_v2"),
-        ("detr", "maskformer"),
         ("dia_decoder", "dia"),
         ("dia_encoder", "dia"),
         ("donut-swin", "donut"),

--- a/tests/repo_utils/test_check_auto.py
+++ b/tests/repo_utils/test_check_auto.py
@@ -1,0 +1,129 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+
+git_repo_path = os.path.abspath(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+utils_path = os.path.join(git_repo_path, "utils")
+if utils_path not in sys.path:
+    sys.path.append(utils_path)
+
+import check_auto  # noqa: E402
+
+
+@contextmanager
+def cwd(path: Path):
+    old = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(old)
+
+
+def _write_config(root: Path, module_name: str, classes: list[tuple[str, str]]) -> None:
+    """Create `src/transformers/models/<module>/configuration_<module>.py` with the given classes.
+
+    `classes` is a list of (class_name, model_type) pairs, all subclassing PreTrainedConfig.
+    """
+    module_dir = root / "src" / "transformers" / "models" / module_name
+    module_dir.mkdir(parents=True, exist_ok=True)
+    body = "from transformers import PreTrainedConfig\n\n"
+    for cls_name, model_type in classes:
+        body += textwrap.dedent(
+            f'''
+            class {cls_name}(PreTrainedConfig):
+                model_type = "{model_type}"
+            '''
+        )
+    (module_dir / f"configuration_{module_name}.py").write_text(body, encoding="utf-8")
+
+
+class BuildConfigMappingNamesTest(unittest.TestCase):
+    """Tests for the natural-match tie-break in `check_auto.build_config_mapping_names`.
+
+    A natural match is one where a config's `model_type` equals its module directory name
+    (e.g. `DetrConfig` with `model_type = "detr"` inside `models/detr/`). When two classes
+    share a `model_type`, the natural one must always win regardless of filesystem ordering.
+    """
+
+    def test_single_natural_match(self):
+        """Baseline: one config in its eponymous module → no special mapping."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_config(root, "detr", [("DetrConfig", "detr")])
+            with cwd(root):
+                model_type_map, special_mappings = check_auto.build_config_mapping_names()
+
+        self.assertEqual(model_type_map, {"detr": "DetrConfig"})
+        self.assertEqual(special_mappings, {})
+
+    def test_natural_wins_when_encountered_first(self):
+        """detr (natural) is alphabetically before maskformer (non-natural for model_type=detr).
+
+        This is the order modern Linux filesystems produce. The natural match must be kept
+        and the alias must not appear in the canonical mapping.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_config(root, "detr", [("DetrConfig", "detr")])
+            _write_config(
+                root,
+                "maskformer",
+                [("MaskFormerConfig", "maskformer"), ("MaskFormerDetrConfig", "detr")],
+            )
+            with cwd(root):
+                model_type_map, special_mappings = check_auto.build_config_mapping_names()
+
+        self.assertEqual(model_type_map["detr"], "DetrConfig")
+        self.assertEqual(model_type_map["maskformer"], "MaskFormerConfig")
+        self.assertNotIn("detr", special_mappings)
+
+    def test_natural_wins_when_encountered_second(self):
+        """The non-natural alias is alphabetically *before* the natural module.
+
+        Without the prefer-natural logic this is the case that breaks: the alias would be
+        recorded first and then never overwritten. The fix must still pick the natural class
+        and clear the now-stale special mapping.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # `aaa_alias` sorts before `foo`, so its non-natural class is processed first.
+            _write_config(root, "aaa_alias", [("AaaConfig", "aaa_alias"), ("FooAliasConfig", "foo")])
+            _write_config(root, "foo", [("FooConfig", "foo")])
+            with cwd(root):
+                model_type_map, special_mappings = check_auto.build_config_mapping_names()
+
+        self.assertEqual(model_type_map["foo"], "FooConfig")
+        self.assertNotIn("foo", special_mappings, "stale alias entry must be cleared")
+        # The alias module's own natural entry is still recorded.
+        self.assertEqual(model_type_map["aaa_alias"], "AaaConfig")
+
+    def test_non_natural_only_records_special_mapping(self):
+        """If a model_type has no natural match, the alias is the canonical entry."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            _write_config(root, "wrapper", [("WrapperConfig", "wrapper"), ("InnerConfig", "inner")])
+            with cwd(root):
+                model_type_map, special_mappings = check_auto.build_config_mapping_names()
+
+        self.assertEqual(model_type_map["inner"], "InnerConfig")
+        self.assertEqual(special_mappings["inner"], "wrapper")

--- a/utils/check_auto.py
+++ b/utils/check_auto.py
@@ -65,13 +65,9 @@ IGNORE_DUPLICATE_CONFIG = ["GPT2Config", "EvollaConfig", "MLCDVisionConfig"]
 def build_config_mapping_names() -> tuple[dict, dict]:
     model_type_map = OrderedDict()
     special_mappings = OrderedDict()
-    # Track which model_types were resolved by a "natural" match (model_type == module_name)
-    # so a later non-natural match (e.g. MaskFormerDetrConfig with model_type="detr" inside
-    # models/maskformer/) does not silently overwrite the canonical class.
-    natural_types: set[str] = set()
 
-    # `glob.glob` is filesystem-order dependent — sort to make the output deterministic.
-    all_files = sorted(glob.glob("src/transformers/models/**/configuration_*.py", recursive=True))
+    # root_path = Path(__file__).resolve().parents[2]
+    all_files = glob.glob("src/transformers/models/**/configuration_*.py", recursive=True)
     for config_path in all_files:
         module_name = config_path.split("/")[-2]
         with open(config_path, "r") as f:
@@ -101,18 +97,9 @@ def build_config_mapping_names() -> tuple[dict, dict]:
                 if not model_type:
                     continue
 
-                is_natural = model_type == module_name
-                # If we already recorded a natural match for this model_type, don't let a
-                # non-natural one overwrite it — the natural class is the canonical owner.
-                if model_type in natural_types and not is_natural:
-                    continue
-
-                model_type_map[model_type] = config_cls_name
-                if is_natural:
-                    natural_types.add(model_type)
-                    special_mappings.pop(model_type, None)
-                else:
+                if model_type != module_name:
                     special_mappings[model_type] = module_name
+                model_type_map[model_type] = config_cls_name
 
     return model_type_map, special_mappings
 

--- a/utils/check_auto.py
+++ b/utils/check_auto.py
@@ -14,6 +14,7 @@
 
 import argparse
 import ast
+import difflib
 import glob
 import os
 import subprocess
@@ -269,9 +270,19 @@ def main(overwrite: bool):
 
     if old_content != new_content:
         if not overwrite:
+            diff = "".join(
+                difflib.unified_diff(
+                    old_content.splitlines(keepends=True),
+                    new_content.splitlines(keepends=True),
+                    fromfile=f"{filename} (on disk)",
+                    tofile=f"{filename} (regenerated)",
+                    n=3,
+                )
+            )
             raise Exception(
-                "Generated auto-mapping is not consistent with the contents of `models/auto/auto_mappings.py`:\n"
-                + "\nRun `make fix-repo` or `python utils/check_auto.py --fix_and_overwrite` to fix them."
+                "Generated auto-mapping is not consistent with the contents of `models/auto/auto_mappings.py`.\n"
+                "Run `make fix-repo` or `python utils/check_auto.py --fix_and_overwrite` to fix them.\n\n"
+                f"Diff (on disk → regenerated):\n{diff}"
             )
         else:
             with open(filename, "w") as f:

--- a/utils/check_auto.py
+++ b/utils/check_auto.py
@@ -65,9 +65,13 @@ IGNORE_DUPLICATE_CONFIG = ["GPT2Config", "EvollaConfig", "MLCDVisionConfig"]
 def build_config_mapping_names() -> tuple[dict, dict]:
     model_type_map = OrderedDict()
     special_mappings = OrderedDict()
+    # Track which model_types were resolved by a "natural" match (model_type == module_name)
+    # so a later non-natural match (e.g. MaskFormerDetrConfig with model_type="detr" inside
+    # models/maskformer/) does not silently overwrite the canonical class.
+    natural_types: set[str] = set()
 
-    # root_path = Path(__file__).resolve().parents[2]
-    all_files = glob.glob("src/transformers/models/**/configuration_*.py", recursive=True)
+    # `glob.glob` is filesystem-order dependent — sort to make the output deterministic.
+    all_files = sorted(glob.glob("src/transformers/models/**/configuration_*.py", recursive=True))
     for config_path in all_files:
         module_name = config_path.split("/")[-2]
         with open(config_path, "r") as f:
@@ -97,9 +101,18 @@ def build_config_mapping_names() -> tuple[dict, dict]:
                 if not model_type:
                     continue
 
-                if model_type != module_name:
-                    special_mappings[model_type] = module_name
+                is_natural = model_type == module_name
+                # If we already recorded a natural match for this model_type, don't let a
+                # non-natural one overwrite it — the natural class is the canonical owner.
+                if model_type in natural_types and not is_natural:
+                    continue
+
                 model_type_map[model_type] = config_cls_name
+                if is_natural:
+                    natural_types.add(model_type)
+                    special_mappings.pop(model_type, None)
+                else:
+                    special_mappings[model_type] = module_name
 
     return model_type_map, special_mappings
 

--- a/utils/checkers.py
+++ b/utils/checkers.py
@@ -135,12 +135,14 @@ def _discover_checkers() -> tuple[dict, dict]:
 
 
 # Inline checkers have no separate script file; they use custom runner functions below.
+# fix_args=[] marks a checker as fix-capable (its custom runner handles --fix internally);
+# fix_args=None marks a check-only entry that `make fix-repo` should silently skip.
 _INLINE_CHECKERS = {
-    "deps_table": ("Dependency versions table", None, None, None),
+    "deps_table": ("Dependency versions table", None, None, []),
     "imports": ("Public imports", None, None, None),
     "import_complexity": ("Import complexity", "check_import_complexity.py", [], None),
-    "ruff_check": ("Ruff linting", None, None, None),
-    "ruff_format": ("Ruff formatting", None, None, None),
+    "ruff_check": ("Ruff linting", None, None, []),
+    "ruff_format": ("Ruff formatting", None, None, []),
 }
 
 _INLINE_FILE_GLOBS = {
@@ -516,6 +518,18 @@ def main():
         print(f"Unknown checkers: {', '.join(unknown)}")
         print(f"Available: {', '.join(sorted(CHECKERS.keys()))}")
         sys.exit(1)
+
+    # In --fix mode, drop checkers that have no fix capability (fix_args is None) so
+    # they don't print bogus "(0.00s)" lines or inflate the final pass count. Print
+    # one transparency line listing what we're skipping.
+    if args.fix:
+        not_fixable = [n for n in names if CHECKERS[n][3] is None]
+        if not_fixable:
+            names = [n for n in names if CHECKERS[n][3] is not None]
+            print(
+                f"Skipping {len(not_fixable)} check-only checker(s) in fix mode: {', '.join(not_fixable)}\n",
+                flush=True,
+            )
 
     is_ci = os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CIRCLECI") == "true"
     is_tty = sys.stdout.isatty() and not is_ci

--- a/utils/update_metadata.py
+++ b/utils/update_metadata.py
@@ -48,7 +48,10 @@ CHECKER_CONFIG = {
     # at runtime. Does not iterate over files matching these globs directly.
     "file_globs": ["src/transformers/models/**/*.py", "docs/**/*.md"],
     "check_args": ["--check-only"],
-    "fix_args": [],
+    # No safe local "fix" mode: running without `--check-only` pushes to the
+    # `huggingface/transformers-metadata` Hub dataset (requires an auth token).
+    # `fix_args=None` makes `make fix-repo` skip this checker, like other check-only ones.
+    "fix_args": None,
 }
 
 # All paths are set with the intent you should run this script from the root of the repo with the command


### PR DESCRIPTION
# What does this PR do?

per https://github.com/huggingface/transformers/pull/45774 we did not run check_auto in the CI

Commit 0e15778202 ("Dynamic auto mapping" [PR #45018](https://github.com/huggingface/transformers/pull/45018), Apr 16 2026) is the one that created `utils/check_auto.py` in the first place. In that same commit, the Makefile was changed so that:

- The CI-run targets (style, check-code-quality) had their old `auto_mappings` entry renamed to `sort_auto_mappings`  i.e., they kept running only the simple alphabetical sorter
  (`utils/sort_auto_mappings.py`), which doesn't have the tempfile bug.
- The new `auto_mappings` entry (the buggy `check_auto.py` regenerator) was added only to `check-repo` and `fix-repo`; both local-developer-only targets.

So the buggy regenerator has never had CI coverage since it was introduced. Before PR #45018, the auto_mappings name in CI referred to the old simple sort script. It wasn't dropped from CI; it was effectively replaced under a different name when the new dynamic mechanism was bolted on.

The current PR fixes it by:

- making sure we run it now in CI
- share the same list of check across all make targets, so we don't regress again there
- display a diff in check_auto so it's easier to debug
- fixed a big in glob.blog ordering (system dependent) 