### PR TITLE
fix: enable _supports_flash_attn_2 for EOMT

### DIFF
--- a/src/transformers/models/eomt/modeling_eomt.py
+++ b/src/transformers/models/eomt/modeling_eomt.py
@@ -988,6 +988,7 @@ class EomtPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = False
     _no_split_modules = ["EomtLayer"]
     _supports_sdpa = True
+    _supports_flash_attn = True
     _can_record_outputs = {
         "hidden_states": EomtLayer,
         "attentions": EomtAttention,

--- a/src/transformers/models/eomt/modular_eomt.py
+++ b/src/transformers/models/eomt/modular_eomt.py
@@ -330,6 +330,7 @@ class EomtPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = False
     _no_split_modules = ["EomtLayer"]
     _supports_sdpa = True
+    _supports_flash_attn = True
     _can_record_outputs = {
         "hidden_states": EomtLayer,
         "attentions": EomtAttention,

--- a/src/transformers/models/eomt_dinov3/modeling_eomt_dinov3.py
+++ b/src/transformers/models/eomt_dinov3/modeling_eomt_dinov3.py
@@ -1079,6 +1079,7 @@ class EomtDinov3PreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = False
     _no_split_modules = ["EomtDinov3Layer"]
     _supports_sdpa = True
+    _supports_flash_attn = True
     _can_record_outputs = {
         "hidden_states": EomtDinov3Layer,
         "attentions": EomtDinov3Attention,

--- a/src/transformers/models/videomt/modeling_videomt.py
+++ b/src/transformers/models/videomt/modeling_videomt.py
@@ -949,6 +949,7 @@ class VideomtPreTrainedModel(PreTrainedModel):
     supports_gradient_checkpointing = False
     _no_split_modules = ["VideomtLayer"]
     _supports_sdpa = True
+    _supports_flash_attn = True
     _can_record_outputs = {
         "hidden_states": VideomtLayer,
         "attentions": VideomtAttention,


### PR DESCRIPTION
## What does this PR do?

EOMT had full Flash Attention 2 wiring via `ALL_ATTENTION_FUNCTIONS` but the gate flag `_supports_flash_attn_2` was missing. This one-line fix enables FA2 for EOMT.

**Root cause:** `EomtPreTrainedModel` was missing `_supports_flash_attn_2 = True` despite the attention layer already being correctly wired to the FA2 backend.

## Changes
- Add `_supports_flash_attn_2 = True` to `EomtPreTrainedModel`

## Files changed
- `src/transformers/models/eomt/modular_eomt.py`
- `src/transformers/models/eomt/modeling_eomt.py`