### PR TITLE
Fix use_cache with seq_len > 1 ( #46032)

### DIFF
--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -255,8 +255,15 @@ class Mamba2Mixer(nn.Module):
             - self.num_heads
         ) // 2
 
+        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
+
+        # getting projected states from cache if it exists
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
+            recurrent_state = cache_params.layers[self.layer_idx].recurrent_states
+
         # Single step calculations via cache
-        if cache_params is not None and cache_params.has_previous_state(self.layer_idx) and seq_len == 1:
+        if use_precomputed_states and seq_len == 1:
             _, _, gate, hidden_states_B_C, dt = projected_states.squeeze(1).split(
                 [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
             )
@@ -264,7 +271,7 @@ class Mamba2Mixer(nn.Module):
             # 2. Convolution sequence transformation
             hidden_states_B_C = causal_conv1d_update(
                 hidden_states_B_C,
-                cache_params.layers[self.layer_idx].conv_states,
+                conv_state,
                 self.conv1d.weight.squeeze(1),
                 self.conv1d.bias,
                 self.activation,
@@ -286,7 +293,7 @@ class Mamba2Mixer(nn.Module):
             C = C.view(batch_size, self.n_groups, C.shape[1] // self.n_groups)
             hidden_states_reshaped = hidden_states.view(batch_size, self.num_heads, self.head_dim)
             hidden_states = selective_state_update(
-                cache_params.layers[self.layer_idx].recurrent_states,
+                recurrent_state,
                 hidden_states_reshaped,
                 dt,
                 A,
@@ -307,7 +314,6 @@ class Mamba2Mixer(nn.Module):
         else:
             A = -torch.exp(self.A_log.float())  # (num_heads) or (intermediate_size, state_size)
             dt_limit_kwargs = {} if self.time_step_limit == (0.0, float("inf")) else {"dt_limit": self.time_step_limit}
-            has_previous_state = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
 
             # 2-4. Fused kernel for conv1d, SSM, and the final projection
             if self.training and cache_params is None:
@@ -338,14 +344,14 @@ class Mamba2Mixer(nn.Module):
                 )
 
                 # 2. Convolution sequence transformation
-                if has_previous_state:
+                if use_precomputed_states:
                     # Seed the causal conv with cached left-context via initial_states
                     hidden_states_B_C, new_conv_state = causal_conv1d_fn(
                         x=hidden_states_B_C.transpose(1, 2),
                         weight=self.conv1d.weight.squeeze(1),
                         bias=self.conv1d.bias,
                         activation=self.activation,
-                        initial_states=cache_params.layers[self.layer_idx].conv_states[:, :, 1:],
+                        initial_states=conv_state[:, :, 1:],
                         return_final_states=True,
                     )
                     hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
@@ -393,7 +399,7 @@ class Mamba2Mixer(nn.Module):
                     return_final_states=True,
                     dt_bias=self.dt_bias,
                     dt_softplus=True,
-                    initial_states=cache_params.layers[self.layer_idx].recurrent_states if has_previous_state else None,
+                    initial_states=recurrent_state if use_precomputed_states else None,
                     **dt_limit_kwargs,
                 )
 
@@ -428,14 +434,10 @@ class Mamba2Mixer(nn.Module):
         )
         hidden_states_B_C = hidden_states_B_C.transpose(1,2)
 
-        use_precomputed_states = (
-            cache_params is not None and cache_params.has_previous_state(self.layer_idx) and seq_len == 1
-        )
-        # Snapshot before any cache
-        has_previous_state = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
+        use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
 
         # 2. Convolution sequence transformation
-        if use_precomputed_states:
+        if use_precomputed_states and seq_len == 1:
             conv_states = cache_params.update_conv_state(hidden_states_B_C, layer_idx=self.layer_idx)
 
             hidden_states_B_C = torch.sum(
@@ -445,7 +447,7 @@ class Mamba2Mixer(nn.Module):
                 hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
             hidden_states_B_C = self.act(hidden_states_B_C)
         else:
-            if has_previous_state:
+            if use_precomputed_states:
                 hidden_states_B_C = torch.cat(
                     [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C], dim=-1
                 )
@@ -457,7 +459,7 @@ class Mamba2Mixer(nn.Module):
                 cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
 
             hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., :hidden_states_B_C.shape[-1]].transpose(1, 2))
-            if has_previous_state:
+            if use_precomputed_states:
                 hidden_states_B_C = hidden_states_B_C[:, -seq_len:, :]
 
         hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
@@ -469,7 +471,7 @@ class Mamba2Mixer(nn.Module):
 
         # 3. SSM transformation
         A = -torch.exp(self.A_log.float())                            # [num_heads]
-        if use_precomputed_states:
+        if use_precomputed_states and seq_len == 1:
             # We need to guarantee that anything regarding the cache is on the same device
             cache_device = cache_params.layers[self.layer_idx].device
 
@@ -574,7 +576,7 @@ class Mamba2Mixer(nn.Module):
             # (middle term of factorization of off-diag blocks; A terms)
             previous_states = (
                 cache_params.layers[self.layer_idx].recurrent_states[:, None].to(dtype=states.dtype, device=states.device)
-                if has_previous_state
+                if use_precomputed_states
                 else torch.zeros_like(states[:, :1])
             )
             states = torch.cat([previous_states, states], dim=1)

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -256,7 +256,7 @@ class Mamba2Mixer(nn.Module):
         ) // 2
 
         # Single step calculations via cache
