### PR TITLE
Fix M-RoPE `inv_freq` device and `meta` → `to_empty` re-init in Qwen3-VL family

### DIFF
--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -161,6 +161,23 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
+    def _apply(self, fn, recurse=True):
+        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
+        # `original_inv_freq` from `meta` onto a real device, so that the standard
+        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
+        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
+        was_meta = self.inv_freq.device.type == "meta"
+        result = super()._apply(fn, recurse=recurse)
+        if was_meta and self.inv_freq.device.type != "meta":
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
+            with torch.no_grad():
+                self.inv_freq.copy_(inv_freq)
+                self.original_inv_freq.copy_(inv_freq)
+        return result
+
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
         Reorganizes frequency layout from chunked [TTT...HHH...WWW] to

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -106,6 +106,9 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
         self.mrope_section = config.rope_parameters.get("mrope_section", [11, 11, 10])
+        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
+        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
+        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -142,6 +145,7 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        self._ensure_inv_freq_initialized(x.device)
         # In contrast to other models, Qwen3_5 has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
@@ -176,7 +180,28 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
             with torch.no_grad():
                 self.inv_freq.copy_(inv_freq)
                 self.original_inv_freq.copy_(inv_freq)
+        self._inv_freq_id = id(self.inv_freq)
         return result
+
+    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
+        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
+        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            return
+        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
+        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
+        # bytes that overflow fp32 in `inv_freq * position_id`
+        if id(self.inv_freq) == self._inv_freq_id:
+            return
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
+        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
+        # device or dtype; direct assignment mirrors the `register_buffer` method
+        self._buffers["inv_freq"] = inv_freq
+        self._buffers["original_inv_freq"] = inv_freq.clone()
+        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -106,9 +106,6 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
         self.mrope_section = config.rope_parameters.get("mrope_section", [11, 11, 10])
-        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
-        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
-        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -145,14 +142,23 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        self._ensure_inv_freq_initialized(x.device)
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            # The `@dynamic_rope_update` decorator on this forward re-registers
+            # `inv_freq` from the current `position_ids` before the body runs
+            inv_freq = self.inv_freq
+        else:
+            # Recompute on `x.device` to bypass any prior state of `self.inv_freq`,
+            # whether uninit from `to_empty`, swapped via direct `_buffers[k] = ...`,
+            # or host-pinned under FSDP non-persistent buffer offload
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, _ = rope_init_fn(self.config, x.device)
         # In contrast to other models, Qwen3_5 has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = (
-            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
-        )
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -164,44 +170,6 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
             sin = emb.sin() * self.attention_scaling
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
-    def _apply(self, fn, recurse=True):
-        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
-        # `original_inv_freq` from `meta` onto a real device, so that the standard
-        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
-        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
-        was_meta = self.inv_freq.device.type == "meta"
-        result = super()._apply(fn, recurse=recurse)
-        if was_meta and self.inv_freq.device.type != "meta":
-            rope_init_fn: Callable = self.compute_default_rope_parameters
-            if self.rope_type != "default":
-                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
-            with torch.no_grad():
-                self.inv_freq.copy_(inv_freq)
-                self.original_inv_freq.copy_(inv_freq)
-        self._inv_freq_id = id(self.inv_freq)
-        return result
-
-    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
-        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
-        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
-        if "dynamic" in self.rope_type or self.rope_type == "longrope":
-            return
-        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
-        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
-        # bytes that overflow fp32 in `inv_freq * position_id`
-        if id(self.inv_freq) == self._inv_freq_id:
-            return
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        if self.rope_type != "default":
-            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
-        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
-        # device or dtype; direct assignment mirrors the `register_buffer` method
-        self._buffers["inv_freq"] = inv_freq
-        self._buffers["original_inv_freq"] = inv_freq.clone()
-        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_5/modeling_qwen3_5.py
+++ b/src/transformers/models/qwen3_5/modeling_qwen3_5.py
@@ -146,7 +146,9 @@ class Qwen3_5TextRotaryEmbedding(nn.Module):
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -157,6 +157,23 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
+    def _apply(self, fn, recurse=True):
+        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
+        # `original_inv_freq` from `meta` onto a real device, so that the standard
+        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
+        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
+        was_meta = self.inv_freq.device.type == "meta"
+        result = super()._apply(fn, recurse=recurse)
+        if was_meta and self.inv_freq.device.type != "meta":
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
+            with torch.no_grad():
+                self.inv_freq.copy_(inv_freq)
+                self.original_inv_freq.copy_(inv_freq)
+        return result
+
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
         Reorganizes frequency layout from chunked [TTT...HHH...WWW] to

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -142,7 +142,9 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -102,6 +102,9 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
         self.mrope_section = config.rope_parameters.get("mrope_section", [11, 11, 10])
+        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
+        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
+        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -138,6 +141,7 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        self._ensure_inv_freq_initialized(x.device)
         # In contrast to other models, Qwen3_5Moe has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
