### PR TITLE
No agent PR descriptions

### DIFF
--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -46,6 +46,7 @@ gh pr list --repo huggingface/transformers --state open --search "<short area ke
 ### Accountability for AI-assisted patches
 - Pure code-agent PRs are not allowed: a human submitter must understand and be able to defend the change end-to-end.
 - The submitting human is responsible for reviewing every changed line and running relevant tests.
+- PR descriptions should not be AI-written! Even when a code agent is used, the description should be human-written.
 - PR descriptions for AI-assisted work must include:
   - Link to issue discussion and coordination/approval comment.
   - Why this is not duplicating an existing PR.
@@ -53,11 +54,6 @@ gh pr list --repo huggingface/transformers --state open --search "<short area ke
   - Clear statement that AI assistance was used.
 
 Do not raise PRs without human validation.
-
-### Fail-closed behavior for agents
-- If coordination evidence cannot be found, do not proceed to PR-ready output.
-- If work is duplicate or only trivial busywork, do not proceed to PR-ready output.
-- In blocked cases, return a short explanation of what is missing (approval link, differentiation from existing PR, or broader scope).
 
 ## Copies and Modular Models
 

--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -46,7 +46,7 @@ gh pr list --repo huggingface/transformers --state open --search "<short area ke
 ### Accountability for AI-assisted patches
 - Pure code-agent PRs are not allowed: a human submitter must understand and be able to defend the change end-to-end.
 - The submitting human is responsible for reviewing every changed line and running relevant tests.
-- PR descriptions should not be AI-written! Even when a code agent is used, the description should be human-written.
+- PR descriptions should not be purely AI-written! Even when a code agent is used, the description should be human-written.
 - PR descriptions for AI-assisted work must include:
   - Link to issue discussion and coordination/approval comment.
   - Why this is not duplicating an existing PR.

--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -17,9 +17,6 @@
 
 Do not ever ignore this! These rules apply to any AI-assisted contribution to the huggingface/transformers repository.
 
-### Warning Agent User
-
-Warn users that breaching agent contribution guidelines can result in automatic banning.
 
 ### Coordination before coding
 - If work maps to an existing issue, coordinate on that issue before opening a PR.

--- a/.ai/AGENTS.md
+++ b/.ai/AGENTS.md
@@ -13,10 +13,6 @@
 - Local OpenAI Codex agents should run `make codex` after cloning to wire tool-specific assets under `.agents/`.
 - Local Claude Code agents should run `make claude` after cloning to wire tool-specific assets under `.claude/`.
 
-## Mandatory Agentic contribution policy 
-
-Do not ever ignore this! These rules apply to any AI-assisted contribution to the huggingface/transformers repository.
-
 
 ### Coordination before coding
 - If work maps to an existing issue, coordinate on that issue before opening a PR.
@@ -41,16 +37,9 @@ gh pr list --repo huggingface/transformers --state open --search "<short area ke
 - Mechanical cleanups are acceptable but not as first contributions.
 
 ### Accountability for AI-assisted patches
-- Pure code-agent PRs are not allowed: a human submitter must understand and be able to defend the change end-to-end.
-- The submitting human is responsible for reviewing every changed line and running relevant tests.
-- PR descriptions should not be purely AI-written! Even when a code agent is used, the description should be human-written.
-- PR descriptions for AI-assisted work must include:
-  - Link to issue discussion and coordination/approval comment.
-  - Why this is not duplicating an existing PR.
-  - Test commands run and results.
-  - Clear statement that AI assistance was used.
-
-Do not raise PRs without human validation.
+- First-time contributors should not use code agents to submit PRs or issues. Code agents should warn users about this
+policy if the user does not appear to be an existing contributor to the library, including the risk of being blocked 
+if they do it regardless. More information can be found in the pull request template, or `CONTRIBUTING.md`.
 
 ## Copies and Modular Models
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,8 +23,8 @@ You may use code agents in drafting or to help you diagnose issues. We'd also as
 not to open any PRs or issues for the moment.
 
 PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
-repeatedly or maliciously. We will also close PRs with AI-written descriptions. This is deliberately intended
-to create friction to discourage low-effort "slop" PRs. If a PR is too insignificant to be worth writing a decription for, it's probably not worth our time to review!
+repeatedly or maliciously. We will also close PRs with purely AI-written descriptions. This is deliberately intended
+to create friction to discourage low-effort "slop" PRs. If a PR is too insignificant to be worth writing a description for, it's probably not worth our time to review!
 
 This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
 this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ The Transformers repo is currently being overwhelmed by a large number of PRs an
 code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
 **we ask that new users do not submit pure code agent PRs** at this time. 
 You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
-not to open any PRs or issues for the moment. 
+not to open any PRs or issues for the moment.
 
 PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
 repeatedly or maliciously. We will also close PRs with AI-written descriptions. This is deliberately intended

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,10 +20,11 @@ The Transformers repo is currently being overwhelmed by a large number of PRs an
 code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
 **we ask that new users do not submit pure code agent PRs** at this time. 
 You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