-        if cache_params is not None and cache_params.has_previous_state(self.layer_idx):
+        if cache_params is not None and cache_params.has_previous_state(self.layer_idx) and seq_len == 1:
             _, _, gate, hidden_states_B_C, dt = projected_states.squeeze(1).split(
                 [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
             )
@@ -302,6 +302,60 @@ class Mamba2Mixer(nn.Module):
 
             # 4. Final linear projection
             out = self.out_proj(hidden_states)[:, None, ...]
+
+        elif cache_params is not None and cache_params.has_previous_state(self.layer_idx):
+            A = -torch.exp(self.A_log.float())
+            dt_limit_kwargs = {} if self.time_step_limit == (0.0, float("inf")) else {"dt_limit": self.time_step_limit}
+            _, _, gate, hidden_states_B_C, dt = projected_states.split(
+                [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
+            )
+            # 2. Convolution: prepend cached left-context so causal conv sees correct history.
+            hidden_states_B_C_t = hidden_states_B_C.transpose(1, 2)
+            hidden_states_B_C_t = torch.cat(
+                [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C_t], dim=-1
+            )
+            new_conv_state = nn.functional.pad(
+                hidden_states_B_C_t, (self.conv_kernel_size - hidden_states_B_C_t.shape[-1], 0)
+            )
+            cache_params.update_conv_state(new_conv_state, layer_idx=self.layer_idx)
+            if causal_conv1d_fn is not None:
+                hidden_states_B_C = causal_conv1d_fn(
+                    x=hidden_states_B_C_t,
+                    weight=self.conv1d.weight.squeeze(1),
+                    bias=self.conv1d.bias,
+                    activation=self.activation,
+                ).transpose(1, 2)[:, -seq_len:, :]
+            else:
+                hidden_states_B_C = self.act(
+                    self.conv1d(hidden_states_B_C_t)[..., :hidden_states_B_C_t.shape[-1]]
+                ).transpose(1, 2)[:, -seq_len:, :]
+            hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
+            hidden_states, B, C = torch.split(
+                hidden_states_B_C,
+                [self.intermediate_size, groups_time_state_size, groups_time_state_size],
+                dim=-1,
+            )
+            # 3. SSM: parallel chunk scan seeded with the cached recurrent state.
+            scan_output, ssm_state = mamba_chunk_scan_combined(
+                hidden_states.view(batch_size, seq_len, -1, self.head_dim),
+                dt,
+                A,
+                B.view(batch_size, seq_len, self.n_groups, -1),
+                C.view(batch_size, seq_len, self.n_groups, -1),
+                chunk_size=self.chunk_size,
+                D=self.D,
+                z=None,
+                seq_idx=None,
+                return_final_states=True,
+                dt_bias=self.dt_bias,
+                dt_softplus=True,
+                initial_states=cache_params.layers[self.layer_idx].recurrent_states,
+                **dt_limit_kwargs,
+            )
+            cache_params.update_recurrent_state(ssm_state, layer_idx=self.layer_idx)
+            scan_output = scan_output.view(batch_size, seq_len, -1)
+            scan_output = self.norm(scan_output, gate)
+            out = self.out_proj(scan_output)
 
         # Fused calculations or step by step if no initialized cache is found
         else:
@@ -416,7 +470,7 @@ class Mamba2Mixer(nn.Module):
         is_decoding = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
 
         # 2. Convolution sequence transformation
-        if is_decoding:
+        if is_decoding and seq_len == 1:
             conv_states = cache_params.update_conv_state(hidden_states_B_C, layer_idx=self.layer_idx)
 
             hidden_states_B_C = torch.sum(
@@ -426,6 +480,10 @@ class Mamba2Mixer(nn.Module):
                 hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
             hidden_states_B_C = self.act(hidden_states_B_C)
         else:
+            if is_decoding:
+                hidden_states_B_C = torch.cat(
+                    [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C], dim=-1
+                )
             # Init cache
             if cache_params is not None:
                 conv_states = nn.functional.pad(
@@ -433,7 +491,10 @@ class Mamba2Mixer(nn.Module):
                 )
                 cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
 
-            hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., :seq_len].transpose(1, 2))
+            n = hidden_states_B_C.shape[-1]
+            hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., :n].transpose(1, 2))
+            if is_decoding:
+                hidden_states_B_C = hidden_states_B_C[:, -seq_len:, :]
 
         hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
         hidden_states, B, C = torch.split(
@@ -444,7 +505,7 @@ class Mamba2Mixer(nn.Module):
 
         # 3. SSM transformation
         A = -torch.exp(self.A_log.float())                            # [num_heads]
-        if is_decoding:
+        if is_decoding and seq_len == 1:
             # We need to guarantee that anything regarding the cache is on the same device
             cache_device = cache_params.layers[self.layer_idx].device
 
@@ -547,7 +608,11 @@ class Mamba2Mixer(nn.Module):
 
             # 3. Compute the inter-chunk SSM recurrence; produces correct SSM states at chunk boundaries
             # (middle term of factorization of off-diag blocks; A terms)
-            previous_states = torch.zeros_like(states[:, :1])
+            previous_states = (
+                cache_params.layers[self.layer_idx].recurrent_states[:, None].to(dtype=states.dtype, device=states.device)
+                if is_decoding
+                else torch.zeros_like(states[:, :1])
+            )
             states = torch.cat([previous_states, states], dim=1)
             decay_chunk = torch.exp(segment_sum(nn.functional.pad(A_cumsum[:, :, :, -1], (1, 0))))
             decay_chunk = decay_chunk.transpose(1, 3)

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -431,6 +431,8 @@ class Mamba2Mixer(nn.Module):
         use_precomputed_states = (
             cache_params is not None and cache_params.has_previous_state(self.layer_idx) and seq_len == 1
         )
+        # Snapshot before any cache
+        has_previous_state = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
 
         # 2. Convolution sequence transformation
         if use_precomputed_states:
@@ -443,7 +445,7 @@ class Mamba2Mixer(nn.Module):
                 hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
             hidden_states_B_C = self.act(hidden_states_B_C)
         else:
-            if cache_params is not None and cache_params.has_previous_state(self.layer_idx):
+            if has_previous_state:
                 hidden_states_B_C = torch.cat(
                     [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C], dim=-1
                 )
@@ -455,7 +457,7 @@ class Mamba2Mixer(nn.Module):
                 cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
 
             hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., :hidden_states_B_C.shape[-1]].transpose(1, 2))
