### PR TITLE
Fix typo in Qwen3-Omni-MoE docs example (cant -> can)

### DIFF
--- a/docs/source/en/model_doc/qwen3_omni_moe.md
+++ b/docs/source/en/model_doc/qwen3_omni_moe.md
@@ -68,7 +68,7 @@ conversations = [
         "role": "user",
         "content": [
             {"type": "video", "video": "/path/to/video.mp4"},
-            {"type": "text", "text": "What cant you hear and see in this video?"},
+            {"type": "text", "text": "What can you hear and see in this video?"},
         ],
     },
 ]
@@ -124,7 +124,7 @@ conversations = [
         "role": "user",
         "content": [
             {"type": "video", "video": "/path/to/video.mp4"},
-            {"type": "text", "text": "What cant you hear and see in this video?"},
+            {"type": "text", "text": "What can you hear and see in this video?"},
         ],
     },
 ]


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in `docs/source/en/model_doc/qwen3_omni_moe.md`. The user-message text in two code examples reads `"What cant you hear and see in this video?"`. The intent (asking the model what it perceives in the clip) is the affirmative form `"What can you hear and see in this video?"`.

## Before submitting
- [x] This PR fixes a typo or improves the docs.
