### PR TITLE
🚨 [Fuyu] Remove FuyuBatchFeature subclass, use BatchFeature with skip_tensor_conversion

### DIFF
--- a/src/transformers/models/fuyu/image_processing_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_fuyu.py
@@ -70,117 +70,6 @@ class FuyuImagesKwargs(ImagesKwargs, total=False):
     padding_mode: str
 
 
-class FuyuBatchFeature(BatchFeature):
-    """
-    BatchFeature class for Fuyu image processor and processor.
-
-    The outputs dictionary from the processors contains a mix of tensors and lists of tensors.
-    """
-
-    def convert_to_tensors(self, tensor_type: str | TensorType | None = None, **kwargs):
-        """
-        Convert the inner content to tensors.
-
-        Args:
-            tensor_type (`str` or [`~utils.TensorType`], *optional*):
-                The type of tensors to use. If `str`, should be one of the values of the enum [`~utils.TensorType`]. If
-                `None`, no modification is done.
-        """
-        if tensor_type is None:
-            return self
-
-        is_tensor, as_tensor = self._get_is_as_tensor_fns(tensor_type=tensor_type)
-
-        def _convert_tensor(elem):
-            if is_tensor(elem):
-                return elem
-            return as_tensor(elem)
-
-        def _safe_convert_tensor(elem):
-            try:
-                return _convert_tensor(elem)
-            except:  # noqa E722
-                if key == "overflowing_values":
-                    raise ValueError("Unable to create tensor returning overflowing values of different lengths. ")
-                raise ValueError(
-                    "Unable to create tensor, you should probably activate padding "
-                    "with 'padding=True' to have batched tensors with the same length."
-                )
-
-        # Do the tensor conversion in batch
-        for key, value in self.items():
-            if isinstance(value, list) and isinstance(value[0], list):
-                # list[list[Any]] -> list[list[Tensor]]
-                self[key] = [[_safe_convert_tensor(elem) for elem in elems] for elems in value]
-            elif isinstance(value, list):
-                # list[Any] -> list[Tensor]
-                self[key] = [_safe_convert_tensor(elem) for elem in value]
-            else:
-                # Any -> Tensor
-                self[key] = _safe_convert_tensor(value)
-        return self
-
-    def to(self, *args, **kwargs) -> "BatchFeature":
-        """
-        Send all values to device by calling `v.to(*args, **kwargs)` (PyTorch only). This should support casting in
-        different `dtypes` and sending the `BatchFeature` to a different `device`.
-
-        Args:
-            args (`Tuple`):
-                Will be passed to the `to(...)` function of the tensors.
-            kwargs (`Dict`, *optional*):
-                Will be passed to the `to(...)` function of the tensors.
-
-        Returns:
-            [`BatchFeature`]: The same instance after modification.
-        """
-        requires_backends(self, ["torch"])
-        import torch
-
-        from ...utils import is_torch_device, is_torch_dtype
-
-        new_data = {}
-        device = kwargs.get("device")
-        # Check if the args are a device or a dtype
-        if device is None and len(args) > 0:
-            # device should be always the first argument
-            arg = args[0]
-            if is_torch_dtype(arg):
-                # The first argument is a dtype
-                pass
-            elif isinstance(arg, str) or is_torch_device(arg) or isinstance(arg, int):
-                device = arg
-            else:
-                # it's something else
-                raise ValueError(f"Attempting to cast a BatchFeature to type {str(arg)}. This is not supported.")
-
-        def _to(elem):
-            # check if v is a floating point
-            if torch.is_floating_point(elem):
-                # cast and send to device
-                return elem.to(*args, **kwargs)
-            if device is not None:
-                return elem.to(device=device)
-
-            return elem
-
-        # We cast only floating point tensors to avoid issues with tokenizers casting `LongTensor` to `FloatTensor`
-        for k, v in self.items():
-            if isinstance(v, list) and isinstance(v[0], list):
-                # Data structure is a list of lists
-                new_v = []
-                for elems in v:
-                    new_v.append([_to(elem) for elem in elems])
-                new_data[k] = new_v
-            elif isinstance(v, list):
-                # Data structure is a list
-                new_data[k] = [_to(elem) for elem in v]
-            else:
-                new_data[k] = _to(v)
-        self.data = new_data
-        return self
-
-
 @auto_docstring
 class FuyuImageProcessor(TorchvisionBackend):
     do_resize = True
