### PR TITLE
Fix/pe audio video bugs

### DIFF
--- a/docs/source/en/model_doc/pe_audio_video.md
+++ b/docs/source/en/model_doc/pe_audio_video.md
@@ -13,24 +13,21 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on 2025-12-16 and added to Hugging Face Transformers on 2025-12-16.*
+*This model was released on {release_date} and added to Hugging Face Transformers on 2025-12-16.*
 
-# PE Audio-Visual (Perception Encoder Audio-Visual)
+# PE Audio Video (Perception Encoder Audio-Video)
 
 ## Overview
 
-Perception Encoder Audio-Visual (PE-AV) was proposed in [Pushing the Frontier of Audiovisual Perception with Large-Scale Multimodal Correspondence Learning](https://huggingface.co/papers/2512.19687) by Apoorv Vyas et al. It extends the Perception Encoder framework to multiple modalities (text, audio, and video).
+TODO
 
-PE-AV is a family of encoders trained on O(100M) audio-video pairs with synthetic captions, using ten pairwise contrastive objectives to align all three modalities in a shared embedding space.
+## Usage
 
-<img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/model_doc/pe-av.png"
-alt="PE-AV architecture" width="600"/>
+### Basic usage
 
-<small>PE-AV architecture. Taken from the <a href="https://ai.meta.com/blog/sam-audio/">Meta AI blog post.</a></small>
-
-Audio and video are processed by dedicated encoders and combined through an Audio-Visual Fusion Encoder, while captions pass through a separate Text Encoder. Each branch produces CLS embeddings: `CLS-A`, `CLS-V`, `CLS-AV` for the three modality views, and `CLS-AT`, `CLS-VT`, `CLS-AVT` for text-projection variants aligned to each target. The model is trained with a combination of single-modality and fused-modality alignment losses.
-
-See the [PE-AV collection](https://huggingface.co/collections/facebook/perception-encoder-audio-visual) on the Hub for the full checkpoint family and usage examples.
+```py
+TODO
+```
 
 ## PeAudioVideoProcessor
 

--- a/docs/source/en/model_doc/pe_audio_video.md
+++ b/docs/source/en/model_doc/pe_audio_video.md
@@ -13,21 +13,24 @@ specific language governing permissions and limitations under the License.
 rendered properly in your Markdown viewer.
 
 -->
-*This model was released on {release_date} and added to Hugging Face Transformers on 2025-12-16.*
+*This model was released on 2025-12-16 and added to Hugging Face Transformers on 2025-12-16.*
 
-# PE Audio Video (Perception Encoder Audio-Video)
+# PE Audio-Visual (Perception Encoder Audio-Visual)
 
 ## Overview
 
-TODO
+Perception Encoder Audio-Visual (PE-AV) was proposed in [Pushing the Frontier of Audiovisual Perception with Large-Scale Multimodal Correspondence Learning](https://huggingface.co/papers/2512.19687) by Apoorv Vyas et al. It extends the Perception Encoder framework to multiple modalities (text, audio, and video).
 
-## Usage
+PE-AV is a family of encoders trained on O(100M) audio-video pairs with synthetic captions, using ten pairwise contrastive objectives to align all three modalities in a shared embedding space.
 
-### Basic usage
+<img src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/model_doc/pe-av.png"
+alt="PE-AV architecture" width="600"/>
 
-```py
-TODO
-```
+<small>PE-AV architecture. Taken from the <a href="https://ai.meta.com/blog/sam-audio/">Meta AI blog post.</a></small>
+
+Audio and video are processed by dedicated encoders and combined through an Audio-Visual Fusion Encoder, while captions pass through a separate Text Encoder. Each branch produces CLS embeddings: `CLS-A`, `CLS-V`, `CLS-AV` for the three modality views, and `CLS-AT`, `CLS-VT`, `CLS-AVT` for text-projection variants aligned to each target. The model is trained with a combination of single-modality and fused-modality alignment losses.
+
+See the [PE-AV collection](https://huggingface.co/collections/facebook/perception-encoder-audio-visual) on the Hub for the full checkpoint family and usage examples.
 
 ## PeAudioVideoProcessor
 

--- a/src/transformers/models/pe_audio_video/modeling_pe_audio_video.py
+++ b/src/transformers/models/pe_audio_video/modeling_pe_audio_video.py
@@ -896,7 +896,10 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         **kwargs,
     ) -> PeAudioVideoOutput:
         if sum([input_ids is not None, pixel_values_videos is not None, input_values is not None]) < 2:
-            raise ValueError("At least two of input_ids, pixel_values_videos, or input_values must be provided")
+            raise ValueError(
+                "At least two of input_ids, pixel_values_videos, or input_values must be provided. "
+                "For encoding individual modalities, get_*_embeds methods are available."
+            )
 
         if pixel_values_videos is None:
             outputs = self.audio_model(

--- a/src/transformers/models/pe_audio_video/modeling_pe_audio_video.py
+++ b/src/transformers/models/pe_audio_video/modeling_pe_audio_video.py
@@ -796,6 +796,7 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         text_outputs: MaskedLMOutput = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
+            output_hidden_states=True,
             return_dict=True,
         )
         text_embeds = text_outputs.hidden_states[-1][:, 0]
@@ -851,6 +852,7 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         text_outputs: MaskedLMOutput = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
+            output_hidden_states=True,
             return_dict=True,
         )
         text_embeds = text_outputs.hidden_states[-1][:, 0]
@@ -873,6 +875,7 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         text_outputs: MaskedLMOutput = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
+            output_hidden_states=True,
             return_dict=True,
         )
         text_embeds = text_outputs.hidden_states[-1][:, 0]

--- a/src/transformers/models/pe_audio_video/modular_pe_audio_video.py
+++ b/src/transformers/models/pe_audio_video/modular_pe_audio_video.py
@@ -588,6 +588,7 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         text_outputs: MaskedLMOutput = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
+            output_hidden_states=True,
             return_dict=True,
         )
         text_embeds = text_outputs.hidden_states[-1][:, 0]
