### PR TITLE
docs: update models architecture count and sync ACL anthology URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ pipeline(
 1. Lower compute costs, smaller carbon footprint:
     - Share trained models instead of training from scratch.
     - Reduce compute time and production costs.
-    - Dozens of model architectures with 1M+ pretrained checkpoints across all modalities.
+    - Hundreds of model architectures with 1M+ pretrained checkpoints across all modalities.
 
 1. Choose the right framework for every part of a model's lifetime:
     - Train state-of-the-art models in 3 lines of code.
@@ -321,7 +321,7 @@ Expand each modality below to see a few example models for various use cases.
 
 ## Citation
 
-We now have a [paper](https://www.aclweb.org/anthology/2020.emnlp-demos.6/) you can cite for the 🤗 Transformers library:
+We now have a [paper](https://aclanthology.org/2020.emnlp-demos.6/) you can cite for the 🤗 Transformers library:
 ```bibtex
 @inproceedings{wolf-etal-2020-transformers,
     title = "Transformers: State-of-the-Art Natural Language Processing",
@@ -331,7 +331,7 @@ We now have a [paper](https://www.aclweb.org/anthology/2020.emnlp-demos.6/) you 
     year = "2020",
     address = "Online",
     publisher = "Association for Computational Linguistics",
-    url = "https://www.aclweb.org/anthology/2020.emnlp-demos.6",
+    url = "https://aclanthology.org/2020.emnlp-demos.6/",
     pages = "38--45"
 }
 ```


### PR DESCRIPTION
# What does this PR do?

- Updated the model architecture statement from "Dozens" to "Hundreds" to reflect accurate current metrics on the Hub.
- Synchronized legacy ACL Web anthology URLs with the official and current 'aclanthology.org' domain format across the documentation and BibTeX citation block.

Fixes # (Not applicable - Direct documentation improvement)

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the contributor guideline?
- [ ] Was this discussed/approved via a Github issue or the forum?
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

## Who can review?
cc: @stevhliu