### PR TITLE
find pytest launch error in torch 2.13.0.dev20260526

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -152,9 +152,6 @@ _pytest.doctest.DoctestModule = HfDoctestModule
 doctest.DocTestParser = HfDocTestParser
 
 if is_torch_available():
-    # The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
-    # We set it to `False` for CI. See https://github.com/pytorch/pytorch/issues/157274#issuecomment-3090791615
-    enable_tf32(False)
     # # torch.backends.fp32_precision does not cascade to torch.backends.cudnn.conv.fp32_precision and torch.backends.cudnn.rnn.fp32_precision
     # TODO: Considering move this to `enable_tf32`, or report a bug to `torch`.
     import torch
@@ -167,6 +164,10 @@ if is_torch_available():
     # TODO: report a bug to `torch`
     if hasattr(torch.backends.cudnn, "allow_tf32"):
         torch.backends.cudnn.allow_tf32 = False
+
+    # The flag below controls whether to allow TF32 on cuDNN. This flag defaults to True.
+    # We set it to `False` for CI. See https://github.com/pytorch/pytorch/issues/157274#issuecomment-3090791615
+    enable_tf32(False)
 
     # This is necessary to make several `test_batching_equivalence` pass (within the tolerance `1e-5`)
     if hasattr(torch.backends.cudnn, "conv") and hasattr(torch.backends.cudnn.conv, "fp32_precision"):


### PR DESCRIPTION
adjust calling sequence to avoid it.

error like
ImportError while loading conftest '/.tests/transformers/conftest.py'.
conftest.py:168: in <module>
    if hasattr(torch.backends.cudnn, "allow_tf32"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/opt/venv/lib/python3.12/site-packages/torch/backends/__init__.py:42: in __get__
    return self.getter()
           ^^^^^^^^^^^^^
E   RuntimeError: PyTorch is checking whether allow_tf32 is enabled for cuDNN without a specific operator name,but the current flag(s) indicate that cuDNN conv and cuDNN RNN have different TF32 flags.This combination indicates that you have used a mix of the legacy and new APIs to set the TF32 flags. We suggest only using the new API to set the TF32 flag(s). See also: https://pytorch.org/docs/main/notes/cuda.html#tensorfloat-32-tf32-on-ampere-and-later-devices
