### PR TITLE
fix(cache): StaticCache.get_seq_length() now returns int instead of Tensor

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -291,7 +291,7 @@ class StaticLayer(CacheLayerMixin):
         super().__init__()
         self.max_cache_len = max_cache_len
         # Very important that it's a tensor here, to avoid recompiling when we update it and use it to create positions
-        self.cumulative_length = torch.tensor([0], dtype=int)
+        self.cumulative_length = torch.tensor(0, dtype=torch.int64)
 
     def lazy_initialization(self, key_states: torch.Tensor, value_states: torch.Tensor) -> None:
         """
@@ -377,7 +377,7 @@ class StaticLayer(CacheLayerMixin):
 
     def get_seq_length(self) -> int:
         """Returns the sequence length of the cached states."""
-        return self.cumulative_length if self.is_initialized else 0
+        return self.cumulative_length.item() if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:
         """Return the maximum cache shape of the cache"""

--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -857,9 +857,6 @@ def _preprocess_mask_arguments(
     # If using a cache, it can give all information about mask sizes based on seen tokens
     if past_key_values is not None:
         q_offset = past_key_values.get_seq_length()
-        # To avoid graph breaks, StaticLayer return a tensor instead of int -> this has no impact on the ops, but we
-        # need the correct device
-        q_offset = q_offset.to(inputs_embeds.device) if isinstance(q_offset, torch.Tensor) else q_offset
         kv_length, kv_offset = past_key_values.get_mask_sizes(q_length, layer_idx)
     # Otherwise, we infer based on our input
     else:

--- a/tests/utils/test_cache_utils.py
+++ b/tests/utils/test_cache_utils.py
@@ -108,6 +108,35 @@ class CacheTest(unittest.TestCase):
         self.assertTrue(cached_keys.shape == (1, 1, 10, 128))
         self.assertTrue(cached_values.shape == (1, 1, 10, 128))
 
+    def test_static_cache_get_seq_length_returns_int(self):
+        """
+        Regression test for https://github.com/huggingface/transformers/issues/45987
+        StaticCache.get_seq_length() must return a plain Python int, not a Tensor,
+        to satisfy its -> int type contract and be interchangeable with DynamicCache.
+        """
+        config = LlamaConfig(num_attention_heads=32)
+        cache = StaticCache(config=config, max_cache_len=10)
+
+        # Before any update: should return 0 (int)
+        seq_len = cache.get_seq_length()
+        self.assertIsInstance(seq_len, int, "get_seq_length() must return int before initialization")
+        self.assertEqual(seq_len, 0)
+
+        # After an update: should still return a plain int
+        random_keys = torch.rand((1, 32, 3, 128))
+        random_values = torch.rand((1, 32, 3, 128))
+        cache.update(random_keys, random_values, 0)
+
+        seq_len = cache.get_seq_length()
+        self.assertIsInstance(seq_len, int, "get_seq_length() must return int after initialization")
+        self.assertEqual(seq_len, 3)
+
+        # Consistent with DynamicCache
+        dynamic_cache = DynamicCache()
+        dynamic_cache.update(random_keys, random_values, 0)
+        self.assertIsInstance(dynamic_cache.get_seq_length(), int)
+        self.assertEqual(cache.get_seq_length(), dynamic_cache.get_seq_length())
+
 
 def _skip_on_failed_cache_prerequisites(test, cache_implementation):
     """Function to skip tests on failed cache prerequisites, given a cache implementation"""


### PR DESCRIPTION
## Problem

`StaticLayer.get_seq_length()` violates its `-> int` type contract by returning a shape-(1,) `torch.Tensor` instead of a Python `int`. This breaks interchangeability with `DynamicCache` and causes subtle type propagation bugs (e.g., `int - tensor([N])` yields a `Tensor`, not an `int`).\n\nFixes #45987\n\n## Root Cause\n\n`StaticLayer.__init__` initializes `cumulative_length` as a shape-(1,) tensor, and `get_seq_length()` returns it directly. A workaround existed in `masking_utils.py` to handle the tensor return.\n\n## Fix\n\n1. **`cache_utils.py`**: Initialize `cumulative_length` as a scalar `torch.int64` tensor and call `.item()` in `get_seq_length()` to return a plain Python `int`. The tensor is preserved for in-place mutation and `torch.compile` graph stability.\n2. **`masking_utils.py`**: Remove the `isinstance(torch.Tensor)` workaround.\n3. **`tests/utils/test_cache_utils.py`**: Add regression test asserting `get_seq_length()` returns `int` and is consistent with `DynamicCache`.