### PR TITLE
Guard torch.distributed.tensor.device_mesh import in continuous_batching

### DIFF
--- a/src/transformers/generation/continuous_batching/distributed.py
+++ b/src/transformers/generation/continuous_batching/distributed.py
@@ -16,7 +16,16 @@ from typing import TypeVar
 
 import torch
 import torch.distributed as dist
-from torch.distributed.tensor.device_mesh import DeviceMesh
+
+
+# `torch.distributed.tensor.device_mesh` is unavailable on some PyTorch builds where the distributed package is
+# incomplete (notably AMD ROCm on Windows, see #46170). `DeviceMesh` is only referenced as a type annotation in this
+# file -- the runtime paths use duck typing -- so we tolerate its absence and fall back to `None`. If a real
+# `DeviceMesh` is ever passed in such an environment (impossible without the class), we raise a clear ImportError.
+try:
+    from torch.distributed.tensor.device_mesh import DeviceMesh
+except (ImportError, AttributeError):
+    DeviceMesh = None
 
 from .requests import logger
 
@@ -27,7 +36,13 @@ T = TypeVar("T")
 class DistributedHelper:
     """A helper class to handle distributed-related operations. Notably, it does not crash when distributed is off."""
 
-    def __init__(self, device_mesh: DeviceMesh | None) -> None:
+    def __init__(self, device_mesh: "DeviceMesh | None") -> None:
+        if device_mesh is not None and DeviceMesh is None:
+            raise ImportError(
+                "torch.distributed.tensor.device_mesh.DeviceMesh is not available on this PyTorch build "
+                "(e.g., AMD ROCm on Windows). Continuous batching distributed/tensor-parallel features are not "
+                "supported in this environment."
+            )
         self.device_mesh = device_mesh
         self.dist_on = dist.is_available() and dist.is_initialized()
 

