### PR TITLE
Block image_start/end_token_id in generation test sampling

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -181,6 +181,8 @@ class GenerationTesterMixin:
                 "audio_start_token_id",
                 "audio_end_token_id",
                 "vision_end_token_id",
+                "image_start_token_id",
+                "image_end_token_id",
             ]:
                 token_index = getattr(config, key, None)
                 if token_index is None and hasattr(self, "model_tester"):


### PR DESCRIPTION
Some tests were flaky because of VLM special tokens in the random outputs. This PR adds a few more tokens to the exclusion list. Fixes tests/models/glm_image/test_modeling_glm_image.py::GlmImageModelTest::test_sample_generate_dict_output among others.