### PR TITLE
hf_argparser: fix parse_yaml_file missing utf-8 encoding and wrong docstring

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -414,7 +414,7 @@ class HfArgumentParser(ArgumentParser):
             yaml_file (`str` or `os.PathLike`):
                 File name of the yaml file to parse
             allow_extra_keys (`bool`, *optional*, defaults to `False`):
-                Defaults to False. If False, will raise an exception if the json file contains keys that are not
+                Defaults to False. If False, will raise an exception if the yaml file contains keys that are not
                 parsed.
 
         Returns:
@@ -422,5 +422,5 @@ class HfArgumentParser(ArgumentParser):
 
                 - the dataclass instances in the same order as they were passed to the initializer.
         """
-        outputs = self.parse_dict(yaml.safe_load(Path(yaml_file).read_text()), allow_extra_keys=allow_extra_keys)
+        outputs = self.parse_dict(yaml.safe_load(Path(yaml_file).read_text(encoding="utf-8")), allow_extra_keys=allow_extra_keys)
         return tuple(outputs)

--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -422,5 +422,7 @@ class HfArgumentParser(ArgumentParser):
 
                 - the dataclass instances in the same order as they were passed to the initializer.
         """
-        outputs = self.parse_dict(yaml.safe_load(Path(yaml_file).read_text(encoding="utf-8")), allow_extra_keys=allow_extra_keys)
+        outputs = self.parse_dict(
+            yaml.safe_load(Path(yaml_file).read_text(encoding="utf-8")), allow_extra_keys=allow_extra_keys
+        )
         return tuple(outputs)


### PR DESCRIPTION
# What does this PR do?

Fixes two small issues in `parse_yaml_file` that were introduced as copy-paste errors from `parse_json_file`.

**Bug 1 — Missing `encoding="utf-8"` (line 425)**

`parse_json_file` explicitly opens files with `encoding="utf-8"`:
```python
with open(Path(json_file), encoding="utf-8") as open_json_file:
```
But `parse_yaml_file` uses `Path.read_text()` without specifying encoding:
```python
yaml.safe_load(Path(yaml_file).read_text())
```
On Windows, `read_text()` defaults to the system locale encoding (e.g. `cp1252`), not utf-8. YAML files containing non-ASCII characters will silently corrupt or raise a `UnicodeDecodeError` on non-utf-8 systems. The fix adds `encoding="utf-8"` to match `parse_json_file`.

**Bug 2 — Wrong word in docstring (line 417)**

The `allow_extra_keys` description says `"the json file contains keys"` — a copy-paste error from `parse_json_file`. Changed to `"the yaml file"`.

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the forum?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
@ArthurZucker