### PR TITLE
[`Configs`] Fix layer type validation to include its mlp counterpart

### DIFF
--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -485,7 +485,7 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
             if not (layers is not None and hasattr(self, "num_hidden_layers")):
                 return
             elif not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in layers):
-                raise ValueError(f"The `layer_types` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
+                raise ValueError(f"The `(mlp)_layer_types` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
             elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
                 raise ValueError(
                     f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of layer types "

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -485,10 +485,10 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
             if not (layers is not None and hasattr(self, "num_hidden_layers")):
                 return
             elif not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in layers):
-                raise ValueError(f"The `(mlp)_layer_types` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
+                raise ValueError(f"The `{layer_types}` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
             elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
                 raise ValueError(
-                    f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of layer types "
+                    f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of `{layer_types}` "
                     f"({len(layers)})"
                 )
 

--- a/src/transformers/configuration_utils.py
+++ b/src/transformers/configuration_utils.py
@@ -480,15 +480,17 @@ class PreTrainedConfig(PushToHubMixin, RotaryEmbeddingConfigMixin):
 
     def validate_layer_type(self):
         """Check that `layer_types` is correctly defined."""
-        if not (getattr(self, "layer_types", None) is not None and hasattr(self, "num_hidden_layers")):
-            return
-        elif not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in self.layer_types):
-            raise ValueError(f"The `layer_types` entries must be in {ALLOWED_LAYER_TYPES} but got {self.layer_types}")
-        elif self.num_hidden_layers is not None and self.num_hidden_layers != len(self.layer_types):
-            raise ValueError(
-                f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of layer types "
-                f"({len(self.layer_types)})"
-            )
+        for layer_types in ["layer_types", "mlp_layer_types"]:
+            layers = getattr(self, layer_types, None)
+            if not (layers is not None and hasattr(self, "num_hidden_layers")):
+                return
+            elif not all(layer_type in ALLOWED_LAYER_TYPES for layer_type in layers):
+                raise ValueError(f"The `layer_types` entries must be in {ALLOWED_LAYER_TYPES} but got {layers}")
+            elif self.num_hidden_layers is not None and self.num_hidden_layers != len(layers):
+                raise ValueError(
+                    f"`num_hidden_layers` ({self.num_hidden_layers}) must be equal to the number of layer types "
+                    f"({len(layers)})"
+                )
 
     @property
     def rope_scaling(self):


### PR DESCRIPTION
Slight rewrite to make the validation of layer type to include mlp layer types (2 separate lists - 1 is attn (e.g. full vs swa) 1 is mlp (dense vs sparse)). Probably got lost in the refactor for strict validation