### PR TITLE
Fix MLX backend detection to respect HF_USE_MLX environment variable

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1338,6 +1338,8 @@ def is_jmespath_available() -> bool:
 
 @lru_cache
 def is_mlx_available() -> bool:
+    if is_env_variable_false("USE_MLX") or is_env_variable_false("HF_USE_MLX"):
+        return False
     return _is_package_available("mlx")[0]
 
 


### PR DESCRIPTION
Fixes huggingface/transformers#45853

This adds support for disabling MLX backend detection via HF_USE_MLX=0 or USE_MLX=0.