@@ -172,7 +176,28 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
             with torch.no_grad():
                 self.inv_freq.copy_(inv_freq)
                 self.original_inv_freq.copy_(inv_freq)
+        self._inv_freq_id = id(self.inv_freq)
         return result
+
+    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
+        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
+        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            return
+        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
+        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
+        # bytes that overflow fp32 in `inv_freq * position_id`
+        if id(self.inv_freq) == self._inv_freq_id:
+            return
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
+        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
+        # device or dtype; direct assignment mirrors the `register_buffer` method
+        self._buffers["inv_freq"] = inv_freq
+        self._buffers["original_inv_freq"] = inv_freq.clone()
+        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
+++ b/src/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py
@@ -102,9 +102,6 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
         self.register_buffer("inv_freq", inv_freq, persistent=False)
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
         self.mrope_section = config.rope_parameters.get("mrope_section", [11, 11, 10])
-        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
-        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
-        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -141,14 +138,23 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        self._ensure_inv_freq_initialized(x.device)
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            # The `@dynamic_rope_update` decorator on this forward re-registers
+            # `inv_freq` from the current `position_ids` before the body runs
+            inv_freq = self.inv_freq
+        else:
+            # Recompute on `x.device` to bypass any prior state of `self.inv_freq`,
+            # whether uninit from `to_empty`, swapped via direct `_buffers[k] = ...`,
+            # or host-pinned under FSDP non-persistent buffer offload
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, _ = rope_init_fn(self.config, x.device)
         # In contrast to other models, Qwen3_5Moe has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = (
-            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
-        )
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -160,44 +166,6 @@ class Qwen3_5MoeTextRotaryEmbedding(nn.Module):
             sin = emb.sin() * self.attention_scaling
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
-    def _apply(self, fn, recurse=True):
-        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
-        # `original_inv_freq` from `meta` onto a real device, so that the standard
-        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
-        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
-        was_meta = self.inv_freq.device.type == "meta"
-        result = super()._apply(fn, recurse=recurse)
-        if was_meta and self.inv_freq.device.type != "meta":
-            rope_init_fn: Callable = self.compute_default_rope_parameters
-            if self.rope_type != "default":
-                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
-            with torch.no_grad():
-                self.inv_freq.copy_(inv_freq)
-                self.original_inv_freq.copy_(inv_freq)
-        self._inv_freq_id = id(self.inv_freq)
-        return result
-
-    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
-        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
-        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
-        if "dynamic" in self.rope_type or self.rope_type == "longrope":
-            return
-        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
-        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
-        # bytes that overflow fp32 in `inv_freq * position_id`
-        if id(self.inv_freq) == self._inv_freq_id:
-            return
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        if self.rope_type != "default":
-            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
-        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
-        # device or dtype; direct assignment mirrors the `register_buffer` method
-        self._buffers["inv_freq"] = inv_freq
-        self._buffers["original_inv_freq"] = inv_freq.clone()
-        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1330,6 +1330,23 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
+    def _apply(self, fn, recurse=True):
+        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
+        # `original_inv_freq` from `meta` onto a real device, so that the standard
+        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
+        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
+        was_meta = self.inv_freq.device.type == "meta"
+        result = super()._apply(fn, recurse=recurse)
+        if was_meta and self.inv_freq.device.type != "meta":
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
+            with torch.no_grad():
+                self.inv_freq.copy_(inv_freq)
+                self.original_inv_freq.copy_(inv_freq)
+        return result
+
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
         Reorganizes frequency layout from chunked [TTT...HHH...WWW] to

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1315,7 +1315,9 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1277,6 +1277,9 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
+        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
+        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
+        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -1311,6 +1314,7 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        self._ensure_inv_freq_initialized(x.device)
         # In contrast to other models, Qwen3OmniMoeThinker has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
@@ -1345,7 +1349,28 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
             with torch.no_grad():
                 self.inv_freq.copy_(inv_freq)
                 self.original_inv_freq.copy_(inv_freq)
+        self._inv_freq_id = id(self.inv_freq)
         return result
+
+    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
+        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
+        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            return
+        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
+        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
+        # bytes that overflow fp32 in `inv_freq * position_id`
+        if id(self.inv_freq) == self._inv_freq_id:
+            return
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
+        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
+        # device or dtype; direct assignment mirrors the `register_buffer` method
+        self._buffers["inv_freq"] = inv_freq
+        self._buffers["original_inv_freq"] = inv_freq.clone()
+        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
+++ b/src/transformers/models/qwen3_omni_moe/modeling_qwen3_omni_moe.py
@@ -1277,9 +1277,6 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
-        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
-        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
-        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -1314,14 +1311,23 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        self._ensure_inv_freq_initialized(x.device)
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            # The `@dynamic_rope_update` decorator on this forward re-registers
+            # `inv_freq` from the current `position_ids` before the body runs
+            inv_freq = self.inv_freq
+        else:
+            # Recompute on `x.device` to bypass any prior state of `self.inv_freq`,
+            # whether uninit from `to_empty`, swapped via direct `_buffers[k] = ...`,
+            # or host-pinned under FSDP non-persistent buffer offload
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, _ = rope_init_fn(self.config, x.device)
         # In contrast to other models, Qwen3OmniMoeThinker has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = (
