### PR TITLE
[Weight converter] Account for base model prefix in scoped weight conversion

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -680,34 +680,56 @@ class WeightTransform:
         self.collected_tensors[source_pattern].append(future)
         self.layer_targets[target_key].add(source_key)
 
-    def _scoped_match(self, source_key: str) -> tuple[str | None, str, re.Match[str]] | None:
+    def _scoped_match(
+        self, source_key: str, base_model_prefix: str | None = None
+    ) -> tuple[str | None, str, re.Match[str]] | None:
         """
-        Apply `scope_prefix` stripping (if any), then match `compiled_sources` against the suffix.
+        Strip `scope_prefix` (if any) from `source_key`, then match `compiled_sources` against the
+        remaining suffix.
 
-        Returns `(prefix_dot, key_to_match, match_object)` when a branch matches, where `prefix_dot` is `None`
-        if `scope_prefix` is unset, else `f"{scope_prefix}."`. Returns `None` when out of scope or unmatched.
+        Returns `(prefix_dot, key_to_match, match_object)` on match, else `None`. `prefix_dot` is
+        the prefix consumed from `source_key`: either `f"{scope_prefix}."` or that same string with
+        one `base_model_prefix` level stripped or prepended when the former didn't match.
+        `None` when `scope_prefix` is unset.
         """
-        prefix_dot = None
-        key_to_match = source_key
-        if self.scope_prefix is not None:
-            prefix_dot = self.scope_prefix + "."
-            if not source_key.startswith(prefix_dot):
+        if self.scope_prefix is None:
+            match_object = self.compiled_sources.search(source_key)
+            if match_object is None:
                 return None
-            key_to_match = source_key[len(prefix_dot) :]
+            return (None, source_key, match_object)
+
+        scope_prefix_dot = self.scope_prefix + "."
+        # Try `scope_prefix.` first; then a single `base_model_prefix` adjustment - strip it off if
+        # `scope_prefix.` already starts with it, otherwise prepend it.
+        candidates = [scope_prefix_dot]
+        if base_model_prefix is not None:
+            base_dot = base_model_prefix + "."
+            if scope_prefix_dot.startswith(base_dot):
+                candidates.append(scope_prefix_dot[len(base_dot) :])
+            else:
+                candidates.append(base_dot + scope_prefix_dot)
+
+        for candidate in candidates:
+            if source_key.startswith(candidate):
+                key_to_match = source_key[len(candidate) :]
+                prefix_dot = candidate
+                break
+        else:
+            return None
 
         match_object = self.compiled_sources.search(key_to_match)
         if match_object is None:
             return None
         return (prefix_dot, key_to_match, match_object)
 
-    def rename_source_key(self, source_key: str) -> tuple[str, str | None]:
+    def rename_source_key(self, source_key: str, base_model_prefix: str | None = None) -> tuple[str, str | None]:
         """
         Return a tuple (renamed_key, source_pattern_producing_the_match).
         Try renaming `source_key` according to the source and target patterns of the current WeightTransform.
         In case of a one-to-many transform, i.e. we have several target patterns, the matching source pattern
         will be replaced by the first of all the target patterns (they are then correctly expanded in the Operations).
         """
-        matched = self._scoped_match(source_key)
+        matched = self._scoped_match(source_key, base_model_prefix)
         if matched is None:
             return source_key, None
 
