### PR TITLE
Fix remaining RAG doc examples that crash on current transformers

### DIFF
--- a/docs/source/en/model_doc/rag.md
+++ b/docs/source/en/model_doc/rag.md
@@ -43,16 +43,17 @@ from transformers import RagRetriever, RagSequenceForGeneration, RagTokenizer
 
 tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
 retriever = RagRetriever.from_pretrained(
-    "facebook/dpr-ctx_encoder-single-nq-base", dataset="wiki_dpr", index_name="compressed"
+    "facebook/rag-sequence-nq", dataset="wiki_dpr", index_name="compressed"
 )
 
 model = RagSequenceForGeneration.from_pretrained(
-    "facebook/rag-token-nq",
+    "facebook/rag-sequence-nq",
     retriever=retriever,
     attn_implementation="flash_attention_2",
- device_map="auto")
-input_dict = tokenizer.prepare_seq2seq_batch("How many people live in Paris?", return_tensors="pt").to(model.device)
-generated = model.generate(input_ids=input_dict["input_ids"])
+    device_map="auto",
+)
+inputs = tokenizer("How many people live in Paris?", return_tensors="pt").to(model.device)
+generated = model.generate(input_ids=inputs["input_ids"])
 print(tokenizer.batch_decode(generated, skip_special_tokens=True)[0])
 ```
 
@@ -72,17 +73,17 @@ bnb = BitsAndBytesConfig(load_in_4bit=True, bnb_4bit_compute_dtype=torch.bfloat1
 
 tokenizer = RagTokenizer.from_pretrained("facebook/rag-sequence-nq")
 retriever = RagRetriever.from_pretrained(
-    "facebook/dpr-ctx_encoder-single-nq-base", dataset="wiki_dpr", index_name="compressed"
+    "facebook/rag-sequence-nq", dataset="wiki_dpr", index_name="compressed"
 )
 
 model = RagSequenceForGeneration.from_pretrained(
-    "facebook/rag-token-nq",
+    "facebook/rag-sequence-nq",
     retriever=retriever,
-    quantization_config=bnb,   # quantizes generator weights
+    quantization_config=bnb,
     device_map="auto",
 )
-input_dict = tokenizer.prepare_seq2seq_batch("How many people live in Paris?", return_tensors="pt").to(model.device)
-generated = model.generate(input_ids=input_dict["input_ids"])
+inputs = tokenizer("How many people live in Paris?", return_tensors="pt").to(model.device)
+generated = model.generate(input_ids=inputs["input_ids"])
 print(tokenizer.batch_decode(generated, skip_special_tokens=True)[0])
 ```
 

--- a/src/transformers/models/rag/retrieval_rag.py
+++ b/src/transformers/models/rag/retrieval_rag.py
@@ -369,7 +369,7 @@ class RagRetriever:
     >>> from transformers import RagRetriever
 
     >>> retriever = RagRetriever.from_pretrained(
-    ...     "facebook/dpr-ctx_encoder-single-nq-base", dataset="wiki_dpr", index_name="compressed"
+    ...     "facebook/rag-sequence-nq", dataset="wiki_dpr", index_name="compressed"
     ... )
 
     >>> # To load your own indexed dataset built with the datasets library.
@@ -378,7 +378,7 @@ class RagRetriever:
     >>> dataset = (
     ...     ...
     ... )  # dataset must be a datasets.Datasets object with columns "title", "text" and "embeddings", and it must have a supported index (e.g., Faiss or other index types depending on your setup)
-    >>> retriever = RagRetriever.from_pretrained("facebook/dpr-ctx_encoder-single-nq-base", indexed_dataset=dataset)
+    >>> retriever = RagRetriever.from_pretrained("facebook/rag-sequence-nq", indexed_dataset=dataset)
 
     >>> # To load your own indexed dataset built with the datasets library that was saved on disk.
     >>> from transformers import RagRetriever
@@ -386,7 +386,7 @@ class RagRetriever:
     >>> dataset_path = "path/to/my/dataset"  # dataset saved via *dataset.save_to_disk(...)*
     >>> index_path = "path/to/my/index"  # index saved via *dataset.get_index("embeddings").save(...)*
     >>> retriever = RagRetriever.from_pretrained(
-    ...     "facebook/dpr-ctx_encoder-single-nq-base",
+    ...     "facebook/rag-sequence-nq",
     ...     index_name="custom",
     ...     passages_path=dataset_path,
     ...     index_path=index_path,
@@ -395,7 +395,7 @@ class RagRetriever:
     >>> # To load the legacy index built originally for Rag's paper
     >>> from transformers import RagRetriever
 
-    >>> retriever = RagRetriever.from_pretrained("facebook/dpr-ctx_encoder-single-nq-base", index_name="legacy")
+    >>> retriever = RagRetriever.from_pretrained("facebook/rag-sequence-nq", index_name="legacy")
     ```"""
 
     def __init__(self, config, question_encoder_tokenizer, generator_tokenizer, index=None, init_retrieval=True):


### PR DESCRIPTION
## Summary

Follow-up to #46035 (merged), which fixed issue 3 of 3 from #46015. This PR addresses the remaining two issues:

**Issue 1 — First doc example crashes with `ValueError`:**
`RagRetriever.from_pretrained("facebook/dpr-ctx_encoder-single-nq-base", ...)` passes a DPR checkpoint to `RagConfig`, which lacks the required `question_encoder` and `generator` sub-configs. Fixed by using `"facebook/rag-sequence-nq"` which ships a proper `RagConfig`.

**Issue 1 (cont.) — `prepare_seq2seq_batch` removed:**
`tokenizer.prepare_seq2seq_batch()` no longer exists. Replaced with the standard `tokenizer()` call.

**Issue 2 — Wrong model for `RagSequenceForGeneration`:**
The examples used `"facebook/rag-token-nq"` with `RagSequenceForGeneration`, but the consistent checkpoint is `"facebook/rag-sequence-nq"`.

### Changes
- `docs/source/en/model_doc/rag.md`: Fix model IDs, replace deprecated tokenizer call, fix formatting
- `src/transformers/models/rag/retrieval_rag.py`: Fix model IDs in all 4 `RagRetriever` docstring examples

### Coordination
- Issue thread: #46015 (comment from reporter confirming issues 1 & 2 remain after #46035)
- No duplicate open PRs found
- AI assistance was used (see disclosure below)

closes: #46015

---

AI-assisted: Yes — Claude Code (Opus 4.6) was used to identify the fixes and draft this PR. All changes were reviewed by the human submitter.