### PR TITLE
fix: handle OOV token ids gracefully in convert_ids_to_tokens

### DIFF
--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -767,7 +767,9 @@ class TokenizersBackend(PreTrainedTokenizerBase):
         if isinstance(ids, int):
             token = self._tokenizer.id_to_token(ids)
             if token is None:
-                logger.warning(f"Token id {ids} is out of vocabulary (vocab size: {self.vocab_size}). Returning empty string.")
+                logger.warning(
+                    f"Token id {ids} is out of vocabulary (vocab size: {self.vocab_size}). Returning empty string."
+                )
                 return ""
             return token
         tokens = []

--- a/src/transformers/tokenization_utils_tokenizers.py
+++ b/src/transformers/tokenization_utils_tokenizers.py
@@ -765,15 +765,22 @@ class TokenizersBackend(PreTrainedTokenizerBase):
             `str` or `list[str]`: The decoded token(s).
         """
         if isinstance(ids, int):
-            return self._tokenizer.id_to_token(ids)
+            token = self._tokenizer.id_to_token(ids)
+            if token is None:
+                logger.warning(f"Token id {ids} is out of vocabulary (vocab size: {self.vocab_size}). Returning empty string.")
+                return ""
+            return token
         tokens = []
-        # self.all_special_ids is an @property which may be slow, so only compute it once before the loop
         ids_to_skip = set(self.all_special_ids) if skip_special_tokens else set()
         for index in ids:
             index = int(index)
             if index in ids_to_skip:
                 continue
-            tokens.append(self._tokenizer.id_to_token(index))
+            token = self._tokenizer.id_to_token(index)
+            if token is None:
+                logger.warning(f"Token id {index} is out of vocabulary (vocab size: {self.vocab_size}). Skipping.")
+                continue
+            tokens.append(token)
         return tokens
 
     def tokenize(self, text: str, pair: str | None = None, add_special_tokens: bool = False, **kwargs) -> list[str]:

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -400,9 +400,9 @@ class OOVTokenHandlingTests(unittest.TestCase):
     """
 
     def _get_tokenizer(self):
+        import tokenizers.pre_tokenizers as pre_tokenizers
         from tokenizers import Tokenizer
         from tokenizers.models import WordLevel
-        import tokenizers.pre_tokenizers as pre_tokenizers
         tok = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1, "world": 2}, unk_token="[UNK]"))
         tok.pre_tokenizer = pre_tokenizers.Whitespace()
         return PreTrainedTokenizerFast(tokenizer_object=tok)

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -403,6 +403,7 @@ class OOVTokenHandlingTests(unittest.TestCase):
         import tokenizers.pre_tokenizers as pre_tokenizers
         from tokenizers import Tokenizer
         from tokenizers.models import WordLevel
+
         tok = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1, "world": 2}, unk_token="[UNK]"))
         tok.pre_tokenizer = pre_tokenizers.Whitespace()
         return PreTrainedTokenizerFast(tokenizer_object=tok)

--- a/tests/tokenization/test_tokenization_fast.py
+++ b/tests/tokenization/test_tokenization_fast.py
@@ -390,3 +390,37 @@ class PatchMistralRegexHubCallTests(unittest.TestCase):
                 "not-a-real/hub-id",
             )
         self.assertIsNotNone(result)
+
+
+@require_tokenizers
+class OOVTokenHandlingTests(unittest.TestCase):
+    """
+    Tests for graceful handling of out-of-vocabulary token ids in convert_ids_to_tokens.
+    Regression tests for https://github.com/huggingface/transformers/issues/29159
+    """
+
+    def _get_tokenizer(self):
+        from tokenizers import Tokenizer
+        from tokenizers.models import WordLevel
+        import tokenizers.pre_tokenizers as pre_tokenizers
+        tok = Tokenizer(WordLevel({"[UNK]": 0, "hello": 1, "world": 2}, unk_token="[UNK]"))
+        tok.pre_tokenizer = pre_tokenizers.Whitespace()
+        return PreTrainedTokenizerFast(tokenizer_object=tok)
+
+    def test_oov_single_id_returns_empty_string(self):
+        """OOV single token id should return empty string, not None."""
+        tokenizer = self._get_tokenizer()
+        result = tokenizer.convert_ids_to_tokens(9999)
+        self.assertEqual(result, "")
+
+    def test_oov_in_list_is_skipped(self):
+        """OOV token ids in a list should be skipped gracefully."""
+        tokenizer = self._get_tokenizer()
+        result = tokenizer.convert_ids_to_tokens([1, 9999, 2])
+        self.assertEqual(result, ["hello", "world"])
+
+    def test_valid_ids_unaffected(self):
+        """Valid token ids should still work correctly after the fix."""
+        tokenizer = self._get_tokenizer()
+        result = tokenizer.convert_ids_to_tokens([0, 1, 2])
+        self.assertEqual(result, ["[UNK]", "hello", "world"])


### PR DESCRIPTION
## What does this PR do?

Fixes #29159

When a token id exceeds the vocabulary size, `id_to_token()` returns 
`None` silently. Previously this `None` was returned/appended without 
any warning, causing silent incorrect behavior.

This fix adds a warning log and:
- Returns `""` (empty string) for single OOV token ids
- Skips OOV tokens when processing a list of ids

This aligns behavior consistently and makes OOV ids visible to the user.

## Before
- Single OOV id → returns `None` silently
- List with OOV ids → appends `None` to results silently

## After  
- Single OOV id → logs warning + returns `""`
- List with OOV ids → logs warning + skips token