### PR TITLE
Init the actual tensor, not a copy

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -2400,7 +2400,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         if isinstance(module, (nn.Linear, nn.Conv1d, nn.Conv2d, nn.Conv3d, nn.ConvTranspose1d, nn.ConvTranspose2d)):
             if getattr(module, "weight", None) is not None:
-                init.normal_(module.weight.float(), mean=0.0, std=std)
+                init.normal_(module.weight, mean=0.0, std=std)
             if module.bias is not None:
                 init.zeros_(module.bias)
         elif isinstance(module, nn.Embedding):


### PR DESCRIPTION
Our weight init code did `init.normal_(module.weight.float())` which is broken because it makes a `float32` copy of the tensor and then initializes that. It worked when the model was `float32` already, because then the dtype conversion was a no-op.

cc @arthurzucker since this snuck in during #45643!

Hopefully fixes #46002