### PR TITLE
[fix] Add `fatal_error` to `ContinuousBatchingManager` so the serving layer can detect a dead CB worker

### DIFF
--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -760,7 +760,7 @@ class CBGenerateManager(BaseGenerateManager):
     def scheduler(self) -> "Scheduler":
         """The CB scheduler (for testing/monitoring)."""
         if self._cb is None or self._cb.batch_processor is None:
-            raise RuntimeError("CB manager not initialized.")
+            raise RuntimeError("Continuous batching processor not initialized.")
         return self._cb.batch_processor.scheduler
 
     def stop(self) -> None:

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -759,7 +759,7 @@ class CBGenerateManager(BaseGenerateManager):
     @property
     def scheduler(self) -> "Scheduler":
         """The CB scheduler (for testing/monitoring)."""
-        if self._cb is None:
+        if self._cb is None or self._cb.batch_processor is None:
             raise RuntimeError("CB manager not initialized.")
         return self._cb.batch_processor.scheduler
 

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -623,7 +623,7 @@ class CBGenerateManager(BaseGenerateManager):
     """
 
     def __init__(self, cb_config: "ContinuousBatchingConfig | None" = None):
-        self._cb: "ContinuousBatchingManager | None" = None
+        self._cb: ContinuousBatchingManager | None = None
         self._cb_config = cb_config
 
     def init_cb(self, model: "PreTrainedModel", gen_config: "GenerationConfig") -> None:

--- a/src/transformers/cli/serving/utils.py
+++ b/src/transformers/cli/serving/utils.py
@@ -623,7 +623,7 @@ class CBGenerateManager(BaseGenerateManager):
     """
 
     def __init__(self, cb_config: "ContinuousBatchingConfig | None" = None):
-        self._cb = None
+        self._cb: "ContinuousBatchingManager | None" = None
         self._cb_config = cb_config
 
     def init_cb(self, model: "PreTrainedModel", gen_config: "GenerationConfig") -> None:

--- a/src/transformers/generation/continuous_batching/continuous_api.py
+++ b/src/transformers/generation/continuous_batching/continuous_api.py
@@ -498,6 +498,7 @@ class ContinuousBatchingManager:
         self._generation_thread = None
         self._request_counter = 0
         self._request_lock = threading.Lock()
+        self.fatal_error: Exception | None = None
 
         # Generation config related arguments
         num_return_sequences = getattr(generation_config, "num_return_sequences", None)
@@ -526,6 +527,7 @@ class ContinuousBatchingManager:
             logger.warning("Manager thread is already running.")
             return
         self.stop_event.clear()
+        self.fatal_error = None
         self._generation_thread = threading.Thread(target=self._run_generation_loop)
         self._generation_thread.start()
 
@@ -853,6 +855,9 @@ class ContinuousBatchingManager:
     @traced
     def _handle_critical_error(self, error: Exception, batch_processor: ContinuousBatchProcessor | None) -> None:
         """Handle critical errors that terminate the generation loop."""
+        # Record so callers (e.g. the serving layer) can fail fast on subsequent requests
+        # instead of enqueuing into a worker that will never drain.
+        self.fatal_error = error
         # Signal stop
         self.stop_event.set()
 


### PR DESCRIPTION
#45691 introduced reads of `self._cb.fatal_error` in `transformers/cli/serving/utils.py` (in `is_alive`, `_check_alive`, and `generate_non_streaming`) 

https://github.com/huggingface/transformers/blob/0226203617df98b2b0807e8336c3428c05ec63e8/src/transformers/cli/serving/utils.py#L648

https://github.com/huggingface/transformers/blob/0226203617df98b2b0807e8336c3428c05ec63e8/src/transformers/cli/serving/utils.py#L656

to fail fast when the CB worker has crashed, but the attribute was never added to `ContinuousBatchingManager`. As a result, every chat-completion request to `transformers serve --continuous-batching` raises:


```
transformers serve Qwen/Qwen3-4B-Thinking-2507 --continuous-batching --attn-implementation kernels-community/flash-attn2
```

```
curl -s http://127.0.0.1:8000/v1/chat/completions -H "Content-Type: application/json" -d "{\"model\":\"Qwen/Qwen3-4B-Thinking-2507\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi in one sentence.\"}]}"
```

```text
AttributeError: 'ContinuousBatchingManager' object has no attribute 'fatal_error'
```

and returns a 500, regardless of whether the worker is healthy.

## Test

Verified that the existing accelerator-gated integration tests `tests/cli/test_serve.py::TestCompletion::test_cb_streaming` and `test_cb_non_streaming` fail without this patch. No new test added: these already cover the regression; they didn't catch it pre-merge because the introducing PR didn't run accelerator/slow CI.
