### PR TITLE
[deepseek_v4] Add DeepseekV4NextNPredictor class for MTP draft-head support

### DIFF
--- a/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
@@ -1139,6 +1139,54 @@ class DeepseekV4DecoderLayer(GradientCheckpointingLayer):
         )
 
 
+class DeepseekV4NextNPredictor(DeepseekV4DecoderLayer):
+    r"""DSv4 Multi-Token-Prediction (MTP) draft-head block.
+
+    Structurally a :class:`DeepseekV4DecoderLayer` (full attention + MoE +
+    hyper-connection plumbing) plus four MTP-specific projections that
+    blend the previous draft hidden state `h` with the next-token
+    embedding `e`:
+
+        e = self.enorm(embed_tokens(next_token_ids))
+        h = self.hnorm(hidden_states)
+        x = self.e_proj(e).unsqueeze(2) + self.h_proj(h).unsqueeze(2)
+        x = super().forward(x, ...)
+        logits = shared_head(self.norm(x), self.hc_head_fn, ...)
+
+    Instantiated by :class:`DeepseekV4Model` when
+    ``config.num_nextn_predict_layers > 0``. Prior to this class existing,
+    ``DeepseekV4PreTrainedModel`` carried
+    ``_keys_to_ignore_on_load_unexpected = [r"(^|\.)mtp\..*"]`` which
+    silently dropped every ``mtp.*`` weight on ``from_pretrained`` — making
+    the MTP draft head unusable for vLLM speculative decoding.
+    """
+
+    def __init__(self, config: "DeepseekV4Config", layer_idx: int):
+        # DeepseekV4Attention / DeepseekV4SparseMoeBlock index into
+        # config.layer_types[layer_idx] and config.mlp_layer_types[layer_idx].
+        # These lists are sized for num_hidden_layers; auto-extend so the
+        # MTP block layer_idx (== num_hidden_layers + i) is in range.
+        n_mtp = getattr(config, "num_nextn_predict_layers", 0)
+        for attr in ("layer_types", "mlp_layer_types"):
+            lst = getattr(config, attr, None)
+            if lst is not None and len(lst) < config.num_hidden_layers + n_mtp:
+                ext = [lst[-1]] * (config.num_hidden_layers + n_mtp - len(lst))
+                setattr(config, attr, list(lst) + ext)
+        super().__init__(config, layer_idx)
+        hidden = config.hidden_size
+        eps = config.rms_norm_eps
+        self.e_proj = nn.Linear(hidden, hidden, bias=False)
+        self.h_proj = nn.Linear(hidden, hidden, bias=False)
+        self.enorm = DeepseekV4RMSNorm(hidden, eps=eps)
+        self.hnorm = DeepseekV4RMSNorm(hidden, eps=eps)
+        self.norm = DeepseekV4RMSNorm(hidden, eps=eps)
+        hc_mult = config.hc_mult
+        hc_dim = hc_mult * hidden
+        self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+
 @auto_docstring
 class DeepseekV4PreTrainedModel(PreTrainedModel):
     config: DeepseekV4Config
@@ -1190,7 +1238,9 @@ class DeepseekV4PreTrainedModel(PreTrainedModel):
         "post_attention_layernorm",
         "norm",
     ]
-    _keys_to_ignore_on_load_unexpected = [r"(^|\.)mtp\..*"]
+    # MTP keys are loaded into DeepseekV4NextNPredictor instances attached
+    # to DeepseekV4Model.mtp; no longer dropped on load.
+    _keys_to_ignore_on_load_unexpected = []
     # ``_is_stateful`` opts out of generation modes that need to roll the cache
     # back across drafts (assisted generation, prompt lookup, contrastive search).
     # The compressor's running-window state isn't rewindable, so `generate`
@@ -1248,6 +1298,16 @@ class DeepseekV4Model(DeepseekV4PreTrainedModel):
         self.rotary_emb = DeepseekV4RotaryEmbedding(config)
         self.gradient_checkpointing = False
         self.hc_head = DeepseekV4HyperHead(config)