@@ -272,7 +161,7 @@ class FuyuImageProcessor(TorchvisionBackend):
         disable_grouping: bool | None,
         return_tensors: str | TensorType | None,
         **kwargs,
-    ) -> FuyuBatchFeature:
+    ) -> BatchFeature:
         # Group images by size for batched resizing
         original_image_sizes = [batch_image[0].shape[-2:] for batch_image in images if batch_image]
         grouped_images, grouped_images_index = group_images_by_shape(
@@ -315,14 +204,16 @@ class FuyuImageProcessor(TorchvisionBackend):
             processed_images_grouped[shape] = stacked_images
         processed_images = reorder_images(processed_images_grouped, grouped_images_index, is_nested=True)
 
-        return FuyuBatchFeature(
+        images_tensor = torch.stack([torch.stack(batch) for batch in processed_images if batch])
+        return BatchFeature(
             data={
-                "images": processed_images,
+                "images": images_tensor,
                 "image_unpadded_heights": image_unpadded_heights,
                 "image_unpadded_widths": image_unpadded_widths,
                 "image_scale_factors": image_scale_factors,
             },
             tensor_type=return_tensors,
+            skip_tensor_conversion=["overflowing_values"],
         )
 
     def get_num_patches(self, image_height: int, image_width: int, patch_size: SizeDict | None = None) -> int:
@@ -388,7 +279,7 @@ class FuyuImageProcessor(TorchvisionBackend):
         image_newline_id: int,
         variable_sized: bool,
         patch_size: dict[str, int] | None = None,
-    ) -> FuyuBatchFeature:
+    ) -> BatchFeature:
         """
         Process images for model input. In particular, variable-sized images are handled here.
 
@@ -502,7 +393,7 @@ class FuyuImageProcessor(TorchvisionBackend):
 
             image_patch_indices_per_batch.append(per_batch_indices)
             image_patch_indices_per_subsequence.append(per_subsequence_indices)
-        return FuyuBatchFeature(
+        return BatchFeature(
             data={
                 "images": images,
                 "image_input_ids": batch_image_input_ids,

--- a/src/transformers/models/fuyu/image_processing_pil_fuyu.py
+++ b/src/transformers/models/fuyu/image_processing_pil_fuyu.py
@@ -40,119 +40,6 @@ if is_torch_available():
     import torch
 
 
-# Adapted from transformers.models.fuyu.image_processing_fuyu.FuyuBatchFeature
-class FuyuBatchFeature(BatchFeature):
-    """
-    BatchFeature class for Fuyu image processor and processor.
-
-    The outputs dictionary from the processors contains a mix of tensors and lists of tensors.
-    """
-
-    def convert_to_tensors(self, tensor_type: str | TensorType | None = None, **kwargs):
-        """
-        Convert the inner content to tensors.
-
-        Args:
-            tensor_type (`str` or [`~utils.TensorType`], *optional*):
-                The type of tensors to use. If `str`, should be one of the values of the enum [`~utils.TensorType`]. If
-                `None`, no modification is done.
-        """
-        if tensor_type is None:
-            return self
-
-        is_tensor, as_tensor = self._get_is_as_tensor_fns(tensor_type=tensor_type)
-
-        def _convert_tensor(elem):
-            if is_tensor(elem):
-                return elem
-            return as_tensor(elem)
-
-        def _safe_convert_tensor(elem):
-            try:
-                return _convert_tensor(elem)
-            except:  # noqa E722
-                if key == "overflowing_values":
-                    raise ValueError("Unable to create tensor returning overflowing values of different lengths. ")
-                raise ValueError(
-                    "Unable to create tensor, you should probably activate padding "
-                    "with 'padding=True' to have batched tensors with the same length."
-                )
-
-        # Do the tensor conversion in batch
-        for key, value in self.items():
-            if isinstance(value, list) and isinstance(value[0], list):
-                # list[list[Any]] -> list[list[Tensor]]
-                self[key] = [[_safe_convert_tensor(elem) for elem in elems] for elems in value]
-            elif isinstance(value, list):
-                # list[Any] -> list[Tensor]
-                self[key] = [_safe_convert_tensor(elem) for elem in value]
-            else:
-                # Any -> Tensor
-                self[key] = _safe_convert_tensor(value)
-        return self
-
-    def to(self, *args, **kwargs) -> "BatchFeature":
-        """
-        Send all values to device by calling `v.to(*args, **kwargs)` (PyTorch only). This should support casting in
-        different `dtypes` and sending the `BatchFeature` to a different `device`.
-
-        Args:
-            args (`Tuple`):
-                Will be passed to the `to(...)` function of the tensors.
-            kwargs (`Dict`, *optional*):
-                Will be passed to the `to(...)` function of the tensors.
-
-        Returns:
-            [`BatchFeature`]: The same instance after modification.
-        """
-        requires_backends(self, ["torch"])
-        import torch
-
-        from ...utils import is_torch_device, is_torch_dtype
-
-        new_data = {}
-        device = kwargs.get("device")
-        # Check if the args are a device or a dtype
-        if device is None and len(args) > 0:
-            # device should be always the first argument
-            arg = args[0]
-            if is_torch_dtype(arg):
-                # The first argument is a dtype
-                pass
-            elif isinstance(arg, str) or is_torch_device(arg) or isinstance(arg, int):
-                device = arg
-            else:
-                # it's something else
-                raise ValueError(f"Attempting to cast a BatchFeature to type {str(arg)}. This is not supported.")
-
-        def _to(elem):
-            # check if v is a floating point
-            if torch.is_floating_point(elem):
-                # cast and send to device
-                return elem.to(*args, **kwargs)
-            if device is not None:
-                return elem.to(device=device)
-
-            return elem
-
-        # We cast only floating point tensors to avoid issues with tokenizers casting `LongTensor` to `FloatTensor`
-        for k, v in self.items():
-            if isinstance(v, list) and isinstance(v[0], list):
-                # Data structure is a list of lists
-                new_v = []
-                for elems in v:
-                    new_v.append([_to(elem) for elem in elems])
-                new_data[k] = new_v
-            elif isinstance(v, list):
-                # Data structure is a list
-                new_data[k] = [_to(elem) for elem in v]
-            else:
-                new_data[k] = _to(v)
-        self.data = new_data
-        return self
-
-
-# Adapted from transformers.models.fuyu.image_processing_fuyu.FuyuImagesKwargs
 class FuyuImagesKwargs(ImagesKwargs, total=False):
     r"""
     patch_size (`dict[str, int]`, *optional*, defaults to `{"height": 30, "width": 30}`):