-            if cache_params is not None and cache_params.has_previous_state(self.layer_idx):
+            if has_previous_state:
                 hidden_states_B_C = hidden_states_B_C[:, -seq_len:, :]
 
         hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
@@ -572,7 +574,7 @@ class Mamba2Mixer(nn.Module):
             # (middle term of factorization of off-diag blocks; A terms)
             previous_states = (
                 cache_params.layers[self.layer_idx].recurrent_states[:, None].to(dtype=states.dtype, device=states.device)
-                if cache_params is not None and cache_params.has_previous_state(self.layer_idx)
+                if has_previous_state
                 else torch.zeros_like(states[:, :1])
             )
             states = torch.cat([previous_states, states], dim=1)

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -319,9 +319,7 @@ class Mamba2Mixer(nn.Module):
                 return_final_states=True,
             )
             hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
-            cache_params.update_conv_state(
-                nn.functional.pad(new_conv_state, (1, 0)), layer_idx=self.layer_idx
-            )
+            cache_params.update_conv_state(nn.functional.pad(new_conv_state, (1, 0)), layer_idx=self.layer_idx)
             hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
             hidden_states, B, C = torch.split(
                 hidden_states_B_C,

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -309,26 +309,19 @@ class Mamba2Mixer(nn.Module):
             _, _, gate, hidden_states_B_C, dt = projected_states.split(
                 [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
             )
-            # 2. Convolution: prepend cached left-context so causal conv sees correct history.
-            hidden_states_B_C_t = hidden_states_B_C.transpose(1, 2)
-            hidden_states_B_C_t = torch.cat(
-                [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C_t], dim=-1
+            # 2. Convolution: seed the causal conv with cached left-context via initial_states.
+            hidden_states_B_C, new_conv_state = causal_conv1d_fn(
+                x=hidden_states_B_C.transpose(1, 2),
+                weight=self.conv1d.weight.squeeze(1),
+                bias=self.conv1d.bias,
+                activation=self.activation,
+                initial_states=cache_params.layers[self.layer_idx].conv_states[:, :, 1:],
+                return_final_states=True,
             )
-            new_conv_state = nn.functional.pad(
-                hidden_states_B_C_t, (self.conv_kernel_size - hidden_states_B_C_t.shape[-1], 0)
+            hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
+            cache_params.update_conv_state(
+                nn.functional.pad(new_conv_state, (1, 0)), layer_idx=self.layer_idx
             )
-            cache_params.update_conv_state(new_conv_state, layer_idx=self.layer_idx)
-            if causal_conv1d_fn is not None:
-                hidden_states_B_C = causal_conv1d_fn(
-                    x=hidden_states_B_C_t,
-                    weight=self.conv1d.weight.squeeze(1),
-                    bias=self.conv1d.bias,
-                    activation=self.activation,
-                ).transpose(1, 2)[:, -seq_len:, :]
-            else:
-                hidden_states_B_C = self.act(
-                    self.conv1d(hidden_states_B_C_t)[..., :hidden_states_B_C_t.shape[-1]]
-                ).transpose(1, 2)[:, -seq_len:, :]
             hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
             hidden_states, B, C = torch.split(
                 hidden_states_B_C,

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -344,39 +344,34 @@ class Mamba2Mixer(nn.Module):
                 )
 
                 # 2. Convolution sequence transformation
+                hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
+                # Multi-token forward (prefill, or chunked-tokens decode when the cache has prior state).
                 if use_precomputed_states:
-                    # Seed the causal conv with cached left-context via initial_states
-                    hidden_states_B_C, new_conv_state = causal_conv1d_fn(
-                        x=hidden_states_B_C.transpose(1, 2),
+                    # Cached chunked-tokens decode: prepend the cached conv context so the causal conv
+                    # sees the correct left-context rather than zero-padding. Dropped from the output
+                    # at the end of this branch.
+                    hidden_states_B_C = torch.cat([conv_state, hidden_states_B_C], dim=-1)
+
+                if cache_params is not None:
+                    new_conv_state = nn.functional.pad(
+                        hidden_states_B_C, (self.conv_kernel_size - hidden_states_B_C.shape[-1], 0)
+                    )
+                    cache_params.update_conv_state(new_conv_state, layer_idx=self.layer_idx)
+
+                if self.activation not in ["silu", "swish"]:
+                    hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., : hidden_states_B_C.shape[-1]])
+                else:
+                    hidden_states_B_C = causal_conv1d_fn(
+                        x=hidden_states_B_C,
                         weight=self.conv1d.weight.squeeze(1),
                         bias=self.conv1d.bias,
                         activation=self.activation,
-                        initial_states=conv_state[:, :, 1:],
-                        return_final_states=True,
                     )
-                    hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
-                    cache_params.update_conv_state(nn.functional.pad(new_conv_state, (1, 0)), layer_idx=self.layer_idx)
-                else:
-                    # Init cache
-                    if cache_params is not None:
-                        hidden_states_B_C_transposed = hidden_states_B_C.transpose(1, 2)
-                        conv_states = nn.functional.pad(
-                            hidden_states_B_C_transposed,
-                            (self.conv_kernel_size - hidden_states_B_C_transposed.shape[-1], 0),
-                        )
-                        cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
 
-                    if self.activation not in ["silu", "swish"]:
-                        hidden_states_B_C = self.act(
-                            self.conv1d(hidden_states_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2)
-                        )
-                    else:
-                        hidden_states_B_C = causal_conv1d_fn(
-                            x=hidden_states_B_C.transpose(1, 2),
-                            weight=self.conv1d.weight.squeeze(1),
-                            bias=self.conv1d.bias,
-                            activation=self.activation,
-                        ).transpose(1, 2)
+                if use_precomputed_states:
+                    hidden_states_B_C = hidden_states_B_C[:, :, -seq_len:]
+
+                hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
 
                 hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
                 hidden_states, B, C = torch.split(
@@ -435,6 +430,8 @@ class Mamba2Mixer(nn.Module):
         hidden_states_B_C = hidden_states_B_C.transpose(1,2)
 
         use_precomputed_states = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
+        if use_precomputed_states:
+            conv_state = cache_params.layers[self.layer_idx].conv_states
 
         # 2. Convolution sequence transformation
         if use_precomputed_states and seq_len == 1:
@@ -448,9 +445,7 @@ class Mamba2Mixer(nn.Module):
             hidden_states_B_C = self.act(hidden_states_B_C)
         else:
             if use_precomputed_states:
-                hidden_states_B_C = torch.cat(
-                    [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C], dim=-1
-                )
+                hidden_states_B_C = torch.cat([conv_state, hidden_states_B_C], dim=-1)
             # Init cache
             if cache_params is not None:
                 conv_states = nn.functional.pad(

--- a/src/transformers/models/mamba2/modeling_mamba2.py
+++ b/src/transformers/models/mamba2/modeling_mamba2.py
@@ -303,55 +303,11 @@ class Mamba2Mixer(nn.Module):
             # 4. Final linear projection
             out = self.out_proj(hidden_states)[:, None, ...]
 
-        elif cache_params is not None and cache_params.has_previous_state(self.layer_idx):
-            A = -torch.exp(self.A_log.float())
-            dt_limit_kwargs = {} if self.time_step_limit == (0.0, float("inf")) else {"dt_limit": self.time_step_limit}
-            _, _, gate, hidden_states_B_C, dt = projected_states.split(
-                [d_mlp, d_mlp, self.intermediate_size, self.conv_dim, self.num_heads], dim=-1
-            )
-            # 2. Convolution: seed the causal conv with cached left-context via initial_states.
-            hidden_states_B_C, new_conv_state = causal_conv1d_fn(
-                x=hidden_states_B_C.transpose(1, 2),
-                weight=self.conv1d.weight.squeeze(1),
-                bias=self.conv1d.bias,
-                activation=self.activation,
-                initial_states=cache_params.layers[self.layer_idx].conv_states[:, :, 1:],
-                return_final_states=True,
-            )
-            hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
-            cache_params.update_conv_state(nn.functional.pad(new_conv_state, (1, 0)), layer_idx=self.layer_idx)
-            hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
-            hidden_states, B, C = torch.split(
-                hidden_states_B_C,
-                [self.intermediate_size, groups_time_state_size, groups_time_state_size],
-                dim=-1,
-            )
-            # 3. SSM: parallel chunk scan seeded with the cached recurrent state.
-            scan_output, ssm_state = mamba_chunk_scan_combined(
-                hidden_states.view(batch_size, seq_len, -1, self.head_dim),
-                dt,
-                A,
-                B.view(batch_size, seq_len, self.n_groups, -1),
-                C.view(batch_size, seq_len, self.n_groups, -1),
-                chunk_size=self.chunk_size,
-                D=self.D,
-                z=None,
-                seq_idx=None,
-                return_final_states=True,
-                dt_bias=self.dt_bias,
-                dt_softplus=True,
-                initial_states=cache_params.layers[self.layer_idx].recurrent_states,
-                **dt_limit_kwargs,
-            )
-            cache_params.update_recurrent_state(ssm_state, layer_idx=self.layer_idx)
-            scan_output = scan_output.view(batch_size, seq_len, -1)
-            scan_output = self.norm(scan_output, gate)
-            out = self.out_proj(scan_output)
-
         # Fused calculations or step by step if no initialized cache is found
         else:
             A = -torch.exp(self.A_log.float())  # (num_heads) or (intermediate_size, state_size)
             dt_limit_kwargs = {} if self.time_step_limit == (0.0, float("inf")) else {"dt_limit": self.time_step_limit}
+            has_previous_state = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
 
             # 2-4. Fused kernel for conv1d, SSM, and the final projection
             if self.training and cache_params is None:
@@ -363,7 +319,7 @@ class Mamba2Mixer(nn.Module):
                     A,
                     D=self.D,
                     chunk_size=self.chunk_size,
-                    seq_idx=None,  # was seq_idx
+                    seq_idx=None,
                     activation=self.activation,
                     rmsnorm_weight=self.norm.weight,
                     rmsnorm_eps=self.norm.variance_epsilon,
@@ -382,26 +338,39 @@ class Mamba2Mixer(nn.Module):
                 )
 
                 # 2. Convolution sequence transformation
-                # Init cache
-                if cache_params is not None:
-                    hidden_states_B_C_transposed = hidden_states_B_C.transpose(1, 2)
-                    conv_states = nn.functional.pad(
-                        hidden_states_B_C_transposed,
-                        (self.conv_kernel_size - hidden_states_B_C_transposed.shape[-1], 0),
-                    )
-                    conv_states = cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
-
-                if self.activation not in ["silu", "swish"]:
-                    hidden_states_B_C = self.act(
-                        self.conv1d(hidden_states_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2)
-                    )
-                else:
-                    hidden_states_B_C = causal_conv1d_fn(
+                if has_previous_state:
+                    # Seed the causal conv with cached left-context via initial_states
+                    hidden_states_B_C, new_conv_state = causal_conv1d_fn(
                         x=hidden_states_B_C.transpose(1, 2),
                         weight=self.conv1d.weight.squeeze(1),
                         bias=self.conv1d.bias,
                         activation=self.activation,
-                    ).transpose(1, 2)
+                        initial_states=cache_params.layers[self.layer_idx].conv_states[:, :, 1:],
+                        return_final_states=True,
+                    )
+                    hidden_states_B_C = hidden_states_B_C.transpose(1, 2)
+                    cache_params.update_conv_state(nn.functional.pad(new_conv_state, (1, 0)), layer_idx=self.layer_idx)
+                else:
+                    # Init cache
+                    if cache_params is not None:
+                        hidden_states_B_C_transposed = hidden_states_B_C.transpose(1, 2)
+                        conv_states = nn.functional.pad(
+                            hidden_states_B_C_transposed,
+                            (self.conv_kernel_size - hidden_states_B_C_transposed.shape[-1], 0),
+                        )
+                        cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
+
+                    if self.activation not in ["silu", "swish"]:
+                        hidden_states_B_C = self.act(
+                            self.conv1d(hidden_states_B_C.transpose(1, 2))[..., :seq_len].transpose(1, 2)
+                        )
+                    else:
+                        hidden_states_B_C = causal_conv1d_fn(
+                            x=hidden_states_B_C.transpose(1, 2),
+                            weight=self.conv1d.weight.squeeze(1),
+                            bias=self.conv1d.bias,
+                            activation=self.activation,
+                        ).transpose(1, 2)
 
                 hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
                 hidden_states, B, C = torch.split(
@@ -424,6 +393,7 @@ class Mamba2Mixer(nn.Module):
                     return_final_states=True,
                     dt_bias=self.dt_bias,
                     dt_softplus=True,
+                    initial_states=cache_params.layers[self.layer_idx].recurrent_states if has_previous_state else None,
                     **dt_limit_kwargs,
                 )
 
@@ -458,10 +428,12 @@ class Mamba2Mixer(nn.Module):
         )
         hidden_states_B_C = hidden_states_B_C.transpose(1,2)
 
-        is_decoding = cache_params is not None and cache_params.has_previous_state(self.layer_idx)
+        use_precomputed_states = (
+            cache_params is not None and cache_params.has_previous_state(self.layer_idx) and seq_len == 1
+        )
 
         # 2. Convolution sequence transformation
-        if is_decoding and seq_len == 1:
+        if use_precomputed_states:
             conv_states = cache_params.update_conv_state(hidden_states_B_C, layer_idx=self.layer_idx)
 
             hidden_states_B_C = torch.sum(
@@ -471,7 +443,7 @@ class Mamba2Mixer(nn.Module):
                 hidden_states_B_C = hidden_states_B_C + self.conv1d.bias
             hidden_states_B_C = self.act(hidden_states_B_C)
         else:
-            if is_decoding:
+            if cache_params is not None and cache_params.has_previous_state(self.layer_idx):
                 hidden_states_B_C = torch.cat(
                     [cache_params.layers[self.layer_idx].conv_states[:, :, 1:], hidden_states_B_C], dim=-1
                 )
@@ -482,9 +454,8 @@ class Mamba2Mixer(nn.Module):
                 )
                 cache_params.update_conv_state(conv_states, layer_idx=self.layer_idx)
 
-            n = hidden_states_B_C.shape[-1]
-            hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., :n].transpose(1, 2))
-            if is_decoding:
+            hidden_states_B_C = self.act(self.conv1d(hidden_states_B_C)[..., :hidden_states_B_C.shape[-1]].transpose(1, 2))
+            if cache_params is not None and cache_params.has_previous_state(self.layer_idx):
                 hidden_states_B_C = hidden_states_B_C[:, -seq_len:, :]
 
         hidden_states_B_C = apply_mask_to_padding_states(hidden_states_B_C, attention_mask)
@@ -496,7 +467,7 @@ class Mamba2Mixer(nn.Module):
 
         # 3. SSM transformation
         A = -torch.exp(self.A_log.float())                            # [num_heads]
-        if is_decoding and seq_len == 1:
+        if use_precomputed_states:
             # We need to guarantee that anything regarding the cache is on the same device
             cache_device = cache_params.layers[self.layer_idx].device
 
@@ -601,7 +572,7 @@ class Mamba2Mixer(nn.Module):
             # (middle term of factorization of off-diag blocks; A terms)
             previous_states = (
                 cache_params.layers[self.layer_idx].recurrent_states[:, None].to(dtype=states.dtype, device=states.device)
-                if is_decoding
+                if cache_params is not None and cache_params.has_previous_state(self.layer_idx)
                 else torch.zeros_like(states[:, :1])
             )
             states = torch.cat([previous_states, states], dim=1)

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -117,7 +117,6 @@ from .utils import (
     is_librosa_available,
     is_liger_kernel_available,
     is_lomo_available,
-    is_mamba_2_ssm_available,
     is_mistral_common_available,
     is_multipart_available,
     is_natten_available,
@@ -761,19 +760,6 @@ def require_causal_conv1d(test_case):
     return unittest.skipUnless(
         is_causal_conv1d_available(),
         "test requires `causal-conv1d`",
-    )(test_case)
-
-
-def require_mamba_2_ssm(test_case):
-    """
-    Decorator marking a test that requires the Mamba2 fast-path kernels (mamba-ssm).
-
-    These tests are skipped when mamba-ssm isn't installed.
-    """
-
-    return unittest.skipUnless(
-        is_mamba_2_ssm_available(),
-        "test requires `mamba-ssm`",
     )(test_case)
 
 

--- a/src/transformers/testing_utils.py
+++ b/src/transformers/testing_utils.py
@@ -117,6 +117,7 @@ from .utils import (
     is_librosa_available,
     is_liger_kernel_available,
     is_lomo_available,
+    is_mamba_2_ssm_available,
     is_mistral_common_available,
     is_multipart_available,
     is_natten_available,
@@ -760,6 +761,19 @@ def require_causal_conv1d(test_case):
     return unittest.skipUnless(
         is_causal_conv1d_available(),
         "test requires `causal-conv1d`",
+    )(test_case)
+
+
+def require_mamba_2_ssm(test_case):
+    """
+    Decorator marking a test that requires the Mamba2 fast-path kernels (mamba-ssm).
+
+    These tests are skipped when mamba-ssm isn't installed.
+    """
+
+    return unittest.skipUnless(
+        is_mamba_2_ssm_available(),
+        "test requires `mamba-ssm`",
     )(test_case)
 
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -166,6 +166,7 @@ from .import_utils import (
     is_liger_kernel_available,
     is_llm_awq_available,
     is_lomo_available,
+    is_mamba_2_ssm_available,
     is_matplotlib_available,
     is_mistral_common_available,
     is_mlx_available,

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -18,12 +18,13 @@ import unittest
 from transformers import AutoTokenizer, Mamba2Config, is_torch_available
 from transformers.testing_utils import (
     Expectations,
+    require_causal_conv1d,
+    require_mamba_2_ssm,
     require_torch,
     require_torch_accelerator,
     slow,
     torch_device,
 )
-from transformers.utils.import_utils import is_causal_conv1d_available, is_mamba_2_ssm_available
 
 from ...generation.test_utils import GenerationTesterMixin
 from ...test_configuration_common import ConfigTester
@@ -227,7 +228,7 @@ class Mamba2ModelTester:
         result_chunk = torch.cat([out_first.last_hidden_state, out_rest.last_hidden_state], dim=1)
 
         self.parent.assertTrue(
-            torch.allclose(result_tbt, result_chunk, atol=1e-3, rtol=1e-3),
+            torch.allclose(result_tbt, result_chunk, atol=1e-4, rtol=1e-4),
             msg=f"Max diff: {(result_tbt - result_chunk).abs().max().item():.6f}",
         )
 
@@ -235,10 +236,6 @@ class Mamba2ModelTester:
         model = Mamba2Model(config)
         model.eval()
 
-        if not (is_mamba_2_ssm_available() and is_causal_conv1d_available()):
-            self.parent.skipTest(
-                "This test needs the Mamba2 fast path. Skipping as the necessary packages have not been found."
-            )
         if torch_device != "cuda":
             self.parent.skipTest("This test needs the Mamba2 fast path. Skipping as we need a cuda capable device.")
 
@@ -290,10 +287,9 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs)
 
     @require_torch_accelerator
+    @require_mamba_2_ssm
+    @require_causal_conv1d
     def test_mamba2_chunked_prefill_cuda_path(self):
-        if not (is_mamba_2_ssm_available() and is_causal_conv1d_available()):
-            self.skipTest("Requires mamba-ssm and causal-conv1d packages.")
-
         torch.manual_seed(0)
         config = self.model_tester.get_config()
         L = 8
@@ -313,10 +309,12 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         result_chunk = torch.cat([out_first.last_hidden_state, out_rest.last_hidden_state], dim=1)
 
         self.assertTrue(
-            torch.allclose(result_tbt, result_chunk, atol=1e-3, rtol=1e-3),
+            torch.allclose(result_tbt, result_chunk, atol=1e-4, rtol=1e-4),
             msg=f"Max diff: {(result_tbt - result_chunk).abs().max().item():.6f}",
         )
 
+    @require_mamba_2_ssm
+    @require_causal_conv1d
     def test_mamba2_slow_vs_fast_forward(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -18,8 +18,7 @@ import unittest
 from transformers import AutoTokenizer, Mamba2Config, is_torch_available
 from transformers.testing_utils import (
     Expectations,
-    require_causal_conv1d,
-    require_mamba_2_ssm,
+    require_kernels,
     require_torch,
     require_torch_accelerator,
     slow,
@@ -208,6 +207,12 @@ class Mamba2ModelTester:
         )
 
     def create_and_check_mamba2_chunked_prefill(self, config, input_ids, *args, device="cpu"):
+        """
+        Adapted from `test_linear_attention_multi_token_cached_forward_matches_single_token`
+        to check whether multi-token cached input is properly handled.
+
+        Can either be run on GPU (fast path) or CPU (slow path), see `test_mamba2_chunked_prefill_*`
+        """
         model = Mamba2Model(config=config)
         model.to(device)
         model.eval()
@@ -237,8 +242,7 @@ class Mamba2ModelTester:
         )
 
     def create_and_check_mamba2_slow_vs_fast_forward(self, config, input_ids, *args, gradient_checkpointing=False):
-        # Device + fast-path-kernel gating is handled by the require_* decorators on the test methods
-        # (require_mamba_2_ssm / require_causal_conv1d both already imply a CUDA device).
+        """Slow vs fast path check guarded by require kernels to enable fast path"""
         model = Mamba2Model(config)
         model.eval()
         model.to(torch_device)
@@ -289,13 +293,13 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs, device="cpu")
 
     @require_torch_accelerator
+    @require_kernels
     def test_mamba2_chunked_prefill_torch_device(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs, device=torch_device)
 
     @require_torch_accelerator
-    @require_mamba_2_ssm
-    @require_causal_conv1d
+    @require_kernels
     def test_mamba2_slow_vs_fast_forward(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_slow_vs_fast_forward(*config_and_inputs)
@@ -304,8 +308,7 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     # creates a grouped SSD configuration in the mamba2 layers
     # See https://github.com/huggingface/transformers/pull/37533/
     @require_torch_accelerator
-    @require_mamba_2_ssm
-    @require_causal_conv1d
+    @require_kernels
     def test_mamba2_slow_vs_fast_forward_grouped(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         config_and_inputs[0].n_groups //= 2

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -207,13 +207,13 @@ class Mamba2ModelTester:
             torch.allclose(torch.cat([output_one, output_two], dim=1), output_whole, atol=1e-3, rtol=1e-3)
         )
 
-    def create_and_check_mamba2_chunked_prefill(self, config, *args):
+    def create_and_check_mamba2_chunked_prefill(self, config, *args, device="cpu"):
         model = Mamba2Model(config=config)
-        model.to("cpu")
+        model.to(device)
         model.eval()
 
         L = 8
-        inputs_embeds = torch.randn(1, L, config.hidden_size)
+        inputs_embeds = torch.randn(1, L, config.hidden_size, device=device)
 
         cache_tbt = DynamicCache(config=config)
         outputs_tbt = []
@@ -233,12 +233,10 @@ class Mamba2ModelTester:
         )
 
     def create_and_check_mamba2_slow_vs_fast_forward(self, config, input_ids, *args, gradient_checkpointing=False):
+        # Device + fast-path-kernel gating is handled by the require_* decorators on the test methods
+        # (require_mamba_2_ssm / require_causal_conv1d both already imply a CUDA device).
         model = Mamba2Model(config)
         model.eval()
-
-        if torch_device != "cuda":
-            self.parent.skipTest("This test needs the Mamba2 fast path. Skipping as we need a cuda capable device.")
-
         model.to(torch_device)
         if gradient_checkpointing:
             model.gradient_checkpointing_enable()
@@ -283,35 +281,10 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         self.model_tester.create_and_check_mamba2_caching(*config_and_inputs)
 
     def test_mamba2_chunked_prefill(self):
+        # Runs on torch_device: exercises the slow path on CPU and, when an accelerator with
+        # mamba-ssm / causal-conv1d is present, the CUDA fast path.
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
-        self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs)
-
-    @require_torch_accelerator
-    @require_mamba_2_ssm
-    @require_causal_conv1d
-    def test_mamba2_chunked_prefill_cuda_path(self):
-        torch.manual_seed(0)
-        config = self.model_tester.get_config()
-        L = 8
-        model = Mamba2Model(config=config).to(torch_device).eval()
-        inputs_embeds = torch.randn(1, L, config.hidden_size, device=torch_device)
-
-        cache_tbt = DynamicCache(config=config)
-        outputs_tbt = []
-        for t in range(L):
-            out = model(inputs_embeds=inputs_embeds[:, t : t + 1, :], cache_params=cache_tbt, use_cache=True)
-            outputs_tbt.append(out.last_hidden_state)
-        result_tbt = torch.cat(outputs_tbt, dim=1)
-
-        cache_chunk = DynamicCache(config=config)
-        out_first = model(inputs_embeds=inputs_embeds[:, :1, :], cache_params=cache_chunk, use_cache=True)
-        out_rest = model(inputs_embeds=inputs_embeds[:, 1:, :], cache_params=cache_chunk, use_cache=True)
-        result_chunk = torch.cat([out_first.last_hidden_state, out_rest.last_hidden_state], dim=1)
-
-        self.assertTrue(
-            torch.allclose(result_tbt, result_chunk, atol=1e-4, rtol=1e-4),
-            msg=f"Max diff: {(result_tbt - result_chunk).abs().max().item():.6f}",
-        )
+        self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs, device=torch_device)
 
     @require_mamba_2_ssm
     @require_causal_conv1d
