### PR TITLE
[pp_formulanet] Fix polynomial ReDoS in remove_chinese_text_wrapping

### DIFF
--- a/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/modular_pp_formulanet.py
@@ -163,8 +163,12 @@ class PPFormulaNetProcessor(NougatProcessor):
         self._rule_noletter_letter = re.compile(r"(?!\\ )(%s)\s+?(%s)" % (noletter, letter))
         self._rule_letter_noletter = re.compile(r"(%s)\s+?(%s)" % (letter, noletter))
 
-        # remove_chinese_text_wrapping() regex
-        self._chinese_text_wrapping_pattern = re.compile(r"\\text\s*{([^{}]*[\u4e00-\u9fff]+[^{}]*)}")
+        # remove_chinese_text_wrapping() regex. The body must stay a single
+        # quantified character class: overlapping `[^{}]*` quantifiers around
+        # an inner CJK class let the engine re-partition long CJK runs and
+        # take cubic time to fail on an unclosed brace. The CJK predicate is
+        # enforced in Python inside `remove_chinese_text_wrapping` instead.
+        self._chinese_text_wrapping_pattern = re.compile(r"\\text\s*{([^{}]*)}")
 
     def __call__(
         self,
@@ -217,7 +221,13 @@ class PPFormulaNetProcessor(NougatProcessor):
 
     def remove_chinese_text_wrapping(self, formula: str) -> str:
         def replacer(match):
-            return match.group(1)
+            body = match.group(1)
+            # Only strip the wrapping when the body contains at least one
+            # CJK Unified Ideograph (U+4E00 to U+9FFF); otherwise keep the
+            # original `\text{...}` substring untouched.
+            if any("一" <= ch <= "鿿" for ch in body):
+                return body
+            return match.group(0)
 
         replaced_formula = self._chinese_text_wrapping_pattern.sub(replacer, formula)
         return replaced_formula.replace('"', "")

--- a/src/transformers/models/pp_formulanet/processing_pp_formulanet.py
+++ b/src/transformers/models/pp_formulanet/processing_pp_formulanet.py
@@ -50,8 +50,12 @@ class PPFormulaNetProcessor(ProcessorMixin):
         self._rule_noletter_letter = re.compile(r"(?!\\ )(%s)\s+?(%s)" % (noletter, letter))
         self._rule_letter_noletter = re.compile(r"(%s)\s+?(%s)" % (letter, noletter))
 
-        # remove_chinese_text_wrapping() regex
-        self._chinese_text_wrapping_pattern = re.compile(r"\\text\s*{([^{}]*[\u4e00-\u9fff]+[^{}]*)}")
+        # remove_chinese_text_wrapping() regex. The body must stay a single
+        # quantified character class: overlapping `[^{}]*` quantifiers around
+        # an inner CJK class let the engine re-partition long CJK runs and
+        # take cubic time to fail on an unclosed brace. The CJK predicate is
+        # enforced in Python inside `remove_chinese_text_wrapping` instead.
+        self._chinese_text_wrapping_pattern = re.compile(r"\\text\s*{([^{}]*)}")
 
     @auto_docstring
     def __call__(
@@ -127,7 +131,13 @@ class PPFormulaNetProcessor(ProcessorMixin):
 
     def remove_chinese_text_wrapping(self, formula: str) -> str:
         def replacer(match):
-            return match.group(1)
+            body = match.group(1)
+            # Only strip the wrapping when the body contains at least one
+            # CJK Unified Ideograph (U+4E00 to U+9FFF); otherwise keep the
+            # original `\text{...}` substring untouched.
+            if any("一" <= ch <= "鿿" for ch in body):
+                return body
+            return match.group(0)
 
         replaced_formula = self._chinese_text_wrapping_pattern.sub(replacer, formula)
         return replaced_formula.replace('"', "")

--- a/tests/models/pp_formulanet/test_processing_pp_formulanet.py
+++ b/tests/models/pp_formulanet/test_processing_pp_formulanet.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 import unittest
 
 from transformers import PPFormulaNetProcessor
@@ -57,3 +58,51 @@ class PPFormulaNetProcessorTest(ProcessorTesterMixin, unittest.TestCase):
     @unittest.skip(reason="PPFormulaNet does not need input_ids")
     def test_kwargs_overrides_default_tokenizer_kwargs(self):
         pass
+
+    def test_remove_chinese_text_wrapping_strips_cjk_wrapping(self):
+        processor = self.get_processor()
+        self.assertEqual(processor.remove_chinese_text_wrapping("\\text{中文}"), "中文")
+        # `\s*` between `\text` and `{` is allowed.
+        self.assertEqual(processor.remove_chinese_text_wrapping("\\text  {中}"), "中")
+        # Embedded double quotes are stripped after the match (existing behaviour).
+        self.assertEqual(processor.remove_chinese_text_wrapping('\\text{"中"}'), "中")
+        # Multiple wrappings: CJK ones get stripped, non-CJK ones left alone.
+        self.assertEqual(
+            processor.remove_chinese_text_wrapping("\\text{中}A\\text{B}"),
+            "中A\\text{B}",
+        )
+
+    def test_remove_chinese_text_wrapping_leaves_non_cjk_untouched(self):
+        processor = self.get_processor()
+        # No CJK in body -> wrapping preserved.
+        self.assertEqual(processor.remove_chinese_text_wrapping("\\text{ABC}"), "\\text{ABC}")
+        # Empty body -> wrapping preserved.
+        self.assertEqual(processor.remove_chinese_text_wrapping("\\text{}"), "\\text{}")
+        # Plain LaTeX with no `\text{...}` is untouched.
+        self.assertEqual(
+            processor.remove_chinese_text_wrapping("a + b = c"),
+            "a + b = c",
+        )
+
+    def test_remove_chinese_text_wrapping_unclosed_brace_is_linear(self):
+        # Regression test for the polynomial-ReDoS in the previous
+        # `\\text\s*{([^{}]*[一-鿿]+[^{}]*)}` pattern: the overlapping
+        # `[^{}]*` quantifiers around an inner CJK class caused cubic
+        # backtracking on `\text{` followed by a long CJK run with no closing
+        # brace. On the unpatched code, the call below takes tens of seconds
+        # for ~10 KB of CJK input; on the patched code it returns in under a
+        # millisecond. The 2-second budget is intentionally loose so this
+        # test stays robust on slow CI runners.
+        processor = self.get_processor()
+        payload = "\\text{" + ("中" * 3200)
+        start = time.perf_counter()
+        result = processor.remove_chinese_text_wrapping(payload)
+        elapsed = time.perf_counter() - start
+        self.assertLess(
+            elapsed,
+            2.0,
+            f"remove_chinese_text_wrapping took {elapsed:.3f}s on an unclosed-brace CJK input; "
+            "regex may have regressed to the cubic-backtracking pattern.",
+        )
+        # No closing brace -> no replacement applied.
+        self.assertEqual(result, payload)


### PR DESCRIPTION
## Summary

Fixes a polynomial ReDoS in `PPFormulaNetProcessor.remove_chinese_text_wrapping`. 

Reported via huntr: https://huntr.com/bounties/72f2cbf7-60af-4c21-89ba-1265f7ba2088


The pattern compiled in PPFormulaNetProcessor.__init__:

    re.compile(r"\\text\s*{([^{}]*[一-鿿]+[^{}]*)}")

has overlapping greedy `[^{}]*` quantifiers around an inner CJK class. `[一-鿿]` is a strict subset of `[^{}]`, so a run of CJK characters can be re-partitioned by the engine in O(N^2) ways. When the closing `}` is missing the engine then walks the tail O(N) times before failing each split, giving O(N^3) total work. A ~10 KB `\text{` + CJK input pins one CPU core for ~50 seconds.

The vulnerable method is reachable from public API: `PPFormulaNetProcessor.post_process_generation(text: str)` and `remove_chinese_text_wrapping(formula: str)` both accept attacker-supplied strings, and a truncated `generate(..., max_new_tokens=K)` that stops inside a `\text{...}` block feeds the same shape into the post-processor with no attacker required.

Fix: drop the inner CJK class from the regex and enforce the CJK predicate in the Python replacer. The body is now `[^{}]*`, a single quantified class the engine cannot re-partition; matching is linear in input length. Semantics are preserved -- the wrapping is still only stripped when the body contains at least one CJK ideograph and no nested braces.

Verified on a 12800-char unclosed-brace CJK payload: 0.12 ms patched vs. tens of seconds unpatched, plus equivalence on closed/empty/ nested-brace/whitespace/mixed inputs against the previous regex.
