### PR TITLE
Fix wrong variable in check_model_type isinstance check

### DIFF
--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -1100,7 +1100,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
                     supported_models_names.append(model_name)
             if hasattr(supported_models, "_model_mapping"):
                 for model in supported_models._model_mapping._extra_content.values():
-                    if isinstance(model_name, tuple):
+                    if isinstance(model, tuple):
                         supported_models_names.extend([m.__name__ for m in model])
                     else:
                         supported_models_names.append(model.__name__)


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in `Pipeline.check_model_type()` where the inner loop over `_model_mapping._extra_content` (line 1102) uses `model` as its iteration variable, but the `isinstance` check on line 1103 referenced `model_name` from the outer loop. This caused incorrect tuple/non-tuple branching for dynamically registered models (via `AutoModel.register()`), potentially raising `AttributeError`.

This bug was introduced in #24960 (2023-07-21) and has been present for nearly 2 years.

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Did you make sure to update the documentation with your changes? N/A, no doc changes needed.
- [ ] Did you write any new necessary tests? No existing tests for `check_model_type`; the fix is a self-evident 1-word variable rename.

## Who can review?

@Rocketknight1 (pipelines)