### PR TITLE
[fix] toctree

### DIFF
--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -32,8 +32,7 @@
         title: Contribute to Transformers
       - local: modular_transformers
         title: Add a model with modular transformers
-      - title: Multimodal models
-        isExpanded: false
+      - isExpanded: false
         sections:
         - local: multimodal_processing
           title: Multimodal processors
@@ -41,6 +40,7 @@
           title: Vision processing components
         - local: add_audio_processing_components
           title: Audio processing components
+        title: Multimodal models
       - local: modeling_rules
         title: Model structure rules
       - local: model_output_tracing

--- a/docs/source/en/_toctree.yml
+++ b/docs/source/en/_toctree.yml
@@ -32,15 +32,12 @@
         title: Contribute to Transformers
       - local: modular_transformers
         title: Add a model with modular transformers
-      - isExpanded: false
-        sections:
-        - local: multimodal_processing
-          title: Multimodal processors
-        - local: add_vision_processing_components
-          title: Vision processing components
-        - local: add_audio_processing_components
-          title: Audio processing components
-        title: Multimodal models
+      - local: multimodal_processing
+        title: Multimodal processors
+      - local: add_vision_processing_components
+        title: Vision processing components
+      - local: add_audio_processing_components
+        title: Audio processing components
       - local: modeling_rules
         title: Model structure rules
       - local: model_output_tracing


### PR DESCRIPTION
fixes misaligned toctree in **Models > Contribute > Multimodal models**. i don't think the doc-builder supports this many nested levels which is why it breaks

<img width="264" height="358" alt="Screenshot 2026-05-20 at 4 35 48 PM" src="https://github.com/user-attachments/assets/73377df9-a636-4b00-b94a-5497f6a54e97" />
