### PR TITLE
Validate shard filenames in get_checkpoint_shard_files

### DIFF
--- a/src/transformers/utils/hub.py
+++ b/src/transformers/utils/hub.py
@@ -871,7 +871,22 @@ def get_checkpoint_shard_files(
 
     # First, let's deal with local folder.
     if os.path.isdir(pretrained_model_name_or_path):
-        shard_filenames = [os.path.join(pretrained_model_name_or_path, subfolder, f) for f in shard_filenames]
+        # `shard_filenames` come from the user-provided index file's `weight_map` values.
+        # Treat them as untrusted: reject path-traversal and absolute paths, and verify the
+        # resolved path stays inside the model directory. Legitimate shard filenames are
+        # flat names like `model-00001-of-00003.safetensors` and never need to escape the
+        # snapshot directory. See https://github.com/huggingface/transformers/issues/46097.
+        base_dir = os.path.realpath(os.path.join(pretrained_model_name_or_path, subfolder))
+        safe_shard_filenames = []
+        for f in shard_filenames:
+            resolved = os.path.realpath(os.path.join(base_dir, f))
+            if resolved != base_dir and not resolved.startswith(base_dir + os.sep):
+                raise OSError(
+                    f"Shard filename {f!r} in {index_filename} resolves outside the model "
+                    f"directory ({base_dir}). The checkpoint index may be malformed or malicious."
+                )
+            safe_shard_filenames.append(resolved)
+        shard_filenames = safe_shard_filenames
         return shard_filenames, sharded_metadata
 
     # At this stage pretrained_model_name_or_path is a model identifier on the Hub. Try to get everything from cache,

--- a/tests/utils/test_hub_utils.py
+++ b/tests/utils/test_hub_utils.py
@@ -22,6 +22,7 @@ from huggingface_hub import constants, hf_hub_download
 from huggingface_hub.errors import HfHubHTTPError, LocalEntryNotFoundError, OfflineModeIsEnabled
 
 from transformers.utils import CONFIG_NAME, WEIGHTS_NAME, cached_file, has_file, list_repo_templates
+from transformers.utils.hub import get_checkpoint_shard_files
 
 
 RANDOM_BERT = "hf-internal-testing/tiny-random-bert"
@@ -202,3 +203,106 @@ class OfflineModeTests(unittest.TestCase):
                 "transformers.utils.hub.snapshot_download", side_effect=LocalEntryNotFoundError("no snapshot found")
             ):
                 self.assertEqual(list_repo_templates(RANDOM_BERT, local_files_only=False), [])
+
+
+class GetCheckpointShardFilesPathTraversalTest(unittest.TestCase):
+    """Tests that ``get_checkpoint_shard_files`` rejects shard filenames that
+    resolve outside the model directory, preventing arbitrary file reads via
+    a crafted index file (CWE-22). See
+    https://github.com/huggingface/transformers/issues/46097.
+    """
+
+    def _write_index(self, directory, weight_map):
+        index_path = os.path.join(directory, "model.safetensors.index.json")
+        with open(index_path, "w") as f:
+            json.dump({"metadata": {"total_size": 0}, "weight_map": weight_map}, f)
+        return index_path
+
+    def test_relative_traversal_is_rejected(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            index_path = self._write_index(
+                model_dir,
+                {
+                    "model.layer.weight": "../../etc/passwd",
+                    "model.embed.weight": "../../etc/hostname",
+                },
+            )
+            with self.assertRaises(OSError) as ctx:
+                get_checkpoint_shard_files(model_dir, index_path)
+            self.assertIn("outside the model directory", str(ctx.exception))
+
+    def test_absolute_path_is_rejected(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            index_path = self._write_index(
+                model_dir,
+                {"model.layer.weight": "/etc/passwd"},
+            )
+            with self.assertRaises(OSError) as ctx:
+                get_checkpoint_shard_files(model_dir, index_path)
+            self.assertIn("outside the model directory", str(ctx.exception))
+
+    def test_symlink_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as parent:
+            model_dir = os.path.join(parent, "model")
+            outside_dir = os.path.join(parent, "outside")
+            os.makedirs(model_dir)
+            os.makedirs(outside_dir)
+            target = os.path.join(outside_dir, "secret.bin")
+            with open(target, "w") as f:
+                f.write("secret")
+            os.symlink(target, os.path.join(model_dir, "shard.safetensors"))
+
+            index_path = self._write_index(
+                model_dir,
+                {"model.layer.weight": "shard.safetensors"},
+            )
+            with self.assertRaises(OSError) as ctx:
+                get_checkpoint_shard_files(model_dir, index_path)
+            self.assertIn("outside the model directory", str(ctx.exception))
+
+    def test_legitimate_flat_shard_filenames_are_accepted(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            shard_names = [
+                "model-00001-of-00003.safetensors",
+                "model-00002-of-00003.safetensors",
+                "model-00003-of-00003.safetensors",
+            ]
+            # The shard files don't need to actually exist on disk for this
+            # function; it returns the joined paths without opening them.
+            index_path = self._write_index(
+                model_dir,
+                {f"layer.{i}.weight": name for i, name in enumerate(shard_names)},
+            )
+            resolved, metadata = get_checkpoint_shard_files(model_dir, index_path)
+            base = os.path.realpath(model_dir)
+            self.assertEqual(len(resolved), len(shard_names))
+            for path in resolved:
+                self.assertTrue(
+                    path == base or path.startswith(base + os.sep),
+                    f"Resolved path {path} escaped base directory {base}",
+                )
+            self.assertEqual(set(metadata["weight_map"].values()), set(shard_names))
+
+    def test_subfolder_paths_are_accepted(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            subfolder = "weights"
+            os.makedirs(os.path.join(model_dir, subfolder))
+            index_path = self._write_index(
+                model_dir,
+                {"layer.0.weight": "model-00001-of-00001.safetensors"},
+            )
+            resolved, _ = get_checkpoint_shard_files(model_dir, index_path, subfolder=subfolder)
+            base = os.path.realpath(os.path.join(model_dir, subfolder))
+            self.assertEqual(len(resolved), 1)
+            self.assertTrue(resolved[0].startswith(base + os.sep))
+
+    def test_traversal_through_subfolder_is_rejected(self):
+        with tempfile.TemporaryDirectory() as model_dir:
+            os.makedirs(os.path.join(model_dir, "weights"))
+            index_path = self._write_index(
+                model_dir,
+                {"layer.0.weight": "../../../etc/passwd"},
+            )
+            with self.assertRaises(OSError) as ctx:
+                get_checkpoint_shard_files(model_dir, index_path, subfolder="weights")
+            self.assertIn("outside the model directory", str(ctx.exception))


### PR DESCRIPTION
weight_map values from the checkpoint index file are joined to the model directory path without validation. A crafted index containing entries like '../../etc/passwd' causes the loader to resolve paths outside the model directory when loading from a local folder.

Add a containment check using os.path.realpath so each resolved shard path must stay under the base model directory. Legitimate shard filenames are flat names (e.g. model-00001-of-00003.safetensors) and never need to escape the snapshot directory, so this is purely defensive with no expected regressions.

Fixes #46097

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.
@Rocketknight1 

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->
