### PR TITLE
Fix OLMo 3 scaled RoPE handling for sliding attention

### DIFF
--- a/src/transformers/models/olmo3/modeling_olmo3.py
+++ b/src/transformers/models/olmo3/modeling_olmo3.py
@@ -268,14 +268,14 @@ class Olmo3DecoderLayer(GradientCheckpointingLayer):
 class Olmo3RotaryEmbedding(nn.Module):
     inv_freq: torch.Tensor  # fix linting for `register_buffer`
 
-    def __init__(self, config: Olmo3Config, device=None):
+    def __init__(self, config: Olmo3Config, device=None, rope_type: str | None = None):
         super().__init__()
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
 
-        self.rope_type = self.config.rope_parameters["rope_type"]
+        self.rope_type = rope_type or self.config.rope_parameters["rope_type"]
         rope_init_fn: Callable = self.compute_default_rope_parameters
         if self.rope_type != "default":
             rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
@@ -361,8 +361,13 @@ class Olmo3Model(Olmo3PreTrainedModel):
             [Olmo3DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
         self.norm = Olmo3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.rotary_emb = Olmo3RotaryEmbedding(config=config)
         self.gradient_checkpointing = False
+        self.rotary_embs = nn.ModuleDict(
+            {
+                "sliding_attention": Olmo3RotaryEmbedding(config=config, rope_type="default"),
+                "full_attention": Olmo3RotaryEmbedding(config=config),
+            }
+        )
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -411,7 +416,10 @@ class Olmo3Model(Olmo3PreTrainedModel):
             }
 
         hidden_states = inputs_embeds
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        position_embeddings_mapping = {
+            "sliding_attention": self.rotary_embs["sliding_attention"](hidden_states, position_ids),
+            "full_attention": self.rotary_embs["full_attention"](hidden_states, position_ids),
+        }
 
         for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
             hidden_states = decoder_layer(
@@ -419,7 +427,7 @@ class Olmo3Model(Olmo3PreTrainedModel):
                 attention_mask=causal_mask_mapping[self.config.layer_types[i]],
                 position_ids=position_ids,
                 past_key_values=past_key_values,
-                position_embeddings=position_embeddings,
+                position_embeddings=position_embeddings_mapping[self.config.layer_types[i]],
                 **kwargs,
             )
 

--- a/src/transformers/models/olmo3/modular_olmo3.py
+++ b/src/transformers/models/olmo3/modular_olmo3.py
@@ -21,6 +21,7 @@ from huggingface_hub.dataclasses import strict
 from ...cache_utils import Cache, DynamicCache
 from ...masking_utils import create_causal_mask, create_sliding_window_causal_mask
 from ...modeling_outputs import BaseModelOutputWithPast
+from ...modeling_rope_utils import ROPE_INIT_FUNCTIONS
 from ...modeling_utils import ALL_ATTENTION_FUNCTIONS
 from ...processing_utils import Unpack
 from ...utils import auto_docstring
@@ -154,8 +155,24 @@ class Olmo3DecoderLayer(Olmo2DecoderLayer):
     pass
 
 
+# OLMo 3 RoPE is identical to Gemma2 RoPE, except:
+# - RoPE scaling is not applied to sliding window attention layers.
 class Olmo3RotaryEmbedding(Gemma2RotaryEmbedding):
-    pass
+    def __init__(self, config: Olmo3Config, device=None, rope_type: str | None = None):
+        nn.Module.__init__(self)
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+
+        self.rope_type = rope_type or self.config.rope_parameters["rope_type"]
+        rope_init_fn: Callable = self.compute_default_rope_parameters
+        if self.rope_type != "default":
+            rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+        inv_freq, self.attention_scaling = rope_init_fn(self.config, device)
+
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.register_buffer("original_inv_freq", inv_freq.clone(), persistent=False)
 
 
 class Olmo3PreTrainedModel(Olmo2PreTrainedModel):