@@ -1145,7 +1167,7 @@ def rename_source_key(
     source_key: str,
     weight_renamings: list[WeightRenaming],
     weight_converters: list[WeightConverter],
-    prefix: str | None = None,
+    base_model_prefix: str | None = None,
     meta_state_dict: dict | None = None,
 ) -> tuple[str, str | None]:
     """
@@ -1163,10 +1185,10 @@ def rename_source_key(
             Applied in order; every matching renaming fires (they may chain).
         weight_converters (`list[WeightConverter]`):
             Applied after all renamings; at most one may match. Subsequent converters are skipped.
-        prefix (`str`, *optional*):
-            Base-model prefix to add or strip when both `prefix` and `meta_state_dict` are given.
+        base_model_prefix (`str`, *optional*):
+            Base-model prefix to add or strip when both `base_model_prefix` and `meta_state_dict` are given.
         meta_state_dict (`dict`, *optional*):
-            Meta state dict used to decide whether `prefix` should be added or stripped.
+            Meta state dict used to decide whether `base_model_prefix` should be added or stripped.
 
     Returns:
         `tuple[str, str | None]`: The renamed key and the matched converter's source pattern
@@ -1176,25 +1198,25 @@ def rename_source_key(
     # 1. apply all renamings in turns (if multiple match, it's the responsibility of the mappings to make sure they
     # are coherent)
     for renaming in weight_renamings:
-        renamed_key, _ = renaming.rename_source_key(renamed_key)
+        renamed_key, _ = renaming.rename_source_key(renamed_key, base_model_prefix=base_model_prefix)
 
     # 2. apply renaming through weight conversions on the key if we have any WeightConverter (here we stop after
     # the first match, as we assume only 1 converter can match any source key)
     source_pattern = None
     for converter in weight_converters:
-        renamed_key, source_pattern = converter.rename_source_key(renamed_key)
+        renamed_key, source_pattern = converter.rename_source_key(renamed_key, base_model_prefix=base_model_prefix)
         if source_pattern is not None:
             break
 
-    # 3. check if we need to add or remove prefix if necessary (only during loading, not saving)
-    if prefix is not None and meta_state_dict is not None:
+    # 3. check if we need to add or remove base_model_prefix if necessary (only during loading, not saving)
+    if base_model_prefix is not None and meta_state_dict is not None:
         if (
-            renamed_key.startswith(prefix)
-            and meta_state_dict.get(re.sub(f"^{prefix}.", "", renamed_key, count=1)) is not None
+            renamed_key.startswith(base_model_prefix)
+            and meta_state_dict.get(re.sub(f"^{base_model_prefix}.", "", renamed_key, count=1)) is not None
         ):
-            renamed_key = re.sub(f"^{prefix}.", "", renamed_key, count=1)
-        elif meta_state_dict.get(f"{prefix}.{renamed_key}") is not None:
-            renamed_key = f"{prefix}.{renamed_key}"
+            renamed_key = re.sub(f"^{base_model_prefix}.", "", renamed_key, count=1)
+        elif meta_state_dict.get(f"{base_model_prefix}.{renamed_key}") is not None:
+            renamed_key = f"{base_model_prefix}.{renamed_key}"
 
     return renamed_key, source_pattern
 
@@ -1292,7 +1314,7 @@ def convert_and_load_state_dict_in_model(
     ```
 
     """
-    prefix = model.base_model_prefix
+    base_model_prefix = model.base_model_prefix
     tp_plan = tp_plan or {}
     device_map = load_config.device_map or {"": "cpu"}
     hf_quantizer = load_config.hf_quantizer
