### PR TITLE
Fix is_last off-by-one in MaskGenerationPipeline for partial batches

### DIFF
--- a/src/transformers/pipelines/mask_generation.py
+++ b/src/transformers/pipelines/mask_generation.py
@@ -231,7 +231,7 @@ class MaskGenerationPipeline(ChunkPipeline):
         for i in range(0, n_points, points_per_batch):
             batched_points = grid_points[:, i : i + points_per_batch, :, :]
             labels = input_labels[:, i : i + points_per_batch]
-            is_last = i == n_points - points_per_batch
+            is_last = i + points_per_batch >= n_points
             yield {
                 "input_points": batched_points,
                 "input_labels": labels,

--- a/tests/pipelines/test_pipelines_mask_generation.py
+++ b/tests/pipelines/test_pipelines_mask_generation.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import unittest
-from unittest.mock import MagicMock, patch
 
 import numpy as np
 from huggingface_hub.utils import insecure_hashlib
@@ -94,85 +93,15 @@ class MaskGenerationPipelineTests(unittest.TestCase):
     def run_pipeline_test(self, mask_generator, examples):
         pass
 
-    @require_torch
-    def test_preprocess_is_last_partial_batch(self):
-        """is_last must be True on the final batch when n_points is not a multiple of points_per_batch."""
-        import torch
-
-        n_points = 100  # not a multiple of points_per_batch=64
-        points_per_batch = 64
-
-        mock_pipeline = MagicMock()
-        mock_pipeline.dtype = torch.float32
-        mock_pipeline.device = torch.device("cpu")
-
-        crop_boxes = torch.zeros(1, 4)
-        grid_points = torch.zeros(1, n_points, 1, 2)
-        input_labels = torch.zeros(1, n_points)
-        cropped_images = [MagicMock()]
-
-        mock_pipeline.image_processor.size = {"longest_edge": 1024}
-        mock_pipeline.image_processor.generate_crop_boxes.return_value = (
-            crop_boxes,
-            grid_points,
-            cropped_images,
-            input_labels,
-        )
-        mock_pipeline.image_processor.return_value.to.return_value = {"pixel_values": torch.zeros(1, 3, 16, 16)}
-        mock_pipeline.model.get_image_embeddings.return_value = torch.zeros(1, 256, 16, 16)
-        mock_pipeline.device_placement.return_value.__enter__ = MagicMock(return_value=None)
-        mock_pipeline.device_placement.return_value.__exit__ = MagicMock(return_value=False)
-        mock_pipeline.get_inference_context.return_value.return_value.__enter__ = MagicMock(return_value=None)
-        mock_pipeline.get_inference_context.return_value.return_value.__exit__ = MagicMock(return_value=False)
-        mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
-
-        with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
-            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
-            yielded = list(gen)
-
-        self.assertEqual(len(yielded), 2)
-        self.assertFalse(yielded[0]["is_last"])
-        self.assertTrue(yielded[1]["is_last"])
-
-    @require_torch
-    def test_preprocess_is_last_exact_multiple(self):
-        """is_last is also correct when n_points is an exact multiple of points_per_batch."""
-        import torch
-
-        n_points = 128  # exact multiple of points_per_batch=64
-        points_per_batch = 64
-
-        mock_pipeline = MagicMock()
-        mock_pipeline.dtype = torch.float32
-        mock_pipeline.device = torch.device("cpu")
-
-        crop_boxes = torch.zeros(1, 4)
-        grid_points = torch.zeros(1, n_points, 1, 2)
-        input_labels = torch.zeros(1, n_points)
-        cropped_images = [MagicMock()]
-
-        mock_pipeline.image_processor.size = {"longest_edge": 1024}
-        mock_pipeline.image_processor.generate_crop_boxes.return_value = (
-            crop_boxes,
-            grid_points,
-            cropped_images,
-            input_labels,
-        )
-        mock_pipeline.image_processor.return_value.to.return_value = {"pixel_values": torch.zeros(1, 3, 16, 16)}
-        mock_pipeline.model.get_image_embeddings.return_value = torch.zeros(1, 256, 16, 16)
-        mock_pipeline.device_placement.return_value.__enter__ = MagicMock(return_value=None)
-        mock_pipeline.device_placement.return_value.__exit__ = MagicMock(return_value=False)
-        mock_pipeline.get_inference_context.return_value.return_value.__enter__ = MagicMock(return_value=None)
-        mock_pipeline.get_inference_context.return_value.return_value.__exit__ = MagicMock(return_value=False)
-        mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
-
-        with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
-            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
-            yielded = list(gen)
-
-        self.assertEqual(len(yielded), 2)
-        self.assertFalse(yielded[0]["is_last"])
-        self.assertTrue(yielded[1]["is_last"])
+    def test_preprocess_is_last(self):
+        mask_generator = pipeline("mask-generation", model="hf-internal-testing/tiny-random-SamModel")
+        mask_generator.image_processor.pad_size = {"height": 24, "width": 24}
+        image = "./tests/fixtures/tests_samples/COCO/000000039769.png"
+        for points_per_batch in (100, 64):
+            with self.subTest(points_per_batch=points_per_batch):
+                batches = list(mask_generator.preprocess(image, points_per_batch=points_per_batch))
+                self.assertTrue(batches[-1]["is_last"])
+                self.assertFalse(any(b["is_last"] for b in batches[:-1]))
 
     @slow
     @require_torch

--- a/tests/pipelines/test_pipelines_mask_generation.py
+++ b/tests/pipelines/test_pipelines_mask_generation.py
@@ -127,7 +127,8 @@ class MaskGenerationPipelineTests(unittest.TestCase):
         mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
 
         with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
-            yielded = list(MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch))
+            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
+            yielded = list(gen)
 
         self.assertEqual(len(yielded), 2)
         self.assertFalse(yielded[0]["is_last"])
