### PR TITLE
Rename liger_kernels -> liger-kernels

### DIFF
--- a/docs/source/en/kernel_doc/loading_kernels.md
+++ b/docs/source/en/kernel_doc/loading_kernels.md
@@ -141,7 +141,7 @@ from transformers import AutoModelForCausalLM, KernelConfig
 
 kernel_config = KernelConfig(
     kernel_mapping={
-        "RMSNorm": "kernels-community/liger_kernels:LigerRMSNorm",
+        "RMSNorm": "kernels-community/liger-kernels:LigerRMSNorm",
     }
 )
 model = AutoModelForCausalLM.from_pretrained(
@@ -161,7 +161,7 @@ from transformers import KernelConfig
 kernel_config = KernelConfig(
     kernel_mapping={
         "RMSNorm": {
-            "cuda": "kernels-community/liger_kernels:LigerRMSNorm",
+            "cuda": "kernels-community/liger-kernels:LigerRMSNorm",
             "rocm": "kernels-community/rocm-kernels:RocmRMSNorm",
             "metal": "kernels-community/metal-kernels:MetalRMSNorm",
             "xpu": "kernels-community/xpu-kernels:XpuRMSNorm"

--- a/src/transformers/integrations/hub_kernels.py
+++ b/src/transformers/integrations/hub_kernels.py
@@ -100,14 +100,14 @@ try:
         "RMSNorm": {
             "cuda": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/liger_kernels",
+                    repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
                     # revision="pure-layer-test",
                 ),
             },
             "rocm": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/liger_kernels",
+                    repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
                 )
             },
@@ -125,7 +125,7 @@ try:
             },
             "npu": {
                 Mode.INFERENCE: LayerRepository(
-                    repo_id="kernels-community/liger_kernels",
+                    repo_id="kernels-community/liger-kernels",
                     layer_name="LigerRMSNorm",
                 )
             },


### PR DESCRIPTION
# What does this PR do?

<img width="583" height="320" alt="Screenshot 2026-05-28 at 12 02 05" src="https://github.com/user-attachments/assets/4d88703f-523b-4d4d-9c5c-a38c0580e9ef" />

^ This repo is not a duplicate of `liger-kernels`; it only contains a `torch-universal` directory inside `build`.

## Who can review?

- kernels: @drbh