-            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
-        )
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -1333,44 +1339,6 @@ class Qwen3OmniMoeThinkerTextRotaryEmbedding(nn.Module):
             sin = emb.sin() * self.attention_scaling
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
-    def _apply(self, fn, recurse=True):
-        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
-        # `original_inv_freq` from `meta` onto a real device, so that the standard
-        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
-        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
-        was_meta = self.inv_freq.device.type == "meta"
-        result = super()._apply(fn, recurse=recurse)
-        if was_meta and self.inv_freq.device.type != "meta":
-            rope_init_fn: Callable = self.compute_default_rope_parameters
-            if self.rope_type != "default":
-                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
-            with torch.no_grad():
-                self.inv_freq.copy_(inv_freq)
-                self.original_inv_freq.copy_(inv_freq)
-        self._inv_freq_id = id(self.inv_freq)
-        return result
-
-    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
-        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
-        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
-        if "dynamic" in self.rope_type or self.rope_type == "longrope":
-            return
-        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
-        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
-        # bytes that overflow fp32 in `inv_freq * position_id`
-        if id(self.inv_freq) == self._inv_freq_id:
-            return
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        if self.rope_type != "default":
-            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
-        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
-        # device or dtype; direct assignment mirrors the `register_buffer` method
-        self._buffers["inv_freq"] = inv_freq
-        self._buffers["original_inv_freq"] = inv_freq.clone()
-        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -354,7 +354,9 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -316,9 +316,6 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
-        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
-        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
-        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -353,14 +350,23 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        self._ensure_inv_freq_initialized(x.device)
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            # The `@dynamic_rope_update` decorator on this forward re-registers
+            # `inv_freq` from the current `position_ids` before the body runs
+            inv_freq = self.inv_freq
+        else:
+            # Recompute on `x.device` to bypass any prior state of `self.inv_freq`,
+            # whether uninit from `to_empty`, swapped via direct `_buffers[k] = ...`,
+            # or host-pinned under FSDP non-persistent buffer offload
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, _ = rope_init_fn(self.config, x.device)
         # In contrast to other models, Qwen3VL has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = (
-            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
-        )
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -372,44 +378,6 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
             sin = emb.sin() * self.attention_scaling
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
-    def _apply(self, fn, recurse=True):
-        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
-        # `original_inv_freq` from `meta` onto a real device, so that the standard
-        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
-        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
-        was_meta = self.inv_freq.device.type == "meta"
-        result = super()._apply(fn, recurse=recurse)
-        if was_meta and self.inv_freq.device.type != "meta":
-            rope_init_fn: Callable = self.compute_default_rope_parameters
-            if self.rope_type != "default":
-                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
-            with torch.no_grad():
-                self.inv_freq.copy_(inv_freq)
-                self.original_inv_freq.copy_(inv_freq)
-        self._inv_freq_id = id(self.inv_freq)
-        return result
-
-    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
-        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
-        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
-        if "dynamic" in self.rope_type or self.rope_type == "longrope":
-            return
-        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
-        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
-        # bytes that overflow fp32 in `inv_freq * position_id`
-        if id(self.inv_freq) == self._inv_freq_id:
-            return
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        if self.rope_type != "default":
-            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
-        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
-        # device or dtype; direct assignment mirrors the `register_buffer` method
-        self._buffers["inv_freq"] = inv_freq
-        self._buffers["original_inv_freq"] = inv_freq.clone()
-        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -369,6 +369,23 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
+    def _apply(self, fn, recurse=True):
+        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
+        # `original_inv_freq` from `meta` onto a real device, so that the standard
+        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
+        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
+        was_meta = self.inv_freq.device.type == "meta"
+        result = super()._apply(fn, recurse=recurse)
+        if was_meta and self.inv_freq.device.type != "meta":
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
+            with torch.no_grad():
+                self.inv_freq.copy_(inv_freq)
+                self.original_inv_freq.copy_(inv_freq)
+        return result
+
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
         Reorganizes frequency layout from chunked [TTT...HHH...WWW] to

--- a/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modeling_qwen3_vl.py
@@ -316,6 +316,9 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
+        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
+        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
+        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -350,6 +353,7 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        self._ensure_inv_freq_initialized(x.device)
         # In contrast to other models, Qwen3VL has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
@@ -384,7 +388,28 @@ class Qwen3VLTextRotaryEmbedding(nn.Module):
             with torch.no_grad():
                 self.inv_freq.copy_(inv_freq)
                 self.original_inv_freq.copy_(inv_freq)
+        self._inv_freq_id = id(self.inv_freq)
         return result
