### PR TITLE
Fix TypeError on list-typed ignore_keys_at_rope_validation in RoPE config

### DIFF
--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -719,7 +719,9 @@ class RotaryEmbeddingConfigMixin:
         partial_rotary_factor = kwargs.get("partial_rotary_factor", getattr(self, "partial_rotary_factor", None))
         if partial_rotary_factor is not None:
             self.rope_parameters.setdefault("partial_rotary_factor", partial_rotary_factor)
-            self.ignore_keys_at_rope_validation = set(self.ignore_keys_at_rope_validation) | {"partial_rotary_factor"}
+            self.ignore_keys_at_rope_validation = set(self.ignore_keys_at_rope_validation or []) | {
+                "partial_rotary_factor"
+            }
 
         self.standardize_rope_params()
         return kwargs

--- a/src/transformers/modeling_rope_utils.py
+++ b/src/transformers/modeling_rope_utils.py
@@ -719,7 +719,7 @@ class RotaryEmbeddingConfigMixin:
         partial_rotary_factor = kwargs.get("partial_rotary_factor", getattr(self, "partial_rotary_factor", None))
         if partial_rotary_factor is not None:
             self.rope_parameters.setdefault("partial_rotary_factor", partial_rotary_factor)
-            self.ignore_keys_at_rope_validation = self.ignore_keys_at_rope_validation | {"partial_rotary_factor"}
+            self.ignore_keys_at_rope_validation = set(self.ignore_keys_at_rope_validation) | {"partial_rotary_factor"}
 
         self.standardize_rope_params()
         return kwargs

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -137,7 +137,7 @@ class RopeTest(unittest.TestCase):
             self.assertIn("implicit factor", logs.output[0])
 
     def test_convert_rope_params_to_dict_with_list_ignore_keys(self):
-        # Regression test: `ignore_keys_at_rope_validation` becomes a list when loaded from a config.json
+        # Regression test for #46121: `ignore_keys_at_rope_validation` becomes a list when loaded from a config.json
         # (JSON has no set type). `convert_rope_params_to_dict` used to do `list | set` and crash with
         # TypeError when `partial_rotary_factor` was also set.
         config = LlamaConfig(partial_rotary_factor=0.25)

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -158,6 +158,12 @@ class RopeTest(unittest.TestCase):
         reloaded.convert_rope_params_to_dict(partial_rotary_factor=0.25)
         self.assertIsInstance(reloaded.ignore_keys_at_rope_validation, set)
 
+        # Also accept None (the class-level attribute can be cleared on an instance).
+        config_none = LlamaConfig(partial_rotary_factor=0.25)
+        config_none.ignore_keys_at_rope_validation = None
+        config_none.convert_rope_params_to_dict(partial_rotary_factor=0.25)
+        self.assertEqual(config_none.ignore_keys_at_rope_validation, {"partial_rotary_factor"})
+
     def test_rope_validation_with_per_attention_type_nested_rope(self):
         """Mirrors `test_rope_validation` with `config.layer_types` set, so that
         `rope_parameters` takes the per-attention-type nested shape."""

--- a/tests/utils/test_modeling_rope_utils.py
+++ b/tests/utils/test_modeling_rope_utils.py
@@ -136,6 +136,28 @@ class RopeTest(unittest.TestCase):
             self.assertEqual(len(logs.output), 1)
             self.assertIn("implicit factor", logs.output[0])
 
+    def test_convert_rope_params_to_dict_with_list_ignore_keys(self):
+        # Regression test: `ignore_keys_at_rope_validation` becomes a list when loaded from a config.json
+        # (JSON has no set type). `convert_rope_params_to_dict` used to do `list | set` and crash with
+        # TypeError when `partial_rotary_factor` was also set.
+        config = LlamaConfig(partial_rotary_factor=0.25)
+        config.ignore_keys_at_rope_validation = ["mrope_section", "mrope_interleaved"]
+
+        config.convert_rope_params_to_dict(partial_rotary_factor=0.25)
+
+        self.assertIsInstance(config.ignore_keys_at_rope_validation, set)
+        self.assertEqual(
+            config.ignore_keys_at_rope_validation,
+            {"mrope_section", "mrope_interleaved", "partial_rotary_factor"},
+        )
+
+        # Round-trip through from_dict to mimic the JSON-deserialized path that triggered this in production.
+        cfg_dict = config.to_dict()
+        cfg_dict["ignore_keys_at_rope_validation"] = ["mrope_section", "mrope_interleaved"]
+        reloaded = LlamaConfig.from_dict(cfg_dict)
+        reloaded.convert_rope_params_to_dict(partial_rotary_factor=0.25)
+        self.assertIsInstance(reloaded.ignore_keys_at_rope_validation, set)
+
     def test_rope_validation_with_per_attention_type_nested_rope(self):
         """Mirrors `test_rope_validation` with `config.layer_types` set, so that
         `rope_parameters` takes the per-attention-type nested shape."""


### PR DESCRIPTION
# What does this PR do?

Fixes #46121

`RotaryEmbeddingConfigMixin.ignore_keys_at_rope_validation` is a `set` at the class level, but JSON has no `set` type, so any `config.json` that serializes this field (e.g. checkpoints written by LoRA merge / export tooling like `ms-swift`) loads it back as a `list` instance attribute that shadows the class default. `RotaryEmbeddingConfigMixin.convert_rope_params_to_dict` then does:

`self.ignore_keys_at_rope_validation = self.ignore_keys_at_rope_validation | {"partial_rotary_factor"}`

which raises `TypeError: unsupported operand type(s) for |: 'list' and 'set'` whenever `partial_rotary_factor` is also set on the config. In practice this prevents serving such merged checkpoints (observed downstream in vLLM with merged Qwen3.5 checkpoints).

This PR coerces the attribute to a set before the union in `src/transformers/modeling_rope_utils.py`, and adds a regression test in `tests/utils/test_modeling_rope_utils.py` covering both direct attribute assignment and the `from_dict` round-trip path that mirrors the JSON-deserialization flow.

## Code Agent Policy
- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [x] Did you write any new necessary tests?


## Who can review?

@Rocketknight1 