### PR TITLE
fix: validate special token ids against attribute values

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -459,12 +459,13 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
         vocab_size = getattr(text_config, "vocab_size", None)
         if vocab_size is not None:
             # Check for all special tokens, e..g. pad_token_id, image_token_id, audio_token_id
-            for value in text_config:
-                if value.endswith("_token_id") and isinstance(value, int) and not 0 <= value < vocab_size:
+            for name in text_config:
+                value = getattr(text_config, name)
+                if name.endswith("_token_id") and isinstance(value, int) and not 0 <= value < vocab_size:
                     # Can't be an exception until we can load configs that fail validation: several configs on the Hub
                     # store invalid special tokens, e.g. `pad_token_id=-1`
                     logger.warning_once(
-                        f"Model config: {value} must be `None` or an integer within the vocabulary (between 0 "
+                        f"Model config: {name} must be `None` or an integer within the vocabulary (between 0 "
                         f"and {vocab_size - 1}), got {value}. This may result in unexpected behavior."
                     )
 


### PR DESCRIPTION
## Summary
In `src/transformers/configuration_utils.py:463`, the special-token-id validation loop iterated over `text_config`, which yields attribute name strings. The subsequent `isinstance(value, int)` check was therefore always False, so out-of-vocab `*_token_id` values silently passed validation and never produced the intended warning.

## Fix
Treat the loop variable as the attribute name and fetch the value via `getattr` before checking the type and range. The warning message now reports the attribute name and its value separately.