@@ -643,6 +644,7 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         text_outputs: MaskedLMOutput = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
+            output_hidden_states=True,
             return_dict=True,
         )
         text_embeds = text_outputs.hidden_states[-1][:, 0]
@@ -665,6 +667,7 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         text_outputs: MaskedLMOutput = self.text_model(
             input_ids=input_ids,
             attention_mask=attention_mask,
+            output_hidden_states=True,
             return_dict=True,
         )
         text_embeds = text_outputs.hidden_states[-1][:, 0]

--- a/src/transformers/models/pe_audio_video/modular_pe_audio_video.py
+++ b/src/transformers/models/pe_audio_video/modular_pe_audio_video.py
@@ -688,7 +688,10 @@ class PeAudioVideoModel(PeAudioVideoPreTrainedModel):
         **kwargs,
     ) -> PeAudioVideoOutput:
         if sum([input_ids is not None, pixel_values_videos is not None, input_values is not None]) < 2:
-            raise ValueError("At least two of input_ids, pixel_values_videos, or input_values must be provided")
+            raise ValueError(
+                "At least two of input_ids, pixel_values_videos, or input_values must be provided. "
+                "For encoding individual modalities, get_*_embeds methods are available."
+            )
 
         if pixel_values_videos is None:
             outputs = self.audio_model(

--- a/src/transformers/models/pe_audio_video/processing_pe_audio_video.py
+++ b/src/transformers/models/pe_audio_video/processing_pe_audio_video.py
@@ -15,10 +15,8 @@ from ...processing_utils import ProcessorMixin
 
 
 class PeAudioVideoProcessor(ProcessorMixin):
-    attributes = ["feature_extractor", "video_processor", "tokenizer"]
-    feature_extractor_class = "PeAudioFeatureExtractor"
-    tokenizer_class = "AutoTokenizer"
-    video_processor_class = "PeVideoVideoProcessor"
+    def __init__(self, feature_extractor=None, video_processor=None, tokenizer=None, **kwargs):
+        super().__init__(feature_extractor, video_processor, tokenizer, **kwargs)
 
 
 __all__ = ["PeAudioVideoProcessor"]


### PR DESCRIPTION
# What does this PR do?

### 1. Migrate PE-AV processor to the v5 sub-processor API
`PeAudioVideoProcessor` still uses the legacy `feature_extractor_class` and `video_processor_class` that #41633 deprecated, so every checkpoint load prints two deprecation warnings. The Auto mappings are already registered, so we can drop the legacy attrs and add an explicit `__init__`.

### 2. Fix `get_*_embeds` crash
The `get_text_*_embeds` helpers call the text model without `output_hidden_states=True` and then access `text_outputs.hidden_states[-1]`, which is `None`, and so they crash with `TypeError`.
The fix is one extra kwarg per helper, mirroring the `forward` behaviour.

### 3. Friendlier `forward` error for single-modality inputs
`forward` requires ≥2 modalities; single modalities are handled by the `get_*_embeds` helpers.
Extended the `ValueError` to mention the existence of those helpers, so users reading the "you can omit any of the modalities, and use the same forward method" in the [model card](https://huggingface.co/facebook/pe-av-small) aren't stuck.

### 4. Fill in `docs/source/en/model_doc/pe_audio_video.md`
Replaced with a short overview, the clean architecture figure (upload pending here https://huggingface.co/datasets/huggingface/documentation-images/discussions/614), and a link to the well-documented [PE-AV collection](https://huggingface.co/collections/facebook/perception-encoder-audio-visual) for checkpoints and end-to-end usage.
I noticed #45612 already proposes a doc fill-in for this page. Happy to drop/adapt this commit if the existing PR is preferred, but the other three fixes are independent of the doc change.

## Testing

Run `facebook/pe-av-small` with the minimal code below.

```python
import torch
from transformers import AutoModel, AutoProcessor

model = AutoModel.from_pretrained("facebook/pe-av-small").eval()
processor = AutoProcessor.from_pretrained("facebook/pe-av-small")
# #4: AutoProcessor.from_pretrained above no longer emits deprecation warnings.
text_inputs = processor(text=["a photo of a cat", "a person speaking"], return_tensors="pt", padding=True)

# #1: previously crashed with TypeError, now returns torch.Size([2, 1024])
with torch.no_grad():
    out = model.get_text_audio_video_embeds(
        input_ids=text_inputs["input_ids"],
        attention_mask=text_inputs.get("attention_mask"),
    )
print(out.shape)

# #2: error now points to get_*_embeds helpers
try:
    model(**text_inputs)
except ValueError as e:
    print(e)
```

## Code Agent Policy
- [x ] I confirm that this is not a pure code agent PR.

## Who can review?
First time so don't hate my if I tag wrong people @zucchini-nlp @stevhliu XD