@@ -172,7 +189,13 @@ class Olmo3Model(Olmo2Model):
         self.layers = nn.ModuleList(
             [Olmo3DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
-        self.rotary_emb = Olmo3RotaryEmbedding(config=config)
+        self.rotary_embs = nn.ModuleDict(
+            {
+                "sliding_attention": Olmo3RotaryEmbedding(config=config, rope_type="default"),
+                "full_attention": Olmo3RotaryEmbedding(config=config),
+            }
+        )
+        del self.rotary_emb
 
     def forward(
         self,
@@ -215,7 +238,10 @@ class Olmo3Model(Olmo2Model):
             }
 
         hidden_states = inputs_embeds
-        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        position_embeddings_mapping = {
+            "sliding_attention": self.rotary_embs["sliding_attention"](hidden_states, position_ids),
+            "full_attention": self.rotary_embs["full_attention"](hidden_states, position_ids),
+        }
 
         for i, decoder_layer in enumerate(self.layers[: self.config.num_hidden_layers]):
             hidden_states = decoder_layer(
@@ -223,7 +249,7 @@ class Olmo3Model(Olmo2Model):
                 attention_mask=causal_mask_mapping[self.config.layer_types[i]],
                 position_ids=position_ids,
                 past_key_values=past_key_values,
-                position_embeddings=position_embeddings,
+                position_embeddings=position_embeddings_mapping[self.config.layer_types[i]],
                 **kwargs,
             )
 

--- a/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
+++ b/src/transformers/models/olmo_hybrid/modeling_olmo_hybrid.py
@@ -418,14 +418,14 @@ class OlmoHybridRotaryEmbedding(nn.Module):
 
     inv_freq: torch.Tensor  # fix linting for `register_buffer`
 
-    def __init__(self, config: OlmoHybridConfig, device=None):
+    def __init__(self, config: OlmoHybridConfig, device=None, rope_type: str | None = None):
         super().__init__()
         self.max_seq_len_cached = config.max_position_embeddings
         self.original_max_seq_len = config.max_position_embeddings
 
         self.config = config
 
-        self.rope_type = self.config.rope_parameters["rope_type"]
+        self.rope_type = rope_type or self.config.rope_parameters["rope_type"]
         rope_init_fn: Callable = self.compute_default_rope_parameters
         if self.rope_type != "default":
             rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]

--- a/tests/models/olmo3/test_modeling_olmo3.py
+++ b/tests/models/olmo3/test_modeling_olmo3.py
@@ -97,6 +97,37 @@ class Olmo3ModelTest(CausalLMModelTest, unittest.TestCase):
         # The output should be different for long inputs
         self.assertFalse(torch.allclose(original_long_output, scaled_long_output, atol=1e-5))
 
+    def test_sliding_attention_uses_default_rope_with_scaled_config(self):
+        config, _ = self.model_tester.prepare_config_and_inputs_for_common()
+        config.num_hidden_layers = 2
+        config.layer_types = ["sliding_attention", "full_attention"]
+        config.rope_parameters = {"rope_type": "yarn", "factor": 10.0, "rope_theta": 10_000.0}
+
+        model = self.model_tester_class.base_model_class(config)
+        model.to(torch_device)
+        model.eval()
+
+        self.assertEqual(model.rotary_embs["sliding_attention"].rope_type, "default")
+        self.assertEqual(model.rotary_embs["full_attention"].rope_type, "yarn")
+
+        x = torch.randn(1, 10, config.hidden_size, device=torch_device)
+        position_ids = torch.arange(10, dtype=torch.long, device=torch_device).unsqueeze(0)
+
+        sliding_cos, sliding_sin = model.rotary_embs["sliding_attention"](x, position_ids)
+        full_cos, full_sin = model.rotary_embs["full_attention"](x, position_ids)
+
+        default_rope = Olmo3RotaryEmbedding(config=config, rope_type="default")
+        default_rope.to(torch_device)
+        default_cos, default_sin = default_rope(x, position_ids)
+
+        torch.testing.assert_close(sliding_cos, default_cos)
+        torch.testing.assert_close(sliding_sin, default_sin)
+
+        with self.assertRaises(AssertionError):
+            torch.testing.assert_close(sliding_cos, full_cos)
+        with self.assertRaises(AssertionError):
+            torch.testing.assert_close(sliding_sin, full_sin)
+
     def test_model_rope_scaling_frequencies(self):
         """Tests the frequency properties of the different RoPE scaling types on the model RoPE layer."""
         config, _ = self.model_tester.prepare_config_and_inputs_for_common()


### PR DESCRIPTION
## Summary

- Restores OLMo 3 per-layer rotary embeddings after the [RoPE layer-type refactor](https://github.com/huggingface/transformers/pull/39847/files#diff-036fcee5ab04376314d213c74252019c66043aa88b7b65d9c5e55e0b8e90265cL302).  
- Uses default, unscaled RoPE for `sliding_attention` layers and configured RoPE for `full_attention` layers.
- Keeps the current `Gemma2RotaryEmbedding` forward behavior, including returning `cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)`.
- Adds a unit test that catches the regression with a mixed sliding/full attention config and YARN RoPE.

## Context

`Olmo3Model` documents that RoPE scaling is not applied to sliding-window attention layers, but the current implementation computes one configured rotary embedding and passes it to every layer. OLMo 3 needs layer-type-specific RoPE: default RoPE for sliding attention and configured/scaled RoPE for full attention.

## Test plan

- `PYTHONPATH=src python utils/check_modular_conversion.py --files src/transformers/models/olmo3/modular_olmo3.py --num_workers 1`
- `ruff check src/transformers/models/olmo3/modular_olmo3.py src/transformers/models/olmo3/modeling_olmo3.py tests/models/olmo3/test_modeling_olmo3.py`
- `git diff --check`
- `PYTHONPATH=src pytest tests/models/olmo3/test_modeling_olmo3.py -k sliding_attention_uses_default_rope_with_scaled_config -q`

AI assistance was used to prepare this PR. I reviewed the generated diff and am responsible for the change.