@@ -1345,12 +1367,16 @@ def convert_and_load_state_dict_in_model(
     for original_key, tensor in state_dict:
         # 1. Rename the key according to all renaming and weight conversion patterns.
         renamed_key, source_pattern = rename_source_key(
-            original_key, renamings, converters, prefix=prefix, meta_state_dict=meta_model_state_dict
+            original_key,
+            renamings,
+            converters,
+            base_model_prefix=base_model_prefix,
+            meta_state_dict=meta_model_state_dict,
         )
         if renamed_key not in meta_model_state_dict and original_key in meta_model_state_dict:
             # Key should probably not have been renamed but we might need the `prefix` to be added.
             renamed_key, source_pattern = rename_source_key(
-                original_key, [], [], prefix=prefix, meta_state_dict=meta_model_state_dict
+                original_key, [], [], base_model_prefix=base_model_prefix, meta_state_dict=meta_model_state_dict
             )
 
         # 2. finally, collect the tensor into the proper converter

--- a/src/transformers/integrations/accelerate.py
+++ b/src/transformers/integrations/accelerate.py
@@ -469,7 +469,9 @@ def accelerate_disk_offload(
 
         # Update the weight names according to the `weight_mapping`
         weight_renaming_map = {
-            rename_source_key(k, renamings, [], prefix=model.base_model_prefix, meta_state_dict=meta_state_dict)[0]: k
+            rename_source_key(
+                k, renamings, [], base_model_prefix=model.base_model_prefix, meta_state_dict=meta_state_dict
+            )[0]: k
             for k in weight_map
         }
 

--- a/src/transformers/integrations/deepspeed.py
+++ b/src/transformers/integrations/deepspeed.py
@@ -352,7 +352,7 @@ def _apply_weight_conversions_to_state_dict(model, state_dict, weight_mapping):
     # Preserve metadata from the original state dict
     metadata = getattr(state_dict, "_metadata", None)
 
-    prefix = model.base_model_prefix
+    base_model_prefix = model.base_model_prefix
 
     # Build a meta state dict for matching - only keys/shapes, no actual tensor data
     # This minimizes memory since we don't duplicate the model's parameters
@@ -368,7 +368,7 @@ def _apply_weight_conversions_to_state_dict(model, state_dict, weight_mapping):
         new_state_dict = {}
         for original_key, tensor in state_dict.items():
             renamed_key, _ = rename_source_key(
-                original_key, renamings, [], prefix=prefix, meta_state_dict=model_state_dict
+                original_key, renamings, [], base_model_prefix=base_model_prefix, meta_state_dict=model_state_dict
             )
             if renamed_key in model_state_dict:
                 new_state_dict[renamed_key] = tensor
@@ -389,7 +389,7 @@ def _apply_weight_conversions_to_state_dict(model, state_dict, weight_mapping):
     for original_key in sorted_keys:
         tensor = state_dict.pop(original_key)
         renamed_key, source_pattern = rename_source_key(
-            original_key, renamings, converters, prefix=prefix, meta_state_dict=model_state_dict
+            original_key, renamings, converters, base_model_prefix=base_model_prefix, meta_state_dict=model_state_dict
         )
 
         # Only process if the renamed key is in the model's state dict

--- a/tests/utils/test_core_model_loading.py
+++ b/tests/utils/test_core_model_loading.py
@@ -585,6 +585,129 @@ class TestConvertAndLoadStateDict(unittest.TestCase):
         torch.testing.assert_close(model.language_model.q.weight, torch.zeros(1, 2))
         torch.testing.assert_close(model.q.weight, torch.zeros(1, 2))
 
+    def test_scoped_match_falls_back_when_checkpoint_omits_base_prefix(self):
+        """``scope_prefix == base_model_prefix`` and the checkpoint key omits the prefix
+        (raw submodule checkpoint, ``old_q.weight``): the rename must still land at
+        ``model.q.weight`` via ``base_model_prefix``-adjusted matching.
+        """
+
+        class _Sub(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q = DummyParamModule((1, 2))
+
+        class _Root(PreTrainedModel):
+            base_model_prefix = "model"
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.model = _Sub()
+                self.post_init()
+
+        model = _Root(PretrainedConfig())
+        val = torch.tensor([[1.0, 2.0]])
+        checkpoint = {"old_q.weight": val.clone()}
+
+        scoped_rename = WeightRenaming("^old_q", "q")
+        scoped_rename.scope_prefix = "model"
+
+        loading_info, _ = convert_and_load_state_dict_in_model(
+            model,
+            checkpoint,
+            LoadStateDictConfig(weight_mapping=[scoped_rename]),
+            tp_plan=None,
+        )
+
+        self.assertEqual(loading_info.missing_keys, set())
+        self.assertEqual(loading_info.unexpected_keys, set())
+        self.assertEqual(loading_info.mismatched_keys, set())
+        self.assertEqual(loading_info.conversion_errors, {})
+        torch.testing.assert_close(model.model.q.weight, val)
+
+    def test_scoped_match_strips_one_base_prefix_level_for_nested_scope(self):
+        """``scope_prefix`` is nested under ``base_model_prefix`` (``'model.sub'`` with
+        ``base_model_prefix='model'``) and the checkpoint omits the outer ``'model.'``
+        (``sub.old_q.weight``): the rename must still land at ``model.sub.q.weight``.
+        """
+
+        class _Inner(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q = DummyParamModule((1, 2))
+
+        class _Middle(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.sub = _Inner()
+
+        class _Root(PreTrainedModel):
+            base_model_prefix = "model"
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.model = _Middle()
+                self.post_init()
+
+        model = _Root(PretrainedConfig())
+        val = torch.tensor([[1.0, 2.0]])
+        checkpoint = {"sub.old_q.weight": val.clone()}
+
+        scoped_rename = WeightRenaming("^old_q", "q")
+        scoped_rename.scope_prefix = "model.sub"
+
+        loading_info, _ = convert_and_load_state_dict_in_model(
+            model,
+            checkpoint,
+            LoadStateDictConfig(weight_mapping=[scoped_rename]),
+            tp_plan=None,
+        )
+
+        self.assertEqual(loading_info.missing_keys, set())
+        self.assertEqual(loading_info.unexpected_keys, set())
+        self.assertEqual(loading_info.mismatched_keys, set())
+        self.assertEqual(loading_info.conversion_errors, {})
+        torch.testing.assert_close(model.model.sub.q.weight, val)
+
+    def test_scoped_match_round_trips_when_scope_equals_base_model_prefix(self):
+        """``scope_prefix == base_model_prefix``: loading a checkpoint and then saving via
+        ``revert_weight_conversion`` must reconstruct the same checkpoint keys (forward and
+        reverse renames are symmetric).
+        """
+
+        class _Sub(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.q = DummyParamModule((1, 2))
+
+        class _Root(PreTrainedModel):
+            base_model_prefix = "model"
+
+            def __init__(self, config):
+                super().__init__(config)
+                self.model = _Sub()
+                self.post_init()
+
+        model = _Root(PretrainedConfig())
+        val = torch.tensor([[1.0, 2.0]])
+        checkpoint = {"model.old_q.weight": val.clone()}
+
+        scoped_rename = WeightRenaming("^old_q", "q")
+        scoped_rename.scope_prefix = "model"
+
+        loading_info, _ = convert_and_load_state_dict_in_model(
+            model,
+            checkpoint,
+            LoadStateDictConfig(weight_mapping=[scoped_rename]),
+            tp_plan=None,
+        )
+        self.assertEqual(loading_info.missing_keys, set())
+        self.assertEqual(loading_info.unexpected_keys, set())
+        self.assertEqual(loading_info.mismatched_keys, set())
+        self.assertEqual(loading_info.conversion_errors, {})
+
+        saved = revert_weight_conversion(model, model.state_dict())
+        self.assertTrue(compare_state_dicts(saved, checkpoint))
+
     def test_interleaved_renaming_and_converter_round_trip(self):
         """A WeightRenaming preceding a WeightConverter must also fire on the save path
         even after the converter has already set source_pattern.


### PR DESCRIPTION
# What does this PR do?

Now that the weight converter patterns are scoped, we need to account for a potential `base_model_prefix` in the original weight (independently of the conversion patterns). Right now we have regression compared to before with integration tests like OneFormer and Mask2Former failing as they load weights with base_model_prefix into base models, and have a backbone (`swin`) with conversion patterns.
This PR accounts for this by trying to match the source weight first with the default scope, then by adding or removing the `base_model_prefix` to the scope (not the pattern).

This is not perfect but with the way `base_model_prefix` and weight conversions are implemented in the repo, we can never know for sure if source model weights have a base_model_prefix attached or not before converting the weights, so this is the best and lightest heuristic I found which doesn't introduce any regressions compared to before scoped weight conversion. 