--- a/tests/generation/test_continuous_batching_distributed_import.py
+++ b/tests/generation/test_continuous_batching_distributed_import.py
@@ -113,5 +113,6 @@ class TestContinuousBatchingDistributedImportGuard(unittest.TestCase):
         self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
         self.assertIn("OK", result.stdout)
 
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/generation/test_continuous_batching_distributed_import.py
+++ b/tests/generation/test_continuous_batching_distributed_import.py
@@ -1,0 +1,117 @@
+# Copyright 2025 The HuggingFace Team Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for transformers#46170.
+
+Some PyTorch builds (notably AMD ROCm on Windows) ship an incomplete `torch.distributed`
+package. Until the fix in `generation/continuous_batching/distributed.py`, the unconditional
+`from torch.distributed.tensor.device_mesh import DeviceMesh` import propagated up to
+`from transformers import ...`, breaking unrelated models such as CLIPSeg.
+
+These tests run in a child interpreter so we can patch the failing import without
+interfering with the parent test process.
+"""
+
+import subprocess
+import sys
+import textwrap
+import unittest
+
+
+def _run_in_subprocess(script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+# Shared preamble: monkeypatch `__import__` so any attempt to import
+# `torch.distributed.tensor.device_mesh` raises ImportError, mirroring the failure
+# reported on AMD ROCm / Windows in #46170.
+_PREAMBLE = textwrap.dedent(
+    """
+    import builtins
+
+    _real_import = builtins.__import__
+
+    def _failing_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "torch.distributed.tensor.device_mesh" or name.startswith("torch.distributed.tensor.device_mesh."):
+            raise ImportError("cannot import name 'FileStore' from 'torch.distributed'")
+        if name == "torch.distributed.tensor" and fromlist and "device_mesh" in fromlist:
+            raise ImportError("cannot import name 'FileStore' from 'torch.distributed'")
+        return _real_import(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = _failing_import
+    """
+)
+
+
+class TestContinuousBatchingDistributedImportGuard(unittest.TestCase):
+    """The distributed helper module must import even when `torch.distributed.tensor.device_mesh` is broken."""
+
+    def test_distributed_module_imports_when_device_mesh_unavailable(self):
+        script = _PREAMBLE + textwrap.dedent(
+            """
+            from transformers.generation.continuous_batching import distributed as cb_dist
+            assert cb_dist.DeviceMesh is None, "DeviceMesh should be None when its import fails"
+            # The class must be defined; the `DeviceMesh | None` annotation must not be evaluated.
+            assert cb_dist.DistributedHelper is not None
+            print("OK")
+            """
+        )
+        result = _run_in_subprocess(script)
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("OK", result.stdout)
+
+    def test_distributed_helper_constructs_with_none_device_mesh(self):
+        # The common single-process path passes `device_mesh=None`; this must succeed even when DeviceMesh is unavailable.
+        script = _PREAMBLE + textwrap.dedent(
+            """
+            from transformers.generation.continuous_batching.distributed import DistributedHelper
+            helper = DistributedHelper(device_mesh=None)
+            assert helper.device_mesh is None
+            assert helper.tp_size == 1
+            assert helper.world_size == 1
+            print("OK")
+            """
+        )
+        result = _run_in_subprocess(script)
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("OK", result.stdout)
+
+    def test_distributed_helper_raises_on_real_device_mesh_when_class_unavailable(self):
+        # If a caller somehow supplies a non-None device_mesh while DeviceMesh itself is unavailable, surface an
+        # actionable ImportError rather than a confusing AttributeError later.
+        script = _PREAMBLE + textwrap.dedent(
+            """
+            from transformers.generation.continuous_batching.distributed import DistributedHelper
+            class _StubMesh:
+                pass
+            try:
+                DistributedHelper(device_mesh=_StubMesh())
+            except ImportError as e:
+                msg = str(e)
+                assert "torch.distributed.tensor.device_mesh" in msg, msg
+                print("OK")
+            else:
+                raise AssertionError("expected ImportError")
+            """
+        )
+        result = _run_in_subprocess(script)
+        self.assertEqual(result.returncode, 0, msg=f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}")
+        self.assertIn("OK", result.stdout)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# What does this PR do?

Fixes #46170.

`src/transformers/generation/continuous_batching/distributed.py` does an unconditional

```python
from torch.distributed.tensor.device_mesh import DeviceMesh
```

at module load. That file is pulled in eagerly by `transformers.generation.utils` (which does `from .continuous_batching import ContinuousMixin`), so any `from transformers import <Model>` walks through it.

On PyTorch builds where `torch.distributed` is incomplete (the reporter is on AMD ROCm 7.2 on Windows with PyTorch 2.9.1+rocm7.2.1), that import raises:

```
ImportError: cannot import name 'FileStore' from 'torch.distributed'
```

Unrelated model loads then break, for example `from transformers import CLIPSegForImageSegmentation`.

There's also a second problem in the same file. `DistributedHelper.__init__` has `device_mesh: DeviceMesh | None` as a parameter annotation, and the module does not use `from __future__ import annotations`. The annotation is evaluated at class-definition time, so even a stub `DeviceMesh = None` would still fall over with `TypeError: unsupported operand type(s) for |`.

## Fix

1. Wrap the import in `try/except (ImportError, AttributeError)` and fall back to `DeviceMesh = None`. This matches the guard pattern already used in `src/transformers/core_model_loading.py:42-46` and `src/transformers/pytorch_utils.py:220`.
2. Quote the parameter annotation as `"DeviceMesh | None"` so it is not evaluated when `DeviceMesh` is `None`.
3. If a caller ever passes a non-`None` device mesh in an environment where the class is missing, raise a clear `ImportError` from `__init__`. That way the failure surfaces with a message naming the missing module instead of an `AttributeError` deep in the dist path later.

There is exactly one call site: `continuous_api.py:518` passes `getattr(self.model, "_device_mesh", None)`. On single-process runs that is `None`, which is unaffected. When TP is configured, a real `DeviceMesh` is passed, which already requires the class to be importable. So the runtime check is defensive only.

The healthy distributed path (CUDA, dist initialized, real `DeviceMesh`) is byte-identical. I verified locally that every instance attribute and every broadcast/reduce method gives the same result with and without the patch.

## Scope note

This PR addresses the one failing import named in the reporter's traceback. Other modules in `src/transformers/` reference `torch.distributed.tensor.*`, but most are already guarded: `core_model_loading.py:46`, `pytorch_utils.py:221`, `distributed/utils.py:48`, `distributed/sharding_utils.py:24,29`, `distributed/tensor_parallel.py:29`. The one outlier is `modeling_utils.py:42`, which imports `DTensor` directly. On the reporter's machine that line apparently does not fail. If it did, the traceback would have started there. If a future report shows it failing, the same guard can be applied.

## Tests

New `tests/generation/test_continuous_batching_distributed_import.py` runs three checks in a child interpreter, with `__import__` monkeypatched so `torch.distributed.tensor.device_mesh` raises the same `ImportError` as the reporter:

1. The module imports cleanly. `DeviceMesh is None`. The class definition succeeds.
2. `DistributedHelper(device_mesh=None)` builds. `tp_size == 1`, `world_size == 1`.
3. `DistributedHelper(device_mesh=<stub>)` raises `ImportError` naming `torch.distributed.tensor.device_mesh`.

All three fail on `main` and pass with this change.

Existing `tests/generation/test_continuous_batching.py` still passes: 55 passed, 51 skipped locally. The 2 pre-existing flakes (`test_block_sharing_with_hybrid_model`, `test_continuous_batching_long_generate`) reproduce on unmodified `upstream/main`, so they are not regressions from this PR. See the triage comment below for the CircleCI `cohere2_moe` failures, which also reproduce on `upstream/main`.

## Code Agent Policy

- [x] I confirm that this is not a pure code agent PR. I used an LLM as a drafting assistant per the policy ("You may use code agents in drafting or to help you diagnose issues"). The fix and tests were verified by reverting the patch to baseline, reproducing the failure, applying the patch, and confirming the pass. I also confirmed byte-identical behavior on the healthy distributed path.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request), Pull Request section?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? See #46170.
- [x] Did you make sure to update the documentation with your changes? `DistributedHelper` is internal and is not referenced in `docs/source/en/`. No doc update needed.
- [x] Did you write any new necessary tests?

## Who can review?

Per CONTRIBUTING.md's reviewer guide:

* continuous batching: @remi-or @ArthurZucker @McPatate
* distributed: @3outeille @ArthurZucker
* AMD ROCm: @ivarflakstad

cc @ArthurZucker @ivarflakstad @3outeille