### PR TITLE
Export is_falcon_mamba_ssm_available alias to restore Falcon-Mamba fast path (#46234)

### DIFF
--- a/src/transformers/utils/import_utils.py
+++ b/src/transformers/utils/import_utils.py
@@ -829,6 +829,16 @@ def is_mamba_2_ssm_available() -> bool:
     return is_torch_cuda_available() and is_available and version.parse(mamba_ssm_version) >= version.parse("2.0.4")
 
 
+# Falcon-Mamba shares the upstream ``mamba_ssm`` kernel (``_HUB_KERNEL_MAPPING``
+# maps ``"falcon_mamba-ssm"`` -> ``kernels-community/mamba-ssm``, and that hub
+# package re-exports ``falcon_mamba_inner_fn = mamba_inner_fn``). When the
+# optional ``kernels`` lib is absent, ``lazy_load_kernel("falcon_mamba-ssm")``
+# falls back to ``getattr(utils, "is_falcon_mamba_ssm_available")``; without
+# this alias the lookup returns ``None`` and the model silently drops to the
+# slow sequential path even when ``mamba_ssm`` is installed locally.
+is_falcon_mamba_ssm_available = is_mamba_ssm_available
+
+
 @lru_cache
 def is_flash_linear_attention_available():
     is_available, fla_version = _is_package_available("fla", return_version=True)


### PR DESCRIPTION
## What does this PR do?

Fixes #46234.

`falcon_mamba/modeling_falcon_mamba.py` calls `lazy_load_kernel("falcon_mamba-ssm")`. When the optional `kernels` library is **not** installed (it lives in `extras["kernels"]`, not in `install_requires`), `lazy_load_kernel`'s fallback path does:

```python
new_kernel_name = kernel_name.replace("-", "_")  # falcon_mamba_ssm
func_name = f"is_{new_kernel_name}_available"    # is_falcon_mamba_ssm_available
is_kernel_available = getattr(utils_mod, func_name, None)
```

`is_falcon_mamba_ssm_available` was never exported from `transformers.utils.import_utils`. `getattr` returns `None`, `falcon_mamba_inner_fn` resolves to `None`, and the model silently drops to `slow_forward`, emitting `Fast path is not available because one of (...) is None. ... install mamba_ssm and causal_conv1d` — even when both are already installed locally. The warning misdirects.

Pure `mamba`, `mamba2`, `jamba`, `bamba`, `zamba`, `falcon_h1`, `granitemoehybrid`, and `nemotron_h` are unaffected; they all call `lazy_load_kernel("mamba-ssm")`, whose matching `is_mamba_ssm_available` helper *is* exported.

## Why an alias is the right fix

Falcon-Mamba and Mamba share the same kernel:

- `_HUB_KERNEL_MAPPING` in `integrations/hub_kernels.py` already maps both `"mamba-ssm"` and `"falcon_mamba-ssm"` to `"kernels-community/mamba-ssm"`.
- That hub package re-exports `falcon_mamba_inner_fn = mamba_inner_fn` for the same reason.

So `is_falcon_mamba_ssm_available` is exactly the same predicate as `is_mamba_ssm_available`. Implementation matches the existing precedent for `is_mamba_2_ssm_available` (separate predicate sharing the same `_is_package_available("mamba_ssm")` probe).

## Repro

```python
# before
from transformers.utils.import_utils import is_mamba_ssm_available           # ok
from transformers.utils.import_utils import is_causal_conv1d_available       # ok
from transformers.utils.import_utils import is_falcon_mamba_ssm_available    # ImportError
```

```
ImportError: cannot import name 'is_falcon_mamba_ssm_available' from
'transformers.utils.import_utils'. Did you mean: 'is_mamba_ssm_available'?
```

After this PR the import resolves and `lazy_load_kernel("falcon_mamba-ssm")` returns the locally-installed `mamba_ssm` module via the fallback path, so Falcon-Mamba uses the fast path with the same dependency set as Mamba.

## Before submitting
- [x] This PR fixes a typo or improves the docs.
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue or the [forum](https://discuss.huggingface.co/)? Please add a link to it if that's the case. — #46234

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)