### PR TITLE
Fix _is_package_available reporting available without a version

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -72,7 +72,8 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
             # Note that this branch will almost never be run, so we do not import packages for nothing here
             package = importlib.import_module(pkg_name)
             package_version = getattr(package, "__version__", "N/A")
-            if package_version == "N/A":
+            # No version + no __file__ means a namespace package (PEP 420) shadowing on sys.path, not a real install.
+            if package_version == "N/A" and getattr(package, "__file__", None) is None:
                 package_exists = False
         logger.debug(f"Detected {pkg_name} version: {package_version}")
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -72,6 +72,8 @@ def _is_package_available(pkg_name: str, return_version: bool = False) -> tuple[
             # Note that this branch will almost never be run, so we do not import packages for nothing here
             package = importlib.import_module(pkg_name)
             package_version = getattr(package, "__version__", "N/A")
+            if package_version == "N/A":
+                package_exists = False
         logger.debug(f"Detected {pkg_name} version: {package_version}")
 
     if return_version:

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,7 +1,9 @@
 import sys
+from types import ModuleType
+from unittest.mock import patch
 
 from transformers.testing_utils import run_test_using_subprocess
-from transformers.utils.import_utils import clear_import_cache
+from transformers.utils.import_utils import _is_package_available, clear_import_cache
 
 
 @run_test_using_subprocess
@@ -24,3 +26,14 @@ def test_clear_import_cache():
 
     assert "transformers.models.auto.modeling_auto" in sys.modules
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
+
+
+def test_is_package_available_namespace_shadow_marked_unavailable():
+    pkg_name = "definitely_not_a_real_pkg_xyz"
+    fake_module = ModuleType(pkg_name)
+
+    with (
+        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
+        patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
+    ):
+        assert _is_package_available(pkg_name, return_version=True) == (False, "N/A")

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -37,3 +37,27 @@ def test_is_package_available_namespace_shadow_marked_unavailable():
         patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
     ):
         assert _is_package_available(pkg_name, return_version=True) == (False, "N/A")
+
+
+def test_is_package_available_versionless_install_marked_available():
+    pkg_name = "definitely_not_a_real_pkg_xyz"
+    fake_module = ModuleType(pkg_name)
+    fake_module.__file__ = "/path/to/site-packages/definitely_not_a_real_pkg_xyz/__init__.py"
+
+    with (
+        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
+        patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
+    ):
+        assert _is_package_available(pkg_name, return_version=True) == (True, "N/A")
+
+
+def test_is_package_available_frozen_install_marked_available():
+    pkg_name = "definitely_not_a_real_pkg_xyz"
+    fake_module = ModuleType(pkg_name)
+    fake_module.__version__ = "1.2.3"
+
+    with (
+        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
+        patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
+    ):
+        assert _is_package_available(pkg_name, return_version=True) == (True, "1.2.3")

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -28,36 +28,23 @@ def test_clear_import_cache():
     assert modeling_auto.__name__ == "transformers.models.auto.modeling_auto"
 
 
-def test_is_package_available_namespace_shadow_marked_unavailable():
+def test_is_package_available_edge_cases():
     pkg_name = "definitely_not_a_real_pkg_xyz"
-    fake_module = ModuleType(pkg_name)
 
-    with (
-        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
-        patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
-    ):
-        assert _is_package_available(pkg_name, return_version=True) == (False, "N/A")
+    namespace_shadow = ModuleType(pkg_name)
+    versionless_install = ModuleType(pkg_name)
+    versionless_install.__file__ = f"/path/to/site-packages/{pkg_name}/__init__.py"
+    with_version = ModuleType(pkg_name)
+    with_version.__version__ = "1.2.3"
 
-
-def test_is_package_available_versionless_install_marked_available():
-    pkg_name = "definitely_not_a_real_pkg_xyz"
-    fake_module = ModuleType(pkg_name)
-    fake_module.__file__ = "/path/to/site-packages/definitely_not_a_real_pkg_xyz/__init__.py"
-
-    with (
-        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
-        patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
-    ):
-        assert _is_package_available(pkg_name, return_version=True) == (True, "N/A")
-
-
-def test_is_package_available_frozen_install_marked_available():
-    pkg_name = "definitely_not_a_real_pkg_xyz"
-    fake_module = ModuleType(pkg_name)
-    fake_module.__version__ = "1.2.3"
-
-    with (
-        patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
-        patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
-    ):
-        assert _is_package_available(pkg_name, return_version=True) == (True, "1.2.3")
+    cases = [
+        (namespace_shadow, (False, "N/A")),
+        (versionless_install, (True, "N/A")),
+        (with_version, (True, "1.2.3")),
+    ]
+    for fake_module, expected in cases:
+        with (
+            patch("transformers.utils.import_utils.importlib.util.find_spec", return_value=object()),
+            patch("transformers.utils.import_utils.importlib.import_module", return_value=fake_module),
+        ):
+            assert _is_package_available(pkg_name, return_version=True) == expected


### PR DESCRIPTION
  `_is_package_available` confuses a directory on `sys.path` with
  an installed PyPI package, returning `(True, "N/A")`. Callers
  that compare versions (`is_kernels_available` for example) then
  crash on `version.parse("N/A")`.

  Fix: if no real version can be read, mark the package as
  unavailable.

  Found while running tests in PyCharm — its pytest runner adds
  `tests/` to `sys.path`, where `tests/kernels/` shadows the real
  PyPI `kernels` package.

  **Tests**
  Added regression test in tests/utils/test_import_utils.py — patches find_spec + import_module to simulate the namespace shadow; asserts (False, "N/A"). Crash before; passes after.
  make check-code-quality && make typing && make check-repo pass.


  **AI**
  Drafted with Claude. I reviewed every line and ran the repro
  locally. No existing issue or open PR.
