### PR TITLE
Fix AutoTokenizer using wrong tokenizer class for olmo2, granite, granitemoehybrid, hyperclovax, and ernie models

### DIFF
--- a/src/transformers/models/auto/tokenization_auto.py
+++ b/src/transformers/models/auto/tokenization_auto.py
@@ -383,6 +383,11 @@ MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS: set[str] = {
     "step3_vl",
     "vipllava",
     "cohere_asr",
+    "ernie",
+    "granite",
+    "granitemoehybrid",
+    "hyperclovax",
+    "olmo2",
 }
 
 for model_type in MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS:


### PR DESCRIPTION
Fixes #45920

Several model types have a `tokenizer_class` field in their Hub `tokenizer_config.json` that points to a slow tokenizer (e.g., `GPT2Tokenizer`, `LlamaTokenizer`), while the model was actually trained with the corresponding fast tokenizer. When `AutoTokenizer.from_pretrained()` loads these models, it instantiates the slow variant, producing incorrect token IDs because the slow and fast tokenizers have different pretokenization algorithms.

This is the same root cause as the already-fixed `deepseek_v2`, `deepseek_v3`, `deepseek_v4`, and `qwen2` entries in `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS`. This PR extends that fix to cover five more affected model families:

- `olmo2` — affected models include `allenai/OLMo-2-0425-1B` (~83K monthly downloads). Hub `tokenizer_class` is `GPT2Tokenizer`, should use `TokenizersBackend`.
- - `granite` / `granitemoehybrid` — affected models include `ibm-granite/granite-4.1-8b` (~14K), `ibm-granite/granite-4.0-micro` (~400K). Hub `tokenizer_class` is `GPT2Tokenizer`.
- - `hyperclovax` — affected models include `naver-hyperclovax/HyperCLOVAX-SEED-Think-14B` (~39K). Hub `tokenizer_class` is `GPT2Tokenizer`. (`hyperclovax_vlm` was already in the list, but the base `hyperclovax` model type was missing.)
- - `ernie` — affected models include `baidu/ERNIE-4.5-21B-A3B-Thinking` (~35K). Hub `tokenizer_class` is `LlamaTokenizer`.
Users can verify the regression by comparing `AutoTokenizer.from_pretrained(model_id)` output against `PreTrainedTokenizerFast.from_pretrained(model_id)` — without this fix, they return different token IDs for the same input string.