### PR TITLE
Fix path traversal when saving Bark voice preset embeddings

### DIFF
--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -17,7 +17,6 @@ Processor class for Bark
 
 import json
 import os
-from pathlib import Path
 
 import numpy as np
 
@@ -168,7 +167,19 @@ class BarkProcessor(ProcessorMixin):
     def _reject_path_traversal(base_dir: str, target_path: str, offending_value: str):
         # base_dir/target_path derive from the untrusted speaker_embeddings json; allow nested
         # subdirectories but reject any value that escapes base_dir (path traversal, CWE-22).
-        if not Path(target_path).resolve().is_relative_to(Path(base_dir).resolve()):
+        # The only untrusted input is the relative path string, so this is a purely lexical check:
+        # we use os.path.abspath (not realpath/Path.resolve) and must NOT follow symlinks here.
+        # When repo_or_path points at a populated HF cache, the referenced snapshot files are
+        # symlinks into a sibling blobs/ directory that sits outside base_dir, so a resolve()-based
+        # containment check would wrongly reject perfectly legitimate loads.
+        base = os.path.abspath(base_dir)
+        target = os.path.abspath(target_path)
+        try:
+            contained = os.path.commonpath([base, target]) == base
+        except ValueError:
+            # e.g. different Windows drives: definitely an escape.
+            contained = False
+        if not contained:
             raise ValueError(f"Invalid voice preset path: {offending_value!r}")
 
     def _load_voice_preset(self, voice_preset: str | None = None, **kwargs):

--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -146,16 +146,14 @@ class BarkProcessor(ProcessorMixin):
 
             embeddings_dict["repo_or_path"] = save_directory
 
-            embeddings_subdir = os.path.join(embeddings_dict["repo_or_path"], speaker_embeddings_directory)
+            embeddings_subdir = os.path.join(save_directory, speaker_embeddings_directory)
             for prompt_key in self.available_voice_presets:
                 voice_preset = self._load_voice_preset(prompt_key)
 
                 tmp_dict = {}
                 for key in self.speaker_embeddings[prompt_key]:
                     target_filepath = os.path.join(embeddings_subdir, f"{prompt_key}_{key}")
-                    # prompt_key is an untrusted dict key from speaker_embeddings_path.json; reject path traversal (CWE-22)
-                    if Path(target_filepath).resolve().parent != Path(embeddings_subdir).resolve():
-                        raise ValueError(f"Invalid voice preset name: {prompt_key!r}")
+                    self._reject_path_traversal(embeddings_subdir, target_filepath, prompt_key)
                     np.save(target_filepath, voice_preset[key], allow_pickle=False)
                     tmp_dict[key] = os.path.join(speaker_embeddings_directory, f"{prompt_key}_{key}.npy")
 
@@ -166,17 +164,28 @@ class BarkProcessor(ProcessorMixin):
 
         super().save_pretrained(save_directory, push_to_hub, **kwargs)
 
+    @staticmethod
+    def _reject_path_traversal(base_dir: str, target_path: str, offending_value: str):
+        # base_dir/target_path derive from the untrusted speaker_embeddings json; allow nested
+        # subdirectories but reject any value that escapes base_dir (path traversal, CWE-22).
+        if not Path(target_path).resolve().is_relative_to(Path(base_dir).resolve()):
+            raise ValueError(f"Invalid voice preset path: {offending_value!r}")
+
     def _load_voice_preset(self, voice_preset: str | None = None, **kwargs):
         voice_preset_paths = self.speaker_embeddings[voice_preset]
 
         voice_preset_dict = {}
         token = kwargs.get("token")
+        repo_or_path = self.speaker_embeddings.get("repo_or_path", "/")
         for key in ["semantic_prompt", "coarse_prompt", "fine_prompt"]:
             if key not in voice_preset_paths:
                 raise ValueError(
                     f"Voice preset unrecognized, missing {key} as a key in self.speaker_embeddings[{voice_preset}]."
                 )
 
