### PR TITLE
Fix typo in Voxtral docs example (speach -> speech)

### DIFF
--- a/docs/source/en/model_doc/voxtral.md
+++ b/docs/source/en/model_doc/voxtral.md
@@ -269,7 +269,7 @@ conversations = [
                 },
                 {
                     "type": "text",
-                    "text": "Who's speaking in the speach and what city's weather is being discussed?",
+                    "text": "Who's speaking in the speech and what city's weather is being discussed?",
                 },
             ],
         }


### PR DESCRIPTION
## What does this PR do?

Fixes a small typo in the Voxtral model docs at `docs/source/en/model_doc/voxtral.md`: the example user message reads `"Who's speaking in the speach"`, which should be `"speech"`.

## Before submitting
- [x] This PR fixes a typo or improves the docs.
