### PR TITLE
docs(readme): use canonical `huggingface.co` domain in prose links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ and adjacent modeling libraries (llama.cpp, mlx, ...) which leverage the model d
 We pledge to help support new state-of-the-art models and democratize their usage by having their model definition be
 simple, customizable, and efficient.
 
-There are over 1M+ Transformers [model checkpoints](https://huggingface.co/models?library=transformers&sort=trending) on the [Hugging Face Hub](https://huggingface.com/models) you can use.
+There are over 1M+ Transformers [model checkpoints](https://huggingface.co/models?library=transformers&sort=trending) on the [Hugging Face Hub](https://huggingface.co/models) you can use.
 
-Explore the [Hub](https://huggingface.com/) today to find a model and use Transformers to help you get started right away.
+Explore the [Hub](https://huggingface.co/) today to find a model and use Transformers to help you get started right away.
 
 ## Installation
 


### PR DESCRIPTION
Two README prose links pointed to `huggingface.com` instead of `huggingface.co`. `.com` does redirect to `.co`, but every other link in the README (and across the org's docs) uses `.co`, so this is an inconsistency in the user-facing prose.

```diff
-There are over 1M+ Transformers [model checkpoints](https://huggingface.co/models?library=transformers&sort=trending) on the [Hugging Face Hub](https://huggingface.com/models) you can use.
+There are over 1M+ Transformers [model checkpoints](https://huggingface.co/models?library=transformers&sort=trending) on the [Hugging Face Hub](https://huggingface.co/models) you can use.
```

```diff
-Explore the [Hub](https://huggingface.com/) today to find a model and use Transformers to help you get started right away.
+Explore the [Hub](https://huggingface.co/) today to find a model and use Transformers to help you get started right away.
```

(Left the badge link on line 28 alone in case the `.com` there is deliberate; happy to update that too if a maintainer prefers.)