+
+    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
+        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
+        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            return
+        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
+        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
+        # bytes that overflow fp32 in `inv_freq * position_id`
+        if id(self.inv_freq) == self._inv_freq_id:
+            return
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
+        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
+        # device or dtype; direct assignment mirrors the `register_buffer` method
+        self._buffers["inv_freq"] = inv_freq
+        self._buffers["original_inv_freq"] = inv_freq.clone()
+        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -32,7 +32,7 @@ from ...image_utils import ImageInput
 from ...masking_utils import create_causal_mask
 from ...modeling_flash_attention_utils import FlashAttentionKwargs
 from ...modeling_outputs import BaseModelOutputWithPast, BaseModelOutputWithPooling
-from ...modeling_rope_utils import RopeParameters, dynamic_rope_update
+from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS, RopeParameters, dynamic_rope_update
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS, PreTrainedModel
 from ...processing_utils import ProcessingKwargs, Unpack
 from ...tokenization_utils_base import PreTokenizedInput, TextInput
@@ -269,6 +269,23 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
         super().__init__(config, device=device)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
+
+    def _apply(self, fn, recurse=True):
+        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
+        # `original_inv_freq` from `meta` onto a real device, so that the standard
+        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
+        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
+        was_meta = self.inv_freq.device.type == "meta"
+        result = super()._apply(fn, recurse=recurse)
+        if was_meta and self.inv_freq.device.type != "meta":
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
+            with torch.no_grad():
+                self.inv_freq.copy_(inv_freq)
+                self.original_inv_freq.copy_(inv_freq)
+        return result
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -294,7 +294,9 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -269,47 +269,6 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
         super().__init__(config, device=device)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
-        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
-        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
-        self._inv_freq_id = id(self.inv_freq)
-
-    def _apply(self, fn, recurse=True):
-        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
-        # `original_inv_freq` from `meta` onto a real device, so that the standard
-        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
-        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
-        was_meta = self.inv_freq.device.type == "meta"
-        result = super()._apply(fn, recurse=recurse)
-        if was_meta and self.inv_freq.device.type != "meta":
-            rope_init_fn: Callable = self.compute_default_rope_parameters
-            if self.rope_type != "default":
-                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
-            with torch.no_grad():
-                self.inv_freq.copy_(inv_freq)
-                self.original_inv_freq.copy_(inv_freq)
-        self._inv_freq_id = id(self.inv_freq)
-        return result
-
-    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
-        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
-        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
-        if "dynamic" in self.rope_type or self.rope_type == "longrope":
-            return
-        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
-        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
-        # bytes that overflow fp32 in `inv_freq * position_id`
-        if id(self.inv_freq) == self._inv_freq_id:
-            return
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        if self.rope_type != "default":
-            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
-        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
-        # device or dtype; direct assignment mirrors the `register_buffer` method
-        self._buffers["inv_freq"] = inv_freq
-        self._buffers["original_inv_freq"] = inv_freq.clone()
-        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
@@ -331,14 +290,23 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        self._ensure_inv_freq_initialized(x.device)
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            # The `@dynamic_rope_update` decorator on this forward re-registers
+            # `inv_freq` from the current `position_ids` before the body runs
+            inv_freq = self.inv_freq
+        else:
+            # Recompute on `x.device` to bypass any prior state of `self.inv_freq`,
+            # whether uninit from `to_empty`, swapped via direct `_buffers[k] = ...`,
+            # or host-pinned under FSDP non-persistent buffer offload
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, _ = rope_init_fn(self.config, x.device)
         # In contrast to other models, Qwen3VL has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = (
-            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
-        )
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
+++ b/src/transformers/models/qwen3_vl/modular_qwen3_vl.py
@@ -269,6 +269,9 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
         super().__init__(config, device=device)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
+        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
+        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
+        self._inv_freq_id = id(self.inv_freq)
 
     def _apply(self, fn, recurse=True):
         # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
@@ -285,7 +288,28 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
             with torch.no_grad():
                 self.inv_freq.copy_(inv_freq)
                 self.original_inv_freq.copy_(inv_freq)
+        self._inv_freq_id = id(self.inv_freq)
         return result
+
+    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
+        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
+        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            return
+        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
+        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
+        # bytes that overflow fp32 in `inv_freq * position_id`
+        if id(self.inv_freq) == self._inv_freq_id:
+            return
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
+        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
+        # device or dtype; direct assignment mirrors the `register_buffer` method
+        self._buffers["inv_freq"] = inv_freq
+        self._buffers["original_inv_freq"] = inv_freq.clone()
+        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
@@ -307,6 +331,7 @@ class Qwen3VLTextRotaryEmbedding(LlamaRotaryEmbedding):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        self._ensure_inv_freq_initialized(x.device)
         # In contrast to other models, Qwen3VL has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -880,6 +880,23 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
 
