### PR TITLE
docs: Fix formatting issues in weightconverter.md

### DIFF
--- a/docs/source/en/weightconverter.md
+++ b/docs/source/en/weightconverter.md
@@ -40,11 +40,11 @@ Checkpoint File → from_pretrained() → convert_and_load_state_dict_in_model()
                          │  1. Match renamed/processed source key to model parameter │
                          │  2. Shard the weight and send to device (async)           │
                          │  3. Collect tensors with the same source_pattern together │
-                         │     (e.g. MoE experts, gate_up_proj)                     │
+                         │     (e.g. MoE experts, gate_up_proj)                      │
                          │  4. Apply dequantization/deserialization (if pre-quant)   │
-                         │  5. Apply conversion (if defined)                        │
-                         │  6. Apply quantization (if enabled and step 4 not used)  │
-                         │  7. Set parameter on model                               │
+                         │  5. Apply conversion (if defined)                         │
+                         │  6. Apply quantization (if enabled and step 4 not used)   │
+                         │  7. Set parameter on model                                │
                          └───────────────────────────────────────────────────────────┘
 ```
 


### PR DESCRIPTION
There were misalignment issues in the first diagram, patched now

Motivation to fix? well, it was misaligned, and now its not, the diagrams look better and it flows a whole lot cleaner without distracting, minor polish work 

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [X] I confirm that this is not a pure code agent PR.

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [X] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- no, its a minor issue i found myself while diagnosing another issue for Deepseek and Gemma models, very simple fix too
- [X] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?
- Not necessary for this


## Who can review?

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->

Not even sure whom to get a hold of for docs these days, but @stevhliu, can you make sure that it doesnt run into troubles via bot tests and stuff?