### PR TITLE
Fix loading with only 1 device or distributed config

### DIFF
--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -799,7 +799,7 @@ class WeightTransform:
                 tensors = [future.result() for future in tensors if future.result() is not None]
             # Sync loading
             elif callable(tensors[0]):
-                tensors = [tensor for func in tensors if (tensor := func()) is not None]
+                tensors = [func() for func in tensors]
             # Add them to the new dictionary
             collected_tensors[key] = tensors
 
@@ -1019,9 +1019,10 @@ def spawn_materialize(
 
     if thread_pool is not None:
         return thread_pool.submit(_job)
-    # Return the Callable here, not the Tensor itself, so we actually delay loading
-    # to avoid saturating cpu memory during Conversion
-    return _job
+    else:
+        # Return the Callable here, not the Tensor itself, so we actually delay loading to avoid saturating cpu
+        # memory during Conversion
+        return _job
 
 
 def dot_natural_key(s: str):
@@ -1307,21 +1308,9 @@ def convert_and_load_state_dict_in_model(
     """
     base_model_prefix = model.base_model_prefix
     tp_plan = tp_plan or {}
+    device_map = load_config.device_map or {"": "cpu"}
     hf_quantizer = load_config.hf_quantizer
     dtype = load_config.dtype
-    device_mesh = load_config.device_mesh
-
-    if load_config.device_map is not None:
-        device_map = load_config.device_map
-    elif device_mesh is not None:
-        if device_mesh.device_type == "cpu":
-            device_map = {"": torch.device("cpu")}
-        else:
-            device_map = {
-                "": torch.device(device_mesh.device_type, getattr(torch, device_mesh.device_type).current_device())
-            }
-    else:
-        device_map = {"": "cpu"}
     disk_offload_folder = load_config.disk_offload_folder
     offload_buffers = load_config.offload_buffers
     dtype_plan = load_config.dtype_plan or {}

--- a/src/transformers/core_model_loading.py
+++ b/src/transformers/core_model_loading.py
@@ -38,12 +38,12 @@ from .utils.logging import get_logger, tqdm
 
 
 _torch_distributed_available = torch.distributed.is_available()
+if _torch_distributed_available:
+    from torch.distributed.tensor import DTensor
 
 if TYPE_CHECKING:
     from .modeling_utils import LoadStateDictConfig, PreTrainedModel
     from .quantizers import HfQuantizer
-elif _torch_distributed_available:
-    from torch.distributed.tensor import DTensor
 
 logger = get_logger(__name__)
 
@@ -800,6 +800,8 @@ class WeightTransform:
             # Sync loading
             elif callable(tensors[0]):
                 tensors = [func() for func in tensors]
+                # Some may be None for some distributed setups
+                tensors = [tensor for tensor in tensors if tensor is not None]
             # Add them to the new dictionary
             collected_tensors[key] = tensors
 

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4193,9 +4193,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
             if device_mesh.device_type == "cpu":
                 device_map = {"": torch.device("cpu")}
             else:
-                device_map = {
-                    "": torch.device(device_mesh.device_type, getattr(torch, device_mesh.device_type).current_device())
-                }
+                device_map = {"": torch.device(device_mesh.device_type, int(os.environ["LOCAL_RANK"]))}
         else:
             # Accelerate path
             if device_map == "auto" and int(os.environ.get("WORLD_SIZE", "0")):

--- a/src/transformers/modeling_utils.py
+++ b/src/transformers/modeling_utils.py
@@ -4188,6 +4188,14 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         if distributed_config is not None:
             device_mesh = init_device_mesh(distributed_config)
+            # When using any distributed setup, we simply set the device_map here to the current rank so that we correctly
+            # load the params on the right device
+            if device_mesh.device_type == "cpu":
+                device_map = {"": torch.device("cpu")}
+            else:
+                device_map = {
+                    "": torch.device(device_mesh.device_type, getattr(torch, device_mesh.device_type).current_device())
+                }
         else:
             # Accelerate path
             if device_map == "auto" and int(os.environ.get("WORLD_SIZE", "0")):
@@ -4342,10 +4350,9 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
 
         if distributed_config is not None:
             model = distribute_model(model, distributed_config, device_mesh)
-        else:
-            # Accelerate path: auto device mapping
-            if device_map is not None:
-                device_map = _get_device_map(model, device_map, max_memory, hf_quantizer)
+        elif device_map is not None:
+            # Expand device_map if it was passed as a `str`, i.e. `device_map="auto"`
+            device_map = _get_device_map(model, device_map, max_memory, hf_quantizer)
 
         # Finalize model weight initialization
         active_tp_plan = (
@@ -4907,7 +4914,7 @@ class PreTrainedModel(nn.Module, EmbeddingAccessMixin, ModuleUtilsMixin, PushToH
         later as they will be tied (overwritten) anyway.
         This is very important as most embeddings are tied, and they are huge params (vocabularies are often 256k), so
         running inits on them is very costly."""
-        for tied_param in self.all_tied_weights_keys.keys():
+        for tied_param in getattr(self, "all_tied_weights_keys", {}).keys():
             param = self.get_parameter(tied_param)
             setattr(param, "_is_hf_initialized", True)
 

--- a/tests/utils/test_modeling_utils.py
+++ b/tests/utils/test_modeling_utils.py
@@ -442,6 +442,7 @@ class ModelUtilsTest(TestCasePlus):
             fake_mesh = mock.Mock()
             fake_mesh.mesh_dim_names = ("fsdp",)
             fake_mesh.ndim = 1
+            fake_mesh.device_type = "cpu"
 
             def fake_apply_fsdp(model, fsdp_mesh, fsdp_plan):
                 call_order.append("distribute")


### PR DESCRIPTION
# What does this PR do?

Supersedes https://github.com/huggingface/transformers/pull/46116. Some params will never go on the correct device if the `device_map` is not set correctly, even with distributed calls (e.g. all non-persistent buffers). This has changed in https://github.com/huggingface/transformers/pull/45028 but should not have (setting the device only in `core_model_loading.py` to load the param is not enough, as non-persistent buffers are not part of the state_dict).
This is because we want to put directly everything on the correct device, INCLUDING non persistent buffers.