+    def _apply(self, fn, recurse=True):
+        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
+        # `original_inv_freq` from `meta` onto a real device, so that the standard
+        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
+        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
+        was_meta = self.inv_freq.device.type == "meta"
+        result = super()._apply(fn, recurse=recurse)
+        if was_meta and self.inv_freq.device.type != "meta":
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
+            with torch.no_grad():
+                self.inv_freq.copy_(inv_freq)
+                self.original_inv_freq.copy_(inv_freq)
+        return result
+
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.
         Reorganizes frequency layout from chunked [TTT...HHH...WWW] to

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -865,7 +865,9 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        inv_freq_expanded = (
+            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
+        )
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -827,9 +827,6 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
-        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
-        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
-        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -864,14 +861,23 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
-        self._ensure_inv_freq_initialized(x.device)
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            # The `@dynamic_rope_update` decorator on this forward re-registers
+            # `inv_freq` from the current `position_ids` before the body runs
+            inv_freq = self.inv_freq
+        else:
+            # Recompute on `x.device` to bypass any prior state of `self.inv_freq`,
+            # whether uninit from `to_empty`, swapped via direct `_buffers[k] = ...`,
+            # or host-pinned under FSDP non-persistent buffer offload
+            rope_init_fn: Callable = self.compute_default_rope_parameters
+            if self.rope_type != "default":
+                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, _ = rope_init_fn(self.config, x.device)
         # In contrast to other models, Qwen3VLMoe has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
             position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
-        inv_freq_expanded = (
-            self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
-        )
+        inv_freq_expanded = inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1).to(x.device)
         position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
 
         device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
@@ -883,44 +889,6 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
             sin = emb.sin() * self.attention_scaling
 
         return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
-
-    def _apply(self, fn, recurse=True):
-        # Re-run `rope_init_fn(self.config, new_device)` when `_apply` migrates `inv_freq` /
-        # `original_inv_freq` from `meta` onto a real device, so that the standard
-        # `init_empty_weights()` + `to_empty(device=...)` materialization pattern (also used
-        # by FSDP2 sharding) lands canonical inverse-frequency values on the target device
-        was_meta = self.inv_freq.device.type == "meta"
-        result = super()._apply(fn, recurse=recurse)
-        if was_meta and self.inv_freq.device.type != "meta":
-            rope_init_fn: Callable = self.compute_default_rope_parameters
-            if self.rope_type != "default":
-                rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-            inv_freq, self.attention_scaling = rope_init_fn(self.config, self.inv_freq.device)
-            with torch.no_grad():
-                self.inv_freq.copy_(inv_freq)
-                self.original_inv_freq.copy_(inv_freq)
-        self._inv_freq_id = id(self.inv_freq)
-        return result
-
-    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
-        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
-        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
-        if "dynamic" in self.rope_type or self.rope_type == "longrope":
-            return
-        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
-        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
-        # bytes that overflow fp32 in `inv_freq * position_id`
-        if id(self.inv_freq) == self._inv_freq_id:
-            return
-        rope_init_fn: Callable = self.compute_default_rope_parameters
-        if self.rope_type != "default":
-            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
-        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
-        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
-        # device or dtype; direct assignment mirrors the `register_buffer` method
-        self._buffers["inv_freq"] = inv_freq
-        self._buffers["original_inv_freq"] = inv_freq.clone()
-        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
+++ b/src/transformers/models/qwen3_vl_moe/modeling_qwen3_vl_moe.py
@@ -827,6 +827,9 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
         self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
         self.mrope_section = config.rope_parameters.get("mrope_section", [24, 20, 20])
