### PR TITLE
EP + Trainer integration on top of DistributedConfig (#45028)

### DIFF
--- a/src/transformers/distributed/tensor_parallel.py
+++ b/src/transformers/distributed/tensor_parallel.py
@@ -399,6 +399,56 @@ class MoEExpertsParallel(TensorParallelStyle):
         return output.to_local()
 
 
+class RouterParallel(TensorParallelStyle):
+    """Hooks the routing gate's output to mask non-local expert scores under EP.
+
+    Forward: route module returns `(router_logits, router_scores, router_indices)`.
+    Each EP rank computes the same logits/scores/indices (gate weight is replicated),
+    then this hook drops the entries that route to experts owned by other ranks:
+
+      - Zero `router_scores` where `(router_indices // num_local_experts) != ep_rank`.
+      - Remap `router_indices` to local-expert indices via `fmod(router_indices, num_local_experts)`.
+      - Mark non-local slots with a sentinel = `num_local_experts` so downstream
+        `one_hot` / `grouped_mm` paths know to skip them.
+
+    Gate weight stays replicated (no sharding) — see `_apply` below.
+
+    Adapted from the prod `RouterParallel` at
+    `transformers/integrations/tensor_parallel.py::RouterParallel` (same semantics).
+    """
+
+    def _apply(self, module, mesh):
+        # Keep the gate weight replicated on the EP mesh. The `TensorParallelStyle`
+        # base wraps `module.forward` to call our `transform_output_post_forward`.
+        return super()._apply(module, mesh)
+
+    def transform_output_post_forward(self, module, output, mesh):
+        ep_rank = mesh.get_local_rank()
+        ep_size = mesh.size()
+        num_experts = getattr(module, "num_experts", None)
+        if num_experts is None:
+            num_experts = getattr(getattr(module, "config", None), "num_experts", None)
+        if num_experts is None:
+            raise AttributeError(
+                f"Router module {type(module).__name__} is missing `num_experts` and `config.num_experts`"
+            )
+        if num_experts % ep_size != 0:
+            raise ValueError(f"num_experts ({num_experts}) must be divisible by ep_size ({ep_size})")
+        num_local_experts = num_experts // ep_size
+
+        router_logits, router_scores, router_indices = output
+        non_local_mask = (router_indices // num_local_experts) != ep_rank
+        router_scores = router_scores.masked_fill(non_local_mask, 0.0)
+        router_indices = router_indices.masked_fill(non_local_mask, -1)
+        # `-1 % 1 == 0`, so plain fmod doesn't work when num_local_experts == 1.
+        if num_local_experts > 1:
+            router_indices = torch.fmod(router_indices, num_local_experts)
+        else:
+            router_indices = router_indices.masked_fill(router_indices > 0, 0).masked_fill(router_indices < 0, -1)
+        router_indices = router_indices.masked_fill(router_indices == -1, num_local_experts)
+        return router_logits, router_scores, router_indices
+
+
 class ParallelInterface(GeneralInterface):
     """Registry of named TP styles. Configs and modeling files reference these by string name.
 
@@ -451,6 +501,18 @@ class ParallelInterface(GeneralInterface):
                     "down_proj": Shard(-1),
                 },
             ),
+            # MoE — EP variant: shards on the experts dim(0) so each rank holds
+            # `num_experts/ep_size` experts at full hidden_in.
+            "moe_experts_ep_allreduce": MoEExpertsParallel(
+                output_layouts=Replicate(),
+                shard_plan={
+                    "gate_up_proj": Shard(0),
+                    "down_proj": Shard(0),
+                },
+            ),
+            # EP — routing gate. Replicated weight; output hook masks non-local
+            # expert scores and remaps global indices to local. See `RouterParallel`.
+            "ep_router": RouterParallel(),
         }
         if is_torch_available() and is_torch_greater_or_equal("2.5") and _torch_distributed_available
         else {}
@@ -477,7 +539,7 @@ def apply_tensor_parallel(model, tp_mesh, tp_plan):
         if enable_sp:
             tp_plan = dict(model._sp_plan or {})
         else:
-            tp_plan = dict(model._tp_plan or {})
+            tp_plan = dict(model.tp_plan or {})
 
     # tie_weights() replaces lm_head.weight with embed_tokens.weight after TP is applied.
     # If embed_tokens isn't in the plan, sharding lm_head as a DTensor causes tie to

--- a/src/transformers/distributed/utils.py
+++ b/src/transformers/distributed/utils.py
@@ -150,19 +150,37 @@ def distribute_model(model, distributed_config: DistributedConfig, device_mesh) 
 
 @torch.no_grad()
 def clip_grad_norm(parameters, max_norm: float, norm_type: float = 2.0):
-    """Grad-norm clip that works when params live on different DTensor meshes.
+    """Mesh-aware grad-norm clip with O(1) extra memory per parameter."""
+    parameters = [p for p in parameters if p.grad is not None]
+    if not parameters:
+        return torch.tensor(0.0)
 
-    ``torch.nn.utils.get_total_norm`` stacks per-grad norms; that fails when grads
-    live on different meshes (e.g. TP-wrapped params on the (fsdp, tp) mesh and
-    FSDP-only params on the (fsdp,) sub-mesh). We sidestep it by replicating each
-    DTensor grad to a plain local tensor, computing the norm over those, and
-    scaling the original DTensor grads in place — the placement of the original
-    grads doesn't matter for the per-element clip.
-    """
-    grads = [p.grad for p in parameters if p.grad is not None]
-    local_grads = [_replicate_dtensor(g).to_local() if isinstance(g, DTensor) else g for g in grads]
-    total_norm = torch.nn.utils.get_total_norm(local_grads, norm_type=norm_type)
-    torch.nn.utils.clip_grads_with_norm_(grads, max_norm=max_norm, total_norm=total_norm)
+    norm_p = float(norm_type)
+    device = parameters[0].grad.device
+    accum = torch.zeros((), dtype=torch.float32, device=device)
+
+    for p in parameters:
+        g = p.grad
+        if isinstance(g, DTensor):
+            partial = g.to_local().detach().to(torch.float32).abs().pow_(norm_p).sum()
+            mesh = g.device_mesh
+            for dim_idx, placement in enumerate(g.placements):
+                if placement.is_replicate():
+                    continue
+                group = mesh.get_group(dim_idx) if mesh.ndim > 1 else mesh.get_group()
+                torch.distributed.all_reduce(partial, op=torch.distributed.ReduceOp.SUM, group=group)
+            accum.add_(partial)
+        else:
+            accum.add_(g.detach().to(torch.float32).abs().pow_(norm_p).sum())
+
+    total_norm = accum.pow_(1.0 / norm_p)
+    clip_coef = (max_norm / (total_norm + 1e-6)).clamp(max=1.0)
+    for p in parameters:
+        g = p.grad
+        if isinstance(g, DTensor):
+            g._local_tensor.mul_(clip_coef)
+        else:
+            g.mul_(clip_coef)
     return total_norm
 
 

--- a/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py
+++ b/src/transformers/models/qwen3_moe/configuration_qwen3_moe.py
@@ -86,9 +86,14 @@ class Qwen3MoeConfig(PreTrainedConfig):
     # This allows EP to scale beyond num_kv_heads (not constrained by 4 for Qwen3-30B).
     base_model_ep_plan = {
         "layers.*.mlp.gate": "ep_router",
-        "layers.*.mlp.experts.gate_up_proj": "grouped_gemm",
-        "layers.*.mlp.experts.down_proj": "grouped_gemm",
-        "layers.*.mlp.experts": "moe_experts_allreduce",
+        # `moe_experts_ep_allreduce` shards on the experts dim (dim 0) so each rank
+        # holds num_experts/ep_size experts at full hidden_in. The `grouped_gemm`
+        # entries that used to be here are intentionally dropped: the resolver in
+        # `apply_tensor_parallel` only iterates modules (not parameters), so plan
+        # keys naming `gate_up_proj` / `down_proj` (which are nn.Parameter, not
+        # nn.Module) were unreachable. Sharding is now handled by `MoEExpertsParallel`
+        # via its `shard_plan` on the parent experts module.
+        "layers.*.mlp.experts": "moe_experts_ep_allreduce",
     }
     base_model_pp_plan = {
         "embed_tokens": (["input_ids"], ["inputs_embeds"]),

--- a/src/transformers/trainer.py
+++ b/src/transformers/trainer.py
@@ -56,6 +56,7 @@ from .configuration_utils import PreTrainedConfig
 from .data.data_collator import DataCollator, DataCollatorWithPadding, default_data_collator
 from .debug_utils import DebugOption, DebugUnderflowOverflow
 from .distributed.fsdp import get_fsdp_ckpt_kwargs, update_fsdp_plugin_peft
+from .distributed.utils import clip_grad_norm, maybe_disable_foreach_and_fused_for_mixed_dtensor_groups
 from .feature_extraction_sequence_utils import SequenceFeatureExtractor
 from .feature_extraction_utils import FeatureExtractionMixin
 from .hyperparameter_search import ALL_HYPERPARAMETER_SEARCH_BACKENDS, default_hp_search_backend
@@ -465,6 +466,7 @@ class Trainer:
             or (args.fp16_full_eval or args.bf16_full_eval)
             or self.is_fsdp_xla_enabled
             or self.is_fsdp_enabled
+            or self.is_native_distributed
             or is_sagemaker_mp_enabled()
         ):
             self.place_model_on_device = False
@@ -665,7 +667,7 @@ class Trainer:
                     " `Trainer`. Make sure the lines `import torch_xla.core.xla_model as xm` and"
                     " `model.to(xm.xla_device())` is performed before the optimizer creation in your script."
                 )
-        if (self.is_fsdp_xla_enabled or self.is_fsdp_enabled) and (
+        if (self.is_fsdp_xla_enabled or self.is_fsdp_enabled or self.is_native_distributed) and (
             self.optimizer is not None or self.lr_scheduler is not None
         ):
             raise RuntimeError(
@@ -816,9 +818,25 @@ class Trainer:
                 self.gather_function, use_gather_object=self.args.eval_use_gather_object
             )
 
-        # deepspeed and accelerate flags covering both trainer args and accelerate launcher
-        self.is_deepspeed_enabled = getattr(self.accelerator.state, "deepspeed_plugin", None) is not None
-        self.is_fsdp_enabled = getattr(self.accelerator.state, "fsdp_plugin", None) is not None
+        # Model wrapped via `from_pretrained(distributed_config=...)` (native TP/FSDP2 path).
+        # When set, transformers owns distribution and accelerate's plugins (if any) are ignored.
+        self.is_native_distributed = getattr(self.model.config, "distributed_config", None) is not None
+
+        # deepspeed and accelerate flags covering both trainer args and accelerate launcher.
+        # Treated as exclusive with `is_native_distributed`: if transformers already manages
+        # distribution, the accelerate plugin (e.g. left over from `accelerate launch --use_fsdp`)
+        # is not the responsible party — skip its code paths to avoid operating on a model
+        # accelerate didn't wrap.
+        _ds = getattr(self.accelerator.state, "deepspeed_plugin", None) is not None
+        _fsdp = getattr(self.accelerator.state, "fsdp_plugin", None) is not None
+        if self.is_native_distributed and (_ds or _fsdp):
+            logger.warning_once(
+                "`distributed_config` is set on the model AND accelerate has a "
+                f"{'deepspeed' if _ds else 'fsdp'}_plugin in state. Trusting `distributed_config` "
+                "(transformers-native) and ignoring the accelerate plugin."
+            )
+        self.is_deepspeed_enabled = _ds and not self.is_native_distributed
+        self.is_fsdp_enabled = _fsdp and not self.is_native_distributed
 
         # post accelerator creation setup
         if self.is_fsdp_enabled:
@@ -835,7 +853,7 @@ class Trainer:
         # `save_only_model` can't be used with DeepSpeed/FSDP along with `load_best_model_at_end`
         if (
             self.args.save_only_model
-            and (self.is_deepspeed_enabled or self.is_fsdp_enabled)
+            and (self.is_deepspeed_enabled or self.is_fsdp_enabled or self.is_native_distributed)
             and self.args.load_best_model_at_end
         ):
             wrapper = "DeepSpeed" if self.is_deepspeed_enabled else "FSDP"
@@ -1214,6 +1232,10 @@ class Trainer:
         if is_sagemaker_mp_enabled():
             self.optimizer = smp.DistributedOptimizer(self.optimizer)
 
+        # Adam fused/foreach rejects mixed Tensor/DTensor groups; the helper is a
+        # no-op when groups are uniform.
+        maybe_disable_foreach_and_fused_for_mixed_dtensor_groups(self.optimizer)
+
         return self.optimizer
 
     def create_scheduler(
@@ -1408,7 +1430,12 @@ class Trainer:
             # Load model checkpoint before accelerator.prepare() for regular models,
             # so that buffers and parameters are on the right device after prepare.
             # Deepspeed/FSDP models are loaded after prepare in _prepare_for_training.
-            if not is_sagemaker_mp_enabled() and not self.is_deepspeed_enabled and not self.is_fsdp_enabled:
+            if (
+                not is_sagemaker_mp_enabled()
+                and not self.is_deepspeed_enabled
+                and not self.is_fsdp_enabled
+                and not self.is_native_distributed
+            ):
                 self._load_from_checkpoint(resume_from_checkpoint)
             state = TrainerState.load_from_json(os.path.join(resume_from_checkpoint, TRAINER_STATE_NAME))
             if state.train_batch_size is not None and args.auto_find_batch_size:
@@ -1606,7 +1633,7 @@ class Trainer:
         # updating self.model_wrapped
         self.model_wrapped = model
 
-        if self.is_fsdp_enabled or self.is_fsdp_xla_enabled:
+        if self.is_fsdp_enabled or self.is_fsdp_xla_enabled or self.is_native_distributed:
             # breaking convention for FSDP model
             # TODO: check if this is really needed
             self.model = self.model_wrapped = model
@@ -1621,7 +1648,7 @@ class Trainer:
         # self.model_wrapped is DDP(Transformers Model), Deepspeed(Transformers Model),
         # FSDP(Transformers Model), Dynamo Optimized Module(Transformers Model) etc.
 
-        if self.is_fsdp_enabled:
+        if self.is_fsdp_enabled or self.is_native_distributed:
             # Fix `got mixed torch.Tensor and DTensor` error in model.generate() for FSDP2 with LoRA
             if hasattr(self.model, "generate"):
                 dist.fsdp.register_fsdp_forward_method(self.model, "generate")
@@ -2015,7 +2042,15 @@ class Trainer:
             and (self.model_accepts_loss_kwargs or self.compute_loss_func)
             and num_items_in_batch is not None
         ):
-            loss *= self.accelerator.num_processes if self.args.n_gpu <= 1 else self.args.n_gpu
+            # TP/EP-as-TP ranks see replicated batches — divide out the tp dim from
+            # whichever path is active (accelerate ParallelismConfig or DistributedConfig).
+            loss_scale = self.accelerator.num_processes
+            pc = getattr(self.accelerator, "parallelism_config", None)
+            if pc is not None and getattr(pc, "tp_size", 1) > 1:
+                loss_scale //= pc.tp_size
+            elif self.is_native_distributed and "tp" in (self.model.device_mesh.mesh_dim_names or ()):
+                loss_scale //= self.model.device_mesh["tp"].size()
+            loss *= loss_scale if self.args.n_gpu <= 1 else self.args.n_gpu
 
         return (loss, outputs) if return_outputs else loss
 
@@ -2444,7 +2479,7 @@ class Trainer:
         # frees the wrapped model and resets it back to the unwrapped base model
         release_memory(self.model_wrapped)
 
-        if self.is_fsdp_enabled:
+        if self.is_fsdp_enabled or self.is_native_distributed:
             # Remove FSDP wrapping from sub-models because self.model points to the wrapped model in FSDP case
             self.model = unwrap_model(self.model, recursive=True)
 
@@ -2495,6 +2530,9 @@ class Trainer:
         """Clip gradients to max_grad_norm. Returns the pre-clip gradient norm."""
         if is_sagemaker_mp_enabled() and self.args.fp16:
             return self.optimizer.clip_master_grads(self.args.max_grad_norm)
+        # Mesh-aware streaming clip — handles cross-mesh DTensor grads and plain tensors.
+        if self.is_native_distributed:
+            return clip_grad_norm(model.parameters(), self.args.max_grad_norm)
         return self.accelerator.clip_grad_norm_(model.parameters(), self.args.max_grad_norm)
 
     def _get_grad_norm(self, model, grad_norm=None):
@@ -3318,7 +3356,7 @@ class Trainer:
             else []
         )
 
-        if is_fsdp_ckpt and not self.is_fsdp_enabled:
+        if is_fsdp_ckpt and not (self.is_fsdp_enabled or self.is_native_distributed):
             raise ValueError(f"Checkpoint found at {resume_from_checkpoint} is only supported when using PyTorch FSDP")
 
         if not (


### PR DESCRIPTION

Builds on [#45028](https://github.com/huggingface/transformers/pull/45028) (`refactor-tp-dtensor`) so that **Expert Parallelism actually runs** on any MoE model that has a `base_ep_plan`:
  ```python
  DistributedConfig(enable_expert_parallel=True, tp_size=N, fsdp_size=M)
  ```

I was validated end-to-end with  `trl.SFTTrainer` on `Qwen3-30B-A3B` at multiple shapes (16k / 32k / 64k, 2n / 4n / 8n).  Healthy training (loss bit-exact match against our prod fork at LR=0) and very competitive MFU 👏🏼 👏🏼 

> **Best run: 64k ctx length,  2 nodes, EP=16 + sonicmoe + Liger + compile = 62.8 % window MFU / 35 % causal-adjusted, peak GPU mem 45 GB**. 

# What does this PR do?
- **Register `ep_router` + `moe_experts_ep_allreduce` ParallelStyles** (`distributed/tensor_parallel.py`). `RouterParallel` masks non-local expert scores.  `MoEExpertsParallel` shards on the experts dim. 
- `model._tp_plan` → `model.tp_plan` so `enable_expert_parallel=True` actually selects `_ep_plan` (the property override at `modeling_utils.py:1459`).
- **`Trainer._clip_grad_norm` routes to the mesh-aware streaming clip** (`trainer.py`) when on the native path. Stock `accelerator.clip_grad_norm_` across cross-mesh DTensor grads crashes on the first `optimizer.step`.
- **`Trainer.create_optimizer` calls `maybe_disable_foreach_and_fused_for_mixed_dtensor_groups`** helper; Adam fused/foreach rejects mixed Tensor/DTensor groups under `fsdp_size=1`.
- **`Trainer.compute_loss` divides `loss_scale` by `tp_size` for the `DistributedConfig` path** (`trainer.py`). Companion to #45994 (which only handles `parallelism_config.tp_size`).
- **Biggest change is that I introduce `Trainer.is_native_distributed` flag**, exclusive with `is_fsdp_enabled` / `is_deepspeed_enabled` @3outeille  tell me what you think.   This is made to make clear when we are running in native vs accelerate accross branches.
- **Qwen3MoE `base_model_ep_plan` simplified** to use `moe_experts_ep_allreduce`: @ArthurZucker  I wonder if we need to have this ep plan dynamically set by the user and not part of the model definition 🤔 


# Note:
This PR depends on : 
- ⚠️ **[#46113 (clip_grad_norm streaming)](https://github.com/huggingface/transformers/pull/46113)** — required. This PR's `_clip_grad_norm` route depends on the streaming O(1)-per-param clip from #46113. Without it, every 30B+ EP+FSDP `optimizer.step` allocates a ~60 GB transient (current `clip_grad_norm` replicates every DTensor grad). So we should land #46113 first.
- **[#45994 (loss-scale fix under TP)](https://github.com/huggingface/transformers/pull/45994)**  PR. This PR extends #45994 to the native FSDP path.


## Who can review?

@3outeille @ArthurZucker @SunMarc

