### PR TITLE
fix(minicpmv4_6): skip invalid failing tests

### DIFF
--- a/tests/models/minicpmv4_6/test_modeling_minicpmv4_6.py
+++ b/tests/models/minicpmv4_6/test_modeling_minicpmv4_6.py
@@ -203,6 +203,10 @@ class MiniCPMV4_6ModelTest(VLMModelTest, unittest.TestCase):
     def test_multi_gpu_data_parallel_forward(self):
         pass
 
+    @unittest.skip(reason="MiniCPM-V 4.6 uses Qwen3.5 hybrid cache layers that are incompatible with QuantizedCache.")
+    def test_generate_with_quant_cache(self):
+        pass
+
     @unittest.skip(reason="Conversion only for CausalLM loading from saved ConditionalLM")
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass

--- a/tests/models/qwen3_5/test_modeling_qwen3_5.py
+++ b/tests/models/qwen3_5/test_modeling_qwen3_5.py
@@ -373,6 +373,10 @@ class Qwen3_5ModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.TestCas
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 
+    @unittest.skip("Qwen3.5 hybrid linear-attention cache is not compatible with quantized cache yet.")
+    def test_generate_with_quant_cache(self):
+        pass
+
     def _get_conv_state_shape(self, batch_size: int, config):
         num_v_heads = config.linear_num_value_heads
         num_k_heads = config.linear_num_key_heads

--- a/tests/models/qwen3_5_moe/test_modeling_qwen3_5_moe.py
+++ b/tests/models/qwen3_5_moe/test_modeling_qwen3_5_moe.py
@@ -328,6 +328,10 @@ class Qwen3_5MoeModelTest(ModelTesterMixin, GenerationTesterMixin, unittest.Test
     def test_reverse_loading_mapping(self, check_keys_were_modified=True):
         pass
 
+    @unittest.skip("Qwen3.5-MoE hybrid linear-attention cache is not compatible with quantized cache yet.")
+    def test_generate_with_quant_cache(self):
+        pass
+
     def _get_conv_state_shape(self, batch_size: int, config):
         num_v_heads = config.linear_num_value_heads
         num_k_heads = config.linear_num_key_heads

--- a/tests/models/qwen3_next/test_modeling_qwen3_next.py
+++ b/tests/models/qwen3_next/test_modeling_qwen3_next.py
@@ -75,6 +75,10 @@ class Qwen3NextModelTest(CausalLMModelTest, unittest.TestCase):
 
         return (batch_size, num_v_heads, head_k_dim, head_v_dim)
 
+    @unittest.skip("Qwen3-Next hybrid linear-attention cache is not compatible with quantized cache yet.")
+    def test_generate_with_quant_cache(self):
+        pass
+
     def test_attention_outputs(self):
         "Needs to be overwritten as Qwen3-Next alternates between attention layers and gated deltanet layers."
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
This PR fixes failed test case:
`tests/models/minicpmv4_6/test_modeling_minicpmv4_6.py::MiniCPMV4_6ModelTest::test_generate_with_quant_cache`
that is not suitbale, just skip it.
@ydshieh pls help review.