+        # Sentinel: snapshot of `id(self.inv_freq)`, refreshed by `_apply` and
+        # `_ensure_inv_freq_initialized` whenever the buffer is legitimately replaced
+        self._inv_freq_id = id(self.inv_freq)
 
     @staticmethod
     def compute_default_rope_parameters(
@@ -861,6 +864,7 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
     @torch.no_grad()
     @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
     def forward(self, x, position_ids):
+        self._ensure_inv_freq_initialized(x.device)
         # In contrast to other models, Qwen3VLMoe has different position ids for the grids
         # So we expand the inv_freq to shape (3, ...)
         if position_ids.ndim == 2:
@@ -895,7 +899,28 @@ class Qwen3VLMoeTextRotaryEmbedding(nn.Module):
             with torch.no_grad():
                 self.inv_freq.copy_(inv_freq)
                 self.original_inv_freq.copy_(inv_freq)
+        self._inv_freq_id = id(self.inv_freq)
         return result
+
+    def _ensure_inv_freq_initialized(self, target_device: torch.device) -> None:
+        # `dynamic` and `longrope` rope types swap `inv_freq` for a seq-len-scaled
+        # variant on the fly via `register_buffer`, changing its `id()` -- skip to avoid stomping that
+        if "dynamic" in self.rope_type or self.rope_type == "longrope":
+            return
+        # A mismatch here means `_buffers["inv_freq"]` was rewritten via a path that
+        # bypasses `_apply` / `register_buffer`, leaving `inv_freq` with uninitialized
+        # bytes that overflow fp32 in `inv_freq * position_id`
+        if id(self.inv_freq) == self._inv_freq_id:
+            return
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, target_device)
+        # Replace (not `copy_`) because the externally-assigned tensor may have wrong
+        # device or dtype; direct assignment mirrors the `register_buffer` method
+        self._buffers["inv_freq"] = inv_freq
+        self._buffers["original_inv_freq"] = inv_freq.clone()
+        self._inv_freq_id = id(self.inv_freq)
 
     def apply_interleaved_mrope(self, freqs, mrope_section):
         """Apply interleaved MRoPE to 3D rotary embeddings.

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -525,7 +525,7 @@ class Qwen3VLTextModelPositionIdsTest(unittest.TestCase):
 
 
 @require_torch
-class Qwen3VLMRopeCrossDeviceTest(unittest.TestCase):
+class Qwen3VLMRopeBufferMaterializationTest(unittest.TestCase):
     @parameterized.expand(MROPE_CROSS_DEVICE_CASES)
     @require_torch_accelerator
     def test_rotary_embedding_handles_cross_device_buffer(
@@ -545,3 +545,33 @@ class Qwen3VLMRopeCrossDeviceTest(unittest.TestCase):
         cos, sin = rotary(x, position_ids)
         self.assertEqual(cos.device.type, torch.device(torch_device).type)
         self.assertEqual(sin.device.type, torch.device(torch_device).type)
+
+    @parameterized.expand(MROPE_CROSS_DEVICE_CASES)
+    @require_torch_accelerator
+    def test_rotary_embedding_reinitializes_after_to_empty(
+        self,
+        _name: str,
+        config_cls: type[PreTrainedConfig],
+        rotary_cls: type["torch.nn.Module"],
+    ) -> None:
+        config = config_cls()
+        rotary = rotary_cls(config, device="meta")
+        self.assertEqual(rotary.inv_freq.device.type, "meta")
+
+        rotary.to_empty(device=torch_device)
+        self.assertEqual(rotary.inv_freq.device.type, torch.device(torch_device).type)
+
+        # Without the `_apply` re-init, `to_empty` would leave both buffers with uninitialized
+        # storage from the caching allocator's free-list, and `inv_freq * position_id` would
+        # overflow fp32 at the first large position
+        self.assertEqual(rotary.rope_type, "default")
+        canonical, _ = rotary.compute_default_rope_parameters(config, torch.device(torch_device))
+        torch.testing.assert_close(rotary.inv_freq, canonical)
+        torch.testing.assert_close(rotary.original_inv_freq, canonical)
+
+        bsz, seq_len = 1, 8
+        x = torch.randn(bsz, seq_len, config.hidden_size, device=torch_device, dtype=torch.bfloat16)
+        position_ids = torch.arange(seq_len, device=torch_device)[None, :]
+        cos, sin = rotary(x, position_ids)
+        self.assertTrue(torch.isfinite(cos).all())
+        self.assertTrue(torch.isfinite(sin).all())

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -575,3 +575,33 @@ class Qwen3VLMRopeBufferMaterializationTest(unittest.TestCase):
         cos, sin = rotary(x, position_ids)
         self.assertTrue(torch.isfinite(cos).all())
         self.assertTrue(torch.isfinite(sin).all())
+
+    @parameterized.expand(MROPE_CROSS_DEVICE_CASES)
+    @require_torch_accelerator
+    def test_rotary_embedding_recovers_from_direct_buffers_reassignment(
+        self,
+        _name: str,
+        config_cls: type[PreTrainedConfig],
+        rotary_cls: type["torch.nn.Module"],
+    ) -> None:
+        config = config_cls()
+        rotary = rotary_cls(config)
+
+        # Simulates the FSDP2 helper pattern used by SkyRL's `_sync_non_persistent_buffers`
+        # (https://github.com/NovaSky-AI/SkyRL/blob/skyrl-v0.2.0/skyrl/backends/skyrl_train/distributed/fsdp_utils.py#L261-L279):
+        # direct dict assignment into `_buffers` that bypasses the standard buffer-registration paths
+        shape = rotary.inv_freq.shape
+        rotary._buffers["inv_freq"] = torch.empty(shape, dtype=torch.float32, device="cpu")
+        rotary._buffers["original_inv_freq"] = torch.empty(shape, dtype=torch.float32, device="cpu")
+
+        bsz, seq_len = 1, 8
+        x = torch.randn(bsz, seq_len, config.hidden_size, device=torch_device, dtype=torch.bfloat16)
+        position_ids = torch.arange(seq_len, device=torch_device)[None, :]
+        cos, sin = rotary(x, position_ids)
+        self.assertTrue(torch.isfinite(cos).all())
+        self.assertTrue(torch.isfinite(sin).all())
+
+        self.assertEqual(rotary.rope_type, "default")
+        canonical, _ = rotary.compute_default_rope_parameters(config, torch.device(torch_device))
+        torch.testing.assert_close(rotary.inv_freq, canonical)
+        torch.testing.assert_close(rotary.original_inv_freq, canonical)

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -17,8 +17,10 @@ import copy
 import unittest
 
 import pytest
+from parameterized import parameterized
 
 from transformers import (
+    PreTrainedConfig,
     Qwen3VLConfig,
     Qwen3VLForConditionalGeneration,
     Qwen3VLModel,
@@ -27,6 +29,7 @@ from transformers import (
 from transformers.models.qwen3_vl.configuration_qwen3_vl import Qwen3VLTextConfig, Qwen3VLVisionConfig
 from transformers.testing_utils import (
     require_torch,
+    require_torch_accelerator,
     torch_device,
 )
 
@@ -41,6 +44,34 @@ if is_torch_available():
 
 if is_torch_available():
     import torch
+
+    from transformers import (
+        Qwen3_5MoeTextConfig,
+        Qwen3_5TextConfig,
+        Qwen3OmniMoeTalkerTextConfig,
+        Qwen3OmniMoeTextConfig,
+        Qwen3VLMoeTextConfig,
+    )
+    from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5TextRotaryEmbedding
+    from transformers.models.qwen3_5_moe.modeling_qwen3_5_moe import Qwen3_5MoeTextRotaryEmbedding
+    from transformers.models.qwen3_omni_moe.modeling_qwen3_omni_moe import (
+        Qwen3OmniMoeTalkerRotaryEmbedding,
+        Qwen3OmniMoeThinkerTextRotaryEmbedding,
+    )
+    from transformers.models.qwen3_vl.modeling_qwen3_vl import Qwen3VLTextRotaryEmbedding
+    from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextRotaryEmbedding
+
+    # The M-RoPE forward originates in ``Qwen3VLTextRotaryEmbedding`` and is propagated
+    # to descendants. All of them must keep ``inv_freq`` and ``x`` on the same device,
+    # including when ``inv_freq`` lives on CPU under FSDP2 cpu offload
+    MROPE_CROSS_DEVICE_CASES = [
+        ("qwen3_vl", Qwen3VLTextConfig, Qwen3VLTextRotaryEmbedding),
+        ("qwen3_5", Qwen3_5TextConfig, Qwen3_5TextRotaryEmbedding),
+        ("qwen3_5_moe", Qwen3_5MoeTextConfig, Qwen3_5MoeTextRotaryEmbedding),
+        ("qwen3_vl_moe", Qwen3VLMoeTextConfig, Qwen3VLMoeTextRotaryEmbedding),
+        ("qwen3_omni_moe_thinker", Qwen3OmniMoeTextConfig, Qwen3OmniMoeThinkerTextRotaryEmbedding),
+        ("qwen3_omni_moe_talker", Qwen3OmniMoeTalkerTextConfig, Qwen3OmniMoeTalkerRotaryEmbedding),
+    ]
 
 
 class Qwen3VLVisionText2TextModelTester(VLMModelTester):
@@ -491,3 +522,26 @@ class Qwen3VLTextModelPositionIdsTest(unittest.TestCase):
             output = model(input_ids=input_ids, position_ids=position_ids_2d, use_cache=False)
         self.assertEqual(output.last_hidden_state.shape, (batch_size, seq_len, config.hidden_size))
         self.assertTrue(torch.isfinite(output.last_hidden_state).all())
+
+
+@require_torch
+class Qwen3VLMRopeCrossDeviceTest(unittest.TestCase):
+    @parameterized.expand(MROPE_CROSS_DEVICE_CASES)
+    @require_torch_accelerator
+    def test_rotary_embedding_handles_cross_device_buffer(
+        self,
+        _name: str,
+        config_cls: type[PreTrainedConfig],
+        rotary_cls: type["torch.nn.Module"],
+    ) -> None:
+        config = config_cls()
+        rotary = rotary_cls(config)
+        self.assertEqual(rotary.inv_freq.device.type, "cpu")
+
+        bsz, seq_len = 1, 8
+        x = torch.randn(bsz, seq_len, config.hidden_size, device=torch_device, dtype=torch.bfloat16)
+        position_ids = torch.arange(seq_len, device=torch_device)[None, :]
+
+        cos, sin = rotary(x, position_ids)
+        self.assertEqual(cos.device.type, torch.device(torch_device).type)
+        self.assertEqual(sin.device.type, torch.device(torch_device).type)

--- a/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
+++ b/tests/models/qwen3_vl/test_modeling_qwen3_vl.py
@@ -548,60 +548,36 @@ class Qwen3VLMRopeBufferMaterializationTest(unittest.TestCase):
 
     @parameterized.expand(MROPE_CROSS_DEVICE_CASES)
     @require_torch_accelerator
-    def test_rotary_embedding_reinitializes_after_to_empty(
+    def test_rotary_forward_is_canonical_for_uninitialized_buffer_states(
         self,
         _name: str,
         config_cls: type[PreTrainedConfig],
         rotary_cls: type["torch.nn.Module"],
     ) -> None:
         config = config_cls()
-        rotary = rotary_cls(config, device="meta")
-        self.assertEqual(rotary.inv_freq.device.type, "meta")
-
-        rotary.to_empty(device=torch_device)
-        self.assertEqual(rotary.inv_freq.device.type, torch.device(torch_device).type)
-
-        # Without the `_apply` re-init, `to_empty` would leave both buffers with uninitialized
-        # storage from the caching allocator's free-list, and `inv_freq * position_id` would
-        # overflow fp32 at the first large position
-        self.assertEqual(rotary.rope_type, "default")
-        canonical, _ = rotary.compute_default_rope_parameters(config, torch.device(torch_device))
-        torch.testing.assert_close(rotary.inv_freq, canonical)
-        torch.testing.assert_close(rotary.original_inv_freq, canonical)
-
         bsz, seq_len = 1, 8
         x = torch.randn(bsz, seq_len, config.hidden_size, device=torch_device, dtype=torch.bfloat16)
         position_ids = torch.arange(seq_len, device=torch_device)[None, :]
+
+        # Reference: forward output from a freshly-constructed-on-device rotary
+        ref_cos, ref_sin = rotary_cls(config, device=torch_device)(x, position_ids)
+
+        # State 1: meta -> to_empty(target_device) leaves buffer storage uninitialized
+        rotary = rotary_cls(config, device="meta")
+        rotary.to_empty(device=torch_device)
         cos, sin = rotary(x, position_ids)
         self.assertTrue(torch.isfinite(cos).all())
-        self.assertTrue(torch.isfinite(sin).all())
+        torch.testing.assert_close(cos, ref_cos)
+        torch.testing.assert_close(sin, ref_sin)
 
-    @parameterized.expand(MROPE_CROSS_DEVICE_CASES)
-    @require_torch_accelerator
-    def test_rotary_embedding_recovers_from_direct_buffers_reassignment(
-        self,
-        _name: str,
-        config_cls: type[PreTrainedConfig],
-        rotary_cls: type["torch.nn.Module"],
-    ) -> None:
-        config = config_cls()
+        # State 2: direct `_buffers[...] = empty(cpu)` -- the FSDP2 helper pattern used by
+        # SkyRL's `_sync_non_persistent_buffers` that bypassing the standard buffer-registration paths
+        # SEE: https://github.com/NovaSky-AI/SkyRL/blob/skyrl-v0.2.0/skyrl/backends/skyrl_train/distributed/fsdp_utils.py#L261-L279
         rotary = rotary_cls(config)
-
-        # Simulates the FSDP2 helper pattern used by SkyRL's `_sync_non_persistent_buffers`
-        # (https://github.com/NovaSky-AI/SkyRL/blob/skyrl-v0.2.0/skyrl/backends/skyrl_train/distributed/fsdp_utils.py#L261-L279):
-        # direct dict assignment into `_buffers` that bypasses the standard buffer-registration paths
         shape = rotary.inv_freq.shape
         rotary._buffers["inv_freq"] = torch.empty(shape, dtype=torch.float32, device="cpu")
         rotary._buffers["original_inv_freq"] = torch.empty(shape, dtype=torch.float32, device="cpu")
-
-        bsz, seq_len = 1, 8
-        x = torch.randn(bsz, seq_len, config.hidden_size, device=torch_device, dtype=torch.bfloat16)
-        position_ids = torch.arange(seq_len, device=torch_device)[None, :]
         cos, sin = rotary(x, position_ids)
         self.assertTrue(torch.isfinite(cos).all())
-        self.assertTrue(torch.isfinite(sin).all())
-
-        self.assertEqual(rotary.rope_type, "default")
-        canonical, _ = rotary.compute_default_rope_parameters(config, torch.device(torch_device))
-        torch.testing.assert_close(rotary.inv_freq, canonical)
-        torch.testing.assert_close(rotary.original_inv_freq, canonical)
+        torch.testing.assert_close(cos, ref_cos)
+        torch.testing.assert_close(sin, ref_sin)


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/45859
Fixes https://github.com/huggingface/transformers/issues/45902

This PR:
- Adds `.to(x.device)` to `Qwen3VLTextRotaryEmbedding.forward` so the M-RoPE matmul stops raising a CUDA-vs-CPU `wrapper_CUDA_bmm` mismatch when `inv_freq` is host-resident under FSDP2 cpu-offload.
    - My https://github.com/huggingface/transformers/pull/45861 cherry picked here.
- Has Qwen3-VL family M-RoPE rotary embeddings recompute `inv_freq` on the activation device every forward (for non-dynamic rope types) via `rope_init_fn(self.config, x.device)`, making forward output independent of the buffer's prior state.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Who can review?

@ArthurZucker @Cyrilvallez @zucchini-nlp 