### PR TITLE
fix: per-instance cache in compile_compatible_method_lru_cache to prevent memory leak

### DIFF
--- a/src/transformers/pytorch_utils.py
+++ b/src/transformers/pytorch_utils.py
@@ -241,19 +241,48 @@ def id_tensor_storage(tensor: torch.Tensor) -> tuple[torch.device, int, int]:
 @wraps(lru_cache)
 def compile_compatible_method_lru_cache(*lru_args, **lru_kwargs):
     """
-    LRU cache decorator from standard functools library, but with a workaround to disable
-    caching when torchdynamo is compiling. Expected to work with class methods.
+    LRU cache decorator that disables caching when torchdynamo is compiling.
+
+    When used on a method, the cache is stored per-instance so that deleting the instance
+    also frees the cache (avoiding the memory leak from class-level lru_cache holding a
+    strong reference to `self` as a cache key -- see gh-45412).
+
+    When used on a standalone function, falls back to a single shared lru_cache.
     """
 
     def decorator(func):
-        func_with_cache = lru_cache(*lru_args, **lru_kwargs)(func)
+        # Detect if this decorates a method (first param is 'self' or 'cls')
+        params = list(inspect.signature(func).parameters.keys())
+        is_method = len(params) > 0 and params[0] in ("self", "cls")
+
+        if not is_method:
+            # Standalone function: use a single shared cache (no leak risk)
+            func_with_cache = lru_cache(*lru_args, **lru_kwargs)(func)
+
+            @wraps(func)
+            def wrapper(*args, **kwargs):
+                if is_torchdynamo_compiling():
+                    return func(*args, **kwargs)
+                return func_with_cache(*args, **kwargs)
+
+            return wrapper
+
+        # Method: store a per-instance cache to avoid preventing garbage collection
+        cache_attr = f"_cache_{func.__name__}"
 
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(self, *args, **kwargs):
             if is_torchdynamo_compiling():
-                return func(*args, **kwargs)
-            else:
-                return func_with_cache(*args, **kwargs)
+                return func(self, *args, **kwargs)
+            cached_fn = getattr(self, cache_attr, None)
+            if cached_fn is None:
+
+                @lru_cache(*lru_args, **lru_kwargs)
+                def cached_fn(*a, **kw):
+                    return func(self, *a, **kw)
+
+                object.__setattr__(self, cache_attr, cached_fn)
+            return cached_fn(*args, **kwargs)
 
         return wrapper
 


### PR DESCRIPTION
## Summary

Fixes #45412

`compile_compatible_method_lru_cache` wraps methods with a class-level `functools.lru_cache`. Since `self` is the first positional arg, it becomes a cache key, creating a strong reference from the class-level cache back to the instance. This prevents garbage collection of the model even after `del model`.

**Affected models:** RT-DETR, RT-DETR-v2, MaskFormer, Mask2Former, OneFormer, SAM2, SAM3, EdgeTAM, BEiT, D-FINE, DEIMv2, and others (20+ call sites).

## Fix

When decorating a **method** (detected via first parameter name being `self`/`cls`), store the `lru_cache` on the instance's `__dict__` rather than at class level. The cache is freed when the instance is deleted.

When decorating a **standalone function** (4 usages: eomt_dinov3, efficientloftr, dinov3_vit), the old shared-cache behavior is preserved.

## Verification

```python
import gc, weakref
import torch
from torch import nn
from transformers.pytorch_utils import compile_compatible_method_lru_cache

class TestModule(nn.Module):
    @compile_compatible_method_lru_cache(maxsize=32)
    def generate_anchors(self, spatial_shapes):
        return torch.ones(spatial_shapes)

module = TestModule()
ref = weakref.ref(module)
module.generate_anchors((3, 3))  # populate cache
del module
gc.collect()
assert ref() is None  # passes with fix, fails without
```

## Why #45708 failed

The previous attempt used `weakref.WeakKeyDictionary` keyed on `self`, which broke when the decorator was also used on standalone functions (where the first arg is an int, not weakref-able). This PR handles the two cases separately.

## Test plan

- Verified GC reclaims model instances after cache population
- Verified cache still returns cached objects (identity check `r1 is r2`)
- Verified standalone function cache still works
- No changes to model behavior -- only lifecycle of the cache changes