### PR TITLE
no empty label when Grounding Dino detects nothing

### DIFF
--- a/src/transformers/models/grounding_dino/processing_grounding_dino.py
+++ b/src/transformers/models/grounding_dino/processing_grounding_dino.py
@@ -217,7 +217,8 @@ class GroundingDinoProcessor(ProcessorMixin):
             # extract text labels
             prob = probs[keep]
             label_ids = get_phrases_from_posmap(prob > text_threshold, input_ids[idx])
-            objects_text_labels = self.batch_decode(label_ids)
+            # batch_decode([]) returns [""] instead of []
+            objects_text_labels = self.batch_decode(label_ids) if label_ids else []
 
             result = DictWithDeprecationWarning(
                 {

--- a/tests/models/grounding_dino/test_processing_grounding_dino.py
+++ b/tests/models/grounding_dino/test_processing_grounding_dino.py
@@ -110,6 +110,20 @@ class GroundingDinoProcessorTest(ProcessorTesterMixin, unittest.TestCase):
         expected_box_slice = torch.tensor([0.6908, 0.4354, 1.0737, 1.3947])
         torch.testing.assert_close(post_processed[0]["boxes"][0], expected_box_slice, rtol=1e-4, atol=1e-4)
 
+    def test_post_process_grounded_object_detection_no_boxes(self):
+        processor = self.get_processor()
+
+        grounding_dino_output = self.get_fake_grounding_dino_output()
+
+        # threshold above any sigmoid output so no box survives
+        post_processed = processor.post_process_grounded_object_detection(grounding_dino_output, threshold=2.0)
+
+        self.assertEqual(len(post_processed), self.batch_size)
+        for result in post_processed:
+            self.assertEqual(result["scores"].shape, (0,))
+            self.assertEqual(result["boxes"].shape, (0, 4))
+            self.assertEqual(result["text_labels"], [])
+
     def test_text_preprocessing_equivalence(self):
         processor = self.get_processor()
 


### PR DESCRIPTION
# What does this PR do?

Avoid this when Grounding Dino returns no result:

```py
list(zip(results["boxes"], results["labels"], results["scores"], strict=True))
# ValueError: zip() argument 2 is longer than argument 1
```

I [tried to fix it at tokenizer level first](#45980) but other models (e.g. Mistral) expect the empty string.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)?
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?


## Who can review?

maybe @yonigozlan or @zucchini-nlp