### PR TITLE
Add video_processor support to VideoClassificationPipeline

### DIFF
--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -31,7 +31,7 @@ from ..models.auto.image_processing_auto import IMAGE_PROCESSOR_MAPPING, AutoIma
 from ..models.auto.modeling_auto import AutoModelForDepthEstimation, AutoModelForImageToImage
 from ..models.auto.processing_auto import PROCESSOR_MAPPING, AutoProcessor
 from ..models.auto.tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
-from ..models.auto.video_processing_auto import VIDEO_PROCESSOR_MAPPING, AutoVideoProcessor
+from ..models.auto.video_processing_auto import AutoVideoProcessor
 from ..processing_utils import ProcessorMixin
 from ..tokenization_python import PreTrainedTokenizer
 from ..utils import (

--- a/src/transformers/pipelines/__init__.py
+++ b/src/transformers/pipelines/__init__.py
@@ -31,6 +31,7 @@ from ..models.auto.image_processing_auto import IMAGE_PROCESSOR_MAPPING, AutoIma
 from ..models.auto.modeling_auto import AutoModelForDepthEstimation, AutoModelForImageToImage
 from ..models.auto.processing_auto import PROCESSOR_MAPPING, AutoProcessor
 from ..models.auto.tokenization_auto import TOKENIZER_MAPPING, AutoTokenizer
+from ..models.auto.video_processing_auto import VIDEO_PROCESSOR_MAPPING, AutoVideoProcessor
 from ..processing_utils import ProcessorMixin
 from ..tokenization_python import PreTrainedTokenizer
 from ..utils import (
@@ -612,6 +613,28 @@ def _resolve_feature_extractor(
     return _load_pipeline_component(load_feature_extractor, feature_extractor, load)
 
 
+def _resolve_video_processor(
+    video_processor, load_video_processor, model_name, config, task, hub_kwargs, model_kwargs
+):
+    """Resolve and optionally load the video processor for video-capable pipelines."""
+
+    def load(video_processor):
+        video_processor = _infer_pipeline_component(
+            video_processor,
+            model_name,
+            config,
+            "Impossible to guess which video processor to use. "
+            "Please provide a BaseVideoProcessor class or a path/identifier to a pretrained video processor.",
+        )
+
+        if not isinstance(video_processor, (str, tuple)):
+            return video_processor
+
+        return AutoVideoProcessor.from_pretrained(video_processor, _from_pipeline=task, **hub_kwargs, **model_kwargs)
+
+    return _load_pipeline_component(load_video_processor, video_processor, load)
+
+
 def _resolve_processor(processor, load_processor, model_name, config, task, hub_kwargs, model_kwargs):
     """Resolve and optionally load a multimodal processor."""
 
@@ -1018,6 +1041,7 @@ def pipeline(
     load_image_processor = getattr(pipeline_class, "_load_image_processor")
     load_feature_extractor = getattr(pipeline_class, "_load_feature_extractor")
     load_processor = getattr(pipeline_class, "_load_processor")
+    load_video_processor = getattr(pipeline_class, "_load_video_processor", None)
 
     tokenizer = _resolve_tokenizer(
         tokenizer=tokenizer,
@@ -1059,6 +1083,15 @@ def pipeline(
         hub_kwargs=hub_kwargs,
         model_kwargs=model_kwargs,
     )
+    video_processor = _resolve_video_processor(
+        video_processor=kwargs.pop("video_processor", None),
+        load_video_processor=load_video_processor,
+        model_name=model_name,
+        config=config,
+        task=task,
+        hub_kwargs=hub_kwargs,
+        model_kwargs=model_kwargs,
+    )
 
     if tokenizer is not None:
         kwargs["tokenizer"] = tokenizer
@@ -1077,5 +1110,8 @@ def pipeline(
 
     if processor is not None:
         kwargs["processor"] = processor
+
+    if video_processor is not None:
+        kwargs["video_processor"] = video_processor
 
     return pipeline_class(model=model, task=task, **kwargs)

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -56,6 +56,9 @@ from ..utils.chat_template_utils import Chat, is_valid_message
 
 GenericTensor = Union[list["GenericTensor"], "torch.Tensor"]
 
+if TYPE_CHECKING:
+    from ..video_processing_utils import BaseVideoProcessor
+
 if is_torch_available() or TYPE_CHECKING:
     import torch
     from torch.utils.data import DataLoader, Dataset
@@ -776,7 +779,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         feature_extractor: PreTrainedFeatureExtractor | None = None,
         image_processor: BaseImageProcessor | None = None,
         processor: ProcessorMixin | None = None,
-        video_processor=None,
+        video_processor: BaseVideoProcessor | None = None,
         task: str = "",
         device: int | torch.device | None = None,
         binary_output: bool = False,

--- a/src/transformers/pipelines/base.py
+++ b/src/transformers/pipelines/base.py
@@ -762,6 +762,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
     _load_image_processor = None
     _load_feature_extractor = None
     _load_tokenizer = None
+    _load_video_processor = None
 
     # Pipelines that call `generate` have shared logic, e.g. preparing the generation config.
     _pipeline_calls_generate = False
@@ -775,6 +776,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         feature_extractor: PreTrainedFeatureExtractor | None = None,
         image_processor: BaseImageProcessor | None = None,
         processor: ProcessorMixin | None = None,
+        video_processor=None,
         task: str = "",
         device: int | torch.device | None = None,
         binary_output: bool = False,
@@ -789,6 +791,7 @@ class Pipeline(_ScikitCompat, PushToHubMixin):
         self.feature_extractor = feature_extractor
         self.image_processor = image_processor
         self.processor = processor
+        self.video_processor = video_processor
 
         # `accelerate` device map
         hf_device_map = getattr(self.model, "hf_device_map", None)

--- a/src/transformers/pipelines/video_classification.py
+++ b/src/transformers/pipelines/video_classification.py
@@ -51,14 +51,20 @@ class VideoClassificationPipeline(Pipeline):
     """
 
     _load_processor = False
-    _load_image_processor = True
+    _load_image_processor = None
     _load_feature_extractor = False
     _load_tokenizer = False
+    _load_video_processor = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         requires_backends(self, "av")
         self.check_model_type(MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING_NAMES)
+        if self.video_processor is None and self.image_processor is None and self.feature_extractor is None:
+            raise ValueError(
+                "The VideoClassificationPipeline requires either a video processor, an image processor, or a feature "
+                "extractor. None were found for this model."
+            )
 
     def _sanitize_parameters(self, top_k=None, num_frames=None, frame_sampling_rate=None, function_to_apply=None):
         preprocess_params = {}
@@ -145,7 +151,8 @@ class VideoClassificationPipeline(Pipeline):
         video = read_video_pyav(container, indices)
         video = list(video)
 
-        model_inputs = self.image_processor(video, return_tensors="pt")
+        preprocessor = self.video_processor or self.image_processor or self.feature_extractor
+        model_inputs = preprocessor(video, return_tensors="pt")
         model_inputs = model_inputs.to(self.dtype)
         return model_inputs
 

--- a/tests/pipelines/test_pipelines_video_classification.py
+++ b/tests/pipelines/test_pipelines_video_classification.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import MagicMock, patch
 
+import numpy as np
+import torch
 from huggingface_hub import VideoClassificationOutputElement, hf_hub_download
 
 from transformers import MODEL_FOR_VIDEO_CLASSIFICATION_MAPPING, VideoMAEImageProcessor
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.modeling_outputs import SequenceClassifierOutput
 from transformers.pipelines import VideoClassificationPipeline, pipeline
 from transformers.testing_utils import (
     compare_pipeline_output_to_hub_spec,
@@ -122,3 +127,41 @@ class VideoClassificationPipelineTests(unittest.TestCase):
         for output in outputs:
             for element in output:
                 compare_pipeline_output_to_hub_spec(element, VideoClassificationOutputElement)
+
+    @require_torch
+    def test_video_processor_path(self):
+        """VideoClassificationPipeline uses video_processor when present, falling back to image_processor."""
+        small_model = "hf-internal-testing/tiny-random-VideoMAEForVideoClassification"
+        video_file_path = hf_hub_download(repo_id="nateraw/video-demo", filename="archery.mp4", repo_type="dataset")
+
+        video_classifier = pipeline(
+            "video-classification",
+            model=small_model,
+            feature_extractor=VideoMAEImageProcessor(
+                size={"shortest_edge": 10}, crop_size={"height": 10, "width": 10}
+            ),
+            frame_sampling_rate=4,
+        )
+
+        # When no video_processor is set, image_processor or feature_extractor should be used
+        self.assertIsNone(video_classifier.video_processor)
+        self.assertIsNotNone(video_classifier.image_processor or video_classifier.feature_extractor)
+
+        # Swap in a fake video_processor and verify it takes priority
+        fake_video_processor = MagicMock()
+        fake_video_processor.return_value = BatchFeature({"pixel_values": torch.zeros(1, 16, 3, 10, 10)})
+        video_classifier.video_processor = fake_video_processor
+        video_classifier.image_processor = None
+
+        fake_model_output = SequenceClassifierOutput(logits=torch.tensor([[0.6, 0.4]]))
+        frames = np.stack([np.zeros((10, 10, 3), dtype=np.uint8) for _ in range(8)])
+        with (
+            patch("transformers.pipelines.video_classification.read_video_pyav", return_value=frames),
+            patch.object(video_classifier, "_forward", return_value=fake_model_output),
+        ):
+            output = video_classifier(video_file_path, top_k=2)
+
+        fake_video_processor.assert_called_once()
+        self.assertEqual(len(output), 2)
+        self.assertIn("score", output[0])
+        self.assertIn("label", output[0])


### PR DESCRIPTION
## What does this PR do?

Fixes #41950.

`VideoClassificationPipeline` previously hardcoded `_load_image_processor = True`, which crashes for models that ship a `VideoProcessor` instead of an `ImageProcessor` (e.g. vjepa2). This PR extends the pipeline to support both, following the established `_load_*` flag pattern used throughout the pipeline base class.

## Changes

- **`pipelines/base.py`**: Add `_load_video_processor = None` class flag and `video_processor` parameter/attribute to `Pipeline.__init__`, matching the existing pattern for `image_processor`, `feature_extractor`, etc.
- **`pipelines/__init__.py`**: Import `AutoVideoProcessor`, add `_resolve_video_processor()` function, and wire it into the `pipeline()` factory.
- **`pipelines/video_classification.py`**: Change `_load_image_processor` from `True` to `None` (optional), add `_load_video_processor = None`, update `preprocess()` to use whichever preprocessor is present (`video_processor` takes priority over `image_processor` over `feature_extractor`), and add a validation error if none are found.
- **`tests/`**: Add `test_video_processor_path` to verify the new code path.

## Before / After

Before: crashes for vjepa2-style models with `AttributeError` -- pipeline always requires an image_processor.

After: works with either processor type; existing image_processor/feature_extractor models are unaffected.

## Tests

```
RUN_PIPELINE_TESTS=1 pytest tests/pipelines/test_pipelines_video_classification.py -k "test_small_model_pt or test_video_processor_path" -v
# 2 passed
```