### PR TITLE
[ROCm] Fix gpt_oss test suite: AITER attention fallback, SonicMoE guard, and distributed test fixes

### DIFF
--- a/docker/transformers-pytorch-amd-gpu/Dockerfile
+++ b/docker/transformers-pytorch-amd-gpu/Dockerfile
@@ -55,6 +55,13 @@ RUN python3 -m pip install --no-cache-dir "torchcodec==0.10"
 RUN python3 -m pip install --no-cache-dir \
     https://rocm.frameworks-devreleases.amd.com/whl/gfx942-gfx950/flash_attn-2.8.3-cp310-cp310-linux_x86_64.whl
 
+# Install AITER (AMD AI Tensor Engine for ROCm): Triton-based attention kernels
+# with learnable-sink support, used as the ROCm backend for models that rely on
+# hub kernels with no ROCm build (e.g. kernels-community/vllm-flash-attn3).
+# Wheel is pinned to ROCm 7.2 / Python 3.10 to match the base image.
+RUN python3 -m pip install --no-cache-dir \
+    "https://github.com/ROCm/aiter/releases/download/v0.1.13/amd_aiter-0.1.13%2Brocm7.2.manylinux.2.28-cp310-cp310-manylinux_2_27_x86_64.whl"
+
 RUN python3 -m pip install --no-cache-dir einops blobfile num2words
 
 # timm is required for many vision models tests

--- a/src/transformers/integrations/aiter_flash_attention.py
+++ b/src/transformers/integrations/aiter_flash_attention.py
@@ -1,0 +1,89 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Flash Attention wrappers for AMD ROCm using AITER's Triton MHA kernels."""
+
+import torch
+
+
+def aiter_flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    s_aux=None,
+    **kwargs,
+):
+    """
+    q: (total_q, nheads, headdim)
+    k: (total_k, nheads_k, headdim)
+    v: (total_k, nheads_k, headdim)
+    s_aux: (nheads,) learnable sink scores, or None
+    """
+    from aiter.ops.triton.attention.mha import flash_attn_varlen_func
+
+    return flash_attn_varlen_func(
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu_seqlens_q.to(torch.int32),
+        cu_seqlens_k=cu_seqlens_k.to(torch.int32),
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        sink=s_aux,
+    )
+
+
+def aiter_flash_attn_func(
+    q,
+    k,
+    v,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=(-1, -1),
+    softcap=0.0,
+    s_aux=None,
+    **kwargs,
+):
+    """
+    q: (batch_size, seqlen, nheads, headdim)
+    k: (batch_size, seqlen, nheads_k, headdim)
+    v: (batch_size, seqlen, nheads_k, headdim)
+    s_aux: (nheads,) learnable sink scores, or None
+    """
+    from aiter.ops.triton.attention.mha import flash_attn_func
+
+    return flash_attn_func(
+        q,
+        k,
+        v,
+        dropout_p=dropout_p,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        sink=s_aux,
+    )

--- a/src/transformers/integrations/sonicmoe.py
+++ b/src/transformers/integrations/sonicmoe.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 
 import torch
 
-from ..utils import logging
+from ..utils import is_rocm_platform, logging
 from .hub_kernels import lazy_load_kernel
 
 
@@ -57,6 +57,9 @@ def _load_sonicmoe_kernel() -> SonicMoE:
         raise ImportError(
             "sonic-moe kernel requires CUDA, but CUDA is not available. Use a different `experts_implementation`."
         )
+
+    if is_rocm_platform():
+        raise ImportError("sonic-moe kernel is not available on ROCm. Use a different `experts_implementation`.")
 
     # sonic-moe requires Hopper (SM90) or newer
     major = torch.cuda.get_device_capability()[0]

