### PR TITLE
Fix import error in moe.py by providing explicit schema to custom_op

### DIFF
--- a/src/transformers/integrations/moe.py
+++ b/src/transformers/integrations/moe.py
@@ -247,7 +247,12 @@ def _grouped_mm_fallback_backward(ctx, grad_output):
 
 
 if is_torch_available():
-    torch.library.custom_op("transformers::grouped_mm_fallback", _grouped_mm_fallback, mutates_args=())
+    torch.library.custom_op(
+        "transformers::grouped_mm_fallback",
+        _grouped_mm_fallback,
+        mutates_args=(),
+        schema="(Tensor input, Tensor weight, Tensor offs) -> Tensor",
+    )
     torch.library.register_fake("transformers::grouped_mm_fallback", _grouped_mm_fallback_fake)
     torch.library.register_autograd(
         "transformers::grouped_mm_fallback",


### PR DESCRIPTION
Fixes [#45800](https://github.com/huggingface/transformers/issues/45800)

In `integrations/moe.py`, the `from __future__ import annotations` import at the top makes all type annotations evaluate as strings, so torch.Tensor is stored as "torch.Tensor" rather than the actual class object at definition time. Because of this, `torch.library.custom_op` (in PyTorch 2.4.1) fails during schema inference.

### Solution

Pass an explicit schema string to `torch.library.custom_op` so PyTorch skips the annotation inference step entirely:

```python
torch.library.custom_op(
    "transformers::grouped_mm_fallback",
    _grouped_mm_fallback,
    mutates_args=(),
    schema="(Tensor input, Tensor weight, Tensor offs) -> Tensor",
)
```

Verified in an isolated venv with the exact versions from the issue report:
```
torch==2.4.1
torchvision==0.19.1
transformers==5.8.0
rfdetr
```
The import succeeds with this fix.

cc: @SunMarc


