### PR TITLE
Fix undefined 'input' variable

### DIFF
--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -645,7 +645,7 @@ class BartDecoder(BartPreTrainedModel):
         )
 
         # embed positions
-        positions = self.embed_positions(input, past_key_values_length, position_ids=position_ids)
+        positions = self.embed_positions(input_ids, past_key_values_length, position_ids=position_ids)
         positions = positions.to(inputs_embeds.device)
 
         hidden_states = inputs_embeds + positions

--- a/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
+++ b/src/transformers/models/bigbird_pegasus/modeling_bigbird_pegasus.py
@@ -1820,7 +1820,7 @@ class BigBirdPegasusDecoder(BigBirdPegasusPreTrainedModel):
         )
 
         # embed positions
-        positions = self.embed_positions(input, past_key_values_length, position_ids=position_ids)
+        positions = self.embed_positions(input_ids, past_key_values_length, position_ids=position_ids)
         positions = positions.to(inputs_embeds.device)
 
         hidden_states = inputs_embeds + positions

--- a/src/transformers/models/mbart/modeling_mbart.py
+++ b/src/transformers/models/mbart/modeling_mbart.py
@@ -727,7 +727,7 @@ class MBartDecoder(MBartPreTrainedModel):
         )
 
         # embed positions
-        position_ids = self.embed_positions(input, past_key_values_length, position_ids=position_ids)
+        position_ids = self.embed_positions(input_ids, past_key_values_length, position_ids=position_ids)
 
         hidden_states = inputs_embeds + position_ids.to(inputs_embeds.device)
         hidden_states = self.layernorm_embedding(hidden_states)

--- a/src/transformers/models/plbart/modeling_plbart.py
+++ b/src/transformers/models/plbart/modeling_plbart.py
@@ -577,7 +577,7 @@ class PLBartDecoder(PLBartPreTrainedModel):
         )
 
         # embed positions
-        positions = self.embed_positions(input, past_key_values_length, position_ids=position_ids)
+        positions = self.embed_positions(input_ids, past_key_values_length, position_ids=position_ids)
         positions = positions.to(inputs_embeds.device)
 
         hidden_states = inputs_embeds + positions

--- a/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modeling_pp_formulanet.py
@@ -909,7 +909,7 @@ class PPFormulaNetTextModel(PPFormulaNetPreTrainedModel):
         )
 
         # embed positions
-        position_ids = self.embed_positions(input, past_key_values_length, position_ids=position_ids)
+        position_ids = self.embed_positions(input_ids, past_key_values_length, position_ids=position_ids)
 
         hidden_states = inputs_embeds + position_ids.to(inputs_embeds.device)
         hidden_states = self.layernorm_embedding(hidden_states)


### PR DESCRIPTION
# What does this PR do?

Fixes `self.embed_positions(input, ...)` which references undefined variable `input` instead of `input_ids` in decoder `forward` methods.

This was introduced during cache refactoring (#35314, #44330) where the `input = input_ids` local alias was removed but the `input` reference was not updated.

```diff
-        positions = self.embed_positions(input, past_key_values_length, position_ids=position_ids)
+        positions = self.embed_positions(input_ids, past_key_values_length, position_ids=position_ids)
```

Currently this works because `position_ids` is always provided, making the first argument to `embed_positions` unused.

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request)?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes? (N/A)
- [ ] Did you write any new necessary tests?

## Who can review?
@ArthurZucker @Cyrilvallez