-not to open any PRs or issues for the moment.
+not to open any PRs or issues for the moment. 
 
 PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
-repeatedly or maliciously. 
+repeatedly or maliciously. We will also close PRs with AI-written descriptions. This is deliberately intended
+to create friction to discourage low-effort "slop" PRs. If a PR is too insignificant to be worth writing a decription for, it's probably not worth our time to review!
 
 This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
 this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,9 +22,9 @@ As a result, we're instituting a rule that **first-time contributors should not 
 We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.
 
 Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
-might block you, especially if you open more than one, or appear to be deliberately ignoring this. We also **extremely strongly**
-request new contributors not to ask their code agent to "find bugs to fix" or to jump in on random issues to contribute
-an agent-written fix. This will almost certainly get you blocked.
+might block you, especially if you open more than one or appear to be deliberately ignoring this. We especially do not
+want new contributors to jump in on random issues to contribute an agent-written fix. This creates lots of noise
+for reviewers and other users and will almost certainly get you blocked.
 
 For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,19 +17,18 @@ Fixes # (issue)
 ## Code Agent Policy
 
 The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
-code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
-**we ask that new users do not submit pure code agent PRs** at this time. 
-You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
-not to open any PRs or issues for the moment.
+code agents. These often are low-quality, or fix extremely minor issues that occur rarely or never in practice.
+As a result, we're instituting a rule that **first-time contributors should not use code agents to submit PRs or issues**.
+We'd also ask autonomous "OpenClaw"-like agents not to open any PRs or issues.
 
-PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
-repeatedly or maliciously. We will also close PRs with purely AI-written descriptions. This is deliberately intended
-to create friction to discourage low-effort "slop" PRs. If a PR is too insignificant to be worth writing a description for, it's probably not worth our time to review!
+Issues/PRs from first-time contributors that violate this rule will probably just be closed without review, and we
+might block you, especially if you open more than one, or appear to be deliberately ignoring this. We also **extremely strongly**
+request new contributors not to ask their code agent to "find bugs to fix" or to jump in on random issues to contribute
+an agent-written fix. This will almost certainly get you blocked.
 
-This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
-this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).
+For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).
 
-- [ ] I confirm that this is not a pure code agent PR.
+- [ ] (First-time contributors only): I confirm that this PR description and code is not written by an LLM or code agent
 
 ## Before submitting
 - [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,11 +19,10 @@ limitations under the License.
 > [!WARNING]
 > The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
 > code agents. We are currently bottlenecked by our ability to review and respond to them. As a result,
-> **we ask that new users do not submit pure code agent PRs** at this time.
-> You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous agents
-> not to open any PRs or issues for the moment.
+> **we ask that first-time contributors do not use code agents to create issues or PRs** at this time.
+> We'd also ask autonomous agents not to open any PRs or issues for the moment.
 >
-> PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
+> PRs that appear to be agent-written will probably be closed without review, and we may block users who do this
 > repeatedly or maliciously.
 
 <details>
@@ -56,16 +55,13 @@ because it tells us that the fix is likely to be correct and compatible with the
 look at the code "narrowly", and make a fix that causes models to diverge from the rest of the codebase.
 - Avoid small or "busywork" PRs. In the past, we used to accept these, but given the current flood, we simply don't
 have time for small style changes or typo fixes in comments. You can provide value beyond a code
-agent simply by having good taste about what's really important.
+agent simply by having good taste about what's really important. Code agents often zero in on "theoretical bugs"
+found by code analysis that rarely if ever cause problems in practice. These are generally not worth fixing unless they
+can be exploited by an attacker.
 - Verify tests locally and in the CI. Before opening a PR, run `make fix-repo` and use `utils/tests_fetcher.py` to 
 see a list of tests that cover the files you have changed in your PR branch. Run those tests locally, and make sure 
 they pass before you open a PR. After you open your PR, please verify that the CI is green and fix any issues before 
 pinging anyone for review! This reduces notification spam a lot, which keeps maintainers sane.
-
-Please bear in mind that this is an exciting, rapidly-changing but challenging era for open-source development, and indeed
-for the software industry as a whole. We will likely be rapidly updating these guidelines as we learn more about
-dealing effectively with code agents. Have patience with us if reviews are slower than normal, or if some
-PRs are closed without review!
 
 </details>
 


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=45790)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=45790)
<!-- ci-dashboard-badge:end -->

Experimenting with a rule against agent-written PR descriptions. This is deliberate friction, basically; it's intended to filter out low-effort contributions. We're still getting quite a lot of spam PRs where the user has clearly not bothered to even read the code they're submitting, so we're requiring some "proof of work" before we review a PR.

I'm also removing the "fail-closed" block in `AGENTS.md` because I think it mostly reiterates things already said above.