### PR TITLE
chore(ci): replace hardcoded maintainer allowlists with team membership check

### DIFF
--- a/.github/workflows/check-maintainer.yml
+++ b/.github/workflows/check-maintainer.yml
@@ -1,0 +1,52 @@
+name: Check maintainer team membership
+
+# Reusable workflow: fails if `actor` is not a member of the
+# `huggingface/transformers-core-maintainers` team.
+#
+# Used to gate comment-triggered CI workflows in place of a hardcoded
+# allowlist of GitHub usernames. The team is the single source of truth
+# for "who can trigger maintainer-only CI" and is managed in GitHub's
+# team UI.
+#
+# Requires a repo secret `HF_ORG_READ_TOKEN` set to a token with
+# `read:org` scope on the `huggingface` org (PAT or GitHub App
+# installation token).
+
+on:
+  workflow_call:
+    inputs:
+      actor:
+        description: "GitHub login to check membership for"
+        required: true
+        type: string
+      team:
+        description: "Team slug under the huggingface org"
+        required: false
+        type: string
+        default: transformers-core-maintainers
+    secrets:
+      org_read_token:
+        description: "Token with read:org scope on the huggingface org"
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check team membership
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check ${{ inputs.actor }} is a member of huggingface/${{ inputs.team }}
+        env:
+          GH_TOKEN: ${{ secrets.org_read_token }}
+          ACTOR: ${{ inputs.actor }}
+          TEAM: ${{ inputs.team }}
+        run: |
+          # Returns 200 if the user is an active member of the team, 404 otherwise.
+          # `gh api` exits non-zero on 404, so a single call is enough.
+          if ! gh api "orgs/huggingface/teams/${TEAM}/memberships/${ACTOR}" --jq '.state' >/dev/null 2>&1; then
+            echo "::error::${ACTOR} is not an active member of huggingface/${TEAM}"
+            exit 1
+          fi
+          echo "${ACTOR} is a member of huggingface/${TEAM}"

--- a/.github/workflows/pr-repo-consistency-bot.yml
+++ b/.github/workflows/pr-repo-consistency-bot.yml
@@ -14,9 +14,18 @@ permissions:
 
 
 jobs:
+  check-maintainer:
+    name: Check maintainer
+    if: ${{ github.event.issue.state == 'open' && (startsWith(github.event.comment.body, '@bot /repo') || startsWith(github.event.comment.body, '@bot /style')) }}
+    uses: ./.github/workflows/check-maintainer.yml
+    with:
+      actor: ${{ github.actor }}
+    secrets:
+      org_read_token: ${{ secrets.HF_ORG_READ_TOKEN }}
+
   get-pr-number:
     name: Get PR number
-    if: ${{ github.event.issue.state == 'open' && contains(fromJSON('["ydshieh", "ArthurZucker", "zucchini-nlp", "molbap", "gante", "LysandreJik", "Cyrilvallez", "Rocketknight1", "SunMarc", "eustlb", "MekkCyber", "vasqu", "ivarflakstad", "stevhliu", "ebezzam", "remi-or", "itazap", "3outeille", "IlyasMoutawwakil", "tarekziade"]'), github.actor) && (startsWith(github.event.comment.body, '@bot /repo') || startsWith(github.event.comment.body, '@bot /style')) }}
+    needs: check-maintainer
     uses: ./.github/workflows/get-pr-number.yml
 
   get-pr-info:

--- a/.github/workflows/pr_build_doc_with_comment.yml
+++ b/.github/workflows/pr_build_doc_with_comment.yml
@@ -12,9 +12,18 @@ permissions: {}
 
 
 jobs:
+  check-maintainer:
+    name: Check maintainer
+    if: ${{ github.event.issue.state == 'open' && startsWith(github.event.comment.body, 'build-doc') }}
+    uses: ./.github/workflows/check-maintainer.yml
+    with:
+      actor: ${{ github.actor }}
+    secrets:
+      org_read_token: ${{ secrets.HF_ORG_READ_TOKEN }}
+
   get-pr-number:
     name: Get PR number