+        # Multi-Token-Prediction (MTP) draft heads. Each block predicts one
+        # additional token beyond the main model output, enabling vLLM
+        # `--speculative-config method=mtp num_speculative_tokens=N`.
+        # DSv4-Flash ships with num_nextn_predict_layers = 1.
+        self.mtp = nn.ModuleList(
+            [
+                DeepseekV4NextNPredictor(config, config.num_hidden_layers + i)
+                for i in range(getattr(config, "num_nextn_predict_layers", 0))
+            ]
+        )
 
         # Initialize weights and apply final processing
         self.post_init()

--- a/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
@@ -1167,10 +1167,14 @@ class DeepseekV4NextNPredictor(DeepseekV4DecoderLayer):
         # These lists are sized for num_hidden_layers; auto-extend so the
         # MTP block layer_idx (== num_hidden_layers + i) is in range.
         n_mtp = getattr(config, "num_nextn_predict_layers", 0)
-        for attr in ("layer_types", "mlp_layer_types"):
+        # MTP uses sliding_attention (the only layer_type where Attention sets
+        # compressor=None) since the upstream MTP checkpoint has no
+        # compressor.*/indexer.* keys. mlp uses the standard moe type.
+        _MTP_LAYER_TYPES = {"layer_types": "sliding_attention", "mlp_layer_types": "moe"}
+        for attr, mtp_type in _MTP_LAYER_TYPES.items():
             lst = getattr(config, attr, None)
             if lst is not None and len(lst) < config.num_hidden_layers + n_mtp:
-                ext = [lst[-1]] * (config.num_hidden_layers + n_mtp - len(lst))
+                ext = [mtp_type] * (config.num_hidden_layers + n_mtp - len(lst))
                 setattr(config, attr, list(lst) + ext)
         super().__init__(config, layer_idx)
         hidden = config.hidden_size

--- a/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
@@ -1006,6 +1006,54 @@ class DeepseekV4DecoderLayer(GradientCheckpointingLayer):
         )
 
 
+class DeepseekV4NextNPredictor(DeepseekV4DecoderLayer):
+    r"""DSv4 Multi-Token-Prediction (MTP) draft-head block.
+
+    Structurally a :class:`DeepseekV4DecoderLayer` (full attention + MoE +
+    hyper-connection plumbing) plus four MTP-specific projections that
+    blend the previous draft hidden state ``h`` with the next-token
+    embedding ``e``:
+
+        e = self.enorm(embed_tokens(next_token_ids))
+        h = self.hnorm(hidden_states)
+        x = self.e_proj(e).unsqueeze(2) + self.h_proj(h).unsqueeze(2)
+        x = super().forward(x, ...)         # main DecoderLayer body
+        logits = shared_head(self.norm(x), self.hc_head_fn, ...)
+
+    Instantiated by :class:`DeepseekV4Model` when
+    ``config.num_nextn_predict_layers > 0``. Prior to this class existing,
+    ``DeepseekV4PreTrainedModel`` carried
+    ``_keys_to_ignore_on_load_unexpected = [r"(^|\\.)mtp\\..*"]`` which
+    silently dropped every ``mtp.*`` weight on ``from_pretrained`` — making
+    the MTP draft head unusable for vLLM speculative decoding.
+    """
+
+    def __init__(self, config: "DeepseekV4Config", layer_idx: int):
+        # `DeepseekV4Attention` / `DeepseekV4SparseMoeBlock` index into
+        # `config.layer_types[layer_idx]` and `config.mlp_layer_types[layer_idx]`.
+        # These lists are sized for `num_hidden_layers`; auto-extend so the
+        # MTP block's layer_idx (== num_hidden_layers + i) is in range.
+        n_mtp = getattr(config, "num_nextn_predict_layers", 0)
+        for attr in ("layer_types", "mlp_layer_types"):
+            lst = getattr(config, attr, None)
+            if lst is not None and len(lst) < config.num_hidden_layers + n_mtp:
+                ext = [lst[-1]] * (config.num_hidden_layers + n_mtp - len(lst))
+                setattr(config, attr, list(lst) + ext)
+        super().__init__(config, layer_idx)
+        hidden = config.hidden_size
+        eps = config.rms_norm_eps
+        self.e_proj = nn.Linear(hidden, hidden, bias=False)
+        self.h_proj = nn.Linear(hidden, hidden, bias=False)
+        self.enorm = DeepseekV4RMSNorm(hidden, eps=eps)
+        self.hnorm = DeepseekV4RMSNorm(hidden, eps=eps)
+        self.norm = DeepseekV4RMSNorm(hidden, eps=eps)
+        hc_mult = config.hc_mult
+        hc_dim = hc_mult * hidden
+        self.hc_head_fn = nn.Parameter(torch.empty(hc_mult, hc_dim, dtype=torch.float32))
+        self.hc_head_base = nn.Parameter(torch.empty(hc_mult, dtype=torch.float32))
+        self.hc_head_scale = nn.Parameter(torch.empty(1, dtype=torch.float32))
+
+
 class DeepseekV4PreTrainedModel(MixtralPreTrainedModel):
     config_class = DeepseekV4Config
     base_model_prefix = "model"
