### PR TITLE
Fix IndexError on 0-d tensor in sdpa_mask/flex_attention_mask cache_position check

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -484,7 +484,7 @@ def sdpa_mask(
 
     """
     # For BC on `cache_positions` that used to be an arg at the position of `q_length`
-    if isinstance(q_length, torch.Tensor):
+    if isinstance(q_length, torch.Tensor) and q_length.ndim > 0:
         logger.warning_once(
             "`cache_position` is deprecated as an arg, and will be removed in Transformers v5.6. Please use `q_length` and "
             "`q_offset` instead, similarly to `kv_length` and `kv_offset`"
@@ -689,7 +689,7 @@ def flex_attention_mask(
             An optional device to create the mask on.
     """
     # For BC on `cache_positions` that used to be an arg at the position of `q_length`
-    if isinstance(q_length, torch.Tensor):
+    if isinstance(q_length, torch.Tensor) and q_length.ndim > 0:
         logger.warning_once(
             "`cache_position` is deprecated as an arg, and will be removed in Transformers v5.6. Please use `q_length` and "
             "`q_offset` instead, similarly to `kv_length` and `kv_offset`"


### PR DESCRIPTION
## Fix

Fixes #45735

When `q_length` is a 0-dimensional scalar tensor (e.g. during `torch.onnx.export` with dynamic shapes), the `isinstance(q_length, torch.Tensor)` check in `sdpa_mask()` and `flex_attention_mask()` incorrectly enters the deprecated `cache_position` backward-compatibility path, which then calls `q_length.shape[0]` on a 0-d tensor, raising `IndexError: tuple index out of range`.

This PR adds a `q_length.ndim > 0` guard so that 0-d scalar tensors skip the deprecated path and are treated as integer lengths (the intended behavior).

## Changes

- `src/transformers/masking_utils.py` line 487: `isinstance(q_length, torch.Tensor)` → `isinstance(q_length, torch.Tensor) and q_length.ndim > 0`
- `src/transformers/masking_utils.py` line 692: same change in `flex_attention_mask()`

## Reproducer (from issue)

```python
import torch
from transformers import AutoModel

model = AutoModel.from_pretrained("answerdotai/ModernBERT-base")
dummy = torch.randint(0, 1000, (1, 128))
torch.onnx.export(model, (dummy,), "/tmp/test.onnx", dynamo=True)
# Before fix: IndexError: tuple index out of range
# After fix: exports successfully
```

## Why this works

During ONNX export with dynamic shapes, PyTorch traces tensor operations symbolically. The `q_length` parameter receives a 0-d `torch.Tensor` (a scalar) rather than a Python `int`. The deprecated `cache_position` path was designed for 1-d position tensors, not scalar lengths. Adding `ndim > 0` correctly distinguishes between:
- A 1-d `cache_position` tensor (deprecated path, enters branch)
- A 0-d scalar tensor representing a length (new path, skips branch)