### PR TITLE
Update a test to avoid writing to the default xet cache

### DIFF
--- a/tests/models/auto/test_modeling_auto.py
+++ b/tests/models/auto/test_modeling_auto.py
@@ -14,6 +14,7 @@
 
 import copy
 import json
+import os
 import sys
 import tempfile
 import unittest
@@ -382,10 +383,11 @@ class AutoModelTest(unittest.TestCase):
 
         # Test that it works with a custom cache dir too
         with tempfile.TemporaryDirectory() as tmp_dir:
-            model = AutoModel.from_pretrained(
-                "hf-internal-testing/test_dynamic_model_v1.0", trust_remote_code=True, cache_dir=tmp_dir
-            )
-            self.assertEqual(model.__class__.__name__, "NewModel")
+            with unittest.mock.patch.dict(os.environ, {"HF_XET_CACHE": tmp_dir}):
+                model = AutoModel.from_pretrained(
+                    "hf-internal-testing/test_dynamic_model_v1.0", trust_remote_code=True, cache_dir=tmp_dir
+                )
+                self.assertEqual(model.__class__.__name__, "NewModel")
 
     def test_new_model_registration(self):
         AutoConfig.register("custom", CustomConfig)


### PR DESCRIPTION
# What does this PR do?

Update a test to avoid writing to the default xet cache.

Fix test_from_pretrained_dynamic_model_with_period failing on read-only shared cache

When `cache_dir=tmp_dir` is passed, xet still writes staging files to
`HF_XET_CACHE` (defaults to the shared read-only `/mnt/cache/xet`),
causing an OSError. Monkey-patch `HF_XET_CACHE` to `tmp_dir` for the
duration of the test so xet staging writes go to the already-writable
temp directory.