### PR TITLE
Fix typos in input_outputs.py docstring (sytem, adresses)

### DIFF
--- a/src/transformers/generation/continuous_batching/input_outputs.py
+++ b/src/transformers/generation/continuous_batching/input_outputs.py
@@ -622,12 +622,12 @@ class ContinuousBatchingAsyncIOs:
 
                                     inputs
                       ┌──────────┐ ────────► ┌────────────┐
-    IO pair object:   │ Host IOs │           │ Device IOs │       (for a CUDA sytem, Host = CPU and Device = GPU)
+    IO pair object:   │ Host IOs │           │ Device IOs │       (for a CUDA system, Host = CPU and Device = GPU)
                       └──────────┘ ◄──────── └────────────┘
                                     outputs
 
     Each pair is separate from the other. This means that each pairs has its own CUDA graphs set, because CUDA graphs
-    need to have static adresses for input tensors. To have a unique set of CUDA graph, we would need to copy the input
+    need to have static addresses for input tensors. To have a unique set of CUDA graph, we would need to copy the input
     tensors to a third device-side buffer. This could limit the memory cost of CUDA graphs but would slow down the
     forward pass.
     But the CUDA streams orchestrating the transfer from host to device (H2D) and device to host (D2H) are the same for


### PR DESCRIPTION
## What does this PR do?

Fixes two small typos in the `ContinuousBatchingAsyncIOs` class docstring in `src/transformers/generation/continuous_batching/input_outputs.py`:

- `CUDA sytem` -> `CUDA system`
- `static adresses` -> `static addresses`

Docstring-only change, no behaviour modified.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [ ] Did you write any new necessary tests?
