### PR TITLE
Fix typo in modular multimodal example (everytime -> every time)

### DIFF
--- a/examples/modular-transformers/modular_multimodal2.py
+++ b/examples/modular-transformers/modular_multimodal2.py
@@ -5,7 +5,7 @@ class Multimodal2VisionModel(CLIPVisionModel):
     pass
 ```
 with the hope that all dependencies will be renamed as `Multimodal2VisionClass`. For this reason, if we want consistency and
-use the "Vision" part everywhere, we need to overwrite the intermediate classes and add the prefix everytime.
+use the "Vision" part everywhere, we need to overwrite the intermediate classes and add the prefix every time.
 This adds noise to the modular, but is unfortunately unavoidable.
 """
 


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the module docstring of `examples/modular-transformers/modular_multimodal2.py`: `add the prefix everytime` -> `add the prefix every time` ("everytime" is not a standard English word; the adverbial phrase is two words).

## Before submitting
- [x] Docstring typo fix.
