### PR TITLE
Add `concurrency` to `PR CI` workflow file (`pr-ci-caller.yml`)

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -3,6 +3,10 @@ name: PR CI
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-ci:
     if: contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association)


### PR DESCRIPTION
# What does this PR do?

Add `concurrency` to `PR CI` workflow workflow file `.github/workflows/pr-ci-caller.yml`, so a new push to the same PR will cancel the previous run.