### PR TITLE
fix: add HF_USE_MLX opt-out for MLX detection

### DIFF
--- a/docs/source/en/reference/environment_variables.md
+++ b/docs/source/en/reference/environment_variables.md
@@ -56,3 +56,21 @@ from transformers import pipeline
 
 model = pipeline(task="text-generation", model="facebook/opt-30b", device_map="auto")
 ```
+
+## HF_USE_MLX
+
+By default, Transformers detects whether MLX is installed when checking MLX availability. Set `HF_USE_MLX=0`
+to disable MLX availability detection. This is useful when MLX is installed but should not be used by Transformers,
+for example to avoid MLX import paths on systems where importing `mlx.core` is unsafe.
+
+Set this environment variable before importing Transformers.
+
+```py
+import os
+
+os.environ["HF_USE_MLX"] = "0"
+
+from transformers import is_mlx_available
+
+assert not is_mlx_available()
+```

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1315,7 +1315,7 @@ def is_jmespath_available() -> bool:
 
 @lru_cache
 def is_mlx_available() -> bool:
-    return _is_package_available("mlx")[0]
+    return not is_env_variable_false("HF_USE_MLX") and _is_package_available("mlx")[0]
 
 
 @lru_cache

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,7 +1,8 @@
 import sys
+from unittest.mock import patch
 
 from transformers.testing_utils import run_test_using_subprocess
-from transformers.utils.import_utils import clear_import_cache
+from transformers.utils.import_utils import clear_import_cache, is_mlx_available
 
 
 @run_test_using_subprocess
@@ -24,3 +25,27 @@ def test_clear_import_cache():
 
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
+
+
+def test_is_mlx_available_disabled_by_env(monkeypatch):
+    monkeypatch.setenv("HF_USE_MLX", "0")
+    is_mlx_available.cache_clear()
+
+    with patch("transformers.utils.import_utils._is_package_available") as mock_is_package_available:
+        assert not is_mlx_available()
+
+    mock_is_package_available.assert_not_called()
+    is_mlx_available.cache_clear()
+
+
+def test_is_mlx_available_checks_package_by_default(monkeypatch):
+    monkeypatch.delenv("HF_USE_MLX", raising=False)
+    is_mlx_available.cache_clear()
+
+    with patch(
+        "transformers.utils.import_utils._is_package_available", return_value=(True, None)
+    ) as mock_is_package_available:
+        assert is_mlx_available()
+
+    mock_is_package_available.assert_called_once_with("mlx")
+    is_mlx_available.cache_clear()


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #45853 (issue)
This PR adds `HF_USE_MLX=0` as a public opt-out for MLX availability detection. When set before importing Transformers, `is_mlx_available()` returns `False` without probing the `mlx` package, which prevents downstream guarded paths from importing `mlx.core`. This is useful for Apple Silicon environments where `mlx` may be installed but importing `mlx.core` can abort the interpreter during native initialization. The PR also documents the new environment variable.
## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Tests
```bash
python -m pytest tests/utils/test_import_utils.py
Result:
3 passed in 5.36s
Additional runtime verification:
HF_USE_MLX=0 python -c 'from transformers import is_mlx_available; assert is_mlx_available() is False'
```
I also verified that with HF_USE_MLX=0, Transformers does not try to import/probe mlx or mlx.core when running the relevant MLX-guarded tensor utility path.


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

Hey! @Rocketknight1 @Cyrilvallez , could you please take a look at this PR when you have a chance?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
