### PR TITLE
fix: StaticLayer.get_seq_length() returns int not Tensor

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -291,7 +291,7 @@ class StaticLayer(CacheLayerMixin):
         super().__init__()
         self.max_cache_len = max_cache_len
         # Very important that it's a tensor here, to avoid recompiling when we update it and use it to create positions
-        self.cumulative_length = torch.tensor([0], dtype=int)
+        self.cumulative_length = torch.tensor(0, dtype=torch.int64)
 
     def lazy_initialization(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
         """
@@ -377,7 +377,7 @@ class StaticLayer(CacheLayerMixin):
 
     def get_seq_length(self) -> int:
         """Returns the sequence length of the cached states."""
-        return self.cumulative_length if self.is_initialized else 0
+        return self.cumulative_length.item() if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:
         """Return the maximum cache shape of the cache"""


### PR DESCRIPTION
Fixes #45987

## What was wrong

`StaticLayer.__init__` initializes `cumulative_length` as a shape-`(1,)` tensor:

```python
self.cumulative_length = torch.tensor([0], dtype=int)  # shape (1,)
```

`get_seq_length()` then returns it directly, so callers get `tensor([8])` instead of `8`. The abstract base class `CacheLayerMixin` declares `get_seq_length() -> int`, and `DynamicLayer.get_seq_length()` correctly returns a plain `int`. This makes `StaticCache` and `DynamicCache` not safely interchangeable.

Downstream effects reported in the issue:
- `isinstance(cache.get_seq_length(), int)` is `False` for `StaticCache`
- `int - tensor([N])` yields a `Tensor`, propagating the wrong type into generation/slicing code
- `masking_utils.py` already has an explicit `isinstance(q_offset, torch.Tensor)` guard with a comment noting this known issue

## Fix

Two minimal changes in `StaticLayer`:

1. Use a 0-dim scalar tensor instead of shape-`(1,)`:
```python
# before
self.cumulative_length = torch.tensor([0], dtype=int)
# after
self.cumulative_length = torch.tensor(0, dtype=torch.int64)
```
All existing in-place ops (`.add_()`, `mark_static_address`, `.to(device)`) work on 0-dim tensors. The compile/cudagraph semantics are preserved since `cumulative_length` is still a tensor.

2. Return `.item()` from `get_seq_length()`:
```python
# before
return self.cumulative_length if self.is_initialized else 0
# after
return self.cumulative_length.item() if self.is_initialized else 0
```
This fulfills the `-> int` contract and makes `StaticCache` consistent with `DynamicCache`.

The workaround in `masking_utils.py` (`isinstance(q_offset, torch.Tensor)` check) remains harmless -- it will always take the `else` branch now.