### PR TITLE
Fix typo in Qwen2.5-Omni docs example (cant -> can)

### DIFF
--- a/docs/source/en/model_doc/qwen2_5_omni.md
+++ b/docs/source/en/model_doc/qwen2_5_omni.md
@@ -68,7 +68,7 @@ conversations = [
         "role": "user",
         "content": [
             {"type": "video", "video": "/path/to/video.mp4"},
-            {"type": "text", "text": "What cant you hear and see in this video?"},
+            {"type": "text", "text": "What can you hear and see in this video?"},
         ],
     },
 ]
@@ -124,7 +124,7 @@ conversations = [
         "role": "user",
         "content": [
             {"type": "video", "video": "/path/to/video.mp4"},
-            {"type": "text", "text": "What cant you hear and see in this video?"},
+            {"type": "text", "text": "What can you hear and see in this video?"},
         ],
     },
 ]


### PR DESCRIPTION
## What does this PR do?

Fixes the same `cant` -> `can` typo in two code examples in `docs/source/en/model_doc/qwen2_5_omni.md` (mirrors the same fix in the qwen3 doc PR).

## Before submitting
- [x] Docs typo fix.