+            self._reject_path_traversal(
+                repo_or_path, os.path.join(repo_or_path, voice_preset_paths[key]), voice_preset_paths[key]
+            )
             path = cached_file(
                 self.speaker_embeddings.get("repo_or_path", "/"),
                 voice_preset_paths[key],

--- a/src/transformers/models/bark/processing_bark.py
+++ b/src/transformers/models/bark/processing_bark.py
@@ -17,6 +17,7 @@ Processor class for Bark
 
 import json
 import os
+from pathlib import Path
 
 import numpy as np
 
@@ -145,18 +146,17 @@ class BarkProcessor(ProcessorMixin):
 
             embeddings_dict["repo_or_path"] = save_directory
 
+            embeddings_subdir = os.path.join(embeddings_dict["repo_or_path"], speaker_embeddings_directory)
             for prompt_key in self.available_voice_presets:
                 voice_preset = self._load_voice_preset(prompt_key)
 
                 tmp_dict = {}
                 for key in self.speaker_embeddings[prompt_key]:
-                    np.save(
-                        os.path.join(
-                            embeddings_dict["repo_or_path"], speaker_embeddings_directory, f"{prompt_key}_{key}"
-                        ),
-                        voice_preset[key],
-                        allow_pickle=False,
-                    )
+                    target_filepath = os.path.join(embeddings_subdir, f"{prompt_key}_{key}")
+                    # prompt_key is an untrusted dict key from speaker_embeddings_path.json; reject path traversal (CWE-22)
+                    if Path(target_filepath).resolve().parent != Path(embeddings_subdir).resolve():
+                        raise ValueError(f"Invalid voice preset name: {prompt_key!r}")
+                    np.save(target_filepath, voice_preset[key], allow_pickle=False)
                     tmp_dict[key] = os.path.join(speaker_embeddings_directory, f"{prompt_key}_{key}.npy")
 
                 embeddings_dict[prompt_key] = tmp_dict

--- a/tests/models/bark/test_processing_bark.py
+++ b/tests/models/bark/test_processing_bark.py
@@ -181,6 +181,43 @@ class BarkProcessorTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 processor._load_voice_preset("evil")
 
+    def test_load_voice_preset_allows_symlinked_cache_files(self):
+        # The path-traversal guard must be lexical, not symlink-resolving: the HF hub cache stores each
+        # snapshot file as a symlink into a sibling `blobs/` dir (snapshots/<rev>/f -> ../../blobs/<sha>),
+        # which sits outside repo_or_path. A resolve()/realpath()-based check would follow that symlink
+        # out of repo_or_path and wrongly reject a legitimate load, so loading must still succeed here.
+        tokenizer = self.get_tokenizer()
+        seq_len = 5
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            # Mimic the hub cache layout: models--org--model/{blobs,snapshots/<rev>/...}.
+            repo_cache = os.path.join(tmp_dir_name, "models--dummy--bark")
+            blobs_dir = os.path.join(repo_cache, "blobs")
+            snapshot_dir = os.path.join(repo_cache, "snapshots", "deadbeef")
+            os.makedirs(blobs_dir)
+            os.makedirs(snapshot_dir)
+
+            arrays = {
+                "semantic_prompt": np.ones(seq_len),
+                "coarse_prompt": np.ones((2, seq_len)),
+                "fine_prompt": np.ones((8, seq_len)),
+            }
+            voice_preset_paths = {}
+            for key, array in arrays.items():
+                blob = os.path.join(blobs_dir, key)  # real content lives in blobs/
+                np.save(blob, array, allow_pickle=False)
+                # ...and the snapshot exposes it as a relative symlink, exactly like the real cache.
+                link = os.path.join(snapshot_dir, f"{key}.npy")
+                os.symlink(os.path.relpath(blob + ".npy", snapshot_dir), link)
+                voice_preset_paths[key] = f"{key}.npy"
+            self.assertTrue(os.path.islink(os.path.join(snapshot_dir, "semantic_prompt.npy")))
+
+            speaker_embeddings = {"repo_or_path": snapshot_dir, "preset": voice_preset_paths}
+            processor = BarkProcessor(tokenizer=tokenizer, speaker_embeddings=speaker_embeddings)
+
+            voice_preset = processor._load_voice_preset("preset")
+            for key, array in arrays.items():
+                self.assertTrue(np.array_equal(voice_preset[key], array))
+
     def test_tokenizer(self):
         tokenizer = self.get_tokenizer()
 

--- a/tests/models/bark/test_processing_bark.py
+++ b/tests/models/bark/test_processing_bark.py
@@ -115,10 +115,8 @@ class BarkProcessorTest(unittest.TestCase):
         inputs = processor(text=self.input_string, voice_preset=self.voice_preset)
 
     def test_speaker_embeddings_saving_rejects_path_traversal(self):
-        # A malicious speaker_embeddings_path.json dict key must not be usable to escape the save directory
-        # and write attacker-controlled content to an arbitrary path (path traversal, CWE-22). The dict key
-        # is used verbatim as a `<name>_<inner>.npy` filename, so `save_pretrained` must reject names that
-        # are not plain filenames instead of silently writing outside the target directory.
+        # A malicious speaker_embeddings_path.json dict key must not be usable to escape the save
+        # directory and write attacker-controlled content to an arbitrary path (path traversal, CWE-22).
         tokenizer = self.get_tokenizer()
         seq_len = 5
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -129,21 +127,59 @@ class BarkProcessorTest(unittest.TestCase):
             np.save(os.path.join(tmp_dir_name, "f.npy"), np.ones((8, seq_len)))
             speaker_embeddings = {
                 "repo_or_path": tmp_dir_name,
-                "../../PWNED": {
-                    "semantic_prompt": "s.npy",
-                    "coarse_prompt": "c.npy",
-                    "fine_prompt": "f.npy",
-                },
+                "../../PWNED": {"semantic_prompt": "s.npy", "coarse_prompt": "c.npy", "fine_prompt": "f.npy"},
             }
             processor = BarkProcessor(tokenizer=tokenizer, speaker_embeddings=speaker_embeddings)
 
             save_dir = os.path.join(tmp_dir_name, "save")
-            # Where the "../../PWNED" key would land if traversal succeeded:
-            # save/speaker_embeddings/../../PWNED_semantic_prompt.npy -> tmp_dir_name/PWNED_semantic_prompt.npy
+            # Where the "../../PWNED" key would land if traversal succeeded.
             canary = os.path.join(tmp_dir_name, "PWNED_semantic_prompt.npy")
             with self.assertRaises(ValueError):
                 processor.save_pretrained(save_dir)
             self.assertFalse(os.path.exists(canary))
+
+    def test_speaker_embeddings_saving_allows_subdirectories(self):
+        # Voice presets are legitimately stored in subdirectories (e.g. the `v2/...` presets in
+        # ylacombe/bark-large), so saving a nested key must be allowed - the guard rejects escapes only.
+        tokenizer = self.get_tokenizer()
+        seq_len = 5
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            np.save(os.path.join(tmp_dir_name, "s.npy"), np.ones(seq_len))
+            np.save(os.path.join(tmp_dir_name, "c.npy"), np.ones((2, seq_len)))
+            np.save(os.path.join(tmp_dir_name, "f.npy"), np.ones((8, seq_len)))
+            speaker_embeddings = {
+                "repo_or_path": tmp_dir_name,
+                "v2/en_speaker_0": {"semantic_prompt": "s.npy", "coarse_prompt": "c.npy", "fine_prompt": "f.npy"},
+            }
+            processor = BarkProcessor(tokenizer=tokenizer, speaker_embeddings=speaker_embeddings)
+
+            save_dir = os.path.join(tmp_dir_name, "save")
+            processor.save_pretrained(save_dir)
+            self.assertTrue(
+                os.path.exists(os.path.join(save_dir, "speaker_embeddings", "v2", "en_speaker_0_semantic_prompt.npy"))
+            )
+
+    def test_load_voice_preset_rejects_path_traversal(self):
+        # The per-prompt paths in speaker_embeddings_path.json are also untrusted and are joined onto
+        # repo_or_path before being read, so a "../x" value must be rejected before the file is loaded.
+        tokenizer = self.get_tokenizer()
+        seq_len = 5
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            repo_dir = os.path.join(tmp_dir_name, "repo")
+            os.makedirs(repo_dir)
+            # A readable .npy outside the repo dir that the traversal would otherwise reach.
+            np.save(os.path.join(tmp_dir_name, "PWNED.npy"), np.ones(seq_len))
+            speaker_embeddings = {
+                "repo_or_path": repo_dir,
+                "evil": {
+                    "semantic_prompt": "../PWNED.npy",
+                    "coarse_prompt": "../PWNED.npy",
+                    "fine_prompt": "../PWNED.npy",
+                },
+            }
+            processor = BarkProcessor(tokenizer=tokenizer, speaker_embeddings=speaker_embeddings)
+            with self.assertRaises(ValueError):
+                processor._load_voice_preset("evil")
 
     def test_tokenizer(self):
         tokenizer = self.get_tokenizer()

--- a/tests/models/bark/test_processing_bark.py
+++ b/tests/models/bark/test_processing_bark.py
@@ -114,6 +114,37 @@ class BarkProcessorTest(unittest.TestCase):
         # test loading voice preset from the hub
         inputs = processor(text=self.input_string, voice_preset=self.voice_preset)
 
+    def test_speaker_embeddings_saving_rejects_path_traversal(self):
+        # A malicious speaker_embeddings_path.json dict key must not be usable to escape the save directory
+        # and write attacker-controlled content to an arbitrary path (path traversal, CWE-22). The dict key
+        # is used verbatim as a `<name>_<inner>.npy` filename, so `save_pretrained` must reject names that
+        # are not plain filenames instead of silently writing outside the target directory.
+        tokenizer = self.get_tokenizer()
+        seq_len = 5
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            # Plant the per-prompt npy files the malicious "repo" claims to provide so that
+            # `_load_voice_preset` succeeds and we reach the vulnerable `np.save` call.
+            np.save(os.path.join(tmp_dir_name, "s.npy"), np.ones(seq_len))
+            np.save(os.path.join(tmp_dir_name, "c.npy"), np.ones((2, seq_len)))
+            np.save(os.path.join(tmp_dir_name, "f.npy"), np.ones((8, seq_len)))
+            speaker_embeddings = {
+                "repo_or_path": tmp_dir_name,
+                "../../PWNED": {
+                    "semantic_prompt": "s.npy",
+                    "coarse_prompt": "c.npy",
+                    "fine_prompt": "f.npy",
+                },
+            }
+            processor = BarkProcessor(tokenizer=tokenizer, speaker_embeddings=speaker_embeddings)
+
+            save_dir = os.path.join(tmp_dir_name, "save")
+            # Where the "../../PWNED" key would land if traversal succeeded:
+            # save/speaker_embeddings/../../PWNED_semantic_prompt.npy -> tmp_dir_name/PWNED_semantic_prompt.npy
+            canary = os.path.join(tmp_dir_name, "PWNED_semantic_prompt.npy")
+            with self.assertRaises(ValueError):
+                processor.save_pretrained(save_dir)
+            self.assertFalse(os.path.exists(canary))
+
     def test_tokenizer(self):
         tokenizer = self.get_tokenizer()
 


### PR DESCRIPTION
The speaker_embeddings dict that BarkProcessor.from_pretrained loads from the model repo's speaker_embeddings_path.json is fully untrusted, but its top-level keys are written out verbatim as `<prompt_key>_<inner>.npy` files by save_pretrained. A key like "../../foo" flows straight into os.path.join(save_directory, speaker_embeddings_directory, f"{prompt_key}_{key}") and lets a saved repo write a file outside the target directory.

This is a sibling of the chat_template path traversal fixed in #46191 — same trust-boundary mistake (config-loaded dict key used verbatim as a filename component), different sink (`np.save` instead of `open(..., "w")`), different config file (`speaker_embeddings_path.json` instead of `tokenizer_config.json`).

Before calling np.save, reject any prompt_key whose resolved path escapes the speaker_embeddings subdirectory, mirroring the check added in #46191. Add a regression test.

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)

