### PR TITLE
Strip language_model. prefix when loading multimodal Gemma 4 checkpoint into Gemma4ForCausalLM

### DIFF
--- a/src/transformers/conversion_mapping.py
+++ b/src/transformers/conversion_mapping.py
@@ -493,6 +493,7 @@ def _build_checkpoint_conversion_mapping():
             WeightRenaming("attention_layer_norm", "input_layernorm"),
             WeightRenaming("feedforward_layer_norm", "post_attention_layernorm"),
         ],
+        "gemma4_text": [PrefixChange(prefix_to_remove="language_model", model_prefix="model")],
         "qwen3_5_text": [PrefixChange(prefix_to_remove="language_model", model_prefix="model")],
         "sam3_tracker": [
             WeightRenaming(


### PR DESCRIPTION
## What does this PR do?

Adds the `gemma4_text` entry to `_build_checkpoint_conversion_mapping` —
one line, adjacent to the existing analogue for `qwen3_5_text`:

```python
"gemma4_text": [PrefixChange(prefix_to_remove="language_model", model_prefix="model")],
"qwen3_5_text": [PrefixChange(prefix_to_remove="language_model", model_prefix="model")],
```

On-disk, `google/gemma-4-E4B-it` is a `Gemma4ForConditionalGeneration`
checkpoint with the language model under `model.language_model.*`.
`AutoModelForCausalLM.from_pretrained(...)` dispatches to the multimodal
class — keys align natively and it works correctly. The broken path is
the text-only class itself: anyone calling
`Gemma4ForCausalLM.from_pretrained("google/gemma-4-E4B-it")` directly
(e.g. fine-tuning / retrofit that doesn't need the vision + audio
towers) gets a silent prefix mismatch — every `model.layers.{0..41}.*`,
`embed_tokens`, `lm_head` is MISSING; every
`model.language_model.layers.*` is UNEXPECTED; the model initialises
from random weights with only a
`tied weights mapping … both are absent from the checkpoint` warning.

Reproducer (pure HF, no other deps):

```python
import torch
from transformers import AutoConfig
from transformers.models.gemma4.modeling_gemma4 import Gemma4ForCausalLM

cfg = AutoConfig.from_pretrained("google/gemma-4-E4B-it").get_text_config()
m = Gemma4ForCausalLM.from_pretrained("google/gemma-4-E4B-it", config=cfg, dtype=torch.bfloat16)
w = m.model.layers[0].self_attn.q_proj.weight.detach().float()
print(w.mean(), w.std())   # ≈ (-4e-6, 0.0199) — HF default Gaussian init, not Gemma weights
```

After the patch the same reproducer shows trained-weight statistics and
the missing-keys list is empty. The entry is keyed on
`model_type == "gemma4_text"` and is a strict no-op for every other
model type — no existing checkpoint loads differently.

## Before submitting

- [x] I confirm that this is not a pure code agent PR.
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [x] Did you make sure to update the documentation with your changes? — N/A, internal weight-conversion mapping.
- [x] Did you write any new necessary tests? — The mirrored `qwen3_5_text` entry has no dedicated unit test either; happy to add one if reviewers prefer.

## Who can review?

@Cyrilvallez (model loading / `from_pretrained`)