### PR TITLE
fix(cache): StaticLayer.get_seq_length() should return int not Tensor

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -377,7 +377,7 @@ class StaticLayer(CacheLayerMixin):
 
     def get_seq_length(self) -> int:
         """Returns the sequence length of the cached states."""
-        return self.cumulative_length if self.is_initialized else 0
+        return self.cumulative_length.item() if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:
         """Return the maximum cache shape of the cache"""


### PR DESCRIPTION
Fixes #45987.

## Summary

`StaticLayer.get_seq_length()` declares `-> int` (matching the abstract base class contract) but returns `self.cumulative_length` directly, which is a shape-`(1,)` tensor stored that way intentionally for `torch.compile` / `mark_static_address` compatibility.

Returning the raw tensor breaks:
- `isinstance(seq, int)` checks downstream
- arithmetic with plain Python ints (`input_len - cache.get_seq_length()` returns `tensor([0])` instead of `0`)
- any code that passes the result to a function expecting a plain `int`

## Fix

Call `.item()` to extract the scalar value before returning:

```python
# BEFORE
return self.cumulative_length if self.is_initialized else 0

# AFTER
return self.cumulative_length.item() if self.is_initialized else 0
```

The internal `self.cumulative_length` tensor is untouched — it is still used as a tensor in `update()` for `cache_position` arithmetic and `mark_static_address`, so `torch.compile` behavior is unaffected.