### PR TITLE
cache: store StaticLayer.cumulative_length as a 0-dim scalar tensor

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -290,8 +290,13 @@ class StaticLayer(CacheLayerMixin):
     def __init__(self, max_cache_len: int):
         super().__init__()
         self.max_cache_len = max_cache_len
-        # Very important that it's a tensor here, to avoid recompiling when we update it and use it to create positions
-        self.cumulative_length = torch.tensor([0], dtype=int)
+        # Very important that it's a tensor here, to avoid recompiling when we update it and use it to create positions.
+        # Use a 0-dim scalar tensor so `get_seq_length()` returns a value
+        # consistent with `DynamicCache.get_seq_length()` (a plain int)
+        # in arithmetic contexts; a shape-(1,) tensor here promoted
+        # downstream `int - past_len` operations into shape-(1,) tensors
+        # (see #45987).
+        self.cumulative_length = torch.tensor(0, dtype=torch.int64)
 
     def lazy_initialization(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
         """


### PR DESCRIPTION
`StaticLayer.cumulative_length` was initialised as `torch.tensor([0])` (shape-(1,)), so `StaticCache.get_seq_length()` returned a shape-(1,) tensor instead of a value consistent with `DynamicCache.get_seq_length()`, which returns a plain `int`. The two cache types weren't safely interchangeable, and downstream `int - past_len` arithmetic promoted to shape-(1,) tensors that can propagate into slicing logic.

Storing the cumulative length as a 0-dim scalar tensor preserves the compile-friendly tensor semantics the existing comment calls out (the value still mutates in-place via `add_()` and is still attached to the static address for `torch.compile`), but makes arithmetic against ints behave the same as with `DynamicCache`.

Fixes #45987