### PR TITLE
chore(ci): set default workflow permissions to contents: read

### DIFF
--- a/.github/workflows/add-model-like.yml
+++ b/.github/workflows/add-model-like.yml
@@ -11,6 +11,9 @@ on:
   #    - ".github/**"
   #  types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   run_tests_templates_like:
     name: "Add new model like template tests"

--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -5,6 +5,9 @@ on:
       - main
     types: [ready_for_review]
 
+permissions:
+  contents: read
+
 jobs:
   assign_reviewers:
     permissions:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -15,6 +15,9 @@ env:
   DATASET_ID: hf-benchmarks/transformers
   MODEL_ID: meta-llama/Llama-3.1-8B-Instruct
 
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: Benchmark

--- a/.github/workflows/benchmark_v2.yml
+++ b/.github/workflows/benchmark_v2.yml
@@ -10,6 +10,9 @@ env:
   # This token is created under the bot `hf-transformers-bot`.
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   benchmark-v2:
     name: Benchmark v2

--- a/.github/workflows/benchmark_v2_a10_caller.yml
+++ b/.github/workflows/benchmark_v2_a10_caller.yml
@@ -3,6 +3,9 @@ name: Benchmark v2 Scheduled Runner - A10 Single-GPU
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmark-v2-default:
     name: Benchmark v2 - Default Models

--- a/.github/workflows/benchmark_v2_mi325_caller.yml
+++ b/.github/workflows/benchmark_v2_mi325_caller.yml
@@ -3,6 +3,9 @@ name: Benchmark v2 Scheduled Runner - MI325 Single-GPU
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   benchmark-v2-default:
     name: Benchmark v2 - Default Models

--- a/.github/workflows/build-ci-docker-images.yml
+++ b/.github/workflows/build-ci-docker-images.yml
@@ -18,6 +18,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -18,6 +18,9 @@ concurrency:
   group: docker-images-builds
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   latest-docker:
     name: "Latest PyTorch [dev]"

--- a/.github/workflows/build-nightly-ci-docker-images.yml
+++ b/.github/workflows/build-nightly-ci-docker-images.yml
@@ -14,6 +14,9 @@ concurrency:
   group: docker-images-builds
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   latest-with-torch-nightly-docker:
     name: "Nightly PyTorch"

--- a/.github/workflows/build-past-ci-docker-images.yml
+++ b/.github/workflows/build-past-ci-docker-images.yml
@@ -9,6 +9,9 @@ concurrency:
   group: docker-images-builds
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   past-pytorch-docker:
     name: "Past PyTorch Docker"

--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,6 +9,9 @@ on:
       - v*-release
       - use_templates
 
+permissions:
+  contents: read
+
 jobs:
    build:
     uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@2430c1ec91d04667414e2fa31ecfc36c153ea391  # main

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/check-workflow-permissions.yml
+++ b/.github/workflows/check-workflow-permissions.yml
@@ -12,6 +12,9 @@ on:
         type: string
         default: "10"
 
+permissions:
+  contents: read
+
 jobs:
   advisor:
     uses: huggingface/security-workflows/.github/workflows/permissions-advisor-reusable.yml@1b6a139c28db347498b30338da6a602e0a06f56c  # main

--- a/.github/workflows/check_failed_tests.yml
+++ b/.github/workflows/check_failed_tests.yml
@@ -46,6 +46,9 @@ env:
   CUDA_VISIBLE_DEVICES: 0,1
 
 
+permissions:
+  contents: read
+
 jobs:
   setup_check_new_failures:
     name: "Setup matrix for finding commits"

--- a/.github/workflows/check_tiny_models.yml
+++ b/.github/workflows/check_tiny_models.yml
@@ -12,6 +12,9 @@ env:
   TOKEN: ${{ secrets.TRANSFORMERS_HUB_BOT_HF_TOKEN }}
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   check_tiny_models:
     name: Check tiny models

--- a/.github/workflows/circleci-failure-summary-comment.yml
+++ b/.github/workflows/circleci-failure-summary-comment.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   comment:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,9 @@ on:
   #   branches: ["main"]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   codeql:
     name: CodeQL Analysis

--- a/.github/workflows/collated-reports.yml
+++ b/.github/workflows/collated-reports.yml
@@ -17,6 +17,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   collated_reports:
     name: Collated reports

--- a/.github/workflows/doctest_job.yml
+++ b/.github/workflows/doctest_job.yml
@@ -18,6 +18,9 @@ env:
   MKL_NUM_THREADS: 16
   TF_FORCE_GPU_ALLOW_GROWTH: true
 
+permissions:
+  contents: read
+
 jobs:
   run_doctests:
     name: " "

