### PR TITLE
Fix StaticLayer.get_seq_length return type annotation (#45987)

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -376,14 +376,7 @@ class StaticLayer(CacheLayerMixin):
         return kv_length, kv_offset
 
     def get_seq_length(self) -> int | torch.Tensor:
-        """Returns the sequence length of the cached states.
-
-        Note: returns a shape-``(1,)`` ``torch.Tensor`` rather than a Python
-        ``int`` so that updates to ``cumulative_length`` can stay in-place and
-        ``torch.compile``-friendly (calling ``.item()`` would force a CUDA
-        sync). The returned tensor broadcasts in arithmetic identically to an
-        ``int`` for the call sites that consume this value.
-        """
+        """Returns the sequence length of the cached states."""
         return self.cumulative_length if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:

--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -69,7 +69,7 @@ class CacheLayerMixin(ABC):
     def get_mask_sizes(self, query_length: int) -> tuple[int, int]: ...
 
     @abstractmethod
-    def get_seq_length(self) -> int: ...
+    def get_seq_length(self) -> int | torch.Tensor: ...
 
     @abstractmethod
     def get_max_cache_shape(self) -> int: ...
@@ -375,8 +375,15 @@ class StaticLayer(CacheLayerMixin):
         kv_length = self.max_cache_len
         return kv_length, kv_offset
 
-    def get_seq_length(self) -> int:
-        """Returns the sequence length of the cached states."""
+    def get_seq_length(self) -> int | torch.Tensor:
+        """Returns the sequence length of the cached states.
+
+        Note: returns a shape-``(1,)`` ``torch.Tensor`` rather than a Python
+        ``int`` so that updates to ``cumulative_length`` can stay in-place and
+        ``torch.compile``-friendly (calling ``.item()`` would force a CUDA
+        sync). The returned tensor broadcasts in arithmetic identically to an
+        ``int`` for the call sites that consume this value.
+        """
         return self.cumulative_length if self.is_initialized else 0
 
     def get_max_cache_shape(self) -> int:


### PR DESCRIPTION
Fixes #45987.

`StaticLayer.cumulative_length` is initialized as a shape-(1,) `torch.Tensor` (so that in-place `.add_()` updates stay `torch.compile`-friendly), and `StaticLayer.get_seq_length()` returns it directly. The current `-> int` annotation lies about that.

Per @Rocketknight1's [comment on the issue](https://github.com/huggingface/transformers/issues/45987):

> I think this is mostly just a type-hint bug, right? There isn't really much difference between a tensor with shape `(1,)` and a 0-dim tensor, they'll both broadcast with any other tensor and work with `item()` etc. Also, we generally want to avoid `item()` where possible because it causes a CUDA sync. So maybe just make the return type `int | Tensor` or something but leave the rest of the code alone?

This PR does exactly that — minimal annotation-only change:

- `CacheLayerMixin.get_seq_length` abstract: `-> int` → `-> int | torch.Tensor`
- `StaticLayer.get_seq_length`: `-> int` → `-> int | torch.Tensor`, plus a docstring note explaining why a tensor is returned.

No runtime behavior change. No `.item()` calls added. Other concrete `get_seq_length` overrides (`DynamicLayer`, `StaticSlidingWindowLayer`, `QuantizedLayer`, ...) already return ints and don't need touching.

The four earlier PRs for this issue (#46005, #46010, #46081, #45997) all attempted heavier rewrites that added `.item()` or restructured `cumulative_length`, which is the opposite of the requested fix. This PR sticks to the maintainer-specified shape.

## Before submitting

- [x] This PR fixes a typing issue and links to the existing issue (#45987).
- [x] Did you make sure to update the documentation with your changes? (Docstring updated to reflect actual return type.)
- [x] Did you write any new necessary tests? Not needed — annotation-only change with no runtime behavior delta.

## Who can review?

@Rocketknight1 (you commented on #45987 with the requested approach)