### PR TITLE
Fix inverted assertion in remove_handler

### DIFF
--- a/src/transformers/utils/logging.py
+++ b/src/transformers/utils/logging.py
@@ -264,7 +264,7 @@ def remove_handler(handler: logging.Handler) -> None:
 
     _configure_library_root_logger()
 
-    assert handler is not None and handler not in _get_library_root_logger().handlers
+    assert handler is not None and handler in _get_library_root_logger().handlers
     _get_library_root_logger().removeHandler(handler)
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes an inverted assertion in `remove_handler()` in `src/transformers/utils/logging.py`.

The current assert checks `handler not in _get_library_root_logger().handlers`, which raises `AssertionError` when calling `remove_handler` with a **registered** handler (the valid use case), while silently passing for **unregistered** handlers (the invalid use case). This one-word fix inverts the condition to correctly validate that the handler exists before removal.

**Bug introduced in:** #10633 (2021-03-10)
**Previously reported in:** #21506 (never fixed)

### Before
```python
assert handler is not None and handler not in _get_library_root_logger().handlers
```
- `remove_handler(registered_handler)` raises `AssertionError`
- `remove_handler(unknown_handler)` passes silently

### After
```python
assert handler is not None and handler in _get_library_root_logger().handlers
```
- `remove_handler(registered_handler)` succeeds
- `remove_handler(unknown_handler)` raises `AssertionError`

Fixes #21506