### PR TITLE
Fix CI: Allow more artifacts to be download in CI

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -139,6 +139,7 @@ jobs:
           pattern: setup_values*
           path: setup_values
           merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare some setup values
         run: |
@@ -269,6 +270,7 @@ jobs:
           pattern: new_failures_with_bad_commit_${{ inputs.job }}*
           path: /transformers/new_failures_with_bad_commit_${{ inputs.job }}
           merge-multiple: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check files
         working-directory: /transformers

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -606,6 +606,7 @@ jobs:
           ACTIONS_ARTIFACT_MAX_ARTIFACT_COUNT: 2000
         with:
           path: warnings_in_ci
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Show artifacts
         run: echo "$(python3 -c 'import os; d = os.listdir(); print(d)')"

--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -58,6 +58,8 @@ jobs:
       - uses: actions/download-artifact@v8
         env:
           ACTIONS_ARTIFACT_MAX_ARTIFACT_COUNT: 2000
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare some setup values
         run: |


### PR DESCRIPTION
# What does this PR do?

It turns out

> Allow more artifacts to be download in CI (#45629)

itself is not sufficient. We still got only the first 1000 artifacts.

We need to also add `github-token: ${{ secrets.GITHUB_TOKEN }}` in order to get the full list of artifacts.