## Code Agent Policy

The Transformers repo is currently being overwhelmed by a large number of PRs and issue comments written by
code agents. We are currently bottlenecked by our ability to review and respond to them. As a result, 
**we ask that new users do not submit pure code agent PRs** at this time. 
You may use code agents in drafting or to help you diagnose issues. We'd also ask autonomous "OpenClaw"-like agents
not to open any PRs or issues for the moment.

PRs that appear to be fully agent-written will probably be closed without review, and we may block users who do this
repeatedly or maliciously. 

This is a rapidly-evolving situation that's causing significant shockwaves in the open-source community. As a result, 
this policy is likely to be updated regularly in the near future. For more information, please read [`CONTRIBUTING.md`](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md).

- [ ] I confirm that this is not a pure code agent PR.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#create-a-pull-request),
      Pull Request section?
- [ ] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link
      to it if that's the case.
- [ ] Did you make sure to update the documentation with your changes? Here are the
      [documentation guidelines](https://github.com/huggingface/transformers/tree/main/docs), and
      [here are tips on formatting docstrings](https://github.com/huggingface/transformers/tree/main/docs#writing-source-documentation).
- [ ] Did you write any new necessary tests?


## Who can review?

Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR.

<!-- Your PR will be replied to more quickly if you can figure out the right person to tag with @

 If you know how to use git blame, that is the easiest way, otherwise, here is a rough guide of **who to tag**.
 Please tag fewer than 3 people.

Models:

- text models: @ArthurZucker @Cyrilvallez
- vision models: @yonigozlan @molbap
- audio models: @eustlb @ebezzam @vasqu
- multimodal models: @zucchini-nlp
- graph models: @clefourrier

Library:

- generate: @zucchini-nlp (visual-language models) or @gante (all others)
- continuous batching: @remi-or @ArthurZucker @McPatate
- pipelines: @Rocketknight1
- tokenizers: @ArthurZucker and @itazap
- trainer: @SunMarc
- attention: @vasqu @ArthurZucker @CyrilVallez
- model loading (from pretrained, etc): @CyrilVallez
- distributed: @3outeille @ArthurZucker
- CIs: @ydshieh

Integrations:

- ray/raytune: @richardliaw, @amogkam
- Big Model Inference: @SunMarc
- quantization: @SunMarc
- kernels: @drbh
- peft: @BenjaminBossan @githubnemo

Devices/Backends:

- AMD ROCm: @ivarflakstad
- Intel XPU: @IlyasMoutawwakil
- Ascend NPU: @ivarflakstad 

Documentation: @stevhliu

Research projects are not maintained and should be taken as is.

 -->