@@ -1047,7 +1095,9 @@ class DeepseekV4PreTrainedModel(MixtralPreTrainedModel):
         "post_attention_layernorm",
         "norm",
     ]
-    _keys_to_ignore_on_load_unexpected = [r"(^|\.)mtp\..*"]
+    # MTP keys are loaded into DeepseekV4NextNPredictor instances attached
+    # to DeepseekV4Model.mtp; no longer dropped on load.
+    _keys_to_ignore_on_load_unexpected = []
     # ``_is_stateful`` opts out of generation modes that need to roll the cache
     # back across drafts (assisted generation, prompt lookup, contrastive search).
     # The compressor's running-window state isn't rewindable, so `generate`
@@ -1104,6 +1154,16 @@ class DeepseekV4Model(LlamaModel):
         )
         self.rotary_emb = DeepseekV4RotaryEmbedding(config)
         self.hc_head = DeepseekV4HyperHead(config)
+        # Multi-Token-Prediction (MTP) draft heads. Each block predicts one
+        # additional token beyond the main model's output, enabling vLLM
+        # `--speculative-config '{"method":"mtp","num_speculative_tokens":N}'`.
+        # DSv4-Flash ships with ``num_nextn_predict_layers = 1``.
+        self.mtp = nn.ModuleList(
+            [
+                DeepseekV4NextNPredictor(config, config.num_hidden_layers + i)
+                for i in range(getattr(config, "num_nextn_predict_layers", 0))
+            ]
+        )
         self.post_init()
 
     @merge_with_config_defaults

--- a/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
@@ -1034,10 +1034,14 @@ class DeepseekV4NextNPredictor(DeepseekV4DecoderLayer):
         # These lists are sized for `num_hidden_layers`; auto-extend so the
         # MTP block's layer_idx (== num_hidden_layers + i) is in range.
         n_mtp = getattr(config, "num_nextn_predict_layers", 0)
-        for attr in ("layer_types", "mlp_layer_types"):
+        # MTP uses sliding_attention (the only layer_type where Attention sets
+        # compressor=None) since the upstream MTP checkpoint has no
+        # compressor.*/indexer.* keys. mlp uses the standard moe type.
+        _MTP_LAYER_TYPES = {"layer_types": "sliding_attention", "mlp_layer_types": "moe"}
+        for attr, mtp_type in _MTP_LAYER_TYPES.items():
             lst = getattr(config, attr, None)
             if lst is not None and len(lst) < config.num_hidden_layers + n_mtp:
