### PR TITLE
fix(ci): remove template injection on pull_request_target workflows

### DIFF
--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -168,18 +168,24 @@ jobs:
         id: pr_info
         if: ${{ inputs.pr_number != '' }}
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
+          COMMIT_SHA: ${{ inputs.commit_sha }}
         with:
-          script: |            
+          script: |
+            const pull_number = parseInt(process.env.PR_NUMBER, 10);
+            const commit_sha = process.env.COMMIT_SHA;
+
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: ${{ inputs.pr_number }}
+              pull_number,
             });
 
-            const { data: merge_commit }  = await github.rest.repos.getCommit({
+            const { data: merge_commit } = await github.rest.repos.getCommit({
               owner: pr.base.repo.owner.login,
               repo: pr.base.repo.name,
-              ref: '${{ inputs.commit_sha }}',
+              ref: commit_sha,
             });
 
             core.setOutput('merge_commit_base_sha', merge_commit.parents[0].sha);

--- a/.github/workflows/collated-reports.yml
+++ b/.github/workflows/collated-reports.yml
@@ -32,12 +32,16 @@ jobs:
           ACCESS_REPO_INFO_TOKEN: ${{ secrets.ACCESS_REPO_INFO_TOKEN }}
           CI_SHA: ${{ github.sha }}
           TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN: ${{ secrets.TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN }}
+          MACHINE_TYPE: ${{ inputs.machine_type }}
+          JOB: ${{ inputs.job }}
+          REPORT_REPO_ID: ${{ inputs.report_repo_id }}
+          GPU_NAME: ${{ inputs.gpu_name }}
         run: |
           pip install huggingface_hub
-          python3 utils/collated_reports.py                  \
-            --path .                                         \
-            --machine-type ${{ inputs.machine_type }}        \
-            --commit-hash ${{ env.CI_SHA }}                  \
-            --job ${{ inputs.job }}                          \
-            --report-repo-id ${{ inputs.report_repo_id }}    \
-            --gpu-name ${{ inputs.gpu_name }}
+          python3 utils/collated_reports.py \
+            --path . \
+            --machine-type "$MACHINE_TYPE" \
+            --commit-hash "$CI_SHA" \
+            --job "$JOB" \
+            --report-repo-id "$REPORT_REPO_ID" \
+            --gpu-name "$GPU_NAME"

--- a/.github/workflows/get-pr-info.yml
+++ b/.github/workflows/get-pr-info.yml
@@ -90,21 +90,25 @@ jobs:
       - name: Extract PR details
         id: pr_info
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        env:
+          PR_NUMBER: ${{ inputs.pr_number }}
         with:
-          script: |            
+          script: |
+            const pull_number = parseInt(process.env.PR_NUMBER, 10);
+
             const { data: pr } = await github.rest.pulls.get({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: ${{ inputs.pr_number }}
+              pull_number,
             });
 
-            const { data: head_commit }  = await github.rest.repos.getCommit({
+            const { data: head_commit } = await github.rest.repos.getCommit({
               owner: pr.head.repo.owner.login,
               repo: pr.head.repo.name,
               ref: pr.head.ref
             });
 
-            const { data: merge_commit }  = await github.rest.repos.getCommit({
+            const { data: merge_commit } = await github.rest.repos.getCommit({
               owner: pr.base.repo.owner.login,
               repo: pr.base.repo.name,
               ref: pr.merge_commit_sha,
@@ -113,7 +117,7 @@ jobs:
             const { data: files } = await github.rest.pulls.listFiles({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: ${{ inputs.pr_number }}
+              pull_number,
             });
 
             core.setOutput('head_repo_full_name', pr.head.repo.full_name);

--- a/.github/workflows/model_jobs_intel_gaudi.yml
+++ b/.github/workflows/model_jobs_intel_gaudi.yml
@@ -50,19 +50,24 @@ jobs:
     steps:
       - name: Echo input and matrix info
         shell: bash
+        env:
+          FOLDER_SLICES: ${{ inputs.folder_slices }}
+          MATRIX_FOLDERS: ${{ matrix.folders }}
+          SLICE: ${{ toJson(fromJson(inputs.folder_slices)[inputs.slice_id]) }}
         run: |
-          echo "${{ inputs.folder_slices }}"
-          echo "${{ matrix.folders }}"
-          echo "${{ toJson(fromJson(inputs.folder_slices)[inputs.slice_id]) }}"
+          echo "$FOLDER_SLICES"
+          echo "$MATRIX_FOLDERS"
+          echo "$SLICE"
 
       - name: Echo folder ${{ matrix.folders }}
         shell: bash
+        env:
+          MATRIX_FOLDERS: ${{ matrix.folders }}
         run: |
-          echo "${{ matrix.folders }}"
-          matrix_folders=${{ matrix.folders }}
-          matrix_folders=${matrix_folders/'models/'/'models_'}
+          echo "$MATRIX_FOLDERS"
+          matrix_folders="${MATRIX_FOLDERS/'models/'/'models_'}"
           echo "$matrix_folders"
-          echo "matrix_folders=$matrix_folders" >> $GITHUB_ENV
+          echo "matrix_folders=$matrix_folders" >> "$GITHUB_ENV"
 
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -87,30 +92,44 @@ jobs:
 
       - name: Set `machine_type` for report and artifact names
         shell: bash
+        env:
+          MACHINE_TYPE: ${{ inputs.machine_type }}
         run: |
-          if [ "${{ inputs.machine_type }}" = "1gaudi" ]; then
+          if [ "$MACHINE_TYPE" = "1gaudi" ]; then
             machine_type=single-gpu
-          elif [ "${{ inputs.machine_type }}" = "2gaudi" ]; then
+          elif [ "$MACHINE_TYPE" = "2gaudi" ]; then
             machine_type=multi-gpu
           else
-            machine_type=${{ inputs.machine_type }}
+            machine_type="$MACHINE_TYPE"
           fi
-          echo "machine_type=$machine_type" >> $GITHUB_ENV
+          echo "machine_type=$machine_type" >> "$GITHUB_ENV"
 
       - name: Run all tests on Gaudi
-        run: python3 -m pytest -v --make-reports=${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports tests/${{ matrix.folders }}
+        env:
+          REPORT_NAME_PREFIX: ${{ inputs.report_name_prefix }}
+          MATRIX_FOLDERS: ${{ matrix.folders }}
+        run: |
+          REPORTS="${machine_type}_${REPORT_NAME_PREFIX}_${MATRIX_FOLDERS}_test_reports"
+          python3 -m pytest -v --make-reports="$REPORTS" "tests/${MATRIX_FOLDERS}"
 
       - name: Failure short reports
         if: ${{ failure() }}
         continue-on-error: true
-        run: cat reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports/failures_short.txt
+        env:
+          REPORT_NAME_PREFIX: ${{ inputs.report_name_prefix }}
+          MATRIX_FOLDERS: ${{ matrix.folders }}
+        run: cat "reports/${machine_type}_${REPORT_NAME_PREFIX}_${MATRIX_FOLDERS}_test_reports/failures_short.txt"
 
       - name: Run test
         shell: bash
+        env:
+          REPORT_NAME_PREFIX: ${{ inputs.report_name_prefix }}
+          MATRIX_FOLDERS: ${{ matrix.folders }}
         run: |
-          mkdir -p reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports
-          echo "hello" > reports/${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports/hello.txt
-          echo "${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ matrix.folders }}_test_reports"
+          REPORTS="${machine_type}_${REPORT_NAME_PREFIX}_${MATRIX_FOLDERS}_test_reports"
+          mkdir -p "reports/$REPORTS"
+          echo "hello" > "reports/$REPORTS/hello.txt"
+          echo "$REPORTS"
 
       - name: "Test suite reports artifacts: ${{ env.machine_type }}_${{ inputs.report_name_prefix }}_${{ env.matrix_folders }}_test_reports"
         if: ${{ always() }}

--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -148,9 +148,9 @@ jobs:
           
           # Initialize git and fetch with full history
           git init
-          git remote add pr-origin https://github.com/${PR_HEAD_REPO_FULL_NAME}.git
-          git fetch pr-origin ${PR_HEAD_REF}
-          git checkout ${PR_HEAD_SHA}
+          git remote add pr-origin "https://github.com/${PR_HEAD_REPO_FULL_NAME}.git"
+          git fetch pr-origin "${PR_HEAD_REF}"
+          git checkout "${PR_HEAD_SHA}"
 
           # Also fetch main branch from upstream for comparison (required by `check_modular_conversion`)
           git remote add upstream https://github.com/${{ github.repository }}.git
@@ -291,13 +291,13 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Add fork as remote with token
-          git remote add origin https://x-access-token:${GITHUB_TOKEN}@github.com/${PR_HEAD_REPO_FULL_NAME}.git
-          
+          git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${PR_HEAD_REPO_FULL_NAME}.git"
+
           # Fetch only the specific branch
-          git fetch origin ${PR_HEAD_REF}
-          
+          git fetch origin "${PR_HEAD_REF}"
+
           # Checkout the branch
-          git checkout -b ${PR_HEAD_REF} origin/${PR_HEAD_REF}
+          git checkout -b "${PR_HEAD_REF}" "origin/${PR_HEAD_REF}"
           
           # Verify we're on the correct SHA
           current_sha=$(git rev-parse HEAD)
@@ -322,7 +322,7 @@ jobs:
           if [ -n "$(git status --porcelain)" ]; then
             git add .
             git commit -m "Apply repo consistency fixes"
-            git push origin HEAD:${PR_HEAD_REF}
+            git push origin "HEAD:${PR_HEAD_REF}"
             echo "✅ Changes pushed successfully"
           else
             echo "No changes to commit"
@@ -353,12 +353,16 @@ jobs:
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         env:
           PR_NUMBER: ${{ needs.get-pr-number.outputs.PR_NUMBER }}
+          COMMENT_ID: ${{ needs.init_comment_with_url.outputs.comment_id }}
+          FINAL_COMMENT: ${{ steps.prepare_final_comment.outputs.final_comment }}
         with:
           script: |
-            const PR_NUMBER = parseInt(process.env.PR_NUMBER, 10);
+            const pr_number = parseInt(process.env.PR_NUMBER, 10);
+            const comment_id = parseInt(process.env.COMMENT_ID, 10);
+            const body = process.env.FINAL_COMMENT;
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              comment_id: ${{ needs.init_comment_with_url.outputs.comment_id }},
-              body: `${{ steps.prepare_final_comment.outputs.final_comment }}`
+              comment_id,
+              body,
             });

--- a/.github/workflows/pr_slow_ci_suggestion.yml
+++ b/.github/workflows/pr_slow_ci_suggestion.yml
@@ -28,42 +28,45 @@ jobs:
         with:
           fetch-depth: "0"
 
-      # We need to use `${{ ... }}` here to avoid `Argument list too long` error when a PR changes a lot of files.
-      # (We could also try to use artifact approach, but it's more involved).
-      # `CodeQL` doesn't identify any security issue here. Also `PR_FILES` is from `get-pr-info.yml` by using an api
-      # `github.rest.pulls.listFiles`, which is fine.
+      # Pass attacker-controlled inputs through env vars so they are never expanded
+      # into the shell or JS source by GitHub Actions `${{ ... }}` templating.
       - name: Write pr_files file
+        env:
+          PR_FILES: ${{ needs.get-pr-info.outputs.PR_FILES }}
         run: |
-          cat > pr_files.txt << 'EOF'
-          ${{ needs.get-pr-info.outputs.PR_FILES }}
-          EOF
+          printf '%s\n' "$PR_FILES" > pr_files.txt
 
       - name: Get repository content
         id: repo_content
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
+        env:
+          PR_HEAD_REPO_OWNER: ${{ needs.get-pr-info.outputs.PR_HEAD_REPO_OWNER }}
+          PR_HEAD_REPO_NAME: ${{ needs.get-pr-info.outputs.PR_HEAD_REPO_NAME }}
+          PR_HEAD_SHA: ${{ needs.get-pr-info.outputs.PR_HEAD_SHA }}
         with:
           script: |
             const fs = require('node:fs');
+            const { PR_HEAD_REPO_OWNER, PR_HEAD_REPO_NAME, PR_HEAD_SHA } = process.env;
 
             const { data: tests_dir } = await github.rest.repos.getContent({
-              owner: '${{ needs.get-pr-info.outputs.PR_HEAD_REPO_OWNER }}',
-              repo: '${{ needs.get-pr-info.outputs.PR_HEAD_REPO_NAME }}',
+              owner: PR_HEAD_REPO_OWNER,
+              repo: PR_HEAD_REPO_NAME,
               path: 'tests',
-              ref: '${{ needs.get-pr-info.outputs.PR_HEAD_SHA }}',
+              ref: PR_HEAD_SHA,
             });
 
             const { data: tests_models_dir } = await github.rest.repos.getContent({
-              owner: '${{ needs.get-pr-info.outputs.PR_HEAD_REPO_OWNER }}',
-              repo: '${{ needs.get-pr-info.outputs.PR_HEAD_REPO_NAME }}',
+              owner: PR_HEAD_REPO_OWNER,
+              repo: PR_HEAD_REPO_NAME,
               path: 'tests/models',
-              ref: '${{ needs.get-pr-info.outputs.PR_HEAD_SHA }}',
+              ref: PR_HEAD_SHA,
             });
 
             const { data: tests_quantization_dir } = await github.rest.repos.getContent({
-              owner: '${{ needs.get-pr-info.outputs.PR_HEAD_REPO_OWNER }}',
-              repo: '${{ needs.get-pr-info.outputs.PR_HEAD_REPO_NAME }}',
+              owner: PR_HEAD_REPO_OWNER,
+              repo: PR_HEAD_REPO_NAME,
               path: 'tests/quantization',
-              ref: '${{ needs.get-pr-info.outputs.PR_HEAD_SHA }}',
+              ref: PR_HEAD_SHA,
             });
 
             // Write to files instead of outputs
@@ -93,42 +96,43 @@ jobs:
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         env:
           BODY: "\n\nrun-slow: ${{ needs.get-jobs.outputs.jobs }}"
+          PR_NUMBER: ${{ needs.get-pr-number.outputs.PR_NUMBER }}
         with:
           script: |
-            const prNumber = ${{ needs.get-pr-number.outputs.PR_NUMBER }};
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const commentPrefix = "**[For maintainers]** Suggested jobs to run (before merge)";
             const thirtyMinutesAgo = new Date(Date.now() - 30 * 60 * 1000); // 30 minutes ago
             const newBody = `${commentPrefix}${process.env.BODY}`;
-            
+
             // Get all comments on the PR
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: prNumber
             });
-            
+
             // Find existing comments that start with our prefix
-            const existingComments = comments.filter(comment => 
-              comment.user.login === 'github-actions[bot]' && 
+            const existingComments = comments.filter(comment =>
+              comment.user.login === 'github-actions[bot]' &&
               comment.body.startsWith(commentPrefix)
             );
-            
+
             let shouldCreateNewComment = true;
             let commentsToDelete = [];
-            
+
             if (existingComments.length > 0) {
               // Get the most recent comment
               const mostRecentComment = existingComments
                 .sort((a, b) => new Date(b.created_at) - new Date(a.created_at))[0];
-              
+
               const commentDate = new Date(mostRecentComment.created_at);
               const isOld = commentDate < thirtyMinutesAgo;
               const isDifferentContent = mostRecentComment.body !== newBody;
-              
+
               console.log(`Most recent comment created: ${mostRecentComment.created_at}`);
               console.log(`Is older than 30 minutes: ${isOld}`);
               console.log(`Has different content: ${isDifferentContent}`);
-              
+
               if (isOld || isDifferentContent) {
                 // Delete all existing comments and create new one
                 commentsToDelete = existingComments;
@@ -141,7 +145,7 @@ jobs:
             } else {
               console.log('No existing comments found, will create new one');
             }
-            
+
             // Delete old comments if needed
             for (const comment of commentsToDelete) {
               console.log(`Deleting comment #${comment.id} (created: ${comment.created_at})`);
@@ -151,7 +155,7 @@ jobs:
                 comment_id: comment.id
               });
             }
-            
+
             // Create new comment if needed
             if (shouldCreateNewComment) {
               await github.rest.issues.createComment({

--- a/.github/workflows/self-scheduled-flash-attn-caller.yml
+++ b/.github/workflows/self-scheduled-flash-attn-caller.yml
@@ -33,10 +33,13 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Setup
+        env:
+          PREV_WORKFLOW_RUN_ID: ${{ inputs.prev_workflow_run_id || env.prev_workflow_run_id }}
+          OTHER_WORKFLOW_RUN_ID: ${{ inputs.other_workflow_run_id || env.other_workflow_run_id }}
         run: |
           mkdir "setup_values"
-          echo "${{ inputs.prev_workflow_run_id || env.prev_workflow_run_id }}" > "setup_values/prev_workflow_run_id.txt"
-          echo "${{ inputs.other_workflow_run_id || env.other_workflow_run_id }}" > "setup_values/other_workflow_run_id.txt"
+          echo "$PREV_WORKFLOW_RUN_ID" > "setup_values/prev_workflow_run_id.txt"
+          echo "$OTHER_WORKFLOW_RUN_ID" > "setup_values/other_workflow_run_id.txt"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/self-scheduled-intel-gaudi.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi.yml
@@ -52,13 +52,15 @@ jobs:
         if: contains(fromJSON('["run_models_gpu", "run_trainer_and_fsdp_gpu"]'), inputs.job)
         name: Identify models to test
         working-directory: tests
+        env:
+          JOB: ${{ inputs.job }}
         run: |
-          if [ "${{ inputs.job }}" = "run_models_gpu" ]; then
-            echo "folder_slices=$(python3 ../utils/split_model_tests.py --num_splits ${{ env.NUM_SLICES }})" >> $GITHUB_OUTPUT
-            echo "slice_ids=$(python3 -c 'd = list(range(${{ env.NUM_SLICES }})); print(d)')" >> $GITHUB_OUTPUT
-          elif [ "${{ inputs.job }}" = "run_trainer_and_fsdp_gpu" ]; then
-            echo "folder_slices=[['trainer'], ['fsdp']]" >> $GITHUB_OUTPUT
-            echo "slice_ids=[0, 1]" >> $GITHUB_OUTPUT
+          if [ "$JOB" = "run_models_gpu" ]; then
+            echo "folder_slices=$(python3 ../utils/split_model_tests.py --num_splits "$NUM_SLICES")" >> "$GITHUB_OUTPUT"
+            echo "slice_ids=$(python3 -c 'import os, sys; print(list(range(int(os.environ[\"NUM_SLICES\"]))))')" >> "$GITHUB_OUTPUT"
+          elif [ "$JOB" = "run_trainer_and_fsdp_gpu" ]; then
+            echo "folder_slices=[['trainer'], ['fsdp']]" >> "$GITHUB_OUTPUT"
+            echo "slice_ids=[0, 1]" >> "$GITHUB_OUTPUT"
           fi
 
       - id: set-matrix-quantization

--- a/.github/workflows/trl-ci-bot.yml
+++ b/.github/workflows/trl-ci-bot.yml
@@ -41,12 +41,12 @@ jobs:
         id: pr
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.issue.pull_request.url }}
         run: |
-          PR_URL="${{ github.event.issue.pull_request.url }}"
           sha=$(gh api "$PR_URL" --jq .head.sha)
           number=$(gh api "$PR_URL" --jq .number)
-          echo "sha=$sha" >> $GITHUB_OUTPUT
-          echo "number=$number" >> $GITHUB_OUTPUT
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "number=$number" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch TRL workflow
         if: steps.trust.outputs.trusted == 'true'


### PR DESCRIPTION
## Summary

Eliminate every `error[template-injection]` finding in `.github/workflows/` by routing PR-author / matrix / input-derived values through `env:` instead of GitHub Actions `${{ ... }}` rendering directly into shell or `actions/github-script` JS source.

Zizmor 1.24.1: **22 `error[template-injection]` → 0**.

## Files touched

### `pull_request_target` / `issue_comment` (highest exposure)
- **`pr_slow_ci_suggestion.yml`** (`pull_request_target`)
  - `PR_FILES` was placed inside a `<< 'EOF'` heredoc in `run:`. The single-quoted heredoc only stops shell expansion *after* GitHub renders `${{ ... }}`; a filename containing `EOF\n<payload>\nEOF` would escape the heredoc and run on the runner. Now `env: { PR_FILES: ... }` + `printf '%s\n' "$PR_FILES"`.
  - `PR_HEAD_REPO_OWNER`, `PR_HEAD_REPO_NAME`, `PR_HEAD_SHA`, `PR_NUMBER` were interpolated directly into `actions/github-script` script bodies; moved to `env:` + `process.env`.
- **`pr-repo-consistency-bot.yml`** (`issue_comment`, gated by maintainer allowlist)
  - Quoted every `${PR_HEAD_REF}`, `${PR_HEAD_SHA}`, `${PR_HEAD_REPO_FULL_NAME}` shell expansion in `git fetch`, `git checkout`, `git remote add`, `git push`.
  - Final `Comment on PR` step now passes `comment_id` and `final_comment` via `env:` (no `${{ ... }}` left in the script body).
- **`trl-ci-bot.yml`** (`issue_comment`, gated by `author_association`)
  - `github.event.issue.pull_request.url` passed via env. GitHub-controlled value, but principle is the same.

### Reusable workflows (callable from PR comment CI)
- **`get-pr-info.yml`**: `inputs.pr_number` passed via env, shared between two API calls.
- **`check_failed_tests.yml`**: `pr_number` + `commit_sha` passed via env in the Extract base commit step.

### Reusable workflows (callable from scheduled / dispatched CI)
- **`collated-reports.yml`**: `machine_type`, `job`, `report_repo_id`, `gpu_name` exposed as env, quoted in the python invocation.
- **`model_jobs_intel_gaudi.yml`**: `inputs.folder_slices`, `inputs.machine_type`, `inputs.report_name_prefix`, `matrix.folders` pulled into `env:`; report-directory name built once and reused.
- **`self-scheduled-flash-attn-caller.yml`**: `prev_workflow_run_id` / `other_workflow_run_id` passed via env before being written to disk.
- **`self-scheduled-intel-gaudi.yml`**: `inputs.job` passed via env; `NUM_SLICES` dereferenced via env in the `python3 -c` snippet.

## Validation

- Zizmor 1.24.1: 22 `error[template-injection]` → 0 across the whole `.github/workflows/` tree.
- `node --check` on every `actions/github-script` `script:` body touched: ✅
- `bash -n` on every `run:` block touched: ✅
- Behavior preserved: the same values reach the same code paths, only the wiring changed (templating → env vars).

## Out of scope (will be follow-up PRs)

- Bumping `actions/github-script@v6` → `@v7` (handled by the pin-by-SHA PR #45955).
- `pr-repo-consistency-bot.yml:7` invalid `branches-ignore` filter on `issue_comment` (pre-existing).
- Replacing the hardcoded maintainer allowlist with a team-membership check.
- Switching `secrets: inherit` to explicit per-secret passing in the 17 callers.