### PR TITLE
fix: raise ValueError when num_beams × vocab_size exceeds torch.multinomial limit

### DIFF
--- a/src/transformers/generation/utils.py
+++ b/src/transformers/generation/utils.py
@@ -2991,6 +2991,16 @@ class GenerationMixin(ContinuousMixin):
 
         # Gather the top K scores from _all_ beams.
         if do_sample:
+            # PyTorch's CUDA multinomial is limited to 2^24 categories. With large num_beams
+            # and large vocab_size their product can exceed this limit, causing a RuntimeError.
+            _multinomial_limit = 2**24
+            if num_beams * vocab_size > _multinomial_limit:
+                raise ValueError(
+                    f"Beam-search sampling requires torch.multinomial over {num_beams * vocab_size:,} candidates "
+                    f"(num_beams={num_beams} × vocab_size={vocab_size:,}), but PyTorch's CUDA multinomial is "
+                    f"limited to {_multinomial_limit:,} categories. "
+                    f"Reduce num_beams to at most {_multinomial_limit // vocab_size} for this model's vocab size."
+                )
             topk_indices = torch.multinomial(
                 nn.functional.softmax(accumulated_log_probs, dim=-1), num_samples=beams_to_keep
             )


### PR DESCRIPTION
## What
`model.generate()` with `do_sample=True` and a large `num_beams` on a large-vocabulary model crashes with a cryptic `RuntimeError: number of categories cannot exceed 2^24` inside `_get_top_k_continuations`. The error comes from PyTorch's CUDA multinomial being limited to 16,777,216 (`2^24`) categories, while the flattened `num_beams × vocab_size` tensor can easily exceed this (e.g. 128 beams × 164,096 vocab = 21M categories).

## Why
The crash happens deep in CUDA internals with no indication of which generation parameters caused it or how to fix it. Users of large multilingual models (Qwen, Yi, Llama-3 variants with 128k+ vocab) are increasingly hitting this when experimenting with large beam counts.

## Reproduce
```python
import torch
# Simulate the limit check without a full model run:
num_beams, vocab_size = 128, 164_096
assert num_beams * vocab_size > 2**24  # 21,004,288 > 16,777,216
# RuntimeError: number of categories cannot exceed 2^24
```

## Fix
Add a `ValueError` in `_get_top_k_continuations` immediately before the `torch.multinomial` call. The error message names the offending parameters and tells the user the maximum safe `num_beams` for their model. This is a **validation-only change** — no behaviour change for valid configurations.

```
ValueError: Beam-search sampling requires torch.multinomial over 21,004,288 candidates
(num_beams=128 × vocab_size=164,096), but PyTorch's CUDA multinomial is limited to
16,777,216 categories. Reduce num_beams to at most 102 for this model's vocab size.
```

Previous PR #45251 was closed for being over-engineered; this PR is the minimal approach discussed in the issue thread.

Fixes #45245