### PR TITLE
fix(laguna): fix failing tests

### DIFF
--- a/tests/models/laguna/test_modeling_laguna.py
+++ b/tests/models/laguna/test_modeling_laguna.py
@@ -39,6 +39,7 @@ class LagunaModelTester(CausalLMModelTester):
 
     def __init__(self, parent):
         super().__init__(parent=parent)
+        self.vocab_size = 64
         self.head_dim = 8
         self.sliding_window = 32
         self.shared_expert_intermediate_size = 16


### PR DESCRIPTION
This PR tries to fix failed test case:
`tests/models/laguna/test_modeling_laguna.py::LagunaModelTest::test_model_parallelism`, before this fix all model weight will be allocated to 1 single device, and it will return error "AttributeError: 'LagunaModel' object has no attribute 'hf_device_map'". W/ this PR it will be split into 2 different cards, and the case will pass. @ydshieh pls help review