--- a/.github/workflows/doctests.yml
+++ b/.github/workflows/doctests.yml
@@ -11,6 +11,9 @@ on:
 env:
   NUM_SLICES: 3
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/extras-smoke-test.yml
+++ b/.github/workflows/extras-smoke-test.yml
@@ -7,6 +7,9 @@ on:
 env:
   SLACK_CHANNEL_ID: '#transformers-gh-ci-central'
 
+permissions:
+  contents: read
+
 jobs:
   get-python-versions:
     name: Get supported Python versions

--- a/.github/workflows/get-pr-info.yml
+++ b/.github/workflows/get-pr-info.yml
@@ -62,6 +62,9 @@ on:
         value: ${{ jobs.get-pr-info.outputs.PR_FILES }}
 
 
+permissions:
+  contents: read
+
 jobs:
   get-pr-info:
     runs-on: ubuntu-22.04

--- a/.github/workflows/get-pr-number.yml
+++ b/.github/workflows/get-pr-number.yml
@@ -6,6 +6,9 @@ on:
         description: "The extracted PR number"
         value: ${{ jobs.get-pr-number.outputs.PR_NUMBER }}
 
+permissions:
+  contents: read
+
 jobs:
   get-pr-number:
     runs-on: ubuntu-22.04

--- a/.github/workflows/model_jobs.yml
+++ b/.github/workflows/model_jobs.yml
@@ -44,6 +44,9 @@ env:
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 
+permissions:
+  contents: read
+
 jobs:
   run_models_gpu:
     name: " "

--- a/.github/workflows/model_jobs_intel_gaudi.yml
+++ b/.github/workflows/model_jobs_intel_gaudi.yml
@@ -28,6 +28,9 @@ env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache/.cache/huggingface
 
+permissions:
+  contents: read
+
 jobs:
   run_models_gpu:
     name: " "

--- a/.github/workflows/new_model_pr_merged_notification.yml
+++ b/.github/workflows/new_model_pr_merged_notification.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'src/transformers/models/*/modeling_*'
 
+permissions:
+  contents: read
+
 jobs:
   notify_new_model:
     name: Notify new model

--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -7,6 +7,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   pr-ci:
     if: contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association)

--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -9,7 +9,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}-${{ startsWith(github.event.comment.body, '@bot /repo') || startsWith(github.event.comment.body, '@bot /style') }}
   cancel-in-progress: true
-permissions: read-all
+permissions:
+  contents: read
 
 
 jobs:

--- a/.github/workflows/pr_slow_ci_suggestion.yml
+++ b/.github/workflows/pr_slow_ci_suggestion.yml
@@ -3,6 +3,9 @@ on:
   pull_request_target:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   get-pr-number:
     name: Get PR number

--- a/.github/workflows/push-important-models.yml
+++ b/.github/workflows/push-important-models.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   get_modified_models:
     name: "Get all modified files"

