### PR TITLE
Fix WeightConverter regex incorrectly matching shared_experts as experts in DeepSeek V4

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -268,15 +268,15 @@ def _build_checkpoint_conversion_mapping():
             ),
             WeightConverter(
                 source_patterns=[
-                    "experts.*.w1.weight",
-                    "experts.*.w3.weight",
+                    r"mlp\.experts\..*\.w1\.weight",
+                    r"mlp\.experts\..*\.w3\.weight",
                 ],
-                target_patterns="experts.gate_up_proj",
+                target_patterns=r"mlp.experts.gate_up_proj",
                 operations=[MergeModulelist(dim=0), Concatenate(dim=1)],
             ),
             WeightConverter(
-                source_patterns="experts.*.w2.weight",
-                target_patterns="experts.down_proj",
+                source_patterns=r"mlp\.experts\..*\.w2\.weight",
+                target_patterns=r"mlp.experts.down_proj",
                 operations=[MergeModulelist(dim=0)],
             ),
         ],


### PR DESCRIPTION
## What this fixes

The `WeightConverter` patterns for DeepSeek V4 routed experts use the bare substring `experts.` in source and target patterns. Since `shared_experts` contains the substring `experts`, the regex `experts.down_proj` also matches `model.layers.X.mlp.shared_experts.down_proj.weight`, and `experts.gate_up_proj` would similarly match `shared_experts.gate_up_proj` if present.

## How the bug manifests

During `save_pretrained`, `revert_weight_conversion` reverses the WeightConverter. The reversed converter's source pattern `experts.down_proj` matches `shared_experts.down_proj.weight`, causing `down_proj.weight` [hidden_size, intermediate_size] to be incorrectly split into `hidden_size` individual row-slices named `shared_experts.{i}.w2.weight.weight` instead of a single `shared_experts.down_proj.weight`.

This bloats the safetensors state dict from 180 keys to 3738 keys (for a 6-layer model with hidden_size=500).

The model still loads correctly because `from_pretrained` remaps the slices back, but the safetensors file is unnecessarily fragmented.

## The fix

Prefix the `WeightConverter` source/target patterns with `mlp.` so they match `mlp.experts.*` but not `mlp.shared_experts.*` (the `shared_` infix breaks the substring match). This is applied to both converters:

- `experts.down_proj` → `mlp.experts.down_proj`
- `experts.gate_up_proj` → `mlp.experts.gate_up_proj`

CC @ArthurZucker