### PR TITLE
docs: document flash attention supports_mapping

### DIFF
--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -529,7 +529,9 @@ def _process_flash_attention_kwargs(
             Determines if the deterministic option introduced in flash_attn>=2.4.1 is enabled.
         s_aux (`torch.Tensor`, *optional*):
             Attention sink auxiliary that adds a `bias` to the attention calculation via an additional head.
-    Return:
+        supports_mapping (`dict[str, bool]`, *optional*):
+            Mapping indicating whether each flash attention feature is supported by the active backend.
+    Returns:
         flash_kwargs (`dict`):
             A dict of kwargs that are requested and supported.
     """


### PR DESCRIPTION
# What does this PR do?

Documents the `supports_mapping` argument in `_process_flash_attention_kwargs` and fixes the docstring section heading from `Return` to `Returns`.

Fixes #45995


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. Issue: #45995
- [x] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests? No new tests were needed for this docstring-only change; ran `python3 -m py_compile src/transformers/modeling_flash_attention_utils.py` and `python3 -m ruff check src/transformers/modeling_flash_attention_utils.py`.


## Who can review?

Documentation: @stevhliu
Attention: @vasqu @ArthurZucker @CyrilVallez
