### PR TITLE
Fix typo in SQuAD processor docstring (dependant -> dependent)

### DIFF
--- a/src/transformers/data/processors/squad.py
+++ b/src/transformers/data/processors/squad.py
@@ -324,7 +324,7 @@ def squad_convert_examples_to_features(
 ):
     """
     Converts a list of examples into a list of features that can be directly given as input to a model. It is
-    model-dependant and takes advantage of many of the tokenizer's features to create the model's inputs.
+    model-dependent and takes advantage of many of the tokenizer's features to create the model's inputs.
 
     Args:
         examples: list of [`~data.processors.squad.SquadExample`]


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the docstring of `squad_convert_examples_to_features` in `src/transformers/data/processors/squad.py`: `model-dependant` -> `model-dependent`.

Docstring-only change.

## Before submitting
- [x] Docstring typo fix.
