### PR TITLE
Fix deepspeed docker

### DIFF
--- a/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-latest-gpu/Dockerfile
@@ -31,6 +31,11 @@ RUN python3 -m pip uninstall -y transformer-engine
 # Uninstall `torch-tensorrt` shipped with the base image
 RUN python3 -m pip uninstall -y torch-tensorrt
 
+# Uninstall outdated `nvtx` (0.2.5 from /rapids/) shipped with the base image:
+# DeepSpeed calls `nvtx.get_domain` (added in 0.2.12) and will crash otherwise.
+# DeepSpeed falls back to `torch.cuda.nvtx` when the standalone package is absent.
+RUN python3 -m pip uninstall -y nvtx
+
 # recompile apex
 RUN python3 -m pip uninstall -y apex
 # RUN git clone https://github.com/NVIDIA/apex

--- a/docker/transformers-pytorch-deepspeed-nightly-gpu/Dockerfile
+++ b/docker/transformers-pytorch-deepspeed-nightly-gpu/Dockerfile
@@ -32,6 +32,11 @@ RUN python3 -m pip uninstall -y transformer-engine
 # Uninstall `torch-tensorrt` and `apex` shipped with the base image
 RUN python3 -m pip uninstall -y torch-tensorrt apex
 
+# Uninstall outdated `nvtx` (0.2.5 from /rapids/) shipped with the base image:
+# DeepSpeed calls `nvtx.get_domain` (added in 0.2.12) and will crash otherwise.
+# DeepSpeed falls back to `torch.cuda.nvtx` when the standalone package is absent.
+RUN python3 -m pip uninstall -y nvtx
+
 # Pre-build **nightly** release of DeepSpeed, so it would be ready for testing (otherwise, the 1st deepspeed test will timeout)
 RUN python3 -m pip uninstall -y deepspeed
 # This has to be run inside the GPU VMs running the tests. (So far, it fails here due to GPU checks during compilation.)


### PR DESCRIPTION
# What does this PR do?

This PR updates the deepspeed docker as it was installing an old version of nvtx which was part of the base image. SInce deepseed relies on a newer version if it is installed, this caused issues and the CI was failing. 

`(line 239)  AttributeError: module 'nvtx' has no attribute 'get_domain'` cc @qgallouedec for viz 