### PR TITLE
fix: remove upper bound on tokenizers version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -147,7 +147,7 @@ _deps = [
     "tomli",
     "tiktoken",
     "timm>=1.0.23",
-    "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers>=0.22.0",
     "torch>=2.4",
     "torchaudio",
     "torchvision",

--- a/src/transformers/convert_slow_tokenizer.py
+++ b/src/transformers/convert_slow_tokenizer.py
@@ -482,7 +482,7 @@ class HerbertConverter(Converter):
         tokenizer.decoder = decoders.BPEDecoder(suffix=token_suffix)
         tokenizer.post_processor = processors.BertProcessing(
             sep=(self.original_tokenizer.sep_token, self.original_tokenizer.sep_token_id),
-            cls=(self.original_tokenizer.cls_token, self.original_tokenizer.cls_token_id),
+            cls_token=(self.original_tokenizer.cls_token, self.original_tokenizer.cls_token_id),
         )
 
         return tokenizer
@@ -553,7 +553,7 @@ class RobertaConverter(Converter):
         tokenizer.decoder = decoders.ByteLevel()
         tokenizer.post_processor = processors.RobertaProcessing(
             sep=(ot.sep_token, ot.sep_token_id),
-            cls=(ot.cls_token, ot.cls_token_id),
+            cls_token=(ot.cls_token, ot.cls_token_id),
             add_prefix_space=ot.add_prefix_space,
             trim_offsets=True,  # True by default on Roberta (historical)
         )
@@ -1455,7 +1455,7 @@ class CLIPConverter(Converter):
         # Hack to have a ByteLevel and TemplateProcessor
         tokenizer.post_processor = processors.RobertaProcessing(
             sep=(self.original_tokenizer.eos_token, self.original_tokenizer.eos_token_id),
-            cls=(self.original_tokenizer.bos_token, self.original_tokenizer.bos_token_id),
+            cls_token=(self.original_tokenizer.bos_token, self.original_tokenizer.bos_token_id),
             add_prefix_space=False,
             trim_offsets=False,
         )

--- a/src/transformers/dependency_versions_table.py
+++ b/src/transformers/dependency_versions_table.py
@@ -74,7 +74,7 @@ deps = {
     "tomli": "tomli",
     "tiktoken": "tiktoken",
     "timm": "timm>=1.0.23",
-    "tokenizers": "tokenizers>=0.22.0,<=0.23.0",
+    "tokenizers": "tokenizers>=0.22.0",
     "torch": "torch>=2.4",
     "torchaudio": "torchaudio",
     "torchvision": "torchvision",

--- a/src/transformers/models/clip/tokenization_clip.py
+++ b/src/transformers/models/clip/tokenization_clip.py
@@ -116,7 +116,7 @@ class CLIPTokenizer(TokenizersBackend):
 
         self._tokenizer.post_processor = processors.RobertaProcessing(
             sep=(str(eos_token), self.eos_token_id),
-            cls=(str(bos_token), self.bos_token_id),
+            cls_token=(str(bos_token), self.bos_token_id),
             add_prefix_space=False,
             trim_offsets=False,
         )

--- a/src/transformers/models/herbert/tokenization_herbert.py
+++ b/src/transformers/models/herbert/tokenization_herbert.py
@@ -104,7 +104,7 @@ class HerbertTokenizer(TokenizersBackend):
 
         self._tokenizer.post_processor = processors.BertProcessing(
             sep=(self.sep_token, 2),
-            cls=(self.cls_token, 0),
+            cls_token=(self.cls_token, 0),
         )
 
 

--- a/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
+++ b/src/transformers/models/layoutlmv3/tokenization_layoutlmv3.py
@@ -227,7 +227,7 @@ class LayoutLMv3Tokenizer(TokenizersBackend):
 
         self._tokenizer.post_processor = processors.RobertaProcessing(
             sep=(sep, sep_token_id),
-            cls=(cls, cls_token_id),
+            cls_token=(cls, cls_token_id),
             add_prefix_space=add_prefix_space,
             trim_offsets=True,
         )

--- a/src/transformers/models/roberta/tokenization_roberta.py
+++ b/src/transformers/models/roberta/tokenization_roberta.py
@@ -169,7 +169,7 @@ class RobertaTokenizer(TokenizersBackend):
         )
         self._tokenizer.post_processor = processors.RobertaProcessing(
             sep=(str(sep_token), self.sep_token_id),
-            cls=(str(cls_token), self.cls_token_id),
+            cls_token=(str(cls_token), self.cls_token_id),
             add_prefix_space=add_prefix_space,
             trim_offsets=trim_offsets,
         )


### PR DESCRIPTION
Removes the upper bound `<=0.23.0` on the `tokenizers` dependency. This was blocking users from installing tokenizers 0.23.1+ which includes performance improvements. The lower bound `>=0.22.0` is kept.                                                            
                                                                                                                                     
  Fixes #45736 