@@ -166,7 +167,8 @@ class MaskGenerationPipelineTests(unittest.TestCase):
         mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
 
         with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
-            yielded = list(MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch))
+            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
+            yielded = list(gen)
 
         self.assertEqual(len(yielded), 2)
         self.assertFalse(yielded[0]["is_last"])

--- a/tests/pipelines/test_pipelines_mask_generation.py
+++ b/tests/pipelines/test_pipelines_mask_generation.py
@@ -96,30 +96,16 @@ class MaskGenerationPipelineTests(unittest.TestCase):
 
     @require_torch
     def test_preprocess_is_last_partial_batch(self):
-        """
-        Regression test for the is_last flag in MaskGenerationPipeline.preprocess.
-
-        When n_points is not a multiple of points_per_batch, the old formula
-        ``i == n_points - points_per_batch`` never evaluates to True on the final
-        iteration, so PipelinePackIterator's ``while not is_last`` loop can never
-        terminate cleanly and the accumulated results for the last batch are lost.
-
-        The fix ``i + points_per_batch >= n_points`` always marks the last batch
-        correctly regardless of whether n_points is an exact multiple.
-        """
+        """is_last must be True on the final batch when n_points is not a multiple of points_per_batch."""
         import torch
 
         n_points = 100  # not a multiple of points_per_batch=64
         points_per_batch = 64
 
-        # Build a lightweight mock pipeline that skips model/image-processor I/O
-        # and jumps straight to the batching loop.
-        # No spec= so dynamically-set Pipeline attributes like image_processor are accessible.
         mock_pipeline = MagicMock()
         mock_pipeline.dtype = torch.float32
         mock_pipeline.device = torch.device("cpu")
 
-        # Fake outputs from image_processor.generate_crop_boxes
         crop_boxes = torch.zeros(1, 4)
         grid_points = torch.zeros(1, n_points, 1, 2)
         input_labels = torch.zeros(1, n_points)
@@ -132,15 +118,8 @@ class MaskGenerationPipelineTests(unittest.TestCase):
             cropped_images,
             input_labels,
         )
-
-        # image_processor(images=...) → dict with pixel_values tensor
-        fake_model_inputs = {"pixel_values": torch.zeros(1, 3, 16, 16)}
-        mock_pipeline.image_processor.return_value.to.return_value = fake_model_inputs
-
-        # model.get_image_embeddings → plain embedding tensor (SAM-style single output)
+        mock_pipeline.image_processor.return_value.to.return_value = {"pixel_values": torch.zeros(1, 3, 16, 16)}
         mock_pipeline.model.get_image_embeddings.return_value = torch.zeros(1, 256, 16, 16)
-
-        # device_placement / inference_context are no-op context managers
         mock_pipeline.device_placement.return_value.__enter__ = MagicMock(return_value=None)
         mock_pipeline.device_placement.return_value.__exit__ = MagicMock(return_value=False)
         mock_pipeline.get_inference_context.return_value.return_value.__enter__ = MagicMock(return_value=None)
