### PR TITLE
fix(mps): build_2d_sinusoidal_position_embedding crashes on Apple Silicon due to float64 on MPS device

### DIFF
--- a/src/transformers/models/aimv2/modeling_aimv2.py
+++ b/src/transformers/models/aimv2/modeling_aimv2.py
@@ -134,7 +134,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -143,11 +144,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -156,9 +157,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class Aimv2VisionEmbeddings(nn.Module):

--- a/src/transformers/models/d_fine/modeling_d_fine.py
+++ b/src/transformers/models/d_fine/modeling_d_fine.py
@@ -631,7 +631,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -640,11 +641,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -653,9 +654,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class DFineSinePositionEmbedding(nn.Module):

--- a/src/transformers/models/deimv2/modeling_deimv2.py
+++ b/src/transformers/models/deimv2/modeling_deimv2.py
@@ -703,7 +703,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -712,11 +713,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -725,9 +726,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class Deimv2SinePositionEmbedding(nn.Module):

--- a/src/transformers/models/pp_doclayout_v2/modeling_pp_doclayout_v2.py
+++ b/src/transformers/models/pp_doclayout_v2/modeling_pp_doclayout_v2.py
@@ -1551,7 +1551,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -1560,11 +1561,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -1573,9 +1574,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class PPDocLayoutV2SinePositionEmbedding(nn.Module):

--- a/src/transformers/models/pp_doclayout_v3/modeling_pp_doclayout_v3.py
+++ b/src/transformers/models/pp_doclayout_v3/modeling_pp_doclayout_v3.py
@@ -804,7 +804,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -813,11 +814,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -826,9 +827,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class PPDocLayoutV3SinePositionEmbedding(nn.Module):

--- a/src/transformers/models/rt_detr/modeling_rt_detr.py
+++ b/src/transformers/models/rt_detr/modeling_rt_detr.py
@@ -847,7 +847,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -856,11 +857,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -869,9 +870,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class RTDetrSinePositionEmbedding(nn.Module):

--- a/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
+++ b/src/transformers/models/rt_detr_v2/modeling_rt_detr_v2.py
@@ -976,7 +976,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -985,11 +986,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -998,9 +999,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class RTDetrV2SinePositionEmbedding(nn.Module):

--- a/src/transformers/models/vit_mae/modeling_vit_mae.py
+++ b/src/transformers/models/vit_mae/modeling_vit_mae.py
@@ -152,7 +152,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -161,11 +162,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -174,9 +175,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 class ViTMAEEmbeddings(nn.Module):

--- a/src/transformers/models/vit_mae/modular_vit_mae.py
+++ b/src/transformers/models/vit_mae/modular_vit_mae.py
@@ -62,7 +62,8 @@ def build_2d_sinusoidal_position_embedding(
         temperature: Base for the frequency decay.
         cls_token: If `True`, prepend a zero row for a CLS token.
         device: Target device; defaults to CPU.
-        dtype: Output dtype; frequency arithmetic uses float64 internally.
+        dtype: Output dtype; frequency arithmetic uses float64 on CPU internally
+            before casting, so precision is preserved regardless of output dtype.
 
     Returns:
         Tensor of shape ``(height * width [+1], embed_dim)``.
@@ -71,11 +72,11 @@ def build_2d_sinusoidal_position_embedding(
         raise ValueError(f"`embed_dim` must be divisible by 4, got {embed_dim}")
 
     pos_dim = embed_dim // 4
-    omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
+    omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim
     omega = 1.0 / temperature**omega  # (D/4,)
 
-    grid_h = torch.arange(height, dtype=torch.float64, device=device)
-    grid_w = torch.arange(width, dtype=torch.float64, device=device)
+    grid_h = torch.arange(height, dtype=torch.float64)
+    grid_w = torch.arange(width, dtype=torch.float64)
     grid_h, grid_w = torch.meshgrid(grid_h, grid_w, indexing="ij")  # (H, W) each
 
     emb_h = grid_h.flatten().outer(omega)  # (H*W, D/4)
@@ -84,9 +85,9 @@ def build_2d_sinusoidal_position_embedding(
     pos_embed = torch.cat([emb_h.sin(), emb_h.cos(), emb_w.sin(), emb_w.cos()], dim=1)
 
     if cls_token:
-        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64, device=device), pos_embed], dim=0)
+        pos_embed = torch.cat([torch.zeros(1, embed_dim, dtype=torch.float64), pos_embed], dim=0)
 
-    return pos_embed.to(dtype)
+    return pos_embed.to(device=device, dtype=dtype)
 
 
 @auto_docstring(


### PR DESCRIPTION
Fixes #46159

## Problem

`build_2d_sinusoidal_position_embedding` hardcodes `torch.float64` **and** passes `device=device` to every intermediate tensor. MPS (Apple Silicon) does not support float64, so any model calling this function with an MPS device crashes with:

```
TypeError: Cannot convert a MPS Tensor to float64 dtype as the MPS framework
doesn't support float64. Please use float32 instead.
```

## Why float64 was there

The original design was intentional: `1.0 / temperature**omega` (temperature=10000) produces very small values where float32 loses significant digits. The function computed everything at float64 precision then cast to the output dtype at the end via `.to(dtype)`. The docstring documented this: *"frequency arithmetic uses float64 internally"*.

Simply replacing `float64` with `dtype` throughout would fix MPS but silently degrade precision for `float16`/`bfloat16` callers.

## Fix

Keep float64 for intermediate arithmetic, but on **CPU** (where float64 always works). Only the final result is moved to the requested device and cast to dtype:

```python
# Before — float64 on the target device → crashes on MPS
omega = torch.arange(pos_dim, dtype=torch.float64, device=device) / pos_dim
...
return pos_embed.to(dtype)

# After — float64 on CPU, move to device at the end → works everywhere
omega = torch.arange(pos_dim, dtype=torch.float64) / pos_dim  # no device=
...
return pos_embed.to(device=device, dtype=dtype)
```

## Scope

The canonical fix is one function in `modular_vit_mae.py`. `make fix-repo` propagated it to all 8 generated files that inline this function: `modeling_vit_mae`, `modeling_rt_detr`, `modeling_rt_detr_v2`, `modeling_aimv2`, `modeling_deimv2`, `modeling_d_fine`, `modeling_pp_doclayout_v2`, `modeling_pp_doclayout_v3`.

## Testing

| Platform | Command | Result |
|---|---|---|
| macOS MPS — Apple Silicon | smoke test: float32 / float16 / bfloat16 | ✅ all pass |
| Linux CPU — arm64 Docker (`python:3.12-slim` + torch CPU wheel) | smoke test: float32 / float16 / bfloat16 / precision check | ✅ all pass |
| Unit tests `vit_mae`, `rt_detr`, `rt_detr_v2` | `pytest tests/models/vit_mae/ tests/models/rt_detr/ tests/models/rt_detr_v2/ -q` | ✅ 288 passed, 0 failed |
| Repo checks | `make fix-repo` | ✅ all 15 checks pass |

> **AI assistance disclosure:** Claude was used to identify the affected modular files and run the fix-repo workflow. Root cause analysis, fix approach, and MPS verification were done by the issue author on real Apple Silicon hardware.