@@ -322,6 +295,8 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     # This test adjusts n_groups to half the original setting and effectively
     # creates a grouped SSD configuration in the mamba2 layers
     # See https://github.com/huggingface/transformers/pull/37533/
+    @require_mamba_2_ssm
+    @require_causal_conv1d
     def test_mamba2_slow_vs_fast_forward_grouped(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         config_and_inputs[0].n_groups //= 2

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -206,6 +206,31 @@ class Mamba2ModelTester:
             torch.allclose(torch.cat([output_one, output_two], dim=1), output_whole, atol=1e-3, rtol=1e-3)
         )
 
+    def create_and_check_mamba2_chunked_prefill(self, config, *args):
+        model = Mamba2Model(config=config)
+        model.to("cpu")
+        model.eval()
+
+        L = 8
+        inputs_embeds = torch.randn(1, L, config.hidden_size)
+
+        cache_tbt = DynamicCache(config=config)
+        outputs_tbt = []
+        for t in range(L):
+            out = model(inputs_embeds=inputs_embeds[:, t : t + 1, :], cache_params=cache_tbt, use_cache=True)
+            outputs_tbt.append(out.last_hidden_state)
+        result_tbt = torch.cat(outputs_tbt, dim=1)
+
+        cache_chunk = DynamicCache(config=config)
+        out_first = model(inputs_embeds=inputs_embeds[:, :1, :], cache_params=cache_chunk, use_cache=True)
+        out_rest = model(inputs_embeds=inputs_embeds[:, 1:, :], cache_params=cache_chunk, use_cache=True)
+        result_chunk = torch.cat([out_first.last_hidden_state, out_rest.last_hidden_state], dim=1)
+
+        self.parent.assertTrue(
+            torch.allclose(result_tbt, result_chunk, atol=1e-3, rtol=1e-3),
+            msg=f"Max diff: {(result_tbt - result_chunk).abs().max().item():.6f}",
+        )
+
     def create_and_check_mamba2_slow_vs_fast_forward(self, config, input_ids, *args, gradient_checkpointing=False):
         model = Mamba2Model(config)
         model.eval()