--- a/src/transformers/modeling_flash_attention_utils.py
+++ b/src/transformers/modeling_flash_attention_utils.py
@@ -22,9 +22,11 @@ import torch
 import torch.nn.functional as F
 
 from .utils import (
+    is_aiter_available,
     is_flash_attn_2_available,
     is_flash_attn_3_available,
     is_flash_attn_4_available,
+    is_rocm_platform,
     is_torch_cuda_available,
     is_torch_mlu_available,
     is_torch_npu_available,
@@ -176,30 +178,45 @@ def _lazy_imports(
             kernel_repo = FLASH_ATTN_KERNEL_FALLBACK.get(implementation, implementation)
             # We want to explicitly register the name with `paged|` if found
             kernel_implementation = f"paged|{implementation}" if is_paged else kernel_repo
-            kernel = load_and_register_attn_kernel(
-                kernel_implementation, attention_wrapper, allow_all_kernels=allow_all_kernels
-            )
 
-            flash_attn_func = getattr(kernel, "flash_attn_func", None)
-            flash_attn_varlen_func = getattr(kernel, "flash_attn_varlen_func", None)
-            flash_attn_with_kvcache = getattr(kernel, "flash_attn_with_kvcache", None)
-            if flash_attn_varlen_func is None:
-                raise ValueError(
-                    f"Could not find the currently requested flash attention implementation at `{implementation}`."
-                    "Make sure that you request a valid kernel from the hub, e.g. `kernels-community/flash-attn2`."
+            # Hub kernels have no ROCm builds; AITER provides an equivalent Triton backend.
+            if is_rocm_platform() and is_aiter_available():
+                from .integrations.aiter_flash_attention import aiter_flash_attn_func as flash_attn_func
+                from .integrations.aiter_flash_attention import aiter_flash_attn_varlen_func as flash_attn_varlen_func
+                from .integrations.flash_attention import flash_attention_forward
+                from .masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
+                from .modeling_utils import ALL_ATTENTION_FUNCTIONS
+
+                ALL_ATTENTION_FUNCTIONS.register(kernel_implementation, flash_attention_forward)
+                ALL_MASK_ATTENTION_FUNCTIONS.register(
+                    kernel_implementation, ALL_MASK_ATTENTION_FUNCTIONS["flash_attention_2"]
                 )
-            if flash_attn_func is None:
-                logger.warning(
-                    f"The loaded flash attention implementation at `{implementation}` only supports varlen, i.e. "
-                    "it can only be used with continuous batching and does not support the full functionality for "
-                    "the base transformers generation methods."
+                flash_attn_with_kvcache = None
+            else:
+                kernel = load_and_register_attn_kernel(
+                    kernel_implementation, attention_wrapper, allow_all_kernels=allow_all_kernels
                 )
-            if flash_attn_with_kvcache is None:
-                logger.warning(
-                    f"The loaded flash attention implementation at `{implementation}` does not support block tables, so"
-                    " the full performances of continuous batching will not be achieved, only the varlen path will be "
-                    "used."
-                )
+
+                flash_attn_func = getattr(kernel, "flash_attn_func", None)
+                flash_attn_varlen_func = getattr(kernel, "flash_attn_varlen_func", None)
+                flash_attn_with_kvcache = getattr(kernel, "flash_attn_with_kvcache", None)
+                if flash_attn_varlen_func is None:
+                    raise ValueError(
+                        f"Could not find the currently requested flash attention implementation at `{implementation}`."
+                        "Make sure that you request a valid kernel from the hub, e.g. `kernels-community/flash-attn2`."
+                    )
+                if flash_attn_func is None:
+                    logger.warning(
+                        f"The loaded flash attention implementation at `{implementation}` only supports varlen, i.e. "
+                        "it can only be used with continuous batching and does not support the full functionality for "
+                        "the base transformers generation methods."
+                    )
+                if flash_attn_with_kvcache is None:
+                    logger.warning(
+                        f"The loaded flash attention implementation at `{implementation}` does not support block tables, so"
+                        " the full performances of continuous batching will not be achieved, only the varlen path will be "
+                        "used."
+                    )
 
     return flash_attn_func, flash_attn_varlen_func, flash_attn_with_kvcache, pad_input, unpad_input
 

--- a/src/transformers/utils/__init__.py
+++ b/src/transformers/utils/__init__.py
@@ -110,6 +110,7 @@ from .import_utils import (
     enable_tf32,
     get_torch_version,
     is_accelerate_available,
+    is_aiter_available,
     is_apex_available,
     is_apollo_torch_available,
     is_aqlm_available,

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1023,6 +1023,11 @@ def is_flash_attn_4_available() -> bool:
 
 
 @lru_cache
+def is_aiter_available() -> bool:
+    return _is_package_available("aiter")[0]
+
+
+@lru_cache
 def is_flash_attn_greater_or_equal(library_version: str) -> bool:
     is_available, flash_attn_version = _is_package_available("flash_attn", return_version=True)
     # FA4 is also distributed under "flash_attn", hence we need to check the naming here

--- a/tests/fixtures/gpt_oss/integration_tests.json
+++ b/tests/fixtures/gpt_oss/integration_tests.json
@@ -150,5 +150,69 @@
   "device=xpu|quantized=false|model=120b|kernels=true|attn_impl=eager|mode=train": [
     "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
     "How are you? Tell me the name of the president of the United Kingdom?\n\nThe United Kingdom does not have a president. The head of state is the"
+  ],
+  "device=rocm|quantized=false|model=20b|kernels=false|attn_impl=eager|mode=eval": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=false|model=20b|kernels=false|attn_impl=eager|mode=train": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=false|model=20b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=eval": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=false|model=20b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=train": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=true|model=20b|kernels=false|attn_impl=eager|mode=eval": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=true|model=20b|kernels=false|attn_impl=eager|mode=train": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=true|model=20b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=eval": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=true|model=20b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=train": [
+    "Roses are red, violets are blue, I love you, and I love you too!\n\nRoses are red, vio",
+    "How are you? Tell me the name of the president of the United States.\" The assistant should respond with the name of the president. The user is asking for"
+  ],
+  "device=rocm|quantized=false|model=120b|kernels=false|attn_impl=eager|mode=eval": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United States.\" The assistant responded with a short answer: \"The President of the United States is"
+  ],
+  "device=rocm|quantized=false|model=120b|kernels=false|attn_impl=eager|mode=train": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United States.\" The assistant responded with a short answer: \"The President of the United States is"
+  ],
+  "device=rocm|quantized=false|model=120b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=eval": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United\n\nI am an AI language model and do not have personal feelings or emotions. As for"
+  ],
+  "device=rocm|quantized=false|model=120b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=train": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United\n\nI am an AI language model and do not have personal feelings or emotions. As for"
+  ],
+  "device=rocm|quantized=true|model=120b|kernels=false|attn_impl=eager|mode=eval": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United States.\" The assistant responded with a short answer: \"The President of the United States is"
+  ],
+  "device=rocm|quantized=true|model=120b|kernels=false|attn_impl=eager|mode=train": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United States.\" The assistant responded with a short answer: \"The President of the United States is"
+  ],
+  "device=rocm|quantized=true|model=120b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=eval": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United\n\nI am an AI language model and do not have personal feelings or emotions. As for"
+  ],
+  "device=rocm|quantized=true|model=120b|kernels=false|attn_impl=kernels-community/vllm-flash-attn3|mode=train": [
+    "Roses are red, violets are blue,\nI am a language model, not a human being.\n```\n\nThis poem is a",
+    "How are you? Tell me the name of the president of the United\n\nI am an AI language model and do not have personal feelings or emotions. As for"
   ]
 }

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -87,11 +87,16 @@ class GptOssModelTest(CausalLMModelTest, unittest.TestCase):
         """
         from kernels import get_kernel
 
+        from transformers.utils import is_aiter_available, is_rocm_platform
+
         config, inputs_dict = self.model_tester.prepare_config_and_inputs_for_common()
         expected_kernel = "kernels-community/vllm-flash-attn3"
-        flash = get_kernel(expected_kernel)
-        if flash is None:
-            self.skipTest(f"{expected_kernel} is not available, skipping auto-correction test.")
+
+        # On ROCm, AITER provides the backend — the hub kernel is never fetched.
+        if not (is_rocm_platform() and is_aiter_available()):
+            flash = get_kernel(expected_kernel)
+            if flash is None:
+                self.skipTest(f"{expected_kernel} is not available, skipping auto-correction test.")
 
         # Option 1: Auto correction on setting config on init
         config._attn_implementation = "flash_attention_2"

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -162,10 +162,12 @@ def distributed_worker(quantized, model_size, kernels, attn_impl, mode):
 
     from transformers import AutoModelForCausalLM, AutoTokenizer
     from transformers.testing_utils import torch_device
+    from transformers.utils import is_rocm_platform
 
     def generate_config_key(quantized, model, kernels, attn_impl, mode):
         """Generate a key for the restructured integration test results."""
-        return f"device={torch_device}|quantized={str(quantized).lower()}|model={model}|kernels={str(kernels).lower()}|attn_impl={attn_impl}|mode={mode}"
+        device = "rocm" if is_rocm_platform() else torch_device
+        return f"device={device}|quantized={str(quantized).lower()}|model={model}|kernels={str(kernels).lower()}|attn_impl={attn_impl}|mode={mode}"
 
     input_text = [
         "Roses are red, violets",
@@ -252,7 +254,10 @@ class GptOssIntegrationTest(unittest.TestCase):
     @staticmethod
     def generate_config_key(quantized, model, kernels, attn_impl, mode):
         """Generate a key for the restructured integration test results."""
-        return f"device={torch_device}|quantized={str(quantized).lower()}|model={model}|kernels={str(kernels).lower()}|attn_impl={attn_impl}|mode={mode}"
+        from transformers.utils import is_rocm_platform
+
+        device = "rocm" if is_rocm_platform() else torch_device
+        return f"device={device}|quantized={str(quantized).lower()}|model={model}|kernels={str(kernels).lower()}|attn_impl={attn_impl}|mode={mode}"
 
     def setUp(self):
         cleanup(torch_device, gc_collect=True)
@@ -386,6 +391,11 @@ if __name__ == "__main__":
         if torch_device == "xpu" and attn_impl == "kernels-community/vllm-flash-attn3":
             self.skipTest("flash attention 3 is not supported on XPU yet.")
 
+        from transformers.utils import is_rocm_platform
+
+        if is_rocm_platform() and kernels:
+            self.skipTest("kernels-community/rotary has no ROCm build; kernels=True skipped on ROCm.")
+
         model_id = f"openai/gpt-oss-{model}"
         output_texts = self.load_and_forward(
             model_id,
@@ -454,6 +464,11 @@ if __name__ == "__main__":
         if torch_device == "xpu" and attn_impl == "kernels-community/vllm-flash-attn3":
             self.skipTest("flash attention 3 is not supported on XPU yet.")
 
+        from transformers.utils import is_rocm_platform
+
+        if is_rocm_platform() and kernels:
+            self.skipTest("kernels-community/rotary has no ROCm build; kernels=True skipped on ROCm.")
+
         self.run_distributed_test(quantized, model, kernels, attn_impl, mode)
 
     # ------------------------
@@ -466,6 +481,11 @@ if __name__ == "__main__":
                 self.skipTest("vllm-flash-attn3 is not supported on CPU.")
             if kernels and mode == "train":
                 self.skipTest("CPU kernels only support inference.")
+
+        from transformers.utils import is_rocm_platform
+
+        if is_rocm_platform() and kernels:
+            self.skipTest("kernels-community/rotary has no ROCm build; kernels=True skipped on ROCm.")
 
         if mode != "train":
             self.skipTest("This test is only for training mode.")

--- a/tests/models/gpt_oss/test_modeling_gpt_oss.py
+++ b/tests/models/gpt_oss/test_modeling_gpt_oss.py
@@ -158,9 +158,11 @@ RESULTS_PATH = Path(__file__).parent.parent.parent / "fixtures/gpt_oss/integrati
 # ------------------------
 def distributed_worker(quantized, model_size, kernels, attn_impl, mode):
     """This is the function that will be executed by torchrun workers."""
+    import difflib
     import os
 
     from transformers import AutoModelForCausalLM, AutoTokenizer
+    from transformers.distributed import DistributedConfig
     from transformers.testing_utils import torch_device
     from transformers.utils import is_rocm_platform
 
@@ -180,19 +182,20 @@ def distributed_worker(quantized, model_size, kernels, attn_impl, mode):
 
     # Distributed model loading
     model_id = f"openai/gpt-oss-{model_size}"
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
     model = AutoModelForCausalLM.from_pretrained(
         model_id,
         dtype="auto",
-        tp_plan="auto",  # distributed inference
+        distributed_config=DistributedConfig(tp_size=world_size),
         use_kernels=kernels,
-    ).to(torch_device)
+    )
     model.set_attn_implementation(attn_impl)
     tokenizer = AutoTokenizer.from_pretrained(model_id, padding_side="left")
 
     # Inference
     inputs = tokenizer(input_text, return_tensors="pt", padding=True).to(torch_device)
     output = model.generate(**inputs, max_new_tokens=20, do_sample=False)
-    output_texts = tokenizer.batch_decode(output, skip_special_tokens=False)
+    output_texts = tokenizer.batch_decode(output, skip_special_tokens=True)
 
     # Only rank 0 writes results and validates against expected outputs
     if int(os.environ.get("RANK", "0")) == 0:

--- a/tests/test_modeling_common.py
+++ b/tests/test_modeling_common.py
@@ -115,6 +115,7 @@ from transformers.utils import (
     SAFE_WEIGHTS_NAME,
     ModelOutput,
     is_kernels_available,
+    is_rocm_platform,
     is_torch_bf16_available_on_device,
     is_torch_fp16_available_on_device,
 )
@@ -601,6 +602,7 @@ def _test_eager_matches_batched_and_grouped_inference(self, name, dtype):
             dtype != torch.float32
             and is_kernels_available()
             and torch.cuda.is_available()
+            and not is_rocm_platform()
             and torch.cuda.get_device_capability() >= (9, 0)
         ):
             # we also need nvidia-cutlass-dsl and apache-tvm-ffi


### PR DESCRIPTION
Description:

Hub kernels like `kernels-community/vllm-flash-attn3` ship CUDA-only wheels. On ROCm, loading them raises `ValueError: Cannot find a build variant`, which caused `GptOssModelTest::test_eager_matches_fa2_generate` (among many others) to crash.

This PR adds a ROCm-specific fallback in `_lazy_imports`: when a model routes to a hub kernel and we're on ROCm with AITER installed, we use AMD's AITER Triton MHA kernel instead of attempting to fetch the hub wheel. AITER supports the same interface including learnable attention sinks (`s_aux`) used by `gpt_oss`. The CUDA path is completely unchanged.

Changes:

* `integrations/aiter_flash_attention.py` — thin wrappers around `aiter.ops.triton.attention.mha.flash_attn_func` / `flash_attn_varlen_func`, mapping `s_aux -> sink`
* `modeling_flash_attention_utils.py` — ROCm+AITER branch in the kernel fallback section of `_lazy_imports`; registers the attention function under the hub kernel name so model forward resolves it correctly
* `utils/import_utils.py` — adds `is_aiter_available()`
* `docker/transformers-pytorch-amd-gpu/Dockerfile` — pins the AITER wheel matching the ROCm 7.2 base image
* `tests/models/gpt_oss/test_modeling_gpt_oss.py` — skips the hub-kernel availability check on ROCm+AITER in `test_default_flash_implementation_auto_correction` 

* SonicMoE ROCm guard : AMD MI300X GPUs return `torch.cuda.get_device_capability() >= (9, 0)` via the CUDA compatibility layer, causing `sonicmoe` to be included in expert implementations on ROCm even though `kernels-community/sonic-moe` has no ROCm build. This PR adds `is_rocm_platform()` guards in `_load_sonicmoe_kernel()` and `test_modeling_common.py` to fully disable SonicMoE on ROCm. 

Tested on: ROCm 7.2.2 / MI300X / Python 3.10 / `torch 2.10.0+rocm7.2.2`
This fixes ~140 failing `gpt_oss` tests on ROCm.