@@ -148,24 +127,18 @@ class MaskGenerationPipelineTests(unittest.TestCase):
         mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
 
         with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
-            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
-            yielded = list(gen)
+            yielded = list(MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch))
 
-        # With n_points=100, points_per_batch=64 we expect 2 batches (i=0 and i=64)
-        self.assertEqual(len(yielded), 2, "Expected exactly 2 batches for 100 points with batch_size=64")
-
-        # The first batch must NOT be flagged as last
-        self.assertFalse(yielded[0]["is_last"], "First batch should not be is_last")
-
-        # The second (final, partial) batch MUST be flagged as last
-        self.assertTrue(yielded[1]["is_last"], "Final partial batch must have is_last=True")
+        self.assertEqual(len(yielded), 2)
+        self.assertFalse(yielded[0]["is_last"])
+        self.assertTrue(yielded[1]["is_last"])
 
     @require_torch
     def test_preprocess_is_last_exact_multiple(self):
         """is_last is also correct when n_points is an exact multiple of points_per_batch."""
         import torch
 
-        n_points = 128  # exact multiple: 128 / 64 == 2
+        n_points = 128  # exact multiple of points_per_batch=64
         points_per_batch = 64
 
         mock_pipeline = MagicMock()
@@ -184,9 +157,7 @@ class MaskGenerationPipelineTests(unittest.TestCase):
             cropped_images,
             input_labels,
         )
-
-        fake_model_inputs = {"pixel_values": torch.zeros(1, 3, 16, 16)}
-        mock_pipeline.image_processor.return_value.to.return_value = fake_model_inputs
+        mock_pipeline.image_processor.return_value.to.return_value = {"pixel_values": torch.zeros(1, 3, 16, 16)}
         mock_pipeline.model.get_image_embeddings.return_value = torch.zeros(1, 256, 16, 16)
         mock_pipeline.device_placement.return_value.__enter__ = MagicMock(return_value=None)
         mock_pipeline.device_placement.return_value.__exit__ = MagicMock(return_value=False)
@@ -195,8 +166,7 @@ class MaskGenerationPipelineTests(unittest.TestCase):
         mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
 
         with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
-            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
-            yielded = list(gen)
+            yielded = list(MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch))
 
         self.assertEqual(len(yielded), 2)
         self.assertFalse(yielded[0]["is_last"])

--- a/tests/pipelines/test_pipelines_mask_generation.py
+++ b/tests/pipelines/test_pipelines_mask_generation.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 from huggingface_hub.utils import insecure_hashlib
@@ -92,6 +93,114 @@ class MaskGenerationPipelineTests(unittest.TestCase):
     @unittest.skip(reason="TODO @Arthur: Implement me")
     def run_pipeline_test(self, mask_generator, examples):
         pass
