### PR TITLE
[Gemma 4] Adds support to batches with mixed samples with only images and only text

### DIFF
--- a/src/transformers/models/gemma4/processing_gemma4.py
+++ b/src/transformers/models/gemma4/processing_gemma4.py
@@ -132,20 +132,29 @@ class Gemma4Processor(ProcessorMixin):
 
         image_inputs = {}
         if images is not None:
-            images = self.image_processor.fetch_images(images)
-            batched_images = make_nested_list_of_images(images)
-            image_inputs = self.image_processor(images, **output_kwargs["images_kwargs"])
+            # For a batch with some samples with images and some without images (only with text), None can be used for samples without images.
+            valid_images, valid_images_idx = zip(*[(img, img_idx) for img_idx, img in enumerate(images) if img is not None])
+            valid_images = self.image_processor.fetch_images(valid_images)
+
+            batched_images = make_nested_list_of_images(valid_images)
+            image_inputs = self.image_processor(valid_images, **output_kwargs["images_kwargs"])
 
             num_soft_tokens = image_inputs.pop("num_soft_tokens_per_image")
 
-            # Create empty text to be replaced with placeholders
-            if not text:
-                text = [" ".join([self.image_token] * len(images)) for images in batched_images]
+            if text:
+                if len(images) > 1 and len(batched_images) + (len(images)-len(valid_images)) != len(text):
+                    raise ValueError(
+                        f"Received inconsistently sized batches of images ({len(batched_images)}) and text ({len(text)})."
+                    )
 
-            if len(batched_images) != len(text):
-                raise ValueError(
-                    f"Received inconsistently sized batches of images ({len(batched_images)}) and text ({len(text)})."
-                )
+                if len(text) == 1:
+                    # To support the case with a single sample with text and many images
+                    valid_images_text = text
+                else:
+                    valid_images_text = [text[image_idx] for image_idx in valid_images_idx]
+            else:
+                # Create empty text to be replaced with placeholders
+                valid_images_text = [" ".join([self.image_token] * len(images_sample)) for images_sample in batched_images]
 
             replacements = [f"{self.boi_token}{self.image_token * n}{self.eoi_token}" for n in num_soft_tokens]
             replacements_iter = iter(replacements)
@@ -153,7 +162,14 @@ class Gemma4Processor(ProcessorMixin):
             # Expand image_token placeholders to per-image soft token sequences.
             # re.sub never re-scans replaced text, so it is safe
             pattern = re.escape(self.image_token)
-            text = [re.sub(pattern, lambda _: next(replacements_iter), prompt) for prompt in text]
+            valid_images_text = [re.sub(pattern, lambda _: next(replacements_iter), prompt) for prompt in valid_images_text]
+
+            if text:
+                for img_idx, image_text in zip(valid_images_idx, valid_images_text):
+                    # Updating text from valid images with the replaced image tokens
+                    text[img_idx] = image_text
+            else:
+                text = valid_images_text
 
         # Process video inputs in same way
         video_inputs = {}

--- a/tests/models/gemma4/test_processing_gemma4.py
+++ b/tests/models/gemma4/test_processing_gemma4.py
@@ -149,6 +149,43 @@ class Gemma4ProcessorTest(ProcessorTesterMixin, unittest.TestCase):
             out_batch_oneimage[self.images_input_name].tolist(), out_multiimages[self.images_input_name].tolist()
         )
 
+
+    def test_batch_with_only_images_or_text_mixed(self):
+        feature_extractor = self.get_component("feature_extractor")
+        image_processor = self.get_component("image_processor")
+        video_processor = self.get_component("video_processor")
+        tokenizer = self.get_component("tokenizer")
+
+        processor = self.processor_class(
+            feature_extractor=feature_extractor,
+            tokenizer=tokenizer,
+            image_processor=image_processor,
+            video_processor=video_processor,
+        )
+        text_image = f"{processor.boi_token}Dummy text!"
+        text_no_image = "Dummy text!"
+
+        image = self.prepare_image_inputs()
+
+        out_images_batch = processor(text=[text_image, text_image], images=[[image], [image]], return_tensors="np")
+        self.assertEqual(out_images_batch[self.images_input_name].shape[0], 2)
+        out_text_batch = processor(text=[text_no_image, text_no_image, text_no_image], return_tensors="np")
+        assert self.images_input_name not in out_text_batch
+        out_images_and_text_batch = processor(text=[text_image, text_no_image, text_no_image], images=[[image], None, None], return_tensors="np")
+        self.assertEqual(out_images_and_text_batch[self.images_input_name].shape[0], 1)
+
+        self.assertListEqual(
+            out_images_batch[self.images_input_name].tolist()[0], out_images_and_text_batch[self.images_input_name].tolist()[0]
+        )
+        self.assertListEqual(
+            out_images_batch["input_ids"].tolist()[0], out_images_and_text_batch["input_ids"].tolist()[0]
+        )
+        text_tokens = out_text_batch["input_ids"].tolist()[0]
+        self.assertListEqual(
+            out_text_batch["input_ids"].tolist()[0], out_images_and_text_batch["input_ids"].tolist()[1][:len(text_tokens)]
+        )
+
+
     def test_special_mm_token_truncation(self):
         """Tests that special vision tokens do not get truncated when `truncation=True` is set."""
 


### PR DESCRIPTION
Currently, if `Gemma4Processor.__call__()` is called for a batch where some samples have images and some don't have (e.g. text-only samples), it raises an exception.
This PR adds support to calling `Gemma4Processor` with a batch containing samples with image mixed with samples containing only text.

## Who can review?
 @Cyrilvallez @yonigozlan 