### PR TITLE
chore(ci): remove dead env vars from circleci-failure-summary-comment.yml

### DIFF
--- a/.github/workflows/circleci-failure-summary-comment.yml
+++ b/.github/workflows/circleci-failure-summary-comment.yml
@@ -12,10 +12,6 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
-    env:
-      TARGET_BRANCH: ${{ github.event.pull_request.head.ref }}
-      TARGET_SHA: ${{ github.event.pull_request.head.sha }}
-      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2


### PR DESCRIPTION
## Summary

`.github/workflows/circleci-failure-summary-comment.yml` declared three env vars at the `comment` job level:

```yaml
env:
  TARGET_BRANCH: ${{ github.event.pull_request.head.ref }}
  TARGET_SHA:    ${{ github.event.pull_request.head.sha }}
  PR_NUMBER:     ${{ github.event.pull_request.number }}
```

None of them are referenced:
- `TARGET_BRANCH` and `TARGET_SHA` are never used by any step in the job.
- `PR_NUMBER` is re-declared as a step-local env in every step that needs it (lines 164, 198, 234), so the job-level binding does nothing.

Drop the whole `env:` block. No behavior change.

Closes #45968 (the hf-security-analysis bot proposed to rename these vars; the right fix is to delete them).