@@ -259,6 +284,38 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     def test_mamba2_caching(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_caching(*config_and_inputs)
+
+    def test_mamba2_chunked_prefill(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs)
+
+    @require_torch_accelerator
+    def test_mamba2_chunked_prefill_cuda_path(self):
+        if not (is_mamba_2_ssm_available() and is_causal_conv1d_available()):
+            self.skipTest("Requires mamba-ssm and causal-conv1d packages.")
+
+        torch.manual_seed(0)
+        config = self.model_tester.get_config()
+        L = 8
+        model = Mamba2Model(config=config).to(torch_device).eval()
+        inputs_embeds = torch.randn(1, L, config.hidden_size, device=torch_device)
+
+        cache_tbt = DynamicCache(config=config)
+        outputs_tbt = []
+        for t in range(L):
+            out = model(inputs_embeds=inputs_embeds[:, t : t + 1, :], cache_params=cache_tbt, use_cache=True)
+            outputs_tbt.append(out.last_hidden_state)
+        result_tbt = torch.cat(outputs_tbt, dim=1)
+
+        cache_chunk = DynamicCache(config=config)
+        out_first = model(inputs_embeds=inputs_embeds[:, :1, :], cache_params=cache_chunk, use_cache=True)
+        out_rest = model(inputs_embeds=inputs_embeds[:, 1:, :], cache_params=cache_chunk, use_cache=True)
+        result_chunk = torch.cat([out_first.last_hidden_state, out_rest.last_hidden_state], dim=1)
+
+        self.assertTrue(
+            torch.allclose(result_tbt, result_chunk, atol=1e-3, rtol=1e-3),
+            msg=f"Max diff: {(result_tbt - result_chunk).abs().max().item():.6f}",
+        )
 
     def test_mamba2_slow_vs_fast_forward(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()

--- a/tests/models/mamba2/test_modeling_mamba2.py
+++ b/tests/models/mamba2/test_modeling_mamba2.py
@@ -207,29 +207,33 @@ class Mamba2ModelTester:
             torch.allclose(torch.cat([output_one, output_two], dim=1), output_whole, atol=1e-3, rtol=1e-3)
         )
 
-    def create_and_check_mamba2_chunked_prefill(self, config, *args, device="cpu"):
+    def create_and_check_mamba2_chunked_prefill(self, config, input_ids, *args, device="cpu"):
         model = Mamba2Model(config=config)
         model.to(device)
         model.eval()
 
-        L = 8
-        inputs_embeds = torch.randn(1, L, config.hidden_size, device=device)
+        input_ids = input_ids[:1].to(device)
+        prefill_len = input_ids.shape[1] // 2 + 1
+        prompt = input_ids[:, :prefill_len]
+        next_token = input_ids[:, prefill_len : prefill_len + 1]
+        distractors = input_ids[:, prefill_len + 1 :]
+        multi_input = torch.cat([next_token, distractors], dim=1)
 
-        cache_tbt = DynamicCache(config=config)
-        outputs_tbt = []
-        for t in range(L):
-            out = model(inputs_embeds=inputs_embeds[:, t : t + 1, :], cache_params=cache_tbt, use_cache=True)
-            outputs_tbt.append(out.last_hidden_state)
-        result_tbt = torch.cat(outputs_tbt, dim=1)
+        cache_single = DynamicCache(config=config)
+        with torch.no_grad():
+            model(input_ids=prompt, cache_params=cache_single, use_cache=True)
+            single_out = model(input_ids=next_token, cache_params=cache_single, use_cache=True)
+        ref_first = single_out.last_hidden_state[:, 0, :]
 
-        cache_chunk = DynamicCache(config=config)
-        out_first = model(inputs_embeds=inputs_embeds[:, :1, :], cache_params=cache_chunk, use_cache=True)
-        out_rest = model(inputs_embeds=inputs_embeds[:, 1:, :], cache_params=cache_chunk, use_cache=True)
-        result_chunk = torch.cat([out_first.last_hidden_state, out_rest.last_hidden_state], dim=1)
+        cache_multi = DynamicCache(config=config)
+        with torch.no_grad():
+            model(input_ids=prompt, cache_params=cache_multi, use_cache=True)
+            multi_out = model(input_ids=multi_input, cache_params=cache_multi, use_cache=True)
+        under_test_first = multi_out.last_hidden_state[:, 0, :]
 
         self.parent.assertTrue(
-            torch.allclose(result_tbt, result_chunk, atol=1e-4, rtol=1e-4),
-            msg=f"Max diff: {(result_tbt - result_chunk).abs().max().item():.6f}",
+            torch.allclose(ref_first, under_test_first, atol=1e-4, rtol=1e-4),
+            msg=f"Max diff: {(ref_first - under_test_first).abs().max().item():.6f}",
         )
 
     def create_and_check_mamba2_slow_vs_fast_forward(self, config, input_ids, *args, gradient_checkpointing=False):
@@ -280,12 +284,16 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_caching(*config_and_inputs)
 
-    def test_mamba2_chunked_prefill(self):
-        # Runs on torch_device: exercises the slow path on CPU and, when an accelerator with
-        # mamba-ssm / causal-conv1d is present, the CUDA fast path.
+    def test_mamba2_chunked_prefill_cpu(self):
+        config_and_inputs = self.model_tester.prepare_config_and_inputs()
+        self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs, device="cpu")
+
+    @require_torch_accelerator
+    def test_mamba2_chunked_prefill_torch_device(self):
         config_and_inputs = self.model_tester.prepare_config_and_inputs()
         self.model_tester.create_and_check_mamba2_chunked_prefill(*config_and_inputs, device=torch_device)
 
