### PR TITLE
fix: include transitive relative imports when loading from local directory

### DIFF
--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -313,16 +313,12 @@ def get_class_in_module(
 
 def _compute_local_source_files_hash(
     pretrained_model_name_or_path: str | os.PathLike,
-    module_file: str | os.PathLike,
     resolved_module_file: str | os.PathLike,
-    modules_needed: list[str],
 ) -> str:
     """
-    Computes a stable hash from the bytes of the local source file and its direct relative-import source files.
+    Computes a stable hash from the bytes of the local source file and its transitive relative-import source files.
     """
     model_path = Path(pretrained_model_name_or_path).resolve()
-    module_parent = Path(module_file).parent
-
     resolved_module_file = Path(resolved_module_file).resolve()
 
     def _resolve_relative_source_path(source_file_path: Path) -> str:
@@ -335,9 +331,9 @@ def _compute_local_source_files_hash(
     files_to_hash = [
         (_resolve_relative_source_path(resolved_module_file), resolved_module_file),
     ]
-    for module_needed in modules_needed:
-        module_needed_path = (model_path / module_parent / f"{module_needed}.py").resolve()
-        files_to_hash.append((_resolve_relative_source_path(module_needed_path), module_needed_path))
+    for source_file in get_relative_import_files(resolved_module_file):
+        source_file_path = Path(source_file).resolve()
+        files_to_hash.append((_resolve_relative_source_path(source_file_path), source_file_path))
 
     source_files_hash = hashlib.sha256()
     for relative_path, file_path in sorted(files_to_hash, key=lambda entry: entry[0]):
@@ -445,9 +441,7 @@ def get_cached_module_file(
     modules_needed = check_imports(resolved_module_file)
     if is_local:
         local_model_name = _sanitize_module_name(os.path.basename(os.path.normpath(pretrained_model_name_or_path)))
-        local_source_files_hash = _compute_local_source_files_hash(
-            pretrained_model_name_or_path, module_file, resolved_module_file, modules_needed
-        )
+        local_source_files_hash = _compute_local_source_files_hash(pretrained_model_name_or_path, resolved_module_file)
         if local_model_name:
             submodule = os.path.sep.join([local_model_name, local_source_files_hash])
         else:
@@ -466,13 +460,15 @@ def get_cached_module_file(
             (submodule_path / module_file).parent.mkdir(parents=True, exist_ok=True)
             shutil.copyfile(resolved_module_file, submodule_path / module_file)
             importlib.invalidate_caches()
-        for module_needed in modules_needed:
-            module_needed = Path(module_file).parent / f"{module_needed}.py"
-            module_needed_file = os.path.join(pretrained_model_name_or_path, module_needed)
-            if not (submodule_path / module_needed).exists() or not filecmp.cmp(
-                module_needed_file, str(submodule_path / module_needed)
-            ):
-                shutil.copyfile(module_needed_file, submodule_path / module_needed)
+        for source_file in get_relative_import_files(resolved_module_file):
+            try:
+                module_needed = Path(source_file).relative_to(pretrained_model_name_or_path)
+                target_path = submodule_path / module_needed
+            except ValueError:
+                continue
+            if not target_path.exists() or not filecmp.cmp(source_file, str(target_path)):
+                target_path.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source_file, target_path)
                 importlib.invalidate_caches()
     else:
         # Get the commit hash

--- a/src/transformers/dynamic_module_utils.py
+++ b/src/transformers/dynamic_module_utils.py
@@ -316,7 +316,7 @@ def _compute_local_source_files_hash(
     resolved_module_file: str | os.PathLike,
 ) -> str:
     """
-    Computes a stable hash from the bytes of the local source file and its transitive relative-import source files.
+    Computes a stable hash from the bytes of the local source file and its relative-import source files.
     """
     model_path = Path(pretrained_model_name_or_path).resolve()
     resolved_module_file = Path(resolved_module_file).resolve()

--- a/tests/utils/test_dynamic_module_utils.py
+++ b/tests/utils/test_dynamic_module_utils.py
@@ -183,6 +183,44 @@ def test_get_cached_module_file_local_cache_key_includes_relative_import_sources
     assert cached_helper_b.read_text(encoding="utf-8") == 'MAGIC = "B"\n'
 
 
+def test_get_cached_module_file_local_copies_transitive_relative_imports(monkeypatch, tmp_path):
+    modules_cache = tmp_path / "hf_modules_cache"
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
+
+    model_dir = tmp_path / "pretrained" / "subdir"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    # A → B → C: only A is the entry point; C is a transitive dep that must still be copied
+    (model_dir / "custom_model.py").write_text("from .helper import VALUE\n", encoding="utf-8")
+    (model_dir / "helper.py").write_text("from .base import BASE\nVALUE = BASE\n", encoding="utf-8")
+    (model_dir / "base.py").write_text('BASE = "transitive"\n', encoding="utf-8")
+
+    cached_module = get_cached_module_file(str(model_dir), "custom_model.py")
+    cache_dir = modules_cache / Path(cached_module).parent
+
+    assert (cache_dir / "helper.py").exists(), "direct import must be copied"
+    assert (cache_dir / "base.py").exists(), "transitive import must be copied"
+
+
+def test_get_cached_module_file_local_cache_key_includes_transitive_import_sources(monkeypatch, tmp_path):
+    modules_cache = tmp_path / "hf_modules_cache"
+    monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))
+
+    for model_dir, base_val in [
+        (tmp_path / "pretrained_a" / "subdir", '"X"'),
+        (tmp_path / "pretrained_b" / "subdir", '"Y"'),
+    ]:
+        model_dir.mkdir(parents=True, exist_ok=True)
+        (model_dir / "custom_model.py").write_text("from .helper import VALUE\n", encoding="utf-8")
+        (model_dir / "helper.py").write_text("from .base import BASE\nVALUE = BASE\n", encoding="utf-8")
+        (model_dir / "base.py").write_text(f"BASE = {base_val}\n", encoding="utf-8")
+
+    cached_a = get_cached_module_file(str(tmp_path / "pretrained_a" / "subdir"), "custom_model.py")
+    cached_b = get_cached_module_file(str(tmp_path / "pretrained_b" / "subdir"), "custom_model.py")
+
+    # Different content in transitive dep → different hash → different cache dirs
+    assert cached_a != cached_b
+
+
 def test_get_cached_module_file_local_cache_key_keeps_hash_stable_with_different_basenames(monkeypatch, tmp_path):
     modules_cache = tmp_path / "hf_modules_cache"
     monkeypatch.setattr(dynamic_module_utils, "HF_MODULES_CACHE", str(modules_cache))


### PR DESCRIPTION
# What does this PR do?

When loading a custom model from a local folder with trust_remote_code=True, only direct relative imports of the entry-point file were copied into the module cache and included in the content hash. Transitive imports (i.e. imports of imports) were silently skipped, causing ImportError at runtime for any dependency beyond the first level.

Fix both sites in the local branch to use get_relative_import_files, which already walks the full transitive closure. Also remove the now-unused module_file and modules_needed parameters from _compute_local_source_files_hash.

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
