### PR TITLE
Use `main` instead of commit SHA for now

### DIFF
--- a/.github/workflows/pr-ci-caller.yml
+++ b/.github/workflows/pr-ci-caller.yml
@@ -17,7 +17,8 @@ jobs:
   pr-ci:
     # Allow `ydshieh2` for testing during development
     if: github.event_name == 'push' || contains(fromJSON('["MEMBER","OWNER","COLLABORATOR"]'), github.event.pull_request.author_association) || github.event.pull_request.user.login == 'ydshieh2'
-    uses: huggingface/transformers-test-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@91d590c4f744e4564a8ae0d3810068c8a35b939e # main
+    # DON'T use commit sha here before the CI migration is finished
+    uses: huggingface/transformers-test-ci/.github/workflows/pr-ci_dynamic_caller_example.yml@main # main
     secrets:
       OTEL_EXPORTER_OTLP_ENDPOINT: ${{ secrets.OTEL_EXPORTER_OTLP_ENDPOINT }}
       OTEL_TOKEN: ${{ secrets.OTEL_TOKEN }}


### PR DESCRIPTION
# What does this PR do?

While the CI migration work is still WIP.
