### PR TITLE
Fix grammar in core_model_loading comment

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -1498,7 +1498,7 @@ def revert_weight_conversion(model: PreTrainedModel, state_dict: dict[str, torch
         weight_conversions = get_model_conversion_mapping(model, add_legacy=False)
         # If the model had no `_weight_conversions` attached, drop any PrefixChange transform - this is because the
         # model was almost surely instantiated from scratch (at least not from `from_pretrained`), and PrefixChange with
-        # `prefix_to_remove` would otherwise add a unwanted prefix (as we dont have any information about whether the prefix
+        # `prefix_to_remove` would otherwise add an unwanted prefix (as we don't have any information about whether the prefix
         # was there or not during load)
         weight_conversions = [x for x in weight_conversions if not isinstance(x, PrefixChange)]
         weight_conversions = weight_conversions if len(weight_conversions) > 0 else None


### PR DESCRIPTION
## What does this PR do?

Fixes two grammar issues in a comment in `src/transformers/core_model_loading.py` (around the PrefixChange weight-conversion fallback):

- `would otherwise add a unwanted prefix` -> `would otherwise add an unwanted prefix`
- `as we dont have any information` -> `as we don't have any information`

Comment-only change.

## Before submitting
- [x] Comment typo fix.
