### PR TITLE
fix: adapt Whisper models to use self.loss_function with num_items_in_batch support

### DIFF
--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -180,7 +180,7 @@ LOSS_MAPPING = {
     "ForTokenClassification": ForTokenClassification,
     "ForSegmentation": ForSegmentationLoss,
     "ForObjectDetection": ForObjectDetectionLoss,
-    "ForConditionalGeneration": ForMaskedLMLoss,
+    "ForConditionalGeneration": ForCausalLMLoss,
     "DeformableDetrForObjectDetection": DeformableDetrForObjectDetectionLoss,
     "ConditionalDetrForObjectDetection": DeformableDetrForObjectDetectionLoss,
     "DabDetrForObjectDetection": DeformableDetrForObjectDetectionLoss,

--- a/src/transformers/loss/loss_utils.py
+++ b/src/transformers/loss/loss_utils.py
@@ -180,7 +180,7 @@ LOSS_MAPPING = {
     "ForTokenClassification": ForTokenClassification,
     "ForSegmentation": ForSegmentationLoss,
     "ForObjectDetection": ForObjectDetectionLoss,
-    "ForConditionalGeneration": ForCausalLMLoss,
+    "ForConditionalGeneration": ForMaskedLMLoss,
     "DeformableDetrForObjectDetection": DeformableDetrForObjectDetectionLoss,
     "ConditionalDetrForObjectDetection": DeformableDetrForObjectDetectionLoss,
     "DabDetrForObjectDetection": DeformableDetrForObjectDetectionLoss,

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -969,8 +969,6 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         self.model = WhisperModel(config)
         self.proj_out = nn.Linear(config.d_model, config.vocab_size, bias=False)
         self.max_target_positions = config.max_target_positions
-        # Encoder-decoder models receive labels already aligned with decoder logits
-        # (no token shift needed), so ForMaskedLMLoss is the correct loss function.
         self.loss_type = "ForMaskedLM"
 
         # Initialize weights and apply final processing
@@ -1090,7 +1088,10 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=lm_logits, labels=labels, vocab_size=self.config.vocab_size, num_items_in_batch=num_items_in_batch
+                logits=lm_logits,
+                labels=labels,
+                vocab_size=self.config.vocab_size,
+                num_items_in_batch=num_items_in_batch,
             )
 
         return Seq2SeqLMOutput(
@@ -1143,8 +1144,6 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
         self.model = WhisperDecoderWrapper(config)
 
         self.proj_out = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
-        # WhisperForCausalLM receives labels already aligned with logits (no shift),
-        # matching the original CrossEntropyLoss behavior preserved here.
         self.loss_type = "ForMaskedLM"
 
         # Initialize weights and apply final processing
@@ -1234,7 +1233,10 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
         loss = None
         if labels is not None:
             loss = self.loss_function(
-                logits=logits, labels=labels, vocab_size=self.config.vocab_size, num_items_in_batch=num_items_in_batch
+                logits=logits,
+                labels=labels,
+                vocab_size=self.config.vocab_size,
+                num_items_in_batch=num_items_in_batch,
             )
 
         return CausalLMOutputWithCrossAttentions(

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1037,6 +1037,10 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
             Labels for computing the language modeling loss. Indices should either be in `[0, ..., config.vocab_size]`
             or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored (masked), the loss is
             only computed for the tokens with labels in `[0, ..., config.vocab_size]`. `sequence_length` should be smaller than or equal to `config.max_target_positions`.
+        num_items_in_batch (`torch.Tensor`, *optional*):
+            Number of non-masked tokens in the batch, used to normalise the loss under gradient accumulation.
+            When provided, the loss uses `reduction="sum"` divided by `num_items_in_batch`; otherwise it uses
+            the default `reduction="mean"`.
 
         Example:
 
@@ -1180,6 +1184,10 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
             Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
             config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
             (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+        num_items_in_batch (`torch.Tensor`, *optional*):
+            Number of non-masked tokens in the batch, used to normalise the loss under gradient accumulation.
+            When provided, the loss uses `reduction="sum"` divided by `num_items_in_batch`; otherwise it uses
+            the default `reduction="mean"`.
 
         Example:
 

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -1003,6 +1003,7 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         decoder_position_ids: tuple[torch.LongTensor] | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
+        num_items_in_batch: torch.Tensor | None = None,
         **kwargs,
     ) -> tuple[torch.Tensor] | Seq2SeqLMOutput:
         r"""
@@ -1081,10 +1082,9 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
 
         loss = None
         if labels is not None:
-            loss_fct = CrossEntropyLoss()
-            # move labels to correct device to enable PP
-            labels = labels.to(lm_logits.device)
-            loss = loss_fct(lm_logits.view(-1, self.config.vocab_size), labels.reshape(-1))
+            loss = self.loss_function(
+                logits=lm_logits, labels=labels, vocab_size=self.config.vocab_size, num_items_in_batch=num_items_in_batch
+            )
 
         return Seq2SeqLMOutput(
             loss=loss,
@@ -1163,6 +1163,7 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
         inputs_embeds: torch.FloatTensor | None = None,
         labels: torch.LongTensor | None = None,
         use_cache: bool | None = None,
+        num_items_in_batch: torch.Tensor | None = None,
         **kwargs,
     ) -> tuple | CausalLMOutputWithCrossAttentions:
         r"""
@@ -1218,9 +1219,9 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
 
         loss = None
         if labels is not None:
-            labels = labels.to(logits.device)
-            loss_fct = CrossEntropyLoss()
-            loss = loss_fct(logits.view(-1, self.config.vocab_size), labels.view(-1))
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, num_items_in_batch=num_items_in_batch
+            )
 
         return CausalLMOutputWithCrossAttentions(
             loss=loss,

--- a/src/transformers/models/whisper/modeling_whisper.py
+++ b/src/transformers/models/whisper/modeling_whisper.py
@@ -969,6 +969,9 @@ class WhisperForConditionalGeneration(WhisperGenerationMixin, WhisperPreTrainedM
         self.model = WhisperModel(config)
         self.proj_out = nn.Linear(config.d_model, config.vocab_size, bias=False)
         self.max_target_positions = config.max_target_positions
+        # Encoder-decoder models receive labels already aligned with decoder logits
+        # (no token shift needed), so ForMaskedLMLoss is the correct loss function.
+        self.loss_type = "ForMaskedLM"
 
         # Initialize weights and apply final processing
         self.post_init()
@@ -1136,6 +1139,9 @@ class WhisperForCausalLM(WhisperPreTrainedModel, GenerationMixin):
         self.model = WhisperDecoderWrapper(config)
 
         self.proj_out = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        # WhisperForCausalLM receives labels already aligned with logits (no shift),
+        # matching the original CrossEntropyLoss behavior preserved here.
+        self.loss_type = "ForMaskedLM"
 
         # Initialize weights and apply final processing
         self.post_init()


### PR DESCRIPTION
## Summary

- Fixes gradient accumulation for Whisper by replacing the manual `CrossEntropyLoss` instantiation with `self.loss_function`, which supports the `num_items_in_batch` parameter introduced in #34191.
- Adds an explicit `num_items_in_batch` parameter to both `WhisperForConditionalGeneration.forward()` and `WhisperForCausalLM.forward()`.
- Sets `self.loss_type = "ForMaskedLM"` in both Whisper class `__init__` methods so the correct (no-shift) loss is used without touching the global `LOSS_MAPPING`.

## Changes

**`src/transformers/models/whisper/modeling_whisper.py`**

- `WhisperForConditionalGeneration.__init__`: sets `self.loss_type = "ForMaskedLM"`. Encoder-decoder models receive labels already aligned with decoder logits — no token shifting is needed.
- `WhisperForConditionalGeneration.forward()`: adds `num_items_in_batch` parameter; replaces manual `CrossEntropyLoss` block with `self.loss_function(...)`.
- `WhisperForCausalLM.__init__`: same `self.loss_type = "ForMaskedLM"` override, preserving the original no-shift behavior.
- `WhisperForCausalLM.forward()`: same treatment.

**`src/transformers/loss/loss_utils.py`**

- No global mapping changes — `LOSS_MAPPING["ForConditionalGeneration"]` remains `ForCausalLMLoss` to avoid affecting decoder-only models like `LlavaForConditionalGeneration` and `PaliGemmaForConditionalGeneration` that rely on label shifting.

## Behavior

- When `num_items_in_batch=None` (default): loss is identical to the previous `CrossEntropyLoss(reduction="mean")` call — no behavior change.
- When `num_items_in_batch` is provided by the Trainer: loss is normalized correctly across gradient accumulation steps, fixing the GA bug.

## Test plan

- [ ] Verify loss is unchanged when `num_items_in_batch=None`
- [ ] Verify loss is correctly normalized when `num_items_in_batch` is supplied
- [ ] Run existing Whisper tests: `pytest tests/models/whisper/ -x`

Closes #36119