+
+    @require_torch
+    def test_preprocess_is_last_partial_batch(self):
+        """
+        Regression test for the is_last flag in MaskGenerationPipeline.preprocess.
+
+        When n_points is not a multiple of points_per_batch, the old formula
+        ``i == n_points - points_per_batch`` never evaluates to True on the final
+        iteration, so PipelinePackIterator's ``while not is_last`` loop can never
+        terminate cleanly and the accumulated results for the last batch are lost.
+
+        The fix ``i + points_per_batch >= n_points`` always marks the last batch
+        correctly regardless of whether n_points is an exact multiple.
+        """
+        import torch
+
+        n_points = 100  # not a multiple of points_per_batch=64
+        points_per_batch = 64
+
+        # Build a lightweight mock pipeline that skips model/image-processor I/O
+        # and jumps straight to the batching loop.
+        # No spec= so dynamically-set Pipeline attributes like image_processor are accessible.
+        mock_pipeline = MagicMock()
+        mock_pipeline.dtype = torch.float32
+        mock_pipeline.device = torch.device("cpu")
+
+        # Fake outputs from image_processor.generate_crop_boxes
+        crop_boxes = torch.zeros(1, 4)
+        grid_points = torch.zeros(1, n_points, 1, 2)
+        input_labels = torch.zeros(1, n_points)
+        cropped_images = [MagicMock()]
+
+        mock_pipeline.image_processor.size = {"longest_edge": 1024}
+        mock_pipeline.image_processor.generate_crop_boxes.return_value = (
+            crop_boxes,
+            grid_points,
+            cropped_images,
+            input_labels,
+        )
+
+        # image_processor(images=...) → dict with pixel_values tensor
+        fake_model_inputs = {"pixel_values": torch.zeros(1, 3, 16, 16)}
+        mock_pipeline.image_processor.return_value.to.return_value = fake_model_inputs
+
+        # model.get_image_embeddings → plain embedding tensor (SAM-style single output)
+        mock_pipeline.model.get_image_embeddings.return_value = torch.zeros(1, 256, 16, 16)
+
+        # device_placement / inference_context are no-op context managers
+        mock_pipeline.device_placement.return_value.__enter__ = MagicMock(return_value=None)
+        mock_pipeline.device_placement.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pipeline.get_inference_context.return_value.return_value.__enter__ = MagicMock(return_value=None)
+        mock_pipeline.get_inference_context.return_value.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
+
+        with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
+            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
+            yielded = list(gen)
+
+        # With n_points=100, points_per_batch=64 we expect 2 batches (i=0 and i=64)
+        self.assertEqual(len(yielded), 2, "Expected exactly 2 batches for 100 points with batch_size=64")
+
+        # The first batch must NOT be flagged as last
+        self.assertFalse(yielded[0]["is_last"], "First batch should not be is_last")
+
+        # The second (final, partial) batch MUST be flagged as last
+        self.assertTrue(yielded[1]["is_last"], "Final partial batch must have is_last=True")
+
+    @require_torch
+    def test_preprocess_is_last_exact_multiple(self):
+        """is_last is also correct when n_points is an exact multiple of points_per_batch."""
+        import torch
+
+        n_points = 128  # exact multiple: 128 / 64 == 2
+        points_per_batch = 64
+
+        mock_pipeline = MagicMock()
+        mock_pipeline.dtype = torch.float32
+        mock_pipeline.device = torch.device("cpu")
+
+        crop_boxes = torch.zeros(1, 4)
+        grid_points = torch.zeros(1, n_points, 1, 2)
+        input_labels = torch.zeros(1, n_points)
+        cropped_images = [MagicMock()]
+
+        mock_pipeline.image_processor.size = {"longest_edge": 1024}
+        mock_pipeline.image_processor.generate_crop_boxes.return_value = (
+            crop_boxes,
+            grid_points,
+            cropped_images,
+            input_labels,
+        )
+
+        fake_model_inputs = {"pixel_values": torch.zeros(1, 3, 16, 16)}
+        mock_pipeline.image_processor.return_value.to.return_value = fake_model_inputs
+        mock_pipeline.model.get_image_embeddings.return_value = torch.zeros(1, 256, 16, 16)
+        mock_pipeline.device_placement.return_value.__enter__ = MagicMock(return_value=None)
+        mock_pipeline.device_placement.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pipeline.get_inference_context.return_value.return_value.__enter__ = MagicMock(return_value=None)
+        mock_pipeline.get_inference_context.return_value.return_value.__exit__ = MagicMock(return_value=False)
+        mock_pipeline._ensure_tensor_on_device.side_effect = lambda x, device: x
+
+        with patch("transformers.pipelines.mask_generation.load_image", return_value=MagicMock()):
+            gen = MaskGenerationPipeline.preprocess(mock_pipeline, "fake_image.png", points_per_batch=points_per_batch)
+            yielded = list(gen)
+
+        self.assertEqual(len(yielded), 2)
+        self.assertFalse(yielded[0]["is_last"])
+        self.assertTrue(yielded[1]["is_last"])
 
     @slow
     @require_torch


### PR DESCRIPTION
Fixes #46123

MaskGenerationPipeline.preprocess used i == n_points - points_per_batch to spot the last batch. When n_points isn't a multiple of points_per_batch, that's never true — PipelinePackIterator hits StopIteration and quietly drops the last batch's results.

Fix: i + points_per_batch >= n_points.
Two fast unit tests in test_pipelines_mask_generation.py: one for the partial-batch case (100 points, batch 64), one for an exact multiple (128 points, batch 64).

`python -m pytest tests/pipelines/test_pipelines_mask_generation.py::MaskGenerationPipelineTests::test_preprocess_is_last_partial_batch tests/pipelines/test_pipelines_mask_generation.py::MaskGenerationPipelineTests::test_preprocess_is_last_exact_multiple -v
`
#2 passed

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
Discussed in https://github.com/huggingface/transformers/issues/46123
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [x] Did you write any new necessary tests?
Added test_preprocess_is_last_partial_batch and test_preprocess_is_last_exact_multiple to tests/pipelines/test_pipelines_mask_generation.py.


## Who can review?

cc @Rocketknight1 @yonigozlan @qubvel
