### PR TITLE
tokenizer: decoding an empty batch returns an empty list

### DIFF
--- a/src/transformers/tokenization_utils_base.py
+++ b/src/transformers/tokenization_utils_base.py
@@ -2881,7 +2881,7 @@ class PreTrainedTokenizerBase(PushToHubMixin):
         token_ids = to_py_obj(token_ids)
 
         # If we received batched input, decode each sequence
-        if isinstance(token_ids, (list, tuple)) and len(token_ids) > 0 and isinstance(token_ids[0], (list, tuple)):
+        if isinstance(token_ids, (list, tuple)) and (len(token_ids) == 0 or isinstance(token_ids[0], (list, tuple))):
             clean_up_tokenization_spaces = kwargs.pop("clean_up_tokenization_spaces", False)
             return [
                 self._decode(

--- a/tests/tokenization/test_tokenization_utils.py
+++ b/tests/tokenization/test_tokenization_utils.py
@@ -201,6 +201,20 @@ class TokenizerUtilsTest(unittest.TestCase):
         self.assertTrue(tokenizer.image_token_id == loaded_tokenizer.convert_tokens_to_ids("<image>"))
 
     @require_tokenizers
+    def test_decoding_empty_batch(self):
+        # decode and batch_decode should treat an empty input as an empty batch of sequences
+        for tokenizer_class in [BertTokenizer, PreTrainedTokenizerFast]:
+            with self.subTest(f"{tokenizer_class}"):
+                tokenizer = tokenizer_class.from_pretrained("google-bert/bert-base-cased")
+
+                self.assertEqual(tokenizer.decode([]), [])
+                self.assertEqual(tokenizer.decode(()), [])
+                self.assertEqual(tokenizer.batch_decode([]), [])
+
+                # a single empty sequence still returns an empty string
+                self.assertEqual(tokenizer.batch_decode([[]]), [""])
+
+    @require_tokenizers
     def test_decoding_skip_special_tokens(self):
         for tokenizer_class in [BertTokenizer, BertTokenizer]:
             with self.subTest(f"{tokenizer_class}"):


### PR DESCRIPTION
# What does this PR do?

This PR makes `tokenizer.batch_decode([])` return `[]` instead of `[""]`.

The reason I found this edge case is if Grounding Dino returns nothing then this breaks because text_labels (and labels) contain an empty string:

```py
zip(result["boxes"], result["scores"], result["text_labels"], strict=True))
# ValueError: zip() argument 2 is longer than argument 1
```

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request) Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?

@ArthurZucker or @itazap (tokenizers)