### PR TITLE
Allow `ydshieh2` for now for testing migration

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -12,7 +12,8 @@ permissions:
 
 jobs:
   pr-ci:
-    if: contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association)
+    # Allow `ydshieh2` for testing during development
+    if: contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) || github.event.pull_request.user.login == 'ydshieh2'
     uses: huggingface/transformers-test-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@91d590c4f744e4564a8ae0d3810068c8a35b939e # main
     secrets:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}


### PR DESCRIPTION
# What does this PR do?

Well well for testing purpose.