### PR TITLE
Fix caching allocator warmup byte estimation for EP model loading

### DIFF
--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -5041,7 +5041,7 @@ def get_total_byte_count(
 
     total_byte_count = defaultdict(lambda: 0)
     tied_param_names = model.all_tied_weights_keys.keys()
-    tp_plan = model._tp_plan if _is_torch_distributed_initialized() else []
+    tp_plan = model.tp_plan if _is_torch_distributed_initialized() else []
 
     for param_name, device in accelerator_device_map.items():
         # Skip if the parameter has already been accounted for (tied weights)


### PR DESCRIPTION
@ArthurZucker  @Cyrilvallez


In EP runs, the effective distributed plan is exposed through model.tp_plan, which switches to the EP plan when distributed_config.enable_expert_parallel is set. Because warmup bypassed that property and read model._tp_plan directly, it could overestimate local device memory and try to preallocate as if expert weights were not sharded.
