### PR TITLE
fix(rf_detr): correct paper URL and stale checkpoint references

### DIFF
--- a/docs/source/en/model_doc/rf_detr.md
+++ b/docs/source/en/model_doc/rf_detr.md
@@ -23,10 +23,11 @@ rendered properly in your Markdown viewer.
 
 # RF-DETR
 
-[RF-DETR](https://huggingface.co/papers/2407.17140) proposes a Receptive Field Detection Transformer (DETR) architecture
-designed to compete with and surpass the dominant YOLO series for real-time object detection. It achieves a new
-state-of-the-art balance between speed (latency) and accuracy (mAP) by combining recent transformer advances with
-efficient design choices.
+[RF-DETR](https://huggingface.co/papers/2511.09554) is a light-weight specialist Detection Transformer (DETR) from
+Roboflow that uses weight-sharing Neural Architecture Search (NAS) to discover accuracy-latency Pareto curves on any
+target dataset. It modernizes LW-DETR by initializing the encoder with a pre-trained DINOv2 backbone, and revisits the
+tunable knobs of NAS to improve the transferability of DETRs to diverse target domains, surpassing prior
+state-of-the-art real-time methods on COCO and Roboflow100-VL.
 
 The RF-DETR architecture is characterized by its simple and efficient structure: a DINOv2 Backbone, a Projector, and a
 shallow DETR Decoder.

--- a/src/transformers/models/rf_detr/configuration_rf_detr.py
+++ b/src/transformers/models/rf_detr/configuration_rf_detr.py
@@ -154,10 +154,10 @@ class RfDetrConfig(PreTrainedConfig):
     ```python
     >>> from transformers import RfDetrConfig, RfDetrModel
 
-    >>> # Initializing a LW-DETR stevenbucaille/RfDetr_small_60e_coco style configuration
+    >>> # Initializing a RF-DETR stevenbucaille/rf-detr-base style configuration
     >>> configuration = RfDetrConfig()
 
-    >>> # Initializing a model (with random weights) from the stevenbucaille/RfDetr_small_60e_coco style configuration
+    >>> # Initializing a model (with random weights) from the stevenbucaille/rf-detr-base style configuration
     >>> model = RfDetrModel(configuration)
 
     >>> # Accessing the model configuration

--- a/src/transformers/models/rf_detr/modeling_rf_detr.py
+++ b/src/transformers/models/rf_detr/modeling_rf_detr.py
@@ -1525,8 +1525,8 @@ class RfDetrModel(RfDetrPreTrainedModel):
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
 
-        >>> image_processor = AutoImageProcessor.from_pretrained("stevenbucaille/rfdetr_small_60e_coco")
-        >>> model = RfDetrModel.from_pretrained("stevenbucaille/rfdetr_small_60e_coco")
+        >>> image_processor = AutoImageProcessor.from_pretrained("stevenbucaille/rf-detr-base")
+        >>> model = RfDetrModel.from_pretrained("stevenbucaille/rf-detr-base")
 
         >>> inputs = image_processor(images=image, return_tensors="pt")
 

--- a/src/transformers/models/rf_detr/modular_rf_detr.py
+++ b/src/transformers/models/rf_detr/modular_rf_detr.py
@@ -159,10 +159,10 @@ class RfDetrConfig(LwDetrConfig):
     ```python
     >>> from transformers import RfDetrConfig, RfDetrModel
 
-    >>> # Initializing a LW-DETR stevenbucaille/RfDetr_small_60e_coco style configuration
+    >>> # Initializing a RF-DETR stevenbucaille/rf-detr-base style configuration
     >>> configuration = RfDetrConfig()
 
-    >>> # Initializing a model (with random weights) from the stevenbucaille/RfDetr_small_60e_coco style configuration
+    >>> # Initializing a model (with random weights) from the stevenbucaille/rf-detr-base style configuration
     >>> model = RfDetrModel(configuration)
 
     >>> # Accessing the model configuration
@@ -667,8 +667,8 @@ class RfDetrModel(LwDetrModel):
         >>> url = "http://images.cocodataset.org/val2017/000000039769.jpg"
         >>> image = Image.open(requests.get(url, stream=True).raw)
 
-        >>> image_processor = AutoImageProcessor.from_pretrained("stevenbucaille/rfdetr_small_60e_coco")
-        >>> model = RfDetrModel.from_pretrained("stevenbucaille/rfdetr_small_60e_coco")
+        >>> image_processor = AutoImageProcessor.from_pretrained("stevenbucaille/rf-detr-base")
+        >>> model = RfDetrModel.from_pretrained("stevenbucaille/rf-detr-base")
 
         >>> inputs = image_processor(images=image, return_tensors="pt")
 


### PR DESCRIPTION
## Summary                                                                                                                                                     
                                                         
1. The RF-DETR model doc (`docs/source/en/model_doc/rf_detr.md`) linked to https://huggingface.co/papers/2407.17140, which is actually the RT-DETRv2 paper ("RT-DETRv2: Improved Baseline with Bag-of-Freebies for Real-Time Detection Transformer", Lv et al., Baidu). The correct RF-DETR paper is https://huggingface.co/papers/2511.09554 ("RF-DETR: Neural Architecture Search for Real-Time Detection Transformers", Robinson et al., Roboflow + CMU).                                                                              
2. The intro called RF-DETR "Receptive Field Detection Transformer", which the paper never says. Rewrote it to match the actual paper: a NAS-based, DINOv2-initialized modernization of LW-DETR.                                                                                                                                    
3. Fixed wrong checkpoint names in docstring examples (`stevenbucaille/rfdetr_small_60e_coco` -> `stevenbucaille/rf-detr-base`) in `modular_rf_detr.py`, and propagated to the generated `configuration_rf_detr.py` and `modeling_rf_detr.py`.  

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?

## Who can review?
@yonigozlan @sbucaille 
