### PR TITLE
[deepseek_v4] keep hc_head / sinks / position_bias in fp32

### DIFF
--- a/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modeling_deepseek_v4.py
@@ -1183,6 +1183,9 @@ class DeepseekV4PreTrainedModel(PreTrainedModel):
     _keep_in_fp32_modules_strict = [
         "attn_hc",
         "ffn_hc",
+        "hc_head",
+        "sinks",
+        "position_bias",
         "e_score_correction_bias",
         "q_a_norm",
         "kv_norm",

--- a/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
+++ b/src/transformers/models/deepseek_v4/modular_deepseek_v4.py
@@ -1040,6 +1040,9 @@ class DeepseekV4PreTrainedModel(MixtralPreTrainedModel):
     _keep_in_fp32_modules_strict = [
         "attn_hc",
         "ffn_hc",
+        "hc_head",
+        "sinks",
+        "position_bias",
         "e_score_correction_bias",
         "q_a_norm",
         "kv_norm",


### PR DESCRIPTION
Fixes #46167 — adds `hc_head`, `sinks`, `position_bias` to `_keep_in_fp32_modules_strict` so the remaining 112 fp32 tensors stop being silently downcast to bf16.

<img width="685" height="83" alt="image" src="https://github.com/user-attachments/assets/17721bce-699a-4aff-9a0d-e9e69f5fe94c" />


<img width="666" height="132" alt="image" src="https://github.com/user-attachments/assets/b9847992-f322-4f92-aeeb-9da3cf623fae" />


<img width="657" height="91" alt="image" src="https://github.com/user-attachments/assets/e46637c2-c738-47cc-906a-5a9b40521d7b" />