### PR TITLE
[Fix] Remove calls to unsupported functions in TP

### DIFF
--- a/src/transformers/distributed/configuration_utils.py
+++ b/src/transformers/distributed/configuration_utils.py
@@ -57,9 +57,14 @@ class DistributedConfig:
 
         if torch.distributed.is_available() and torch.distributed.is_initialized():
             world_size = torch.distributed.get_world_size()
-            assert self.tp_size * self.fsdp_size == world_size, (
-                f"tp_size ({self.tp_size}) * fsdp_size ({self.fsdp_size}) must be equal to world_size ({world_size})"
-            )
+            if self.tp_size * self.fsdp_size != world_size:
+                raise RuntimeError(
+                    f"tp_size ({self.tp_size}) * fsdp_size ({self.fsdp_size}) is not equal to world_size ({world_size})"
+                )
+        # TODO (remi-or) the check above should probably happen during actual model sharding, same as the check below
+        # elif self.tp_size > 1 or self.fsdp_size > 1:
+        #     issue = "not initialized" if torch.distributed.is_available() else "not available"
+        #     raise ValueError(f"Requested {self.tp_size = }, {self.fsdp_size = } but torch.distributed is {issue}.")
 
     @classmethod
     def from_dict(cls, config_dict: dict, **kwargs) -> "DistributedConfig":

--- a/src/transformers/distributed/sharding_utils.py
+++ b/src/transformers/distributed/sharding_utils.py
@@ -30,6 +30,10 @@ if is_torch_available():
     from torch.distributed.tensor._utils import compute_local_shape_and_global_offset
     from torch.distributed.tensor.placement_types import Shard, _StridedShard
 
+    # torch < 2.10 names as an underscore before `local_shard_size_and_offset`: alias it the non-underscored version
+    if not hasattr(Shard, "local_shard_size_and_offset") and hasattr(Shard, "_local_shard_size_and_offset"):
+        Shard.local_shard_size_and_offset = Shard._local_shard_size_and_offset
+
 
 class DtensorShardOperation:
     """Shard-on-read: slice a full checkpoint tensor down to this rank's local

--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -125,14 +125,9 @@ def init_device_mesh(distributed_config: DistributedConfig) -> torch.distributed
         dims.append(tp_size)
         names.append("tp")
 
-    # Build from a 1D world mesh via _unflatten so that PyTorch can flatten
-    # sub-dimensions back when needed (e.g. for single all_reduce across
-    # [fsdp, tp] during grad norm computation instead of 2 sequential ones).
-    world_mesh = torch.distributed.init_device_mesh(device_type, (world_size,), mesh_dim_names=("world",))
-    mesh = world_mesh._unflatten(0, tuple(dims), tuple(names))
-
-    # Pre-create flattened sub-mesh for multi-dimensional meshes so DTensor
-    # can use a single collective instead of sequential per-dimension ones.
+    # Build the N-dimensional device mesh
+    mesh = torch.distributed.init_device_mesh(device_type, tuple(dims), mesh_dim_names=tuple(names))
+    # If N > 1, create a flattened sub-mesh so all-reduces across the world mesh ae done in one collective
     if len(dims) > 1:
         mesh._flatten("_".join(names))
 


### PR DESCRIPTION
In #45028 some code was introduced that is not compatible with torch < 2.9.1 . Since we support up to torch 2.4 this PR fixes two instances of this and also adds a TODO for check when instantiating a distributed model.