### PR TITLE
Add Qwen3.5 support for token classification

### DIFF
--- a/docs/source/en/model_doc/qwen3_5.md
+++ b/docs/source/en/model_doc/qwen3_5.md
@@ -75,6 +75,11 @@ TODO
 [[autodoc]] Qwen3_5ForSequenceClassification
     - forward
 
+## Qwen3_5ForTokenClassification
+
+[[autodoc]] Qwen3_5ForTokenClassification
+    - forward
+
 ## Qwen3_5ForConditionalGeneration
 
 [[autodoc]] Qwen3_5ForConditionalGeneration

--- a/src/transformers/models/auto/modeling_auto.py
+++ b/src/transformers/models/auto/modeling_auto.py
@@ -1556,6 +1556,8 @@ MODEL_FOR_TOKEN_CLASSIFICATION_MAPPING_NAMES = OrderedDict(
         ("qwen2", "Qwen2ForTokenClassification"),
         ("qwen2_moe", "Qwen2MoeForTokenClassification"),
         ("qwen3", "Qwen3ForTokenClassification"),
+        ("qwen3_5", "Qwen3_5ForTokenClassification"),
+        ("qwen3_5_text", "Qwen3_5ForTokenClassification"),
         ("qwen3_moe", "Qwen3MoeForTokenClassification"),
         ("qwen3_next", "Qwen3NextForTokenClassification"),
         ("rembert", "RemBertForTokenClassification"),

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -34,7 +34,11 @@ from ...generation import GenerationMixin
 from ...integrations import use_kernelized_func
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
-from ...modeling_layers import GenericForSequenceClassification, GenericForTokenClassification, GradientCheckpointingLayer
+from ...modeling_layers import (
+    GenericForSequenceClassification,
+    GenericForTokenClassification,
+    GradientCheckpointingLayer,
+)
 from ...modeling_outputs import (
     BaseModelOutputWithPast,
     BaseModelOutputWithPooling,

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -34,7 +34,7 @@ from ...generation import GenerationMixin
 from ...integrations import use_kernelized_func
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
-from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
+from ...modeling_layers import GenericForSequenceClassification, GenericForTokenClassification, GradientCheckpointingLayer
 from ...modeling_outputs import (
     BaseModelOutputWithPast,
     BaseModelOutputWithPooling,
@@ -1782,6 +1782,10 @@ class Qwen3_5ForSequenceClassification(GenericForSequenceClassification, Qwen3_5
     config: Qwen3_5TextConfig
 
 
+class Qwen3_5ForTokenClassification(GenericForTokenClassification, Qwen3_5PreTrainedModel):
+    config: Qwen3_5TextConfig
+
+
 @auto_docstring(
     custom_intro="""
     Base class for Qwen3_5 causal language model (or autoregressive) outputs.
@@ -2189,6 +2193,7 @@ __all__ = [
     "Qwen3_5Model",
     "Qwen3_5ForCausalLM",
     "Qwen3_5ForSequenceClassification",
+    "Qwen3_5ForTokenClassification",
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5PreTrainedModel",
 ]

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -23,7 +23,11 @@ from torch import nn
 from ... import initialization as init
 from ...cache_utils import Cache, DynamicCache
 from ...masking_utils import create_causal_mask
-from ...modeling_layers import GenericForSequenceClassification, GenericForTokenClassification, GradientCheckpointingLayer
+from ...modeling_layers import (
+    GenericForSequenceClassification,
+    GenericForTokenClassification,
+    GradientCheckpointingLayer,
+)
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack

--- a/src/transformers/models/qwen3_5/modular_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modular_qwen3_5.py
@@ -23,7 +23,7 @@ from torch import nn
 from ... import initialization as init
 from ...cache_utils import Cache, DynamicCache
 from ...masking_utils import create_causal_mask
-from ...modeling_layers import GenericForSequenceClassification, GradientCheckpointingLayer
+from ...modeling_layers import GenericForSequenceClassification, GenericForTokenClassification, GradientCheckpointingLayer
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
 from ...modeling_utils import PreTrainedModel
 from ...processing_utils import Unpack
@@ -672,6 +672,10 @@ class Qwen3_5ForSequenceClassification(GenericForSequenceClassification, Qwen3_5
     config: Qwen3_5TextConfig
 
 
+class Qwen3_5ForTokenClassification(GenericForTokenClassification, Qwen3_5PreTrainedModel):
+    config: Qwen3_5TextConfig
+
+
 class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
     def get_video_features(
         self,
@@ -695,6 +699,7 @@ __all__ = [
     "Qwen3_5Model",
     "Qwen3_5ForCausalLM",
     "Qwen3_5ForSequenceClassification",
+    "Qwen3_5ForTokenClassification",
     "Qwen3_5ForConditionalGeneration",
     "Qwen3_5PreTrainedModel",
 ]

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -47,6 +47,7 @@ if is_torch_available():
         Qwen3_5ForCausalLM,
         Qwen3_5ForConditionalGeneration,
         Qwen3_5ForSequenceClassification,
+        Qwen3_5ForTokenClassification,
         Qwen3_5Model,
         Qwen3_5TextConfig,
         Qwen3_5TextModel,
@@ -58,6 +59,7 @@ class Qwen3_5TextModelTester(CausalLMModelTester):
         base_model_class = Qwen3_5TextModel
         causal_lm_class = Qwen3_5ForCausalLM
         sequence_classification_class = Qwen3_5ForSequenceClassification
+        token_classification_class = Qwen3_5ForTokenClassification
 
     def __init__(self, parent):
         super().__init__(parent=parent)


### PR DESCRIPTION
Adds token-classification support for Qwen3.5 in AutoModelForTokenClassification.

**What does this PR do?**
This PR enables loading Qwen3.5 checkpoints with `AutoModelForTokenClassification`, which previously failed with:
`ValueError: Unrecognized configuration class Qwen3_5Config for AutoModelForTokenClassification`.

**Changes**

- Adds Qwen3_5ForTokenClassification in:
  - `src/transformers/models/qwen3_5/modular_qwen3_5.py`
  - generated `src/transformers/models/qwen3_5/modeling_qwen3_5.py`
- Exports the new class via the Qwen3.5 modeling `__all__`.
- Registers auto-mapping entries in:
  - `src/transformers/models/auto/modeling_auto.py`
  - `("qwen3_5", "Qwen3_5ForTokenClassification")`
  - `("qwen3_5_text", "Qwen3_5ForTokenClassification")`
- Adds documentation in `docs/source/en/model_doc/qwen3_5.md`
- Adds test class registration in `tests/models/qwen3_5/test_modeling_qwen3_5.py`

**Why both mappings?**
Qwen3.5 uses a composite VLM config (qwen3_5) with a text sub-config (`qwen3_5_text`).
Registering **both** ensures classification works for direct text config usage and composite config loading paths.

**Before:**
Loading from e.g. Qwen/Qwen3.5-0.8B raises `ValueError: Unrecognized configuration class Qwen3_5Config for AutoModelForTokenClassification`.

**After this PR:**
Loading from `Qwen/Qwen3.5-0.8B` now resolves to `Qwen3_5ForTokenClassification`.

This PR follows the same pattern as #44406 (SequenceClassification support).

@Cyrilvallez @zucchini-nlp @ArthurZucker