### PR TITLE
Widen tols for float16/bfloat16

### DIFF
--- a/tests/generation/test_utils.py
+++ b/tests/generation/test_utils.py
@@ -1488,7 +1488,7 @@ class GenerationTesterMixin:
 
                 # Check 2: The outputs must be similar to the case with dynamic cache
                 dynamic_cache_generation = model.generate(**generation_kwargs, **inputs_dict)
-                if is_moe_model(config):
+                if is_moe_model(config) or dtype != torch.float32:
                     atol = rtol = 1e-3
                 else:
                     atol = rtol = 1e-5

--- a/tests/models/gemma3n/test_modeling_gemma3n.py
+++ b/tests/models/gemma3n/test_modeling_gemma3n.py
@@ -558,7 +558,10 @@ class Gemma3nTextModelTest(CausalLMModelTest, unittest.TestCase):
 
                 # Check 2: The outputs must be similar to the case with dynamic cache
                 dynamic_cache_generation = model.generate(**generation_kwargs, **inputs_dict)
-                assert_similar_generate_outputs(dynamic_cache_generation, static_cache_generation)
+                atol = rtol = 1e-5 if dtype == torch.float32 else 1e-3
+                assert_similar_generate_outputs(
+                    dynamic_cache_generation, static_cache_generation, atol=atol, rtol=rtol
+                )
 
     def test_model_rope_scaling_frequencies(self):
         """Tests the frequency properties of the different RoPE scaling types on the model RoPE layer."""


### PR DESCRIPTION
We have [some flaky tests](https://app.circleci.com/pipelines/github/huggingface/transformers/175084/workflows/94a9c675-ec4a-4b6c-aa39-f21b9bbb53bb/jobs/2314705) caused by bfloat16 + narrow tolerances . This PR just modifies the checks so that we use wider tolerances when the test isn't `float32`.