### PR TITLE
[CB] Hide activation footprint by using the CUDA graph pool

### DIFF
--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -138,7 +138,9 @@ class ModelRunner:
             forward_fn(*args)
         # Capture using a thread-local capture mode to avoid capturing GPU operations from outside the model forward
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, stream=compute_stream, pool=self.graph_pool_id, capture_error_mode="thread_local"):
+        with torch.cuda.graph(
+            graph, stream=compute_stream, pool=self.graph_pool_id, capture_error_mode="thread_local"
+        ):
             forward_fn(*args)
         # Store
         self.inputs_and_outputs.set_graph(graph)

--- a/src/transformers/generation/continuous_batching/model_runner.py
+++ b/src/transformers/generation/continuous_batching/model_runner.py
@@ -25,7 +25,7 @@ from .cache import PagedAttentionCache
 from .cb_logits_processors import ContinuousBatchingLogitsProcessorList
 from .input_outputs import ContinuousBatchingAsyncIOs, ContinuousBatchingIOs
 from .requests import RequestStatus, logger
-from .utils import create_warmup_future_states, pad_to_interval, pad_to_pow2
+from .utils import create_warmup_future_states, get_cuda_pools, mem_pool_ctx, pad_to_interval, pad_to_pow2
 
 
 class ModelRunner:
@@ -58,9 +58,9 @@ class ModelRunner:
 
         # Set up the graph pool. This allows all graphs to share the same memory pool, greatly saving memory.
         if self.use_cuda_graph_varlen or self.use_cuda_graph_decode:
-            self.graph_pool = torch.cuda.graph_pool_handle()
+            self.mem_pool, self.graph_pool_id = get_cuda_pools()
         else:
-            self.graph_pool = None
+            self.mem_pool, self.graph_pool_id = None, None
 
         # Set up compiled version of the forward pass for the varlen path
         self._compiled_varlen = None
@@ -134,11 +134,11 @@ class ModelRunner:
     def _capture_graph(self, forward_fn: Callable, compute_stream: torch.cuda.Stream, *args) -> None:
         """Helper function to capture and store a graph for a given forward function."""
         # Warmup (ensures the right result is computed before capturing the graph)
-        with torch.cuda.stream(compute_stream):
+        with torch.cuda.stream(compute_stream), mem_pool_ctx(self.mem_pool):
             forward_fn(*args)
         # Capture using a thread-local capture mode to avoid capturing GPU operations from outside the model forward
         graph = torch.cuda.CUDAGraph()
-        with torch.cuda.graph(graph, stream=compute_stream, pool=self.graph_pool, capture_error_mode="thread_local"):
+        with torch.cuda.graph(graph, stream=compute_stream, pool=self.graph_pool_id, capture_error_mode="thread_local"):
             forward_fn(*args)
         # Store
         self.inputs_and_outputs.set_graph(graph)

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import OrderedDict
+from contextlib import contextmanager
 from dataclasses import dataclass
 from math import ceil, log2
 from typing import Any
@@ -19,6 +20,7 @@ from typing import Any
 import torch
 
 from transformers.configuration_utils import PretrainedConfig
+from transformers.utils import is_torch_greater_or_equal
 
 from .requests import FutureRequestState, RequestState, RequestStatus, logger
 
@@ -204,3 +206,25 @@ def create_warmup_future_states(
             FutureRequestState(state, has_new_token=True, complete_blocks=0, query_length=num_q_tokens)
         )
     return future_states
+
+def get_cuda_pools():  # no type hint because it would make torch 2.4 crash
+    """Returns a tuple of (mem_pool, graph_pool_id) for CUDA graphs. Since the MemPool object is only available in torch
+    2.5+, we only return a graph_pool_id for older versions."""
+    if is_torch_greater_or_equal("2.5.0"):
+        mem_pool = torch.cuda.MemPool()
+        graph_pool_id = mem_pool.id
+        return mem_pool, graph_pool_id
+    else:
+        mem_pool = None
+        graph_pool_id = torch.cuda.graph_pool_handle()
+        return mem_pool, graph_pool_id
+
+@contextmanager
+def mem_pool_ctx(mem_pool):
+    """A context manager to use a CUDA mem pool. If the mem pool is None, it is a no-op. No type hint because it would
+    make torch 2.4 or below crash."""
+    if mem_pool is not None:
+        with torch.cuda.use_mem_pool(mem_pool):
+            yield
+    else:
+        yield

--- a/src/transformers/generation/continuous_batching/utils.py
+++ b/src/transformers/generation/continuous_batching/utils.py
@@ -207,6 +207,7 @@ def create_warmup_future_states(
         )
     return future_states
 
+
 def get_cuda_pools():  # no type hint because it would make torch 2.4 crash
     """Returns a tuple of (mem_pool, graph_pool_id) for CUDA graphs. Since the MemPool object is only available in torch
     2.5+, we only return a graph_pool_id for older versions."""
@@ -218,6 +219,7 @@ def get_cuda_pools():  # no type hint because it would make torch 2.4 crash
         mem_pool = None
         graph_pool_id = torch.cuda.graph_pool_handle()
         return mem_pool, graph_pool_id
+
 
 @contextmanager
 def mem_pool_ctx(mem_pool):


### PR DESCRIPTION
After this PR, activations created when warming up for a new CUDA graph catpure will be allocated inside the existing CUDA graph pool, as long as torch version is >= 2.4 . This is because the `Mempool` object of pytorch was inroduced in 2.5 . 
This ensures there is no OOM when warming for a new CUDA graph, which could previously happen because CB did not budget for two sets of activations on the GPU at the same time. 

## Performance

No major change. Peak VRAM used goes down as expected. Investigating a weird 16K rollout number.

## Tests

TBD