--- a/.github/workflows/release-conda.yml
+++ b/.github/workflows/release-conda.yml
@@ -10,6 +10,9 @@ on:
 env:
   ANACONDA_API_TOKEN: ${{ secrets.ANACONDA_API_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   build_and_package:
     runs-on: ubuntu-22.04

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'v*-release'
 
+permissions:
+  contents: read
+
 jobs:
   build_and_test:
     name: build release

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -9,7 +9,8 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}-${{ startsWith(github.event.comment.body, 'run-slow') || startsWith(github.event.comment.body, 'run slow') || startsWith(github.event.comment.body, 'run_slow') }}
   cancel-in-progress: true
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   HF_HOME: /mnt/cache

--- a/.github/workflows/self-nightly-caller.yml
+++ b/.github/workflows/self-nightly-caller.yml
@@ -18,6 +18,9 @@ env:
     other_workflow_run_id: ""
 
 
+permissions:
+  contents: read
+
 jobs:
   build_nightly_torch_ci_images:
     name: Build CI Docker Images with nightly torch

--- a/.github/workflows/self-nightly-past-ci-caller.yml
+++ b/.github/workflows/self-nightly-past-ci-caller.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - run_past_ci*
 
+permissions:
+  contents: read
+
 jobs:
   get_number:
     name: Get number

--- a/.github/workflows/self-past-caller.yml
+++ b/.github/workflows/self-past-caller.yml
@@ -16,6 +16,9 @@ on:
         required: false
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   model-ci:
     name: Model CI

--- a/.github/workflows/self-scheduled-amd-caller.yml
+++ b/.github/workflows/self-scheduled-amd-caller.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "17 5 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   run_scheduled_amd_ci:
     name: Trigger Scheduled AMD CI

--- a/.github/workflows/self-scheduled-amd-mi250-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi250-caller.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - run_amd_scheduled_ci_caller*
 
+permissions:
+  contents: read
+
 jobs:
   model-ci:
     name: Model CI

--- a/.github/workflows/self-scheduled-amd-mi325-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi325-caller.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - run_amd_scheduled_ci_caller*
 
+permissions:
+  contents: read
+
 jobs:
   model-ci:
     name: Model CI

--- a/.github/workflows/self-scheduled-amd-mi355-caller.yml
+++ b/.github/workflows/self-scheduled-amd-mi355-caller.yml
@@ -13,6 +13,9 @@ on:
     branches:
       - run_amd_scheduled_ci_caller*
 
+permissions:
+  contents: read
+
 jobs:
   model-ci:
     name: Model CI

--- a/.github/workflows/self-scheduled-caller.yml
+++ b/.github/workflows/self-scheduled-caller.yml
@@ -27,6 +27,9 @@ env:
     other_workflow_run_id: ""
 
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/self-scheduled-flash-attn-caller.yml
+++ b/.github/workflows/self-scheduled-flash-attn-caller.yml
@@ -27,6 +27,9 @@ env:
     other_workflow_run_id: ""
 
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/self-scheduled-intel-gaudi.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi.yml
@@ -28,6 +28,9 @@ env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
   HF_HOME: /mnt/cache/.cache/huggingface
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     if: contains(fromJSON('["run_models_gpu", "run_trainer_and_fsdp_gpu"]'), inputs.job)

--- a/.github/workflows/self-scheduled-intel-gaudi3-caller.yml
+++ b/.github/workflows/self-scheduled-intel-gaudi3-caller.yml
@@ -6,6 +6,9 @@ on:
   schedule:
     - cron: "17 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   model-ci:
     name: Model CI

--- a/.github/workflows/self-scheduled.yml
+++ b/.github/workflows/self-scheduled.yml
@@ -62,6 +62,9 @@ env:
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 
+permissions:
+  contents: read
+
 jobs:
   setup:
     name: Setup

--- a/.github/workflows/slack-report.yml
+++ b/.github/workflows/slack-report.yml
@@ -35,6 +35,9 @@ on:
 env:
   TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN: ${{ secrets.TRANSFORMERS_CI_RESULTS_UPLOAD_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   send_results:
     name: Send results to webhook

--- a/.github/workflows/ssh-runner.yml
+++ b/.github/workflows/ssh-runner.yml
@@ -23,6 +23,9 @@ env:
   TF_FORCE_GPU_ALLOW_GROWTH: true
   CUDA_VISIBLE_DEVICES: 0,1
 
+permissions:
+  contents: read
+
 jobs:
   get_runner:
     name: "Get runner to use"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   close_stale_issues:
     name: Close Stale Issues

--- a/.github/workflows/update_metdata.yml
+++ b/.github/workflows/update_metdata.yml
@@ -6,6 +6,9 @@ on:
       - main
       - update_transformers_metadata*
 
+permissions:
+  contents: read
+
 jobs:
   build_and_package:
     runs-on: ubuntu-22.04

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -6,6 +6,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main


### PR DESCRIPTION
## Summary

Add an explicit top-level `permissions:` block to every workflow that did not have one. The new default grants only `contents: read`, so each job's auto-generated `GITHUB_TOKEN` starts at the minimum needed to checkout the repo. Jobs that need more (issue/PR comments, statuses, OIDC token, packages write, etc.) already declare job-level `permissions:` overrides; those are preserved.

Also tightens `pr-repo-consistency-bot.yml` and `self-comment-ci.yml` from `permissions: read-all` to `permissions: { contents: read }`. `read-all` grants every readonly scope (issues, packages, actions, deployments, ...), which is broader than these workflows need.

## Impact

- Zizmor 1.24.1: **116 `warning[excessive-permissions]` -> 0** across `.github/workflows/`.
- Closes the matching CodeQL `actions/missing-workflow-permissions` alerts that started firing after the SHA-pinning rescan.
- Behavior unchanged: workflows that emit PR comments, update statuses, push images, etc. already had job-level grants and continue to work. This change only removes the implicit write-everything hammock for jobs that never used it.

## Reviewer notes

- The diff is large (50 files) but uniform: 3 added lines per workflow (`permissions:` + `contents: read` + blank). The two `read-all` replacements are 1-line edits.
- `benchmark.yml` and `check_tiny_models.yml` had CRLF line endings on `main`; both committed with their original CRLF preserved.
- The remaining zizmor warnings (`secrets-inherit`, `artipacked`, `unpinned-images`, `dangerous-triggers`) are tracked for follow-up PRs.