### PR TITLE
fix model parallel device mismatch issue in `create_bidirectional_mask`

### DIFF
--- a/src/transformers/masking_utils.py
+++ b/src/transformers/masking_utils.py
@@ -1058,7 +1058,11 @@ def create_bidirectional_mask(
         return attention_mask
 
     embeds = encoder_hidden_states if encoder_hidden_states is not None else inputs_embeds
-    batch_size, dtype, device = embeds.shape[0], embeds.dtype, embeds.device
+    batch_size, dtype = embeds.shape[0], embeds.dtype
+    # Use `inputs_embeds.device` to stay consistent with `_preprocess_mask_arguments`, which moves the 2D
+    # `attention_mask` to that device. In model parallel setups, `encoder_hidden_states` may live on a different
+    # device than `inputs_embeds` (e.g. cross-attention from a decoder to encoder states).
+    device = inputs_embeds.device
     mask_factory_function = bidirectional_mask_function
     mask_interface = ALL_MASK_ATTENTION_FUNCTIONS[config._attn_implementation]
 


### PR DESCRIPTION
In `create_bidirectional_mask` func, we need to keep the device align with input_embeds.
e.g. in this case:
`tests/models/t5gemma/test_modeling_t5gemma.py::T5GemmaModelTest::test_model_parallel_beam_search`,
`encoder_hidden_states` may live on a different device than `inputs_embeds` (e.g. cross-attention from a decoder to encoder states) in model parallel scene. I think it may be a common bug for decoder-encoder model family. And this PR tries to solve it.
@CyrilVallez @vasqu pls help review, thx!