### PR TITLE
fix(testing): use worker-specific captured_info files for pytest-xdist compatibility

### DIFF
--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -3529,8 +3529,9 @@ def _prepare_debugging_info(test_info, info):
     """Combine the information about the test and the call information to a patched function/method within it."""
 
     info = f"{test_info}\n\n{info}"
-    p = os.path.join(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""), "captured_info.txt")
-    # TODO (ydshieh): This is not safe when we use pytest-xdist with more than 1 worker.
+    # Use worker-specific filename to avoid race conditions when running with pytest-xdist
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    p = os.path.join(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""), f"captured_info_{worker}.txt")
     with open(p, "a") as fp:
         fp.write(f"{info}\n\n{'=' * 120}\n\n")
 
@@ -3761,7 +3762,9 @@ def patch_testing_methods_to_collect_info():
     This will allow us to collect the call information, e.g. the argument names and values, also the literal expressions
     passed as the arguments.
     """
-    p = os.path.join(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""), "captured_info.txt")
+    # Use worker-specific filename to avoid race conditions when running with pytest-xdist
+    worker = os.environ.get("PYTEST_XDIST_WORKER", "gw0")
+    p = os.path.join(os.environ.get("_PATCHED_TESTING_METHODS_OUTPUT_DIR", ""), f"captured_info_{worker}.txt")
     Path(p).unlink(missing_ok=True)
 
     if is_torch_available():


### PR DESCRIPTION
## Problem

When running tests with `pytest -n 2` (pytest-xdist with multiple workers), the captured debugging output in `testing_utils.py` has a race condition:

1. `_prepare_debugging_info()` appends to `captured_info.txt`
2. `patch_testing_methods_to_collect_info()` unlinks (deletes) `captured_info.txt`
3. Multiple workers share the same `_PATCHED_TESTING_METHODS_OUTPUT_DIR`
4. Workers clobber each other's output - one worker can delete or interleave another worker's captured debugging data

The existing code even has a TODO comment acknowledging this: `# TODO (ydshieh): This is not safe when we use pytest-xdist with more than 1 worker.`

## Solution

Use worker-specific filenames based on `PYTEST_XDIST_WORKER` environment variable:
- `captured_info_gw0.txt`, `captured_info_gw1.txt`, etc.
- Each xdist worker writes to and deletes only its own file
- Preserves single-file behavior for non-xdist runs (defaults to `gw0`)

## Changes

- `_prepare_debugging_info()`: use `PYTEST_XDIST_WORKER` to create worker-specific filename
- `patch_testing_methods_to_collect_info()`: use same worker-specific filename pattern
- Removes the TODO comment as the issue is now fixed

Closes #45561