### PR TITLE
Fix torchao behavior for xpu

### DIFF
--- a/src/transformers/integrations/torchao.py
+++ b/src/transformers/integrations/torchao.py
@@ -18,7 +18,7 @@ import types
 import torch
 
 from transformers.utils import logging
-from transformers.utils.import_utils import is_torch_available, is_torchao_available
+from transformers.utils.import_utils import is_torch_accelerator_available, is_torch_available, is_torchao_available
 
 
 if is_torch_available():
@@ -69,7 +69,8 @@ class TorchAoQuantize(ConversionOps):
 
         target_device = next(module.parameters()).device
         if self.hf_quantizer.offload_to_cpu and target_device.type == "cpu":
-            module.to(torch.accelerator.current_accelerator())
+            device = torch.accelerator.current_accelerator() if is_torch_accelerator_available() else "cuda"
+            module.to(device)
             quantize_(module, config, *args, **kwargs)
             module.to("cpu")
         else:

--- a/src/transformers/integrations/torchao.py
+++ b/src/transformers/integrations/torchao.py
@@ -69,7 +69,7 @@ class TorchAoQuantize(ConversionOps):
 
         target_device = next(module.parameters()).device
         if self.hf_quantizer.offload_to_cpu and target_device.type == "cpu":
-            module.to("cuda")
+            module.to(torch.accelerator.current_accelerator())
             quantize_(module, config, *args, **kwargs)
             module.to("cpu")
         else:

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -127,6 +127,7 @@ class TorchAoTestBase:
             {
                 ("cuda", None): "What are we having for dinner?\nRed, white, and green beans,",
                 ("xpu", None): "What are we having for dinner?\n\nJessica: (smiling)",
+                ("xpu", 5): "What are we having for dinner?\n\n[Scene 2]\n\n[",
             }
         )
         # fmt: on
@@ -539,6 +540,7 @@ class TorchAoAcceleratorTest(TorchAoTestBase, unittest.TestCase):
             {
                 ("cuda", None): "What are we having for dinner?\nRed, white, and green beans,",
                 ("xpu", None): "What are we having for dinner?\n\nJessica: (smiling)",
+                ("xpu", 5): "What are we having for dinner?\n\n[Scene 2]\n\n[",
             }
         )
         # fmt: on
@@ -572,6 +574,7 @@ class TorchAoAcceleratorTest(TorchAoTestBase, unittest.TestCase):
             {
                 ("cuda", None): "What are we having for dinner?\nRed, white, and green beans,",
                 ("xpu", None): "What are we having for dinner?\n\nJessica: (smiling)",
+                ("xpu", 5): "What are we having for dinner?\n\n[Scene 2]\n\n[",
             }
         )
         self.assertEqual(tokenizer.decode(output[0], skip_special_tokens=True), EXPECTED_OUTPUT.get_expectation())
@@ -595,7 +598,7 @@ class TorchAoSerializationTest(unittest.TestCase):
             ("Int8DynamicActivationInt8WeightConfig", Int8DynamicActivationInt8WeightConfig(version=2), ALL_DEVICES_COMMON),
             ("Float8DynamicActivationFloat8WeightConfig", Float8DynamicActivationFloat8WeightConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): "What are we having for dinner?\n\nJess: (smiling) I"})),
             ("Float8WeightOnlyConfig", Float8WeightOnlyConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): COMMON_OUTPUT})),
-            ("Int4WeightOnlyConfig", Int4WeightOnlyConfig(int4_packing_format="plain_int32" if torch_device == "xpu" else "tile_packed_to_4d"), Expectations({("cuda", None): "What are we having for dinner?\nRed, white, and green beans,", ("xpu", None): COMMON_OUTPUT})),
+            ("Int4WeightOnlyConfig", Int4WeightOnlyConfig(int4_packing_format="plain_int32" if torch_device == "xpu" else "tile_packed_to_4d"), Expectations({("cuda", None): "What are we having for dinner?\nRed, white, and green beans,", ("xpu", None): COMMON_OUTPUT, ("xpu", 5): "What are we having for dinner?\n\n[Scene 2]\n\n["})),
             ("Int8DynamicActivationIntxWeightConfig", Int8DynamicActivationIntxWeightConfig(), Expectations({("cpu", None): COMMON_OUTPUT, ("cuda", 9): COMMON_OUTPUT, ("cuda", 8): "What are we having for dinner?\n\nJEN: (smiling) I", ("xpu", None): COMMON_OUTPUT})),
             ("IntxWeightOnlyConfig", IntxWeightOnlyConfig(), ALL_DEVICES_COMMON),
             ("NVFP4DynamicActivationNVFP4WeightConfig", NVFP4DynamicActivationNVFP4WeightConfig(), Expectations({("cuda", None): "What are we having for dinner?\n\n10. Avoid using \"I"})),

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -105,7 +105,8 @@ class TorchAoTestBase:
         """
         Simple LLM model testing int4 weight only quantization
         """
-        config = Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d")
+        int4_packing_format = "plain_int32" if self.device == "xpu" else "tile_packed_to_4d"
+        config = Int4WeightOnlyConfig(int4_packing_format=int4_packing_format)
         quant_config = TorchAoConfig(config)
 
         quantized_model = AutoModelForCausalLM.from_pretrained(
@@ -518,7 +519,8 @@ class TorchAoAcceleratorTest(TorchAoTestBase, unittest.TestCase):
             "lm_head": 0,
         }
 
