### PR TITLE
Fix LlamaConfig rejecting explicit head_dim when hidden_size is not divisible by num_attention_heads

### DIFF
--- a/src/transformers/models/arcee/configuration_arcee.py
+++ b/src/transformers/models/arcee/configuration_arcee.py
@@ -101,6 +101,11 @@ class ArceeConfig(PreTrainedConfig):
     head_dim: int | None = None
 
     def __post_init__(self, **kwargs):
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (ArceeAttention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -110,7 +115,7 @@ class ArceeConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -104,6 +104,11 @@ class AriaTextConfig(PreTrainedConfig):
     moe_num_shared_experts: int = 2
 
     def __post_init__(self, **kwargs):
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (AriaTextAttention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -113,7 +118,7 @@ class AriaTextConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/cwm/configuration_cwm.py
+++ b/src/transformers/models/cwm/configuration_cwm.py
@@ -127,6 +127,11 @@ class CwmConfig(PreTrainedConfig):
         self.sliding_window = int(self.sliding_window) if self.sliding_window else None
         self.layer_types = list(self.layer_types)
         self.eos_token_id = self.eos_token_id if self.eos_token_id is not None else [128001, 128008, 128009]
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (CwmAttention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -136,7 +141,7 @@ class CwmConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -139,6 +139,11 @@ class DeepseekV2Config(PreTrainedConfig):
 
     def __post_init__(self, **kwargs):
         self.head_dim = self.qk_rope_head_dim
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (DeepseekV2Attention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -148,7 +153,7 @@ class DeepseekV2Config(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -113,6 +113,11 @@ class EuroBertConfig(PreTrainedConfig):
     def __post_init__(self, **kwargs):
         if self.num_key_value_heads is None:
             self.num_key_value_heads = self.num_attention_heads
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (EuroBertAttention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -122,7 +127,7 @@ class EuroBertConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
@@ -133,6 +133,11 @@ class HiggsAudioV2Config(PreTrainedConfig):
                 "original_max_position_embeddings": 1024,
                 "rope_type": "llama3",
             }
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (HiggsAudioV2Attention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -142,7 +147,7 @@ class HiggsAudioV2Config(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/hrm_text/configuration_hrm_text.py
+++ b/src/transformers/models/hrm_text/configuration_hrm_text.py
@@ -140,7 +140,7 @@ class HrmTextConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/jais2/configuration_jais2.py
+++ b/src/transformers/models/jais2/configuration_jais2.py
@@ -102,6 +102,11 @@ class Jais2Config(PreTrainedConfig):
     layer_norm_eps: float = 1e-5
 
     def __post_init__(self, **kwargs):
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (Jais2Attention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -111,7 +116,7 @@ class Jais2Config(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -105,6 +105,11 @@ class LlamaConfig(PreTrainedConfig):
     head_dim: int | None = None
 
     def __post_init__(self, **kwargs):
+        # Track whether `head_dim` was explicitly provided so `validate_architecture`
+        # can allow non-divisible `hidden_size`/`num_attention_heads` when the user
+        # has supplied an explicit `head_dim` (LlamaAttention sizes its projections
+        # from `num_attention_heads * head_dim`, so this case is well-defined).
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -114,7 +119,7 @@ class LlamaConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
                 f"heads ({self.num_attention_heads})."

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -35,6 +35,7 @@ if is_torch_available():
     import torch
 
     from transformers import (
+        LlamaConfig,
         LlamaForCausalLM,
         LlamaModel,
         LlamaTokenizer,
@@ -56,6 +57,43 @@ class LlamaModelTest(CausalLMModelTest, unittest.TestCase):
 
     # used in `test_torch_compile_for_training`
     _torch_compile_train_cls = LlamaForCausalLM if is_torch_available() else None
+
+    def test_config_explicit_head_dim_with_non_divisible_hidden_size(self):
+        # Regression test for https://github.com/huggingface/transformers/issues/46082
+        # `LlamaAttention` sizes its projections from `num_attention_heads * head_dim`,
+        # so an explicit `head_dim` should be allowed even when `hidden_size` is not
+        # divisible by `num_attention_heads`.
+        config = LlamaConfig(
+            vocab_size=99,
+            hidden_size=512,
+            intermediate_size=1024,
+            num_hidden_layers=1,
+            num_attention_heads=9,
+            num_key_value_heads=1,
+            head_dim=56,
+        )
+        self.assertEqual(config.head_dim, 56)
+        # Model construction should succeed with the matching projection shapes.
+        model = LlamaForCausalLM(config)
+        self.assertEqual(
+            model.model.layers[0].self_attn.q_proj.weight.shape,
+            (config.num_attention_heads * config.head_dim, config.hidden_size),
+        )
+
+    def test_config_implicit_head_dim_with_non_divisible_hidden_size_still_raises(self):
+        # Regression preventer: omitting `head_dim` with non-divisible dims must
+        # still raise, since the auto-derived `head_dim = hidden_size // num_attention_heads`
+        # would silently truncate.
+        with self.assertRaises(Exception) as ctx:
+            LlamaConfig(
+                vocab_size=99,
+                hidden_size=512,
+                intermediate_size=1024,
+                num_hidden_layers=1,
+                num_attention_heads=9,
+                num_key_value_heads=1,
+            )
+        self.assertIn("not a multiple", str(ctx.exception))
 
 
 @require_torch_accelerator


### PR DESCRIPTION
# What does this PR do?

Fixes #46082.

`LlamaAttention` already sizes its projections from `num_attention_heads * head_dim` rather than `hidden_size`, so a config where `hidden_size % num_attention_heads != 0` is well-defined as long as `head_dim` is explicitly provided. The divisibility check in `LlamaConfig.validate_architecture` fires unconditionally though (it runs after `__post_init__` has filled in the fallback `head_dim`, so checking `head_dim is not None` in the validator doesn't work).

This PR follows the approach @matdou outlined in the issue:

- Capture `self._head_dim_was_explicit = self.head_dim is not None` in `__post_init__` before falling back to the derived value.
- Gate the divisibility error in `validate_architecture` on `not self._head_dim_was_explicit`.

`_head_dim_was_explicit` is recomputed in `__post_init__`, so save/reload via `save_pretrained` / `from_pretrained` works without persisting the flag (the saved `head_dim` is the explicit value, so the flag is set correctly on reload).

The original validation error is preserved when `head_dim` is *not* explicitly provided.

## Reproduction (from the issue)

```python
from transformers import LlamaConfig, LlamaForCausalLM

config = LlamaConfig(
    vocab_size=99,
    hidden_size=512,
    intermediate_size=1024,
    num_hidden_layers=1,
    num_attention_heads=9,
    num_key_value_heads=1,
    head_dim=56,
)
model = LlamaForCausalLM(config)
```

Passes after this change, raises before.

## Tests

Added two cases in `tests/models/llama/test_modeling_llama.py`:

- `head_dim` explicit + non-divisible dims, config accepted, model instantiates.
- `head_dim` omitted + non-divisible dims, original `ValueError` still raised.

## Who can review?

@ArthurZucker @Cyrilvallez

Credit to @matdou for the diagnosis in the issue comments.