### PR TITLE
hf_argparser: fix TypeError when resolving Optional of generic type

### DIFF
--- a/src/transformers/hf_argparser.py
+++ b/src/transformers/hf_argparser.py
@@ -182,7 +182,7 @@ class HfArgumentParser(ArgumentParser):
             elif bool not in field.type.__args__:
                 # filter `NoneType` in Union (except for `Union[bool, NoneType]`)
                 field.type = (
-                    field.type.__args__[0] if isinstance(None, field.type.__args__[1]) else field.type.__args__[1]
+                    field.type.__args__[0] if field.type.__args__[1] is type(None) else field.type.__args__[1]
                 )
                 origin_type = getattr(field.type, "__origin__", field.type)
 


### PR DESCRIPTION
# What does this PR do?

Fixes a `TypeError` in `HfArgumentParser._parse_dataclass_field` when a dataclass field is typed as `Optional[X]` where `X` is a subscripted generic (e.g. `Optional[List[str]]`, `Optional[list[str]]`, `Optional[Dict[str, int]]`).

The root cause is on line 185, where `isinstance(None, field.type.__args__[1])` is used to detect whether the second type argument is `NoneType`. This works for plain classes like `int` or `str`, but raises `TypeError: Subscripted generics cannot be used with class and instance checks` when `args[1]` is a generic alias — which happens when `None` appears first in the union, e.g. `Union[None, List[str]]`.

The fix replaces the `isinstance` call with an identity check: `field.type.__args__[1] is type(None)`. This is the correct, idiomatic way to test for `NoneType` and mirrors the pattern already used two lines above (`type(None) not in field.type.__args__`). It is safe for all types including generics, and produces identical results for plain classes where `isinstance` happened to work.

Fixes # (issue)

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?
@ArthurZucker