### PR TITLE
[Image Processor] Speed up image processors by casting to array before BatchFeature

### DIFF
--- a/src/transformers/image_processing_backends.py
+++ b/src/transformers/image_processing_backends.py
@@ -421,6 +421,9 @@ class TorchvisionBackend(BaseImageProcessor):
         if do_pad:
             processed_images = self.pad(processed_images, pad_size=pad_size, disable_grouping=disable_grouping)
 
+        if return_tensors is not None:
+            processed_images = torch.stack(processed_images)
+
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 
 
@@ -674,6 +677,9 @@ class PilBackend(BaseImageProcessor):
 
         if do_pad:
             processed_images = self.pad(processed_images, pad_size=pad_size)
+
+        if return_tensors is not None:
+            processed_images = np.array(processed_images)
 
         return BatchFeature(data={"pixel_values": processed_images}, tensor_type=return_tensors)
 


### PR DESCRIPTION
I noticed that our image processors were slowing down a bit when handling large batches because we were passing raw Python lists into BatchFeature.
I've added a quick optimization to the PilBackend and TorchvisionBackend that stacks the images into a single array or tensor right after they're padded. This way, BatchFeature doesn't have to do the heavy lifting of converting the list element-by-element, which makes the whole preprocessing pipeline feel a lot snappier.
I made sure to put the change after the padding logic so we don't run into shape mismatch issues. I've also run ruff on the file to keep the styling consistent with the rest of the repo.