-                ext = [lst[-1]] * (config.num_hidden_layers + n_mtp - len(lst))
+                ext = [mtp_type] * (config.num_hidden_layers + n_mtp - len(lst))
                 setattr(config, attr, list(lst) + ext)
         super().__init__(config, layer_idx)
         hidden = config.hidden_size


### PR DESCRIPTION
## Summary

DeepSeek-V4-Flash ships with a Multi-Token-Prediction (MTP) draft block (`num_nextn_predict_layers = 1`) whose weights are stored under an `mtp.0.*` prefix in the safetensors index. The current implementation drops these on load via:

```python
_keys_to_ignore_on_load_unexpected = [r"(^|\.)mtp\..*"]
```

…which makes the MTP head unusable for vLLM's speculative decoding (`--speculative-config '{"method":"mtp","num_speculative_tokens":N}'`).

## Changes

1. Adds `DeepseekV4NextNPredictor` as a `DeepseekV4DecoderLayer` subclass with MTP-specific projections (`e_proj`, `h_proj`, `enorm`, `hnorm`, `norm`) and head parameters (`hc_head_fn`, `hc_head_base`, `hc_head_scale`). Mirrors the upstream reference at `DeepSeek-V4-Flash/inference/model.py:MTPBlock`.

2. Wires `DeepseekV4Model.__init__` to instantiate `self.mtp` as a `nn.ModuleList` of `num_nextn_predict_layers` blocks. Empty when the config has `num_nextn_predict_layers = 0` (no behavior change for non-MTP variants).

3. Drops the silent-drop regex from `_keys_to_ignore_on_load_unexpected` (now `[]`). With the MTP module class instantiated, `mtp.*` keys load into real submodules instead of being filtered out.

4. Auto-extends `config.layer_types` and `config.mlp_layer_types` from inside `DeepseekV4NextNPredictor.__init__` to cover the MTP layer's index. `DeepseekV4Attention` and `DeepseekV4SparseMoeBlock` index these lists by `layer_idx`; without the extension, instantiating at `layer_idx = num_hidden_layers` raises `IndexError`.

## Verification

Tested locally with the DSv4-Flash config (`num_hidden_layers=43`, `num_nextn_predict_layers=1`, `hc_mult=8`):

```
OK: MTP block instantiated
params: 6.629190907 B
missing expected children: none
hc_head_* params: ['hc_head_fn', 'hc_head_base', 'hc_head_scale']
```

Class instantiates, `named_modules()` enumerates the full sub-tree (including `mtp.0.mlp.experts.0..255.{gate_proj,down_proj,up_proj}` and `mtp.0.self_attn.{q_a_proj,q_b_proj,kv_proj,o_a_proj,o_b_proj}`), `from_pretrained` loads `mtp.0.*` keys into the new submodules.

## Open items (for follow-up commits or follow-on PRs)

- `DeepseekV4NextNPredictor.forward()` implementation for inference-time draft. This PR adds the structural shell; the weights load and submodules are walkable for downstream calibration / quantization tooling, but invoking the draft head at inference time requires the embed + e_proj/h_proj composition and the `super().forward` + `norm` + head wiring.
- Integration with `DeepseekV4Model.forward` (gated kwarg to invoke the MTP draft after the main forward).
- Tests under `tests/models/deepseek_v4/`:
  - `from_pretrained` round-trip preserves `mtp.0.*` weights
  - `model.mtp[0]` reachable via `named_modules()`
  - `num_nextn_predict_layers = 0` path unchanged

## Note on modular vs generated file

I edited both `modular_deepseek_v4.py` (source of truth) and `modeling_deepseek_v4.py` manually because my local environment doesn't have `libcst` installed to run `utils/modular_model_converter.py`. Please re-run the converter if the manual edit to the generated file drifts from what the converter would produce.

## Related

Discussed at vllm-project/llm-compressor#2735 (the calibration side of the MTP-retention story).

cc @kylesayrs — companion to your active DSv4 iteration on `kylesayrs/transformers-v5` in the llm-compressor repo.