### PR TITLE
fix: handle anchored FP8 weight source patterns

### DIFF
--- a/src/transformers/quantizers/quantizer_finegrained_fp8.py
+++ b/src/transformers/quantizers/quantizer_finegrained_fp8.py
@@ -208,11 +208,11 @@ class FineGrainedFP8HfQuantizer(HfQuantizer):
             if not isinstance(conv, WeightConverter):
                 updated.append(conv)
                 continue
-            weight_sources = [p for p in conv.source_patterns if p.endswith(".weight")]
+            weight_sources = [p for p in conv.source_patterns if p.rstrip("$").endswith(".weight")]
             if weight_sources:
-                anchored_weight = [p + "$" for p in weight_sources]
-                scale_sources = [p[: -len(".weight")] + ".weight_scale_inv$" for p in weight_sources]
-                other = [p for p in conv.source_patterns if not p.endswith(".weight")]
+                anchored_weight = [p.rstrip("$") + "$" for p in weight_sources]
+                scale_sources = [p.rstrip("$")[: -len(".weight")] + ".weight_scale_inv$" for p in weight_sources]
+                other = [p for p in conv.source_patterns if not p.rstrip("$").endswith(".weight")]
                 new_sources = anchored_weight + scale_sources + other
                 new_ops = [Fp8Dequantize(self)] + list(conv.operations)
                 conv = WeightConverter(

--- a/tests/quantization/finegrained_fp8/test_fp8.py
+++ b/tests/quantization/finegrained_fp8/test_fp8.py
@@ -50,6 +50,33 @@ def _patch_no_accelerator():
         yield
 
 
+@unittest.skipIf(not is_torch_available(), "test requires PyTorch")
+class FineGrainedFP8WeightConversionTest(unittest.TestCase):
+    def test_dequantize_weight_conversion_handles_anchored_weight_sources(self):
+        from transformers.core_model_loading import WeightConverter
+        from transformers.integrations.finegrained_fp8 import Fp8Dequantize
+
+        config = FineGrainedFP8Config(dequantize=True)
+        quantizer = FineGrainedFP8HfQuantizer(config)
+        quantizer.pre_quantized = True
+        converter = WeightConverter(
+            source_patterns=["mlp.experts.*.w2.weight$", "mlp.experts.*.w2.bias"],
+            target_patterns="mlp.experts.*.down_proj.weight",
+            operations=[Fp8Dequantize(quantizer)],
+        )
+
+        updated = quantizer.update_weight_conversions([converter])
+        converted = next(
+            conv
+            for conv in updated
+            if isinstance(conv, WeightConverter) and conv.target_patterns == ["mlp.experts.*.down_proj.weight"]
+        )
+
+        self.assertIn("mlp.experts.*.w2.weight$", converted.source_patterns)
+        self.assertIn("mlp.experts.*.w2.weight_scale_inv$", converted.source_patterns)
+        self.assertIn("mlp.experts.*.w2.bias", converted.source_patterns)
+
+
 @require_torch_accelerator
 class FineGrainedFP8ConfigTest(unittest.TestCase):
     def test_to_dict(self):


### PR DESCRIPTION
﻿## What does this PR do?

Fixes #46238.

`FineGrainedFP8HfQuantizer.update_weight_conversions()` only treated source patterns ending exactly with `.weight` as dequantizable weight tensors. Some model mappings, including the DeepSeek-V4 `w2` mapping from the issue, already anchor those sources with a trailing `$`.

That made the method skip the source as a weight, so it never added the paired `*.weight_scale_inv$` source and the FP8 dequantization op could not run for that converter.

This PR normalizes only the trailing regex anchor while checking/building those derived source patterns:

- `foo.weight` still becomes `foo.weight$` and `foo.weight_scale_inv$`
- `foo.weight$` stays anchored as `foo.weight$` and also gets `foo.weight_scale_inv$`
- non-weight companion sources, like bias sources, are preserved

## Tests

```text
PYTHONPATH=src python -m pytest tests\quantization\finegrained_fp8\test_fp8.py::FineGrainedFP8WeightConversionTest::test_dequantize_weight_conversion_handles_anchored_weight_sources -q
python -m py_compile src\transformers\quantizers\quantizer_finegrained_fp8.py tests\quantization\finegrained_fp8\test_fp8.py
python -m ruff check src\transformers\quantizers\quantizer_finegrained_fp8.py tests\quantization\finegrained_fp8\test_fp8.py
python -m ruff format --check src\transformers\quantizers\quantizer_finegrained_fp8.py tests\quantization\finegrained_fp8\test_fp8.py
git diff --check
```

I also checked the updated conversion output manually for the issue-shaped pattern:

```text
['mlp.experts.*.w2.weight$', 'mlp.experts.*.w2.weight_scale_inv$', 'mlp.experts.*.w2.bias']
```

I did not run a full DeepSeek-V4 load locally; this adds a focused CPU-level regression for the source-pattern conversion that caused the reported miss.
