### PR TITLE
Fix Gemma4 use_bidirectional_attention="all" mask behavior

### DIFF
--- a/src/transformers/models/gemma4/configuration_gemma4.py
+++ b/src/transformers/models/gemma4/configuration_gemma4.py
@@ -194,6 +194,7 @@ class Gemma4TextConfig(PreTrainedConfig):
 
     def __post_init__(self, **kwargs):
         if self.use_bidirectional_attention == "all":
+            self.is_causal = False
             self.sliding_window = (self.sliding_window // 2) + 1  # due to fa we set exclusive bounds
 
         if self.layer_types is None:

--- a/tests/models/gemma4/test_modeling_gemma4.py
+++ b/tests/models/gemma4/test_modeling_gemma4.py
@@ -125,6 +125,21 @@ class Gemma4TextModelTest(CausalLMModelTest, unittest.TestCase):
     def test_tp_generation_quantized(self):
         pass
 
+    def test_all_bidirectional_attention_uses_bidirectional_mask(self):
+        self.model_tester.use_bidirectional_attention = "all"
+        config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
+        config._attn_implementation = "eager"
+
+        model = Gemma4TextModel(config).to(torch_device)
+        model.eval()
+
+        input_ids = inputs_dict["input_ids"][:1]
+        with torch.no_grad():
+            out = model(input_ids=input_ids, output_attentions=True)
+
+        for attention in out.attentions:
+            self.assertTrue((attention[..., :4, :4] != 0).all().item())
+
     def test_model_training(self):
         pass
 


### PR DESCRIPTION
Fixes #46077

This makes `Gemma4TextConfig(use_bidirectional_attention="all")` set `config.is_causal = False`.

Gemma4 already marks attention modules as non-causal for `"all"`, but mask creation goes through the shared masking helpers, which use `config.is_causal` to switch from causal masks to bidirectional masks. Without the config flag, `"all"` can still produce causal masks.

The change is intentionally small: one config line plus a regression test that checks Gemma4 eager attentions are actually unmasked for future tokens.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR.

AI assistance was used to investigate and draft the patch. I reviewed the changed lines and ran the checks below.

## Before submitting

- [ ] This PR fixes a typo or improves the docs.
- [x] I read the contributor guideline Pull Request section.
- [x] This was discussed/approved via GitHub issue: #ISSUE_NUMBER
- [x] Documentation changes are not needed; this fixes behavior to match existing bidirectional attention docs.
- [x] I wrote a regression test.

## Duplicate-work check

I did not find a direct duplicate. Related but different work:

- #45201 / #45202: Gemma4 FlashAttention `global_head_dim=512` compatibility.
- #45482: Gemma4 CPU offload/device mismatch issues.
- #43705: general merged `is_causal` support for decoder-only models as encoders.

## Tests

```bash
TRANSFORMERS_TEST_DEVICE=cpu PYTHONPATH=src uv run --no-sync python -m pytest tests/models/gemma4/test_modeling_gemma4.py::Gemma4TextModelTest::test_all_bidirectional_attention_uses_bidirectional_mask -q
```

Result: `1 passed, 26 warnings in 4.23s`.

```bash
make style
```

Result: passed.
