### PR TITLE
DOC: fix incorrect parameter name in set_training docstring (Fixes #46231)

### DIFF
--- a/src/transformers/training_args.py
+++ b/src/transformers/training_args.py
@@ -2180,7 +2180,7 @@ class TrainingArguments:
             weight_decay (`float`, *optional*, defaults to 0):
                 The weight decay to apply (if not zero) to all layers except all bias and LayerNorm weights in the
                 optimizer.
-            num_train_epochs(`float`, *optional*, defaults to 3.0):
+            num_epochs (`float`, *optional*, defaults to 3):
                 Total number of training epochs to perform (if not an integer, will perform the decimal part percents
                 of the last epoch before stopping training).
             max_steps (`int`, *optional*, defaults to -1):


### PR DESCRIPTION
## Description

Fixes #46231.

The `Args` section of `TrainingArguments.set_training()` documents the parameter as `num_train_epochs`, but the actual parameter in the function signature is `num_epochs`. A user following the documentation would write:

```python
args.set_training(num_train_epochs=5)
