### PR TITLE
Enable push event (to main) for PR CI workflow

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -2,6 +2,9 @@ name: PR CI
 
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -13,7 +16,7 @@ permissions:
 jobs:
   pr-ci:
     # Allow `ydshieh2` for testing during development
-    if: contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) || github.event.pull_request.user.login == 'ydshieh2'
+    if: github.event_name == 'push' || contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) || github.event.pull_request.user.login == 'ydshieh2'
     uses: huggingface/transformers-test-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@91d590c4f744e4564a8ae0d3810068c8a35b939e # main
     secrets:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}


### PR DESCRIPTION
# What does this PR do?

As discussed with @tarekziade offline: we need this to have more runs so to work on the dashboard.

But, we also need this: same as CircleCI which are runs on both PR and push event.