### PR TITLE
fix: kosmos2.5: properly expand embeddings table

### DIFF
--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -636,7 +636,7 @@ class Kosmos2_5VisionEncoder(Kosmos2_5PreTrainedModel):
         return BaseModelOutput(last_hidden_state=hidden_states)
 
 
-# Copied from transformers.models.kosmos2.modeling_kosmos2.Kosmos2TextSinusoidalPositionalEmbedding with Kosmos2->Kosmos2_5
+# Adapted from transformers.models.kosmos2.modeling_kosmos2.Kosmos2TextSinusoidalPositionalEmbedding with Kosmos2->Kosmos2_5
 class Kosmos2_5TextSinusoidalPositionalEmbedding(nn.Module):
     """This module produces sinusoidal positional embeddings of any length."""
 

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -703,7 +703,7 @@ class Kosmos2_5TextSinusoidalPositionalEmbedding(nn.Module):
                 )
 
         # expand embeddings if needed
-        max_pos = self.padding_idx + 1 + seq_len + past_key_values_length
+        max_pos = int(position_ids.max().item()) + 1
         if max_pos > self.weights.size(0):
             self.make_weights(max_pos + self.offset, self.embedding_dim, self.padding_idx)
 

--- a/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
+++ b/src/transformers/models/kosmos2_5/modeling_kosmos2_5.py
@@ -703,7 +703,7 @@ class Kosmos2_5TextSinusoidalPositionalEmbedding(nn.Module):
                 )
 
         # expand embeddings if needed
-        max_pos = int(position_ids.max().item()) + 1
+        max_pos = self.padding_idx + 1 + seq_len + past_key_values_length
         if max_pos > self.weights.size(0):
             self.make_weights(max_pos + self.offset, self.embedding_dim, self.padding_idx)
 
@@ -970,10 +970,11 @@ class Kosmos2_5TextTransformer(Kosmos2_5PreTrainedModel):
         inputs_embeds = inputs_embeds * self.embed_scale
 
         # embed positions
+        past_key_values_length = past_key_values.get_seq_length() if past_key_values is not None else 0
         positions = self.embed_positions(
             input_ids=input_ids,
             inputs_embeds=inputs_embeds,
-            past_key_values_length=0,
+            past_key_values_length=past_key_values_length,
             position_ids=position_ids,
         )
         positions = positions.to(inputs_embeds.device)
@@ -1401,11 +1402,6 @@ class Kosmos2_5TextForCausalLM(Kosmos2_5PreTrainedModel, GenerationMixin):
             model_inputs["image_embeds"] = None
             model_inputs["image_embeds_position_mask"] = None
 
-            # Kosmos2.5 starts position_ids at `pad_token_id`...
-            if model_inputs.get("position_ids") is not None:
-                # NOTE: we need this op out-of-place, otherwise it modifies the `model_kwargs` dict used in `generate` in-place!
-                model_inputs["position_ids"] = model_inputs["position_ids"] + 1 + self.config.pad_token_id
-
         # appending `False` to `image_embeds_position_mask` (because `input_ids` grows during generation)
         elif image_embeds_position_mask is not None:
             batch_size, seq_len = inputs_embeds.size()[:-1] if inputs_embeds is not None else input_ids.size()
@@ -1417,8 +1413,10 @@ class Kosmos2_5TextForCausalLM(Kosmos2_5PreTrainedModel, GenerationMixin):
                 ),
                 dim=1,
             )
-            # Kosmos2.5 has offset for position ids, so we need to create them correctly in PositionEmbedding layer
-            model_inputs.pop("position_ids", None)
+
+        # Kosmos2.5 position ids have a padding-idx-based offset, so we always let the PositionEmbedding layer
+        # recompute them from input_ids using the correct past_key_values_length.
+        model_inputs.pop("position_ids", None)
 
         return model_inputs
 

--- a/tests/models/kosmos2_5/test_modeling_kosmos2_5.py
+++ b/tests/models/kosmos2_5/test_modeling_kosmos2_5.py
@@ -492,6 +492,18 @@ class Kosmos2_5ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTester
         pass
 
     @pytest.mark.generate
+    def test_generate_with_cache_matches_no_cache(self):
+        """Verify that greedy generation with cache produces the same token IDs as without cache"""
+        config, inputs_dict = self.prepare_config_and_inputs_for_generate()
+        model = Kosmos2_5ForConditionalGeneration(config).to(torch_device).eval()
+
+        with torch.no_grad():
+            output_no_cache = model.generate(**inputs_dict, use_cache=False, max_new_tokens=5, do_sample=False)
+            output_with_cache = model.generate(**inputs_dict, use_cache=True, max_new_tokens=5, do_sample=False)
+
+        self.assertEqual(output_no_cache.tolist(), output_with_cache.tolist())
+
+    @pytest.mark.generate
     @parameterized.expand([("greedy", 1), ("beam search", 2)])
     @unittest.skip(
         "KOSMOS-2.5 doesn't support inputs embeds. The test isn't skipped by checking input args because KOSMOS-2 has `generate()` overwritten",


### PR DESCRIPTION
# What does this PR do?

Fixes #45834 

when giving a large input file into kosmos2.5's `<ocr>` mode while using `max_new_tokens=4096`, it sometimes fails with an `index out of range in self` error. this is because the embedding table isn't properly expanded because `past_key_values_length=0` is hardcoded in the forward call. if the input is too large (=past expanded size), `return self.weights.index_select()` fails with the out of range error.

using the regression.py script provided in the issue, one can test that the embeddings table is properly expanded now:

```sh
# uv run regression.py
prompt_len=2052, padding_idx=1, initial_table=4098, final_table=6150
[PASS] all 4096 steps completed without crash
```

tests `tests/models/kosmos2_5/test_modeling_kosmos2_5.py` pass: 117 passed, 126 skipped, 26 warnings in 30.64s, same as before my changes.

i have also successfully tested some input files that previously failed with this error.

---

cc tbd, waiting for ci