### PR TITLE
Warn about forgetting attention mask functions

### DIFF
--- a/docs/source/en/attention_interface.md
+++ b/docs/source/en/attention_interface.md
@@ -130,8 +130,8 @@ model = AutoModelForImageTextToText.from_pretrained(
 
 Customize or create new attention functions by adding them to the attention registry with [`AttentionInterface.register`]. Models use these functions through the `attn_implementation` argument.
 
-> [!WARNING]
-> If you register a new attention function, you likely also need to register a new attention _mask_ function. If you do not register a new attention _mask_ function, **the mask is set to `None`, i.e., completely ignored**. This could break your model in unexpected ways (e.g., by silently discarding Causal Masking).
+> [!WARNING]  
+> When you register a custom attention function, also register a matching attention _mask_ function. If the custom `attn_implementation` name is not registered in [`AttentionMaskInterface`], Transformers skips mask creation and passes `attention_mask=None` to the attention layers. If you don't register a matching attention mask function, your attention function must handle causal, padding, packing, or sliding-window constraints itself, or those constraints would be silently dropped.
 
 This example customizes the attention function to print a statement for each layer. It keeps the mask in the original implementation by registering `masking_utils.sdpa_mask` as the attention mask function.
 

--- a/docs/source/en/attention_interface.md
+++ b/docs/source/en/attention_interface.md
@@ -130,18 +130,23 @@ model = AutoModelForImageTextToText.from_pretrained(
 
 Customize or create new attention functions by adding them to the attention registry with [`AttentionInterface.register`]. Models use these functions through the `attn_implementation` argument.
 
-This example customizes the attention function to print a statement for each layer.
+> [!WARNING]
+> If you register a new attention function, you likely also need to register a new attention _mask_ function. If you do not register a new attention _mask_ function, **the mask is set to `None`, i.e., completely ignored**. This could break your model in unexpected ways (e.g., by silently discarding Causal Masking).
+
+This example customizes the attention function to print a statement for each layer (and keeps whatever mask is used in the original implementation, by registering [`masking_utils.sdpa_mask`] as attention mask function):
 
 ```python
 import torch
-from transformers import AutoModelForCausalLM, AttentionInterface
+from transformers import AutoModelForCausalLM, AttentionInterface, AttentionMaskInterface
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
+from transformers.masking_utils import sdpa_mask
 
 def my_new_sdpa(*args, **kwargs):
     print("I just entered the attention computation")
     return sdpa_attention_forward(*args, **kwargs)
 
 AttentionInterface.register("my_new_sdpa", my_new_sdpa)
+AttentionMaskInterface.register("my_new_sdpa", sdpa_mask)  # must have the same name as the registered attention function
 
 model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-3.2-1B", attn_implementation="my_new_sdpa")
 model(torch.ones(1, 5, dtype=int))
@@ -151,8 +156,9 @@ You can also add new arguments to the attention function. Models supporting [`At
 
 ```python
 import torch
-from transformers import AutoModelForCausalLM, AttentionInterface
+from transformers import AutoModelForCausalLM, AttentionInterface, AttentionMaskInterface
 from transformers.integrations.sdpa_attention import sdpa_attention_forward
+from transformers.masking_utils import sdpa_mask
 
 def custom_attention(
     module: torch.nn.Module,  # required arg
@@ -168,6 +174,7 @@ def custom_attention(
     return attn_output, attn_weights  # attn_weights are optional here
 
 AttentionInterface.register("custom", custom_attention)
+AttentionMaskInterface.register("custom", sdpa_mask)  # to leave the existing mask untouched
 
 model = AutoModelForCausalLM.from_pretrained(model_id, attn_implementation="custom")
 model(torch.ones(1, 5, dtype=int), a_new_kwargs=..., another_new_kwargs=...)

--- a/docs/source/en/attention_interface.md
+++ b/docs/source/en/attention_interface.md
@@ -131,7 +131,7 @@ model = AutoModelForImageTextToText.from_pretrained(
 Customize or create new attention functions by adding them to the attention registry with [`AttentionInterface.register`]. Models use these functions through the `attn_implementation` argument.
 
 > [!WARNING]  
-> When you register a custom attention function, also register a matching attention _mask_ function. If the custom `attn_implementation` name is not registered in [`AttentionMaskInterface`], Transformers skips mask creation and passes `attention_mask=None` to the attention layers. If you don't register a matching attention mask function, your attention function must handle causal, padding, packing, or sliding-window constraints itself, or those constraints would be silently dropped.
+> Register a matching attention mask function when you register a custom attention function. If the custom `attn_implementation` name is not registered in [`AttentionMaskInterface`], Transformers skips mask creation and passes `attention_mask=None` to the attention layers. Your attention function must handle causal, padding, packing, or sliding-window constraints itself, or those constraints can be silently dropped.
 
 This example customizes the attention function to print a statement for each layer. It keeps the mask in the original implementation by registering `masking_utils.sdpa_mask` as the attention mask function.
 

--- a/docs/source/en/attention_interface.md
+++ b/docs/source/en/attention_interface.md
@@ -133,7 +133,7 @@ Customize or create new attention functions by adding them to the attention regi
 > [!WARNING]
 > If you register a new attention function, you likely also need to register a new attention _mask_ function. If you do not register a new attention _mask_ function, **the mask is set to `None`, i.e., completely ignored**. This could break your model in unexpected ways (e.g., by silently discarding Causal Masking).
 
-This example customizes the attention function to print a statement for each layer (and keeps whatever mask is used in the original implementation, by registering [`masking_utils.sdpa_mask`] as attention mask function):
+This example customizes the attention function to print a statement for each layer. It keeps the mask in the original implementation by registering `masking_utils.sdpa_mask` as the attention mask function.
 
 ```python
 import torch


### PR DESCRIPTION
As it is implemented currently, when registering a custom attention function, but not a custom attention mask function, the mask is set to `None`.

This can cause unexpected issues, as it means that e.g., causal masking is silently discarded when you only try to change a minor detail of the attention implementation of an existing model, with grave changes to the overall performance (the model starts to cheat). This happened to me in one of my recent projects.

## What does this PR do?

To hopefully save future readers of the docs that problem, this PR adds:

1. An explicit warning that a mask function should likely be registered
2. Copyable code to register the sdpa mask as a default (so that if you just copy/paste code from the docs, you shouldn't fall victim to this issue).

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

(in fact, no LLM whatsoever were involved in creating this PR)

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?

## Who can review?

@stevhliu, maybe?
