### PR TITLE
fix(granite4_vision): auto-fix failing tests

### DIFF
--- a/src/transformers/models/granite4_vision/modeling_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modeling_granite4_vision.py
@@ -197,10 +197,8 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         downsampled_side = num_windows * self.query_side
         downsampled_windowed = self._windowed_raster(downsampled, downsampled_side, self.query_side)
 
-        query_embeds = self.query.to(downsampled_windowed.device) + downsampled_windowed
-        encoder_embeds = self.dropout(
-            windowed_image_features + self.image_positions.to(windowed_image_features.device)
-        )
+        query_embeds = self.query + downsampled_windowed
+        encoder_embeds = self.dropout(windowed_image_features + self.image_positions)
         out_windowed = self.qformer(
             query_embeds=query_embeds,
             encoder_hidden_states=encoder_embeds,

--- a/src/transformers/models/granite4_vision/modeling_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modeling_granite4_vision.py
@@ -197,8 +197,10 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         downsampled_side = num_windows * self.query_side
         downsampled_windowed = self._windowed_raster(downsampled, downsampled_side, self.query_side)
 
-        query_embeds = self.query + downsampled_windowed
-        encoder_embeds = self.dropout(windowed_image_features + self.image_positions)
+        query_embeds = self.query.to(downsampled_windowed.device) + downsampled_windowed
+        encoder_embeds = self.dropout(
+            windowed_image_features + self.image_positions.to(windowed_image_features.device)
+        )
         out_windowed = self.qformer(
             query_embeds=query_embeds,
             encoder_hidden_states=encoder_embeds,

--- a/src/transformers/models/granite4_vision/modeling_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modeling_granite4_vision.py
@@ -522,7 +522,7 @@ class Granite4VisionPreTrainedModel(PreTrainedModel):
     base_model_prefix = "model"
     input_modalities = ("image", "text")
     supports_gradient_checkpointing = True
-    _no_split_modules = ["Granite4VisionTextDecoderLayer"]
+    _no_split_modules = ["Granite4VisionTextDecoderLayer", "Granite4VisionWindowQFormerDownsampler"]
     _skip_keys_device_placement = "past_key_values"
 
     _supports_flash_attn = True

--- a/src/transformers/models/granite4_vision/modular_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modular_granite4_vision.py
@@ -328,8 +328,8 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         downsampled_side = num_windows * self.query_side
         downsampled_windowed = self._windowed_raster(downsampled, downsampled_side, self.query_side)
 
-        query_embeds = self.query + downsampled_windowed
-        encoder_embeds = self.dropout(windowed_image_features + self.image_positions)
+        query_embeds = self.query.to(downsampled_windowed.device) + downsampled_windowed
+        encoder_embeds = self.dropout(windowed_image_features + self.image_positions.to(windowed_image_features.device))
         out_windowed = self.qformer(
             query_embeds=query_embeds,
             encoder_hidden_states=encoder_embeds,

--- a/src/transformers/models/granite4_vision/modular_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modular_granite4_vision.py
@@ -329,7 +329,9 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         downsampled_windowed = self._windowed_raster(downsampled, downsampled_side, self.query_side)
 
         query_embeds = self.query.to(downsampled_windowed.device) + downsampled_windowed
-        encoder_embeds = self.dropout(windowed_image_features + self.image_positions.to(windowed_image_features.device))
+        encoder_embeds = self.dropout(
+            windowed_image_features + self.image_positions.to(windowed_image_features.device)
+        )
         out_windowed = self.qformer(
             query_embeds=query_embeds,
             encoder_hidden_states=encoder_embeds,
@@ -357,7 +359,7 @@ class Granite4VisionTextDecoderLayer(GraniteDecoderLayer):
 
 
 class Granite4VisionPreTrainedModel(LlavaNextPreTrainedModel):
-    _no_split_modules = ["Granite4VisionTextDecoderLayer"]
+    _no_split_modules = ["Granite4VisionTextDecoderLayer", "Granite4VisionWindowQFormerDownsampler"]
     _can_record_outputs = {
         "hidden_states": Granite4VisionTextDecoderLayer,
         "attentions": Granite4VisionTextAttention,

--- a/src/transformers/models/granite4_vision/modular_granite4_vision.py
+++ b/src/transformers/models/granite4_vision/modular_granite4_vision.py
@@ -328,10 +328,8 @@ class Granite4VisionWindowQFormerDownsampler(nn.Module):
         downsampled_side = num_windows * self.query_side
         downsampled_windowed = self._windowed_raster(downsampled, downsampled_side, self.query_side)
 
-        query_embeds = self.query.to(downsampled_windowed.device) + downsampled_windowed
-        encoder_embeds = self.dropout(
-            windowed_image_features + self.image_positions.to(windowed_image_features.device)
-        )
+        query_embeds = self.query + downsampled_windowed
+        encoder_embeds = self.dropout(windowed_image_features + self.image_positions)
         out_windowed = self.qformer(
             query_embeds=query_embeds,
             encoder_hidden_states=encoder_embeds,

--- a/tests/models/granite4_vision/test_modeling_granite4_vision.py
+++ b/tests/models/granite4_vision/test_modeling_granite4_vision.py
@@ -28,6 +28,7 @@ from transformers.image_utils import load_image
 from transformers.testing_utils import (
     Expectations,
     cleanup,
+    require_deterministic_for_xpu,
     require_torch,
     slow,
     torch_device,
@@ -155,6 +156,7 @@ class Granite4VisionIntegrationTest(unittest.TestCase):
     def tearDown(self):
         cleanup(torch_device, gc_collect=True)
 
+    @require_deterministic_for_xpu
     @slow
     def test_small_model_integration_test(self):
         model = Granite4VisionForConditionalGeneration.from_pretrained(self.model_id, torch_dtype=torch.bfloat16).to(
@@ -169,10 +171,12 @@ class Granite4VisionIntegrationTest(unittest.TestCase):
         EXPECTED_RESPONSE = Expectations({
             ("cuda", None): "The image depicts two cats resting on a pink couch. They are lying in a relaxed, sprawled position, with one cat appearing to be in a",
             ("cuda", (8, 6)): "The image depicts two cats resting on a pink blanket. They are lying in a relaxed, sprawled position, with one cat appearing to be in a",
+            ("xpu", None): "The image depicts two cats resting on a pink blanket. They are lying in a relaxed, sprawled position, with one cat appearing to be in a",
         }).get_expectation()  # fmt: skip
 
         self.assertEqual(self.processor.decode(new_tokens[0], skip_special_tokens=True), EXPECTED_RESPONSE)
 
+    @require_deterministic_for_xpu
     @slow
     def test_small_model_integration_test_batch(self):
         model = Granite4VisionForConditionalGeneration.from_pretrained(self.model_id, torch_dtype=torch.bfloat16).to(
@@ -195,6 +199,10 @@ class Granite4VisionIntegrationTest(unittest.TestCase):
 
         EXPECTED_RESPONSE = Expectations({
             ("cuda", (8, 6)): [
+                'i see two cats lying on a pink blanket. one cat is on the left side, and the other is on the right side. there are two',
+                'in the image, i see a group of people, including children and adults, standing on a tennis court. they appear to be posing for a group',
+            ],
+            ("xpu", None): [
                 'i see two cats lying on a pink blanket. one cat is on the left side, and the other is on the right side. there are two',
                 'in the image, i see a group of people, including children and adults, standing on a tennis court. they appear to be posing for a group',
             ]


### PR DESCRIPTION
Add `Granite4VisionWindowQFormerDownsampler` to `no_split_modules` to fix failed model parallel case:
`tests/models/granite4_vision/test_modeling_granite4_vision.py::Granite4VisionModelTest::test_model_parallel_beam_search`