-        config = Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d")
+        int4_packing_format = "plain_int32" if self.device == "xpu" else "tile_packed_to_4d"
+        config = Int4WeightOnlyConfig(int4_packing_format=int4_packing_format)
         quant_config = TorchAoConfig(config)
 
         quantized_model = AutoModelForCausalLM.from_pretrained(
@@ -550,7 +552,8 @@ class TorchAoAcceleratorTest(TorchAoTestBase, unittest.TestCase):
         set ZE_AFFINITY_MASK=0,1 if you have more than 2 Intel XPUs
         """
 
-        config = Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d")
+        int4_packing_format = "plain_int32" if self.device == "xpu" else "tile_packed_to_4d"
+        config = Int4WeightOnlyConfig(int4_packing_format=int4_packing_format)
         quant_config = TorchAoConfig(config)
         quantized_model = AutoModelForCausalLM.from_pretrained(
             self.model_name,
@@ -592,7 +595,7 @@ class TorchAoSerializationTest(unittest.TestCase):
             ("Int8DynamicActivationInt8WeightConfig", Int8DynamicActivationInt8WeightConfig(version=2), ALL_DEVICES_COMMON),
             ("Float8DynamicActivationFloat8WeightConfig", Float8DynamicActivationFloat8WeightConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): "What are we having for dinner?\n\nJess: (smiling) I"})),
             ("Float8WeightOnlyConfig", Float8WeightOnlyConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): COMMON_OUTPUT})),
-            ("Int4WeightOnlyConfig", Int4WeightOnlyConfig(int4_packing_format="tile_packed_to_4d"), Expectations({("cuda", None): "What are we having for dinner?\nRed, white, and green beans,", ("xpu", None): COMMON_OUTPUT})),
+            ("Int4WeightOnlyConfig", Int4WeightOnlyConfig(int4_packing_format="plain_int32" if torch_device == "xpu" else "tile_packed_to_4d"), Expectations({("cuda", None): "What are we having for dinner?\nRed, white, and green beans,", ("xpu", None): COMMON_OUTPUT})),
             ("Int8DynamicActivationIntxWeightConfig", Int8DynamicActivationIntxWeightConfig(), Expectations({("cpu", None): COMMON_OUTPUT, ("cuda", 9): COMMON_OUTPUT, ("cuda", 8): "What are we having for dinner?\n\nJEN: (smiling) I", ("xpu", None): COMMON_OUTPUT})),
             ("IntxWeightOnlyConfig", IntxWeightOnlyConfig(), ALL_DEVICES_COMMON),
             ("NVFP4DynamicActivationNVFP4WeightConfig", NVFP4DynamicActivationNVFP4WeightConfig(), Expectations({("cuda", None): "What are we having for dinner?\n\n10. Avoid using \"I"})),

--- a/tests/quantization/torchao_integration/test_torchao.py
+++ b/tests/quantization/torchao_integration/test_torchao.py
@@ -596,7 +596,7 @@ class TorchAoSerializationTest(unittest.TestCase):
         [
             ("Int8WeightOnlyConfig", Int8WeightOnlyConfig(version=2), ALL_DEVICES_COMMON),
             ("Int8DynamicActivationInt8WeightConfig", Int8DynamicActivationInt8WeightConfig(version=2), ALL_DEVICES_COMMON),
-            ("Float8DynamicActivationFloat8WeightConfig", Float8DynamicActivationFloat8WeightConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): "What are we having for dinner?\n\nJess: (smiling) I"})),
+            ("Float8DynamicActivationFloat8WeightConfig", Float8DynamicActivationFloat8WeightConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): "What are we having for dinner?\n\nJess: (smiling) I", ("xpu", 5): COMMON_OUTPUT})),
             ("Float8WeightOnlyConfig", Float8WeightOnlyConfig(), Expectations({("cuda", None): COMMON_OUTPUT, ("xpu", None): COMMON_OUTPUT})),
             ("Int4WeightOnlyConfig", Int4WeightOnlyConfig(int4_packing_format="plain_int32" if torch_device == "xpu" else "tile_packed_to_4d"), Expectations({("cuda", None): "What are we having for dinner?\nRed, white, and green beans,", ("xpu", None): COMMON_OUTPUT, ("xpu", 5): "What are we having for dinner?\n\n[Scene 2]\n\n["})),
             ("Int8DynamicActivationIntxWeightConfig", Int8DynamicActivationIntxWeightConfig(), Expectations({("cpu", None): COMMON_OUTPUT, ("cuda", 9): COMMON_OUTPUT, ("cuda", 8): "What are we having for dinner?\n\nJEN: (smiling) I", ("xpu", None): COMMON_OUTPUT})),


### PR DESCRIPTION
This PR fixes torchao behavior on XPU.

It updates the torchao integration to use the current accelerator instead of assuming CUDA during offload, which prevents XPU runs from incorrectly moving modules to CUDA. It also aligns the torchao int4 XPU tests with the expected XPU configuration and output behavior, including B60-specific ground truth updates where needed.

Overall, this makes torchao XPU support more robust and keeps the test suite consistent with actual XPU execution results.