+    @require_torch_accelerator
     @require_mamba_2_ssm
     @require_causal_conv1d
     def test_mamba2_slow_vs_fast_forward(self):
@@ -295,6 +303,7 @@ class Mamba2ModelTest(ModelTesterMixin, GenerationTesterMixin, PipelineTesterMix
     # This test adjusts n_groups to half the original setting and effectively
     # creates a grouped SSD configuration in the mamba2 layers
     # See https://github.com/huggingface/transformers/pull/37533/
+    @require_torch_accelerator
     @require_mamba_2_ssm
     @require_causal_conv1d
     def test_mamba2_slow_vs_fast_forward_grouped(self):


### PR DESCRIPTION


# What does this PR do?

Add a third dispatch path to Mamba2Mixer for the case where a prior cached state exists and seq_len > 1 (chunked prefill / speculative decode verification).

Previously:
   - cuda_kernels_forward: .squeeze(1) crashed or corrupted tensors for seq_len > 1 when has_previous_state was True.
   - torch_forward: dt[:, 0, :] silently dropped all tokens after index 0, and previous_states was always zero-initialised ignoring the cache.

Both paths now:
   - Gate the single-step kernel on seq_len == 1.
   - For seq_len > 1, prepend the cached conv buffer (last K-1 entries) to the chunk input, run a full causal conv, drop the prepended prefix from the output, and pass the cached recurrent_state as initial_states  to mamba_chunk_scan_combined / as previous_states in the naive SSD.

This PR follows the same pattern applied to GDN-based models in #45513,  as discussed in the issues I added test_mamba2_chunked_prefill (CPU/torch path, always runs) and test_mamba2_chunked_prefill_cuda_path (skipped without mamba-ssm).

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes #46032 

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case. #46032 
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@zucchini-nlp @Cyrilvallez 🤗@vasqu @Clara2911
<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
