### PR TITLE
Fix image-segmentation pipeline support for RF-DETR

### DIFF
--- a/docs/source/en/model_doc/rf_detr.md
+++ b/docs/source/en/model_doc/rf_detr.md
@@ -114,6 +114,22 @@ RF-DETR also supports instance segmentation via the `Roboflow/rf-detr-seg-*` che
   detected instance, with no overlap resolution. Instances can overlap freely. This matches the output format of the
   original [`rfdetr`](https://github.com/roboflow/rf-detr) library.
 
+<hfoptions id="segmentation-usage">
+<hfoption id="Pipeline">
+
+```python
+from transformers import pipeline
+
+pipe = pipeline("image-segmentation", model="Roboflow/rf-detr-seg-medium", device_map="auto")
+
+results = pipe("http://images.cocodataset.org/val2017/000000039769.jpg")
+for result in results:
+    print(f"{result['label']}: {result['score']:.2f}")
+```
+
+</hfoption>
+<hfoption id="AutoModel">
+
 ```python
 from transformers import AutoImageProcessor, AutoModelForInstanceSegmentation
 from PIL import Image
@@ -153,6 +169,9 @@ for result in results:
         label = model.config.id2label[segment["label_id"]]
         print(f"{label}: {segment['score']:.2f}, pixels={mask.sum().item()}")
 ```
+
+</hfoption>
+</hfoptions>
 
 ## Resources
 

--- a/src/transformers/models/rf_detr/image_processing_rf_detr.py
+++ b/src/transformers/models/rf_detr/image_processing_rf_detr.py
@@ -649,6 +649,7 @@ class RfDetrImageProcessor(TorchvisionBackend):
         return_coco_annotation: bool = False,
         return_binary_maps: bool = False,
         top_k: int | None = None,
+        **kwargs,
     ) -> list[dict[str, Any]]:
         """
         Converts the output of [`RfDetrForInstanceSegmentation`] into instance segmentation predictions.

--- a/src/transformers/models/rf_detr/modular_rf_detr.py
+++ b/src/transformers/models/rf_detr/modular_rf_detr.py
@@ -268,6 +268,7 @@ class RfDetrImageProcessor(DetrImageProcessor):
         return_coco_annotation: bool = False,
         return_binary_maps: bool = False,
         top_k: int | None = None,
+        **kwargs,
     ) -> list[dict[str, Any]]:
         """
         Converts the output of [`RfDetrForInstanceSegmentation`] into instance segmentation predictions.


### PR DESCRIPTION
# What does this PR do?
The pipeline was passing a non supporter arg to the post_processing method, which was causing a crash. This PR fixes it and add a snippet in the docs
