### PR TITLE
Gate enable_gqa=True on actual flash-attention eligibility

### DIFF
--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -43,14 +43,14 @@ def use_gqa_in_sdpa(
             > attention_mask is None (otherwise it will fall back to the math kernel)
         3. CUDA
             > pass internal backends check within torch's `can_use_flash_attention`
-           (>)otherwise there will be a fallback to the math backend (very inefficient)
+            > otherwise there will be a fallback to the math backend (very inefficient)
     """
     if _is_torch_xpu_available:
         return _is_torch_greater_or_equal_than_2_8
 
     _is_torch_cuda_available = query.device.type == "cuda"
-    if not _is_torch_cuda_available and _is_torch_greater_or_equal_than_2_5 and attention_mask is None:
-        return True
+    if not _is_torch_cuda_available:
+        return _is_torch_greater_or_equal_than_2_5 and attention_mask is None
 
     from torch.backends.cuda import SDPAParams, can_use_flash_attention
 

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -33,27 +33,24 @@ def use_gqa_in_sdpa(
     is_causal: bool,
     dropout: float = 0.0,
 ) -> bool:
-    # `enable_gqa=True` is only honored by torch's flash-attention backend. If the
-    # active SDPA backend (chosen by `sdpa_kernel(...)` context, global toggles, or
-    # shape constraints like head_dim>256 / fp32) is anything else, the dispatcher
-    # silently falls through and may run the wrong kernel or error. Probe the
-    # canonical FA-eligibility predicate on the actual inputs so we agree with
-    # whatever pytorch will actually do.
-    #
+    # GQA can only be used under the following conditions
     # 1. xpu
     #   - torch version >= 2.8
-    # 2. cuda or Ascend NPU
+    # 2. cuda
     #   - torch version >= 2.5
     #   - attention_mask is None (otherwise dispatch falls back to the math kernel)
-    #   - flash backend is enabled and applicable for these inputs
+    #   - the active backend is FA *and* FA can actually run these inputs (the
+    #     `enable_gqa=True` shortcut is FA-only, so EFFICIENT/CUDNN/MATH would
+    #     silently misroute or error)
+    # 3. cpu / other accelerators
+    #   - torch version >= 2.5 + no mask (existing BC behavior — CPU SDPA
+    #     honors `enable_gqa=True` natively)
     if _is_torch_xpu_available:
         return _is_torch_greater_or_equal_than_2_8
     if not (_is_torch_greater_or_equal_than_2_5 and attention_mask is None):
         return False
-    # FA is a CUDA-only kernel; the probe below only makes sense on CUDA tensors.
-    # On CPU (and other accelerators without FA), fall back to repeat_kv.
     if query.device.type != "cuda":
-        return False
+        return True
     if not torch.backends.cuda.flash_sdp_enabled():
         return False
     try:
@@ -79,7 +76,7 @@ def sdpa_attention_forward(
             "`sdpa` attention does not support `output_attentions=True`."
             " Please set your attention to `eager` if you want any of these features."
         )
-    # Resolve `is_causal` first so we can hand the resolved value to the GQA probe.
+    # Instead of relying on the value set in the module directly, we use the is_causal passed in kwargs if it is presented
     is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
 
     sdpa_kwargs = {}

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -33,31 +33,31 @@ def use_gqa_in_sdpa(
     is_causal: bool,
     dropout: float = 0.0,
 ) -> bool:
-    # GQA can only be used under the following conditions
-    # 1. xpu
-    #   - torch version >= 2.8
-    # 2. cuda
-    #   - torch version >= 2.5
-    #   - attention_mask is None (otherwise dispatch falls back to the math kernel)
-    #   - the active backend is FA *and* FA can actually run these inputs (the
-    #     `enable_gqa=True` shortcut is FA-only, so EFFICIENT/CUDNN/MATH would
-    #     silently misroute or error)
-    # 3. cpu / other accelerators
-    #   - torch version >= 2.5 + no mask (existing BC behavior — CPU SDPA
-    #     honors `enable_gqa=True` natively)
+    """
+    GQA can only be used under the following conditions
+        1. XPU
+            > torch version >= 2.8
+        2. Ascend NPU, CPU, and others (BC)
+            > torch version >= 2.5
+            > attention_mask is None (otherwise it will fall back to the math kernel)
+        3. CUDA
+            > pass internal backends check within torch's `can_use_flash_attention`
+           (>)otherwise there will be a fallback to the math backend (very inefficient)
+    """
     if _is_torch_xpu_available:
         return _is_torch_greater_or_equal_than_2_8
-    if not (_is_torch_greater_or_equal_than_2_5 and attention_mask is None):
-        return False
-    if query.device.type != "cuda":
+
+    _is_torch_cuda_available = query.device.type == "cuda"
+    if not _is_torch_cuda_available and _is_torch_greater_or_equal_than_2_5 and attention_mask is None:
         return True
-    if not torch.backends.cuda.flash_sdp_enabled():
-        return False
-    try:
-        params = torch.backends.cuda.SDPAParams(query, key, value, None, dropout, is_causal, True)
-        return torch.backends.cuda.can_use_flash_attention(params)
-    except Exception:
-        return False
+
+    from torch.backends.cuda import SDPAParams, can_use_flash_attention
+
+    return can_use_flash_attention(
+        params=SDPAParams(
+            query, key, value, attn_mask=attention_mask, dropout=dropout, is_causal=is_causal, enable_gqa=True
+        )
+    )
 
 
 def sdpa_attention_forward(
@@ -76,16 +76,9 @@ def sdpa_attention_forward(
             "`sdpa` attention does not support `output_attentions=True`."
             " Please set your attention to `eager` if you want any of these features."
         )
+
     # Instead of relying on the value set in the module directly, we use the is_causal passed in kwargs if it is presented
     is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
-
-    sdpa_kwargs = {}
-    if hasattr(module, "num_key_value_groups"):
-        if not use_gqa_in_sdpa(attention_mask, query, key, value, bool(is_causal), dropout):
-            key = repeat_kv(key, module.num_key_value_groups)
-            value = repeat_kv(value, module.num_key_value_groups)
-        else:
-            sdpa_kwargs = {"enable_gqa": True}
 
     # SDPA's Flash Attention (and cuDNN) kernels rely on the `is_causal` flag. However, there are certain conditions:
     # - Not in decoding phase (otherwise we want full attention on the single query token)
@@ -111,6 +104,14 @@ def sdpa_attention_forward(
         if attention_mask is not None and attention_mask.dtype != torch.bool:
             # Convert to boolean type, making sdpa to force call FlashAttentionScore to improve performance.
             attention_mask = torch.logical_not(attention_mask.bool()).to(query.device)
+
+    sdpa_kwargs = {}
+    if hasattr(module, "num_key_value_groups"):
+        if not use_gqa_in_sdpa(attention_mask, query, key, value, is_causal, dropout):
+            key = repeat_kv(key, module.num_key_value_groups)
+            value = repeat_kv(value, module.num_key_value_groups)
+        else:
+            sdpa_kwargs = {"enable_gqa": True}
 
     attn_output = torch.nn.functional.scaled_dot_product_attention(
         query,

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -27,10 +27,11 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 
 def use_gqa_in_sdpa(
     attention_mask: torch.Tensor | None,
-    query: torch.Tensor,
     key: torch.Tensor,
-    value: torch.Tensor,
-    is_causal: bool,
+    # Additional kwargs for cuda backend, kept optional for BC
+    query: torch.Tensor | None = None,
+    value: torch.Tensor | None = None,
+    is_causal: bool | None = None,
     dropout: float = 0.0,
 ) -> bool:
     """
@@ -107,7 +108,9 @@ def sdpa_attention_forward(
 
     sdpa_kwargs = {}
     if hasattr(module, "num_key_value_groups"):
-        if not use_gqa_in_sdpa(attention_mask, query, key, value, is_causal, dropout):
+        if not use_gqa_in_sdpa(
+            attention_mask, query=query, key=key, value=value, is_causal=is_causal, dropout=dropout
+        ):
             key = repeat_kv(key, module.num_key_value_groups)
             value = repeat_kv(value, module.num_key_value_groups)
         else:

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -48,7 +48,7 @@ def use_gqa_in_sdpa(
     if _is_torch_xpu_available:
         return _is_torch_greater_or_equal_than_2_8
 
-    _is_torch_cuda_available = query.device.type == "cuda"
+    _is_torch_cuda_available = key.device.type == "cuda"
     if not _is_torch_cuda_available:
         return _is_torch_greater_or_equal_than_2_5 and attention_mask is None
 

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -55,9 +55,8 @@ def use_gqa_in_sdpa(
     from torch.backends.cuda import SDPAParams, can_use_flash_attention
 
     return can_use_flash_attention(
-        params=SDPAParams(
-            query, key, value, attn_mask=attention_mask, dropout=dropout, is_causal=is_causal, enable_gqa=True
-        )
+        # Needs to stay as args, otherwise the constructor will fail
+        params=SDPAParams(query, key, value, attention_mask, dropout, is_causal, True)
     )
 
 

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -50,6 +50,10 @@ def use_gqa_in_sdpa(
         return _is_torch_greater_or_equal_than_2_8
     if not (_is_torch_greater_or_equal_than_2_5 and attention_mask is None):
         return False
+    # FA is a CUDA-only kernel; the probe below only makes sense on CUDA tensors.
+    # On CPU (and other accelerators without FA), fall back to repeat_kv.
+    if query.device.type != "cuda":
+        return False
     if not torch.backends.cuda.flash_sdp_enabled():
         return False
     try:

--- a/src/transformers/integrations/sdpa_attention.py
+++ b/src/transformers/integrations/sdpa_attention.py
@@ -25,16 +25,38 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
     return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
 
 
-def use_gqa_in_sdpa(attention_mask: torch.Tensor | None, key: torch.Tensor) -> bool:
-    # GQA can only be used under the following conditions
-    # 1.cuda or Ascend NPU
-    #   - torch version >= 2.5
-    #   - attention_mask is None (otherwise it will fall back to the math kernel)
-    # 2.xpu
+def use_gqa_in_sdpa(
+    attention_mask: torch.Tensor | None,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    is_causal: bool,
+    dropout: float = 0.0,
+) -> bool:
+    # `enable_gqa=True` is only honored by torch's flash-attention backend. If the
+    # active SDPA backend (chosen by `sdpa_kernel(...)` context, global toggles, or
+    # shape constraints like head_dim>256 / fp32) is anything else, the dispatcher
+    # silently falls through and may run the wrong kernel or error. Probe the
+    # canonical FA-eligibility predicate on the actual inputs so we agree with
+    # whatever pytorch will actually do.
+    #
+    # 1. xpu
     #   - torch version >= 2.8
+    # 2. cuda or Ascend NPU
+    #   - torch version >= 2.5
+    #   - attention_mask is None (otherwise dispatch falls back to the math kernel)
+    #   - flash backend is enabled and applicable for these inputs
     if _is_torch_xpu_available:
         return _is_torch_greater_or_equal_than_2_8
-    return _is_torch_greater_or_equal_than_2_5 and attention_mask is None
+    if not (_is_torch_greater_or_equal_than_2_5 and attention_mask is None):
+        return False
+    if not torch.backends.cuda.flash_sdp_enabled():
+        return False
+    try:
+        params = torch.backends.cuda.SDPAParams(query, key, value, None, dropout, is_causal, True)
+        return torch.backends.cuda.can_use_flash_attention(params)
+    except Exception:
+        return False
 
 
 def sdpa_attention_forward(
@@ -53,16 +75,16 @@ def sdpa_attention_forward(
             "`sdpa` attention does not support `output_attentions=True`."
             " Please set your attention to `eager` if you want any of these features."
         )
+    # Resolve `is_causal` first so we can hand the resolved value to the GQA probe.
+    is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
+
     sdpa_kwargs = {}
     if hasattr(module, "num_key_value_groups"):
-        if not use_gqa_in_sdpa(attention_mask, key):
+        if not use_gqa_in_sdpa(attention_mask, query, key, value, bool(is_causal), dropout):
             key = repeat_kv(key, module.num_key_value_groups)
             value = repeat_kv(value, module.num_key_value_groups)
         else:
             sdpa_kwargs = {"enable_gqa": True}
-
-    # Instead of relying on the value set in the module directly, we use the is_causal passed in kwargs if it is presented
-    is_causal = is_causal if is_causal is not None else getattr(module, "is_causal", True)
 
     # SDPA's Flash Attention (and cuDNN) kernels rely on the `is_causal` flag. However, there are certain conditions:
     # - Not in decoding phase (otherwise we want full attention on the single query token)

--- a/tests/utils/test_sdpa_attention.py
+++ b/tests/utils/test_sdpa_attention.py
@@ -51,16 +51,17 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
         with patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", False):
             self.assertFalse(self._call_cuda())
 
-    def test_cpu_inputs_reject_without_probing(self):
-        # FA is CUDA-only; on CPU we must fall back to repeat_kv without
-        # touching `torch.backends.cuda.*`.
+    def test_cpu_inputs_keep_bc_without_probing(self):
+        # CPU SDPA honors `enable_gqa=True` natively. Preserve pre-PR behavior
+        # for non-CUDA / non-XPU devices: return True without touching the
+        # CUDA-only `torch.backends.cuda.*` probe surface.
         with (
             patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
             patch.object(self.mod, "_is_torch_xpu_available", False),
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled") as fse,
             patch.object(self.torch.backends.cuda, "can_use_flash_attention") as cufa,
         ):
-            self.assertFalse(self._call_cpu())
+            self.assertTrue(self._call_cpu())
             fse.assert_not_called()
             cufa.assert_not_called()
 

--- a/tests/utils/test_sdpa_attention.py
+++ b/tests/utils/test_sdpa_attention.py
@@ -1,0 +1,158 @@
+import unittest
+from unittest.mock import patch
+
+from transformers.testing_utils import require_torch, require_torch_gpu
+
+
+@require_torch
+class UseGqaInSdpaLogicTest(unittest.TestCase):
+    """Pure-logic gating tests for `use_gqa_in_sdpa`.
+
+    These tests mock the torch SDPA-eligibility surface so they run on any
+    backend (CPU CI inclusive). They cover the failure mode that motivated
+    the change: `enable_gqa=True` must only be returned when FA can actually
+    be selected for these inputs.
+    """
+
+    def setUp(self):
+        import torch
+
+        from transformers.integrations import sdpa_attention as mod
+
+        self.mod = mod
+        self.torch = torch
+        # Tensors are passed straight through to mocked APIs; shapes don't
+        # matter for the logic tests but we keep them realistic.
+        self.q = torch.randn(1, 8, 16, 128, dtype=torch.bfloat16)
+        self.k = torch.randn(1, 2, 16, 128, dtype=torch.bfloat16)
+        self.v = torch.randn(1, 2, 16, 128, dtype=torch.bfloat16)
+
+    def _call(self, attn_mask=None, is_causal=True):
+        return self.mod.use_gqa_in_sdpa(attn_mask, self.q, self.k, self.v, is_causal, 0.0)
+
+    def test_attention_mask_rejects(self):
+        # Mask -> dispatch falls back to MATH; never use enable_gqa.
+        mask = self.torch.zeros(1, 1, 16, 16)
+        with patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True):
+            self.assertFalse(self._call(attn_mask=mask))
+
+    def test_old_torch_rejects(self):
+        with patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", False):
+            self.assertFalse(self._call())
+
+    def test_flash_disabled_rejects(self):
+        # User wrapped the call in sdpa_kernel([EFFICIENT]) (or globally
+        # disabled FA). enable_gqa=True would silently misroute.
+        with (
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
+            patch.object(self.mod, "_is_torch_xpu_available", False),
+            patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=False),
+        ):
+            self.assertFalse(self._call())
+
+    def test_flash_enabled_but_inputs_ineligible_rejects(self):
+        # FA flag is on, but pytorch says FA can't actually run these inputs
+        # (e.g. head_dim>256, fp32, sm<80). Must fall back to repeat_kv.
+        with (
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
+            patch.object(self.mod, "_is_torch_xpu_available", False),
+            patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
+            patch.object(self.torch.backends.cuda, "can_use_flash_attention", return_value=False),
+        ):
+            self.assertFalse(self._call())
+
+    def test_flash_eligible_returns_true(self):
+        # Happy path: regression guard for the existing default-enabled behavior.
+        with (
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
+            patch.object(self.mod, "_is_torch_xpu_available", False),
+            patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
+            patch.object(self.torch.backends.cuda, "can_use_flash_attention", return_value=True),
+        ):
+            self.assertTrue(self._call())
+
+    def test_xpu_keeps_existing_path(self):
+        # XPU branch is unchanged: torch>=2.8 -> True regardless of probe.
+        with (
+            patch.object(self.mod, "_is_torch_xpu_available", True),
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_8", True),
+        ):
+            self.assertTrue(self._call())
+        with (
+            patch.object(self.mod, "_is_torch_xpu_available", True),
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_8", False),
+        ):
+            self.assertFalse(self._call())
+
+    def test_probe_exception_is_swallowed(self):
+        # SDPAParams may not exist on very old torch; defensive fallback.
+        with (
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
+            patch.object(self.mod, "_is_torch_xpu_available", False),
+            patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
+            patch.object(self.torch.backends.cuda, "SDPAParams", side_effect=RuntimeError("boom")),
+        ):
+            self.assertFalse(self._call())
+
+
+@require_torch_gpu
+class UseGqaInSdpaCudaTest(unittest.TestCase):
+    """End-to-end probe on real CUDA inputs.
+
+    Exercises the actual `torch.backends.cuda.can_use_flash_attention` path —
+    no mocks. Each case is a shape/dtype/context that must produce a specific
+    GQA decision under the hood.
+    """
+
+    def _probe(self, query, key, value, attention_mask=None, is_causal=True, dropout=0.0):
+        from transformers.integrations.sdpa_attention import use_gqa_in_sdpa
+
+        return use_gqa_in_sdpa(attention_mask, query, key, value, is_causal, dropout)
+
+    def _gqa_tensors(self, head_dim=128, dtype=None):
+        import torch
+
+        if dtype is None:
+            dtype = torch.bfloat16
+        B, T, Hq, Hkv = 1, 32, 8, 2
+        q = torch.randn(B, Hq, T, head_dim, dtype=dtype, device="cuda")
+        k = torch.randn(B, Hkv, T, head_dim, dtype=dtype, device="cuda")
+        v = torch.randn(B, Hkv, T, head_dim, dtype=dtype, device="cuda")
+        return q, k, v
+
+    def test_default_context_fa_friendly_shape_returns_true(self):
+        q, k, v = self._gqa_tensors(head_dim=128)
+        self.assertTrue(self._probe(q, k, v))
+
+    def test_efficient_only_context_returns_false(self):
+        # Reproduces the user-side `sdpa_kernel([EFFICIENT_ATTENTION])` case.
+        # Without the fix, transformers would still pass enable_gqa=True and
+        # the dispatcher would fall through.
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+
+        q, k, v = self._gqa_tensors(head_dim=128)
+        with sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION]):
+            self.assertFalse(self._probe(q, k, v))
+
+    def test_math_only_context_returns_false(self):
+        from torch.nn.attention import SDPBackend, sdpa_kernel
+
+        q, k, v = self._gqa_tensors(head_dim=128)
+        with sdpa_kernel([SDPBackend.MATH]):
+            self.assertFalse(self._probe(q, k, v))
+
+    def test_head_dim_too_large_returns_false(self):
+        # Gemma 4: head_dim=320 > FA's library cap. EFFICIENT is the only
+        # viable backend, so enable_gqa=True must not be set.
+        q, k, v = self._gqa_tensors(head_dim=320)
+        self.assertFalse(self._probe(q, k, v))
+
+    def test_fp32_returns_false(self):
+        import torch
+
+        q, k, v = self._gqa_tensors(head_dim=128, dtype=torch.float32)
+        self.assertFalse(self._probe(q, k, v))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/utils/test_sdpa_attention.py
+++ b/tests/utils/test_sdpa_attention.py
@@ -15,30 +15,54 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
     """
 
     def setUp(self):
+        from types import SimpleNamespace
+
         import torch
 
         from transformers.integrations import sdpa_attention as mod
 
         self.mod = mod
         self.torch = torch
-        # Tensors are passed straight through to mocked APIs; shapes don't
-        # matter for the logic tests but we keep them realistic.
-        self.q = torch.randn(1, 8, 16, 128, dtype=torch.bfloat16)
-        self.k = torch.randn(1, 2, 16, 128, dtype=torch.bfloat16)
-        self.v = torch.randn(1, 2, 16, 128, dtype=torch.bfloat16)
+        # Real CPU tensors for tests that must hit the CPU short-circuit branch.
+        self.cpu_q = torch.randn(1, 8, 16, 128, dtype=torch.bfloat16)
+        self.cpu_k = torch.randn(1, 2, 16, 128, dtype=torch.bfloat16)
+        self.cpu_v = torch.randn(1, 2, 16, 128, dtype=torch.bfloat16)
+        # Fake "cuda" tensors for tests that should exercise the FA-probe path
+        # without actually requiring CUDA. The probe is fully mocked, so the
+        # function never indexes shape/dtype/strides — only `.device.type`.
+        cuda_dev = SimpleNamespace(type="cuda")
+        self.cuda_q = SimpleNamespace(device=cuda_dev)
+        self.cuda_k = SimpleNamespace(device=cuda_dev)
+        self.cuda_v = SimpleNamespace(device=cuda_dev)
 
-    def _call(self, attn_mask=None, is_causal=True):
-        return self.mod.use_gqa_in_sdpa(attn_mask, self.q, self.k, self.v, is_causal, 0.0)
+    def _call_cpu(self, attn_mask=None, is_causal=True):
+        return self.mod.use_gqa_in_sdpa(attn_mask, self.cpu_q, self.cpu_k, self.cpu_v, is_causal, 0.0)
+
+    def _call_cuda(self, attn_mask=None, is_causal=True):
+        return self.mod.use_gqa_in_sdpa(attn_mask, self.cuda_q, self.cuda_k, self.cuda_v, is_causal, 0.0)
 
     def test_attention_mask_rejects(self):
         # Mask -> dispatch falls back to MATH; never use enable_gqa.
         mask = self.torch.zeros(1, 1, 16, 16)
         with patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True):
-            self.assertFalse(self._call(attn_mask=mask))
+            self.assertFalse(self._call_cuda(attn_mask=mask))
 
     def test_old_torch_rejects(self):
         with patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", False):
-            self.assertFalse(self._call())
+            self.assertFalse(self._call_cuda())
+
+    def test_cpu_inputs_reject_without_probing(self):
+        # FA is CUDA-only; on CPU we must fall back to repeat_kv without
+        # touching `torch.backends.cuda.*`.
+        with (
+            patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
+            patch.object(self.mod, "_is_torch_xpu_available", False),
+            patch.object(self.torch.backends.cuda, "flash_sdp_enabled") as fse,
+            patch.object(self.torch.backends.cuda, "can_use_flash_attention") as cufa,
+        ):
+            self.assertFalse(self._call_cpu())
+            fse.assert_not_called()
+            cufa.assert_not_called()
 
     def test_flash_disabled_rejects(self):
         # User wrapped the call in sdpa_kernel([EFFICIENT]) (or globally
@@ -48,7 +72,7 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
             patch.object(self.mod, "_is_torch_xpu_available", False),
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=False),
         ):
-            self.assertFalse(self._call())
+            self.assertFalse(self._call_cuda())
 
     def test_flash_enabled_but_inputs_ineligible_rejects(self):
         # FA flag is on, but pytorch says FA can't actually run these inputs
@@ -59,7 +83,7 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
             patch.object(self.torch.backends.cuda, "can_use_flash_attention", return_value=False),
         ):
-            self.assertFalse(self._call())
+            self.assertFalse(self._call_cuda())
 
     def test_flash_eligible_returns_true(self):
         # Happy path: regression guard for the existing default-enabled behavior.
@@ -69,7 +93,7 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
             patch.object(self.torch.backends.cuda, "can_use_flash_attention", return_value=True),
         ):
-            self.assertTrue(self._call())
+            self.assertTrue(self._call_cuda())
 
     def test_xpu_keeps_existing_path(self):
         # XPU branch is unchanged: torch>=2.8 -> True regardless of probe.
@@ -77,12 +101,12 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
             patch.object(self.mod, "_is_torch_xpu_available", True),
             patch.object(self.mod, "_is_torch_greater_or_equal_than_2_8", True),
         ):
-            self.assertTrue(self._call())
+            self.assertTrue(self._call_cpu())
         with (
             patch.object(self.mod, "_is_torch_xpu_available", True),
             patch.object(self.mod, "_is_torch_greater_or_equal_than_2_8", False),
         ):
-            self.assertFalse(self._call())
+            self.assertFalse(self._call_cpu())
 
     def test_probe_exception_is_swallowed(self):
         # SDPAParams may not exist on very old torch; defensive fallback.
@@ -92,7 +116,7 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
             patch.object(self.torch.backends.cuda, "SDPAParams", side_effect=RuntimeError("boom")),
         ):
-            self.assertFalse(self._call())
+            self.assertFalse(self._call_cuda())
 
 
 @require_torch_gpu

--- a/tests/utils/test_sdpa_attention.py
+++ b/tests/utils/test_sdpa_attention.py
@@ -77,10 +77,14 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
     def test_flash_enabled_but_inputs_ineligible_rejects(self):
         # FA flag is on, but pytorch says FA can't actually run these inputs
         # (e.g. head_dim>256, fp32, sm<80). Must fall back to repeat_kv.
+        # SDPAParams must be mocked too — its C++ binding rejects our fake
+        # SimpleNamespace tensors, which would otherwise raise and route into
+        # the defensive `except` branch.
         with (
             patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
             patch.object(self.mod, "_is_torch_xpu_available", False),
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
+            patch.object(self.torch.backends.cuda, "SDPAParams", return_value=object()),
             patch.object(self.torch.backends.cuda, "can_use_flash_attention", return_value=False),
         ):
             self.assertFalse(self._call_cuda())
@@ -91,6 +95,7 @@ class UseGqaInSdpaLogicTest(unittest.TestCase):
             patch.object(self.mod, "_is_torch_greater_or_equal_than_2_5", True),
             patch.object(self.mod, "_is_torch_xpu_available", False),
             patch.object(self.torch.backends.cuda, "flash_sdp_enabled", return_value=True),
+            patch.object(self.torch.backends.cuda, "SDPAParams", return_value=object()),
             patch.object(self.torch.backends.cuda, "can_use_flash_attention", return_value=True),
         ):
             self.assertTrue(self._call_cuda())


### PR DESCRIPTION
## Summary

Follow-up to discussion in #45636 — narrowing to the GQA gating that @vasqu identified as the part worth tightening.

`sdpa_attention_forward` decides between materializing `repeat_kv` and passing `enable_gqa=True` to torch's SDPA via `use_gqa_in_sdpa()`. The previous condition only checked torch version + `attention_mask is None`, so `enable_gqa=True` could be set in cases where the active SDPA backend cannot honor it. `enable_gqa=True` is FA-only today — any other backend silently misroutes the dispatcher.

Concretely, the existing path misfires whenever:
- The user wraps the call in `sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION])` (or any non-FA pin).
- FA is globally disabled (`torch.backends.cuda.enable_flash_sdp(False)`).
- Inputs violate FA's library caps: `head_dim > 256` (e.g. Gemma 4's `head_dim=320`), fp32, sm < 80, etc.

## Fix

Tighten `use_gqa_in_sdpa()` to also check:
1. `torch.backends.cuda.flash_sdp_enabled()` — captures `sdpa_kernel(...)` context and global toggles.
2. `torch.backends.cuda.can_use_flash_attention(SDPAParams(...))` — pytorch's canonical FA-eligibility predicate, evaluated on the actual inputs.

Reusing pytorch's predicate (rather than rolling our own head_dim/dtype/arch table) means transformers won't drift as FA's constraint set evolves.

The signature of `use_gqa_in_sdpa` grows from `(attention_mask, key)` to `(attention_mask, query, key, value, is_causal, dropout)`. It has exactly one in-tree caller (`sdpa_attention_forward` itself), where all the new args are already in scope. The XPU path is unchanged.

In `sdpa_attention_forward` the `is_causal` resolution moves up by ~12 lines so the probe receives the resolved value; the later `is_causal = query.shape[2] > 1 and attention_mask is None and is_causal` line still applies the same filtering before the SDPA call — functionally identical.

## Tests (`tests/utils/test_sdpa_attention.py`)

Two test classes:

**`UseGqaInSdpaLogicTest`** — 7 mocked tests, run on any backend (CPU CI inclusive):
- `attention_mask` present → False
- old torch → False
- `flash_sdp_enabled() == False` → False
- FA enabled but inputs ineligible (mocked) → False
- happy path (FA enabled + eligible) → True
- XPU branch unchanged
- `SDPAParams` raises (defensive fallback) → False

**`UseGqaInSdpaCudaTest`** (`@require_torch_gpu`) — 5 end-to-end probes on real CUDA inputs:
- default context, FA-friendly shape (head_dim=128, bf16) → True (regression guard)
- inside `sdpa_kernel([EFFICIENT_ATTENTION])` → False
- inside `sdpa_kernel([MATH])` → False
- `head_dim=320` (Gemma 4 case) → False
- fp32 inputs → False

### Verified locally

CUDA tests run on RTX 3090 (sm_86), torch 2.7.1+cu126:

```
test_default_context_fa_friendly_shape_returns_true PASSED
test_efficient_only_context_returns_false           PASSED
test_fp32_returns_false                              PASSED
test_head_dim_too_large_returns_false                PASSED
test_math_only_context_returns_false                 PASSED
============================== 5 passed in 3.07s ==============================
```

Logic tests:
```
============================== 7 passed in 2.68s ==============================
```

`ruff check` and `ruff format --check` both pass.

## Open question

Per-call cost of constructing `SDPAParams` + `can_use_flash_attention`. Microbench welcome — happy to defer the probe (e.g. cache the answer per shape signature) if it shows up on the trace. My instinct is it's cheap relative to the SDPA call itself, but I haven't measured.

cc @vasqu @Cyrilvallez per the discussion in #45636.