### PR TITLE
Forward `revision` to `list_repo_files` in tokenizer loading

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -1682,7 +1682,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         remote_files = []
         if not is_local and not local_files_only:
             try:
-                remote_files = list_repo_files(pretrained_model_name_or_path)
+                remote_files = list_repo_files(pretrained_model_name_or_path, revision=revision)
             except Exception:
                 remote_files = []
         elif pretrained_model_name_or_path and os.path.isdir(pretrained_model_name_or_path):


### PR DESCRIPTION
# What does this PR do?

Fixes https://github.com/huggingface/transformers/issues/45907 (explanation is there as well)

Short version: forward `revision` to `list_repo_files`, matching the convention used three lines above for `list_repo_templates` in the same function. One-line fix!

Otherwise using Kimi-K2.6 as follows with an older revision results in a `ValueError`:

```python
from transformers import AutoTokenizer

# Old revision: no tokenizer.json in this commit, just tiktoken.model + tokenization_kimi.py
AutoTokenizer.from_pretrained(
    "moonshotai/Kimi-K2.6",
    revision="5a49d036ab7472b7d5912ded487150ec1358c11d",
    trust_remote_code=True,
)
```

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
N/A I think?
- [ ] Did you write any new necessary tests?
Also N/A I think

## Who can review?
- tokenizers: @ArthurZucker and @itazap