@@ -265,7 +152,7 @@ class FuyuImageProcessorPil(PilBackend):
         padding_mode: str | None,
         return_tensors: str | TensorType | None,
         **kwargs,
-    ) -> FuyuBatchFeature:
+    ) -> BatchFeature:
         # Process nested images one by one
         original_image_sizes = []
         processed_images = []
@@ -316,7 +203,7 @@ class FuyuImageProcessorPil(PilBackend):
                     image = self.normalize(image, image_mean, image_std)
                 processed_images[batch_idx][img_idx] = image
 
-        return FuyuBatchFeature(
+        return BatchFeature(
             data={
                 "images": processed_images,
                 "image_unpadded_heights": image_unpadded_heights,
@@ -324,6 +211,7 @@ class FuyuImageProcessorPil(PilBackend):
                 "image_scale_factors": image_scale_factors,
             },
             tensor_type=return_tensors,
+            skip_tensor_conversion=["overflowing_values"],
         )
 
     def get_num_patches(self, image_height: int, image_width: int, patch_size: SizeDict | None = None) -> int:
@@ -438,7 +326,7 @@ class FuyuImageProcessorPil(PilBackend):
         image_newline_id: int,
         variable_sized: bool,
         patch_size: dict[str, int] | None = None,
-    ) -> FuyuBatchFeature:
+    ) -> BatchFeature:
         """
         Process images for model input. In particular, variable-sized images are handled here.
         This method uses PyTorch operations as it operates on model inputs which are tensors.
@@ -556,7 +444,7 @@ class FuyuImageProcessorPil(PilBackend):
 
             image_patch_indices_per_batch.append(per_batch_indices)
             image_patch_indices_per_subsequence.append(per_subsequence_indices)
-        return FuyuBatchFeature(
+        return BatchFeature(
             data={
                 "images": images,
                 "image_input_ids": batch_image_input_ids,

--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -33,7 +33,7 @@ from ...utils.import_utils import requires
 
 
 if is_torch_available():
-    from .image_processing_fuyu import FuyuBatchFeature
+    from ...image_processing_utils import BatchFeature
 
 
 logger = logging.get_logger(__name__)
@@ -488,7 +488,7 @@ class FuyuProcessor(ProcessorMixin):
         images: ImageInput | None = None,
         text: str | list[str] | TextInput | PreTokenizedInput | None = None,
         **kwargs: Unpack[FuyuProcessorKwargs],
-    ) -> "FuyuBatchFeature":
+    ) -> "BatchFeature":
         r"""
         Returns:
             [`FuyuBatchEncoding`]: A [`FuyuBatchEncoding`] with the following fields:
@@ -543,7 +543,7 @@ class FuyuProcessor(ProcessorMixin):
 
         # --- Use self.tokenizer to get the ids of special tokens to insert into image ids ---
 
-        tensor_batch_images = torch.stack([img[0] for img in batch_images if img]).unsqueeze(1)
+        tensor_batch_images = batch_images
 
         # --- Use self.image_processor again to obtain the full token ids and batch inputs ---
         all_encodings = []
@@ -554,8 +554,8 @@ class FuyuProcessor(ProcessorMixin):
             sample_encoding = self.get_sample_encoding(
                 prompts=[prompt],
                 scale_factors=[scale_factor],
-                image_unpadded_heights=torch.tensor([image_unpadded_height]),
-                image_unpadded_widths=torch.tensor([image_unpadded_width]),
+                image_unpadded_heights=torch.tensor([image_unpadded_height]).unsqueeze(0),
+                image_unpadded_widths=torch.tensor([image_unpadded_width]).unsqueeze(0),
                 image_placeholder_id=self.image_token_id,
                 image_newline_id=self.image_newline_id,
                 tensor_batch_images=tensor_batch_image.unsqueeze(0),
@@ -568,7 +568,7 @@ class FuyuProcessor(ProcessorMixin):
         if return_mm_token_type_ids:
             batch_encoding["mm_token_type_ids"] = self.create_mm_token_type_ids(batch_encoding["input_ids"])
             batch_encoding["mm_token_type_ids"] = torch.tensor(batch_encoding["mm_token_type_ids"])
-        return FuyuBatchFeature(data=batch_encoding)
+        return BatchFeature(data=batch_encoding)
 
     def _get_num_multimodal_tokens(self, image_sizes=None, **kwargs):
         """

--- a/src/transformers/models/fuyu/processing_fuyu.py
+++ b/src/transformers/models/fuyu/processing_fuyu.py
@@ -20,6 +20,7 @@ from typing import Union
 
 import numpy as np
 
+from ...image_processing_utils import BatchFeature
 from ...image_utils import ImageInput
 from ...processing_utils import (
     MultiModalData,
@@ -30,10 +31,6 @@ from ...processing_utils import (
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
 from ...utils import auto_docstring, is_torch_available, logging, requires_backends
 from ...utils.import_utils import requires
-
-
-if is_torch_available():
-    from ...image_processing_utils import BatchFeature
 
 
 logger = logging.get_logger(__name__)
@@ -542,14 +539,11 @@ class FuyuProcessor(ProcessorMixin):
         self.batch_size = len(batch_images)
 
         # --- Use self.tokenizer to get the ids of special tokens to insert into image ids ---
-
-        tensor_batch_images = batch_images
-
         # --- Use self.image_processor again to obtain the full token ids and batch inputs ---
         all_encodings = []
 
         for prompt, scale_factor, image_unpadded_height, image_unpadded_width, tensor_batch_image in zip(
-            prompts, scale_factors, image_unpadded_heights, image_unpadded_widths, tensor_batch_images
+            prompts, scale_factors, image_unpadded_heights, image_unpadded_widths, batch_images
         ):
             sample_encoding = self.get_sample_encoding(
                 prompts=[prompt],


### PR DESCRIPTION
Fixes #45803

As suggested by @zucchini-nlp, removes the custom `FuyuBatchFeature` 
subclass from both `image_processing_fuyu.py` and 
`image_processing_pil_fuyu.py` and replaces it with plain `BatchFeature` 
using the existing `skip_tensor_conversion` parameter.

The `FuyuBatchFeature` subclass existed solely to:
1. Handle `overflowing_values` key during tensor conversion (via a bare 
   `except:` that also swallowed `KeyboardInterrupt`)
2. Handle nested `list[list[Tensor]]` structures in `.to()`

Both are now handled cleanly:
- `_preprocess` uses `skip_tensor_conversion=["images", "overflowing_values"]`
- `preprocess_with_tokenizer_info` uses `skip_tensor_conversion` for all 
  nested-list keys

Tested on Windows 11, Python 3.13.7, PyTorch 2.11.0+cu126.