### PR TITLE
Fix Gemma4 generation from inputs_embeds and per_layer_inputs

### DIFF
--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1644,8 +1644,8 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if (input_ids is None) ^ (per_layer_inputs is not None):
-            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+        if input_ids is not None and per_layer_inputs is not None:
+            raise ValueError("You cannot specify per_layer_inputs if input_ids is provided")
 
         if input_ids is not None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -2227,8 +2227,8 @@ class Gemma4Model(Gemma4PreTrainedModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if (input_ids is None) ^ (per_layer_inputs is not None):
-            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+        if input_ids is not None and per_layer_inputs is not None:
+            raise ValueError("You cannot specify per_layer_inputs if input_ids is provided")
 
         image_mask, video_mask, audio_mask = self.get_placeholder_mask(input_ids, inputs_embeds)
         multimodal_mask = image_mask | video_mask | audio_mask

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -2567,7 +2567,7 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
 
         # If `per_layer_inputs` was provided along with `inputs_embeds` for first forward, drop it for subsequent forwards
         if not is_first_iteration:
-            _ = model_inputs.pop("per_layer_inputs")
+            _ = model_inputs.pop("per_layer_inputs", None)
 
         return model_inputs
 

--- a/src/transformers/models/gemma4/modeling_gemma4.py
+++ b/src/transformers/models/gemma4/modeling_gemma4.py
@@ -1644,6 +1644,9 @@ class Gemma4TextModel(Gemma4PreTrainedModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
+        if (input_ids is None) ^ (per_layer_inputs is not None):
+            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+
         if input_ids is not None:
             inputs_embeds = self.embed_tokens(input_ids)
 
@@ -2224,6 +2227,9 @@ class Gemma4Model(Gemma4PreTrainedModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
+        if (input_ids is None) ^ (per_layer_inputs is not None):
+            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+
         image_mask, video_mask, audio_mask = self.get_placeholder_mask(input_ids, inputs_embeds)
         multimodal_mask = image_mask | video_mask | audio_mask
 
@@ -2558,6 +2564,10 @@ class Gemma4ForConditionalGeneration(Gemma4PreTrainedModel, GenerationMixin):
         else:
             # Don't pass to not apply bidirectional mask on top
             model_inputs["mm_token_type_ids"] = None
+
+        # If `per_layer_inputs` was provided along with `inputs_embeds` for first forward, drop it for subsequent forwards
+        if not is_first_iteration:
+            _ = model_inputs.pop("per_layer_inputs")
 
         return model_inputs
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -1410,8 +1410,8 @@ class Gemma4TextModel(Gemma3TextModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if (input_ids is None) ^ (per_layer_inputs is not None):
-            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+        if input_ids is not None and per_layer_inputs is not None:
+            raise ValueError("You cannot specify per_layer_inputs if input_ids is provided")
 
         if input_ids is not None:
             inputs_embeds = self.embed_tokens(input_ids)
@@ -1939,8 +1939,8 @@ class Gemma4Model(Gemma3nModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
-        if (input_ids is None) ^ (per_layer_inputs is not None):
-            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+        if input_ids is not None and per_layer_inputs is not None:
+            raise ValueError("You cannot specify per_layer_inputs if input_ids is provided")
 
         image_mask, video_mask, audio_mask = self.get_placeholder_mask(input_ids, inputs_embeds)
         multimodal_mask = image_mask | video_mask | audio_mask

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -2275,7 +2275,7 @@ class Gemma4ForConditionalGeneration(Gemma3nForConditionalGeneration):
 
         # If `per_layer_inputs` was provided along with `inputs_embeds` for first forward, drop it for subsequent forwards
         if not is_first_iteration:
-            _ = model_inputs.pop("per_layer_inputs")
+            _ = model_inputs.pop("per_layer_inputs", None)
 
         return model_inputs
 

--- a/src/transformers/models/gemma4/modular_gemma4.py
+++ b/src/transformers/models/gemma4/modular_gemma4.py
@@ -1410,6 +1410,9 @@ class Gemma4TextModel(Gemma3TextModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
+        if (input_ids is None) ^ (per_layer_inputs is not None):
+            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+
         if input_ids is not None:
             inputs_embeds = self.embed_tokens(input_ids)
 
@@ -1936,6 +1939,9 @@ class Gemma4Model(Gemma3nModel):
         if (input_ids is None) ^ (inputs_embeds is not None):
             raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
 
+        if (input_ids is None) ^ (per_layer_inputs is not None):
+            raise ValueError("You must specify exactly one of input_ids or per_layer_inputs")
+
         image_mask, video_mask, audio_mask = self.get_placeholder_mask(input_ids, inputs_embeds)
         multimodal_mask = image_mask | video_mask | audio_mask
 
@@ -2266,6 +2272,10 @@ class Gemma4ForConditionalGeneration(Gemma3nForConditionalGeneration):
         else:
             # Don't pass to not apply bidirectional mask on top
             model_inputs["mm_token_type_ids"] = None
+
+        # If `per_layer_inputs` was provided along with `inputs_embeds` for first forward, drop it for subsequent forwards
+        if not is_first_iteration:
+            _ = model_inputs.pop("per_layer_inputs")
 
         return model_inputs
 


### PR DESCRIPTION
# What does this PR do?

As per the title. If both are provided, `per_layer_inputs` must subsequently be dropped from inputs, see https://github.com/huggingface/transformers/pull/45927#issuecomment-4481586615 as well