### PR TITLE
fix: forward use_cache kwarg to attention mixer in nemotron_h

### DIFF
--- a/src/transformers/models/nemotron_h/modeling_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modeling_nemotron_h.py
@@ -938,7 +938,7 @@ class NemotronHBlock(GradientCheckpointingLayer):
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
-                user_cache=use_cache,
+                use_cache=use_cache,
                 **kwargs,
             )
         else:

--- a/src/transformers/models/nemotron_h/modular_nemotron_h.py
+++ b/src/transformers/models/nemotron_h/modular_nemotron_h.py
@@ -291,7 +291,7 @@ class NemotronHBlock(GradientCheckpointingLayer):
                 past_key_values=past_key_values,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
-                user_cache=use_cache,
+                use_cache=use_cache,
                 **kwargs,
             )
         else:


### PR DESCRIPTION
In `src/transformers/models/nemotron_h/modular_nemotron_h.py:294` the attention mixer is called with `user_cache=use_cache`. The typo means `use_cache` is never forwarded and an unexpected `user_cache` kwarg gets passed through instead.

Simply, Rename the keyword argument from `user_cache` to `use_cache` so the flag actually reaches the attention mixer.
