### PR TITLE
Fix `StaticCache` building an empty layer list when `num_kv_shared_layers == 0`

### DIFF
--- a/src/transformers/cache_utils.py
+++ b/src/transformers/cache_utils.py
@@ -1392,8 +1392,9 @@ class StaticCache(Cache):
             else:
                 layer_types = ["full_attention" for _ in range(config.num_hidden_layers)]
         # Some models have shared layers thus no cache is needed for them (e.g. Gemma3n)
-        if hasattr(config, "num_kv_shared_layers"):
-            layer_types = layer_types[: -config.num_kv_shared_layers]
+        num_kv_shared_layers = getattr(config, "num_kv_shared_layers", 0)
+        if num_kv_shared_layers > 0:
+            layer_types = layer_types[:-num_kv_shared_layers]
 
         sliding_layer_types = {
             name


### PR DESCRIPTION
# What does this PR do?

`StaticCache.__init__` shortens its per-layer cache list whenever the text config exposes a `num_kv_shared_layers` attribute:

```python
if hasattr(config, "num_kv_shared_layers"):
    layer_types = layer_types[: -config.num_kv_shared_layers]
```

For configs that set `num_kv_shared_layers = 0` this hits the Python `[:-0]`, i.e. `[]`, not the full list. The resulting `StaticCache` is built with an empty `layers` list and the first attention layer crashes on `past_key_values.update(...)`:

```
File ".../transformers/cache_utils.py", line 993, in update
    keys, values = self.layers[layer_idx].update(key_states, value_states, *args, **kwargs)
                   ~~~~~~~~~~~^^^^^^^^^^^
IndexError: list index out of range
```
This PR guards the slice so it only runs when `num_kv_shared_layers > 0`.

A way to check that this is relevant, is to test it with model `google/gemma-4-26B-A4B-it` (I found the issue while testing that).

```python
from transformers import AutoConfig
from transformers.cache_utils import StaticCache

config = AutoConfig.from_pretrained("google/gemma-4-26B-A4B-it")
cache = StaticCache(config=config, max_cache_len=8)
print(len(cache.layers))  # main: 0   |   this PR: 30
```

- [x] I confirm that this is not a pure code agent PR.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?


