### PR TITLE
fix(llama): allow explicit head_dim when hidden_size not divisible by num_attention_heads

### DIFF
--- a/src/transformers/models/arcee/configuration_arcee.py
+++ b/src/transformers/models/arcee/configuration_arcee.py
@@ -101,6 +101,10 @@ class ArceeConfig(PreTrainedConfig):
     head_dim: int | None = None
 
     def __post_init__(self, **kwargs):
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -110,10 +114,14 @@ class ArceeConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/aria/configuration_aria.py
+++ b/src/transformers/models/aria/configuration_aria.py
@@ -104,6 +104,10 @@ class AriaTextConfig(PreTrainedConfig):
     moe_num_shared_experts: int = 2
 
     def __post_init__(self, **kwargs):
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -113,10 +117,14 @@ class AriaTextConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/cwm/configuration_cwm.py
+++ b/src/transformers/models/cwm/configuration_cwm.py
@@ -127,6 +127,10 @@ class CwmConfig(PreTrainedConfig):
         self.sliding_window = int(self.sliding_window) if self.sliding_window else None
         self.layer_types = list(self.layer_types)
         self.eos_token_id = self.eos_token_id if self.eos_token_id is not None else [128001, 128008, 128009]
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -136,10 +140,14 @@ class CwmConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
+++ b/src/transformers/models/deepseek_v2/configuration_deepseek_v2.py
@@ -139,6 +139,10 @@ class DeepseekV2Config(PreTrainedConfig):
 
     def __post_init__(self, **kwargs):
         self.head_dim = self.qk_rope_head_dim
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -148,10 +152,14 @@ class DeepseekV2Config(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/eurobert/configuration_eurobert.py
+++ b/src/transformers/models/eurobert/configuration_eurobert.py
@@ -113,6 +113,10 @@ class EuroBertConfig(PreTrainedConfig):
     def __post_init__(self, **kwargs):
         if self.num_key_value_heads is None:
             self.num_key_value_heads = self.num_attention_heads
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -122,10 +126,14 @@ class EuroBertConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
+++ b/src/transformers/models/higgs_audio_v2/configuration_higgs_audio_v2.py
@@ -133,6 +133,10 @@ class HiggsAudioV2Config(PreTrainedConfig):
                 "original_max_position_embeddings": 1024,
                 "rope_type": "llama3",
             }
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -142,10 +146,14 @@ class HiggsAudioV2Config(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/hrm_text/configuration_hrm_text.py
+++ b/src/transformers/models/hrm_text/configuration_hrm_text.py
@@ -140,10 +140,14 @@ class HrmTextConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
     @property

--- a/src/transformers/models/hrm_text/configuration_hrm_text.py
+++ b/src/transformers/models/hrm_text/configuration_hrm_text.py
@@ -120,6 +120,11 @@ class HrmTextConfig(PreTrainedConfig):
     num_layers_per_stack: int | None = None  # Usually inferred in post init
 
     def __post_init__(self, **kwargs):
+        # hrm_text always carries an explicit head_dim (default 128) and never derives it from
+        # hidden_size / num_attention_heads, so the divisibility check in validate_architecture
+        # never applies to this model.
+        self._head_dim_was_explicit = self.head_dim is not None
+
         if self.L_bp_cycles is None:
             # Default `[2]` matches upstream `hrm_nocarry_more_bp_no_x`. Left-padding to length
             # `L_cycles` is performed inside [`HrmTextModel`] since it depends on `L_cycles`.

--- a/src/transformers/models/hrm_text/configuration_hrm_text.py
+++ b/src/transformers/models/hrm_text/configuration_hrm_text.py
@@ -122,7 +122,7 @@ class HrmTextConfig(PreTrainedConfig):
     def __post_init__(self, **kwargs):
         # hrm_text always carries an explicit head_dim (default 128) and never derives it from
         # hidden_size / num_attention_heads, so the divisibility check in validate_architecture
-        # never applies to this model.
+        # (inherited from LlamaConfig) never applies to this model.
         self._head_dim_was_explicit = self.head_dim is not None
 
         if self.L_bp_cycles is None:

--- a/src/transformers/models/hrm_text/modular_hrm_text.py
+++ b/src/transformers/models/hrm_text/modular_hrm_text.py
@@ -103,6 +103,11 @@ class HrmTextConfig(LlamaConfig):
     num_layers_per_stack: int | None = None  # Usually inferred in post init
 
     def __post_init__(self, **kwargs):
+        # hrm_text always carries an explicit head_dim (default 128) and never derives it from
+        # hidden_size / num_attention_heads, so the divisibility check in validate_architecture
+        # (inherited from LlamaConfig) never applies to this model.
+        self._head_dim_was_explicit = self.head_dim is not None
+
         if self.L_bp_cycles is None:
             # Default `[2]` matches upstream `hrm_nocarry_more_bp_no_x`. Left-padding to length
             # `L_cycles` is performed inside [`HrmTextModel`] since it depends on `L_cycles`.

--- a/src/transformers/models/jais2/configuration_jais2.py
+++ b/src/transformers/models/jais2/configuration_jais2.py
@@ -102,6 +102,10 @@ class Jais2Config(PreTrainedConfig):
     layer_norm_eps: float = 1e-5
 
     def __post_init__(self, **kwargs):
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -111,10 +115,14 @@ class Jais2Config(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/src/transformers/models/llama/configuration_llama.py
+++ b/src/transformers/models/llama/configuration_llama.py
@@ -105,6 +105,10 @@ class LlamaConfig(PreTrainedConfig):
     head_dim: int | None = None
 
     def __post_init__(self, **kwargs):
+        # Track whether head_dim was supplied by the caller before we derive a fallback.
+        # validate_architecture uses this to skip the hidden_size divisibility check when
+        # the caller has explicitly defined the per-head dimension.
+        self._head_dim_was_explicit = self.head_dim is not None
         if self.head_dim is None:
             self.head_dim = self.hidden_size // self.num_attention_heads
         if self.num_key_value_heads is None:
@@ -114,10 +118,14 @@ class LlamaConfig(PreTrainedConfig):
 
     def validate_architecture(self):
         """Part of `@strict`-powered validation. Validates the architecture of the config."""
-        if self.hidden_size % self.num_attention_heads != 0:
+        # When head_dim is derived (not user-supplied), hidden_size must be exactly divisible
+        # by num_attention_heads so that head_dim = hidden_size / num_attention_heads is lossless.
+        # When head_dim is supplied explicitly the attention projections are sized from
+        # num_attention_heads * head_dim, so the divisibility constraint does not apply.
+        if self.hidden_size % self.num_attention_heads != 0 and not self._head_dim_was_explicit:
             raise ValueError(
                 f"The hidden size ({self.hidden_size}) is not a multiple of the number of attention "
-                f"heads ({self.num_attention_heads})."
+                f"heads ({self.num_attention_heads}). Pass an explicit `head_dim` to override."
             )
 
 

--- a/tests/models/llama/test_modeling_llama.py
+++ b/tests/models/llama/test_modeling_llama.py
@@ -58,6 +58,64 @@ class LlamaModelTest(CausalLMModelTest, unittest.TestCase):
     _torch_compile_train_cls = LlamaForCausalLM if is_torch_available() else None
 
 
+class LlamaConfigTest(unittest.TestCase):
+    """Tests for LlamaConfig validation logic."""
+
+    def test_explicit_head_dim_allows_non_divisible_hidden_size(self):
+        """Explicit head_dim should bypass the hidden_size % num_attention_heads check."""
+        from transformers import LlamaConfig
+
+        # 512 % 9 != 0, but head_dim is explicitly provided — must not raise.
+        config = LlamaConfig(
+            vocab_size=99,
+            hidden_size=512,
+            intermediate_size=1024,
+            num_hidden_layers=1,
+            num_attention_heads=9,
+            num_key_value_heads=1,
+            head_dim=56,
+        )
+        self.assertEqual(config.head_dim, 56)
+        self.assertTrue(config._head_dim_was_explicit)
+
+    def test_derived_head_dim_requires_divisible_hidden_size(self):
+        """Without an explicit head_dim the divisibility constraint must still be enforced."""
+        import huggingface_hub.errors as hf_errors
+
+        from transformers import LlamaConfig
+
+        with self.assertRaises(hf_errors.StrictDataclassClassValidationError):
+            LlamaConfig(
+                vocab_size=99,
+                hidden_size=512,
+                intermediate_size=1024,
+                num_hidden_layers=1,
+                num_attention_heads=9,  # 512 % 9 != 0, no explicit head_dim
+            )
+
+    def test_explicit_head_dim_roundtrip(self):
+        """A config with an explicit head_dim should survive a save/load cycle."""
+        import tempfile
+
+        from transformers import LlamaConfig
+
+        config = LlamaConfig(
+            vocab_size=99,
+            hidden_size=512,
+            intermediate_size=1024,
+            num_hidden_layers=1,
+            num_attention_heads=9,
+            num_key_value_heads=1,
+            head_dim=56,
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config.save_pretrained(tmpdir)
+            reloaded = LlamaConfig.from_pretrained(tmpdir)
+        self.assertEqual(reloaded.head_dim, 56)
+        # head_dim is present in the JSON so it is still treated as explicit on reload.
+        self.assertTrue(reloaded._head_dim_was_explicit)
+
+
 @require_torch_accelerator
 class LlamaIntegrationTest(unittest.TestCase):
     def setup(self):


### PR DESCRIPTION
<!-- ci-dashboard-badge:start -->
[![CPU CI](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46211&event=pr-ci)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46211) [![GPU run-slow](https://transformers-ci.lor-e.huggingface.cool/badge/pr?pr=46211&event=run-slow)](https://transformers-ci.lor-e.huggingface.cool/d/pytest-observability-by-pr/pytest-observability-branch?var-pr=46211)
<!-- ci-dashboard-badge:end -->

## What this fixes

`LlamaConfig.validate_architecture()` unconditionally checks `hidden_size % num_attention_heads == 0`, but `LlamaAttention` already sizes its Q/K/V projections from `num_attention_heads * head_dim`, not from `hidden_size`. When `head_dim` is user-supplied the divisibility constraint is unnecessary and incorrectly blocks valid configs (issue #46082).

Reproduction (before fix):
```python
LlamaConfig(hidden_size=512, num_attention_heads=9, head_dim=56)
# StrictDataclassClassValidationError: The hidden size (512) is not a multiple of the number of attention heads (9).
```

## Approach

Track whether `head_dim` was user-supplied in `__post_init__` via a private `_head_dim_was_explicit` sentinel — set **before** the `None`-fallback so it captures caller intent rather than the derived value. Gate the `ValueError` on `not _head_dim_was_explicit`.

The sentinel is a private attribute (not a declared dataclass field), so it is excluded from JSON serialisation. On save/reload `head_dim` is present in the JSON, so `__post_init__` correctly re-derives `_head_dim_was_explicit = True` — no round-trip regression.

## Tests

Three new tests in `LlamaConfigTest`:
1. Explicit `head_dim` with non-divisible `hidden_size` → no error
2. No `head_dim`, non-divisible `hidden_size` → still raises
3. Save/reload roundtrip with explicit `head_dim` → works

```
python -m pytest tests/models/llama/test_modeling_llama.py::LlamaConfigTest -v
# 3 passed
```

Full suite (`tests/models/llama/test_modeling_llama.py`) shows 0 regressions vs `main` — 8 pre-existing FSDP/TP failures present identically on both branches.

Coordinated at: #46082 (no existing PR addresses this issue)

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (claude-sonnet-4-6)

Generated-by: Claude Code (claude-sonnet-4-6) following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)