### PR TITLE
Cache `merged_typed_dict` to not break `validate_typed_dict` caching

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -572,7 +572,7 @@ class MultiModalData:
         raise AttributeError(f"{self.__class__.__name__} has no attribute {key}")
 
 
-@functools.lru_cache
+@functools.lru_cache(maxsize=8)
 def _merge_typed_dict(preprocessor_typed_dict: type, modality_typed_dict: type) -> type:
     return TypedDict(
         "merged_typed_dict",

--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -17,6 +17,7 @@ Processing saving/loading class for common processors.
 
 import bisect
 import copy
+import functools
 import inspect
 import json
 import os
@@ -569,6 +570,15 @@ class MultiModalData:
         if hasattr(self, key):
             return getattr(self, key)
         raise AttributeError(f"{self.__class__.__name__} has no attribute {key}")
+
+
+@functools.lru_cache
+def _merge_typed_dict(preprocessor_typed_dict: type, modality_typed_dict: type) -> type:
+    return TypedDict(
+        "merged_typed_dict",
+        {**preprocessor_typed_dict.__annotations__, **modality_typed_dict.__annotations__},
+        total=False,
+    )
 
 
 class ProcessorMixin(PushToHubMixin):
@@ -1369,11 +1379,7 @@ class ProcessorMixin(PushToHubMixin):
                 if preprocessor is None or getattr(preprocessor, "valid_kwargs", None) is None:
                     continue
                 preprocessor_typed_dict_obj = getattr(preprocessor, "valid_kwargs")
-                typed_dict_obj = TypedDict(
-                    "merged_typed_dict",
-                    {**preprocessor_typed_dict_obj.__annotations__, **typed_dict_obj.__annotations__},
-                    total=False,
-                )
+                typed_dict_obj = _merge_typed_dict(preprocessor_typed_dict_obj, typed_dict_obj)
             validate_typed_dict(typed_dict_obj, output_kwargs[key])
         return output_kwargs
 


### PR DESCRIPTION
# What does this PR do?

#40793 introduced type validation

[`validate_typed_dict` calls the lru-cached  `_build_strict_cls_from_typed_dict` function](https://github.com/huggingface/huggingface_hub/blob/ac0156ba47cb5f1a0cbf164ca2c62564f5c36ec5/src/huggingface_hub/dataclasses.py#L329-L337). However since we re-create `merged_typed_dict` on every run this cache will always be ignore and recompute strict type dict. This can be slow.

This PR fixes it by also caching the `merged_typed_dict` creation. Alternatively we could manually validate the two type dicts individually.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

/cc @zucchini-nlp
