### PR TITLE
Fix typo in Falcon-H1 comments (dependant -> dependent)

### DIFF
--- a/src/transformers/models/falcon_h1/modeling_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modeling_falcon_h1.py
@@ -411,7 +411,7 @@ class FalconH1Mixer(nn.Module):
             projection_size,
             bias=self.use_bias,
         )
-        # selective projection used to make dt, B and C input dependant
+        # selective projection used to make dt, B and C input dependent
 
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel

--- a/src/transformers/models/falcon_h1/modular_falcon_h1.py
+++ b/src/transformers/models/falcon_h1/modular_falcon_h1.py
@@ -198,7 +198,7 @@ class FalconH1Mixer(nn.Module):
             projection_size,
             bias=self.use_bias,
         )
-        # selective projection used to make dt, B and C input dependant
+        # selective projection used to make dt, B and C input dependent
 
         # time step projection (discretization)
         # instantiate once and copy inv_dt in init_weights of PretrainedModel


### PR DESCRIPTION
## What does this PR do?

Fixes the same comment typo in both the modular and modeling files for Falcon-H1: `input dependant` -> `input dependent`. Comment-only change.

- `src/transformers/models/falcon_h1/modular_falcon_h1.py`
- `src/transformers/models/falcon_h1/modeling_falcon_h1.py`

Both files are kept in sync (modular + generated) per the modular models convention.

## Before submitting
- [x] Comment-only typo fix.