-    if: ${{ github.event.issue.state == 'open' && contains(fromJSON('["ydshieh", "ArthurZucker", "zucchini-nlp", "molbap", "gante", "LysandreJik", "Cyrilvallez", "Rocketknight1", "SunMarc", "eustlb", "MekkCyber", "vasqu", "ivarflakstad", "stevhliu", "ebezzam", "itazap", "tarekziade"]'), github.actor) && (startsWith(github.event.comment.body, 'build-doc')) }}
+    needs: check-maintainer
     uses: ./.github/workflows/get-pr-number.yml
 
   get-pr-info:

--- a/.github/workflows/self-comment-ci.yml
+++ b/.github/workflows/self-comment-ci.yml
@@ -26,9 +26,18 @@ env:
 
 
 jobs:
+  check-maintainer:
+    name: Check maintainer
+    if: ${{ github.event.issue.state == 'open' && (startsWith(github.event.comment.body, 'run-slow') || startsWith(github.event.comment.body, 'run slow') || startsWith(github.event.comment.body, 'run_slow')) }}
+    uses: ./.github/workflows/check-maintainer.yml
+    with:
+      actor: ${{ github.actor }}
+    secrets:
+      org_read_token: ${{ secrets.HF_ORG_READ_TOKEN }}
+
   get-pr-number:
     name: Get PR number
-    if: ${{ github.event.issue.state == 'open' && contains(fromJSON('["ydshieh", "ArthurZucker", "zucchini-nlp", "molbap", "LysandreJik", "Cyrilvallez", "Rocketknight1", "SunMarc", "eustlb", "vasqu", "ivarflakstad", "stevhliu", "ebezzam", "remi-or", "itazap", "3outeille", "IlyasMoutawwakil", "tarekziade", "yonigozlan"]'), github.actor) && (startsWith(github.event.comment.body, 'run-slow') || startsWith(github.event.comment.body, 'run slow') || startsWith(github.event.comment.body, 'run_slow')) }}
+    needs: check-maintainer
     uses: ./.github/workflows/get-pr-number.yml
 
   get-pr-info:


### PR DESCRIPTION
## Summary

The expression `contains(fromJSON('["ydshieh", ..., "tarekziade"]'), github.actor)` was duplicated across three workflows:
- `self-comment-ci.yml`
- `pr-repo-consistency-bot.yml`
- `pr_build_doc_with_comment.yml`

Each list had to be kept in sync by hand whenever a maintainer joined or left. The lists had already drifted (different sets of usernames in each file). A recent hf-security-analysis suggestion (#45971) proposed adding a fourth copy on `build-doc` for defense in depth, which is what motivated this refactor.

Replace all three by a single reusable workflow `.github/workflows/check-maintainer.yml` that gates downstream jobs on membership of the `huggingface/transformers-core-maintainers` team via the GitHub API. The team becomes the single source of truth.

## Wiring

- `check-maintainer.yml` is a `workflow_call` reusable that takes the actor and team slug as inputs and an `org_read_token` secret with `read:org` scope. It runs one `gh api orgs/huggingface/teams/<team>/memberships/<actor>` call and fails the workflow with a clear error if the actor is not an active member.
- Each caller now declares a new `check-maintainer` job at the top of its `jobs:` block, gated on the same comment-prefix filter as before so it only runs for relevant comments.
- Downstream jobs (`get-pr-number`, etc.) gain `needs: check-maintainer` and drop the `contains(fromJSON([...]), github.actor)` portion of their `if:`. If `check-maintainer` fails, none of the downstream jobs run.

## Required before merge

This PR will not function end-to-end until two things are in place:

1. **Populate the team.** `huggingface/transformers-core-maintainers` currently has 4 members; the previous hardcoded allowlists effectively expected ~20 (the exact set varied per workflow). Every maintainer who is expected to be able to comment-trigger CI must be added to the team.
2. **Add a repo secret `HF_ORG_READ_TOKEN`.** Token with `read:org` scope on the `huggingface` org. A fine-grained PAT or a GitHub App installation token both work. Without this secret, `check-maintainer` will fail every run.

I'd recommend keeping this PR in draft until those two are done so it doesn't accidentally block legitimate maintainers in production.

## Out of scope

- A handful of read-only / non-sensitive workflows still reference allowlists via `author_association` (e.g. `trl-ci-bot.yml`, which checks for `MEMBER|OWNER|COLLABORATOR`). Those gates do not need team granularity and are left as is for now.