### PR TITLE
Fix slow Trainer path with 4D attention mask

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2652,7 +2652,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             # Call .keys() explicitly for compatibility with TensorDict and other Mapping subclasses
             encoded_inputs = {key: [example[key] for example in encoded_inputs] for key in encoded_inputs[0].keys()}
 
-        # Pop 4D nested-list attention masks and stack 
+        # Pop 4D nested-list attention masks and stack
         # them at the end to avoid slow `to_py_obj`
         preserved_attention_mask = None
         if "attention_mask" in encoded_inputs:

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2652,6 +2652,17 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             # Call .keys() explicitly for compatibility with TensorDict and other Mapping subclasses
             encoded_inputs = {key: [example[key] for example in encoded_inputs] for key in encoded_inputs[0].keys()}
 
+        # `_pad` assumes 1D-per-sample inputs. A higher-rank per-sample `attention_mask`
+        # (e.g. a 4D causal mask of shape (batch, 1, q_len, kv_len)) is left untouched
+        # by the padding logic, but routing it through `to_py_obj` + `torch.tensor` on
+        # a deeply nested Python list dominates the runtime. Set it aside and stack it
+        # directly at the end of the batched path.
+        preserved_attention_mask = None
+        if "attention_mask" in encoded_inputs:
+            mask = encoded_inputs["attention_mask"]
+            if isinstance(mask, list) and mask and getattr(mask[0], "ndim", 0) > 1:
+                preserved_attention_mask = encoded_inputs.pop("attention_mask")
+
         # The model's main input name, usually `input_ids`, has been passed for padding
         if self.model_input_names[0] not in encoded_inputs:
             raise ValueError(
@@ -2734,6 +2745,17 @@ class PreTrainedTokenizerBase(PushToHubMixin):
                 if key not in batch_outputs:
                     batch_outputs[key] = []
                 batch_outputs[key].append(value)
+
+        if preserved_attention_mask is not None:
+            sample = preserved_attention_mask[0]
+            if is_torch_tensor(sample):
+                import torch
+
+                batch_outputs["attention_mask"] = torch.stack(preserved_attention_mask)
+            elif isinstance(sample, np.ndarray):
+                batch_outputs["attention_mask"] = np.stack(preserved_attention_mask)
+            else:
+                batch_outputs["attention_mask"] = np.array(preserved_attention_mask)
 
         return BatchEncoding(batch_outputs, tensor_type=return_tensors)
 

--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2652,11 +2652,8 @@ class PreTrainedTokenizerBase(PushToHubMixin):
             # Call .keys() explicitly for compatibility with TensorDict and other Mapping subclasses
             encoded_inputs = {key: [example[key] for example in encoded_inputs] for key in encoded_inputs[0].keys()}
 
-        # `_pad` assumes 1D-per-sample inputs. A higher-rank per-sample `attention_mask`
-        # (e.g. a 4D causal mask of shape (batch, 1, q_len, kv_len)) is left untouched
-        # by the padding logic, but routing it through `to_py_obj` + `torch.tensor` on
-        # a deeply nested Python list dominates the runtime. Set it aside and stack it
-        # directly at the end of the batched path.
+        # Pop 4D nested-list attention masks and stack 
+        # them at the end to avoid slow `to_py_obj`
         preserved_attention_mask = None
         if "attention_mask" in encoded_inputs:
             mask = encoded_inputs["attention_mask"]

--- a/tests/trainer/test_data_collator.py
+++ b/tests/trainer/test_data_collator.py
@@ -266,6 +266,47 @@ class TestDataCollatorWithPadding(DataCollatorTestMixin, unittest.TestCase):
             features = [{"input_ids": [0, 1, 2]}, {"input_ids": [0, 1, 2, 3, 4, 5]}]
             self._check_immutability(collator, features)
 
+    def test_4d_attention_mask_preserved(self):
+        """A 4D per-sample `attention_mask` is stacked into the batch unchanged.
+
+        `tokenizer.pad`'s 1D-per-sample padding logic does not apply to higher-rank
+        masks, so the collator must preserve their shape, dtype, and per-sample
+        contents.
+        """
+        tokenizer = BertTokenizer(self.vocab_file)
+        seq_len = 6
+        batch_size = 3
+
+        for sample_factory, expected_dtype in (
+            (lambda i: torch.full((1, seq_len, seq_len), float(i)), torch.float32),
+            (lambda i: np.full((1, seq_len, seq_len), float(i), dtype=np.float32), torch.float32),
+        ):
+            features = [
+                {"input_ids": list(range(seq_len)), "attention_mask": sample_factory(i)} for i in range(batch_size)
+            ]
+            collator = DataCollatorWithPadding(tokenizer)
+            batch = collator(features)
+
+            self.assertEqual(batch["attention_mask"].shape, torch.Size([batch_size, 1, seq_len, seq_len]))
+            self.assertEqual(batch["attention_mask"].dtype, expected_dtype)
+            for i in range(batch_size):
+                self.assertTrue(torch.all(batch["attention_mask"][i] == float(i)))
+
+    def test_4d_attention_mask_asymmetric_kv(self):
+        """A 4D mask with `kv_len != q_len` (e.g. KV-cache style) is preserved."""
+        tokenizer = BertTokenizer(self.vocab_file)
+        q_len, kv_len, batch_size = 4, 9, 2
+        features = [
+            {
+                "input_ids": list(range(q_len)),
+                "attention_mask": torch.zeros((1, q_len, kv_len), dtype=torch.float32),
+            }
+            for _ in range(batch_size)
+        ]
+        batch = DataCollatorWithPadding(tokenizer)(features)
+
+        self.assertEqual(batch["attention_mask"].shape, torch.Size([batch_size, 1, q_len, kv_len]))
+
 
 # =============================================================================
 # DataCollatorWithFlattening tests


### PR DESCRIPTION
Fixes #32101

`Trainer` with a pretrained tokenizer and a 4D `attention_mask` is dramatically slower than the 2D-mask path because `PreTrainedTokenizerBase.pad` routes the multi-dim per-sample mask through `to_py_obj` and then rebuilds it with `torch.tensor(deeply_nested_list)` in `BatchEncoding.convert_to_tensors`. That round trip is the dominant cost on the 4D path, and `_pad` itself cannot extend rank > 1 per-sample masks, so the conversion is wasted work.

This PR pops a multi-dim per-sample `attention_mask` out before the per-sample padding loop and stacks it back with `torch.stack` / `np.stack` at the end.

End-to-end on the OP's repro (CPU, `batch=32`, `grad_accum=32`, `seq=1024`, 1 optimizer step) the 4D `Trainer` step drops from 225.59 s to 114.62 s, within 13% of the 2D path's 101.52 s; the collator alone goes from ~3.65 s / batch to ~11.8 ms / batch.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
      Issue: https://github.com/huggingface/transformers/issues/32101.
      Maintainer invitation to open a PR: https://github.com/huggingface/transformers/issues/32101#issuecomment-4406013253.
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Who can review?

@SunMarc (trainer) and @ArthurZucker (tokenizers, text models).

---

## Numbers

End-to-end Trainer benchmark (CPU, single optimizer step, `batch=32`, `grad_accum=32`, `seq=1024`) matching the OP's repro (tiny `LlamaForCausalLM`, 6 layers, hidden=384, vocab=10):

| `attention_mask` | before | after |
| --- | ---: | ---: |
| 2D `(seq,)` per sample | 99.53 s | 101.52 s |
| 4D `(1, q, q)` per sample | 225.59 s | 114.62 s |

Before the fix the 4D step was 2.27x slower than the 2D step. After the fix it is within 13%, since the remaining cost is dominated by the model forward / backward (~100 s on this CPU). On hardware where the model is faster (e.g. the OP's, where the 2D step took 16 s and the 4D step took 340 s), the fix recovers a much larger relative speedup at the same parity point, for the same reason: the collator stops being the bottleneck.

### Collator-only decomposition

`DataCollatorWithPadding` timed in isolation across three shapes; mean ms / batch over `n_repeat` calls after a warm-up:

| (batch, seq) | n_repeat | mask | before (ms / batch) | after (ms / batch) | speedup |
| --- | ---: | --- | ---: | ---: | ---: |
| (8, 128) | 200 | 2D | 0.32 | 0.33 | ~1.0x |
| (8, 128) | 200 | 4D `(1, q, q)` | 13.16 | 0.26 | **~50x** |
| (16, 256) | 50 | 2D | 1.20 | 1.16 | ~1.0x |
| (16, 256) | 50 | 4D `(1, q, q)` | 110.13 | 0.92 | **~120x** |
| (32, 1024) | 20 | 2D | 8.96 | 8.89 | ~1.0x |
| (32, 1024) | 20 | 4D `(1, q, q)` (OP shape) | 3650.73 | 11.80 | **~310x** |

The 2D path is unchanged within noise. The 4D speedup grows with shape because the dominant pre-fix cost is `torch.tensor` on a deeply nested Python list of size O(batch * q * kv); after the fix, a single `torch.stack` scales linearly with elements rather than super-linearly with Python overhead.

Numerical equivalence is verified by the new `test_4d_attention_mask_preserved` regression test: per-sample shape, dtype, and contents match the stacked batch slice exactly, for both torch and numpy inputs.