### PR TITLE
fix(utils): register tensorflow_text in BACKENDS_MAPPING to prevent import error

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1375,6 +1375,11 @@ def is_mistral_common_available() -> bool:
 
 
 @lru_cache
+def is_tensorflow_text_available() -> bool:
+    return _is_package_available("tensorflow_text")[0]
+
+
+@lru_cache
 def is_pynvml_available() -> bool:
     return _is_package_available("pynvml")[0]
 
@@ -1977,6 +1982,9 @@ MISTRAL_COMMON_IMPORT_ERROR = """
 {0} requires the mistral-common library but it was not found in your environment. You can install it with pip: `pip install mistral-common`. Please note that you may need to restart your runtime after installation.
 """
 
+TENSORFLOW_TEXT_IMPORT_ERROR = """
+{0} requires the tensorflow-text library but it was not found in your environment. You can install it with:
+"""
 
 BACKENDS_MAPPING = OrderedDict(
     [
@@ -2025,6 +2033,7 @@ BACKENDS_MAPPING = OrderedDict(
         ("uvicorn", (is_uvicorn_available, UVICORN_IMPORT_ERROR)),
         ("openai", (is_openai_available, OPENAI_IMPORT_ERROR)),
         ("mistral-common", (is_mistral_common_available, MISTRAL_COMMON_IMPORT_ERROR)),
+        ("tensorflow_text", (is_tensorflow_text_available, "{0} requires the tensorflow_text library but it was not found in your environment.")),
     ]
 )
 

--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -1984,6 +1984,8 @@ MISTRAL_COMMON_IMPORT_ERROR = """
 
 TENSORFLOW_TEXT_IMPORT_ERROR = """
 {0} requires the tensorflow-text library but it was not found in your environment. You can install it with:
+`pip install tensorflow-text`
+Please note that you may need to restart your runtime after installation.
 """
 
 BACKENDS_MAPPING = OrderedDict(
@@ -2033,7 +2035,7 @@ BACKENDS_MAPPING = OrderedDict(
         ("uvicorn", (is_uvicorn_available, UVICORN_IMPORT_ERROR)),
         ("openai", (is_openai_available, OPENAI_IMPORT_ERROR)),
         ("mistral-common", (is_mistral_common_available, MISTRAL_COMMON_IMPORT_ERROR)),
-        ("tensorflow_text", (is_tensorflow_text_available, "{0} requires the tensorflow_text library but it was not found in your environment.")),
+        ("tensorflow_text", (is_tensorflow_text_available, TENSORFLOW_TEXT_IMPORT_ERROR)),
     ]
 )
 


### PR DESCRIPTION
# What does this PR do?

Fixes a `ValueError: Backend should be defined in the BACKENDS_MAPPING` error that gets triggered during lazy module initialization when importing `transformers` (v5.9.0) in downstream applications like ComfyUI. 

The issue arises because `tensorflow_text` is used as a backend within the codebase but was missing from `BACKENDS_MAPPING` inside `import_utils.py`, along with its environment availability checks.

### Changes:
- Defined the missing `TENSORFLOW_TEXT_IMPORT_ERROR` string constant with full instructions.
- Added the `@lru_cache` decorated `is_tensorflow_text_available()` helper function.
- Properly registered `"tensorflow_text"` inside `BACKENDS_MAPPING` to resolve the import failure.

Fixes #46178

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?

## Who can review?

@ArthurZucker @itazap (Since this touches `utils/import_utils.py` and maps backend constants for lazy modules).