### PR TITLE
Processor compatibility with vLLM 

### DIFF
--- a/src/transformers/processing_utils.py
+++ b/src/transformers/processing_utils.py
@@ -852,12 +852,15 @@ class ProcessorMixin(PushToHubMixin):
             return text, []
 
         # Use named regex so we can extract groups later and replace
+        # TODO @raushan: vllm encodes text and mm-data separately causing errors when a placeholder
+        # has no associated mm-data. Thus we can check if there are any `replacements` and skip otherwise
+        # Plan: update all models and contrib to vllm, they might benefit largely from `replacement_offsets`
         token_groups = []
-        if image_token := getattr(self, "image_token", None):
+        if len(images_replacements) > 0 and (image_token := getattr(self, "image_token", None)) is not None:
             token_groups.append(f"(?P<image>{re.escape(image_token)})")
-        if video_token := getattr(self, "video_token", None):
+        if len(videos_replacements) > 0 and (video_token := getattr(self, "video_token", None)) is not None:
             token_groups.append(f"(?P<video>{re.escape(video_token)})")
-        if audio_token := getattr(self, "audio_token", None):
+        if len(audio_replacements) > 0 and (audio_token := getattr(self, "audio_token", None)) is not None:
             token_groups.append(f"(?P<audio>{re.escape(audio_token)})")
 
         regex_special_mm_tokens = "|".join(token_groups) or r"(?!)"


### PR DESCRIPTION
# What does this PR do?

As per title, recent refactor broken vLLM. Can be checked with `vllm serve Qwen/Qwen3-VL-8B-Instruct --gpu-memory-utilization 0.7 --max-model-len 8192`. It fails on main and passed on PR branch

Plan is to update all models first, and check what can we do with vllm after that. Personally, I want us to be strict and actually raise an error when an input text has `image_token` with no associated `image`. This PR suppresses such errors to be completely BC
